### PR TITLE
feat: resolve tokenized-equity address from the ticker in alpaca CLI

### DIFF
--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1124,6 +1124,18 @@ impl Ctx {
             .get(symbol)
             .is_some_and(|config| config.wrapped_equity_recovery == OperationMode::Enabled)
     }
+
+    /// Returns the configured tokenized-equity (minted onchain token) address
+    /// for `symbol`, or `None` when the symbol is absent from
+    /// `[assets.equities]`. Lets operator commands resolve the token from the
+    /// ticker instead of taking an error-prone address argument.
+    pub fn tokenized_equity(&self, symbol: &Symbol) -> Option<Address> {
+        self.assets
+            .equities
+            .symbols
+            .get(symbol)
+            .map(|config| config.tokenized_equity)
+    }
 }
 
 /// Test-only constructor for `Ctx` that internalizes fields e2e tests

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -13,8 +13,10 @@ on any specific command.
 
 ## Token Address Reference
 
-The `-t` flag on tokenization/redemption commands expects the **unwrapped**
-token contract address for that equity. Current addresses:
+The **unwrapped** tokenized-equity contract address per symbol. The tokenization
+and redemption commands resolve this from `-s` via `[assets.equities]`, so it no
+longer has to be passed by hand; the table is kept for reference and
+cross-checking. Current addresses:
 
 | Symbol | Unwrapped Token Address                      |
 | ------ | -------------------------------------------- |
@@ -52,11 +54,11 @@ Alpaca dashboard to confirm the order filled before proceeding.
 
 ```
 stox alpaca-tokenize -s COIN -q 10 \
-  -t 0x626757e6f50675d17fcad312e82f989ae7a23d38 \
   -r 0xbd41F40D91eE4E816Ada1Aa842e94aEb6B6385a6
 ```
 
-- `-t` is the unwrapped token contract address (see table above)
+- The tokenized-equity address is resolved from `-s` via `[assets.equities]`, so
+  it never has to be entered by hand
 - `-r` is the wallet that receives the minted tokens -- **always specify this**.
   Use the Fireblocks liquidity address
   (`0xbd41F40D91eE4E816Ada1Aa842e94aEb6B6385a6`)
@@ -86,7 +88,6 @@ stox buy -s COIN -q 10
 
 ```
 stox alpaca-tokenize -s COIN -q 10 \
-  -t 0x626757e6f50675d17fcad312e82f989ae7a23d38 \
   -r <dividend turnkey wallet address>
 ```
 
