### PR TITLE
fix: break COIN equity rebalance guard/recovery deadlock

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -15,7 +15,7 @@ use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
 use sqlx_apalis::sqlite::{SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode};
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use task_supervisor::SupervisorHandle;
 use tokio::sync::{Mutex, broadcast};
@@ -67,6 +67,7 @@ use crate::rebalancing::equity::{
     CrossVenueEquityTransfer, EquityTransferServices, TransferEquityToHedgingCtx,
     TransferEquityToMarketMakingCtx,
 };
+use crate::rebalancing::trigger::GuardState;
 use crate::rebalancing::usdc::{
     TransferUsdcToHedgingCtx, TransferUsdcToMarketMakingCtx, UsdcSettlementParams,
 };
@@ -1282,6 +1283,9 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
 
         let transfer_equity_to_market_making_ctx = Arc::new(TransferEquityToMarketMakingCtx {
             transfer: recovery_transfer.clone(),
+            equity_in_progress: rebalancing_service.equity_in_progress.clone(),
+            mint_store: mint_store.clone(),
+            equities_config: deps.ctx.assets.equities.clone(),
         });
 
         let transfer_equity_to_hedging_ctx = Arc::new(TransferEquityToHedgingCtx {
@@ -1391,6 +1395,8 @@ async fn recover_interrupted_tokenization_aggregates(
     let interrupted_mints = interrupted_mint_ids(pool).await?;
     let interrupted_redemptions = interrupted_redemption_ids(pool).await?;
 
+    let mut resume_mints = Vec::new();
+
     for mint_id in &interrupted_mints {
         let Some(mint) = mint_store.load(mint_id).await? else {
             return Err(anyhow::anyhow!(
@@ -1401,6 +1407,17 @@ async fn recover_interrupted_tokenization_aggregates(
         rebalancing_service
             .recover_mint_state(mint_id, &mint)
             .await?;
+
+        // Exclude pre-wrap mints (TokensReceived, WrapSubmitted) that are
+        // HeldForRecovery from direct resume. UnwrappedEquityRecovery owns
+        // those and will re-wrap + deposit the tokens. Calling resume_mint
+        // on the same aggregate would race with the recovery job (both would
+        // try to submit the wrap tx). TokensWrapped and VaultDepositSubmitted
+        // mints are always safe to resume (vault deposit is idempotent and
+        // the aggregate/inventory guard both converge to Done).
+        if !is_pre_wrap_held_for_recovery(&mint, &rebalancing_service.equity_in_progress) {
+            resume_mints.push(mint_id.clone());
+        }
     }
 
     for redemption_id in &interrupted_redemptions {
@@ -1416,9 +1433,34 @@ async fn recover_interrupted_tokenization_aggregates(
     }
 
     recover_stuck_redemptions(pool, inventory).await?;
-    resume_interrupted_transfers(transfer, &interrupted_mints, &interrupted_redemptions).await;
+    resume_interrupted_transfers(transfer, &resume_mints, &interrupted_redemptions).await;
 
     Ok(())
+}
+
+/// Returns `true` when `mint` is a pre-wrap post-receipt state
+/// (`TokensReceived` or `WrapSubmitted`) AND its symbol's guard is
+/// `HeldForRecovery`. These mints are excluded from direct `resume_mints`
+/// because `UnwrappedEquityRecovery` owns the slot and will re-wrap and
+/// deposit the tokens; calling `resume_mint` concurrently would race.
+fn is_pre_wrap_held_for_recovery(
+    mint: &TokenizedEquityMint,
+    equity_in_progress: &RwLock<HashMap<Symbol, GuardState>>,
+) -> bool {
+    if let TokenizedEquityMint::TokensReceived { symbol, .. }
+    | TokenizedEquityMint::WrapSubmitted { symbol, .. } = mint
+    {
+        let guard = match equity_in_progress.read() {
+            Ok(guard) => guard,
+            Err(poison) => poison.into_inner(),
+        };
+        match guard.get(symbol) {
+            Some(GuardState::HeldForRecovery) => true,
+            Some(GuardState::ActiveTransfer { .. }) | None => false,
+        }
+    } else {
+        false
+    }
 }
 
 async fn resume_interrupted_transfers(
@@ -2532,8 +2574,8 @@ mod tests {
     use rain_math_float::Float;
     use sqlx::{ConnectOptions, SqlitePool};
     use std::future::pending;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, RwLock};
     use task_supervisor::SupervisorBuilder;
     use tokio::sync::broadcast;
 
@@ -2566,6 +2608,7 @@ mod tests {
         OnchainTradeBuilder, get_test_log, get_test_order, rebalancing_enabled_equities,
         setup_test_db, setup_test_pools,
     };
+    use crate::tokenized_equity_mint::{TokenizationRequestId, issuer_request_id};
     use crate::trading::onchain::inclusion::EmittedOnChain;
     use crate::trading::onchain::trade_accountant::AccountForDexTrade;
     use crate::unwrapped_equity_recovery::UnwrappedEquityRecoveryJob;
@@ -6797,5 +6840,93 @@ mod tests {
         let join_error = handle.await.unwrap_err();
 
         check_monitor_drain_result(Err(join_error)).unwrap_err();
+    }
+
+    /// `is_pre_wrap_held_for_recovery` excludes `TokensReceived` and
+    /// `WrapSubmitted` mints whose guard is `HeldForRecovery` from
+    /// `resume_mints`. All other states are included regardless.
+    #[test]
+    fn resume_exclusion_predicate_excludes_only_pre_wrap_held_for_recovery() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let equity_in_progress: Arc<RwLock<HashMap<Symbol, GuardState>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+
+        let tokens_received = TokenizedEquityMint::TokensReceived {
+            symbol: symbol.clone(),
+            quantity: float!(5),
+            wallet: Address::ZERO,
+            issuer_request_id: issuer_request_id("exc-tokens-received"),
+            tokenization_request_id: TokenizationRequestId("TOK-TR".to_string()),
+            tx_hash: TxHash::ZERO,
+            shares_minted: U256::from(5u64),
+            fees: None,
+            requested_at: now,
+            accepted_at: now,
+            received_at: now,
+        };
+        let wrap_submitted = TokenizedEquityMint::WrapSubmitted {
+            symbol: symbol.clone(),
+            quantity: float!(5),
+            wallet: Address::ZERO,
+            issuer_request_id: issuer_request_id("exc-wrap-submitted"),
+            tokenization_request_id: TokenizationRequestId("TOK-WS".to_string()),
+            tx_hash: TxHash::ZERO,
+            shares_minted: U256::from(5u64),
+            fees: None,
+            requested_at: now,
+            accepted_at: now,
+            received_at: now,
+            wrap_tx_hash: TxHash::ZERO,
+        };
+        let tokens_wrapped = TokenizedEquityMint::TokensWrapped {
+            symbol: symbol.clone(),
+            quantity: float!(5),
+            wallet: Address::ZERO,
+            issuer_request_id: issuer_request_id("exc-tokens-wrapped"),
+            tokenization_request_id: TokenizationRequestId("TOK-TW".to_string()),
+            tx_hash: TxHash::ZERO,
+            shares_minted: U256::from(5u64),
+            requested_at: now,
+            accepted_at: now,
+            received_at: now,
+            wrap_tx_hash: TxHash::ZERO,
+            wrapped_shares: U256::from(5u64),
+            wrap_block: None,
+            wrapped_at: now,
+        };
+
+        // Without HeldForRecovery -- no mint is excluded.
+        equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::ActiveTransfer { generation: 0 });
+        assert!(
+            !is_pre_wrap_held_for_recovery(&tokens_received, &equity_in_progress),
+            "TokensReceived + ActiveTransfer must NOT be excluded"
+        );
+        assert!(
+            !is_pre_wrap_held_for_recovery(&wrap_submitted, &equity_in_progress),
+            "WrapSubmitted + ActiveTransfer must NOT be excluded"
+        );
+
+        // With HeldForRecovery -- only pre-wrap states are excluded.
+        equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol, GuardState::HeldForRecovery);
+        assert!(
+            is_pre_wrap_held_for_recovery(&tokens_received, &equity_in_progress),
+            "TokensReceived + HeldForRecovery must be excluded from resume_mints"
+        );
+        assert!(
+            is_pre_wrap_held_for_recovery(&wrap_submitted, &equity_in_progress),
+            "WrapSubmitted + HeldForRecovery must be excluded from resume_mints"
+        );
+        assert!(
+            !is_pre_wrap_held_for_recovery(&tokens_wrapped, &equity_in_progress),
+            "TokensWrapped must NEVER be excluded (deposit idempotent)"
+        );
     }
 }

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -14,10 +14,11 @@ use httpmock::Mock;
 use httpmock::prelude::*;
 use serde_json::json;
 use sqlx::SqlitePool;
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::sync::broadcast;
+use uuid::Uuid;
 
 use rain_math_float::Float;
 use st0x_config::{
@@ -32,7 +33,7 @@ use st0x_execution::{
 use st0x_finance::{Usd, Usdc};
 use st0x_float_macro::float;
 use st0x_raindex::{Raindex, RaindexVaultId};
-use st0x_wrapper::MockWrapper;
+use st0x_wrapper::{MockWrapper, Wrapper};
 
 use super::{ExpectedEvent, assert_events, fetch_events};
 use crate::bindings::{IERC20, TestERC20};
@@ -40,6 +41,7 @@ use crate::conductor::job::Job;
 use crate::equity_redemption::{
     EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,
 };
+use crate::inventory::view::InFlightEquityLocation;
 use crate::inventory::{BroadcastingInventory, ImbalanceThreshold, InventoryView, Venue};
 use crate::offchain::order::OffchainOrderId;
 use crate::onchain::mock::MockRaindex;
@@ -49,6 +51,7 @@ use crate::rebalancing::equity::{
     TransferEquityToHedgingCtx, TransferEquityToMarketMaking, TransferEquityToMarketMakingCtx,
     TransferEquityToMarketMakingJobError,
 };
+use crate::rebalancing::trigger::GuardState;
 use crate::rebalancing::usdc::{TransferUsdcToHedging, TransferUsdcToMarketMaking};
 use crate::rebalancing::{
     RebalancingSchedulers, RebalancingService, RebalancingServiceConfig, drain_pending_jobs,
@@ -60,9 +63,23 @@ use crate::tokenization::alpaca::tests::{
     tokenization_requests_path,
 };
 use crate::tokenization::mock::MockTokenizer;
-use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMint};
+use crate::tokenized_equity_mint::{
+    IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintCommand, issuer_request_id,
+};
+use crate::unwrapped_equity_recovery::aggregate::{
+    UnwrappedEquityRecovery, UnwrappedEquityRecoveryId, UnwrappedEquityRecoveryServices,
+};
+use crate::unwrapped_equity_recovery::{
+    UnwrappedEquityRecoveryCtx, UnwrappedEquityRecoveryJob, UnwrappedEquityRecoveryJobQueue,
+};
 use crate::vault_lookup::{MockVaultLookup, VaultLookup};
 use crate::vault_registry::{VaultRegistry, VaultRegistryCommand, VaultRegistryId};
+use crate::wrapped_equity_recovery::aggregate::{
+    WrappedEquityRecovery, WrappedEquityRecoveryId, WrappedEquityRecoveryServices,
+};
+use crate::wrapped_equity_recovery::{
+    WrappedEquityRecoveryCtx, WrappedEquityRecoveryJob, WrappedEquityRecoveryJobQueue,
+};
 
 const TEST_ORDERBOOK: Address = address!("0x0000000000000000000000000000000000000001");
 const TEST_ORDER_OWNER: Address = address!("0x0000000000000000000000000000000000000002");
@@ -732,8 +749,20 @@ async fn equity_offchain_imbalance_triggers_mint() {
             )]));
     });
 
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
+        pool.clone(),
+        EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            vault_lookup: Arc::new(MockVaultLookup::new()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: Arc::new(MockWrapper::new()),
+        },
+    ));
     let ctx = TransferEquityToMarketMakingCtx {
         transfer: equity_transfer,
+        equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
+        mint_store,
+        equities_config: EquitiesConfig::default(),
     };
     Job::perform(&job, &ctx).await.unwrap();
 
