### PR TITLE
ci: fix externally-merged workflow broken by --slurp + --jq

### DIFF
--- a/.github/workflows/externally-merged.yaml
+++ b/.github/workflows/externally-merged.yaml
@@ -50,14 +50,16 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          # --slurp collects all pages into a single JSON array of arrays before
-          # running --jq, so .[][] flattens them. Without --slurp, --jq runs per
-          # page and multi-line output from page 2+ breaks the boolean check.
+          # --slurp collects all pages into a single JSON array of arrays, then
+          # piped jq flattens them with .[][]. Without --slurp, jq would run per
+          # page and multi-line output from page 2+ breaks the boolean check. The
+          # runner's gh rejects --slurp combined with gh's own --jq, so we pipe to
+          # standalone jq instead of using --jq.
           merged=$(gh api --paginate --slurp \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-            --jq '[.[][]
+            | jq -r '[.[][]
               | select(.user.login == "graphite-app[bot]")
               | .body
               | contains("Merged by the [Graphite merge queue]")
@@ -227,14 +229,16 @@ jobs:
             # close PR), so retry a few times before giving up rather than
             # skip on the first miss.
             # --slurp + .[][] flattens page-arrays before filtering so the
-            # boolean is correct even when comments span multiple pages.
+            # boolean is correct even when comments span multiple pages. The
+            # runner's gh rejects --slurp combined with gh's own --jq, so we pipe
+            # to standalone jq instead of using --jq.
             marker_found=false
             for attempt in 1 2 3; do
               result=$(gh api --paginate --slurp \
                 -H "Accept: application/vnd.github+json" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 "/repos/$GITHUB_REPOSITORY/issues/$pr/comments" \
-                --jq '[.[][]
+                | jq -r '[.[][]
                   | select(.user.login == "graphite-app[bot]")
                   | .body
                   | contains("Merged by the [Graphite merge queue]")


### PR DESCRIPTION
Closes [RAI-1116](https://linear.app/makeitrain/issue/RAI-1116).

## What

- Fix the `Externally merged label` workflow, which has failed on **every** run since #862 landed (2026-06-15) — both the fast-path `label` job and the `push-backstop` job — so Graphite-MQ-merged PRs stopped getting the `externally-merged` label and their linked Linear issues stayed open.

## Why

- The runner's `gh` rejects `gh api --paginate --slurp` combined with gh's own `--jq`: `the --slurp option is not supported with --jq or --template`. The Graphite merge-marker comment lookup exits 1, so the job dies before applying any label.
- #862 introduced the `--slurp` + `--jq` combo in both jobs; runs flipped from green to red the moment it landed.

## How

- Pipe the slurped pages to standalone `jq -r` instead of gh's `--jq`, in both the `label` job's marker check and the `push-backstop` job's retry loop.
- `--slurp` alone is supported, so the array-of-arrays shape and `.[][]` flattening are unchanged — only the JSON consumer moves from `--jq` to a piped `jq`.

## Testing

- No automated tests (GitHub Actions workflow). Verified the `jq -r` filter against `--slurp`-shaped fixtures: marker present → `true`, absent → `false`, empty pages → `false`; confirmed the YAML parses. The 11 PRs missed during the outage were back-filled with the label manually.

## Anything else

- The same outage also surfaced pre-#862 dropped-event gaps (#834, #776, #786) that had no backstop at the time — now labelled manually; the restored `push-backstop` covers that class going forward.
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784410218&installation_id=125569124&pr_number=888&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F888&signature=813fbc423c9a09926c2064b7ea5083340acbdd2db1d29a68bcd3f05f87181e80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