@@ -109,8 +110,7 @@ Reverse of buying and minting: redeem tokens offchain, then sell the shares.
 **Step 1: Redeem tokens**
 
 ```
-stox alpaca-redeem -s COIN -q 10 \
-  -t 0x626757e6f50675d17fcad312e82f989ae7a23d38
+stox alpaca-redeem -s COIN -q 10
 ```
 
 **Step 2: Sell shares offchain**

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -519,15 +519,13 @@ pub enum Commands {
     /// This is an isolated test command that only interacts with Alpaca's API,
     /// without any Raindex/vault operations.
     AlpacaTokenize {
-        /// Stock symbol (e.g., AAPL, TSLA)
+        /// Stock symbol (e.g., AAPL, TSLA) -- resolves the tokenized-equity
+        /// address from `[assets.equities]`
         #[arg(short = 's', long = "symbol")]
         symbol: Symbol,
         /// Number of shares to tokenize (supports fractional shares)
         #[arg(short = 'q', long = "quantity")]
         quantity: FractionalShares,
-        /// Token contract address (to verify balance after tokenization)
-        #[arg(short = 't', long = "token")]
-        token: Address,
         /// Recipient wallet address (defaults to configured wallet address)
         #[arg(short = 'r', long = "recipient")]
         recipient: Option<Address>,
@@ -539,15 +537,13 @@ pub enum Commands {
     /// This is an isolated test command that only interacts with Alpaca's API,
     /// without any Raindex/vault operations.
     AlpacaRedeem {
-        /// Stock symbol (e.g., AAPL, TSLA)
+        /// Stock symbol (e.g., AAPL, TSLA) -- resolves the tokenized-equity
+        /// address from `[assets.equities]`
         #[arg(short = 's', long = "symbol")]
         symbol: Symbol,
         /// Number of shares to redeem (supports fractional shares)
         #[arg(short = 'q', long = "quantity")]
         quantity: FractionalShares,
-        /// Token contract address
-        #[arg(short = 't', long = "token")]
-        token: Address,
         /// Alpaca redemption wallet (overrides [tokenization] config)
         #[arg(long = "redemption-wallet")]
         redemption_wallet: Option<Address>,
@@ -969,13 +965,11 @@ enum ProviderCommand {
     AlpacaTokenize {
         symbol: Symbol,
         quantity: FractionalShares,
-        token: Address,
         recipient: Option<Address>,
     },
     AlpacaRedeem {
         symbol: Symbol,
         quantity: FractionalShares,
-        token: Address,
         redemption_wallet: Option<Address>,
     },
     AlpacaTokenizationRequests,
@@ -1119,23 +1113,19 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         Commands::AlpacaTokenize {
             symbol,
             quantity,
-            token,
             recipient,
         } => Err(ProviderCommand::AlpacaTokenize {
             symbol,
             quantity,
-            token,
             recipient,
         }),
         Commands::AlpacaRedeem {
             symbol,
             quantity,
-            token,
             redemption_wallet,
         } => Err(ProviderCommand::AlpacaRedeem {
             symbol,
             quantity,
-            token,
             redemption_wallet,
         }),
         Commands::OrderStatus { order_id } => Ok(SimpleCommand::OrderStatus { order_id }),
@@ -1507,29 +1497,18 @@ async fn run_provider_command<W: Write>(
         ProviderCommand::AlpacaTokenize {
             symbol,
             quantity,
-            token,
             recipient,
         } => {
-            rebalancing::alpaca_tokenize_command(
-                stdout, symbol, quantity, token, recipient, ctx, provider,
-            )
-            .await
+            rebalancing::alpaca_tokenize_command(stdout, symbol, quantity, recipient, ctx, provider)
+                .await
         }
         ProviderCommand::AlpacaRedeem {
             symbol,
             quantity,
-            token,
             redemption_wallet,
         } => {
-            rebalancing::alpaca_redeem_command(
-                stdout,
-                symbol,
-                quantity,
-                token,
-                redemption_wallet,
-                ctx,
-            )
-            .await
+            rebalancing::alpaca_redeem_command(stdout, symbol, quantity, redemption_wallet, ctx)
+                .await
         }
         ProviderCommand::AlpacaTokenizationRequests => {
             rebalancing::alpaca_tokenization_requests_command(stdout, ctx).await

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -814,7 +814,6 @@ pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clon
     stdout: &mut Writer,
     symbol: Symbol,
     quantity: FractionalShares,
-    token: Address,
     recipient: Option<Address>,
     ctx: &Ctx,
     provider: Prov,
@@ -822,6 +821,10 @@ pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clon
     writeln!(stdout, "🔄 Requesting tokenization via Alpaca API")?;
     writeln!(stdout, "   Symbol: {symbol}")?;
     writeln!(stdout, "   Quantity: {quantity}")?;
+
+    let token = ctx
+        .tokenized_equity(&symbol)
+        .ok_or_else(|| anyhow::anyhow!("equity {symbol} is not configured in [assets.equities]"))?;
     writeln!(stdout, "   Token: {token}")?;
 
     let BrokerCtx::AlpacaBrokerApi(alpaca_auth) = &ctx.broker else {
@@ -946,13 +949,16 @@ pub(super) async fn alpaca_redeem_command<Writer: Write>(
     stdout: &mut Writer,
     symbol: Symbol,
     quantity: FractionalShares,
-    token: Address,
     redemption_wallet_flag: Option<Address>,
     ctx: &Ctx,
 ) -> anyhow::Result<()> {
     writeln!(stdout, "🔄 Requesting redemption via Alpaca API")?;
     writeln!(stdout, "   Symbol: {symbol}")?;
     writeln!(stdout, "   Quantity: {quantity}")?;
+
+    let token = ctx
+        .tokenized_equity(&symbol)
+        .ok_or_else(|| anyhow::anyhow!("equity {symbol} is not configured in [assets.equities]"))?;
     writeln!(stdout, "   Token: {token}")?;
 
     let BrokerCtx::AlpacaBrokerApi(alpaca_auth) = &ctx.broker else {
@@ -1247,6 +1253,7 @@ pub(crate) async fn recheck_transfer_command<W: Write>(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, address, b256};
+    use alloy::providers::ProviderBuilder;
     use rain_math_float::Float;
     use url::Url;
     use uuid::uuid;
@@ -1266,7 +1273,8 @@ mod tests {
     use st0x_config::RebalancingCtx;
     use st0x_config::create_test_issuance_ctx;
     use st0x_config::{
-        AssetsConfig, CashAssetConfig, EquitiesConfig, LogLevel, OperationMode, TradingMode,
+        AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, LogLevel, OperationMode,
+        TradingMode,
     };
 
     /// RAI-835: the manual redrive loop must re-invoke `resume` on the same id
@@ -2813,6 +2821,85 @@ mod tests {
         assert!(
             err_msg.contains("only valid from BridgingSubmitting or WithdrawalComplete"),
             "WithdrawalFailed state must be rejected as not in bridging phase; got: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn tokenized_equity_resolves_from_config() {
+        let mut ctx = create_ctx_without_rebalancing();
+        let token = address!("0x626757e6f50675d17fcad312e82f989ae7a23d38");
+        ctx.assets.equities.symbols.insert(
+            Symbol::new("COIN").unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: token,
+                tokenized_equity_derivative: Address::ZERO,
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+
+        assert_eq!(
+            ctx.tokenized_equity(&Symbol::new("COIN").unwrap()),
+            Some(token),
+            "a configured symbol must resolve to its tokenized_equity address",
+        );
+        assert_eq!(
+            ctx.tokenized_equity(&Symbol::new("AAPL").unwrap()),
+            None,
+            "an unconfigured symbol must resolve to None, never a default address",
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_tokenize_fails_when_symbol_not_configured() {
+        let ctx = create_alpaca_ctx_without_rebalancing();
+        let provider =
+            ProviderBuilder::new().connect_http(Url::parse("http://localhost:8545").unwrap());
+        let mut stdout = Vec::new();
+
+        let error = alpaca_tokenize_command(
+            &mut stdout,
+            Symbol::new("COIN").unwrap(),
+            FractionalShares::new(float!(10)),
+            None,
+            &ctx,
+            provider,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("equity COIN is not configured in [assets.equities]"),
+            "an unconfigured symbol must fail before any network call, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_redeem_fails_when_symbol_not_configured() {
+        let ctx = create_alpaca_ctx_without_rebalancing();
+        let mut stdout = Vec::new();
+
+        let error = alpaca_redeem_command(
+            &mut stdout,
+            Symbol::new("COIN").unwrap(),
+            FractionalShares::new(float!(10)),
+            None,
+            &ctx,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("equity COIN is not configured in [assets.equities]"),
+            "an unconfigured symbol must fail before any network call, got: {error}"
         );
     }
 }


### PR DESCRIPTION
## What

Make `alpaca-tokenize` and `alpaca-redeem` resolve the tokenized-equity contract
address from the `-s <ticker>` argument via `[assets.equities]` config, and drop
the now-redundant `-t/--token` flag.

## Why

Both commands already take the equity ticker, and the token address is held in
config keyed by that ticker. Requiring the operator to also paste the address by
hand was redundant and an easy way to mint/redeem against the wrong token.

## How

- Add `Ctx::tokenized_equity(symbol) -> Option<Address>` resolving the per-symbol
  `tokenized_equity` address.
- `alpaca-tokenize`/`alpaca-redeem` resolve the token from the ticker and fail
  fast (`equity <SYMBOL> is not configured in [assets.equities]`) on an unknown
  symbol, before any network call.
- Remove the `-t/--token` arg from both commands and their plumbing.
- Update the cli-ops runbook: tokenize/redeem examples no longer pass `-t`, and
  the Token Address Reference section no longer claims `-t` exists on these
  commands.

## Testing

- Unit: `tokenized_equity` resolves a configured symbol and returns `None` for an
  unconfigured one (never a default address).
- Unit: `alpaca-tokenize`/`alpaca-redeem` fail fast on an unconfigured symbol
  before any network call.
- `cargo check`, `cargo nextest run -p st0x-hedge cli::rebalancing` (42 passed),
  `cargo clippy` -- all green.

## Anything else

Addresses review feedback on the dividend CLI (resolve from ticker, less human
error). `vault-deposit`/`vault-withdraw` intentionally keep their explicit
`--token`: they are generic, symbol-agnostic commands.