@@ -1641,8 +1670,20 @@ async fn mint_api_failure_produces_rejected_event() {
     drain_pending_jobs(&service).await.unwrap();
 
     let job = fetch_pending_equity_mint_job(&apalis_pool).await;
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
+        pool.clone(),
+        EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            vault_lookup: Arc::new(MockVaultLookup::new()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: Arc::new(MockWrapper::new()),
+        },
+    ));
     let ctx = TransferEquityToMarketMakingCtx {
         transfer: equity_transfer,
+        equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
+        mint_store,
+        equities_config: EquitiesConfig::default(),
     };
     let error = Job::perform(&job, &ctx).await.unwrap_err();
     assert!(
@@ -2189,11 +2230,24 @@ async fn mint_accepted_sets_offchain_inflight() {
     // The poll will return pending, so the mint aggregate will time out or loop,
     // but MintAccepted has already fired by then. We spawn and cancel to
     // get just the MintAccepted event through.
+    let mint_store_for_spawn = Arc::new(test_store::<TokenizedEquityMint>(
+        pool.clone(),
+        EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            vault_lookup: Arc::new(MockVaultLookup::new()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: Arc::new(MockWrapper::new()),
+        },
+    ));
     let transfer_handle = tokio::spawn({
         let equity_transfer = Arc::clone(&equity_transfer);
+        let mint_store = Arc::clone(&mint_store_for_spawn);
         async move {
             let ctx = TransferEquityToMarketMakingCtx {
                 transfer: equity_transfer,
+                equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
+                mint_store,
+                equities_config: EquitiesConfig::default(),
             };
             let _ = Job::perform(&job, &ctx).await;
         }
@@ -2390,8 +2444,20 @@ async fn completed_mint_clears_inflight_and_updates_inventory() {
     };
 
     // Execute the full mint lifecycle through the job's perform
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
+        pool.clone(),
+        EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            vault_lookup: Arc::new(MockVaultLookup::new()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: Arc::new(MockWrapper::new()),
+        },
+    ));
     let ctx = TransferEquityToMarketMakingCtx {
         transfer: Arc::clone(&equity_transfer) as _,
+        equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
+        mint_store,
+        equities_config: EquitiesConfig::default(),
     };
     Job::perform(&job, &ctx).await.unwrap();
 
@@ -2550,5 +2616,528 @@ async fn transfer_failed_cancels_redemption_inflight() {
     assert!(
         available_after_fail.inner().eq(float!("80")).unwrap(),
         "Available should be restored to 80 after TransferFailed, got {available_after_fail:?}"
+    );
+}
+
+/// WrappedEquityRecovery claims a `HeldForRecovery` slot (the wrap-landed-but-
+/// unconfirmed handoff), but when inventory shows NO wrapped balance yet it
+/// must RESCHEDULE itself rather than drop the slot: the inventory reactor only
+/// re-dispatches recovery on a positive balance, so dropping here would restore
+/// `HeldForRecovery` with no job left to drain it -- wedging the symbol. The
+/// guard is restored to `HeldForRecovery` and a delayed job keeps polling.
+///
+/// For the case where the wrapped balance IS present, see
+/// `recovery_job_breaks_deadlock_when_wrap_landed_wrapped_equity_recovery`.
+#[tokio::test]
+async fn wrapped_recovery_reschedules_when_held_for_recovery_but_no_balance() {
+    let symbol = Symbol::new("AAPL").unwrap();
+
+    // Guard is HeldForRecovery: set by the transfer job when PostReceipt fired.
+    let equity_in_progress = Arc::new(RwLock::new(HashMap::from([(
+        symbol.clone(),
+        GuardState::HeldForRecovery,
+    )])));
+
+    let (pool, apalis_pool) = setup_test_pools().await;
+
+    let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+    let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
+    let vault_lookup: Arc<dyn VaultLookup> = Arc::new(MockVaultLookup::new());
+    let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
+
+    let equity_services = EquityTransferServices {
+        raindex: Arc::clone(&raindex),
+        vault_lookup: Arc::clone(&vault_lookup),
+        tokenizer: Arc::clone(&tokenizer),
+        wrapper: Arc::clone(&wrapper),
+    };
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
+        pool.clone(),
+        equity_services.clone(),
+    ));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(
+        pool.clone(),
+        equity_services,
+    ));
+    let transfer = Arc::new(CrossVenueEquityTransfer::new(
+        Arc::clone(&raindex),
+        Arc::clone(&vault_lookup),
+        Arc::clone(&tokenizer),
+        Arc::clone(&wrapper),
+        Address::random(),
+        Arc::clone(&mint_store),
+        Arc::clone(&redemption_store),
+    ));
+    let store = Arc::new(test_store(
+        pool.clone(),
+        WrappedEquityRecoveryServices {
+            raindex,
+            vault_lookup,
+            wrapper,
+            transfer,
+        },
+    ));
+
+    let (sender, _receiver) = broadcast::channel(16);
+    let inventory = Arc::new(BroadcastingInventory::new(InventoryView::default(), sender));
+
+    let ctx = WrappedEquityRecoveryCtx {
+        inventory,
+        store: Arc::clone(&store),
+        mint_store,
+        redemption_store,
+        equity_in_progress: Arc::clone(&equity_in_progress),
+        queue: WrappedEquityRecoveryJobQueue::new(&apalis_pool),
+        reschedule_interval: Duration::from_secs(1),
+    };
+
+    let recovery_id = WrappedEquityRecoveryId(Uuid::new_v4());
+    let job = WrappedEquityRecoveryJob {
+        symbol: symbol.clone(),
+        recovery_id: recovery_id.clone(),
+    };
+
+    // The job claims HeldForRecovery, finds no wrapped balance, and reschedules
+    // (returns Ok(())) to keep polling -- the guard is restored on drop.
+    job.perform(&ctx)
+        .await
+        .expect("wrapped recovery must return Ok(()) when rescheduling");
+
+    // The guard must be restored to HeldForRecovery after the no-balance drop.
+    assert_eq!(
+        equity_in_progress.read().unwrap().get(&symbol),
+        Some(&GuardState::HeldForRecovery),
+        "equity_in_progress must be restored to HeldForRecovery after a no-balance reschedule; \
+         the slot must not be cleared so recovery retries can still claim it",
+    );
+
+    // No work was done past the no-balance skip, so the aggregate is absent.
+    let state = store.load(&recovery_id).await.unwrap();
+    assert!(
+        state.is_none(),
+        "wrapped recovery must not create the aggregate when it reschedules; got {state:?}",
+    );
+
+    // A rescheduled job must have been enqueued so polling continues.
+    let (rescheduled,): (i64,) =
+        sqlx_apalis::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<WrappedEquityRecoveryJob>())
+            .fetch_one(ctx.queue.pool())
+            .await
+            .unwrap();
+    assert_eq!(
+        rescheduled, 1,
+        "a HeldForRecovery claim with no balance must enqueue a delayed job to keep polling",
+    );
+}
+
+/// LANDED-BUT-UNCONFIRMED SCENARIO: the transfer job got a `PostReceipt` error
+/// in `WrapSubmitted` and handed the slot to recovery as `HeldForRecovery`, but
+/// the wrap tx actually LANDED -- only its confirmation read failed under a
+/// stale RPC. The tokens are therefore WRAPPED in the base wallet (inventory:
+/// `BaseWalletWrapped`), and `WrappedEquityRecovery` is the job the reactor
+/// dispatches. It must:
+/// 1. Claim the `HeldForRecovery` slot (not reschedule -- the old orphan-only
+///    claim refused it, wedging the slot with no job able to drain it).
+/// 2. Drive the orphan deposit sequence to `OrphanDeposited`.
+/// 3. Release the guard (map empty after completion).
+#[tokio::test]
+async fn recovery_job_breaks_deadlock_when_wrap_landed_wrapped_equity_recovery() {
+    let symbol = Symbol::new("AAPL").unwrap();
+
+    // Guard is HeldForRecovery: set by the transfer job after a PostReceipt
+    // error in WrapSubmitted. The wrap tx landed, so tokens are WRAPPED.
+    let equity_in_progress = Arc::new(RwLock::new(HashMap::from([(
+        symbol.clone(),
+        GuardState::HeldForRecovery,
+    )])));
+
+    let (pool, apalis_pool) = setup_test_pools().await;
+
+    let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+    let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
+    let vault_lookup: Arc<dyn VaultLookup> = Arc::new(
+        MockVaultLookup::new()
+            .with_vault(Address::ZERO, RaindexVaultId(B256::ZERO))
+            .with_default_vault(RaindexVaultId(B256::ZERO)),
+    );
+    let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
+
+    let equity_services = EquityTransferServices {
+        raindex: Arc::clone(&raindex),
+        vault_lookup: Arc::clone(&vault_lookup),
+        tokenizer: Arc::clone(&tokenizer),
+        wrapper: Arc::clone(&wrapper),
+    };
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
+        pool.clone(),
+        equity_services.clone(),
+    ));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(
+        pool.clone(),
+        equity_services,
+    ));
+    let transfer = Arc::new(CrossVenueEquityTransfer::new(
+        Arc::clone(&raindex),
+        Arc::clone(&vault_lookup),
+        Arc::clone(&tokenizer),
+        Arc::clone(&wrapper),
+        Address::random(),
+        Arc::clone(&mint_store),
+        Arc::clone(&redemption_store),
+    ));
+    let store = Arc::new(test_store(
+        pool.clone(),
+        WrappedEquityRecoveryServices {
+            raindex,
+            vault_lookup,
+            wrapper,
+            transfer,
+        },
+    ));
+
+    // Inventory reports WRAPPED balance: the wrap landed, tokens are wtSTOCK
+    // in the base wallet outside Raindex.
+    let shares = FractionalShares::new(float!(5));
+    let mut balances = BTreeMap::new();
+    balances.insert(symbol.clone(), shares);
+    let now = Utc::now();
+    let view = InventoryView::default().set_inflight_equity_at_location(
+        InFlightEquityLocation::BaseWalletWrapped,
+        &balances,
+        now,
+        now,
+    );
+
+    let (sender, _receiver) = broadcast::channel(16);
+    let inventory = Arc::new(BroadcastingInventory::new(view, sender));
+
+    let ctx = WrappedEquityRecoveryCtx {
+        inventory,
+        store: Arc::clone(&store),
+        mint_store,
+        redemption_store,
+        equity_in_progress: Arc::clone(&equity_in_progress),
+        queue: WrappedEquityRecoveryJobQueue::new(&apalis_pool),
+        reschedule_interval: Duration::from_secs(1),
+    };
+
+    let recovery_id = WrappedEquityRecoveryId(Uuid::new_v4());
+    let job = WrappedEquityRecoveryJob {
+        symbol: symbol.clone(),
+        recovery_id: recovery_id.clone(),
+    };
+
+    // The job must claim HeldForRecovery and run to completion.
+    job.perform(&ctx)
+        .await
+        .expect("WrappedEquityRecovery must run to completion when guard is HeldForRecovery");
+
+    // Verify the aggregate reached a terminal state (orphan deposit path).
+    let state = store.load(&recovery_id).await.unwrap();
+    assert!(
+        matches!(state, Some(WrappedEquityRecovery::OrphanDeposited { .. })),
+        "WrappedEquityRecovery must drive orphan path to OrphanDeposited, got {state:?}",
+    );
+
+    // Verify the guard was released: the slot must be absent after completion.
+    assert_eq!(
+        equity_in_progress.read().unwrap().get(&symbol),
+        None,
+        "equity_in_progress must be empty after WrappedEquityRecovery completes; \
+         a stuck guard would block future transfers for {symbol}",
+    );
+
+    // Verify no rescheduled jobs were enqueued.
+    let (rescheduled,): (i64,) =
+        sqlx_apalis::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<WrappedEquityRecoveryJob>())
+            .fetch_one(ctx.queue.pool())
+            .await
+            .unwrap();
+    assert_eq!(
+        rescheduled, 0,
+        "WrappedEquityRecovery must NOT reschedule when it can claim HeldForRecovery and drain \
+         the wrapped balance; a reschedule count > 0 means the deadlock-break failed",
+    );
+}
+
+/// ORPHAN-DISPATCH VARIANT (RAI-1070): the ERC-4626 wrap reverted, so tokens
+/// are still UNWRAPPED in the base wallet (inventory: `BaseWalletUnwrapped`),
+/// and there is NO active mint in the inventory view, so `decide_dispatch`
+/// resolves to `Orphan`. `UnwrappedEquityRecovery` must:
+/// 1. Claim the `HeldForRecovery` slot (not reschedule).
+/// 2. Drive the orphan wrap+deposit sequence to `OrphanDeposited`.
+/// 3. Release the guard (map empty after completion).
+///
+/// The prod path usually carries an active mint (see
+/// `recovery_job_breaks_deadlock_when_wrap_failed_dispatches_active_mint` for
+/// the `ActiveMint` -> `DispatchToMint` variant); this test isolates the
+/// orphan branch.
+///
+/// Before this fix, `mark_held_for_recovery` only fired for `TokensWrapped`,
+/// so the prod (wrap-failed) path left the guard as `ActiveTransfer` after
+/// apalis retry exhaustion, deadlocking all future mints for the symbol.
+#[tokio::test]
+async fn recovery_job_breaks_deadlock_when_wrap_failed_unwrapped_equity_recovery() {
+    let symbol = Symbol::new("AAPL").unwrap();
+
+    // Guard is HeldForRecovery: set by the transfer job when it got a
+    // PostReceipt error with the aggregate in TokensReceived/WrapSubmitted.
+    let equity_in_progress = Arc::new(RwLock::new(HashMap::from([(
+        symbol.clone(),
+        GuardState::HeldForRecovery,
+    )])));
+
+    let (pool, apalis_pool) = setup_test_pools().await;
+
+    let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+    let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
+    let vault_lookup: Arc<dyn VaultLookup> = Arc::new(
+        MockVaultLookup::new()
+            .with_vault(Address::ZERO, RaindexVaultId(B256::ZERO))
+            .with_default_vault(RaindexVaultId(B256::ZERO)),
+    );
+    let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
+
+    let equity_services = EquityTransferServices {
+        raindex: Arc::clone(&raindex),
+        vault_lookup: Arc::clone(&vault_lookup),
+        tokenizer: Arc::clone(&tokenizer),
+        wrapper: Arc::clone(&wrapper),
+    };
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
+        pool.clone(),
+        equity_services.clone(),
+    ));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(
+        pool.clone(),
+        equity_services,
+    ));
+    let transfer = Arc::new(CrossVenueEquityTransfer::new(
+        Arc::clone(&raindex),
+        Arc::clone(&vault_lookup),
+        Arc::clone(&tokenizer),
+        Arc::clone(&wrapper),
+        Address::random(),
+        Arc::clone(&mint_store),
+        Arc::clone(&redemption_store),
+    ));
+    let store = Arc::new(test_store(
+        pool.clone(),
+        UnwrappedEquityRecoveryServices {
+            raindex,
+            vault_lookup,
+            wrapper,
+            transfer,
+            wallet: Address::ZERO,
+        },
+    ));
+
+    // Inventory reports UNWRAPPED balance: wrap failed, tokens are raw tSTOCK
+    // in the base wallet.
+    let shares = FractionalShares::new(float!(5));
+    let mut balances = BTreeMap::new();
+    balances.insert(symbol.clone(), shares);
+    let now = Utc::now();
+    let view = InventoryView::default().set_inflight_equity_at_location(
+        InFlightEquityLocation::BaseWalletUnwrapped,
+        &balances,
+        now,
+        now,
+    );
+
+    let (sender, _receiver) = broadcast::channel(16);
+    let inventory = Arc::new(BroadcastingInventory::new(view, sender));
+
+    let ctx = UnwrappedEquityRecoveryCtx {
+        inventory,
+        store: Arc::clone(&store),
+        mint_store,
+        redemption_store,
+        equity_in_progress: Arc::clone(&equity_in_progress),
+        queue: UnwrappedEquityRecoveryJobQueue::new(&apalis_pool),
+        reschedule_interval: Duration::from_secs(1),
+    };
+
+    let recovery_id = UnwrappedEquityRecoveryId(Uuid::new_v4());
+    let job = UnwrappedEquityRecoveryJob {
+        symbol: symbol.clone(),
+        recovery_id: recovery_id.clone(),
+    };
+
+    // The job must claim HeldForRecovery and run to completion.
+    job.perform(&ctx)
+        .await
+        .expect("UnwrappedEquityRecovery must run to completion when guard is HeldForRecovery");
+
+    // Verify the aggregate reached a terminal state (orphan wrap+deposit path).
+    let state = store.load(&recovery_id).await.unwrap();
+    assert!(
+        matches!(state, Some(UnwrappedEquityRecovery::OrphanDeposited { .. })),
+        "UnwrappedEquityRecovery must drive orphan path to OrphanDeposited, got {state:?}",
+    );
+
+    // Verify the guard was released: the slot must be absent after completion.
+    assert_eq!(
+        equity_in_progress.read().unwrap().get(&symbol),
+        None,
+        "equity_in_progress must be empty after UnwrappedEquityRecovery completes; \
+         a stuck guard would block future transfers for {symbol}",
+    );
+
+    // Verify no rescheduled jobs were enqueued.
+    let (rescheduled,): (i64,) =
+        sqlx_apalis::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<UnwrappedEquityRecoveryJob>())
+            .fetch_one(ctx.queue.pool())
+            .await
+            .unwrap();
+    assert_eq!(
+        rescheduled, 0,
+        "UnwrappedEquityRecovery must NOT reschedule when it can claim HeldForRecovery; \
+         a reschedule count > 0 means the job incorrectly treated it as contention",
+    );
+}
+
+/// ACTIVE-MINT VARIANT (RAI-1070): the path prod actually takes. A wrap-failed
+/// mint is in `TokensReceived`/`WrapSubmitted`, and the snapshot reactor's
+/// `update_active_mint` has populated `active_mint`, so `decide_dispatch`
+/// resolves to `ActiveMint` -- recovery dispatches `DispatchToMint`, which
+/// `resume_mint`s the persisted mint from its pre-wrap state, reaching
+/// `DispatchedToMint`. The orphan variant above covers only the
+/// no-active-mint branch, which is not what prod hits for a wrap-failed mint.
+#[tokio::test]
+async fn recovery_job_breaks_deadlock_when_wrap_failed_dispatches_active_mint() {
+    let symbol = Symbol::new("AAPL").unwrap();
+    let mint_id = issuer_request_id("active-mint-deadlock");
+
+    // Guard is HeldForRecovery: handed off by the transfer job after PostReceipt.
+    let equity_in_progress = Arc::new(RwLock::new(HashMap::from([(
+        symbol.clone(),
+        GuardState::HeldForRecovery,
+    )])));
+
+    let (pool, apalis_pool) = setup_test_pools().await;
+
+    let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+    let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
+    let vault_lookup: Arc<dyn VaultLookup> = Arc::new(
+        MockVaultLookup::new()
+            .with_vault(Address::ZERO, RaindexVaultId(B256::ZERO))
+            .with_default_vault(RaindexVaultId(B256::ZERO)),
+    );
+    let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
+
+    let equity_services = EquityTransferServices {
+        raindex: Arc::clone(&raindex),
+        vault_lookup: Arc::clone(&vault_lookup),
+        tokenizer: Arc::clone(&tokenizer),
+        wrapper: Arc::clone(&wrapper),
+    };
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
+        pool.clone(),
+        equity_services.clone(),
+    ));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(
+        pool.clone(),
+        equity_services,
+    ));
+    let transfer = Arc::new(CrossVenueEquityTransfer::new(
+        Arc::clone(&raindex),
+        Arc::clone(&vault_lookup),
+        Arc::clone(&tokenizer),
+        Arc::clone(&wrapper),
+        Address::random(),
+        Arc::clone(&mint_store),
+        Arc::clone(&redemption_store),
+    ));
+    let store = Arc::new(test_store(
+        pool.clone(),
+        UnwrappedEquityRecoveryServices {
+            raindex,
+            vault_lookup,
+            wrapper,
+            transfer,
+            wallet: Address::ZERO,
+        },
+    ));
+
+    // Seed the mint aggregate in TokensReceived (the persisted pre-wrap state)
+    // with quantity matching the unwrapped wallet balance, so resume_mint can
+    // re-drive it and validate_active_aggregate_quantity passes.
+    mint_store
+        .send(
+            &mint_id,
+            TokenizedEquityMintCommand::RequestMint {
+                issuer_request_id: mint_id.clone(),
+                symbol: symbol.clone(),
+                quantity: float!(5),
+                wallet: Address::ZERO,
+            },
+        )
+        .await
+        .expect("RequestMint must persist");
+    mint_store
+        .send(&mint_id, TokenizedEquityMintCommand::Poll)
+        .await
+        .expect("Poll must transition the mint to TokensReceived");
+
+    // Inventory reports UNWRAPPED balance AND an active mint, so decide_dispatch
+    // resolves to ActiveMint (the prod path) instead of Orphan.
+    let shares = FractionalShares::new(float!(5));
+    let mut balances = BTreeMap::new();
+    balances.insert(symbol.clone(), shares);
+    let now = Utc::now();
+    let view = InventoryView::default()
+        .set_inflight_equity_at_location(
+            InFlightEquityLocation::BaseWalletUnwrapped,
+            &balances,
+            now,
+            now,
+        )
+        .set_active_mint(symbol.clone(), mint_id.clone());
+
+    let (sender, _receiver) = broadcast::channel(16);
+    let inventory = Arc::new(BroadcastingInventory::new(view, sender));
+
+    let ctx = UnwrappedEquityRecoveryCtx {
+        inventory,
+        store: Arc::clone(&store),
+        mint_store,
+        redemption_store,
+        equity_in_progress: Arc::clone(&equity_in_progress),
+        queue: UnwrappedEquityRecoveryJobQueue::new(&apalis_pool),
+        reschedule_interval: Duration::from_secs(1),
+    };
+
+    let recovery_id = UnwrappedEquityRecoveryId(Uuid::new_v4());
+    let job = UnwrappedEquityRecoveryJob {
+        symbol: symbol.clone(),
+        recovery_id: recovery_id.clone(),
+    };
+
+    // The job must claim HeldForRecovery and dispatch through the ActiveMint path.
+    job.perform(&ctx)
+        .await
+        .expect("UnwrappedEquityRecovery must run to completion on the ActiveMint path");
+
+    // Verify the recovery aggregate dispatched via DispatchToMint (NOT the orphan
+    // wrap path), reaching the DispatchedToMint terminal state.
+    let state = store.load(&recovery_id).await.unwrap();
+    assert!(
+        matches!(
+            state,
+            Some(UnwrappedEquityRecovery::DispatchedToMint { .. })
+        ),
+        "recovery must drive the ActiveMint path to DispatchedToMint, got {state:?}",
+    );
+
+    // Verify the guard was released after completion.
+    assert_eq!(
+        equity_in_progress.read().unwrap().get(&symbol),
+        None,
+        "equity_in_progress must be empty after recovery dispatches the active mint; \
+         a stuck guard would block future transfers for {symbol}",
     );
 }

--- a/src/rebalancing/equity/job.rs
+++ b/src/rebalancing/equity/job.rs
@@ -19,18 +19,23 @@
 //! guard latched so automation does not re-arm a fresh transfer on top of a
 //! partial one.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tracing::warn;
 
+use st0x_config::EquitiesConfig;
+use st0x_event_sorcery::Store;
 use st0x_execution::{FractionalShares, Symbol};
 
 use super::{CrossVenueEquityTransfer, MintTransferError, RedemptionError};
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::equity_redemption::RedemptionAggregateId;
-use crate::tokenized_equity_mint::IssuerRequestId;
+use crate::rebalancing::trigger::GuardState;
+use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMint};
 
 /// Apalis queue type for [`TransferEquityToMarketMaking`].
 pub(crate) type TransferEquityToMarketMakingJobQueue = JobQueue<TransferEquityToMarketMaking>;
