### PR TITLE
docs: fix README workspace crate list

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,14 +306,21 @@ Workspace crates:
   conductor, dashboard backend, and CLI
 - **`st0x-dto`** (`crates/dto/`) - Dashboard DTOs and TypeScript binding
   generation
-- **`st0x-event-sorcery`** (`crates/event-sorcery/`) - CQRS/event-sourcing
-  helpers, snapshot-backed loading, compactable observational event streams, and
-  testing utilities
+- **`st0x-event-sorcery`** (git dependency) - CQRS/event-sourcing helpers,
+  snapshot-backed loading, compactable observational event streams, and testing
+  utilities
 - **`st0x-execution`** (`crates/execution/`) - Standalone `Executor` trait
-  abstraction with Alpaca Broker API and mock implementations
+  abstraction with Alpaca Broker API, Alpaca wallet ops, and mock implementations
 - **`st0x-bridge`** (`crates/bridge/`) - Cross-chain bridge abstractions and
   CCTP implementation
-- **`st0x-evm`** (`crates/evm/`) - EVM wallet, provider, and test-chain support
+- **`st0x-raindex`** (`crates/raindex/`) - Rain OrderBook V6 abstraction with
+  `Raindex` trait for vault deposit/withdraw operations
+- **`st0x-wrapper`** (`crates/wrapper/`) - ERC-4626 wrap/unwrap abstractions
+  with `Wrapper` trait and ratio math
+- **`st0x-evm`** (`crates/evm/`) - EVM wallet, provider, ABI bindings (IERC20,
+  IPyth), chain/token constants, and test-chain support
+- **`st0x-config`** (`crates/config/`) - Configuration loading and runtime
+  context assembly; restricted to server and CLI binaries
 - **`st0x-finance`** (`crates/finance/`) - Shared financial primitives:
   `Symbol`, `FractionalShares`, `Usdc`, `Usd`, and related domain types
 - **`st0x-float-serde`** (`crates/float-serde/`) - Shared Rain Float formatting


### PR DESCRIPTION
## What

Fix the Cargo Workspace crate list in `README.md`.

## Why

Three recent refactors left the README's workspace crate inventory out of
sync with the actual repo:

- **#881** moved `IERC20`/`IPyth` ABI bindings and USDC address constants into
  `st0x-evm`; the README description of that crate didn't reflect this.
- **#882** moved the `alpaca_wallet` module from the root crate into
  `st0x-execution`; the README description of `st0x-execution` still said only
  "Alpaca Broker API and mock implementations".
- The README listed `st0x-event-sorcery` with path `(crates/event-sorcery/)`,
  but that directory does not exist — `st0x-event-sorcery` is a git dependency,
  not a local workspace crate.
- Three local workspace crates (`st0x-raindex`, `st0x-wrapper`, `st0x-config`)
  were absent from the list entirely.

## How

- Corrected `st0x-event-sorcery` label from `(crates/event-sorcery/)` to
  `(git dependency)`.
- Updated `st0x-execution` description to include Alpaca wallet ops.
- Updated `st0x-evm` description to include ABI bindings and chain/token
  constants.
- Added `st0x-raindex`, `st0x-wrapper`, and `st0x-config` entries with their
  correct paths and one-line descriptions matching their crate doc comments.

## Testing

Verified all listed local paths exist under `crates/` and descriptions match
the `//!` doc comments in each crate's `lib.rs`. No code changes.

## Anything else

No functional changes; documentation only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBNoKJjEt8nFdQ9vVTUD4H)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784603216&installation_id=125569124&pr_number=903&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F903&signature=728b1799eacc45107efda4c78f0c309c936fd5bab6b43b20ca42eccffa88be59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation with expanded structure overview and detailed component descriptions to provide clearer guidance on available modules and their capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->