### PR TITLE
ci: tighten externally-merged workflow to pull-requests: read

### DIFF
--- a/.github/workflows/externally-merged.yaml
+++ b/.github/workflows/externally-merged.yaml
@@ -24,7 +24,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   label:


### PR DESCRIPTION
## What

Reduce the `externally-merged` workflow's `pull-requests` permission from
`write` to `read`.

## Why

The workflow performs no writes against the pulls API — its only pulls call is
`GET /repos/.../pulls/{pr}` to read PR metadata. Every label write goes through
the **issues** API and is covered by `issues: write` (unchanged). So
`pull-requests: write` is unused, and granting it violates least privilege
(zizmor flags it as `excessive-permissions`).

CodeRabbit surfaced the same thing while reviewing the sibling port into
`st0x.issuance` (#201); this keeps both repos consistent.

## How

One-line change in `.github/workflows/externally-merged.yaml`:

```diff
 permissions:
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
```

## Testing

- `pull-requests: read` is sufficient for `GET /pulls/{pull_number}` (the
  endpoint's fine-grained permission requirement).
- Label create/apply use the issues API and retain `issues: write`.
- YAML validated.

https://claude.ai/code/session_016L66113DDJa7K6XmycM8E3