@@ -63,6 +68,33 @@ impl ResumeEquityToMarketMaking for CrossVenueEquityTransfer {
 /// Dependencies the job needs to drive the mint.
 pub(crate) struct TransferEquityToMarketMakingCtx {
     pub(crate) transfer: Arc<dyn ResumeEquityToMarketMaking>,
+    /// Shared in-progress map. When a `PostReceipt` error surfaces and the
+    /// aggregate is in a pre-wrap post-receipt state (`TokensReceived` or
+    /// `WrapSubmitted`) AND `wrapped_equity_recovery` is enabled for the
+    /// symbol, the job transitions this entry from `ActiveTransfer` to
+    /// `HeldForRecovery` and returns `Ok(())` so apalis does not retry.
+    /// `UnwrappedEquityRecovery` claims the `HeldForRecovery` slot and
+    /// re-wraps + deposits the tokens.
+    ///
+    /// `TokensWrapped` and `VaultDepositSubmitted` are NOT handed off to
+    /// recovery: the deposit stage is idempotent and apalis retrying the
+    /// transfer job's `resume_mint` is the correct path for those states.
+    ///
+    /// When recovery is disabled for the symbol, `Err(PostReceipt)` is
+    /// propagated so apalis retries the transfer job as before the PR —
+    /// no stranding occurs.
+    pub(crate) equity_in_progress: Arc<RwLock<HashMap<Symbol, GuardState>>>,
+    /// Mint aggregate store. After a `PostReceipt` error the job loads the
+    /// aggregate to confirm which post-receipt state it is in before
+    /// transitioning the guard. Absent/pre-receipt/terminal states propagate
+    /// `Err` so apalis retries normally.
+    pub(crate) mint_store: Arc<Store<TokenizedEquityMint>>,
+    /// Per-symbol equity asset configuration. Used to gate the `HeldForRecovery`
+    /// handoff on `wrapped_equity_recovery = "enabled"` for the symbol — the
+    /// same predicate the inventory reactor uses when dispatching recovery jobs.
+    /// Keeping the check here ensures the two paths cannot disagree: if recovery
+    /// is disabled, `Err(PostReceipt)` is returned instead and apalis retries.
+    pub(crate) equities_config: EquitiesConfig,
 }
 
 /// Errors emitted by [`TransferEquityToMarketMaking::perform`].
@@ -80,6 +112,15 @@ pub(crate) struct TransferEquityToMarketMaking {
     pub(crate) issuer_request_id: IssuerRequestId,
     pub(crate) symbol: Symbol,
     pub(crate) quantity: FractionalShares,
+    /// Generation of the `ActiveTransfer` slot this job holds. Used by
+    /// `mark_held_for_recovery` to detect if the timeout sweeper cleared this
+    /// job's slot and a new transfer claimed it before the PostReceipt handler ran.
+    ///
+    /// Defaults to 0 on deserialization for rows enqueued before this field was
+    /// added. A mismatch in `mark_held_for_recovery` is safe: it returns
+    /// `GenerationMismatch -> Ok(())` rather than overwriting a new transfer's slot.
+    #[serde(default)]
+    pub(crate) generation: u64,
 }
 
 impl Job<TransferEquityToMarketMakingCtx> for TransferEquityToMarketMaking {
@@ -103,12 +144,216 @@ impl Job<TransferEquityToMarketMakingCtx> for TransferEquityToMarketMaking {
         &self,
         ctx: &TransferEquityToMarketMakingCtx,
     ) -> Result<Self::Output, Self::Error> {
-        ctx.transfer
+        let result = ctx
+            .transfer
             .resume_equity_to_market_making(&self.issuer_request_id, &self.symbol, self.quantity)
-            .await?;
+            .await;
 
-        Ok(())
+        // Success needs no post-processing. Only a `PostReceipt` error (Alpaca
+        // already delivered the tokens onchain) gets the recovery handoff below;
+        // any other transfer error propagates for apalis to retry.
+        let Err(transfer_error) = result else {
+            return Ok(());
+        };
+
+        match transfer_error {
+            MintTransferError::PostReceipt(mint_error) => {
+                // PostReceipt means Alpaca already delivered tokens onchain.
+                // Only pre-wrap states (TokensReceived, WrapSubmitted) hand
+                // off to UnwrappedEquityRecovery: tokens are UNWRAPPED in the
+                // base wallet and need re-wrap + deposit.
+                //
+                // TokensWrapped and VaultDepositSubmitted are NOT handed off:
+                // the deposit stage is idempotent, and apalis retrying
+                // resume_mint via the transfer job is the correct path.
+                // WrappedEquityRecovery remains orphan-only (absent guard).
+                //
+                // The handoff is only done when recovery is enabled. When
+                // disabled, propagate Err so apalis retries.
+                let state = ctx
+                    .mint_store
+                    .load(&self.issuer_request_id)
+                    .await
+                    .inspect_err(|error| {
+                        warn!(
+                            target: "rebalance",
+                            symbol = %self.symbol,
+                            issuer_request_id = %self.issuer_request_id,
+                            ?error,
+                            "PostReceipt handler: failed to load mint aggregate state; \
+                             treating as non-recoverable and propagating error for apalis retry"
+                        );
+                    });
+
+                let is_post_receipt_recoverable = matches!(
+                    state,
+                    Ok(Some(
+                        TokenizedEquityMint::TokensReceived { .. }
+                            | TokenizedEquityMint::WrapSubmitted { .. } // TokensWrapped and VaultDepositSubmitted intentionally excluded:
+                                                                        // the deposit stage is idempotent; apalis retrying resume_mint is
+                                                                        // the correct path. WrappedEquityRecovery handles orphaned wrapped
+                                                                        // tokens (absent guard) independently.
+                    ))
+                );
+
+                let recovery_enabled =
+                    ctx.equities_config
+                        .symbols
+                        .get(&self.symbol)
+                        .is_some_and(|cfg| {
+                            cfg.wrapped_equity_recovery == st0x_config::OperationMode::Enabled
+                        });
+
+                if is_post_receipt_recoverable && recovery_enabled {
+                    match mark_held_for_recovery(
+                        &ctx.equity_in_progress,
+                        &self.symbol,
+                        self.generation,
+                    ) {
+                        MarkHeldResult::Transitioned | MarkHeldResult::AlreadyHeld => {
+                            warn!(
+                                target: "rebalance",
+                                symbol = %self.symbol,
+                                issuer_request_id = %self.issuer_request_id,
+                                ?mint_error,
+                                "PostReceipt error with tokens in wallet (state: \
+                                 TokensReceived / WrapSubmitted); transitioning guard to \
+                                 HeldForRecovery. UnwrappedEquityRecovery will re-wrap and \
+                                 deposit. Apalis will NOT retry this job."
+                            );
+                            Ok(())
+                        }
+                        MarkHeldResult::EntryAbsent => {
+                            warn!(
+                                target: "rebalance",
+                                symbol = %self.symbol,
+                                issuer_request_id = %self.issuer_request_id,
+                                "PostReceipt handler: guard entry absent (cleared by timeout \
+                                 sweeper?); propagating Err so apalis retries"
+                            );
+                            Err(TransferEquityToMarketMakingJobError::Transfer(
+                                MintTransferError::PostReceipt(mint_error),
+                            ))
+                        }
+                        MarkHeldResult::GenerationMismatch => {
+                            // Timeout sweeper cleared this job's slot and a new transfer
+                            // reclaimed it. No HeldForRecovery handoff is needed — the
+                            // new transfer will drive its own lifecycle. Return Ok(()) so
+                            // apalis marks this job Done rather than retrying it (which
+                            // would operate on a stale aggregate state).
+                            //
+                            // Note: the guard is re-checked atomically inside
+                            // mark_held_for_recovery under the write lock, so this
+                            // decision is race-free with any concurrent transition.
+                            warn!(
+                                target: "rebalance",
+                                symbol = %self.symbol,
+                                issuer_request_id = %self.issuer_request_id,
+                                "PostReceipt handler: generation mismatch (new transfer owns \
+                                 the slot); returning Ok(()) — no recovery handoff"
+                            );
+                            Ok(())
+                        }
+                    }
+                } else {
+                    // Aggregate is absent, pre-receipt, already terminal,
+                    // TokensWrapped/VaultDepositSubmitted, DB load failed, or
+                    // recovery is disabled. Propagate Err so apalis retries or
+                    // records a failed job.
+                    Err(TransferEquityToMarketMakingJobError::Transfer(
+                        MintTransferError::PostReceipt(mint_error),
+                    ))
+                }
+            }
+            other @ MintTransferError::PreReceipt(_) => {
+                Err(TransferEquityToMarketMakingJobError::Transfer(other))
+            }
+        }
     }
+}
+
+/// Outcome of [`mark_held_for_recovery`].
+enum MarkHeldResult {
+    /// Successfully transitioned `ActiveTransfer` -> `HeldForRecovery`.
+    Transitioned,
+    /// Slot was already `HeldForRecovery` (idempotent double-call after retry).
+    AlreadyHeld,
+    /// Guard entry is absent (cleared by timeout sweeper before `PostReceipt`
+    /// handler ran). Caller should propagate `Err` so apalis retries; the
+    /// tokens remain in the wallet and the next inventory poll re-triggers
+    /// recovery via the orphan path.
+    EntryAbsent,
+    /// The slot holds `ActiveTransfer` with a different generation: the timeout
+    /// sweeper cleared this job's slot and a new transfer reclaimed it. The
+    /// caller should return `Ok(())` — no handoff to recovery is needed because
+    /// this job's tokens are either already handled or will be by the new transfer.
+    GenerationMismatch,
+}
+
+/// Atomically transitions the guard from `ActiveTransfer` to `HeldForRecovery`.
+///
+/// Returns [`MarkHeldResult`] describing the outcome:
+/// - `Transitioned`: slot updated; call site should return `Ok(())`.
+/// - `AlreadyHeld`: slot was already held (idempotent); return `Ok(())`.
+/// - `EntryAbsent`: guard was cleared externally; return `Err` for apalis retry.
+/// - `GenerationMismatch`: a newer transfer owns the slot; return `Ok(())`.
+fn mark_held_for_recovery(
+    map: &RwLock<HashMap<Symbol, GuardState>>,
+    symbol: &Symbol,
+    expected_generation: u64,
+) -> MarkHeldResult {
+    let mut poisoned = false;
+    let result = {
+        let mut guard = match map.write() {
+            Ok(guard) => guard,
+            Err(poison) => {
+                poisoned = true;
+                poison.into_inner()
+            }
+        };
+        match guard.get(symbol) {
+            Some(GuardState::ActiveTransfer { generation })
+                if *generation == expected_generation =>
+            {
+                guard.insert(symbol.clone(), GuardState::HeldForRecovery);
+                MarkHeldResult::Transitioned
+            }
+            Some(GuardState::ActiveTransfer { .. }) => MarkHeldResult::GenerationMismatch,
+            Some(GuardState::HeldForRecovery) => MarkHeldResult::AlreadyHeld,
+            None => MarkHeldResult::EntryAbsent,
+        }
+    };
+
+    if poisoned {
+        warn!(
+            target: "rebalance",
+            %symbol,
+            "mark_held_for_recovery: equity_in_progress lock poisoned; recovering inner guard"
+        );
+    }
+    match result {
+        MarkHeldResult::GenerationMismatch => {
+            // A newer transfer claimed the slot after the timeout sweeper
+            // cleared this job's slot. Leave the new claim untouched.
+            warn!(
+                target: "rebalance",
+                %symbol,
+                expected_generation,
+                "mark_held_for_recovery: generation mismatch; a newer transfer owns the \
+                 slot. No HeldForRecovery handoff."
+            );
+        }
+        MarkHeldResult::AlreadyHeld => {
+            warn!(
+                target: "rebalance",
+                %symbol,
+                "mark_held_for_recovery: slot already HeldForRecovery; possible \
+                 double-call after idempotent retry"
+            );
+        }
+        MarkHeldResult::Transitioned | MarkHeldResult::EntryAbsent => {}
+    }
+    result
 }
 
 /// Apalis queue type for [`TransferEquityToHedging`].
@@ -187,19 +432,102 @@ impl Job<TransferEquityToHedgingCtx> for TransferEquityToHedging {
 mod tests {
     use std::sync::Mutex;
 
+    use alloy::primitives::{Address, TxHash, U256};
     use serde_json::json;
+    use st0x_config::{EquityAssetConfig, OperationMode};
+    use st0x_event_sorcery::test_store;
     use st0x_float_macro::float;
+    use st0x_raindex::Raindex;
+    use st0x_wrapper::{MockWrapper, Wrapper};
 
     use super::*;
     use crate::equity_redemption::redemption_aggregate_id;
-    use crate::rebalancing::equity::MintError;
-    use crate::tokenized_equity_mint::issuer_request_id;
+    use crate::onchain::mock::MockRaindex;
+    use crate::rebalancing::equity::{EquityTransferServices, MintError};
+    use crate::tokenization::mock::MockTokenizer;
+    use crate::tokenized_equity_mint::{TokenizedEquityMintCommand, issuer_request_id};
+    use crate::vault_lookup::MockVaultLookup;
+
+    /// Builds a test ctx with recovery enabled for AAPL and an empty guard map.
+    async fn test_ctx(
+        transfer: Arc<dyn ResumeEquityToMarketMaking>,
+    ) -> TransferEquityToMarketMakingCtx {
+        test_ctx_with_recovery(transfer, OperationMode::Enabled).await
+    }
+
+    /// Builds a test ctx with the given `wrapped_equity_recovery` mode for AAPL.
+    async fn test_ctx_with_recovery(
+        transfer: Arc<dyn ResumeEquityToMarketMaking>,
+        recovery_mode: OperationMode,
+    ) -> TransferEquityToMarketMakingCtx {
+        let (pool, _apalis_pool) = crate::test_utils::setup_test_pools().await;
+        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+        let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
+        let transfer_services = EquityTransferServices {
+            raindex: raindex.clone(),
+            vault_lookup: Arc::new(MockVaultLookup::new()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: wrapper.clone(),
+        };
+        let mint_store = Arc::new(test_store(pool, transfer_services));
+
+        let aapl_config = EquityAssetConfig {
+            tokenized_equity: Address::ZERO,
+            tokenized_equity_derivative: Address::ZERO,
+            pyth_feed_id: None,
+            vault_ids: vec![],
+            trading: OperationMode::Disabled,
+            rebalancing: OperationMode::Enabled,
+            wrapped_equity_recovery: recovery_mode,
+            operational_limit: None,
+        };
+        let mut equities_config = EquitiesConfig::default();
+        equities_config
+            .symbols
+            .insert(Symbol::new("AAPL").unwrap(), aapl_config);
+
+        TransferEquityToMarketMakingCtx {
+            transfer,
+            equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
+            mint_store,
+            equities_config,
+        }
+    }
 
     /// Records the resume call and returns a configurable outcome, so the
     /// job's `perform` can be tested without broker/onchain setup.
     struct RecordingResume {
-        fail: bool,
+        outcome: ResumeOutcome,
         captured: Mutex<Option<(IssuerRequestId, Symbol, FractionalShares)>>,
+    }
+
+    enum ResumeOutcome {
+        Success,
+        PreReceipt,
+        PostReceipt,
+    }
+
+    impl RecordingResume {
+        fn success() -> Self {
+            Self {
+                outcome: ResumeOutcome::Success,
+                captured: Mutex::new(None),
+            }
+        }
+
+        fn pre_receipt_failure() -> Self {
+            Self {
+                outcome: ResumeOutcome::PreReceipt,
+                captured: Mutex::new(None),
+            }
+        }
+
+        fn post_receipt_failure() -> Self {
+            Self {
+                outcome: ResumeOutcome::PostReceipt,
+                captured: Mutex::new(None),
+            }
+        }
     }
 
     #[async_trait]
@@ -212,31 +540,33 @@ mod tests {
         ) -> Result<(), MintTransferError> {
             *self.captured.lock().unwrap() =
                 Some((issuer_request_id.clone(), symbol.clone(), quantity));
-
-            if self.fail {
-                Err(MintTransferError::PreReceipt(MintError::EntityNotFound {
-                    issuer_request_id: issuer_request_id.clone(),
-                    expected_state: "test-induced",
-                }))
-            } else {
-                Ok(())
+            match self.outcome {
+                ResumeOutcome::Success => Ok(()),
+                ResumeOutcome::PreReceipt => {
+                    Err(MintTransferError::PreReceipt(MintError::EntityNotFound {
+                        issuer_request_id: issuer_request_id.clone(),
+                        expected_state: "test-induced-pre",
+                    }))
+                }
+                ResumeOutcome::PostReceipt => {
+                    Err(MintTransferError::PostReceipt(MintError::EntityNotFound {
+                        issuer_request_id: issuer_request_id.clone(),
+                        expected_state: "test-induced-post",
+                    }))
+                }
             }
         }
     }
 
     #[tokio::test]
     async fn perform_forwards_id_symbol_and_quantity_to_resume() {
-        let stub = Arc::new(RecordingResume {
-            fail: false,
-            captured: Mutex::new(None),
-        });
-        let ctx = TransferEquityToMarketMakingCtx {
-            transfer: stub.clone(),
-        };
+        let stub = Arc::new(RecordingResume::success());
+        let ctx = test_ctx(Arc::clone(&stub) as Arc<dyn ResumeEquityToMarketMaking>).await;
         let job = TransferEquityToMarketMaking {
             issuer_request_id: issuer_request_id("mint-forward"),
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: FractionalShares::new(float!(10)),
+            generation: 0,
         };
 
         Job::perform(&job, &ctx).await.unwrap();
@@ -250,29 +580,634 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn perform_propagates_resume_failure() {
-        let ctx = TransferEquityToMarketMakingCtx {
-            transfer: Arc::new(RecordingResume {
-                fail: true,
-                captured: Mutex::new(None),
-            }),
-        };
+    async fn perform_propagates_pre_receipt_failure() {
+        let ctx = test_ctx(Arc::new(RecordingResume::pre_receipt_failure())).await;
         let job = TransferEquityToMarketMaking {
             issuer_request_id: issuer_request_id("mint-fail"),
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: FractionalShares::new(float!(10)),
+            generation: 0,
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
 
-        // The failure must propagate (not be swallowed) so apalis retries and
-        // the event-driven `equity_in_progress` guard stays latched until the
-        // aggregate reaches a terminal state -- swallowing it would free the
-        // guard and let a fresh mint arm on top of a partial one.
+        // PreReceipt must propagate so apalis retries and the guard stays latched
+        // until the aggregate reaches a terminal state.
         assert!(matches!(
             error,
             TransferEquityToMarketMakingJobError::Transfer(MintTransferError::PreReceipt(_))
         ));
+    }
+
+    /// PostReceipt with the aggregate ABSENT from the store (never persisted,
+    /// or already cleaned up) must propagate as Err so apalis retries.
+    /// Note: only `TokensReceived` and `WrapSubmitted` transition the guard to
+    /// `HeldForRecovery` and return `Ok(())` when recovery is enabled.
+    /// `TokensWrapped` and `VaultDepositSubmitted` instead propagate Err for
+    /// apalis retry (the deposit stage is idempotent).
+    #[tokio::test]
+    async fn perform_post_receipt_error_propagates_when_aggregate_absent() {
+        // The mint aggregate is absent in the store (never persisted) — the
+        // error must propagate for apalis retry.
+        let ctx = test_ctx(Arc::new(RecordingResume::post_receipt_failure())).await;
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_request_id("test-post-receipt"),
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: FractionalShares::new(float!(10)),
+            generation: 0,
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                TransferEquityToMarketMakingJobError::Transfer(MintTransferError::PostReceipt(_))
+            ),
+            "PostReceipt on absent aggregate must propagate for apalis retry, got {error:?}"
+        );
+
+        // Guard must not transition (it stays unchanged from before the call).
+        assert!(
+            !ctx.equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&Symbol::new("AAPL").unwrap()),
+            "guard must not be modified when aggregate is absent from the store"
+        );
+    }
+
+    /// Seeds the mint store to `TokensWrapped` state by driving the commands
+    /// needed to reach that state without any real broker/RPC calls.
+    async fn seed_tokens_wrapped(
+        ctx: &TransferEquityToMarketMakingCtx,
+        issuer_id: &IssuerRequestId,
+        symbol: &Symbol,
+    ) {
+        ctx.mint_store
+            .send(
+                issuer_id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: issuer_id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(5),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .expect("RequestMint must persist");
+
+        ctx.mint_store
+            .send(issuer_id, TokenizedEquityMintCommand::Poll)
+            .await
+            .expect("Poll must transition to TokensReceived");
+
+        ctx.mint_store
+            .send(
+                issuer_id,
+                TokenizedEquityMintCommand::WrapTokens {
+                    wrap_tx_hash: TxHash::ZERO,
+                    wrapped_shares: U256::from(5u64),
+                    wrap_block: 1,
+                },
+            )
+            .await
+            .expect("WrapTokens must transition to TokensWrapped");
+    }
+
+    /// `PostReceipt` error with aggregate in `TokensWrapped` state must
+    /// propagate `Err` so apalis retries the transfer job. `TokensWrapped` is
+    /// excluded from the `HeldForRecovery` handoff: the deposit stage is
+    /// idempotent and `WrappedEquityRecovery` is orphan-only (absent guard).
+    #[tokio::test]
+    async fn perform_post_receipt_with_tokens_wrapped_propagates_err_for_apalis_retry() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let issuer_id = issuer_request_id("post-receipt-wrapped");
+        let ctx = test_ctx(Arc::new(RecordingResume::post_receipt_failure())).await;
+
+        // Pre-seed the guard as ActiveTransfer (as the live transfer job would).
+        ctx.equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::ActiveTransfer { generation: 0 });
+
+        // Seed the mint store to TokensWrapped.
+        seed_tokens_wrapped(&ctx, &issuer_id, &symbol).await;
+
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_id.clone(),
+            symbol: symbol.clone(),
+            quantity: FractionalShares::new(float!(5)),
+            generation: 0,
+        };
+
+        // TokensWrapped propagates Err: apalis retries resume_mint (idempotent
+        // vault deposit). WrappedEquityRecovery is orphan-only; no handoff.
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+        assert!(
+            matches!(
+                error,
+                TransferEquityToMarketMakingJobError::Transfer(MintTransferError::PostReceipt(_))
+            ),
+            "TokensWrapped must propagate PostReceipt for apalis retry, got {error:?}"
+        );
+
+        // Guard must remain ActiveTransfer — no HeldForRecovery handoff.
+        assert!(
+            matches!(
+                ctx.equity_in_progress.read().unwrap().get(&symbol),
+                Some(GuardState::ActiveTransfer { .. })
+            ),
+            "TokensWrapped must not transition guard to HeldForRecovery"
+        );
+    }
+
+    /// `PostReceipt` error with aggregate in `VaultDepositSubmitted` state must
+    /// propagate `Err` so apalis retries the transfer job, which idempotently
+    /// confirms the submitted deposit. `VaultDepositSubmitted` is intentionally
+    /// excluded from the `HeldForRecovery` handoff: the deposit tx is already
+    /// on-chain and the wallet balance is zero (tokens are in the vault), so
+    /// `WrappedEquityRecovery` would find no balance and skip.
+    #[tokio::test]
+    async fn perform_post_receipt_with_vault_deposit_submitted_propagates_err_for_apalis_retry() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let issuer_id = issuer_request_id("post-receipt-deposit-submitted");
+        let ctx = test_ctx(Arc::new(RecordingResume::post_receipt_failure())).await;
+
+        // Pre-seed the guard as ActiveTransfer.
+        ctx.equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::ActiveTransfer { generation: 0 });
+
+        // Seed through TokensWrapped, then SubmitVaultDeposit to reach
+        // VaultDepositSubmitted state.
+        seed_tokens_wrapped(&ctx, &issuer_id, &symbol).await;
+
+        ctx.mint_store
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::SubmitVaultDeposit {
+                    vault_deposit_tx_hash: TxHash::ZERO,
+                },
+            )
+            .await
+            .expect("SubmitVaultDeposit must transition to VaultDepositSubmitted");
+
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_id.clone(),
+            symbol: symbol.clone(),
+            quantity: FractionalShares::new(float!(5)),
+            generation: 0,
+        };
+
+        // VaultDepositSubmitted propagates Err so apalis retries the transfer job,
+        // which idempotently confirms the submitted deposit. Recovery is not used
+        // because the deposit tx is already on-chain and inventory won't show
+        // a positive wrapped wallet balance once the deposit landed.
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+        assert!(
+            matches!(
+                error,
+                TransferEquityToMarketMakingJobError::Transfer(MintTransferError::PostReceipt(_))
+            ),
+            "VaultDepositSubmitted must propagate PostReceipt for apalis retry, got {error:?}"
+        );
+
+        // Guard must remain ActiveTransfer — the apalis retry of the transfer job
+        // handles the confirmation; no HeldForRecovery handoff.
+        assert!(
+            matches!(
+                ctx.equity_in_progress.read().unwrap().get(&symbol),
+                Some(GuardState::ActiveTransfer { .. })
+            ),
+            "VaultDepositSubmitted must not transition guard to HeldForRecovery"
+        );
+    }
+
+    /// `PostReceipt` error with aggregate in `TokensReceived` state (wrap not
+    /// attempted yet) must transition the guard to `HeldForRecovery` and return
+    /// `Ok(())`. This is the production RAI-1070 failure path: the ERC-4626 wrap
+    /// reverted, tokens remain UNWRAPPED in the base wallet, and
+    /// `UnwrappedEquityRecovery` is the correct job to re-attempt the wrap+deposit.
+    #[tokio::test]
+    async fn perform_post_receipt_with_tokens_received_transitions_guard_to_held_for_recovery() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let issuer_id = issuer_request_id("post-receipt-tokens-received");
+        let ctx = test_ctx(Arc::new(RecordingResume::post_receipt_failure())).await;
+
+        ctx.equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::ActiveTransfer { generation: 0 });
+
+        // Drive the aggregate to TokensReceived (RequestMint + Poll) but do NOT wrap.
+        ctx.mint_store
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: issuer_id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(5),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .expect("RequestMint must persist");
+
+        ctx.mint_store
+            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .await
+            .expect("Poll must transition to TokensReceived");
+
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_id.clone(),
+            symbol: symbol.clone(),
+            quantity: FractionalShares::new(float!(5)),
+            generation: 0,
+        };
+
+        // Must return Ok(()) — apalis does not retry; UnwrappedEquityRecovery takes over.
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            ctx.equity_in_progress.read().unwrap().get(&symbol),
+            Some(&GuardState::HeldForRecovery),
+            "guard must transition to HeldForRecovery for TokensReceived so \
+             UnwrappedEquityRecovery can resume the wrap+deposit"
+        );
+    }
+
+    /// `PostReceipt` error with aggregate in `WrapSubmitted` state (wrap tx submitted
+    /// but not yet confirmed) must transition the guard to `HeldForRecovery` and
+    /// return `Ok(())`. This is the primary production scenario for RAI-1070: the
+    /// wrap tx was submitted but confirmation failed; tokens are UNWRAPPED in the
+    /// base wallet and `UnwrappedEquityRecovery` is the correct retry path.
+    #[tokio::test]
+    async fn perform_post_receipt_with_wrap_submitted_transitions_guard_to_held_for_recovery() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let issuer_id = issuer_request_id("post-receipt-wrap-submitted");
+        let ctx = test_ctx(Arc::new(RecordingResume::post_receipt_failure())).await;
+
+        ctx.equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::ActiveTransfer { generation: 0 });
+
+        // Drive to TokensReceived then SubmitWrap to reach WrapSubmitted.
+        ctx.mint_store
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: issuer_id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(5),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .expect("RequestMint must persist");
+
+        ctx.mint_store
+            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .await
+            .expect("Poll must transition to TokensReceived");
+
+        ctx.mint_store
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::SubmitWrap {
+                    wrap_tx_hash: TxHash::ZERO,
+                },
+            )
+            .await
+            .expect("SubmitWrap must transition to WrapSubmitted");
+
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_id.clone(),
+            symbol: symbol.clone(),
+            quantity: FractionalShares::new(float!(5)),
+            generation: 0,
+        };
+
+        // Must return Ok(()) — apalis does not retry; UnwrappedEquityRecovery takes over.
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            ctx.equity_in_progress.read().unwrap().get(&symbol),
+            Some(&GuardState::HeldForRecovery),
+            "guard must transition to HeldForRecovery for WrapSubmitted so \
+             UnwrappedEquityRecovery can confirm/resume the wrap+deposit"
+        );
+    }
+
+    /// `PostReceipt` error where the timeout sweeper cleared this job's slot and
+    /// a NEW transfer reclaimed it (a different `generation`) must return `Ok(())`
+    /// WITHOUT touching the new transfer's slot. `mark_held_for_recovery` detects
+    /// the generation mismatch under the write lock, so no `HeldForRecovery`
+    /// handoff happens and apalis marks this stale job Done instead of clobbering
+    /// the live claim.
+    #[tokio::test]
+    async fn perform_post_receipt_generation_mismatch_leaves_new_claim_untouched() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let issuer_id = issuer_request_id("post-receipt-generation-mismatch");
+        let ctx = test_ctx(Arc::new(RecordingResume::post_receipt_failure())).await;
+
+        // This job holds generation 0.
+        ctx.equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::ActiveTransfer { generation: 0 });
+
+        // Drive the aggregate to TokensReceived (a recoverable pre-wrap state).
+        ctx.mint_store
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: issuer_id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(5),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .expect("RequestMint must persist");
+
+        ctx.mint_store
+            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .await
+            .expect("Poll must transition to TokensReceived");
+
+        // Simulate the timeout sweeper clearing this job's slot and a NEW
+        // transfer reclaiming it with a fresh generation before PostReceipt runs.
+        ctx.equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::ActiveTransfer { generation: 1 });
+
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_id.clone(),
+            symbol: symbol.clone(),
+            quantity: FractionalShares::new(float!(5)),
+            generation: 0,
+        };
+
+        // Must return Ok(()) so apalis marks the stale job Done -- no retry.
+        Job::perform(&job, &ctx).await.unwrap();
+
+        // The new transfer's slot (generation 1) must be left untouched: no
+        // HeldForRecovery handoff, no removal.
+        assert_eq!(
+            ctx.equity_in_progress.read().unwrap().get(&symbol),
+            Some(&GuardState::ActiveTransfer { generation: 1 }),
+            "a generation mismatch must leave the new transfer's ActiveTransfer slot untouched",
+        );
+    }
+
+    /// When `wrapped_equity_recovery` is disabled for the symbol, a `PostReceipt`
+    /// error must propagate as `Err` so apalis retries — no stranding, no guard
+    /// transition. The `HeldForRecovery` handoff is only valid when a recovery job
+    /// will actually be enqueued to claim the slot.
+    #[tokio::test]
+    async fn perform_post_receipt_propagates_when_recovery_disabled() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let issuer_id = issuer_request_id("post-receipt-recovery-disabled");
+        let ctx = test_ctx_with_recovery(
+            Arc::new(RecordingResume::post_receipt_failure()),
+            OperationMode::Disabled,
+        )
+        .await;
+
+        ctx.equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::ActiveTransfer { generation: 0 });
+
+        // Drive to TokensReceived so the aggregate IS in a recoverable state,
+        // but recovery is disabled — the error must still propagate.
+        ctx.mint_store
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: issuer_id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(5),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .expect("RequestMint must persist");
+
+        ctx.mint_store
+            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .await
+            .expect("Poll must transition to TokensReceived");
+
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_id.clone(),
+            symbol: symbol.clone(),
+            quantity: FractionalShares::new(float!(5)),
+            generation: 0,
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                TransferEquityToMarketMakingJobError::Transfer(MintTransferError::PostReceipt(_))
+            ),
+            "PostReceipt must propagate as Err when recovery is disabled, got {error:?}"
+        );
+
+        // Guard must remain ActiveTransfer — no handoff to recovery.
+        assert!(
+            matches!(
+                ctx.equity_in_progress.read().unwrap().get(&symbol),
+                Some(GuardState::ActiveTransfer { .. })
+            ),
+            "guard must not be modified to HeldForRecovery when recovery is disabled"
+        );
+    }
+
+    /// `PostReceipt` error with the mint aggregate already in a terminal state
+    /// (e.g. `Failed`) must propagate as `Err` — not transition the guard to
+    /// `HeldForRecovery`. If this were allowed, a finished mint's symbol would be
+    /// permanently blocked for future transfers.
+    #[tokio::test]
+    async fn perform_post_receipt_error_propagates_when_aggregate_terminal() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let issuer_id = issuer_request_id("post-receipt-terminal");
+        let ctx = test_ctx_with_recovery(
+            Arc::new(RecordingResume::post_receipt_failure()),
+            OperationMode::Enabled,
+        )
+        .await;
+
+        ctx.equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::ActiveTransfer { generation: 0 });
+
+        // Drive the aggregate to TokensReceived, then fail it (terminal Failed state).
+        ctx.mint_store
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: issuer_id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(5),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .expect("RequestMint must persist");
+
+        ctx.mint_store
+            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .await
+            .expect("Poll must transition to TokensReceived");
+
+        ctx.mint_store
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::FailWrapping {
+                    reason: "test: forced terminal state".to_string(),
+                },
+            )
+            .await
+            .expect("FailWrapping must transition to terminal Failed");
+
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_id.clone(),
+            symbol: symbol.clone(),
+            quantity: FractionalShares::new(float!(5)),
+            generation: 0,
+        };
+
+        // Terminal aggregate must propagate Err — it is not a recoverable state.
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+        assert!(
+            matches!(
+                error,
+                TransferEquityToMarketMakingJobError::Transfer(MintTransferError::PostReceipt(_))
+            ),
+            "PostReceipt on terminal aggregate must propagate Err, got {error:?}"
+        );
+
+        // Guard must remain ActiveTransfer — terminal aggregate propagates Err,
+        // so no HeldForRecovery handoff occurs and the guard is unchanged.
+        assert!(
+            matches!(
+                ctx.equity_in_progress.read().unwrap().get(&symbol),
+                Some(GuardState::ActiveTransfer { .. })
+            ),
+            "terminal aggregate must leave guard unchanged as ActiveTransfer"
+        );
+    }
+
+    /// `PostReceipt` error with guard already `HeldForRecovery` (idempotent
+    /// re-entry after a retry) must still return `Ok(())` without double-
+    /// transitioning or panicking.
+    #[tokio::test]
+    async fn perform_post_receipt_idempotent_when_guard_already_held_for_recovery() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let issuer_id = issuer_request_id("post-receipt-idempotent");
+        let ctx = test_ctx(Arc::new(RecordingResume::post_receipt_failure())).await;
+
+        // Pre-seed the guard as HeldForRecovery (as if a prior attempt already
+        // ran and set the guard before crashing).
+        ctx.equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::HeldForRecovery);
+
+        // Drive to TokensReceived so the aggregate IS in a recoverable state.
+        ctx.mint_store
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: issuer_id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(5),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .expect("RequestMint must persist");
+
+        ctx.mint_store
+            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .await
+            .expect("Poll must transition to TokensReceived");
+
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_id.clone(),
+            symbol: symbol.clone(),
+            quantity: FractionalShares::new(float!(5)),
+            generation: 0,
+        };
+
+        // Idempotent: guard already held, state is recoverable -> still Ok(()).
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            ctx.equity_in_progress.read().unwrap().get(&symbol),
+            Some(&GuardState::HeldForRecovery),
+            "idempotent re-entry must leave guard in HeldForRecovery"
+        );
+    }
+
+    /// `PostReceipt` error with the guard absent (e.g. cleared by timeout
+    /// sweeper) must propagate `Err` so apalis retries. Tokens remain in the
+    /// wallet; the next inventory poll re-triggers recovery via orphan path.
+    #[tokio::test]
+    async fn perform_post_receipt_propagates_err_when_guard_entry_absent() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let issuer_id = issuer_request_id("post-receipt-guard-absent");
+        let ctx = test_ctx(Arc::new(RecordingResume::post_receipt_failure())).await;
+
+        // Guard is absent (not seeded) — simulates timeout sweeper clearing it.
+        // Drive to TokensReceived so the aggregate IS in a recoverable state;
+        // the absent guard is the only reason the handoff must fail.
+        ctx.mint_store
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: issuer_id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(5),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .expect("RequestMint must persist");
+
+        ctx.mint_store
+            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .await
+            .expect("Poll must transition to TokensReceived");
+
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_id.clone(),
+            symbol: symbol.clone(),
+            quantity: FractionalShares::new(float!(5)),
+            generation: 0,
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+        assert!(
+            matches!(
+                error,
+                TransferEquityToMarketMakingJobError::Transfer(MintTransferError::PostReceipt(_))
+            ),
+            "absent guard must propagate PostReceipt for apalis retry, got {error:?}"
+        );
+
+        assert!(
+            !ctx.equity_in_progress.read().unwrap().contains_key(&symbol),
+            "absent guard must remain absent after failed handoff"
+        );
     }
 
     #[test]
