### PR TITLE
config: tune prod USDC + equity rebalancing bands + op-limit

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -57,12 +57,12 @@ attestation_retry_deadline_secs = 86400
 
 [rebalancing.usdc]
 mode = "enabled"
-target = 0.5
-deviation = 0.2
+target = 0.6
+deviation = 0.05
 
 [rebalancing.equity]
-target = 0.6
-deviation = 0.1
+target = 0.5
+deviation = 0.05
 
 [rest_api]
 url = "https://api.st0x.io"
@@ -88,7 +88,7 @@ vault_id = "0xfab4"
 # Whether automatic USDC rebalancing between venues is active.
 rebalancing = "enabled"
 # Maximum USDC moved per rebalance operation.
-operational_limit = 1000
+operational_limit = 10000
 # No cash reserve: all offchain USDC is available for rebalancing.
 # (Omitted because `reserved` is typed Positive<Usd> and rejects 0.)
 


### PR DESCRIPTION
## What
- `[rebalancing.usdc]`: `target` 0.5 -> 0.6, `deviation` 0.2 -> 0.05 (band [30%, 70%] -> [55%, 65%]).
- `[rebalancing.equity]`: `target` 0.6 -> 0.5, `deviation` 0.1 -> 0.05 (band [50%, 70%] -> [45%, 55%]).
- `[assets.cash]`: `operational_limit` 1000 -> 10000 (max USDC per automatic rebalance).
- File: `config/prod/st0x-hedge.toml` (prod only).

## Why
- USDC: keep more onchain (60% vs 50%) to back Raindex liquidity; tighter band holds the split closer to target.
- Equity: target a 50-50 venue split with a 5% trigger band (was 60-40 with a 10% band).
- Cash: raise the per-rebalance cap so the bot corrects a large imbalance in one cycle instead of many 1k steps.

## How
- Config-only; no code paths changed. Rebalance fires when `onchain/total` leaves `target +/- deviation`, then moves toward target capped at `operational_limit`.

## Testing
- Config-only. `taplo` TOML lint passed via pre-commit; no code paths changed.

## Anything else
- prod only. Staging has no `[rebalancing.usdc]`; `example.config.toml` keeps its illustrative values -- both unchanged.
- Tradeoffs: a +/-5% band rebalances more frequently than the prior wider bands; a 10k op-limit lets a single automatic rebalance move up to 10k USDC (one CCTP transfer) instead of chunking.
