### PR TITLE
fix: run interrupted-tokenization resume off the startup path

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -6,6 +6,7 @@ mod exit;
 pub(crate) mod job;
 mod manifest;
 pub(crate) mod monitor;
+mod trading_queues;
 
 use alloy::primitives::Address;
 use alloy::providers::{Provider, ProviderBuilder};
@@ -48,9 +49,8 @@ use crate::inventory::{
     BroadcastingInventory, Inventory, InventoryProjection, InventorySnapshot, Venue,
 };
 use crate::offchain::order::{
-    ExecutorOrderPlacer, HandleOrderRejectionJobQueue, OffchainOrder, OffchainOrderCommand,
-    OffchainOrderId, OrderPlacer, PollOrderStatus, PollOrderStatusJobQueue,
-    ReconcileOrderFillJobQueue, recover_submitted_offchain_orders,
+    ExecutorOrderPlacer, OffchainOrder, OffchainOrderCommand, OffchainOrderId, OrderPlacer,
+    PollOrderStatus, PollOrderStatusJobQueue,
 };
 use crate::onchain::OnchainTrade;
 use crate::onchain::USDC_BASE;
@@ -62,10 +62,10 @@ use crate::onchain::backfill::BackfillJobQueue;
 use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vaults_from_clear};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeError, OnChainTradeId};
 use crate::position::{Position, PositionCommand, PositionError, TradeId};