@@ -281,12 +1216,14 @@ mod tests {
             issuer_request_id: issuer_request_id("mint-roundtrip"),
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: FractionalShares::new(float!(2.5)),
+            generation: 0,
         };
 
         let expected = json!({
             "issuer_request_id": issuer_request_id("mint-roundtrip").to_string(),
             "symbol": "AAPL",
             "quantity": "2.5",
+            "generation": 0_u64,
         });
 
         assert_eq!(serde_json::to_value(&job).unwrap(), expected);
@@ -296,6 +1233,16 @@ mod tests {
         assert_eq!(roundtripped.issuer_request_id, job.issuer_request_id);
         assert_eq!(roundtripped.symbol, job.symbol);
         assert_eq!(roundtripped.quantity, job.quantity);
+        assert_eq!(roundtripped.generation, job.generation);
+
+        // Old rows without the generation field must deserialize to generation=0.
+        let legacy_payload = json!({
+            "issuer_request_id": issuer_request_id("mint-roundtrip").to_string(),
+            "symbol": "AAPL",
+            "quantity": "2.5",
+        });
+        let legacy: TransferEquityToMarketMaking = serde_json::from_value(legacy_payload).unwrap();
+        assert_eq!(legacy.generation, 0, "missing generation must default to 0");
     }
 
     /// Records the redemption resume call and returns a configurable outcome.

--- a/src/rebalancing/trigger/equity.rs
+++ b/src/rebalancing/trigger/equity.rs
@@ -1,7 +1,7 @@
 //! Equity-specific trigger types and logic.
 
-use std::collections::HashSet;
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use alloy::primitives::Address;
 use rain_math_float::{Float, FloatError};
@@ -35,42 +35,95 @@ pub(crate) enum EquityTriggerError {
     Float(#[from] FloatError),
 }
 
+/// Discriminates why the equity in-progress slot is held.
+///
+/// Allows recovery jobs to proceed when the slot is in `HeldForRecovery`
+/// state, while still blocking new transfer triggers from starting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GuardState {
+    /// A transfer job (mint or redemption) is actively running.
+    /// Blocks both new triggers and recovery jobs.
+    ///
+    /// The `generation` counter identifies which specific claim holds this
+    /// slot. It is incremented each time a new claim is made, enabling
+    /// `RecoveryGuard::Drop` to detect the ABA race: if a terminal event
+    /// cleared the slot and a new transfer immediately claimed it, Drop sees
+    /// a different `generation` and does not clobber the new claim.
+    ActiveTransfer { generation: u64 },
+    /// Tokens were received but post-receipt processing failed.
+    /// A recovery job must run to wrap/deposit them.
+    /// Blocks new triggers; does NOT block `UnwrappedEquityRecovery` or
+    /// `WrappedEquityRecovery`.
+    HeldForRecovery,
+}
+
+/// Monotonic counter for `GuardState::ActiveTransfer` generation tokens.
+///
+/// Starts at 1 so [`next_generation`] never returns 0: generation 0 is reserved
+/// for legacy transfer-job payloads that predate the `generation` field and
+/// deserialize via `#[serde(default)]` to 0. Because every live claim is >= 1,
+/// such a stale payload can never coincide with a real `ActiveTransfer` slot, so
+/// its `mark_held_for_recovery`/`Drop` generation check always mismatches (a safe
+/// no-op) instead of clobbering the wrong active transfer.
+static GUARD_GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+/// Returns the next `ActiveTransfer` generation token. Always >= 1; 0 is the
+/// reserved legacy/default-payload sentinel (see [`GUARD_GENERATION`]).
+pub(super) fn next_generation() -> u64 {
+    GUARD_GENERATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
 /// RAII guard that holds an equity in-progress claim.
 /// Automatically releases the claim on drop unless `defuse` is called.
-pub(super) struct InProgressGuard {
+pub(crate) struct InProgressGuard {
     /// The symbol this guard holds a claim for.
     symbol: Symbol,
-    /// Shared reference to the in-progress set for cleanup on drop.
-    in_progress: Arc<std::sync::RwLock<HashSet<Symbol>>>,
+    /// Shared reference to the in-progress map for cleanup on drop.
+    in_progress: Arc<std::sync::RwLock<HashMap<Symbol, GuardState>>>,
+    /// Generation token matching the `ActiveTransfer { generation }` this
+    /// guard inserted. Used on Drop to avoid clobbering a newer claim.
+    generation: u64,
     /// When true, the guard will not release the claim on drop.
     defused: bool,
 }
 
 impl InProgressGuard {
-    /// Attempts to claim the in-progress slot for a symbol.
-    /// Returns `None` if already claimed by another operation.
-    pub(super) fn try_claim(
+    /// Attempts to claim the in-progress slot for a new transfer.
+    ///
+    /// Inserts `ActiveTransfer { generation }`. Returns `None` if any state
+    /// is already present -- including `HeldForRecovery` -- so a new transfer
+    /// cannot start while recovery is pending.
+    pub(crate) fn try_claim_for_transfer(
         symbol: Symbol,
-        in_progress: Arc<std::sync::RwLock<HashSet<Symbol>>>,
+        in_progress: Arc<std::sync::RwLock<HashMap<Symbol, GuardState>>>,
     ) -> Option<Self> {
+        let generation = next_generation();
         {
             let mut guard = match in_progress.write() {
                 Ok(guard) => guard,
                 Err(poison) => poison.into_inner(),
             };
 
-            if guard.contains(&symbol) {
+            if guard.contains_key(&symbol) {
                 return None;
             }
 
-            guard.insert(symbol.clone());
+            guard.insert(symbol.clone(), GuardState::ActiveTransfer { generation });
         }
 
         Some(Self {
             symbol,
             in_progress,
+            generation,
             defused: false,
         })
+    }
+
+    /// Returns the generation token for this guard's `ActiveTransfer` slot.
+    /// Used by the transfer job to store the generation in its payload so
+    /// `mark_held_for_recovery` can detect if a newer transfer claimed the slot.
+    pub(super) fn generation(&self) -> u64 {
+        self.generation
     }
 
     /// Prevents the guard from releasing the claim on drop.
@@ -87,9 +140,191 @@ impl Drop for InProgressGuard {
                 Ok(guard) => guard,
                 Err(poison) => poison.into_inner(),
             };
-            guard.remove(&self.symbol);
+            // Only remove if this guard still owns the slot (same generation).
+            // A terminal event may have cleared the slot and a new transfer
+            // claimed it before this drop -- in that case, leave the new claim.
+            if guard.get(&self.symbol)
+                == Some(&GuardState::ActiveTransfer {
+                    generation: self.generation,
+                })
+            {
+                guard.remove(&self.symbol);
+            }
         }
     }
+}
+
+/// Tracks how a [`RecoveryGuard`] was originally claimed, so Drop knows
+/// what state to restore on failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoveryClaimOrigin {
+    /// Claimed from `HeldForRecovery` (deadlock-break path). On Drop, the
+    /// slot is restored to `HeldForRecovery` so the next recovery attempt can
+    /// claim it without a new transfer job starting in the meantime.
+    HeldForRecovery,
+    /// Claimed from absent (orphan path). On Drop, the slot is removed so
+    /// the next inventory poll can start a fresh recovery or transfer job.
+    Orphan,
+}
+
+/// RAII guard for recovery jobs. Holds the `equity_in_progress` slot for a
+/// symbol.
+///
+/// **Normal drop (recovery failed or panicked):**
+/// - Claimed from `HeldForRecovery`: restores to `HeldForRecovery` so
+///   subsequent recovery retries can proceed but new transfer jobs cannot
+///   start (preventing double-mints while tokens are still stranded).
+/// - Claimed from absent (orphan): removes the entry entirely.
+///
+/// **After `release()` (recovery succeeded):** the entry is always removed
+/// regardless of claim origin so the symbol is fully unblocked.
+///
+/// In all cases, Drop only acts if the slot still holds
+/// `ActiveTransfer { generation: self.generation }` (i.e. this guard still
+/// owns it). A concurrent terminal event that cleared the slot and a new
+/// transfer claiming `ActiveTransfer` with a different generation are both
+/// safely left untouched -- this closes the ABA race.
+pub(crate) struct RecoveryGuard {
+    symbol: Symbol,
+    map: Arc<RwLock<HashMap<Symbol, GuardState>>>,
+    /// Generation token matching the `ActiveTransfer` entry this guard
+    /// inserted. Drop only acts when the map still holds this exact generation.
+    generation: u64,
+    /// Tracks the state the slot was in before this guard claimed it.
+    claim_origin: RecoveryClaimOrigin,
+    /// When true, Drop removes the entry instead of restoring prior state.
+    /// Set by `release()` after a successful recovery.
+    released: bool,
+}
+
+impl RecoveryGuard {
+    /// Signals successful completion. The slot is removed on drop regardless
+    /// of `claim_origin`, fully unblocking the symbol for future transfers.
+    ///
+    /// Consuming `self` here triggers `Drop::drop` with `released == true`,
+    /// which removes the map entry. No explicit drop or map write is needed.
+    pub(crate) fn release(mut self) {
+        self.released = true;
+        // Drop fires here at end of scope, executing Drop::drop with released=true.
+    }
+
+    /// Returns `true` when this guard was claimed from a `HeldForRecovery` slot
+    /// (the deadlock-break handoff) rather than from an absent slot (orphan).
+    ///
+    /// Recovery jobs use this to decide whether a no-balance skip must
+    /// self-reschedule: the inventory reactor only re-dispatches a recovery on
+    /// a POSITIVE wallet balance, so a `HeldForRecovery`-origin job that finds
+    /// zero balance and simply drops would restore `HeldForRecovery` with no
+    /// job left to drain it -- wedging the symbol. Re-enqueuing with a delay
+    /// keeps polling until the balance resolves or the slot is cleared.
+    pub(crate) fn claimed_from_held_for_recovery(&self) -> bool {
+        self.claim_origin == RecoveryClaimOrigin::HeldForRecovery
+    }
+}
+
+impl Drop for RecoveryGuard {
+    fn drop(&mut self) {
+        let mut guard = match self.map.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                warn!(
+                    symbol = %self.symbol,
+                    "equity_in_progress lock poisoned during recovery guard drop; releasing \
+                     entry from inner guard"
+                );
+                poisoned.into_inner()
+            }
+        };
+        // Only act if this guard still owns the slot. We check the exact
+        // generation token to close the ABA race: if (1) a terminal event
+        // cleared the slot, (2) a new transfer claimed ActiveTransfer with a
+        // different generation, and (3) this Drop fires, the generation
+        // mismatch causes us to leave the new claim untouched.
+        if guard.get(&self.symbol)
+            != Some(&GuardState::ActiveTransfer {
+                generation: self.generation,
+            })
+        {
+            return;
+        }
+
+        if self.released {
+            // Recovery succeeded: remove the entry to unblock future transfers.
+            guard.remove(&self.symbol);
+        } else {
+            match self.claim_origin {
+                RecoveryClaimOrigin::HeldForRecovery => {
+                    // Recovery failed: restore to HeldForRecovery so retries can
+                    // claim the slot but a new transfer cannot start while tokens
+                    // are still stranded (prevents double-mints).
+                    guard.insert(self.symbol.clone(), GuardState::HeldForRecovery);
+                }
+                RecoveryClaimOrigin::Orphan => {
+                    // Orphan failure: no prior guard state; remove entirely so
+                    // inventory-driven recovery can restart on the next poll.
+                    guard.remove(&self.symbol);
+                }
+            }
+        }
+    }
+}
+
+/// Two-path guard claim for recovery jobs.
+///
+/// Used by BOTH [`UnwrappedEquityRecovery`] and [`WrappedEquityRecovery`]: a
+/// `PostReceipt` failure can strand tokens either UNWRAPPED (wrap reverted) or
+/// WRAPPED (the wrap landed but its confirmation read failed under a stale
+/// RPC), and the inventory location -- not the guard -- decides which recovery
+/// job the reactor dispatches. Both must therefore be able to claim a
+/// `HeldForRecovery` slot, and the atomic check-and-insert below makes
+/// concurrent claims safe: the first transitions the slot to `ActiveTransfer`,
+/// the second sees `ActiveTransfer` and reschedules.
+///
+/// 1. `HeldForRecovery` -> `ActiveTransfer`: the deadlock-break path -- a live
+///    transfer job set `HeldForRecovery` and returned `Ok(())`; recovery owns
+///    the slot now. On drop, the slot is restored to `HeldForRecovery` so
+///    recovery retries can proceed but new transfer jobs cannot start.
+/// 2. Absent -> `ActiveTransfer`: the orphan path -- no active transfer was in
+///    progress; recovery detected a wallet balance outside a mint cycle. On
+///    drop, the slot is removed entirely.
+/// 3. `ActiveTransfer`: a live transfer job owns the slot; returns `None` so
+///    the caller reschedules.
+pub(crate) fn claim_guard_for_recovery_or_orphan(
+    map: &Arc<RwLock<HashMap<Symbol, GuardState>>>,
+    symbol: &Symbol,
+) -> Option<RecoveryGuard> {
+    let mut guard = match map.write() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            warn!(
+                %symbol,
+                "equity_in_progress lock poisoned in claim_guard_for_recovery_or_orphan; \
+                 recovering inner guard so future recovery attempts can proceed"
+            );
+            poisoned.into_inner()
+        }
+    };
+
+    let claim_origin = match guard.get(symbol) {
+        Some(GuardState::ActiveTransfer { .. }) => {
+            // A live transfer job owns the slot; reschedule.
+            return None;
+        }
+        Some(GuardState::HeldForRecovery) => RecoveryClaimOrigin::HeldForRecovery,
+        None => RecoveryClaimOrigin::Orphan,
+    };
+
+    let generation = next_generation();
+    guard.insert(symbol.clone(), GuardState::ActiveTransfer { generation });
+    drop(guard);
+
+    Some(RecoveryGuard {
+        symbol: symbol.clone(),
+        map: Arc::clone(map),
+        generation,
+        claim_origin,
+        released: false,
+    })
 }
 
 /// Checks inventory for equity imbalance and returns the appropriate rebalancing operation.
@@ -318,12 +553,31 @@ mod tests {
 
     use st0x_dto::Statement;
     use st0x_execution::FractionalShares;
+    use st0x_float_macro::float;
     use st0x_wrapper::RATIO_ONE;
 
     use super::*;
     use crate::inventory::view::Operator;
     use crate::inventory::{Inventory, InventoryView, TransferOp, Venue};
-    use st0x_float_macro::float;
+
+    fn make_in_progress() -> Arc<std::sync::RwLock<HashMap<Symbol, GuardState>>> {
+        Arc::new(std::sync::RwLock::new(HashMap::new()))
+    }
+
+    /// `next_generation` must never return 0: 0 is the reserved sentinel for
+    /// legacy `#[serde(default)]` transfer-job payloads. A live claim colliding
+    /// with it would let a stale payload clobber a real active transfer,
+    /// defeating the ABA guard. The counter is process-global and shared across
+    /// tests, so assert the invariant rather than a specific value.
+    #[test]
+    fn next_generation_never_returns_legacy_zero_sentinel() {
+        for _ in 0..1_000 {
+            assert!(
+                next_generation() >= 1,
+                "next_generation must never return the reserved legacy sentinel 0"
+            );
+        }
+    }
 
     fn one_to_one_ratio() -> UnderlyingPerWrapped {
         UnderlyingPerWrapped::new(RATIO_ONE).unwrap()
@@ -359,44 +613,241 @@ mod tests {
 
     #[test]
     fn test_guard_releases_on_drop() {
-        let in_progress = Arc::new(std::sync::RwLock::new(HashSet::new()));
+        let in_progress = make_in_progress();
         let symbol = Symbol::new("AAPL").unwrap();
 
         {
             let guard =
-                InProgressGuard::try_claim(symbol.clone(), Arc::clone(&in_progress)).unwrap();
-            assert!(in_progress.read().unwrap().contains(&symbol));
+                InProgressGuard::try_claim_for_transfer(symbol.clone(), Arc::clone(&in_progress))
+                    .unwrap();
+            assert!(
+                matches!(
+                    in_progress.read().unwrap().get(&symbol),
+                    Some(GuardState::ActiveTransfer { .. })
+                ),
+                "try_claim_for_transfer must insert ActiveTransfer"
+            );
             drop(guard);
         }
 
-        assert!(!in_progress.read().unwrap().contains(&symbol));
+        assert!(!in_progress.read().unwrap().contains_key(&symbol));
     }
 
     #[test]
     fn test_guard_defuse_prevents_release() {
-        let in_progress = Arc::new(std::sync::RwLock::new(HashSet::new()));
+        let in_progress = make_in_progress();
         let symbol = Symbol::new("AAPL").unwrap();
 
         {
             let guard =
-                InProgressGuard::try_claim(symbol.clone(), Arc::clone(&in_progress)).unwrap();
-            assert!(in_progress.read().unwrap().contains(&symbol));
+                InProgressGuard::try_claim_for_transfer(symbol.clone(), Arc::clone(&in_progress))
+                    .unwrap();
+            assert!(in_progress.read().unwrap().contains_key(&symbol));
             guard.defuse();
         }
 
-        // Should still be in progress after defused guard dropped
-        assert!(in_progress.read().unwrap().contains(&symbol));
+        // Should still be in progress after defused guard dropped.
+        assert!(in_progress.read().unwrap().contains_key(&symbol));
     }
 
     #[test]
     fn test_guard_try_claim_fails_when_already_claimed() {
-        let in_progress = Arc::new(std::sync::RwLock::new(HashSet::new()));
+        let in_progress = make_in_progress();
         let symbol = Symbol::new("AAPL").unwrap();
 
-        let _guard = InProgressGuard::try_claim(symbol.clone(), Arc::clone(&in_progress)).unwrap();
+        let _guard =
+            InProgressGuard::try_claim_for_transfer(symbol.clone(), Arc::clone(&in_progress))
+                .unwrap();
 
-        let second_claim = InProgressGuard::try_claim(symbol, Arc::clone(&in_progress));
+        let second_claim =
+            InProgressGuard::try_claim_for_transfer(symbol, Arc::clone(&in_progress));
         assert!(second_claim.is_none());
+    }
+
+    #[test]
+    fn guard_state_for_transfer_blocks_second_transfer_and_recovery_claim() {
+        let in_progress = make_in_progress();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        let _guard =
+            InProgressGuard::try_claim_for_transfer(symbol.clone(), Arc::clone(&in_progress))
+                .unwrap();
+
+        // A second transfer claim must fail.
+        assert!(
+            InProgressGuard::try_claim_for_transfer(symbol.clone(), Arc::clone(&in_progress))
+                .is_none(),
+            "ActiveTransfer must block a second transfer claim"
+        );
+
+        // A recovery claim must also fail when state is ActiveTransfer.
+        assert!(
+            claim_guard_for_recovery_or_orphan(&in_progress, &symbol).is_none(),
+            "ActiveTransfer must block a recovery claim"
+        );
+    }
+
+    #[test]
+    fn guard_state_held_for_recovery_blocks_transfer_but_allows_recovery_claim() {
+        let in_progress = make_in_progress();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        // Manually insert HeldForRecovery state (as mark_held_for_recovery would do).
+        in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::HeldForRecovery);
+
+        // A transfer claim must fail -- no new transfer while recovery pending.
+        assert!(
+            InProgressGuard::try_claim_for_transfer(symbol.clone(), Arc::clone(&in_progress))
+                .is_none(),
+            "HeldForRecovery must block a transfer claim"
+        );
+
+        // A recovery claim via the production function must succeed.
+        let guard = claim_guard_for_recovery_or_orphan(&in_progress, &symbol);
+        let guard = guard.expect("HeldForRecovery must allow a recovery claim");
+        drop(guard);
+    }
+
+    #[test]
+    fn guard_state_held_for_recovery_transitions_to_active_on_recovery_claim() {
+        let in_progress = make_in_progress();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::HeldForRecovery);
+
+        let _guard = claim_guard_for_recovery_or_orphan(&in_progress, &symbol).unwrap();
+
+        // After claiming for recovery, state transitions to ActiveTransfer.
+        assert!(
+            matches!(
+                in_progress.read().unwrap().get(&symbol),
+                Some(GuardState::ActiveTransfer { .. })
+            ),
+            "claim_guard_for_recovery_or_orphan must transition state to ActiveTransfer"
+        );
+    }
+
+    /// When a recovery job claims from `HeldForRecovery` and then fails (drop
+    /// without `release()`), the slot must be RESTORED to `HeldForRecovery` --
+    /// not removed. This prevents a new transfer from starting while tokens are
+    /// still stranded (double-mint safety guarantee).
+    #[test]
+    fn recovery_guard_drop_from_held_for_recovery_restores_held_for_recovery() {
+        let map = make_in_progress();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        map.write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::HeldForRecovery);
+
+        let guard = claim_guard_for_recovery_or_orphan(&map, &symbol)
+            .expect("HeldForRecovery must allow claim");
+        assert!(
+            matches!(
+                map.read().unwrap().get(&symbol),
+                Some(GuardState::ActiveTransfer { .. })
+            ),
+            "claim must transition to ActiveTransfer"
+        );
+
+        // Simulate recovery failure: drop without release().
+        drop(guard);
+
+        // Must restore to HeldForRecovery (not absent, not ActiveTransfer).
+        assert_eq!(
+            map.read().unwrap().get(&symbol),
+            Some(&GuardState::HeldForRecovery),
+            "drop from HeldForRecovery claim must restore to HeldForRecovery, not remove"
+        );
+
+        // A subsequent recovery claim must still succeed (recovery can retry).
+        let second_guard = claim_guard_for_recovery_or_orphan(&map, &symbol).expect(
+            "a subsequent recovery claim must succeed after guard is restored to HeldForRecovery",
+        );
+        assert!(
+            matches!(
+                map.read().unwrap().get(&symbol),
+                Some(GuardState::ActiveTransfer { .. })
+            ),
+            "second claim must transition to ActiveTransfer"
+        );
+        drop(second_guard);
+    }
+
+    /// ABA race: a terminal event clears the slot (absent), a NEW transfer
+    /// immediately claims `ActiveTransfer`, and THEN an old `RecoveryGuard` drops.
+    /// The old guard must detect the generation mismatch and NOT clobber the new
+    /// transfer's claim.
+    #[test]
+    fn recovery_guard_drop_does_not_clobber_new_transfer_after_aba_race() {
+        let map = make_in_progress();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        // Step 1: Recovery claims the slot from HeldForRecovery.
+        map.write()
+            .unwrap()
+            .insert(symbol.clone(), GuardState::HeldForRecovery);
+        let recovery_guard = claim_guard_for_recovery_or_orphan(&map, &symbol)
+            .expect("HeldForRecovery must allow claim");
+
+        // Step 2: Simulate terminal event clearing the slot (as if clear_equity_in_progress
+        // fired -- e.g. the aggregate reached DepositedIntoRaindex).
+        map.write().unwrap().remove(&symbol);
+
+        // Step 3: A new transfer immediately claims ActiveTransfer (new generation).
+        let new_transfer =
+            InProgressGuard::try_claim_for_transfer(symbol.clone(), Arc::clone(&map))
+                .expect("absent slot must allow new transfer after terminal event");
+        let new_gen = match map.read().unwrap().get(&symbol) {
+            Some(GuardState::ActiveTransfer { generation }) => *generation,
+            other => panic!("expected ActiveTransfer after new claim, got {other:?}"),
+        };
+
+        // Step 4: Old recovery guard drops (ABA scenario). Must NOT remove or
+        // overwrite the new transfer's claim.
+        drop(recovery_guard);
+
+        // The new transfer's ActiveTransfer entry must survive, unchanged.
+        assert_eq!(
+            map.read().unwrap().get(&symbol),
+            Some(&GuardState::ActiveTransfer {
+                generation: new_gen
+            }),
+            "ABA: old RecoveryGuard drop must not clobber the new transfer's guard claim"
+        );
+
+        // The new transfer's own drop cleans up normally.
+        drop(new_transfer);
+        assert!(
+            !map.read().unwrap().contains_key(&symbol),
+            "new transfer guard drop must remove the entry"
+        );
+    }
+
+    /// An absent entry is treated as the orphan path: `claim_guard_for_recovery_or_orphan`
+    /// returns `Some` and inserts `ActiveTransfer`, unblocking recovery without requiring
+    /// a prior `HeldForRecovery` state.
+    #[test]
+    fn guard_absent_state_is_treated_as_orphan_by_recovery_claim() {
+        let in_progress = make_in_progress();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        let _guard = claim_guard_for_recovery_or_orphan(&in_progress, &symbol)
+            .expect("absent entry must be treated as orphan and allow a recovery claim");
+
+        assert!(
+            matches!(
+                in_progress.read().unwrap().get(&symbol),
+                Some(GuardState::ActiveTransfer { .. })
+            ),
+            "orphan claim from absent entry must insert ActiveTransfer"
+        );
     }
 
     #[tokio::test]

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -3,6 +3,10 @@
 mod equity;
 mod usdc;
 