-use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
 use crate::rebalancing::equity::{
-    CrossVenueEquityTransfer, EquityTransferServices, TransferEquityToHedgingCtx,
-    TransferEquityToMarketMakingCtx,
+    CrossVenueEquityTransfer, EquityTransferServices, ResumeTokenizationAggregate,
+    ResumeTokenizationCtx, ResumeTokenizationJobQueue, ResumeTokenizationTarget,
+    TransferEquityToHedgingCtx, TransferEquityToMarketMakingCtx,
 };
 use crate::rebalancing::trigger::GuardState;
 use crate::rebalancing::usdc::{
@@ -97,6 +97,7 @@ use crate::wrapped_equity_recovery::{
 
 pub(crate) use builder::CqrsFrameworks;
 use manifest::QueryManifest;
+use trading_queues::{EquityRecoveryInputs, TradingJobQueues, setup_trading_job_queues};
 
 /// CQRS/event-store and apalis worker pools over the same SQLite database.
 #[derive(Clone)]
@@ -448,10 +449,14 @@ impl Conductor {
             transfer_usdc_to_market_making_ctx,
             transfer_equity_to_market_making_ctx,
             transfer_equity_to_hedging_ctx,
+            resume_tokenization_queue,
         } = PositionAndRebalancing::setup(
             rebalancing,
             &ctx,
-            &pool,
+            &DatabasePools {
+                cqrs: pool.clone(),
+                apalis: apalis_pool.clone(),
+            },
             inventory.clone(),
             event_sender,
             vault_registry.clone(),
@@ -500,64 +505,32 @@ impl Conductor {
             snapshot,
         };
 
-        let hedge_queue = crate::conductor::job::JobQueue::new(&apalis_pool);
-        let mut poll_status_queue = PollOrderStatusJobQueue::new(&apalis_pool);
-        let reconcile_queue = ReconcileOrderFillJobQueue::new(&apalis_pool);
-        let rejection_queue = HandleOrderRejectionJobQueue::new(&apalis_pool);
-
-        // A previous process may have died mid-job anywhere on the
-        // fill-to-hedge path, leaving apalis `Running` rows no live worker
-        // owns. Reset them before the monitor spawns, exactly like the
-        // transfer/backfill/recovery queues above. Trade accounting is the
-        // one that cannot be recovered any other way: once the backfill
-        // checkpoint advances, its job row is the only record of the fill.
-        requeue_trading_orphans(&job_queue, "trade accounting").await?;
-        requeue_trading_orphans(&hedge_queue, "hedge placement").await?;
-        requeue_trading_orphans(&poll_status_queue, "order status polling").await?;
-        requeue_trading_orphans(&reconcile_queue, "order fill reconciliation").await?;
-        requeue_trading_orphans(&rejection_queue, "order rejection handling").await?;
-
-        let wrapped_equity_recovery_queue = WrappedEquityRecoveryJobQueue::new(&apalis_pool);
-        let unwrapped_equity_recovery_queue = UnwrappedEquityRecoveryJobQueue::new(&apalis_pool);
-
-        let wrapped_equity_recovery_ctx = build_wrapped_equity_recovery_ctx(
-            wrapped_equity_recovery_store,
-            rebalancing_service.clone(),
-            mint_store.clone(),
-            redemption_store.clone(),
-            inventory.clone(),
-            wrapped_equity_recovery_queue.clone(),
-            Duration::from_secs(ctx.inventory_poll_interval),
-        );
-
-        let unwrapped_equity_recovery_ctx = build_unwrapped_equity_recovery_ctx(
-            unwrapped_equity_recovery_store,
-            rebalancing_service.clone(),
-            mint_store,
-            redemption_store,
-            inventory.clone(),
-            unwrapped_equity_recovery_queue.clone(),
-            Duration::from_secs(ctx.inventory_poll_interval),
-        );
-
-        requeue_equity_recovery_orphans(
-            wrapped_equity_recovery_ctx.as_ref(),
-            unwrapped_equity_recovery_ctx.as_ref(),
-            &wrapped_equity_recovery_queue,
-            &unwrapped_equity_recovery_queue,
-        )
-        .await?;
-
-        let check_positions_queue = CheckPositionsJobQueue::new(&apalis_pool);
-
-        recover_submitted_offchain_orders(
+        let TradingJobQueues {
+            hedge_queue,
+            poll_status_queue,
+            reconcile_queue,
+            rejection_queue,
+            wrapped_equity_recovery_queue,
+            unwrapped_equity_recovery_queue,
+            wrapped_equity_recovery_ctx,
+            unwrapped_equity_recovery_ctx,
+            check_positions_queue,
+        } = setup_trading_job_queues(
+            &apalis_pool,
+            &job_queue,
+            EquityRecoveryInputs {
+                wrapped_store: wrapped_equity_recovery_store,
+                unwrapped_store: unwrapped_equity_recovery_store,
+                rebalancing_service: rebalancing_service.clone(),
+                mint_store: mint_store.clone(),
+                redemption_store: redemption_store.clone(),
+                inventory: inventory.clone(),
+                inventory_poll_interval: Duration::from_secs(ctx.inventory_poll_interval),
+            },
             &frameworks.offchain_order_projection,
-            &mut poll_status_queue,
             executor.to_supported_executor(),
         )
         .await?;
-
-        bootstrap_check_positions(&apalis_pool, &check_positions_queue).await?;
 
         let job_cleanup = spawn_finished_job_cleanup(
             pool.clone(),
@@ -583,6 +556,25 @@ impl Conductor {
         // Clone before the builder consumes it; the recovery handle needs the
         // rebalancing service to rebuild tracking during recheck recovery.
         let recovery_rebalancing_service = rebalancing_service.clone();
+
+        // Build ResumeTokenizationCtx only when BOTH the queue and the
+        // recovery_transfer are present (rebalancing enabled). zip() makes the
+        // dual-Some requirement explicit: if either is None the ctx is None,
+        // and the compiler flags any mismatch if one arm is accidentally set
+        // without the other.
+        let resume_tokenization_ctx = resume_tokenization_queue
+            .as_ref()
+            .zip(recovery_transfer.as_ref())
+            .map(|(_, transfer)| {
+                Arc::new(ResumeTokenizationCtx {
+                    transfer: transfer.clone(),
+                })
+            });
+
+        // Provide a fallback empty queue when rebalancing is disabled, so the
+        // builder always receives a concrete queue (it is never consumed).
+        let resume_tokenization_queue = resume_tokenization_queue
+            .unwrap_or_else(|| ResumeTokenizationJobQueue::new(&apalis_pool));
 
         let mut conductor = builder::spawn()
             .context(conductor_ctx)
@@ -610,6 +602,8 @@ impl Conductor {
             .maybe_rebalancing_service(rebalancing_service)
             .seed_vault_registry_queue(seed_vault_registry_queue)
             .seed_vault_registry_ctx(seed_vault_registry_ctx)
+            .resume_tokenization_queue(resume_tokenization_queue)
+            .maybe_resume_tokenization_ctx(resume_tokenization_ctx)
             .job_cleanup(job_cleanup)
             .call();
 
@@ -971,11 +965,13 @@ struct RebalancingInfrastructure {
     transfer_usdc_to_market_making_ctx: Arc<TransferUsdcToMarketMakingCtx>,
     transfer_equity_to_market_making_ctx: Arc<TransferEquityToMarketMakingCtx>,
     transfer_equity_to_hedging_ctx: Arc<TransferEquityToHedgingCtx>,
+    resume_tokenization_queue: ResumeTokenizationJobQueue,
 }
 
 /// Shared infrastructure dependencies needed to spawn rebalancing.
 struct RebalancingDeps {
     pool: SqlitePool,
+    apalis_pool: apalis_sqlite::SqlitePool,
     ctx: Ctx,
     inventory: Arc<BroadcastingInventory>,
     event_sender: broadcast::Sender<Statement>,
@@ -1004,19 +1000,23 @@ struct PositionAndRebalancing {
     transfer_usdc_to_market_making_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
     transfer_equity_to_market_making_ctx: Option<Arc<TransferEquityToMarketMakingCtx>>,
     transfer_equity_to_hedging_ctx: Option<Arc<TransferEquityToHedgingCtx>>,
+    resume_tokenization_queue: Option<ResumeTokenizationJobQueue>,
 }
 
 impl PositionAndRebalancing {
     async fn setup(
         rebalancing: Option<RebalancingCtx>,
         ctx: &Ctx,
-        pool: &SqlitePool,
+        pools: &DatabasePools,
         inventory: Arc<BroadcastingInventory>,
         event_sender: broadcast::Sender<Statement>,
         vault_registry: Arc<Store<VaultRegistry>>,
         vault_registry_projection: Arc<Projection<VaultRegistry>>,
         schedulers: RebalancingSchedulers,
     ) -> anyhow::Result<Self> {
+        let pool = &pools.cqrs;
+        let apalis_pool = &pools.apalis;
+
         if let Some(rebalancing_ctx) = rebalancing {
             let wallet_ctx = ctx.wallet()?;
             let ethereum_wallet = wallet_ctx.ethereum_wallet().clone();
@@ -1029,6 +1029,7 @@ impl PositionAndRebalancing {
                 base_wallet.clone(),
                 RebalancingDeps {
                     pool: pool.clone(),
+                    apalis_pool: apalis_pool.clone(),
                     ctx: ctx.clone(),
                     inventory: inventory.clone(),
                     event_sender,
@@ -1064,6 +1065,7 @@ impl PositionAndRebalancing {
                     infra.transfer_equity_to_market_making_ctx,
                 ),
                 transfer_equity_to_hedging_ctx: Some(infra.transfer_equity_to_hedging_ctx),
+                resume_tokenization_queue: Some(infra.resume_tokenization_queue),
             })
         } else {
             let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
@@ -1093,6 +1095,7 @@ impl PositionAndRebalancing {
                 transfer_usdc_to_market_making_ctx: None,
                 transfer_equity_to_market_making_ctx: None,
                 transfer_equity_to_hedging_ctx: None,
+                resume_tokenization_queue: None,
             })
         }
     }
@@ -1213,13 +1216,15 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             )
             .await?;
 
+        let mut resume_tokenization_queue = ResumeTokenizationJobQueue::new(&deps.apalis_pool);
+
         recover_interrupted_tokenization_aggregates(
             &deps.pool,
             &rebalancing_service,
             deps.inventory.as_ref(),
-            &recovery_transfer,
             built.mint.clone(),
             built.redemption.clone(),
+            &mut resume_tokenization_queue,
         )
         .await?;
 
@@ -1307,6 +1312,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             transfer_usdc_to_market_making_ctx,
             transfer_equity_to_market_making_ctx,
             transfer_equity_to_hedging_ctx,
+            resume_tokenization_queue,
         })
     })
 }
@@ -1388,14 +1394,53 @@ async fn recover_interrupted_tokenization_aggregates(
     pool: &SqlitePool,
     rebalancing_service: &RebalancingService,
     inventory: &BroadcastingInventory,
-    transfer: &CrossVenueEquityTransfer,
     mint_store: Arc<Store<TokenizedEquityMint>>,
     redemption_store: Arc<Store<EquityRedemption>>,
+    resume_queue: &mut ResumeTokenizationJobQueue,
 ) -> anyhow::Result<()> {
+    // First promote any Running/Queued orphans (from a previous process that
+    // crashed mid-job) back to Pending. Then discard ALL pending rows.
+    // Order matters: if cancel_all_pending ran first, the orphan-reset step
+    // would re-activate those rows as Pending AFTER the cancel, leaving
+    // duplicate Pending rows for the same aggregates.
+    //
+    // Intentionally soft-fail (warn, not ?) unlike every other orphan-requeue
+    // call at startup. Propagating would re-introduce the startup-gating that
+    // moving resume off the startup path removes: the whole point of the async
+    // resume worker is that a slow or failing issuer cannot block monitoring
+    // from starting.
+    //
+    // When requeue_orphaned fails, a Running orphan is NOT promoted to Pending
+    // and therefore survives the subsequent cancel_all_pending. The fresh push
+    // below then leaves a Running+Pending PAIR for the same aggregate, not a
+    // plain duplicate Pending. Because the resume worker uses a deterministic
+    // WORKER_NAME, a restarted process keeps the orphan's heartbeat fresh, so
+    // apalis never re-enqueues or re-executes that Running row -- it stays stuck,
+    // and only the fresh Pending row runs. This is safe ONLY because resume_mint
+    // and resume_redemption are idempotent: the fresh run redoes any side effect
+    // the crashed attempt left partially applied. Idempotency is a load-bearing
+    // invariant here -- any future non-idempotent side-effect in resume would
+    // break this design.
+    if let Err(error) = resume_queue.requeue_orphaned().await {
+        warn!(
+            target: "tokenization",
+            %error,
+            "Failed to reset orphaned resume-tokenization rows; a Running orphan \
+             from a crashed process survives as a stuck row (the deterministic \
+             worker keeps its heartbeat fresh, so apalis never re-runs it) while \
+             the fresh Pending job executes. Tolerated because resume is idempotent."
+        );
+    }
+    resume_queue.cancel_all_pending().await;
+
+    // If the process dies after cancel_all_pending() but before the first push()
+    // below, the interrupted aggregates have neither a Pending nor a Running row,
+    // so they are not resumed until the next restart re-derives them from the
+    // events table (interrupted_mint_ids / interrupted_redemption_ids read the
+    // event store, not the queue). This self-heals on reboot.
+
     let interrupted_mints = interrupted_mint_ids(pool).await?;
     let interrupted_redemptions = interrupted_redemption_ids(pool).await?;
-
-    let mut resume_mints = Vec::new();
 
     for mint_id in &interrupted_mints {
         let Some(mint) = mint_store.load(mint_id).await? else {
@@ -1415,8 +1460,16 @@ async fn recover_interrupted_tokenization_aggregates(
         // try to submit the wrap tx). TokensWrapped and VaultDepositSubmitted
         // mints are always safe to resume (vault deposit is idempotent and
         // the aggregate/inventory guard both converge to Done).
+        //
+        // If cancel_all_pending silently failed above, a stale Pending row for
+        // this aggregate may still exist. The duplicate Pending row is tolerated
+        // because resume_mint is idempotent.
         if !is_pre_wrap_held_for_recovery(&mint, &rebalancing_service.equity_in_progress) {
-            resume_mints.push(mint_id.clone());
+            resume_queue
+                .push(ResumeTokenizationAggregate {
+                    target: ResumeTokenizationTarget::Mint(mint_id.clone()),
+                })
+                .await?;
         }
     }
 
@@ -1430,10 +1483,18 @@ async fn recover_interrupted_tokenization_aggregates(
         rebalancing_service
             .recover_redemption_state(redemption_id, &redemption)
             .await?;
+
+        // If cancel_all_pending silently failed above, a stale Pending row for
+        // this aggregate may still exist. The duplicate Pending row is tolerated
+        // because resume_redemption is idempotent.
+        resume_queue
+            .push(ResumeTokenizationAggregate {
+                target: ResumeTokenizationTarget::Redemption(redemption_id.clone()),
+            })
+            .await?;
     }
 
     recover_stuck_redemptions(pool, inventory).await?;
-    resume_interrupted_transfers(transfer, &resume_mints, &interrupted_redemptions).await;
 
     Ok(())
 }
@@ -1461,47 +1522,6 @@ fn is_pre_wrap_held_for_recovery(
     } else {
         false
     }
-}
-
-async fn resume_interrupted_transfers(
-    transfer: &CrossVenueEquityTransfer,
-    interrupted_mints: &[crate::tokenized_equity_mint::IssuerRequestId],
-    interrupted_redemptions: &[crate::equity_redemption::RedemptionAggregateId],
-) {
-    let mut failed_mints = 0usize;
-    let mut failed_redemptions = 0usize;
-
-    for mint_id in interrupted_mints {
-        failed_mints += usize::from(
-            transfer
-                .resume_mint(mint_id)
-                .await
-                .inspect_err(|error| {
-                    error!(%mint_id, ?error, "Failed to resume mint -- skipping");
-                })
-                .is_err(),
-        );
-    }
-
-    for redemption_id in interrupted_redemptions {
-        failed_redemptions += usize::from(
-            transfer
-                .resume_redemption(redemption_id)
-                .await
-                .inspect_err(|error| {
-                    error!(%redemption_id, ?error, "Failed to resume redemption -- skipping");
-                })
-                .is_err(),
-        );
-    }
-
-    info!(
-        mint_count = interrupted_mints.len(),
-        redemption_count = interrupted_redemptions.len(),
-        failed_mints,
-        failed_redemptions,
-        "Interrupted tokenization transfer resume completed"
-    );
 }
 
 /// Recovers positions whose `pending_offchain_order_id` references an
@@ -2591,28 +2611,38 @@ mod tests {
     };
     use st0x_finance::{Usd, Usdc};
     use st0x_float_macro::float;
-    use st0x_wrapper::{MockWrapper, RATIO_ONE, UnderlyingPerWrapped};
+    use st0x_raindex::Raindex;
+    use st0x_wrapper::{MockWrapper, RATIO_ONE, UnderlyingPerWrapped, Wrapper};
 
     use super::*;
     use crate::bindings::IRaindexV6::{
         ClearConfigV2, ClearV3, EvaluableV4, IOV2, OrderV4, TakeOrderConfigV4, TakeOrderV3,
     };
     use crate::conductor::builder::CqrsFrameworks;
+    use crate::equity_redemption::{EquityRedemptionCommand, redemption_aggregate_id};
     use crate::inventory::view::Operator;
     use crate::inventory::{ImbalanceThreshold, Inventory, InventoryView, Venue};
     use crate::offchain::order::OrderPlacementResult;
+    use crate::onchain::mock::MockRaindex;
     use crate::onchain::trade::OnchainTrade;
-    use crate::rebalancing::equity::{TransferEquityToHedging, TransferEquityToMarketMaking};
+    use crate::rebalancing::equity::{
+        EquityTransferServices, ResumeTokenizationAggregate, ResumeTokenizationJobQueue,
+        ResumeTokenizationTarget, TransferEquityToHedging, TransferEquityToMarketMaking,
+    };
     use crate::rebalancing::{RebalancingSchedulers, RebalancingService};
     use crate::test_utils::{
         OnchainTradeBuilder, get_test_log, get_test_order, rebalancing_enabled_equities,
         setup_test_db, setup_test_pools,
     };
-    use crate::tokenized_equity_mint::{TokenizationRequestId, issuer_request_id};
+    use crate::tokenization::mock::MockTokenizer;
+    use crate::tokenized_equity_mint::{
+        TokenizationRequestId, TokenizedEquityMintCommand, issuer_request_id,
+    };
     use crate::trading::onchain::inclusion::EmittedOnChain;
     use crate::trading::onchain::trade_accountant::AccountForDexTrade;
     use crate::unwrapped_equity_recovery::UnwrappedEquityRecoveryJob;
     use crate::unwrapped_equity_recovery::aggregate::UnwrappedEquityRecoveryId;
+    use crate::vault_lookup::MockVaultLookup;
 
     fn one_to_one_ratio() -> UnderlyingPerWrapped {
         UnderlyingPerWrapped::new(RATIO_ONE).unwrap()
@@ -2683,6 +2713,592 @@ mod tests {
                 .unwrap();
         assert_eq!(status, Status::Pending.to_string());
         assert_eq!(lock_by, None);
+    }
+
+    struct InterruptedAggregateFixture {
+        pool: sqlx::SqlitePool,
+        apalis_pool: apalis_sqlite::SqlitePool,
+        services: crate::rebalancing::equity::EquityTransferServices,
+        mint_id: crate::tokenized_equity_mint::IssuerRequestId,
+        redemption_id: crate::equity_redemption::RedemptionAggregateId,
+        tokenizer: Arc<crate::tokenization::mock::MockTokenizer>,
+        rebalancing_service: RebalancingService,
+        inventory: Arc<BroadcastingInventory>,
+        resume_queue: crate::rebalancing::equity::ResumeTokenizationJobQueue,
+    }
+
+    /// Shared setup for the three `recover_interrupted_tokenization_aggregates`
+    /// tests. Seeds one mint (MintAccepted state) and one redemption
+    /// (VaultWithdrawPending state) into an in-memory database, then builds the
+    /// `RebalancingService` and `ResumeTokenizationJobQueue` that the recovery
+    /// function requires.
+    async fn seed_interrupted_aggregates_and_build_service(
+        wallet_byte: u8,
+        mint_label: &str,
+        redemption_label: &str,
+    ) -> InterruptedAggregateFixture {
+        let (pool, apalis_pool) = setup_test_pools().await;
+
+        let mint_id = issuer_request_id(mint_label);
+        let redemption_id = redemption_aggregate_id(redemption_label);
+
+        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+        let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
+        let tokenizer = Arc::new(MockTokenizer::new());
+
+        let services = EquityTransferServices {
+            raindex: raindex.clone(),
+            vault_lookup: Arc::new(MockVaultLookup::new()),
+            tokenizer: tokenizer.clone(),
+            wrapper: wrapper.clone(),
+        };
+
+        let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(
+            pool.clone(),
+            services.clone(),
+        ));
+        let seeding_redemption_store = Arc::new(test_store::<EquityRedemption>(
+            pool.clone(),
+            services.clone(),
+        ));
+
+        seeding_mint_store
+            .send(
+                &mint_id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: mint_id.clone(),
+                    symbol: st0x_execution::Symbol::new("AAPL").unwrap(),
+                    quantity: st0x_float_macro::float!(10.0),
+                    wallet: alloy::primitives::Address::from([wallet_byte; 20]),
+                },
+            )
+            .await
+            .unwrap();
+
+        seeding_redemption_store
+            .send(
+                &redemption_id,
+                EquityRedemptionCommand::Redeem {
+                    symbol: st0x_execution::Symbol::new("AAPL").unwrap(),
+                    quantity: st0x_float_macro::float!(5.0),
+                    token: alloy::primitives::Address::from([wallet_byte; 20]),
+                    amount: alloy::primitives::U256::from(5_000_000_000_000_000_000_u128),
+                },
+            )
+            .await
+            .unwrap();
+
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            crate::inventory::InventoryView::default(),
+            event_sender,
+        ));
+        let vault_registry: Arc<Store<VaultRegistry>> = Arc::new(test_store(pool.clone(), ()));
+        let rebalancing_service = RebalancingService::new(
+            RebalancingServiceConfig {
+                equity: crate::inventory::ImbalanceThreshold {
+                    target: st0x_float_macro::float!(0.5),
+                    deviation: st0x_float_macro::float!(0.2),
+                },
+                usdc: None,
+                transfer_timeout: Duration::from_secs(60),
+                assets: AssetsConfig {
+                    equities: rebalancing_enabled_equities(&["AAPL"]),
+                    cash: None,
+                },
+            },
+            vault_registry,
+            alloy::primitives::Address::ZERO,
+            alloy::primitives::Address::ZERO,
+            inventory.clone(),
+            Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&apalis_pool),
+        );
+
+        let resume_queue = ResumeTokenizationJobQueue::new(&apalis_pool);
+
+        InterruptedAggregateFixture {
+            pool,
+            apalis_pool,
+            services,
+            mint_id,
+            redemption_id,
+            tokenizer,
+            rebalancing_service,
+            inventory,
+            resume_queue,
+        }
+    }
+
+    /// Regression: `recover_interrupted_tokenization_aggregates` must enqueue
+    /// a `ResumeTokenizationAggregate` job for each interrupted aggregate and
+    /// return immediately without calling any issuer (tokenizer) method.
+    ///
+    /// The previous implementation called `resume_interrupted_transfers` inline
+    /// which awaited `poll_for_redemption` / `poll_mint_until_complete`, blocking
+    /// startup for up to 30 minutes when the issuer was down.
+    #[tokio::test]
+    async fn issuer_down_does_not_block_tokenization_resume() {
+        let InterruptedAggregateFixture {
+            pool,
+            apalis_pool,
+            services,
+            mint_id,
+            redemption_id,
+            tokenizer,
+            rebalancing_service,
+            inventory,
+            mut resume_queue,
+        } = seed_interrupted_aggregates_and_build_service(
+            1,
+            "test-interrupted-mint",
+            "test-interrupted-redemption",
+        )
+        .await;
+
+        // The recover function only calls store.load() (event replay); it does
+        // not invoke tokenizer methods. Use the same services for the function
+        // call -- MockTokenizer methods are never called during load().
+        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
+            pool.clone(),
+            services.clone(),
+        ));
+        let redemption_store = Arc::new(test_store::<EquityRedemption>(
+            pool.clone(),
+            services.clone(),
+        ));
+        let calls_before = tokenizer.call_count();
+
+        // Must complete in under 1 second: no issuer poll blocking.
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            recover_interrupted_tokenization_aggregates(
+                &pool,
+                &rebalancing_service,
+                inventory.as_ref(),
+                mint_store,
+                redemption_store,
+                &mut resume_queue,
+            ),
+        )
+        .await
+        .expect("recover_interrupted_tokenization_aggregates must not block on issuer")
+        .expect("recover_interrupted_tokenization_aggregates must succeed");
+
+        // Recovery must not invoke the issuer at all -- it only replays stored
+        // events. Issuer calls happen later when the apalis worker runs the job.
+        assert_eq!(
+            tokenizer.call_count(),
+            calls_before,
+            "recover_interrupted_tokenization_aggregates must not call the issuer"
+        );
+
+        // Both interrupted aggregates must be enqueued -- assert the payloads
+        // (one targeting the mint, one the redemption), not just the count, so a
+        // regression that enqueued e.g. two mint jobs would be caught.
+        let payloads: Vec<Vec<u8>> = sqlx_apalis::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<ResumeTokenizationAggregate>())
+        .fetch_all(&apalis_pool)
+        .await
+        .unwrap();
+
+        let targets: Vec<ResumeTokenizationTarget> = payloads
+            .iter()
+            .map(|job| {
+                serde_json::from_slice::<ResumeTokenizationAggregate>(job)
+                    .expect("queued resume job must deserialize")
+                    .target
+            })
+            .collect();
+
+        assert_eq!(
+            targets.len(),
+            2,
+            "expected 2 pending ResumeTokenizationAggregate jobs (one mint + one redemption), \
+             got {targets:?}"
+        );
+        assert!(
+            targets.contains(&ResumeTokenizationTarget::Mint(mint_id.clone())),
+            "a queued resume job must target the interrupted mint {mint_id}, got {targets:?}"
+        );
+        assert!(
+            targets.contains(&ResumeTokenizationTarget::Redemption(redemption_id.clone())),
+            "a queued resume job must target the interrupted redemption {redemption_id}, \
+             got {targets:?}"
+        );
+    }
+
+    /// `recover_interrupted_tokenization_aggregates` called twice (simulating a
+    /// crash-restart cycle) must not accumulate duplicate pending jobs.
+    #[tokio::test]
+    async fn recover_interrupted_tokenization_aggregates_does_not_duplicate_jobs_on_restart() {
+        let InterruptedAggregateFixture {
+            pool,
+            apalis_pool,
+            services,
+            mint_id: _,
+            redemption_id: _,
+            tokenizer: _,
+            rebalancing_service,
+            inventory,
+            mut resume_queue,
+        } = seed_interrupted_aggregates_and_build_service(
+            2,
+            "dup-test-mint",
+            "dup-test-redemption",
+        )
+        .await;
+
+        // First call -- simulates initial startup.
+        recover_interrupted_tokenization_aggregates(
+            &pool,
+            &rebalancing_service,
+            inventory.as_ref(),
+            Arc::new(test_store::<TokenizedEquityMint>(
+                pool.clone(),
+                services.clone(),
+            )),
+            Arc::new(test_store::<EquityRedemption>(
+                pool.clone(),
+                services.clone(),
+            )),
+            &mut resume_queue,
+        )
+        .await
+        .unwrap();
+
+        let after_first = pending_job_count::<ResumeTokenizationAggregate>(&apalis_pool).await;
+        assert_eq!(
+            after_first, 2,
+            "first call must enqueue exactly 2 pending jobs, got {after_first}"
+        );
+
+        // Second call -- simulates crash-restart. Must not add more pending rows.
+        recover_interrupted_tokenization_aggregates(
+            &pool,
+            &rebalancing_service,
+            inventory.as_ref(),
+            Arc::new(test_store::<TokenizedEquityMint>(
+                pool.clone(),
+                services.clone(),
+            )),
+            Arc::new(test_store::<EquityRedemption>(
+                pool.clone(),
+                services.clone(),
+            )),
+            &mut resume_queue,
+        )
+        .await
+        .unwrap();
+
+        let after_second = pending_job_count::<ResumeTokenizationAggregate>(&apalis_pool).await;
+        assert_eq!(
+            after_second, 2,
+            "second call (crash-restart) must not duplicate pending jobs,              expected 2, got {after_second}"
+        );
+    }
+
+    /// Extension of the above: a crash mid-job leaves a `Running` row (not
+    /// `Pending`). `cancel_all_pending` alone cannot clean it up; the orphan
+    /// must be promoted to `Pending` first and then cancelled. Without the
+    /// `requeue_orphaned` call inside the function, the `Running` row would
+    /// survive `cancel_all_pending`, then get promoted by `requeue_orphaned`
+    /// later (in the old startup ordering), creating a duplicate `Pending` row.
+    #[tokio::test]
+    async fn recover_interrupted_tokenization_aggregates_does_not_duplicate_running_orphan() {
+        let InterruptedAggregateFixture {
+            pool,
+            apalis_pool,
+            services,
+            mint_id: _,
+            redemption_id: _,
+            tokenizer: _,
+            rebalancing_service,
+            inventory,
+            mut resume_queue,
+        } = seed_interrupted_aggregates_and_build_service(
+            3,
+            "running-orphan-mint",
+            "running-orphan-redemption",
+        )
+        .await;
+
+        // First call: simulate a previous startup that enqueued jobs.
+        recover_interrupted_tokenization_aggregates(
+            &pool,
+            &rebalancing_service,
+            inventory.as_ref(),
+            Arc::new(test_store::<TokenizedEquityMint>(
+                pool.clone(),
+                services.clone(),
+            )),
+            Arc::new(test_store::<EquityRedemption>(
+                pool.clone(),
+                services.clone(),
+            )),
+            &mut resume_queue,
+        )
+        .await
+        .unwrap();
+
+        // Simulate a crash mid-job: force both Pending rows to Running state.
+        let job_type = std::any::type_name::<ResumeTokenizationAggregate>();
+        sqlx_apalis::query("UPDATE Jobs SET status = ?, lock_at = 1 WHERE job_type = ?")
+            .bind(Status::Running.to_string())
+            .bind(job_type)
+            .execute(&apalis_pool)
+            .await
+            .unwrap();
+
+        // Second call: must not create duplicate Pending rows even though the
+        // previous rows are in Running state (not Pending).
+        recover_interrupted_tokenization_aggregates(
+            &pool,
+            &rebalancing_service,
+            inventory.as_ref(),
+            Arc::new(test_store::<TokenizedEquityMint>(
+                pool.clone(),
+                services.clone(),
+            )),
+            Arc::new(test_store::<EquityRedemption>(
+                pool.clone(),
+                services.clone(),
+            )),
+            &mut resume_queue,
+        )
+        .await
+        .unwrap();
+
+        let after_restart = pending_job_count::<ResumeTokenizationAggregate>(&apalis_pool).await;
+        assert_eq!(
+            after_restart, 2,
+            "crash-restart with Running orphan must not duplicate pending jobs,              expected 2, got {after_restart}"
+        );
+    }
+
+    /// Integration test: `recover_interrupted_tokenization_aggregates` must NOT
+    /// enqueue a resume job for a mint in a pre-wrap state (`TokensReceived`)
+    /// when `wrapped_equity_recovery` is enabled. `recover_mint_state` sets the
+    /// guard to `HeldForRecovery` automatically, and `is_pre_wrap_held_for_recovery`
+    /// then gates the push. `UnwrappedEquityRecovery` owns those aggregates and
+    /// would race with a concurrent resume. Control case: same state with
+    /// recovery disabled (guard stays `ActiveTransfer`) DOES produce a job.
+    #[tokio::test]
+    async fn recover_interrupted_tokenization_aggregates_excludes_held_for_recovery_pre_wrap_mint()
+    {
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        // Helper that builds a single-symbol EquitiesConfig with a configurable
+        // wrapped_equity_recovery mode.
+        let make_equities_config = |wrapped_equity_recovery_mode: OperationMode| EquitiesConfig {
+            operational_limit: None,
+            symbols: std::iter::once((
+                symbol.clone(),
+                EquityAssetConfig {
+                    tokenized_equity: alloy::primitives::Address::ZERO,
+                    tokenized_equity_derivative: alloy::primitives::Address::ZERO,
+                    pyth_feed_id: None,
+                    vault_ids: Vec::new(),
+                    trading: OperationMode::Disabled,
+                    rebalancing: OperationMode::Enabled,
+                    wrapped_equity_recovery: wrapped_equity_recovery_mode,
+                    operational_limit: None,
+                },
+            ))
+            .collect(),
+        };
+
+        // --- HeldForRecovery case: zero jobs expected ---
+        // With wrapped_equity_recovery ENABLED, recover_mint_state sets the guard
+        // to HeldForRecovery automatically for TokensReceived state, so
+        // is_pre_wrap_held_for_recovery blocks the resume push.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let mint_id = issuer_request_id("pre-wrap-held-mint");
+        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+        let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
+        let tokenizer = Arc::new(MockTokenizer::new());
+
+        let services = EquityTransferServices {
+            raindex: raindex.clone(),
+            vault_lookup: Arc::new(MockVaultLookup::new()),
+            tokenizer: tokenizer.clone(),
+            wrapper: wrapper.clone(),
+        };
+
+        let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(
+            pool.clone(),
+            services.clone(),
+        ));
+
+        // RequestMint (Pending) -> MintAccepted state.
+        // Poll with Completed outcome -> TokensReceived state (pre-wrap).
+        seeding_mint_store
+            .send(
+                &mint_id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: mint_id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(5.0),
+                    wallet: alloy::primitives::Address::from([3u8; 20]),
+                },
+            )
+            .await
+            .unwrap();
+
+        seeding_mint_store
+            .send(&mint_id, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            crate::inventory::InventoryView::default(),
+            event_sender,
+        ));
+        let vault_registry: Arc<Store<VaultRegistry>> = Arc::new(test_store(pool.clone(), ()));
+        let rebalancing_service = RebalancingService::new(
+            RebalancingServiceConfig {
+                equity: crate::inventory::ImbalanceThreshold {
+                    target: st0x_float_macro::float!(0.5),
+                    deviation: st0x_float_macro::float!(0.2),
+                },
+                usdc: None,
+                transfer_timeout: Duration::from_secs(60),
+                assets: AssetsConfig {
+                    // wrapped_equity_recovery ENABLED: recover_mint_state will set
+                    // HeldForRecovery on TokensReceived, blocking the resume push.
+                    equities: make_equities_config(OperationMode::Enabled),
+                    cash: None,
+                },
+            },
+            vault_registry,
+            alloy::primitives::Address::ZERO,
+            alloy::primitives::Address::ZERO,
+            inventory.clone(),
+            Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&apalis_pool),
+        );
+
+        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
+            pool.clone(),
+            services.clone(),
+        ));
+        let redemption_store = Arc::new(test_store::<EquityRedemption>(
+            pool.clone(),
+            services.clone(),
+        ));
+        let mut resume_queue = ResumeTokenizationJobQueue::new(&apalis_pool);
+
+        recover_interrupted_tokenization_aggregates(
+            &pool,
+            &rebalancing_service,
+            inventory.as_ref(),
+            mint_store,
+            redemption_store,
+            &mut resume_queue,
+        )
+        .await
+        .unwrap();
+
+        let held_jobs = pending_job_count::<ResumeTokenizationAggregate>(&apalis_pool).await;
+        assert_eq!(
+            held_jobs, 0,
+            "HeldForRecovery + TokensReceived must be excluded from resume jobs, \
+             got {held_jobs} pending jobs"
+        );
+
+        // --- Control case: recovery DISABLED keeps ActiveTransfer, job IS enqueued ---
+        let (pool2, apalis_pool2) = setup_test_pools().await;
+        let mint_id2 = issuer_request_id("pre-wrap-active-mint");
+
+        let services2 = EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            vault_lookup: Arc::new(MockVaultLookup::new()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: Arc::new(MockWrapper::new()),
+        };
+
+        let seeding_mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(
+            pool2.clone(),
+            services2.clone(),
+        ));
+
+        seeding_mint_store2
+            .send(
+                &mint_id2,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: mint_id2.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(5.0),
+                    wallet: alloy::primitives::Address::from([4u8; 20]),
+                },
+            )
+            .await
+            .unwrap();
+
+        seeding_mint_store2
+            .send(&mint_id2, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+
+        let (event_sender2, _) = broadcast::channel::<Statement>(16);
+        let inventory2 = Arc::new(BroadcastingInventory::new(
+            crate::inventory::InventoryView::default(),
+            event_sender2.clone(),
+        ));
+        let vault_registry2: Arc<Store<VaultRegistry>> = Arc::new(test_store(pool2.clone(), ()));
+        let rebalancing_service2 = RebalancingService::new(
+            RebalancingServiceConfig {
+                equity: crate::inventory::ImbalanceThreshold {
+                    target: st0x_float_macro::float!(0.5),
+                    deviation: st0x_float_macro::float!(0.2),
+                },
+                usdc: None,
+                transfer_timeout: Duration::from_secs(60),
+                assets: AssetsConfig {
+                    // wrapped_equity_recovery DISABLED: recover_mint_state keeps
+                    // ActiveTransfer, so the pre-wrap exclusion does NOT fire.
+                    equities: make_equities_config(OperationMode::Disabled),
+                    cash: None,
+                },
+            },
+            vault_registry2,
+            alloy::primitives::Address::ZERO,
+            alloy::primitives::Address::ZERO,
+            inventory2.clone(),
+            Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&apalis_pool2),
+        );
+
+        let mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(
+            pool2.clone(),
+            services2.clone(),
+        ));
+        let redemption_store2 = Arc::new(test_store::<EquityRedemption>(
+            pool2.clone(),
+            services2.clone(),
+        ));
+        let mut resume_queue2 = ResumeTokenizationJobQueue::new(&apalis_pool2);
+
+        recover_interrupted_tokenization_aggregates(
+            &pool2,
+            &rebalancing_service2,
+            inventory2.as_ref(),
+            mint_store2,
+            redemption_store2,
+            &mut resume_queue2,
+        )
+        .await
+        .unwrap();
+
+        let active_jobs = pending_job_count::<ResumeTokenizationAggregate>(&apalis_pool2).await;
+        assert_eq!(
+            active_jobs, 1,
+            "ActiveTransfer (recovery disabled) + TokensReceived must produce 1 resume job, \
+             got {active_jobs}"
+        );
     }
 
     /// A crash mid trade-accounting job leaves a `Running` row that apalis