+#[cfg(test)]
+pub(crate) use equity::InProgressGuard;
+pub(crate) use equity::{GuardState, claim_guard_for_recovery_or_orphan};
+
 use alloy::primitives::{Address, TxHash};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -471,7 +475,7 @@ pub(crate) struct RebalancingService {
     orderbook: Address,
     order_owner: Address,
     inventory: Arc<BroadcastingInventory>,
-    pub(crate) equity_in_progress: Arc<std::sync::RwLock<HashSet<Symbol>>>,
+    pub(crate) equity_in_progress: Arc<std::sync::RwLock<HashMap<Symbol, equity::GuardState>>>,
     pending_offchain_order_symbols: Arc<RwLock<HashSet<Symbol>>>,
     pub(crate) usdc_in_progress: Arc<AtomicBool>,
     wrapper: Arc<dyn Wrapper>,
@@ -579,7 +583,7 @@ impl RebalancingService {
             orderbook,
             order_owner,
             inventory,
-            equity_in_progress: Arc::new(std::sync::RwLock::new(HashSet::new())),
+            equity_in_progress: Arc::new(std::sync::RwLock::new(HashMap::new())),
             pending_offchain_order_symbols: Arc::new(RwLock::new(HashSet::new())),
             usdc_in_progress: Arc::new(AtomicBool::new(false)),
             wrapper,
@@ -705,9 +709,61 @@ impl RebalancingService {
         };
 
         for id in timed_out_ids {
+            let Some(symbol) = self
+                .mint_tracking
+                .read()
+                .await
+                .get(&id)
+                .map(|t| t.symbol.clone())
+            else {
+                debug!(
+                    target: "rebalance",
+                    ?id,
+                    "Skipping timed-out mint: tracking entry already removed"
+                );
+                continue;
+            };
+
+            // Steady-state skip: if recovery already owns the slot, leave the
+            // mint untouched -- recovery drives it to terminal, and removing its
+            // tracking or failing it would clear the guard and allow a
+            // double-mint while the tokens are still unwrapped in the wallet. A
+            // concurrent flip to `HeldForRecovery` AFTER this read is closed
+            // atomically at the clear below.
+            let held_for_recovery = {
+                let guard = match self.equity_in_progress.read() {
+                    Ok(guard) => guard,
+                    Err(poison) => poison.into_inner(),
+                };
+                guard.get(&symbol) == Some(&equity::GuardState::HeldForRecovery)
+            };
+            if held_for_recovery {
+                continue;
+            }
+
             let Some((tracking, elapsed)) = self.cleanup_timed_out_mint(&id, now).await? else {
                 continue;
             };
+
+            // Atomically clear the guard UNLESS recovery claimed the slot during
+            // the async cleanup above. Holding the write lock across the re-check
+            // and the clear closes the TOCTOU race: a concurrent
+            // `mark_held_for_recovery` can flip `ActiveTransfer` ->
+            // `HeldForRecovery` after the steady-state check, and a non-atomic
+            // clear would then drop a recovery-owned guard and fail a mint whose
+            // tokens are still in the wallet -- re-opening the double-mint window
+            // this guard exists to close. If recovery now owns the slot, leave
+            // the guard and skip the failure event.
+            if !self.clear_equity_in_progress_unless_held_for_recovery(&symbol) {
+                debug!(
+                    target: "rebalance",
+                    aggregate_id = %id,
+                    %symbol,
+                    "Timed-out mint flipped to HeldForRecovery during cleanup; \
+                     recovery now owns it -- leaving guard and skipping failure event"
+                );
+                continue;
+            }
 
             let elapsed_secs = elapsed.as_secs();
             error!(
@@ -719,8 +775,6 @@ impl RebalancingService {
                 outcome = "timeout",
                 "Mint transfer timed out; clearing trigger guard and inventory inflight"
             );
-
-            self.clear_equity_in_progress(&tracking.symbol);
 
             if let Some(store) = self.mint_store.read().await.as_ref() {
                 let reason = format!(
@@ -2099,8 +2153,14 @@ impl RebalancingService {
         }
     }
 
-    fn try_claim_equity_guard(&self, symbol: &Symbol) -> Option<equity::InProgressGuard> {
-        equity::InProgressGuard::try_claim(symbol.clone(), Arc::clone(&self.equity_in_progress))
+    fn try_claim_equity_guard_for_transfer(
+        &self,
+        symbol: &Symbol,
+    ) -> Option<equity::InProgressGuard> {
+        equity::InProgressGuard::try_claim_for_transfer(
+            symbol.clone(),
+            Arc::clone(&self.equity_in_progress),
+        )
     }
 
     async fn has_pending_offchain_order(&self, symbol: &Symbol) -> bool {
@@ -2384,7 +2444,7 @@ impl RebalancingService {
             return Ok(());
         }
 
-        let Some(guard) = self.try_claim_equity_guard(symbol) else {
+        let Some(guard) = self.try_claim_equity_guard_for_transfer(symbol) else {
             debug!(target: "rebalance", %symbol, "Skipped equity trigger: already in progress");
             return Ok(());
         };
@@ -2431,7 +2491,7 @@ impl RebalancingService {
 
         let dispatched = match operation {
             TriggeredOperation::Mint { symbol, quantity } => {
-                self.enqueue_transfer_equity_to_market_making(symbol, quantity)
+                self.enqueue_transfer_equity_to_market_making(symbol, quantity, guard.generation())
                     .await
             }
             TriggeredOperation::Redemption {
@@ -2750,6 +2810,7 @@ impl RebalancingService {
         &self,
         symbol: Symbol,
         quantity: FractionalShares,
+        generation: u64,
     ) -> bool {
         // A non-terminal row in flight longer than this is treated as likely
         // stuck: the suppression is logged at warn (with the row id and age)
@@ -2805,6 +2866,7 @@ impl RebalancingService {
                 issuer_request_id: issuer_request_id.clone(),
                 symbol: symbol.clone(),
                 quantity,
+                generation,
             })
             .await;
 
@@ -2921,6 +2983,10 @@ impl RebalancingService {
     }
 
     /// Clears the in-progress flag for an equity symbol.
+    ///
+    /// Removes the entry regardless of its current `GuardState`. Called by
+    /// `on_mint`/`on_redemption` terminal event arms and by guard-drop in all
+    /// transfer and recovery job paths.
     pub(crate) fn clear_equity_in_progress(&self, symbol: &Symbol) {
         let mut guard = match self.equity_in_progress.write() {
             Ok(guard) => guard,
@@ -2929,12 +2995,60 @@ impl RebalancingService {
         guard.remove(symbol);
     }
 
-    fn mark_equity_in_progress(&self, symbol: &Symbol) {
+    /// Clears the in-progress guard for a timed-out mint unless recovery owns
+    /// the slot, in a single write-lock acquisition.
+    ///
+    /// Returns `true` after removing an `ActiveTransfer` (or absent) guard so
+    /// the caller can fail the mint and free the symbol for a fresh rebalance.
+    /// Returns `false` without touching a `HeldForRecovery` slot: recovery owns
+    /// the mint and will drive it to terminal. Holding the lock across the
+    /// check and the clear closes the TOCTOU race where a concurrent
+    /// `mark_held_for_recovery` flips `ActiveTransfer` -> `HeldForRecovery`
+    /// between a separate check and clear.
+    pub(crate) fn clear_equity_in_progress_unless_held_for_recovery(
+        &self,
+        symbol: &Symbol,
+    ) -> bool {
         let mut guard = match self.equity_in_progress.write() {
             Ok(guard) => guard,
             Err(poison) => poison.into_inner(),
         };
-        guard.insert(symbol.clone());
+        match guard.get(symbol) {
+            Some(equity::GuardState::HeldForRecovery) => false,
+            Some(equity::GuardState::ActiveTransfer { .. }) | None => {
+                guard.remove(symbol);
+                true
+            }
+        }
+    }
+
+    /// Marks the slot as `ActiveTransfer` (startup recovery and tracking-rebuild
+    /// paths that re-establish a live transfer's guard on restart).
+    fn mark_equity_active_transfer(&self, symbol: &Symbol) {
+        let mut guard = match self.equity_in_progress.write() {
+            Ok(guard) => guard,
+            Err(poison) => poison.into_inner(),
+        };
+        guard.insert(
+            symbol.clone(),
+            equity::GuardState::ActiveTransfer {
+                generation: equity::next_generation(),
+            },
+        );
+    }
+
+    /// Sets the in-progress guard to `HeldForRecovery` for a symbol.
+    ///
+    /// Used during startup reconstruction for post-receipt mint states when
+    /// recovery is enabled: instead of `ActiveTransfer` (which would block
+    /// the recovery job), we set `HeldForRecovery` so `claim_guard_for_recovery_or_orphan`
+    /// can claim the slot and resume.
+    fn mark_equity_held_for_recovery(&self, symbol: &Symbol) {
+        let mut guard = match self.equity_in_progress.write() {
+            Ok(guard) => guard,
+            Err(poison) => poison.into_inner(),
+        };
+        guard.insert(symbol.clone(), equity::GuardState::HeldForRecovery);
     }
 
     /// Releases the in-progress guard and tracking for a mint whose recovery
@@ -3306,7 +3420,30 @@ impl RebalancingService {
                         last_progress_at,
                     },
                 );
-                self.mark_equity_in_progress(symbol);
+
+                // For pre-wrap post-receipt states (TokensReceived, WrapSubmitted),
+                // the transfer job may have already handed off to recovery via
+                // HeldForRecovery and returned Ok(()) — the apalis job is Done and
+                // will never be re-picked. On restart, reconstructing these states as
+                // ActiveTransfer would block UnwrappedEquityRecovery from claiming.
+                //
+                // When recovery is enabled, reconstruct as HeldForRecovery so
+                // claim_guard_for_recovery_or_orphan can claim the slot. When recovery
+                // is disabled, ActiveTransfer is correct — resume_interrupted_transfers
+                // will call resume_mint and the transfer job retries normally.
+                //
+                // TokensWrapped and VaultDepositSubmitted are always reconstructed as
+                // ActiveTransfer: the deposit is idempotent and resume_interrupted_transfers
+                // drives them to completion. WrappedEquityRecovery is orphan-only.
+                let is_pre_wrap_post_receipt_state =
+                    matches!(entity, TokensReceived { .. } | WrapSubmitted { .. });
+
+                if is_pre_wrap_post_receipt_state && self.is_wrapped_equity_recovery_enabled(symbol)
+                {
+                    self.mark_equity_held_for_recovery(symbol);
+                } else {
+                    self.mark_equity_active_transfer(symbol);
+                }
 
                 let mut inventory = self.inventory.write().await;
                 let mut updated = inventory.clone();
@@ -3450,7 +3587,7 @@ impl RebalancingService {
                 last_progress_at: Utc::now(),
             },
         );
-        self.mark_equity_in_progress(symbol);
+        self.mark_equity_active_transfer(symbol);
         Ok(RecoveryClaim::Claimed(rollback))
     }
 
@@ -3605,7 +3742,7 @@ impl RebalancingService {
                 last_progress_at: Utc::now(),
             },
         );
-        self.mark_equity_in_progress(symbol);
+        self.mark_equity_active_transfer(symbol);
         Ok(RecoveryClaim::Claimed(rollback))
     }
 
@@ -3763,7 +3900,7 @@ impl RebalancingService {
                         last_progress_at,
                     },
                 );
-                self.mark_equity_in_progress(symbol);
+                self.mark_equity_active_transfer(symbol);
 
                 let mut inventory = self.inventory.write().await;
                 let updated = inventory.clone().update_equity(
@@ -4332,7 +4469,13 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
 
         let tracking = trigger
             .mint_tracking
@@ -4365,6 +4508,236 @@ mod tests {
         assert_eq!(inflight, Some(FractionalShares::new(float!(10))));
     }
 
+    /// Builds a `RebalancingService` with `wrapped_equity_recovery = Enabled` for `symbol`.
+    async fn make_trigger_with_recovery_enabled(symbol: &Symbol) -> Arc<RebalancingService> {
+        let config = RebalancingServiceConfig {
+            assets: AssetsConfig {
+                equities: EquitiesConfig {
+                    operational_limit: None,
+                    symbols: HashMap::from([(
+                        symbol.clone(),
+                        EquityAssetConfig {
+                            tokenized_equity: Address::ZERO,
+                            tokenized_equity_derivative: Address::ZERO,
+                            pyth_feed_id: None,
+                            vault_ids: Vec::new(),
+                            trading: OperationMode::Disabled,
+                            rebalancing: OperationMode::Enabled,
+                            wrapped_equity_recovery: OperationMode::Enabled,
+                            operational_limit: None,
+                        },
+                    )]),
+                },
+                cash: None,
+            },
+            ..test_config()
+        };
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default(),
+            event_sender,
+        ));
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
+        let wrapper = Arc::new(MockWrapper::new());
+        Arc::new(RebalancingService::new(
+            config,
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            TEST_ORDERBOOK,
+            TEST_ORDER_OWNER,
+            inventory,
+            wrapper,
+            RebalancingSchedulers::new(&apalis_pool),
+        ))
+    }
+
+    /// `recover_mint_state` startup guard reconstruction: all four post-receipt
+    /// states produce the correct `GuardState`.
+    ///
+    /// - `TokensReceived` / `WrapSubmitted` (pre-wrap, recovery enabled):
+    ///   `HeldForRecovery` — `UnwrappedEquityRecovery` owns the slot; a new
+    ///   transfer cannot start until recovery completes.
+    /// - `TokensWrapped` / `VaultDepositSubmitted` (post-wrap, recovery
+    ///   enabled): `ActiveTransfer` — deposit is idempotent;
+    ///   `resume_interrupted_transfers` drives them via `resume_mint`.
+    /// - `TokensReceived` (recovery disabled): `ActiveTransfer` — no recovery
+    ///   job will run; the transfer job retries normally via apalis.
+    #[tokio::test]
+    async fn recover_mint_state_reconstructs_all_post_receipt_states() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let trigger_enabled = make_trigger_with_recovery_enabled(&symbol).await;
+        let trigger_disabled = make_trigger().await;
+
+        async fn check(
+            trigger: &RebalancingService,
+            symbol: &Symbol,
+            mint_id_str: &str,
+            entity: TokenizedEquityMint,
+            expected: equity::GuardState,
+            label: &str,
+        ) {
+            // Clear any prior guard state so each case starts clean.
+            trigger.equity_in_progress.write().unwrap().remove(symbol);
+            let mint_id = issuer_request_id(mint_id_str);
+            trigger.recover_mint_state(&mint_id, &entity).await.unwrap();
+            assert_eq!(
+                trigger
+                    .equity_in_progress
+                    .read()
+                    .unwrap()
+                    .get(symbol)
+                    .cloned(),
+                Some(expected),
+                "{label}"
+            );
+        }
+
+        check(
+            &trigger_enabled,
+            &symbol,
+            "startup-tokens-received",
+            TokenizedEquityMint::TokensReceived {
+                symbol: symbol.clone(),
+                quantity: float!(5),
+                wallet: Address::ZERO,
+                issuer_request_id: issuer_request_id("startup-tokens-received"),
+                tokenization_request_id: TokenizationRequestId("TOK-TR".to_string()),
+                tx_hash: TxHash::ZERO,
+                shares_minted: U256::from(5u64),
+                fees: None,
+                requested_at: now,
+                accepted_at: now,
+                received_at: now,
+            },
+            equity::GuardState::HeldForRecovery,
+            "TokensReceived + recovery enabled must reconstruct as HeldForRecovery",
+        )
+        .await;
+
+        check(
+            &trigger_enabled,
+            &symbol,
+            "startup-wrap-submitted",
+            TokenizedEquityMint::WrapSubmitted {
+                symbol: symbol.clone(),
+                quantity: float!(5),
+                wallet: Address::ZERO,
+                issuer_request_id: issuer_request_id("startup-wrap-submitted"),
+                tokenization_request_id: TokenizationRequestId("TOK-WS".to_string()),
+                tx_hash: TxHash::ZERO,
+                shares_minted: U256::from(5u64),
+                fees: None,
+                requested_at: now,
+                accepted_at: now,
+                received_at: now,
+                wrap_tx_hash: TxHash::ZERO,
+            },
+            equity::GuardState::HeldForRecovery,
+            "WrapSubmitted + recovery enabled must reconstruct as HeldForRecovery",
+        )
+        .await;
+
+        // For ActiveTransfer cases the generation counter is opaque so we use
+        // matches! rather than assert_eq! to verify the variant without pinning
+        // the generation value.
+        async fn check_active_transfer(
+            trigger: &RebalancingService,
+            symbol: &Symbol,
+            mint_id_str: &str,
+            entity: TokenizedEquityMint,
+            label: &str,
+        ) {
+            trigger.equity_in_progress.write().unwrap().remove(symbol);
+            let mint_id = issuer_request_id(mint_id_str);
+            trigger.recover_mint_state(&mint_id, &entity).await.unwrap();
+            assert!(
+                matches!(
+                    trigger
+                        .equity_in_progress
+                        .read()
+                        .unwrap()
+                        .get(symbol)
+                        .cloned(),
+                    Some(equity::GuardState::ActiveTransfer { .. })
+                ),
+                "{label}"
+            );
+        }
+
+        check_active_transfer(
+            &trigger_enabled,
+            &symbol,
+            "startup-tokens-wrapped",
+            TokenizedEquityMint::TokensWrapped {
+                symbol: symbol.clone(),
+                quantity: float!(5),
+                wallet: Address::ZERO,
+                issuer_request_id: issuer_request_id("startup-tokens-wrapped"),
+                tokenization_request_id: TokenizationRequestId("TOK-TW".to_string()),
+                tx_hash: TxHash::ZERO,
+                shares_minted: U256::from(5u64),
+                requested_at: now,
+                accepted_at: now,
+                received_at: now,
+                wrap_tx_hash: TxHash::ZERO,
+                wrapped_shares: U256::from(5u64),
+                wrap_block: None,
+                wrapped_at: now,
+            },
+            "TokensWrapped must always reconstruct as ActiveTransfer \
+             (deposit idempotent; WrappedEquityRecovery is orphan-only)",
+        )
+        .await;
+
+        check_active_transfer(
+            &trigger_enabled,
+            &symbol,
+            "startup-vault-deposit-submitted",
+            TokenizedEquityMint::VaultDepositSubmitted {
+                symbol: symbol.clone(),
+                quantity: float!(5),
+                wallet: Address::ZERO,
+                issuer_request_id: issuer_request_id("startup-vault-deposit-submitted"),
+                tokenization_request_id: TokenizationRequestId("TOK-VDS".to_string()),
+                tx_hash: TxHash::ZERO,
+                shares_minted: U256::from(5u64),
+                requested_at: now,
+                accepted_at: now,
+                received_at: now,
+                wrap_tx_hash: TxHash::ZERO,
+                wrapped_shares: U256::from(5u64),
+                wrapped_at: now,
+                vault_deposit_tx_hash: TxHash::ZERO,
+            },
+            "VaultDepositSubmitted must always reconstruct as ActiveTransfer \
+             (deposit tx on-chain; resume_mint confirms idempotently)",
+        )
+        .await;
+
+        check_active_transfer(
+            &trigger_disabled,
+            &symbol,
+            "startup-tokens-received-disabled",
+            TokenizedEquityMint::TokensReceived {
+                symbol: symbol.clone(),
+                quantity: float!(5),
+                wallet: Address::ZERO,
+                issuer_request_id: issuer_request_id("startup-tokens-received-disabled"),
+                tokenization_request_id: TokenizationRequestId("TOK-TR-D".to_string()),
+                tx_hash: TxHash::ZERO,
+                shares_minted: U256::from(5u64),
+                fees: None,
+                requested_at: now,
+                accepted_at: now,
+                received_at: now,
+            },
+            "TokensReceived + recovery disabled must reconstruct as ActiveTransfer \
+             (apalis transfer job retries normally)",
+        )
+        .await;
+    }
+
     #[tokio::test]
     async fn recover_redemption_state_restores_tracking_and_inflight() {
         let trigger = make_trigger().await;
@@ -4388,7 +4761,13 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
 
         let tracking = trigger
             .redemption_tracking
@@ -4710,7 +5089,13 @@ mod tests {
 
         assert_eq!(trigger.inventory.read().await.active_mint(&symbol), None);
         assert!(!trigger.mint_tracking.read().await.contains_key(&mint_id));
-        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
     }
 
     #[tokio::test]
@@ -4751,7 +5136,13 @@ mod tests {
         assert_eq!(inventory.active_mint(&symbol), Some(&other));
         drop(inventory);
         assert!(!trigger.mint_tracking.read().await.contains_key(&recovering));
-        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
     }
 
     #[tokio::test]
@@ -4851,7 +5242,13 @@ mod tests {
                 .await
                 .contains_key(&recovering)
         );
-        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
     }
 
     #[tokio::test]
@@ -4982,7 +5379,13 @@ mod tests {
         assert_eq!(inventory.active_mint(&symbol), None);
         drop(inventory);
         assert!(!trigger.mint_tracking.read().await.contains_key(&mint_id));
-        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
     }
 
     #[tokio::test]
@@ -5066,7 +5469,13 @@ mod tests {
         );
         drop(inventory);
         assert!(!trigger.mint_tracking.read().await.contains_key(&mint_id));
-        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
     }
 
     #[tokio::test]
@@ -5153,7 +5562,13 @@ mod tests {
                 .await
                 .contains_key(&redemption_id)
         );
-        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
     }
 
     #[tokio::test]
@@ -5212,7 +5627,13 @@ mod tests {
                 .await
                 .contains_key(&redemption_id)
         );
-        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
     }
 
     #[tokio::test]
@@ -5673,7 +6094,10 @@ mod tests {
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         tokio::time::timeout(
@@ -5875,14 +6299,66 @@ mod tests {
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
-        assert!(trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
 
         trigger.clear_equity_in_progress(&symbol);
 
-        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_equity_in_progress_removes_both_active_and_held_for_recovery_states() {
+        let trigger = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        // Verify clear works on ActiveTransfer.
+        trigger.equity_in_progress.write().unwrap().insert(
+            symbol.clone(),
+            equity::GuardState::ActiveTransfer { generation: 0 },
+        );
+        trigger.clear_equity_in_progress(&symbol);
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol),
+            "clear must remove ActiveTransfer entry"
+        );
+
+        // Verify clear works on HeldForRecovery.
+        trigger
+            .equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), equity::GuardState::HeldForRecovery);
+        trigger.clear_equity_in_progress(&symbol);
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol),
+            "clear must remove HeldForRecovery entry"
+        );
     }
 
     #[tokio::test]
@@ -6973,9 +7449,18 @@ mod tests {
         // Mark symbol as in-progress.
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
-        assert!(trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
 
         // Check that DepositedIntoRaindex is detected as terminal.
         assert!(RebalancingService::is_terminal_mint_event(
@@ -6984,7 +7469,13 @@ mod tests {
 
         // Simulate what dispatch does - clear in-progress on terminal.
         trigger.clear_equity_in_progress(&symbol);
-        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
     }
 
     #[tokio::test]
@@ -6997,7 +7488,10 @@ mod tests {
         // Mark symbol as in-progress.
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         assert!(RebalancingService::is_terminal_mint_event(
@@ -7005,7 +7499,13 @@ mod tests {
         ));
 
         trigger.clear_equity_in_progress(&symbol);
-        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
     }
 
     #[test]
@@ -7055,7 +7555,10 @@ mod tests {
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         let harness = ReactorHarness::new(Arc::clone(&trigger));
@@ -7072,7 +7575,11 @@ mod tests {
             .unwrap();
 
         assert!(
-            !trigger.equity_in_progress.read().unwrap().contains(&symbol),
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol),
             "In-progress flag should be cleared after terminal MintRejected"
         );
     }
@@ -7092,7 +7599,10 @@ mod tests {
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         let harness = ReactorHarness::new(Arc::clone(&trigger));
@@ -7112,7 +7622,11 @@ mod tests {
             .unwrap();
 
         assert!(
-            !trigger.equity_in_progress.read().unwrap().contains(&symbol),
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol),
             "In-progress flag should be cleared after terminal Completed"
         );
     }
@@ -7302,7 +7816,10 @@ mod tests {
         // Set in-progress flag to verify terminal event clears it
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         let id = issuer_request_id("mint-deposit");
@@ -7329,7 +7846,11 @@ mod tests {
             .unwrap();
 
         assert!(
-            !trigger.equity_in_progress.read().unwrap().contains(&symbol),
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol),
             "In-progress flag should be cleared after terminal DepositedIntoRaindex"
         );
     }
@@ -7358,7 +7879,10 @@ mod tests {
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         let id = issuer_request_id("mint-wrapping-fail");
@@ -7374,7 +7898,11 @@ mod tests {
             .unwrap();
 
         assert!(
-            !trigger.equity_in_progress.read().unwrap().contains(&symbol),
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol),
             "In-progress flag should be cleared after terminal WrappingFailed"
         );
     }
@@ -7403,7 +7931,10 @@ mod tests {
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         let id = issuer_request_id("mint-deposit-fail");
@@ -7419,7 +7950,11 @@ mod tests {
             .unwrap();
 
         assert!(
-            !trigger.equity_in_progress.read().unwrap().contains(&symbol),
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol),
             "In-progress flag should be cleared after terminal RaindexDepositFailed"
         );
     }
@@ -7442,7 +7977,10 @@ mod tests {
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         let id = redemption_aggregate_id("redemption-transfer-fail");
@@ -7461,7 +7999,11 @@ mod tests {
             .unwrap();
 
         assert!(
-            !trigger.equity_in_progress.read().unwrap().contains(&symbol),
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol),
             "In-progress flag should be cleared after terminal TransferFailed"
         );
     }
@@ -7484,7 +8026,10 @@ mod tests {
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         let id = redemption_aggregate_id("redemption-detection-fail");
@@ -7503,7 +8048,11 @@ mod tests {
             .unwrap();
 
         assert!(
-            !trigger.equity_in_progress.read().unwrap().contains(&symbol),
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol),
             "In-progress flag should be cleared after terminal DetectionFailed"
         );
     }
@@ -7526,7 +8075,10 @@ mod tests {
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         let id = redemption_aggregate_id("redemption-rejected");
@@ -7545,7 +8097,11 @@ mod tests {
             .unwrap();
 
         assert!(
-            !trigger.equity_in_progress.read().unwrap().contains(&symbol),
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol),
             "In-progress flag should be cleared after terminal RedemptionRejected"
         );
     }
@@ -9640,9 +10196,18 @@ mod tests {
         // Mark symbol as in-progress.
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
-        assert!(trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
 
         // Check that Completed is detected as terminal.
         assert!(RebalancingService::is_terminal_redemption_event(
@@ -9651,7 +10216,13 @@ mod tests {
 
         // Simulate what dispatch does - clear in-progress on terminal.
         trigger.clear_equity_in_progress(&symbol);
-        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+        assert!(
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol)
+        );
     }
 
     #[test]
@@ -14884,7 +15455,10 @@ mod tests {
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         trigger.redemption_tracking.write().await.insert(
@@ -14902,7 +15476,11 @@ mod tests {
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
 
         assert!(
-            !trigger.equity_in_progress.read().unwrap().contains(&symbol),
+            !trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .contains_key(&symbol),
             "equity timeout should clear the symbol in-progress guard"
         );
         assert!(
@@ -15041,7 +15619,10 @@ mod tests {
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         trigger.redemption_tracking.write().await.insert(
@@ -16235,7 +16816,7 @@ mod tests {
 
         // A different symbol is not suppressed by AAPL's pending row.
         let enqueued = trigger
-            .enqueue_transfer_equity_to_market_making(Symbol::new("TSLA").unwrap(), shares(30))
+            .enqueue_transfer_equity_to_market_making(Symbol::new("TSLA").unwrap(), shares(30), 0)
             .await;
         assert!(
             enqueued,
@@ -16330,7 +16911,10 @@ mod tests {
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
-            guard.insert(symbol.clone());
+            guard.insert(
+                symbol.clone(),
+                equity::GuardState::ActiveTransfer { generation: 0 },
+            );
         }
 
         EquityRebalancingCheck {
@@ -16918,6 +17502,154 @@ mod tests {
             inflight,
             Some(usdc(400)),
             "replayed Initiated must not double-count inflight"
+        );
+    }
+
+    /// `expire_stuck_mints` must skip mints whose symbol's in-progress guard is
+    /// `HeldForRecovery`. The recovery job owns those mints and is responsible for
+    /// driving them to a terminal state; timing them out would clear the guard and
+    /// allow a double-mint while the original tokens are still in the wallet.
+    #[tokio::test]
+    async fn expire_stuck_mints_skips_held_for_recovery_mints() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        // Use a very short timeout so the mint would normally be cleaned up.
+        let config = test_config_with_timeout(Duration::from_secs(60));
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default(),
+            event_sender,
+        ));
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
+        let wrapper = Arc::new(MockWrapper::new());
+        let trigger = Arc::new(RebalancingService::new(
+            config,
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            TEST_ORDERBOOK,
+            TEST_ORDER_OWNER,
+            inventory,
+            wrapper,
+            RebalancingSchedulers::new(&apalis_pool),
+        ));
+
+        let id = issuer_request_id("held-for-recovery-timeout");
+
+        // Seed a mint tracking entry at a post-receipt stage with a stale
+        // last_progress_at so the timeout sweep would normally pick it up.
+        trigger.mint_tracking.write().await.insert(
+            id.clone(),
+            MintTracking {
+                symbol: symbol.clone(),
+                quantity: shares(10),
+                tokenization_request_id: None,
+                stage: MintTrackingStage::TokensReceived,
+                last_progress_at: now - ChronoDuration::hours(2),
+            },
+        );
+
+        // Set the guard to HeldForRecovery for this symbol (simulating the
+        // PostReceipt handoff from the transfer job).
+        trigger
+            .equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), equity::GuardState::HeldForRecovery);
+
+        // Run expire_stuck_mints with a far-future now so the mint is well past
+        // the timeout threshold.
+        trigger
+            .expire_stuck_mints(now + ChronoDuration::hours(24))
+            .await
+            .unwrap();
+
+        // The mint tracking entry must NOT have been removed.
+        assert!(
+            trigger.mint_tracking.read().await.contains_key(&id),
+            "expire_stuck_mints must not clean up a HeldForRecovery mint"
+        );
+
+        // The guard must still be HeldForRecovery.
+        assert_eq!(
+            trigger
+                .equity_in_progress
+                .read()
+                .unwrap()
+                .get(&symbol)
+                .cloned(),
+            Some(equity::GuardState::HeldForRecovery),
+            "expire_stuck_mints must not clear a HeldForRecovery guard"
+        );
+    }
+
+    /// `clear_equity_in_progress_unless_held_for_recovery` is the single-lock
+    /// check-and-clear that closes the timeout-sweep TOCTOU race: a concurrent
+    /// `mark_held_for_recovery` can flip `ActiveTransfer` -> `HeldForRecovery`
+    /// after the steady-state check but before the clear, and a non-atomic clear
+    /// would drop the recovery-owned guard and fail a mint whose tokens are still
+    /// in the wallet -- the double-mint this guard exists to prevent. This
+    /// verifies the invariant the race hinges on: a `HeldForRecovery` slot is
+    /// never cleared (caller skips the failure event), while an `ActiveTransfer`
+    /// or absent slot is cleared so a fresh rebalance can proceed.
+    #[tokio::test]
+    async fn clear_equity_in_progress_unless_held_for_recovery_preserves_recovery_ownership() {
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        let config = test_config_with_timeout(Duration::from_secs(60));
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default(),
+            event_sender,
+        ));
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
+        let wrapper = Arc::new(MockWrapper::new());
+        let trigger = Arc::new(RebalancingService::new(
+            config,
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            TEST_ORDERBOOK,
+            TEST_ORDER_OWNER,
+            inventory,
+            wrapper,
+            RebalancingSchedulers::new(&apalis_pool),
+        ));
+
+        // HeldForRecovery: recovery owns the slot -- must be left untouched and
+        // signal the caller (returns false) to skip the failure event.
+        trigger
+            .equity_in_progress
+            .write()
+            .unwrap()
+            .insert(symbol.clone(), equity::GuardState::HeldForRecovery);
+        assert!(
+            !trigger.clear_equity_in_progress_unless_held_for_recovery(&symbol),
+            "a HeldForRecovery slot must not be cleared by the timeout path",
+        );
+        assert_eq!(
+            trigger.equity_in_progress.read().unwrap().get(&symbol),
+            Some(&equity::GuardState::HeldForRecovery),
+            "the HeldForRecovery guard must remain after a refused clear",
+        );
+
+        // ActiveTransfer: a live transfer that genuinely timed out -- clear it so
+        // a fresh rebalance can proceed.
+        trigger.equity_in_progress.write().unwrap().insert(
+            symbol.clone(),
+            equity::GuardState::ActiveTransfer { generation: 0 },
+        );
+        assert!(
+            trigger.clear_equity_in_progress_unless_held_for_recovery(&symbol),
+            "an ActiveTransfer slot must be cleared so a fresh rebalance can proceed",
+        );
+        assert_eq!(
+            trigger.equity_in_progress.read().unwrap().get(&symbol),
+            None,
+            "the ActiveTransfer guard must be removed after a successful clear",
+        );
+
+        // Absent: clearing is a no-op that still reports success.
+        assert!(
+            trigger.clear_equity_in_progress_unless_held_for_recovery(&symbol),
+            "an absent slot must report a successful (no-op) clear",
         );
     }
 }

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -33,7 +33,7 @@
 //! up wherever the previous attempt stopped.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use thiserror::Error;
@@ -50,6 +50,7 @@ use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::equity_redemption::{EquityRedemption, RedemptionAggregateId};
 use crate::inventory::BroadcastingInventory;
 use crate::inventory::view::{InFlightEquityLocation, InventoryView};
+use crate::rebalancing::trigger::{GuardState, claim_guard_for_recovery_or_orphan};
 use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMint};
 
 /// Apalis queue type for [`UnwrappedEquityRecoveryJob`].
@@ -63,7 +64,7 @@ pub(crate) struct UnwrappedEquityRecoveryCtx {
     pub(crate) store: Arc<Store<UnwrappedEquityRecovery>>,
     pub(crate) mint_store: Arc<Store<TokenizedEquityMint>>,
     pub(crate) redemption_store: Arc<Store<EquityRedemption>>,
-    pub(crate) equity_in_progress: Arc<RwLock<HashSet<Symbol>>>,
+    pub(crate) equity_in_progress: Arc<RwLock<HashMap<Symbol, GuardState>>>,
     /// Queue the job re-pushes itself onto when it loses the per-symbol
     /// guard, so a skipped recovery is re-dispatched rather than stranded.
     pub(crate) queue: UnwrappedEquityRecoveryJobQueue,
@@ -132,6 +133,11 @@ pub(crate) enum UnwrappedEquityRecoveryJobError {
     ),
     #[error("failed to reschedule recovery job after guard contention: {0}")]
     Reschedule(#[from] QueuePushError),
+    #[error(
+        "no positive unwrapped balance in inventory view for symbol {symbol}; \
+         guard drop restores HeldForRecovery or removes orphan entry"
+    )]
+    NoBalanceSkip { symbol: Symbol },
 }
 
 /// Apalis job payload. The reactor pushes one of these per symbol with a
@@ -163,12 +169,23 @@ impl Job<UnwrappedEquityRecoveryCtx> for UnwrappedEquityRecoveryJob {
     async fn perform(&self, ctx: &UnwrappedEquityRecoveryCtx) -> Result<Self::Output, Self::Error> {
         let symbol = self.symbol.clone();
 
-        let Some(guard) = claim_guard(&ctx.equity_in_progress, &symbol) else {
+        // Two-path guard claim:
+        // 1. `HeldForRecovery` -> `ActiveTransfer`: claim from a handoff set by
+        //    the transfer job after a PostReceipt error. When the mint aggregate
+        //    is in TokensReceived or WrapSubmitted, the ERC-4626 wrap reverted,
+        //    tokens are UNWRAPPED in the base wallet, and this job is the correct
+        //    deadlock-break claimant. (WrappedEquityRecovery handles the deposit-
+        //    failed path when the aggregate is in TokensWrapped.)
+        // 2. Absent -> `ActiveTransfer`: orphan path -- no active transfer was
+        //    in progress; inventory detected a wallet balance independently.
+        // 3. `ActiveTransfer`: a live transfer job owns the slot; reschedule.
+        let Some(guard) = claim_guard_for_recovery_or_orphan(&ctx.equity_in_progress, &symbol)
+        else {
             debug!(
                 target: "rebalance",
                 %symbol,
                 recovery_id = %self.recovery_id,
-                "Rescheduling unwrapped equity recovery: equity_in_progress already held",
+                "Rescheduling unwrapped equity recovery: equity_in_progress held by active transfer",
             );
             ctx.queue
                 .clone()
@@ -188,7 +205,7 @@ impl Job<UnwrappedEquityRecoveryCtx> for UnwrappedEquityRecoveryJob {
                 recovery_id = %self.recovery_id,
                 "Skipping unwrapped equity recovery: aggregate already terminal",
             );
-            drop(guard);
+            guard.release();
             return Ok(());
         }
 
@@ -219,8 +236,54 @@ impl Job<UnwrappedEquityRecoveryCtx> for UnwrappedEquityRecoveryJob {
             ) => Ok(()),
         };
 
-        drop(guard);
-        result
+        // Single exhaustive match on result:
+        // - Ok(()): release guard (removes slot); recovery completed.
+        // - Err(NoBalanceSkip): map to Ok(()) so apalis does NOT retry; guard
+        //   drops normally (HeldForRecovery origin restores to HeldForRecovery;
+        //   orphan removes). A HeldForRecovery-origin skip self-reschedules
+        //   (push_with_delay) since the reactor only re-dispatches on a positive
+        //   balance; an orphan skip relies on that next positive-balance poll.
+        // - Err(other): propagate; guard drops, restoring prior state.
+        match result {
+            Ok(()) => {
+                guard.release();
+                Ok(())
+            }
+            Err(UnwrappedEquityRecoveryJobError::NoBalanceSkip { symbol: ref sym }) => {
+                // No unwrapped balance to drain this cycle. The reactor only
+                // re-dispatches recovery on a POSITIVE balance, so a
+                // HeldForRecovery-origin claim that simply drops here would
+                // restore HeldForRecovery with no job left to drain it --
+                // wedging the symbol if the tokens left the wallet out of band.
+                // Re-enqueue with a delay to keep polling. An orphan claim
+                // instead drops to absent, so the next positive-balance poll
+                // re-triggers it without help.
+                if guard.claimed_from_held_for_recovery() {
+                    debug!(
+                        target: "rebalance",
+                        symbol = %sym,
+                        recovery_id = %self.recovery_id,
+                        "Rescheduling unwrapped equity recovery: no balance yet but slot is \
+                         HeldForRecovery; re-enqueueing with delay to keep polling until the \
+                         balance resolves or the slot is cleared",
+                    );
+                    ctx.queue
+                        .clone()
+                        .push_with_delay(self.clone(), ctx.reschedule_interval)
+                        .await?;
+                } else {
+                    info!(
+                        target: "rebalance",
+                        symbol = %sym,
+                        "Unwrapped equity recovery: no balance in inventory view; orphan \
+                         claim, guard drop removes the entry; next positive-balance poll \
+                         re-dispatches",
+                    );
+                }
+                Ok(())
+            }
+            Err(other) => Err(other),
+        }
     }
 }
 
@@ -236,9 +299,15 @@ async fn start_from_detect(
             target: "rebalance",
             %symbol,
             %recovery_id,
-            "Skipping unwrapped equity recovery: no positive balance in inventory view",
+            "Skipping unwrapped equity recovery: no positive balance in inventory view; \
+             guard drop restores HeldForRecovery or removes orphan entry",
         );
-        return Ok(());
+        // Return Err so the caller does NOT call guard.release(). Drop restores
+        // HeldForRecovery (if claimed from handoff) or removes the entry (orphan),
+        // letting the next inventory poll re-trigger recovery once tokens are visible.
+        return Err(UnwrappedEquityRecoveryJobError::NoBalanceSkip {
+            symbol: symbol.clone(),
+        });
     };
 
     validate_active_aggregate_quantity(ctx, symbol, &snapshot).await?;
@@ -426,7 +495,8 @@ fn is_business_validation_error(error: &UnwrappedEquityRecoveryJobError) -> bool
         | UnwrappedEquityRecoveryJobError::Domain(_)
         | UnwrappedEquityRecoveryJobError::ActiveMintAggregate(_)
         | UnwrappedEquityRecoveryJobError::ActiveRedemptionAggregate(_)
-        | UnwrappedEquityRecoveryJobError::Reschedule(_) => false,
+        | UnwrappedEquityRecoveryJobError::Reschedule(_)
+        | UnwrappedEquityRecoveryJobError::NoBalanceSkip { .. } => false,
     }
 }
 
@@ -619,51 +689,6 @@ fn decide_dispatch(view: &InventoryView, symbol: &Symbol) -> DispatchDecision {
     }
 }
 
-/// RAII helper that inserts `symbol` into `equity_in_progress` and removes
-/// it on drop. Returns `None` if another task already holds the guard.
-struct InProgressGuard {
-    symbol: Symbol,
-    set: Arc<RwLock<HashSet<Symbol>>>,
-}
-
-impl Drop for InProgressGuard {
-    fn drop(&mut self) {
-        let mut guard = match self.set.write() {
-            Ok(guard) => guard,
-            Err(poisoned) => {
-                warn!(
-                    symbol = %self.symbol,
-                    "equity_in_progress lock poisoned during drop; releasing entry from inner guard"
-                );
-                poisoned.into_inner()
-            }
-        };
-        guard.remove(&self.symbol);
-    }
-}
-
-fn claim_guard(set: &Arc<RwLock<HashSet<Symbol>>>, symbol: &Symbol) -> Option<InProgressGuard> {
-    let mut guard = match set.write() {
-        Ok(guard) => guard,
-        Err(poisoned) => {
-            warn!(
-                %symbol,
-                "equity_in_progress lock poisoned; recovering inner guard so future recovery attempts can proceed"
-            );
-            poisoned.into_inner()
-        }
-    };
-    if guard.contains(symbol) {
-        return None;
-    }
-    guard.insert(symbol.clone());
-    drop(guard);
-    Some(InProgressGuard {
-        symbol: symbol.clone(),
-        set: Arc::clone(set),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, B256, TxHash, U256};
@@ -682,6 +707,7 @@ mod tests {
     };
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
+    use crate::rebalancing::trigger::InProgressGuard;
     use crate::tokenization::Tokenizer;
     use crate::tokenization::mock::{MockCompletionOutcome, MockDetectionOutcome, MockTokenizer};
     use crate::tokenized_equity_mint::{
@@ -699,10 +725,10 @@ mod tests {
     }
 
     /// Builds a fully-wired recovery ctx around the given inventory view and
-    /// in-progress set, with every service backed by a succeeding mock.
+    /// in-progress map, with every service backed by a succeeding mock.
     async fn test_ctx(
         view: InventoryView,
-        equity_in_progress: HashSet<Symbol>,
+        equity_in_progress: HashMap<Symbol, GuardState>,
     ) -> UnwrappedEquityRecoveryCtx {
         test_ctx_with_tokenizer(view, equity_in_progress, Arc::new(MockTokenizer::new())).await
     }
@@ -712,7 +738,7 @@ mod tests {
     /// outcome.
     async fn test_ctx_with_tokenizer(
         view: InventoryView,
-        equity_in_progress: HashSet<Symbol>,
+        equity_in_progress: HashMap<Symbol, GuardState>,
         tokenizer: Arc<dyn Tokenizer>,
     ) -> UnwrappedEquityRecoveryCtx {
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
@@ -783,7 +809,10 @@ mod tests {
     #[tokio::test]
     async fn guard_contention_reschedules_without_halting_the_bot() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let equity_in_progress = Arc::new(RwLock::new(HashSet::from([symbol.clone()])));
+        let equity_in_progress = Arc::new(RwLock::new(HashMap::from([(
+            symbol.clone(),
+            GuardState::ActiveTransfer { generation: 0 },
+        )])));
 
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
@@ -924,7 +953,7 @@ mod tests {
             store,
             mint_store,
             redemption_store,
-            equity_in_progress: Arc::new(RwLock::new(HashSet::new())),
+            equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
             queue: UnwrappedEquityRecoveryJobQueue::new(&apalis_pool),
             reschedule_interval: Duration::from_secs(1),
         };
@@ -1054,36 +1083,101 @@ mod tests {
     }
 
     #[test]
-    fn claim_guard_blocks_second_claim_and_releases_on_drop() {
+    fn claim_guard_for_recovery_or_orphan_blocks_active_transfer_and_releases_on_drop() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let set = Arc::new(RwLock::new(HashSet::new()));
+        let map = Arc::new(RwLock::new(HashMap::new()));
 
-        let guard = claim_guard(&set, &symbol).expect("first claim should succeed");
+        // Absent -> succeeds (orphan path).
+        let guard = claim_guard_for_recovery_or_orphan(&map, &symbol)
+            .expect("absent entry: first claim should succeed");
         assert!(
-            set.read().unwrap().contains(&symbol),
-            "claiming should insert the symbol into the in-progress set",
+            matches!(
+                map.read().unwrap().get(&symbol),
+                Some(GuardState::ActiveTransfer { .. })
+            ),
+            "claiming from absent must insert ActiveTransfer",
         );
 
-        let contended = claim_guard(&set, &symbol);
+        // ActiveTransfer -> blocks.
+        let contended = claim_guard_for_recovery_or_orphan(&map, &symbol);
         assert!(
             contended.is_none(),
-            "a second claim while the guard is held must return None",
+            "a second claim while ActiveTransfer must return None",
         );
 
         drop(guard);
         assert!(
-            !set.read().unwrap().contains(&symbol),
-            "dropping the guard must remove the symbol from the in-progress set",
+            !map.read().unwrap().contains_key(&symbol),
+            "dropping the guard must remove the symbol from the in-progress map",
         );
 
-        claim_guard(&set, &symbol).expect("claim should succeed again once released");
+        // After drop, absent again -> succeeds.
+        claim_guard_for_recovery_or_orphan(&map, &symbol)
+            .expect("claim should succeed again once released");
+    }
+
+    #[test]
+    fn claim_guard_for_recovery_or_orphan_succeeds_from_held_for_recovery() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let map = Arc::new(RwLock::new(HashMap::from([(
+            symbol.clone(),
+            GuardState::HeldForRecovery,
+        )])));
+
+        let guard = claim_guard_for_recovery_or_orphan(&map, &symbol)
+            .expect("HeldForRecovery must allow claim");
+        assert!(
+            matches!(
+                map.read().unwrap().get(&symbol),
+                Some(GuardState::ActiveTransfer { .. })
+            ),
+            "HeldForRecovery claim must transition to ActiveTransfer",
+        );
+
+        // Drop restores to HeldForRecovery (not removes) so recovery retries
+        // can proceed but a new transfer job cannot start while tokens are
+        // still stranded.
+        drop(guard);
+        assert_eq!(
+            map.read().unwrap().get(&symbol),
+            Some(&GuardState::HeldForRecovery),
+            "dropping guard claimed from HeldForRecovery must restore to HeldForRecovery, \
+             not remove, so recovery retries are not blocked",
+        );
+    }
+
+    /// When the guard drops back to `HeldForRecovery` after a recovery failure,
+    /// a new transfer claim must be blocked (no double-mint while tokens are stranded).
+    #[test]
+    fn recovery_guard_drop_to_held_for_recovery_blocks_new_transfer_claim() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let map = Arc::new(RwLock::new(HashMap::from([(
+            symbol.clone(),
+            GuardState::HeldForRecovery,
+        )])));
+
+        let guard = claim_guard_for_recovery_or_orphan(&map, &symbol)
+            .expect("HeldForRecovery must allow claim");
+        drop(guard);
+
+        // The slot is now HeldForRecovery; a new transfer claim must fail.
+        assert_eq!(
+            map.read().unwrap().get(&symbol),
+            Some(&GuardState::HeldForRecovery),
+        );
+
+        // Verify the restored HeldForRecovery actually blocks a new transfer claim.
+        assert!(
+            InProgressGuard::try_claim_for_transfer(symbol, Arc::clone(&map)).is_none(),
+            "HeldForRecovery restored by Drop must block new transfer claims (prevents double-mint)"
+        );
     }
 
     #[tokio::test]
     async fn read_recovery_snapshot_skips_zero_and_absent_balance() {
         let symbol = Symbol::new("AAPL").unwrap();
 
-        let absent = test_ctx(InventoryView::default(), HashSet::new()).await;
+        let absent = test_ctx(InventoryView::default(), HashMap::new()).await;
         assert!(
             read_recovery_snapshot(&absent.inventory, &symbol)
                 .await
@@ -1093,7 +1187,7 @@ mod tests {
 
         let zero = test_ctx(
             view_with_unwrapped_balance(&symbol, FractionalShares::ZERO),
-            HashSet::new(),
+            HashMap::new(),
         )
         .await;
         assert!(
@@ -1105,7 +1199,7 @@ mod tests {
 
         let positive = test_ctx(
             view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5))),
-            HashSet::new(),
+            HashMap::new(),
         )
         .await;
         let snapshot = read_recovery_snapshot(&positive.inventory, &symbol)
@@ -1122,7 +1216,7 @@ mod tests {
     async fn validate_active_mint_quantity_accepts_exact_match() {
         let symbol = Symbol::new("AAPL").unwrap();
         let mint_id = issuer_request_id("ISS001");
-        let ctx = test_ctx(InventoryView::default(), HashSet::new()).await;
+        let ctx = test_ctx(InventoryView::default(), HashMap::new()).await;
 
         ctx.mint_store
             .send(
@@ -1150,7 +1244,7 @@ mod tests {
     async fn validate_active_mint_quantity_rejects_mismatch() {
         let symbol = Symbol::new("AAPL").unwrap();
         let mint_id = issuer_request_id("ISS001");
-        let ctx = test_ctx(InventoryView::default(), HashSet::new()).await;
+        let ctx = test_ctx(InventoryView::default(), HashMap::new()).await;
 
         ctx.mint_store
             .send(
@@ -1185,7 +1279,7 @@ mod tests {
     async fn validate_active_redemption_reports_missing_aggregate() {
         let symbol = Symbol::new("AAPL").unwrap();
         let redemption_id = redemption_aggregate_id("RED-NONEXISTENT");
-        let ctx = test_ctx(InventoryView::default(), HashSet::new()).await;
+        let ctx = test_ctx(InventoryView::default(), HashMap::new()).await;
 
         let snapshot = RecoverySnapshot {
             shares: FractionalShares::new(float!(5)),
@@ -1211,7 +1305,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let ctx = test_ctx(
             view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5))),
-            HashSet::new(),
+            HashMap::new(),
         )
         .await;
         let job = UnwrappedEquityRecoveryJob {
@@ -1236,7 +1330,7 @@ mod tests {
         let mint_id = issuer_request_id("missing-mint");
         let view = view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5)))
             .set_active_mint(symbol.clone(), mint_id);
-        let ctx = test_ctx(view, HashSet::new()).await;
+        let ctx = test_ctx(view, HashMap::new()).await;
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
@@ -1264,7 +1358,7 @@ mod tests {
     #[tokio::test]
     async fn perform_skips_when_inventory_reports_no_balance() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let ctx = test_ctx(InventoryView::default(), HashSet::new()).await;
+        let ctx = test_ctx(InventoryView::default(), HashMap::new()).await;
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
@@ -1279,6 +1373,68 @@ mod tests {
             state.is_none(),
             "no inventory balance must not start a recovery aggregate, got {state:?}",
         );
+
+        // Orphan-origin (absent guard) no-balance skip must NOT self-reschedule:
+        // the slot drops to absent and the reactor re-triggers on the next
+        // positive-balance poll. Only a HeldForRecovery-origin skip reschedules.
+        let (rescheduled,): (i64,) =
+            sqlx_apalis::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                .bind(std::any::type_name::<UnwrappedEquityRecoveryJob>())
+                .fetch_one(ctx.queue.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            rescheduled, 0,
+            "an orphan no-balance skip must NOT reschedule; the reactor re-triggers on next poll",
+        );
+    }
+
+    /// When `start_from_detect` returns `NoBalanceSkip` and the guard was claimed
+    /// from `HeldForRecovery`, Drop restores the slot to `HeldForRecovery` AND the
+    /// job must self-reschedule with a delay. The inventory reactor only
+    /// re-dispatches on a positive balance, so without the reschedule a slot whose
+    /// tokens left the wallet out of band would wedge with no job to drain it.
+    #[tokio::test]
+    async fn perform_no_balance_skip_restores_held_for_recovery_and_reschedules() {
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        // Inventory reports zero balance for the symbol (no tokens in wallet).
+        let ctx = test_ctx(
+            InventoryView::default(),
+            HashMap::from([(symbol.clone(), GuardState::HeldForRecovery)]),
+        )
+        .await;
+
+        let job = UnwrappedEquityRecoveryJob {
+            symbol: symbol.clone(),
+            recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
+        };
+
+        // Must return Ok(()) -- no apalis retry.
+        job.perform(&ctx)
+            .await
+            .expect("no-balance skip must return Ok");
+
+        // Guard must be restored to HeldForRecovery (Drop behavior for
+        // HeldForRecovery origin without release()).
+        assert_eq!(
+            ctx.equity_in_progress.read().unwrap().get(&symbol),
+            Some(&GuardState::HeldForRecovery),
+            "no-balance skip from HeldForRecovery claim must restore to HeldForRecovery"
+        );
+
+        // A delayed job must have been enqueued so polling continues until the
+        // balance resolves or the slot is cleared.
+        let (rescheduled,): (i64,) =
+            sqlx_apalis::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                .bind(std::any::type_name::<UnwrappedEquityRecoveryJob>())
+                .fetch_one(ctx.queue.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            rescheduled, 1,
+            "a HeldForRecovery-origin no-balance skip must enqueue a delayed job to keep polling",
+        );
     }
 
     #[tokio::test]
@@ -1286,7 +1442,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let ctx = test_ctx(
             view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5))),
-            HashSet::new(),
+            HashMap::new(),
         )
         .await;
         let recovery_id = UnwrappedEquityRecoveryId(Uuid::new_v4());
@@ -1341,7 +1497,7 @@ mod tests {
         let view = view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5)))
             .set_active_mint(symbol.clone(), mint_id.clone())
             .set_active_redemption(symbol.clone(), redemption_id.clone());
-        let ctx = test_ctx(view, HashSet::new()).await;
+        let ctx = test_ctx(view, HashMap::new()).await;
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
@@ -1366,7 +1522,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let ctx = test_ctx(
             view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5))),
-            HashSet::new(),
+            HashMap::new(),
         )
         .await;
         let recovery_id = UnwrappedEquityRecoveryId(Uuid::new_v4());
@@ -1405,7 +1561,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let ctx = test_ctx(
             view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(3))),
-            HashSet::new(),
+            HashMap::new(),
         )
         .await;
         let recovery_id = UnwrappedEquityRecoveryId(Uuid::new_v4());
@@ -1446,7 +1602,7 @@ mod tests {
     #[tokio::test]
     async fn perform_resume_from_detected_with_zero_balance_fails_aggregate() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let ctx = test_ctx(InventoryView::default(), HashSet::new()).await;
+        let ctx = test_ctx(InventoryView::default(), HashMap::new()).await;
         let recovery_id = UnwrappedEquityRecoveryId(Uuid::new_v4());
 
         ctx.store
@@ -1487,7 +1643,7 @@ mod tests {
         let mint_id = issuer_request_id("ISS001");
         let view = view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5)))
             .set_active_mint(symbol.clone(), mint_id.clone());
-        let ctx = test_ctx(view, HashSet::new()).await;
+        let ctx = test_ctx(view, HashMap::new()).await;
 
         // Seed the mint to `TokensWrapped` so `resume_mint` runs to completion
         // under the succeeding mocks:
@@ -1572,7 +1728,7 @@ mod tests {
                 .with_detection_outcome(MockDetectionOutcome::Detected)
                 .with_completion_outcome(MockCompletionOutcome::Completed),
         );
-        let ctx = test_ctx_with_tokenizer(view, HashSet::new(), tokenizer).await;
+        let ctx = test_ctx_with_tokenizer(view, HashMap::new(), tokenizer).await;
 
         // Seed the redemption at `VaultWithdrawSubmitted` (Redeem submits the
         // withdrawal); `resume_redemption` walks it to `Completed` under the
@@ -1628,7 +1784,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let ctx = test_ctx(
             view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5))),
-            HashSet::new(),
+            HashMap::new(),
         )
         .await;
         let recovery_id = UnwrappedEquityRecoveryId(Uuid::new_v4());
@@ -1686,7 +1842,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let ctx = test_ctx(
             view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5))),
-            HashSet::new(),
+            HashMap::new(),
         )
         .await;
         let recovery_id = UnwrappedEquityRecoveryId(Uuid::new_v4());
@@ -1751,7 +1907,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let ctx = test_ctx(
             view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5))),
-            HashSet::new(),
+            HashMap::new(),
         )
         .await;
         let recovery_id = UnwrappedEquityRecoveryId(Uuid::new_v4());

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -9,9 +9,10 @@
 //!
 //! Steps:
 //!
-//! 1. Claim the `equity_in_progress` guard for the symbol. If another task
-//!    already holds it, the job reschedules itself with a delay so an
-//!    unchanged wallet balance is not stranded waiting for another snapshot.
+//! 1. Claim the `equity_in_progress` guard for the symbol (from absent or
+//!    `HeldForRecovery`). If a live transfer owns it (`ActiveTransfer`), the
+//!    job reschedules itself with a delay so an unchanged wallet balance is
+//!    not stranded waiting for another snapshot.
 //! 2. Read the inventory view's wallet balance + active mint/redemption
 //!    maps to pick a `DispatchDecision`.
 //! 3. Send `Detect` followed by the path-specific command sequence:
@@ -25,7 +26,7 @@
 //! the previous attempt stopped.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use thiserror::Error;