@@ -5787,7 +6403,10 @@ mod tests {
         let position_and_rebalancing = PositionAndRebalancing::setup(
             None,
             &ctx,
-            &pool,
+            &DatabasePools {
+                cqrs: pool.clone(),
+                apalis: apalis_pool.clone(),
+            },
             inventory,
             event_sender,
             vault_registry,

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -22,7 +22,10 @@ use super::Conductor;
 use super::exit::MonitorTaskError;
 #[cfg(any(test, feature = "test-support"))]
 use super::job::FailureInjector;
-use super::job::{FAIL_STOP_RECOVERY_TIMEOUT, build_supervised_worker};
+use super::job::{
+    FAIL_STOP_RECOVERY_TIMEOUT, build_best_effort_worker, build_supervised_worker,
+    build_worker_inner,
+};
 use super::monitor::executor_maintenance::ExecutorMaintenance;
 use super::monitor::gas::{GasMonitor, ProviderBalanceReader};
 use super::monitor::inventory::InventoryMonitor;
@@ -44,6 +47,7 @@ use crate::onchain_trade::OnChainTrade;
 use crate::position::Position;
 use crate::position_check::{CheckPositions, CheckPositionsCtx, CheckPositionsJobQueue};
 use crate::rebalancing::equity::{
+    ResumeTokenizationAggregate, ResumeTokenizationCtx, ResumeTokenizationJobQueue,
     TransferEquityToHedging, TransferEquityToHedgingCtx, TransferEquityToHedgingJobQueue,
     TransferEquityToMarketMaking, TransferEquityToMarketMakingCtx,
     TransferEquityToMarketMakingJobQueue,
@@ -126,6 +130,8 @@ pub(crate) fn spawn<Prov, Exec>(
     rebalancing_service: Option<Arc<RebalancingService>>,
     seed_vault_registry_queue: SeedVaultRegistryJobQueue,
     seed_vault_registry_ctx: Arc<SeedVaultRegistryCtx>,
+    resume_tokenization_queue: ResumeTokenizationJobQueue,
+    resume_tokenization_ctx: Option<Arc<ResumeTokenizationCtx>>,
     job_cleanup: JoinHandle<()>,
 ) -> Conductor
 where
@@ -353,6 +359,8 @@ where
         transfer_equity_to_market_making_ctx,
         transfer_equity_to_hedging_queue,
         transfer_equity_to_hedging_ctx,
+        resume_tokenization_queue,
+        resume_tokenization_ctx,
         apalis_shutdown_token,
         seed_vault_registry_queue,
         #[cfg(any(test, feature = "test-support"))]
@@ -409,6 +417,8 @@ where
     transfer_equity_to_market_making_ctx: Option<Arc<TransferEquityToMarketMakingCtx>>,
     transfer_equity_to_hedging_queue: TransferEquityToHedgingJobQueue,
     transfer_equity_to_hedging_ctx: Option<Arc<TransferEquityToHedgingCtx>>,
+    resume_tokenization_queue: ResumeTokenizationJobQueue,
+    resume_tokenization_ctx: Option<Arc<ResumeTokenizationCtx>>,
     apalis_shutdown_token: CancellationToken,
     seed_vault_registry_queue: SeedVaultRegistryJobQueue,
     #[cfg(any(test, feature = "test-support"))]
@@ -454,6 +464,8 @@ where
             transfer_equity_to_market_making_ctx,
             transfer_equity_to_hedging_queue,
             transfer_equity_to_hedging_ctx,
+            resume_tokenization_queue,
+            resume_tokenization_ctx,
             apalis_shutdown_token,
             seed_vault_registry_queue,
             #[cfg(any(test, feature = "test-support"))]
@@ -490,6 +502,8 @@ where
         let failure_injector_for_transfer_equity_to_market_making = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_transfer_equity_to_hedging = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_resume_tokenization = failure_injector.clone();
         let failure_notify = Arc::new(tokio::sync::Notify::new());
         let failure_notify_for_hedge = failure_notify.clone();
         let failure_notify_for_backfill = failure_notify.clone();
@@ -526,6 +540,20 @@ where
         let fail_stop_for_transfer_usdc_to_market_making = fail_stop.clone();
         let fail_stop_for_transfer_equity_to_market_making = fail_stop.clone();
         let fail_stop_for_transfer_equity_to_hedging = fail_stop.clone();
+        // Best-effort workers must not latch idle after failures. We WANT a
+        // never-opening circuit, but apalis-core 1.0.0-rc.9's live worker path
+        // (`CircuitBreakerService::call`) hardcodes `failure_count >= 5` and
+        // never consults the configured `failure_threshold`, so `u32::MAX` does
+        // NOT keep the circuit closed: after 5 failed calls (e.g. interrupted
+        // aggregates exhausting retries while the issuer is down) the circuit
+        // opens and throttles resume. The short `recovery_timeout` is the real
+        // bound -- it IS honored by `call`, so the open state self-heals within
+        // 10s and resume keeps making progress instead of latching idle. The
+        // `with_failure_threshold(u32::MAX)` records the intended behavior and
+        // takes effect only if a future apalis release honors the config.
+        let best_effort_circuit = CircuitBreakerConfig::default()
+            .with_failure_threshold(u32::MAX)
+            .with_recovery_timeout(std::time::Duration::from_secs(10));
 
         let accountant_ctx_for_backfill = accountant_ctx.clone();
 
@@ -667,7 +695,7 @@ where
                 apalis_monitor,
                 wrapped_equity_recovery_ctx,
                 wrapped_equity_recovery_queue,
-                fail_stop_for_wrapped_equity_recovery,
+                FailStopCircuit(fail_stop_for_wrapped_equity_recovery),
                 failure_notify_for_wrapped_equity_recovery,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_wrapped_equity_recovery,
@@ -677,7 +705,7 @@ where
                 apalis_monitor,
                 unwrapped_equity_recovery_ctx,
                 unwrapped_equity_recovery_queue,
-                fail_stop_for_unwrapped_equity_recovery,
+                FailStopCircuit(fail_stop_for_unwrapped_equity_recovery),
                 failure_notify_for_unwrapped_equity_recovery,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_unwrapped_equity_recovery,
@@ -687,7 +715,7 @@ where
                 apalis_monitor,
                 transfer_usdc_to_hedging_ctx,
                 transfer_usdc_to_hedging_queue,
-                fail_stop_for_transfer_usdc_to_hedging,
+                FailStopCircuit(fail_stop_for_transfer_usdc_to_hedging),
                 failure_notify_for_transfer_usdc_to_hedging,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_transfer_usdc_to_hedging,
@@ -697,7 +725,7 @@ where
                 apalis_monitor,
                 transfer_usdc_to_market_making_ctx,
                 transfer_usdc_to_market_making_queue,
-                fail_stop_for_transfer_usdc_to_market_making,
+                FailStopCircuit(fail_stop_for_transfer_usdc_to_market_making),
                 failure_notify_for_transfer_usdc_to_market_making,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_transfer_usdc_to_market_making,
@@ -707,7 +735,7 @@ where
                 apalis_monitor,
                 transfer_equity_to_market_making_ctx,
                 transfer_equity_to_market_making_queue,
-                fail_stop_for_transfer_equity_to_market_making,
+                FailStopCircuit(fail_stop_for_transfer_equity_to_market_making),
                 failure_notify_for_transfer_equity_to_market_making,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_transfer_equity_to_market_making,
@@ -717,10 +745,19 @@ where
                 apalis_monitor,
                 transfer_equity_to_hedging_ctx,
                 transfer_equity_to_hedging_queue,
-                fail_stop_for_transfer_equity_to_hedging,
+                FailStopCircuit(fail_stop_for_transfer_equity_to_hedging),
                 failure_notify_for_transfer_equity_to_hedging,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_transfer_equity_to_hedging,
+            );
+
+            let apalis_monitor = register_resume_tokenization_worker(
+                apalis_monitor,
+                resume_tokenization_ctx,
+                resume_tokenization_queue,
+                BestEffortCircuit(best_effort_circuit),
+                #[cfg(any(test, feature = "test-support"))]
+                failure_injector_for_resume_tokenization,
             );
 
             let is_draining = apalis_shutdown_token.clone();
@@ -795,6 +832,20 @@ fn log_optional_task_status(task_name: &str, is_configured: bool) {
     }
 }
 
+/// A circuit-breaker config for a FAIL-STOP worker (threshold 1, ~1yr timeout):
+/// a single terminal failure opens the circuit and latches the worker idle,
+/// tripping the conductor-wide fail-stop. A distinct type from
+/// [`BestEffortCircuit`] so the two policies cannot be cross-assigned at a
+/// worker-registration site -- passing the wrong one would be a compile error
+/// rather than a silent freeze.
+struct FailStopCircuit(CircuitBreakerConfig);
+
+/// A circuit-breaker config for a BEST-EFFORT worker: a failing job must not
+/// latch the worker idle (see `spawn_apalis_monitor` for the apalis caveat on
+/// the hardcoded open threshold). A distinct type from [`FailStopCircuit`] so
+/// the two policies cannot be cross-assigned.
+struct BestEffortCircuit(CircuitBreakerConfig);
+
 /// Conditionally registers the wrapped-equity recovery worker against the
 /// apalis monitor. Extracted because this is the only `Option`-gated worker
 /// registration and inlining the let-else + debug log keeps
@@ -803,7 +854,7 @@ fn register_wrapped_equity_recovery_worker(
     monitor: Monitor,
     recovery_ctx: Option<Arc<WrappedEquityRecoveryCtx>>,
     recovery_queue: WrappedEquityRecoveryJobQueue,
-    fail_stop: CircuitBreakerConfig,
+    FailStopCircuit(fail_stop): FailStopCircuit,
     failure_notify: Arc<tokio::sync::Notify>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
@@ -835,7 +886,7 @@ fn register_unwrapped_equity_recovery_worker(
     monitor: Monitor,
     recovery_ctx: Option<Arc<UnwrappedEquityRecoveryCtx>>,
     recovery_queue: UnwrappedEquityRecoveryJobQueue,
-    fail_stop: CircuitBreakerConfig,
+    FailStopCircuit(fail_stop): FailStopCircuit,
     failure_notify: Arc<tokio::sync::Notify>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
@@ -869,7 +920,7 @@ fn register_transfer_usdc_to_hedging_worker(
     monitor: Monitor,
     transfer_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
     transfer_queue: TransferUsdcToHedgingJobQueue,
-    fail_stop: CircuitBreakerConfig,
+    FailStopCircuit(fail_stop): FailStopCircuit,
     failure_notify: Arc<tokio::sync::Notify>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
@@ -901,7 +952,7 @@ fn register_transfer_usdc_to_market_making_worker(
     monitor: Monitor,
     transfer_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
     transfer_queue: TransferUsdcToMarketMakingJobQueue,
-    fail_stop: CircuitBreakerConfig,
+    FailStopCircuit(fail_stop): FailStopCircuit,
     failure_notify: Arc<tokio::sync::Notify>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
@@ -934,7 +985,7 @@ fn register_transfer_equity_to_market_making_worker(
     monitor: Monitor,
     transfer_ctx: Option<Arc<TransferEquityToMarketMakingCtx>>,
     transfer_queue: TransferEquityToMarketMakingJobQueue,
-    fail_stop: CircuitBreakerConfig,
+    FailStopCircuit(fail_stop): FailStopCircuit,
     failure_notify: Arc<tokio::sync::Notify>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
@@ -966,7 +1017,7 @@ fn register_transfer_equity_to_hedging_worker(
     monitor: Monitor,
     transfer_ctx: Option<Arc<TransferEquityToHedgingCtx>>,
     transfer_queue: TransferEquityToHedgingJobQueue,
-    fail_stop: CircuitBreakerConfig,
+    FailStopCircuit(fail_stop): FailStopCircuit,
     failure_notify: Arc<tokio::sync::Notify>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
@@ -986,6 +1037,38 @@ fn register_transfer_equity_to_hedging_worker(
             transfer_ctx.clone(),
             fail_stop.clone(),
             failure_notify.clone(),
+            #[cfg(any(test, feature = "test-support"))]
+            failure_injector.clone(),
+        )
+    })
+}
+
+/// Conditionally registers the `ResumeTokenizationAggregate` worker. The ctx is
+/// `None` when rebalancing is disabled; in that case the queue exists but no
+/// worker consumes it. When enabled, runs interrupted mint/redemption aggregates
+/// off the startup path so a slow or down issuer cannot block monitoring.
+fn register_resume_tokenization_worker(
+    monitor: Monitor,
+    resume_ctx: Option<Arc<ResumeTokenizationCtx>>,
+    resume_queue: ResumeTokenizationJobQueue,
+    BestEffortCircuit(circuit): BestEffortCircuit,
+    #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
+) -> Monitor {
+    let Some(resume_ctx) = resume_ctx else {
+        debug!(
+            "ResumeTokenizationAggregate worker not registered: rebalancing disabled \
+             (no resume ctx). Interrupted tokenization aggregates will not be resumed."
+        );
+        return monitor;
+    };
+
+    monitor.register(move |index| {
+        build_best_effort_worker!(
+            ::<ResumeTokenizationCtx, ResumeTokenizationAggregate>,
+            index,
+            resume_queue.clone(),
+            resume_ctx.clone(),
+            circuit.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector.clone(),
         )

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -267,26 +267,22 @@ where
     async fn perform(&self, ctx: &Ctx) -> Result<Self::Output, Self::Error>;
 }
 
-/// Builds a `Worker` for a `Job<Ctx>` impl.
+/// Shared worker-construction body for [`build_supervised_worker!`] and
+/// [`build_best_effort_worker!`]. Not part of the public crate API; always
+/// called via one of the two public macros. Must be exported so the outer
+/// macros can call it from expansion sites in sibling modules.
 ///
-/// Mirrors the `work::<Ctx, Job>` turbofish style: pass the same two
-/// types and the macro expands to a fully-wired worker (queue backend,
-/// retry policy, fail-stop circuit breaker, terminal-failure notifier,
-/// `.build(work::<Ctx, Job>)`).
-///
-/// A macro because `.build()` returns a deeply-nested
-/// `Worker<Args, Ctx, Backend, Svc, Middleware>` whose `Svc` and
-/// `Middleware` types accumulate from the layer stack and have no
-/// public alias or `impl Trait` shorthand. Macro expansion lets the
-/// compiler infer the type at the call site.
-macro_rules! build_supervised_worker {
+/// `$on_event:expr` must be a value of type
+/// `impl Fn(&WorkerContext, &Event) + Send + Sync + 'static`, produced by
+/// either [`on_terminal_failure`] or [`on_terminal_failure_log_only`].
+macro_rules! build_worker_inner {
     (
         ::<$ctx_type:ty, $job:ty>,
         $index:expr,
         $queue:expr,
         $ctx:expr,
-        $fail_stop:expr,
-        $failure_notify:expr
+        $circuit:expr,
+        $on_event:expr
         $(, $failure_injector:expr)? $(,)?
     ) => {{
         use ::apalis::layers::WorkerBuilderExt;
@@ -316,16 +312,93 @@ macro_rules! build_supervised_worker {
                 RetryPolicy::retries(3)
                     .with_backoff($crate::conductor::job::RETRY_BACKOFF.clone()),
             )
-            .break_circuit_with($fail_stop)
-            .on_event($crate::conductor::job::on_terminal_failure(
-                $failure_notify,
-                <$job as $crate::conductor::job::Job<$ctx_type>>::TERMINAL_FAILURE_MSG,
-            ))
+            .break_circuit_with($circuit)
+            .on_event($on_event)
             .build($crate::conductor::job::work::<$ctx_type, $job>)
     }};
 }
 
+pub(crate) use build_worker_inner;
+
+/// Builds a `Worker` for a `Job<Ctx>` impl.
+///
+/// Mirrors the `work::<Ctx, Job>` turbofish style: pass the same two
+/// types and the macro expands to a fully-wired worker (queue backend,
+/// retry policy, fail-stop circuit breaker, terminal-failure notifier,
+/// `.build(work::<Ctx, Job>)`).
+///
+/// A macro because `.build()` returns a deeply-nested
+/// `Worker<Args, Ctx, Backend, Svc, Middleware>` whose `Svc` and
+/// `Middleware` types accumulate from the layer stack and have no
+/// public alias or `impl Trait` shorthand. Macro expansion lets the
+/// compiler infer the type at the call site.
+macro_rules! build_supervised_worker {
+    (
+        ::<$ctx_type:ty, $job:ty>,
+        $index:expr,
+        $queue:expr,
+        $ctx:expr,
+        $fail_stop:expr,
+        $failure_notify:expr
+        $(, $failure_injector:expr)? $(,)?
+    ) => {{
+        build_worker_inner!(
+            ::<$ctx_type, $job>,
+            $index,
+            $queue,
+            $ctx,
+            $fail_stop,
+            $crate::conductor::job::on_terminal_failure(
+                $failure_notify,
+                <$job as $crate::conductor::job::Job<$ctx_type>>::TERMINAL_FAILURE_MSG,
+            )
+            $(, $failure_injector)?
+        )
+    }};
+}
+
 pub(crate) use build_supervised_worker;
+
+/// Builds a best-effort `Worker` for a `Job<Ctx>` impl.
+///
+/// Identical to [`build_supervised_worker!`] but uses
+/// [`on_terminal_failure_log_only`] instead of [`on_terminal_failure`]:
+/// a terminal job failure is logged at `error!` level but does NOT trip the
+/// conductor-wide fail-stop and does NOT stop the worker.
+///
+/// Callers MUST pass a permissive `CircuitBreakerConfig` (e.g. high
+/// `failure_threshold`, short `recovery_timeout`) so a single failing job
+/// does not latch the worker idle for a long period. Passing the conductor-wide
+/// fail-stop config (threshold 1, 1-year timeout) would silently neutralise
+/// the best-effort guarantee.
+///
+/// Use for background recovery workers (e.g. `ResumeTokenizationAggregate`)
+/// where a persistently failing individual job must not block processing of
+/// sibling jobs or bring down hedging and fill detection.
+macro_rules! build_best_effort_worker {
+    (
+        ::<$ctx_type:ty, $job:ty>,
+        $index:expr,
+        $queue:expr,
+        $ctx:expr,
+        $circuit:expr
+        $(, $failure_injector:expr)? $(,)?
+    ) => {{
+        build_worker_inner!(
+            ::<$ctx_type, $job>,
+            $index,
+            $queue,
+            $ctx,
+            $circuit,
+            $crate::conductor::job::on_terminal_failure_log_only(
+                <$job as $crate::conductor::job::Job<$ctx_type>>::TERMINAL_FAILURE_MSG,
+            )
+            $(, $failure_injector)?
+        )
+    }};
+}
+
+pub(crate) use build_best_effort_worker;
 
 /// Human-readable identifier for an enqueued job, used in structured logging.
 #[derive(Debug)]
@@ -368,6 +441,7 @@ pub enum JobKind {
     TransferUsdcToMarketMaking,
     TransferEquityToMarketMaking,
     TransferEquityToHedging,
+    ResumeTokenizationAggregate,
 }
 
 /// Job execution error. Wraps the concrete `Job::Error` type at
@@ -408,6 +482,7 @@ pub struct FailureInjector {
     transfer_usdc_to_market_making: Arc<Mutex<InjectionState>>,
     transfer_equity_to_market_making: Arc<Mutex<InjectionState>>,
     transfer_equity_to_hedging: Arc<Mutex<InjectionState>>,
+    resume_tokenization_aggregate: Arc<Mutex<InjectionState>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -446,6 +521,7 @@ impl FailureInjector {
             transfer_usdc_to_market_making: Arc::new(Mutex::new(InjectionState::Idle)),
             transfer_equity_to_market_making: Arc::new(Mutex::new(InjectionState::Idle)),
             transfer_equity_to_hedging: Arc::new(Mutex::new(InjectionState::Idle)),
+            resume_tokenization_aggregate: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
@@ -496,6 +572,7 @@ impl FailureInjector {
             JobKind::TransferUsdcToMarketMaking => &self.transfer_usdc_to_market_making,
             JobKind::TransferEquityToMarketMaking => &self.transfer_equity_to_market_making,
             JobKind::TransferEquityToHedging => &self.transfer_equity_to_hedging,
+            JobKind::ResumeTokenizationAggregate => &self.resume_tokenization_aggregate,
         };
 
         match mutex.lock() {
@@ -583,6 +660,27 @@ pub(crate) fn on_terminal_failure(
             error!(%err, worker = %ctx.name(), "{error_msg}");
             failure_notify.notify_waiters();
             let _ = ctx.stop();
+        }
+    }
+}
+
+/// On-event handler for workers where terminal failure must not crash the
+/// conductor. Logs the error at `error!` level but does NOT call
+/// `failure_notify.notify_waiters()` and does NOT call `ctx.stop()`.
+/// Used for best-effort background workers (e.g. `ResumeTokenizationAggregate`)
+/// where a persistently failing individual job should not bring down hedging
+/// and fill detection. The worker circuit-breaker config must also be
+/// permissive — see [`build_best_effort_worker!`].
+///
+/// Structural invariant: unlike [`on_terminal_failure`], this function takes
+/// no `Notify` argument and therefore can never call `notify_waiters()` or
+/// `ctx.stop()`, regardless of how it is called.
+pub(crate) fn on_terminal_failure_log_only(
+    error_msg: &'static str,
+) -> impl Fn(&WorkerContext, &Event) + Send + Sync + 'static {
+    move |ctx, event| {
+        if let Event::Error(err) = event {
+            error!(%err, worker = %ctx.name(), "{error_msg}");
         }
     }
 }
@@ -777,6 +875,7 @@ mod tests {
 
     struct TestCtx {
         success_count: AtomicUsize,
+        success_notify: Arc<tokio::sync::Notify>,
     }
 
     impl Job<TestCtx> for TestJob {
@@ -796,6 +895,7 @@ mod tests {
             }
 
             ctx.success_count.fetch_add(1, Ordering::SeqCst);
+            ctx.success_notify.notify_waiters();
             Ok(())
         }
     }
@@ -816,6 +916,7 @@ mod tests {
 
         let ctx = Arc::new(TestCtx {
             success_count: AtomicUsize::new(0),
+            success_notify: Arc::new(tokio::sync::Notify::new()),
         });
         let ctx_for_assert = ctx.clone();
 
@@ -923,6 +1024,83 @@ mod tests {
                 "pending".to_string(),
                 "running".to_string()
             ]
+        );
+    }
+
+    /// With a permissive circuit-breaker config, a terminally-failing job does
+    /// NOT latch the worker idle: the circuit opens briefly (short
+    /// `recovery_timeout`) and then closes so subsequent jobs can run. This is
+    /// the key behavioral contract of the best-effort worker design.
+    ///
+    /// Regression test: the previous code passed the conductor-wide fail-stop
+    /// config (threshold 1, 1-year timeout) to the best-effort worker,
+    /// permanently blocking all sibling jobs after the first terminal failure.
+    ///
+    /// Goes through `build_best_effort_worker!` with the same permissive
+    /// `CircuitBreakerConfig` that `register_resume_tokenization_worker` in
+    /// `conductor/builder.rs` constructs, so the test validates the real
+    /// production path.
+    #[tokio::test]
+    async fn best_effort_circuit_does_not_latch_on_single_terminal_failure() {
+        let apalis_pool = setup_test_apalis_pool().await;
+
+        let mut queue: JobQueue<TestJob> = JobQueue::new(&apalis_pool);
+        // Failing job first, then a successful one. With a permissive circuit
+        // breaker (threshold = u32::MAX), the second job must still complete.
+        queue.push(TestJob { should_fail: true }).await.unwrap();
+        queue.push(TestJob { should_fail: false }).await.unwrap();
+
+        // success_notify is wired into TestCtx; TestJob::perform calls
+        // notify_waiters() after each successful run.
+        let success_notify = Arc::new(tokio::sync::Notify::new());
+        let ctx = Arc::new(TestCtx {
+            success_count: AtomicUsize::new(0),
+            success_notify: success_notify.clone(),
+        });
+        let ctx_for_assert = ctx.clone();
+
+        // Mirror the production config from register_resume_tokenization_worker:
+        // high threshold + short recovery so a single failure reopens the circuit
+        // quickly but does not permanently latch the worker idle.
+        let best_effort_circuit = CircuitBreakerConfig::default()
+            .with_failure_threshold(u32::MAX)
+            .with_recovery_timeout(Duration::from_secs(10));
+
+        let monitor_handle = tokio::spawn({
+            let monitor = Monitor::new()
+                .should_restart(|_ctx, _error, _attempt| false)
+                .register(move |index| {
+                    build_best_effort_worker!(
+                        ::<TestCtx, TestJob>,
+                        index,
+                        queue.clone(),
+                        ctx.clone(),
+                        best_effort_circuit.clone(),
+                        FailureInjector::new(),
+                    )
+                });
+            async move { monitor.run().await }
+        });
+
+        // Wait deterministically for the successful job to complete.
+        // TestJob::perform fires success_notify after incrementing success_count,
+        // so this unblocks as soon as job 2 succeeds -- no fixed sleep needed.
+        //
+        // The 30s budget accounts for the production RETRY_BACKOFF baked into
+        // build_best_effort_worker! via build_worker_inner!: 3 retries at 1s,
+        // 2s, 4s = 7s before the failing job goes terminal, plus the 10s
+        // recovery_timeout before the circuit closes. 30s gives ~3x headroom
+        // over the 17s worst case so the test is not flaky under CI load.
+        tokio::time::timeout(Duration::from_secs(30), success_notify.notified())
+            .await
+            .expect("second job must complete within 30s; circuit must not latch indefinitely");
+
+        monitor_handle.abort();
+
+        assert_eq!(
+            ctx_for_assert.success_count.load(Ordering::SeqCst),
+            1,
+            "second job must complete even after the first job terminally fails;              a permissive circuit breaker must not latch idle on a single failure"
         );
     }
 

--- a/src/conductor/trading_queues.rs
+++ b/src/conductor/trading_queues.rs
@@ -1,0 +1,156 @@
+//! Startup wiring for the trading-pipeline and equity-recovery job queues.
+//!
+//! [`setup_trading_job_queues`] is called once during conductor startup, before
+//! the apalis monitor spawns, to create every fill-to-hedge and equity-recovery
+//! queue, reset orphaned `Running` rows left by a previous crash, recover
+//! in-flight submitted orders, and bootstrap the position-check queue. Extracted
+//! from the `conductor` module to keep that module focused on lifecycle
+//! orchestration.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use st0x_event_sorcery::{Projection, Store};
+use st0x_execution::SupportedExecutor;
+
+use super::{
+    build_unwrapped_equity_recovery_ctx, build_wrapped_equity_recovery_ctx,
+    requeue_equity_recovery_orphans, requeue_trading_orphans,
+};
+use crate::equity_redemption::EquityRedemption;
+use crate::inventory::BroadcastingInventory;
+use crate::offchain::order::{
+    HandleOrderRejectionJobQueue, OffchainOrder, PollOrderStatusJobQueue,
+    ReconcileOrderFillJobQueue, recover_submitted_offchain_orders,
+};
+use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
+use crate::rebalancing::RebalancingService;
+use crate::tokenized_equity_mint::TokenizedEquityMint;
+use crate::trading::offchain::hedge::HedgeJobQueue;
+use crate::trading::onchain::trade_accountant::DexTradeAccountingJobQueue;
+use crate::unwrapped_equity_recovery::{
+    UnwrappedEquityRecovery, UnwrappedEquityRecoveryCtx, UnwrappedEquityRecoveryJobQueue,
+};
+use crate::wrapped_equity_recovery::{
+    WrappedEquityRecovery, WrappedEquityRecoveryCtx, WrappedEquityRecoveryJobQueue,
+};
+
+/// Equity-recovery stores and related state passed to [`setup_trading_job_queues`].
+/// Bundles the optional rebalancing-side inputs needed to build the equity
+/// recovery contexts, keeping the function argument count within the lint limit.
+pub(super) struct EquityRecoveryInputs {
+    pub(super) wrapped_store: Option<Arc<Store<WrappedEquityRecovery>>>,
+    pub(super) unwrapped_store: Option<Arc<Store<UnwrappedEquityRecovery>>>,
+    pub(super) rebalancing_service: Option<Arc<RebalancingService>>,
+    pub(super) mint_store: Option<Arc<Store<TokenizedEquityMint>>>,
+    pub(super) redemption_store: Option<Arc<Store<EquityRedemption>>>,
+    pub(super) inventory: Arc<BroadcastingInventory>,
+    pub(super) inventory_poll_interval: Duration,
+}
+
+/// All trading-related and equity-recovery job queues and contexts produced
+/// at startup. Returned by [`setup_trading_job_queues`].
+pub(super) struct TradingJobQueues {
+    pub(super) hedge_queue: HedgeJobQueue,
+    pub(super) poll_status_queue: PollOrderStatusJobQueue,
+    pub(super) reconcile_queue: ReconcileOrderFillJobQueue,
+    pub(super) rejection_queue: HandleOrderRejectionJobQueue,
+    pub(super) wrapped_equity_recovery_queue: WrappedEquityRecoveryJobQueue,
+    pub(super) unwrapped_equity_recovery_queue: UnwrappedEquityRecoveryJobQueue,
+    pub(super) wrapped_equity_recovery_ctx: Option<Arc<WrappedEquityRecoveryCtx>>,
+    pub(super) unwrapped_equity_recovery_ctx: Option<Arc<UnwrappedEquityRecoveryCtx>>,
+    pub(super) check_positions_queue: CheckPositionsJobQueue,
+}
+
+/// Creates all trading-side and equity-recovery job queues, resets any orphaned
+/// `Running` rows left by a previous crash, recovers in-flight submitted orders,
+/// and bootstraps the position-check queue. Called once during conductor startup,
+/// before the apalis monitor spawns, so every `Running` row is orphaned by
+/// definition.
+pub(super) async fn setup_trading_job_queues(
+    apalis_pool: &apalis_sqlite::SqlitePool,
+    job_queue: &DexTradeAccountingJobQueue,
+    equity_recovery: EquityRecoveryInputs,
+    offchain_order_projection: &Arc<Projection<OffchainOrder>>,
+    executor_type: SupportedExecutor,
+) -> anyhow::Result<TradingJobQueues> {
+    let EquityRecoveryInputs {
+        wrapped_store: wrapped_equity_recovery_store,
+        unwrapped_store: unwrapped_equity_recovery_store,
+        rebalancing_service,
+        mint_store,
+        redemption_store,
+        inventory,
+        inventory_poll_interval,
+    } = equity_recovery;
+    let hedge_queue: HedgeJobQueue = crate::conductor::job::JobQueue::new(apalis_pool);
+    let mut poll_status_queue = PollOrderStatusJobQueue::new(apalis_pool);
+    let reconcile_queue = ReconcileOrderFillJobQueue::new(apalis_pool);
+    let rejection_queue = HandleOrderRejectionJobQueue::new(apalis_pool);
+
+    // A previous process may have died mid-job anywhere on the
+    // fill-to-hedge path, leaving apalis `Running` rows no live worker
+    // owns. Reset them before the monitor spawns, exactly like the
+    // transfer/backfill/recovery queues above. Trade accounting is the
+    // one that cannot be recovered any other way: once the backfill
+    // checkpoint advances, its job row is the only record of the fill.
+    requeue_trading_orphans(job_queue, "trade accounting").await?;
+    requeue_trading_orphans(&hedge_queue, "hedge placement").await?;
+    requeue_trading_orphans(&poll_status_queue, "order status polling").await?;
+    requeue_trading_orphans(&reconcile_queue, "order fill reconciliation").await?;
+    requeue_trading_orphans(&rejection_queue, "order rejection handling").await?;
+
+    let wrapped_equity_recovery_queue = WrappedEquityRecoveryJobQueue::new(apalis_pool);
+    let unwrapped_equity_recovery_queue = UnwrappedEquityRecoveryJobQueue::new(apalis_pool);
+
+    let wrapped_equity_recovery_ctx = build_wrapped_equity_recovery_ctx(
+        wrapped_equity_recovery_store,
+        rebalancing_service.clone(),
+        mint_store.clone(),
+        redemption_store.clone(),
+        inventory.clone(),
+        wrapped_equity_recovery_queue.clone(),
+        inventory_poll_interval,
+    );
+
+    let unwrapped_equity_recovery_ctx = build_unwrapped_equity_recovery_ctx(
+        unwrapped_equity_recovery_store,
+        rebalancing_service,
+        mint_store,
+        redemption_store,
+        inventory,
+        unwrapped_equity_recovery_queue.clone(),
+        inventory_poll_interval,
+    );
+
+    requeue_equity_recovery_orphans(
+        wrapped_equity_recovery_ctx.as_ref(),
+        unwrapped_equity_recovery_ctx.as_ref(),
+        &wrapped_equity_recovery_queue,
+        &unwrapped_equity_recovery_queue,
+    )
+    .await?;
+
+    let check_positions_queue = CheckPositionsJobQueue::new(apalis_pool);
+
+    recover_submitted_offchain_orders(
+        offchain_order_projection,
+        &mut poll_status_queue,
+        executor_type,
+    )
+    .await?;
+
+    bootstrap_check_positions(apalis_pool, &check_positions_queue).await?;
+
+    Ok(TradingJobQueues {
+        hedge_queue,
+        poll_status_queue,
+        reconcile_queue,
+        rejection_queue,
+        wrapped_equity_recovery_queue,
+        unwrapped_equity_recovery_queue,
+        wrapped_equity_recovery_ctx,
+        unwrapped_equity_recovery_ctx,
+        check_positions_queue,
+    })
+}

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -10,6 +10,7 @@
 //!   from a Raindex vault and sends it to Alpaca for redemption.
 
 mod job;
+mod resume_job;
 
 #[cfg(test)]
 pub(crate) use job::TransferEquityToMarketMakingJobError;
@@ -17,6 +18,10 @@ pub(crate) use job::{
     TransferEquityToHedging, TransferEquityToHedgingCtx, TransferEquityToHedgingJobQueue,
     TransferEquityToMarketMaking, TransferEquityToMarketMakingCtx,
     TransferEquityToMarketMakingJobQueue,
+};
+pub(crate) use resume_job::{
+    ResumeTokenizationAggregate, ResumeTokenizationCtx, ResumeTokenizationJobQueue,
+    ResumeTokenizationTarget,
 };
 
 use alloy::hex::FromHexError;

--- a/src/rebalancing/equity/resume_job.rs
+++ b/src/rebalancing/equity/resume_job.rs
@@ -1,0 +1,578 @@
+//! Apalis job that resumes an interrupted tokenization aggregate
+//! (mint or redemption) off the startup path.
+//!
+//! [`ResumeTokenizationAggregate`] is enqueued once per interrupted aggregate
+//! at startup by `recover_interrupted_tokenization_aggregates` and dispatches
+//! to [`CrossVenueEquityTransfer::resume_mint`] or
+//! [`CrossVenueEquityTransfer::resume_redemption`]. Running the poll off-path
+//! means a slow or down issuer cannot block the
+//! [`crate::conductor::monitor::order_fills::OrderFillMonitor`] or
+//! [`crate::conductor::monitor::inventory::InventoryMonitor`] from starting.
+//!
+//! Transient errors propagate as `Err` so apalis retries up to three times.
+//! If all retries are exhausted the terminal failure is logged at `error!` but
+//! does NOT trip the conductor-wide fail-stop, so hedging and fill detection
+//! continue running. Aggregates already in a terminal state return `Ok(())`
+//! (idempotent).
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::{CrossVenueEquityTransfer, MintError, RedemptionError};
+use crate::conductor::job::{Job, JobQueue, Label};
+use crate::equity_redemption::RedemptionAggregateId;
+use crate::tokenized_equity_mint::IssuerRequestId;
+
+/// Apalis queue type for [`ResumeTokenizationAggregate`].
+pub(crate) type ResumeTokenizationJobQueue = JobQueue<ResumeTokenizationAggregate>;
+
+/// Which interrupted aggregate should be resumed.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) enum ResumeTokenizationTarget {
+    Mint(IssuerRequestId),
+    Redemption(RedemptionAggregateId),
+}
+
+/// Apalis job payload. Holds the target aggregate to resume.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct ResumeTokenizationAggregate {
+    pub(crate) target: ResumeTokenizationTarget,
+}
+
+/// Dependencies the job needs.
+pub(crate) struct ResumeTokenizationCtx {
+    pub(crate) transfer: Arc<CrossVenueEquityTransfer>,
+}
+
+/// Errors emitted by [`ResumeTokenizationAggregate::perform`].
+#[derive(Debug, Error)]
+pub(crate) enum ResumeTokenizationJobError {
+    #[error(transparent)]
+    Mint(#[from] MintError),
+    #[error(transparent)]
+    Redemption(#[from] RedemptionError),
+}
+
+impl Job<ResumeTokenizationCtx> for ResumeTokenizationAggregate {
+    type Output = ();
+    type Error = ResumeTokenizationJobError;
+
+    const WORKER_NAME: &'static str = "resume-tokenization-aggregate-worker";
+    const TERMINAL_FAILURE_MSG: &'static str = "Interrupted tokenization aggregate failed all resume retries; \
+         the aggregate remains stuck. Operator action required.";
+
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::ResumeTokenizationAggregate;
+
+    fn label(&self) -> Label {
+        match &self.target {
+            ResumeTokenizationTarget::Mint(issuer_request_id) => Label::new(format!(
+                "ResumeTokenizationAggregate:mint:{issuer_request_id}"
+            )),
+            ResumeTokenizationTarget::Redemption(aggregate_id) => Label::new(format!(
+                "ResumeTokenizationAggregate:redemption:{aggregate_id}"
+            )),
+        }
+    }
+
+    async fn perform(&self, ctx: &ResumeTokenizationCtx) -> Result<Self::Output, Self::Error> {
+        match &self.target {
+            ResumeTokenizationTarget::Mint(issuer_request_id) => {
+                ctx.transfer.resume_mint(issuer_request_id).await?;
+            }
+            ResumeTokenizationTarget::Redemption(aggregate_id) => {
+                ctx.transfer.resume_redemption(aggregate_id).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{Address, B256, TxHash, U256};
+    use serde_json::json;
+    use st0x_event_sorcery::test_store;
+    use st0x_float_macro::float;
+    use st0x_raindex::{Raindex, RaindexVaultId};
+    use st0x_wrapper::{MockWrapper, Wrapper};
+
+    use super::*;
+    use crate::equity_redemption::{
+        EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,
+    };
+    use crate::onchain::mock::MockRaindex;
+    use crate::rebalancing::equity::EquityTransferServices;
+    use crate::tokenization::mock::{MockCompletionOutcome, MockDetectionOutcome, MockTokenizer};
+    use crate::tokenized_equity_mint::{
+        TokenizationRequestId, TokenizedEquityMint, TokenizedEquityMintCommand, issuer_request_id,
+    };
+    use crate::vault_lookup::MockVaultLookup;
+
+    /// Builds a [`ResumeTokenizationCtx`] backed by in-memory stores, plus
+    /// the underlying stores for seeding aggregate state and the tokenizer
+    /// for asserting call counts.
+    async fn build_ctx() -> (
+        ResumeTokenizationCtx,
+        Arc<st0x_event_sorcery::Store<crate::tokenized_equity_mint::TokenizedEquityMint>>,
+        Arc<st0x_event_sorcery::Store<EquityRedemption>>,
+        Arc<MockTokenizer>,
+    ) {
+        build_ctx_with_tokenizer(Arc::new(MockTokenizer::new())).await
+    }
+
+    /// Like [`build_ctx`] but with a caller-provided tokenizer, so a redemption
+    /// resume can configure detection/completion outcomes.
+    async fn build_ctx_with_tokenizer(
+        tokenizer: Arc<MockTokenizer>,
+    ) -> (
+        ResumeTokenizationCtx,
+        Arc<st0x_event_sorcery::Store<crate::tokenized_equity_mint::TokenizedEquityMint>>,
+        Arc<st0x_event_sorcery::Store<EquityRedemption>>,
+        Arc<MockTokenizer>,
+    ) {
+        let (pool, _apalis_pool) = crate::test_utils::setup_test_pools().await;
+        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+        let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
+        let vault_lookup =
+            Arc::new(MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO)));
+
+        let transfer_services = EquityTransferServices {
+            raindex: raindex.clone(),
+            vault_lookup: vault_lookup.clone(),
+            tokenizer: tokenizer.clone(),
+            wrapper: wrapper.clone(),
+        };
+
+        let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
+        let redemption_store = Arc::new(test_store(pool, transfer_services));
+
+        let transfer = Arc::new(CrossVenueEquityTransfer::new(
+            raindex,
+            vault_lookup,
+            tokenizer.clone(),
+            wrapper,
+            Address::ZERO,
+            mint_store.clone(),
+            redemption_store.clone(),
+        ));
+
+        let ctx = ResumeTokenizationCtx { transfer };
+        (ctx, mint_store, redemption_store, tokenizer)
+    }
+
+    /// `perform` on a `Mint` target with a terminal aggregate (`DepositedIntoRaindex`)
+    /// returns `Ok(())` immediately without issuer contact.
+    #[tokio::test]
+    async fn perform_mint_target_returns_ok_for_terminal_aggregate() {
+        let (ctx, mint_store, _, tokenizer) = build_ctx().await;
+        let id = issuer_request_id("resume-mint-terminal");
+        let symbol = st0x_execution::Symbol::new("AAPL").unwrap();
+
+        // Drive mint to DepositedIntoRaindex (terminal) via command chain.
+        // MockTokenizer returns tokens immediately so Poll succeeds.
+        mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(1.0),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .unwrap();
+
+        mint_store
+            .send(&id, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+
+        // TokensReceived -> TokensWrapped
+        mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::WrapTokens {
+                    wrap_tx_hash: TxHash::ZERO,
+                    wrapped_shares: U256::from(1u64),
+                    wrap_block: 1,
+                },
+            )
+            .await
+            .unwrap();
+
+        // TokensWrapped -> DepositedIntoRaindex
+        mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::DepositToVault {
+                    vault_deposit_tx_hash: TxHash::ZERO,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Capture seeding call count before the perform call.
+        let calls_before = tokenizer.call_count();
+
+        let job = ResumeTokenizationAggregate {
+            target: ResumeTokenizationTarget::Mint(id),
+        };
+
+        // Terminal aggregate: resume_mint returns Ok(()) immediately.
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            tokenizer.call_count(),
+            calls_before,
+            "terminal mint aggregate must not invoke any tokenizer method during resume"
+        );
+    }
+
+    /// `perform` on a `Mint` target with a `Failed` aggregate returns `Ok(())`
+    /// (both terminal states are no-ops per `resume_mint` semantics).
+    #[tokio::test]
+    async fn perform_mint_target_returns_ok_for_failed_aggregate() {
+        let (ctx, mint_store, _, tokenizer) = build_ctx().await;
+        let id = issuer_request_id("resume-mint-failed");
+        let symbol = st0x_execution::Symbol::new("AAPL").unwrap();
+
+        // Drive to Failed via RequestMint + Poll + FailWrapping.
+        mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(1.0),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .unwrap();
+
+        mint_store
+            .send(&id, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+
+        mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::FailWrapping {
+                    reason: "test: force failed".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let job = ResumeTokenizationAggregate {
+            target: ResumeTokenizationTarget::Mint(id),
+        };
+
+        let calls_before = tokenizer.call_count();
+
+        // Failed aggregate is terminal: resume_mint returns Ok(()).
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            tokenizer.call_count(),
+            calls_before,
+            "failed mint aggregate must not invoke any tokenizer method during resume"
+        );
+    }
+
+    /// `perform` on a `Redemption` target with a `Completed` aggregate returns
+    /// `Ok(())` immediately (terminal no-op).
+    #[tokio::test]
+    async fn perform_redemption_target_returns_ok_for_completed_aggregate() {
+        let (ctx, _, redemption_store, tokenizer) = build_ctx().await;
+        let id = redemption_aggregate_id("resume-redemption-completed");
+        let symbol = st0x_execution::Symbol::new("AAPL").unwrap();
+
+        // Drive redemption to Completed: Redeem -> SubmitWithdraw ->
+        // ConfirmWithdraw -> UnwrapTokens -> SubmitUnwrap -> ConfirmUnwrap ->
+        // PrepareSend -> SendTokens -> (TokensSent). Then detect via DetectSend.
+        // MockRaindex and MockWrapper complete synchronously.
+        redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::Redeem {
+                    symbol: symbol.clone(),
+                    quantity: float!(1.0),
+                    token: Address::ZERO,
+                    amount: U256::from(1_000_000_000_000_000_000_u128),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Drive through intermediate states to SendPending.
+        for cmd in [
+            EquityRedemptionCommand::SubmitWithdraw,
+            EquityRedemptionCommand::ConfirmWithdraw,
+            EquityRedemptionCommand::UnwrapTokens,
+            EquityRedemptionCommand::SubmitUnwrap,
+            EquityRedemptionCommand::ConfirmUnwrap,
+            EquityRedemptionCommand::PrepareSend,
+        ] {
+            redemption_store.send(&id, cmd).await.unwrap();
+        }
+
+        // SendTokens uses MockTokenizer.send_for_redemption which succeeds.
+        // Drives SendPending -> TokensSent.
+        redemption_store
+            .send(&id, EquityRedemptionCommand::SendTokens)
+            .await
+            .unwrap();
+
+        // TokensSent -> Pending (Alpaca detected the token transfer).
+        redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::Detect {
+                    tokenization_request_id: TokenizationRequestId("test-req-id".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Pending -> Completed (Alpaca completed the redemption).
+        redemption_store
+            .send(&id, EquityRedemptionCommand::Complete)
+            .await
+            .unwrap();
+
+        // Capture seeding call count before the perform call.
+        let calls_before = tokenizer.call_count();
+
+        let job = ResumeTokenizationAggregate {
+            target: ResumeTokenizationTarget::Redemption(id),
+        };
+
+        // Completed aggregate is terminal: resume_redemption returns Ok(()).
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            tokenizer.call_count(),
+            calls_before,
+            "terminal redemption aggregate must not invoke any tokenizer method during resume"
+        );
+    }
+
+    /// `perform` on a `Mint` target with a NON-TERMINAL (interrupted) aggregate
+    /// must actually drive the resume: contact the issuer (tokenizer Poll) and
+    /// advance the aggregate past its seeded state. Without this, a stubbed
+    /// `Ok(())` body would pass every other test in this module (terminal tests
+    /// assert call_count unchanged; missing tests assert error propagation).
+    #[tokio::test]
+    async fn perform_mint_target_resumes_interrupted_aggregate() {
+        let (ctx, mint_store, _, tokenizer) = build_ctx().await;
+        let id = issuer_request_id("resume-mint-interrupted");
+        let symbol = st0x_execution::Symbol::new("AAPL").unwrap();
+
+        // RequestMint emits MintRequested + MintAccepted (MockTokenizer accepts),
+        // leaving a non-terminal MintAccepted aggregate -- the interrupted state.
+        mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(1.0),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .unwrap();
+
+        let seeded = mint_store.load(&id).await.unwrap();
+        assert!(
+            matches!(seeded, Some(TokenizedEquityMint::MintAccepted { .. })),
+            "seed must be a non-terminal MintAccepted aggregate, got {seeded:?}"
+        );
+
+        let calls_before = tokenizer.call_count();
+
+        let job = ResumeTokenizationAggregate {
+            target: ResumeTokenizationTarget::Mint(id.clone()),
+        };
+        Job::perform(&job, &ctx).await.unwrap();
+
+        // The resume must have contacted the issuer (Poll) ...
+        assert!(
+            tokenizer.call_count() > calls_before,
+            "resuming a MintAccepted aggregate must call the tokenizer (Poll); \
+             call_count stayed at {calls_before}"
+        );
+
+        // ... and advanced the aggregate off MintAccepted to its terminal state.
+        let resumed = mint_store.load(&id).await.unwrap();
+        assert!(
+            matches!(
+                resumed,
+                Some(TokenizedEquityMint::DepositedIntoRaindex { .. })
+            ),
+            "resume must drive the MintAccepted aggregate to DepositedIntoRaindex, \
+             got {resumed:?}"
+        );
+    }
+
+    /// `perform` on a `Mint` target with a non-existent aggregate propagates
+    /// the error so apalis retries.
+    #[tokio::test]
+    async fn perform_mint_target_propagates_error_for_missing_aggregate() {
+        let (ctx, _, _, _tokenizer) = build_ctx().await;
+        let id = issuer_request_id("resume-mint-missing");
+
+        let job = ResumeTokenizationAggregate {
+            target: ResumeTokenizationTarget::Mint(id),
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+        assert!(
+            matches!(
+                error,
+                ResumeTokenizationJobError::Mint(MintError::EntityNotFound { .. })
+            ),
+            "missing mint aggregate must propagate EntityNotFound so apalis retries, got {error:?}"
+        );
+    }
+
+    /// `perform` on a `Redemption` target with a non-existent aggregate
+    /// propagates the error so apalis retries.
+    #[tokio::test]
+    async fn perform_redemption_target_propagates_error_for_missing_aggregate() {
+        let (ctx, _, _, _tokenizer) = build_ctx().await;
+        let id = redemption_aggregate_id("resume-redemption-missing");
+
+        let job = ResumeTokenizationAggregate {
+            target: ResumeTokenizationTarget::Redemption(id),
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+        assert!(
+            matches!(
+                error,
+                ResumeTokenizationJobError::Redemption(RedemptionError::EntityNotFound { .. })
+            ),
+            "missing redemption aggregate must propagate EntityNotFound so apalis retries, \
+             got {error:?}"
+        );
+    }
+
+    /// `perform` on a `Redemption` target with a NON-TERMINAL (interrupted)
+    /// aggregate must drive the resume: contact the issuer (send/detect/complete)
+    /// and advance the aggregate to its terminal state. Mirror of
+    /// `perform_mint_target_resumes_interrupted_aggregate` for the redemption arm.
+    #[tokio::test]
+    async fn perform_redemption_target_resumes_interrupted_aggregate() {
+        // Detection defaults to Detected; completion must be configured (the
+        // default panics) so resume_redemption can reach Completed.
+        let tokenizer = Arc::new(
+            MockTokenizer::new()
+                .with_detection_outcome(MockDetectionOutcome::Detected)
+                .with_completion_outcome(MockCompletionOutcome::Completed),
+        );
+        let (ctx, _, redemption_store, tokenizer) = build_ctx_with_tokenizer(tokenizer).await;
+        let id = redemption_aggregate_id("resume-redemption-interrupted");
+        let symbol = st0x_execution::Symbol::new("AAPL").unwrap();
+
+        // Drive the redemption to a non-terminal SendPending state (Redeem ->
+        // ... -> PrepareSend): an interrupted aggregate that has NOT yet sent
+        // tokens to the issuer or completed.
+        redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::Redeem {
+                    symbol: symbol.clone(),
+                    quantity: float!(1.0),
+                    token: Address::ZERO,
+                    amount: U256::from(1_000_000_000_000_000_000_u128),
+                },
+            )
+            .await
+            .unwrap();
+        for cmd in [
+            EquityRedemptionCommand::SubmitWithdraw,
+            EquityRedemptionCommand::ConfirmWithdraw,
+            EquityRedemptionCommand::UnwrapTokens,
+            EquityRedemptionCommand::SubmitUnwrap,
+            EquityRedemptionCommand::ConfirmUnwrap,
+            EquityRedemptionCommand::PrepareSend,
+        ] {
+            redemption_store.send(&id, cmd).await.unwrap();
+        }
+
+        let seeded = redemption_store.load(&id).await.unwrap();
+        assert!(
+            matches!(seeded, Some(EquityRedemption::SendPending { .. })),
+            "seed must be a non-terminal SendPending aggregate, got {seeded:?}"
+        );
+
+        let calls_before = tokenizer.call_count();
+
+        let job = ResumeTokenizationAggregate {
+            target: ResumeTokenizationTarget::Redemption(id.clone()),
+        };
+        Job::perform(&job, &ctx).await.unwrap();
+
+        // The resume must have contacted the issuer (send/detect/complete) ...
+        assert!(
+            tokenizer.call_count() > calls_before,
+            "resuming a SendPending redemption must call the tokenizer; \
+             call_count stayed at {calls_before}"
+        );
+
+        // ... and advanced the aggregate off SendPending to Completed.
+        let resumed = redemption_store.load(&id).await.unwrap();
+        assert!(
+            matches!(resumed, Some(EquityRedemption::Completed { .. })),
+            "resume must drive the SendPending redemption to Completed, got {resumed:?}"
+        );
+    }
+
+    /// Job payload for both variants serializes and deserializes correctly.
+    #[test]
+    fn payload_roundtrips_through_json() {
+        let mint_id = issuer_request_id("roundtrip-mint");
+        let redemption_id = redemption_aggregate_id("roundtrip-redemption");
+
+        let mint_job = ResumeTokenizationAggregate {
+            target: ResumeTokenizationTarget::Mint(mint_id.clone()),
+        };
+
+        let expected_mint = json!({ "target": { "Mint": mint_id.to_string() } });
+        assert_eq!(serde_json::to_value(&mint_job).unwrap(), expected_mint);
+
+        let roundtripped_mint: ResumeTokenizationAggregate =
+            serde_json::from_value(expected_mint).unwrap();
+        assert_eq!(
+            roundtripped_mint.target,
+            ResumeTokenizationTarget::Mint(mint_id),
+            "roundtripped mint target must match original"
+        );
+
+        let redemption_job = ResumeTokenizationAggregate {
+            target: ResumeTokenizationTarget::Redemption(redemption_id.clone()),
+        };
+
+        let expected_redemption = json!({ "target": { "Redemption": redemption_id.to_string() } });
+        assert_eq!(
+            serde_json::to_value(&redemption_job).unwrap(),
+            expected_redemption
+        );
+
+        let roundtripped_redemption: ResumeTokenizationAggregate =
+            serde_json::from_value(expected_redemption).unwrap();
+        assert_eq!(
+            roundtripped_redemption.target,
+            ResumeTokenizationTarget::Redemption(redemption_id),
+            "roundtripped redemption target must match original"
+        );
+    }
+}

--- a/src/tokenization/mock.rs
+++ b/src/tokenization/mock.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use rain_math_float::Float;
 use reqwest::StatusCode;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use st0x_evm::{EvmError, NODE_SYNC_MAX_ATTEMPTS};
 use st0x_execution::{FractionalShares, Symbol};
@@ -103,6 +104,8 @@ pub(crate) struct MockTokenizer {
     wait_for_block_calls: Mutex<Vec<u64>>,
     list_pending_outcome: MockListPendingOutcome,
     last_issuer_request_id: Mutex<Option<IssuerRequestId>>,
+    /// Total number of tokenizer method calls made (across all methods).
+    call_count: AtomicUsize,
     pending_requests: Vec<TokenizationRequest>,
     /// Override the token_symbol in completed mint responses.
     token_symbol_behavior: MockTokenSymbolBehavior,
@@ -125,10 +128,16 @@ impl MockTokenizer {
             wait_for_block_calls: Mutex::new(Vec::new()),
             list_pending_outcome: MockListPendingOutcome::Succeed,
             last_issuer_request_id: Mutex::new(None),
+            call_count: AtomicUsize::new(0),
             token_symbol_behavior: MockTokenSymbolBehavior::Default,
             fees_override: None,
             pending_requests: Vec::new(),
         }
+    }
+
+    /// Returns the total number of tokenizer method calls made since construction.
+    pub(crate) fn call_count(&self) -> usize {
+        self.call_count.load(Ordering::Relaxed)
     }
 
     pub(crate) fn with_mint_request_outcome(mut self, outcome: MockMintRequestOutcome) -> Self {
@@ -217,6 +226,7 @@ impl Tokenizer for MockTokenizer {
         _wallet: Address,
         issuer_request_id: IssuerRequestId,
     ) -> Result<TokenizationRequest, TokenizerError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
         *self.last_issuer_request_id.lock().unwrap() = Some(issuer_request_id);
 
         match self.mint_request_outcome {
@@ -239,6 +249,7 @@ impl Tokenizer for MockTokenizer {
         &self,
         _id: &TokenizationRequestId,
     ) -> Result<TokenizationRequest, TokenizerError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
         match self.mint_poll_outcome {
             MockMintPollOutcome::Completed => {
                 let mut request = TokenizationRequest::mock_completed();
@@ -272,6 +283,7 @@ impl Tokenizer for MockTokenizer {
         &self,
         id: &TokenizationRequestId,
     ) -> Result<TokenizationRequest, TokenizerError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
         self.pending_requests
             .iter()
             .find(|request| &request.id == id)
@@ -282,10 +294,12 @@ impl Tokenizer for MockTokenizer {
     }
 
     fn redemption_wallet(&self) -> Option<Address> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
         self.redemption_wallet
     }
 
     async fn wait_for_block(&self, block: u64) -> Result<(), EvmError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
         self.wait_for_block_calls.lock().unwrap().push(block);
 
         match self.wait_for_block_outcome {
@@ -303,6 +317,7 @@ impl Tokenizer for MockTokenizer {
         _token: Address,
         _amount: U256,
     ) -> Result<TxHash, TokenizerError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
         match self.send_outcome {
             MockSendOutcome::ApiError => {
                 Err(TokenizerError::Alpaca(AlpacaTokenizationError::ApiError {
@@ -318,6 +333,7 @@ impl Tokenizer for MockTokenizer {
         &self,
         _tx_hash: &TxHash,
     ) -> Result<TokenizationRequest, TokenizerError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
         match self.detection_outcome {
             Some(MockDetectionOutcome::Detected) | None => Ok(TokenizationRequest::mock(
                 TokenizationRequestStatus::Pending,
@@ -340,6 +356,7 @@ impl Tokenizer for MockTokenizer {
         &self,
         tx_hash: &TxHash,
     ) -> Result<Option<TokenizationRequest>, TokenizerError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
         Ok(self
             .pending_requests
             .iter()
@@ -351,6 +368,7 @@ impl Tokenizer for MockTokenizer {
         &self,
         _id: &TokenizationRequestId,
     ) -> Result<TokenizationRequest, TokenizerError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
         match self.completion_outcome {
             Some(MockCompletionOutcome::Completed) => Ok(TokenizationRequest::mock(
                 TokenizationRequestStatus::Completed,
@@ -376,6 +394,7 @@ impl Tokenizer for MockTokenizer {
         wallet: Address,
         expected_amount: U256,
     ) -> Result<(), MintVerificationError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
         match self.verification_outcome {
             MockVerificationOutcome::Success => Ok(()),
             MockVerificationOutcome::ReceiptNotFound => {
@@ -402,6 +421,7 @@ impl Tokenizer for MockTokenizer {
     }
 
     async fn list_pending_requests(&self) -> Result<Vec<TokenizationRequest>, TokenizerError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
         match self.list_pending_outcome {
             MockListPendingOutcome::ApiError => {
                 return Err(TokenizerError::Alpaca(AlpacaTokenizationError::ApiError {


### PR DESCRIPTION
## What

- Move interrupted-tokenization resume (mint/redemption detection + completion polling) off the blocking startup path so a slow/down issuer can no longer wedge the bot. Implements [RAI-1081](https://linear.app/makeitrain/issue/RAI-1081/run-interrupted-tokenization-resume-off-the-startup-path-so-a-slowdown).
- `recover_interrupted_tokenization_aggregates` now enqueues a `ResumeTokenizationAggregate` job per interrupted aggregate instead of awaiting the issuer inline; the order-fill and inventory monitors start unconditionally.

## Why

- Startup awaited `recover_interrupted_tokenization_aggregates(...).await?` in `spawn_rebalancing_infrastructure` **before** spawning the monitors. For a redemption left in `Sent`, that polled the issuer for up to the full `PollingConfig` timeout (~30 min).
- While that poll ran, the bot stopped hedging and stopped detecting on-chain fills, yet systemd still reported `active (running)`. On timeout with a non-terminal redemption, startup errored and the process exited — systemd restarted it and the 30-minute block repeated: a silent freeze/crash-loop driven purely by issuer latency.
- Found diagnosing a prod freeze (2026-06-17): a QQQM redemption stuck in `Sent` blocked startup because the issuer had registered nothing that day.

## How

- New `ResumeTokenizationAggregate` apalis job (`src/rebalancing/equity/resume_job.rs`): enum target `Mint(IssuerRequestId)` / `Redemption(RedemptionAggregateId)`, ctx holds `Arc<CrossVenueEquityTransfer>`. `perform()` dispatches to `resume_mint`/`resume_redemption`; transient errors propagate for apalis retry; already-terminal aggregates return `Ok(())`.
- `recover_interrupted_tokenization_aggregates` (`src/conductor.rs`) now `requeue_orphaned()` then `cancel_all_pending()` then pushes one fresh job per interrupted aggregate — replacing the deleted blocking `resume_interrupted_transfers`. This ordering prevents duplicate Pending jobs across crash-restarts (a former-Running orphan is reset then cancelled before fresh pushes). The fast in-memory state recovery (`recover_mint_state`, `recover_redemption_state`, `recover_stuck_redemptions`) stays inline. The pre-wrap `HeldForRecovery` exclusion is preserved.
- The resume worker is registered as a **best-effort** worker, not fail-stop: new `build_best_effort_worker!` macro + `on_terminal_failure_log_only` handler (`src/conductor/job.rs`), wired with a permissive circuit-breaker config (`failure_threshold = u32::MAX`, 10s recovery) rather than the conductor-wide fail-stop. Exhausted retries on one aggregate log at `error!` and leave the conductor running — they neither crash the process nor latch the worker idle, so other interrupted aggregates still resume. `build_supervised_worker!` and `build_best_effort_worker!` now share a private `build_worker_inner!` macro.
- `apalis_pool` is threaded into `RebalancingDeps`; the resume queue is created in `spawn_rebalancing_infrastructure` and the worker registered in `builder::spawn`.
- The `requeue_orphaned` step here is intentionally soft-fail (logs and continues) — unlike sibling startup queues that abort — because gating startup on the resume queue is exactly what this PR removes; resume is idempotent so a surviving orphan is at worst a tolerated duplicate.

## Testing

- `recover_interrupted_tokenization_aggregates` tests (in-memory SQLite, aggregates seeded via CQRS commands + `MockTokenizer`, no raw `events` inserts): `issuer_down_does_not_block_tokenization_resume` (panic-on-issuer mock — completes <1s, jobs enqueued, zero issuer calls), `..._does_not_duplicate_jobs_on_restart`, `..._does_not_duplicate_running_orphan` (crash-restart with a Running orphan), `..._excludes_held_for_recovery_pre_wrap_mint`.
- `resume_job.rs` unit tests: dispatch per target variant, terminal/failed/completed aggregates return `Ok` with zero issuer I/O, missing aggregates propagate errors, payload JSON roundtrip.
- `best_effort_circuit_does_not_latch_on_single_terminal_failure` (`src/conductor/job.rs`): runs a job through `build_best_effort_worker!` with the production circuit config; one terminal failure does not stop the worker — a second job still succeeds.
- Full local CI green: `cargo check`/`clippy --all-targets --all-features` (0 warnings), `cargo fmt --check`, nixfmt, pre-commit hooks.

## Anything else

- No SPEC.md change — the startup-sequencing invariant was already stated; this is a code correction to match it. `docs/conductor.md` startup section updated.
- Self-reviewed via a multi-model panel over four passes; the headline fix (best-effort worker must not crash *or* latch on a persistently-failing aggregate) was surfaced and fixed during review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced conductor startup with improved resumption of interrupted tokenization workflows for mint and redemption operations
  * Optimized recovery handling for orphaned transaction states during startup

* **Tests**
  * Extended test coverage for tokenization recovery scenarios, including failure injection and state consistency validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->