@@ -42,6 +43,7 @@ use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::equity_redemption::{EquityRedemption, RedemptionAggregateId};
 use crate::inventory::BroadcastingInventory;
 use crate::inventory::view::{InFlightEquityLocation, InventoryView};
+use crate::rebalancing::trigger::{GuardState, claim_guard_for_recovery_or_orphan};
 use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMint};
 
 /// Apalis queue type for [`WrappedEquityRecoveryJob`].
@@ -55,7 +57,7 @@ pub(crate) struct WrappedEquityRecoveryCtx {
     pub(crate) store: Arc<Store<WrappedEquityRecovery>>,
     pub(crate) mint_store: Arc<Store<TokenizedEquityMint>>,
     pub(crate) redemption_store: Arc<Store<EquityRedemption>>,
-    pub(crate) equity_in_progress: Arc<RwLock<HashSet<Symbol>>>,
+    pub(crate) equity_in_progress: Arc<RwLock<HashMap<Symbol, GuardState>>>,
     /// Queue used for delayed self-reschedule when the shared equity guard is
     /// held by another recovery/transfer job.
     pub(crate) queue: WrappedEquityRecoveryJobQueue,
@@ -162,12 +164,25 @@ impl Job<WrappedEquityRecoveryCtx> for WrappedEquityRecoveryJob {
     async fn perform(&self, ctx: &WrappedEquityRecoveryCtx) -> Result<Self::Output, Self::Error> {
         let symbol = self.symbol.clone();
 
-        let Some(guard) = claim_guard(&ctx.equity_in_progress, &symbol) else {
+        // Two-path claim: this job handles a positive `BaseWalletWrapped`
+        // balance, which can be either an orphan (absent guard) or the
+        // landed-but-unconfirmed `WrapSubmitted` outcome -- the wrap tx
+        // actually landed so the tokens are WRAPPED, but the confirmation read
+        // failed and the transfer job handed the slot to recovery as
+        // `HeldForRecovery`. Claiming `HeldForRecovery` here is what drains that
+        // slot; refusing it (as the old orphan-only claim did) left it wedged
+        // because `UnwrappedEquityRecovery` `NoBalanceSkip`s on a wrapped
+        // balance. The atomic claim makes a concurrent `UnwrappedEquityRecovery`
+        // claim safe -- only one wins, the other reschedules. Returns None only
+        // for `ActiveTransfer` (a live transfer job owns the slot).
+        let Some(guard) = claim_guard_for_recovery_or_orphan(&ctx.equity_in_progress, &symbol)
+        else {
             debug!(
                 target: "rebalance",
                 %symbol,
                 recovery_id = %self.recovery_id,
-                "Rescheduling wrapped equity recovery: equity_in_progress already held",
+                "Rescheduling wrapped equity recovery: equity_in_progress held by \
+                 active transfer; deferring",
             );
             ctx.queue
                 .clone()
@@ -185,18 +200,41 @@ impl Job<WrappedEquityRecoveryCtx> for WrappedEquityRecoveryJob {
                 recovery_id = %self.recovery_id,
                 "Skipping wrapped equity recovery: aggregate already terminal",
             );
-            drop(guard);
+            guard.release();
             return Ok(());
         }
 
         let Some(snapshot) = read_recovery_snapshot(&ctx.inventory, &symbol).await else {
-            debug!(
-                target: "rebalance",
-                %symbol,
-                recovery_id = %self.recovery_id,
-                "Skipping wrapped equity recovery: no positive balance in inventory view",
-            );
-            drop(guard);
+            // No wrapped balance to drain this cycle. Do NOT release the guard:
+            // an orphan claim drops to absent (the reactor re-triggers on the
+            // next positive-balance poll), while a `HeldForRecovery` claim drops
+            // back to `HeldForRecovery`. The reactor only re-dispatches on a
+            // POSITIVE balance, so a `HeldForRecovery`-origin claim that finds
+            // zero balance must self-reschedule or the slot wedges with no job
+            // left to drain it.
+            if guard.claimed_from_held_for_recovery() {
+                debug!(
+                    target: "rebalance",
+                    %symbol,
+                    recovery_id = %self.recovery_id,
+                    "Rescheduling wrapped equity recovery: no positive balance yet but slot \
+                     is HeldForRecovery; re-enqueueing with delay to keep polling until the \
+                     balance resolves or the slot is cleared",
+                );
+                ctx.queue
+                    .clone()
+                    .push_with_delay(self.clone(), ctx.reschedule_interval)
+                    .await?;
+            } else {
+                debug!(
+                    target: "rebalance",
+                    %symbol,
+                    recovery_id = %self.recovery_id,
+                    "Skipping wrapped equity recovery: no positive balance in inventory view; \
+                     orphan claim, guard drop removes entry so future inventory polls can \
+                     re-trigger recovery",
+                );
+            }
             return Ok(());
         };
 
@@ -209,7 +247,9 @@ impl Job<WrappedEquityRecoveryCtx> for WrappedEquityRecoveryJob {
                 "Wrapped equity recovery: active aggregate quantity mismatch; \
                  skipping dispatch",
             );
-            drop(guard);
+            // Validation failure is a retryable error: guard drops normally,
+            // restoring its claim origin (orphan removes the entry;
+            // HeldForRecovery restores HeldForRecovery for the next retry).
             return Err(error);
         }
 
@@ -285,15 +325,24 @@ impl Job<WrappedEquityRecoveryCtx> for WrappedEquityRecoveryJob {
                         WrappedEquityRecoveryCommand::FailRecovery { reason },
                     )
                     .await?;
-                Err(WrappedEquityRecoveryJobError::ConflictingActiveTransfers {
+                // Aggregate is now terminal (FailRecovery). Release the guard
+                // directly here so future transfers are not permanently blocked.
+                guard.release();
+                return Err(WrappedEquityRecoveryJobError::ConflictingActiveTransfers {
                     symbol: symbol.clone(),
                     mint_id,
                     redemption_id,
-                })
+                });
             }
         };
 
-        drop(guard);
+        // Release the guard on success (removes the slot). On non-terminal
+        // failure, the guard drops normally: an orphan-origin claim removes the
+        // entry, while a HeldForRecovery-origin claim restores HeldForRecovery
+        // for a later recovery attempt.
+        if result.is_ok() {
+            guard.release();
+        }
         result
     }
 }
@@ -399,51 +448,6 @@ fn decide_dispatch(view: &InventoryView, symbol: &Symbol) -> DispatchDecision {
     }
 }
 
-/// RAII helper that inserts `symbol` into `equity_in_progress` and removes
-/// it on drop. Returns `None` if another task already holds the guard.
-struct InProgressGuard {
-    symbol: Symbol,
-    set: Arc<RwLock<HashSet<Symbol>>>,
-}
-
-impl Drop for InProgressGuard {
-    fn drop(&mut self) {
-        let mut guard = match self.set.write() {
-            Ok(guard) => guard,
-            Err(poisoned) => {
-                warn!(
-                    symbol = %self.symbol,
-                    "equity_in_progress lock poisoned during drop; releasing entry from inner guard"
-                );
-                poisoned.into_inner()
-            }
-        };
-        guard.remove(&self.symbol);
-    }
-}
-
-fn claim_guard(set: &Arc<RwLock<HashSet<Symbol>>>, symbol: &Symbol) -> Option<InProgressGuard> {
-    let mut guard = match set.write() {
-        Ok(guard) => guard,
-        Err(poisoned) => {
-            warn!(
-                %symbol,
-                "equity_in_progress lock poisoned; recovering inner guard so future recovery attempts can proceed"
-            );
-            poisoned.into_inner()
-        }
-    };
-    if guard.contains(symbol) {
-        return None;
-    }
-    guard.insert(symbol.clone());
-    drop(guard);
-    Some(InProgressGuard {
-        symbol: symbol.clone(),
-        set: Arc::clone(set),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use alloy::primitives::Address;
@@ -467,7 +471,10 @@ mod tests {
     #[tokio::test]
     async fn guard_contention_reschedules_without_dropping_the_recovery() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let equity_in_progress = Arc::new(RwLock::new(HashSet::from([symbol.clone()])));
+        let equity_in_progress = Arc::new(RwLock::new(HashMap::from([(
+            symbol.clone(),
+            GuardState::ActiveTransfer { generation: 0 },
+        )])));
 
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 


### PR DESCRIPTION
## What

- Breaks the COIN equity rebalance deadlock where a mint that succeeded but failed to wrap/deposit left the `equity_in_progress` guard set in a way that blocked its own recovery job, freezing rebalancing indefinitely.
- Replaces the boolean `equity_in_progress` set with a `GuardState` enum (`ActiveTransfer { generation }` | `HeldForRecovery`) so "held by a live transfer" and "held for recovery hand-off" are distinct, representable states.
- Makes the mint-succeeded-but-wrap-failed state self-heal: the stranded tokens get wrapped + deposited by the recovery job and the guard is released, with no manual intervention.

Closes [RAI-1070](https://linear.app/makeitrain/issue/RAI-1070/coin-equity-rebalance-deadlock-equity-in-progress-guard-kept-for).

## Why

- On prod (2026-06-16) a 15.52 COIN mint succeeded, the follow-up ERC-4626 wrap reverted (stale-RPC class), and the flow kept the guard set "for recovery" — but `UnwrappedEquityRecovery`'s precondition was that the guard is *not* held, so it rescheduled forever. The guard and its own recovery were mutually exclusive.
- This deadlock is a distinct latent bug reachable from any wrap failure after a successful mint, independent of the stale-RPC trigger fixed in the parent PR.

## How

- **Hand-off on failure (`rebalancing/equity/job.rs`):** on a transfer-job `PostReceipt` error, if the mint aggregate is in a pre-wrap state (`TokensReceived`/`WrapSubmitted`) and recovery is enabled for the symbol, transition the guard `ActiveTransfer -> HeldForRecovery` and return `Ok(())` so the periodic `UnwrappedEquityRecovery` job can take over. `mark_held_for_recovery` returns a `MarkHeldResult` enum and is generation-checked so it never clobbers a newer transfer's claim.
- **Deposit stage unchanged:** `TokensWrapped`/`VaultDepositSubmitted` are excluded from the hand-off and keep using apalis retry of the idempotent `resume_mint` — avoiding double-submitted deposits and startup double-drive.
- **Config-aware:** when `wrapped_equity_recovery` is disabled (the default in example/e2e configs) there is no recovery job to hand off to, so `PostReceipt` propagates `Err` and apalis retries as before — no silently-stranded tokens.
- **Guard lifecycle (`rebalancing/trigger/equity.rs`):** `RecoveryGuard` is an RAII claim with origin tracking. `UnwrappedEquityRecovery` claims a `HeldForRecovery` or absent (orphan) slot; `WrappedEquityRecovery` is orphan-only. The guard is `release()`d only on successful terminal recovery; on any failure/skip its `Drop` restores the prior state (`HeldForRecovery` stays blocking new transfers, preventing double-mint). A `generation` counter on `ActiveTransfer` prevents an ABA where a stale guard drop clobbers a fresh transfer's claim.
- **Timeout sweeper (`rebalancing/trigger/mod.rs`):** `expire_stuck_mints` skips `HeldForRecovery` mints (recovery owns them) under a single atomic write-lock, so a concurrent hand-off can't be raced into a spurious `FailWrapping`. `ActiveTransfer` mints still time out as before.
- **Startup (`conductor.rs`):** interrupted pre-wrap mints whose guard is `HeldForRecovery` are excluded from direct resume (recovery owns them); deposit-stage mints are resumed directly.
- The new `generation` field on the `TransferEquityToMarketMaking` job payload uses `#[serde(default)]` so already-queued jobs deserialize unchanged.

## Testing

- Unit tests: guard-state transitions, generation-mismatch no-op, `mark_held_for_recovery` outcomes, `RecoveryGuard` release-vs-restore on success/failure/orphan, config-disabled `Err` propagation, and the `expire_stuck_mints` `HeldForRecovery` skip.
- Integration tests: the production deadlock-break path (wrap-failed -> `HeldForRecovery` -> `UnwrappedEquityRecovery` re-wraps, deposits, and releases the guard rather than rescheduling forever), `WrappedEquityRecovery` rescheduling when the slot is held for recovery, and startup reconstruction across all four post-receipt states.
- Verified locally: full `st0x-hedge` test suite green and `cargo clippy -p st0x-hedge --all-targets` clean.

## Anything else

- Redemption-side timeout handling of `HeldForRecovery` is out of scope (this PR covers the equity mint/rebalance guard); flagged for a potential follow-up.
- Stacked on the RAI-1069 stale-RPC fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race conditions between concurrent transfer and wrapped/unwrapped recovery for the same equity symbol.
  * Prevented transfers from starting when a symbol is reserved for recovery, avoiding double-mint conflicts.
  * Improved startup recovery by selectively resuming only safe interrupted mints and skipping pre-wrap states held for recovery.
  * Enhanced wrap-failed and no-balance recovery handling, including correct rescheduling behavior until balances appear and safe guard release on completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->