### PR TITLE
feat(execution): extended-hours execution-layer primitives

### DIFF
--- a/crates/execution/src/alpaca_broker_api/client.rs
+++ b/crates/execution/src/alpaca_broker_api/client.rs
@@ -15,7 +15,7 @@ use super::journal::{JournalRequest, JournalResponse};
 use super::order::{
     CryptoOrderRequest, CryptoOrderResponse, LimitOrderRequest, OrderRequest, OrderResponse,
 };
-use crate::{ClientOrderId, FractionalShares, Positive, Symbol};
+use crate::{CancellationOutcome, ClientOrderId, FractionalShares, Positive, Symbol};
 
 /// Request timeout applied to every Alpaca Broker API HTTP call.
 ///
@@ -203,6 +203,47 @@ impl AlpacaBrokerApiClient {
         }
     }
 
+    /// Cancel an order by ID.
+    ///
+    /// A 404 (the broker does not recognise the order id) is surfaced as
+    /// [`CancellationOutcome::OrderNotFound`] rather than collapsed into
+    /// success: the caller must resolve the order as terminal instead of
+    /// waiting for a cancellation confirmation that `get_order_status` (which
+    /// would also 404) can never deliver.
+    ///
+    /// NOTE: 404 means "order id not found" ONLY. An order that exists but is in
+    /// a non-cancelable terminal state (filled / expired / already canceled)
+    /// returns 422, which is propagated as an error here. Per the endpoint
+    /// reference (https://docs.alpaca.markets/reference/deleteorderforaccount):
+    /// 204 No Content on success, 404 "Resource does not exist", 422 when the
+    /// order is no longer cancelable. Cancel-and-replace
+    /// still converges in that case because the caller runs
+    /// `reconcile_pre_cancel` (a broker status read) before every DELETE: a
+    /// just-filled order is observed terminal on the retry and short-circuits
+    /// before the DELETE is reattempted.
+    pub(super) async fn cancel_order(
+        &self,
+        order_id: Uuid,
+    ) -> Result<CancellationOutcome, AlpacaBrokerApiError> {
+        let url = format!(
+            "{}/v1/trading/accounts/{}/orders/{}",
+            self.base_url, self.account_id, order_id
+        );
+
+        debug!("Cancelling order {} at {}", order_id, url);
+
+        match self.delete(&url).await {
+            Ok(()) => Ok(CancellationOutcome::Requested),
+            Err(AlpacaBrokerApiError::ApiError { status, .. })
+                if status == reqwest::StatusCode::NOT_FOUND =>
+            {
+                debug!(%order_id, "Cancel returned 404; broker does not recognise the order");
+                Ok(CancellationOutcome::OrderNotFound)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     /// Get asset information by symbol
     pub(super) async fn get_asset(
         &self,
@@ -307,6 +348,20 @@ impl AlpacaBrokerApiClient {
         self.handle_response(Method::GET, response).await
     }
 
+    /// Perform a DELETE request, expecting no response body.
+    pub(super) async fn delete(&self, url: &str) -> Result<(), AlpacaBrokerApiError> {
+        let response = self.http_client.delete(url).send().await?;
+        let status = response.status();
+
+        if status.is_success() {
+            return Ok(());
+        }
+
+        let bytes = response.bytes().await?;
+
+        Err(parse_api_error(status, &bytes))
+    }
+
     /// Perform a POST request with JSON body
     pub(super) async fn post<T: serde::de::DeserializeOwned + Send, B: Serialize + Sync>(
         &self,
@@ -344,16 +399,23 @@ impl AlpacaBrokerApiClient {
             return Ok(serde_json::from_slice(&bytes)?);
         }
 
-        let (alpaca_code, message) = match serde_json::from_slice::<AlpacaApiErrorBody>(&bytes) {
-            Ok(parsed) => (parsed.code, parsed.message),
-            Err(_) => (None, String::from_utf8_lossy(&bytes).into_owned()),
-        };
+        Err(parse_api_error(status, &bytes))
+    }
+}
 
-        Err(AlpacaBrokerApiError::ApiError {
-            status,
-            alpaca_code,
-            message,
-        })
+/// Parse an Alpaca error response body into an `ApiError`, falling back to the
+/// raw (lossy-decoded) body when it does not match `AlpacaApiErrorBody`. Shared
+/// by `delete` and `handle_response` so both error paths stay in sync.
+fn parse_api_error(status: reqwest::StatusCode, bytes: &[u8]) -> AlpacaBrokerApiError {
+    let (alpaca_code, message) = match serde_json::from_slice::<AlpacaApiErrorBody>(bytes) {
+        Ok(parsed) => (parsed.code, parsed.message),
+        Err(_) => (None, String::from_utf8_lossy(bytes).into_owned()),
+    };
+
+    AlpacaBrokerApiError::ApiError {
+        status,
+        alpaca_code,
+        message,
     }
 }
 
@@ -431,6 +493,79 @@ mod tests {
         assert!(!debug_output.contains("test_secret_key"));
         assert!(debug_output.contains("904837e3-3b76-47ec-b432-046db621571b"));
         assert!(debug_output.contains("Sandbox"));
+    }
+
+    #[tokio::test]
+    async fn cancel_order_succeeds_on_2xx() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = uuid!("11111111-1111-1111-1111-111111111111");
+
+        let mock = server.mock(|when, then| {
+            when.method(DELETE).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(204);
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let outcome = client.cancel_order(order_id).await.unwrap();
+
+        mock.assert();
+        assert_eq!(outcome, CancellationOutcome::Requested);
+    }
+
+    #[tokio::test]
+    async fn cancel_order_maps_404_to_order_not_found() {
+        // A 404 means the broker no longer recognises the id. It must surface
+        // as a distinct outcome -- not success (the order would wait forever
+        // for a cancellation confirmation) and not a retryable error (the
+        // DELETE can never succeed).
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = uuid!("22222222-2222-2222-2222-222222222222");
+
+        let mock = server.mock(|when, then| {
+            when.method(DELETE).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(404)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({ "code": 40_410_000, "message": "order not found" }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let outcome = client.cancel_order(order_id).await.unwrap();
+
+        mock.assert();
+        assert_eq!(outcome, CancellationOutcome::OrderNotFound);
+    }
+
+    #[tokio::test]
+    async fn cancel_order_propagates_non_404_error() {
+        // A 5xx (or 422 non-cancelable) must NOT be swallowed -- only 404 is
+        // idempotent. The caller's pre-cancel reconcile handles terminal states.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = uuid!("33333333-3333-3333-3333-333333333333");
+
+        let mock = server.mock(|when, then| {
+            when.method(DELETE).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(500)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({ "message": "internal error" }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let error = client.cancel_order(order_id).await.unwrap_err();
+
+        mock.assert();
+        let AlpacaBrokerApiError::ApiError { status, .. } = error else {
+            panic!("expected ApiError, got {error:?}");
+        };
+        assert_eq!(status, reqwest::StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[tokio::test]

--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -16,11 +16,12 @@ use super::journal::JournalResponse;
 use super::order::{
     AlpacaLimitOrder, ConversionDirection, CryptoOrderOutcome, CryptoOrderResponse,
 };
-use super::{AlpacaBrokerApiError, AssetStatus, TimeInForce};
+use super::{AlpacaBrokerApiError, AssetStatus, MissingOrderField, TimeInForce};
 use crate::{
-    ClientOrderId, CounterTradePreflight, Direction, Executor, FractionalShares, InventoryResult,
-    MarketOrder, OrderPlacement, OrderState, OrderStatus, Positive, SupportedExecutor, Symbol,
-    TryIntoExecutor, buying_power_counter_trade_preflight, estimate_buffered_cost_cents,
+    CancellationOutcome, ClientOrderId, CounterTradePreflight, Direction, Executor,
+    ExecutorOrderId, FractionalShares, InventoryResult, LimitOrder, MarketOrder, MarketSession,
+    OrderPlacement, OrderState, OrderStatus, Positive, SupportedExecutor, Symbol, TryIntoExecutor,
+    Usd, buying_power_counter_trade_preflight, estimate_buffered_cost_cents,
 };
 
 /// Response from the asset endpoint
@@ -140,25 +141,69 @@ impl Executor for AlpacaBrokerApi {
 
         match order_update.status {
             OrderStatus::Pending | OrderStatus::Submitted => Ok(OrderState::Submitted {
-                order_id: order_id.clone(),
+                order_id: ExecutorOrderId::new(order_id),
             }),
-            OrderStatus::Filled => {
-                let price = order_update.price.ok_or_else(|| {
-                    AlpacaBrokerApiError::IncompleteFilledOrder {
-                        order_id: order_id.clone(),
-                        field: "price".to_string(),
+            OrderStatus::PartiallyFilled => {
+                let shares_filled = order_update.shares_filled.ok_or_else(|| {
+                    AlpacaBrokerApiError::IncompleteOrder {
+                        order_id: ExecutorOrderId::new(order_id),
+                        field: MissingOrderField::FilledQty,
                     }
                 })?;
 
-                Ok(OrderState::Filled {
-                    executed_at: order_update.updated_at,
-                    order_id: order_id.clone(),
-                    price,
+                Ok(OrderState::PartiallyFilled {
+                    order_id: ExecutorOrderId::new(order_id),
+                    shares_filled,
+                    avg_price: order_update.price.map(Usd::new),
+                    partially_filled_at: order_update.updated_at,
                 })
             }
+            OrderStatus::Filled => {
+                let price =
+                    order_update
+                        .price
+                        .ok_or_else(|| AlpacaBrokerApiError::IncompleteOrder {
+                            order_id: ExecutorOrderId::new(order_id),
+                            field: MissingOrderField::Price,
+                        })?;
+
+                Ok(OrderState::Filled {
+                    executed_at: order_update.updated_at,
+                    order_id: ExecutorOrderId::new(order_id),
+                    price: Usd::new(price),
+                })
+            }
+            // Alpaca always reports filled_qty ("0" when unfilled), so a
+            // terminal response without it is malformed: passing None through
+            // would be indistinguishable from a no-fill terminal order
+            // downstream, silently dropping any partial fill (the
+            // double-hedge failure mode). Fail closed like PartiallyFilled.
+            OrderStatus::Cancelled => {
+                let shares_filled = order_update.shares_filled.ok_or_else(|| {
+                    AlpacaBrokerApiError::IncompleteOrder {
+                        order_id: ExecutorOrderId::new(order_id),
+                        field: MissingOrderField::FilledQty,
+                    }
+                })?;
+                Ok(OrderState::Cancelled {
+                    cancelled_at: order_update.updated_at,
+                    order_id: ExecutorOrderId::new(order_id),
+                    shares_filled,
+                    avg_price: order_update.price.map(Usd::new),
+                })
+            }
+            // Unlike Cancelled, Failed does NOT fail closed on a missing
+            // filled_qty: rejected-order payloads have been observed without
+            // the field, and erroring here would wedge rejection handling
+            // (the poll retries the same read forever and the position never
+            // releases). A genuine partial fill on a failed order carries
+            // filled_qty, which the retained-fill path records; an absent
+            // field on a rejection means no fill.
             OrderStatus::Failed => Ok(OrderState::Failed {
                 failed_at: order_update.updated_at,
                 error_reason: None,
+                shares_filled: order_update.shares_filled,
+                avg_price: order_update.price.map(Usd::new),
             }),
         }
     }
@@ -202,7 +247,7 @@ impl Executor for AlpacaBrokerApi {
                 let account_funds = super::positions::get_account_funds(&self.client).await?;
                 let estimated_cost_cents = estimate_buffered_cost_cents(
                     order.shares,
-                    latest_trade_price.inner(),
+                    latest_trade_price.inner().inner(),
                     self.counter_trade_slippage_bps,
                 )?;
 
@@ -225,6 +270,52 @@ impl Executor for AlpacaBrokerApi {
                 Ok(preflight)
             }
         }
+    }
+
+    async fn fetch_latest_trade_price(
+        &self,
+        symbol: &Symbol,
+    ) -> Result<Option<Positive<Usd>>, Self::Error> {
+        let price = crate::alpaca_market_data::fetch_latest_trade_price(
+            self.client.market_data_http_client(),
+            self.client.market_data_base_url(),
+            symbol,
+        )
+        .await?;
+        Ok(Some(price))
+    }
+
+    async fn market_session(&self) -> Result<MarketSession, Self::Error> {
+        super::market_hours::market_session(&self.client).await
+    }
+
+    async fn place_limit_order(
+        &self,
+        order: LimitOrder,
+    ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
+        let asset = self.get_asset_cached(&order.symbol).await?;
+        Self::validate_asset(&order.symbol, &asset)?;
+
+        let alpaca_limit_price = super::order::AlpacaLimitPrice::try_new(order.limit_price)?;
+
+        let alpaca_order = AlpacaLimitOrder {
+            symbol: order.symbol,
+            shares: order.shares,
+            direction: order.direction,
+            limit_price: alpaca_limit_price,
+            extended_hours: order.extended_hours,
+            client_order_id: order.client_order_id,
+        };
+
+        super::order::place_limit_order(&self.client, alpaca_order).await
+    }
+
+    async fn cancel_order(
+        &self,
+        order_id: &Self::OrderId,
+    ) -> Result<CancellationOutcome, Self::Error> {
+        let order_uuid = Uuid::parse_str(order_id)?;
+        self.client.cancel_order(order_uuid).await
     }
 }
 
@@ -316,12 +407,12 @@ impl AlpacaBrokerApi {
             .await
     }
 
-    /// Place a manual Alpaca Broker API limit order for operator intervention.
+    /// Place a manual Alpaca-specific limit order for operator intervention.
     ///
-    /// This stays outside the generic `Executor` trait because automated hedging
-    /// uses market orders only; manual CLI limit orders are an Alpaca-specific
-    /// workflow.
-    pub async fn place_limit_order(
+    /// Accepts `AlpacaLimitOrder` directly (pre-validated Alpaca price type).
+    /// For automated counter-trading, use the `Executor::place_limit_order`
+    /// trait method which accepts the broker-agnostic `LimitOrder` type.
+    pub async fn place_alpaca_limit_order(
         &self,
         order: AlpacaLimitOrder,
     ) -> Result<OrderPlacement<String>, AlpacaBrokerApiError> {
@@ -387,7 +478,7 @@ mod tests {
     use crate::alpaca_broker_api::order::AlpacaLimitPrice;
     use crate::{
         ClientOrderId, CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason,
-        Direction, FractionalShares, Positive, Usd,
+        Direction, FractionalShares, LimitOrder, Positive, Usd,
     };
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
@@ -847,7 +938,8 @@ mod tests {
                     "type": "limit",
                     "limit_price": "195.25",
                     "time_in_force": "day",
-                    "extended_hours": true
+                    "extended_hours": true,
+                    "client_order_id": "88888888-8888-4888-8888-888888888888"
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -1135,14 +1227,112 @@ mod tests {
             )
             .unwrap(),
             extended_hours: true,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "88888888-8888-4888-8888-888888888888"
+            )),
         };
 
-        let result = executor.place_limit_order(order).await.unwrap();
+        let result = executor.place_alpaca_limit_order(order).await.unwrap();
 
         asset_mock.assert();
         order_mock.assert();
         assert_eq!(result.order_id, "61e7b016-9c91-4a97-b912-615c9d365c9d");
         assert_eq!(result.symbol, Symbol::new("AAPL").unwrap());
+    }
+
+    #[tokio::test]
+    async fn executor_place_limit_order_maps_broker_agnostic_fields() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        let account_mock = create_account_mock(&server);
+        let asset_mock = create_asset_mock(&server, "AAPL", "active", true);
+        let order_mock = create_limit_order_mock(&server);
+
+        let executor = AlpacaBrokerApi::try_from_ctx(ctx).await.unwrap();
+        account_mock.assert();
+
+        let limit_price = Positive::new(Usd::new(float!(195.25))).unwrap();
+        let order = LimitOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
+            direction: Direction::Buy,
+            limit_price,
+            extended_hours: true,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "88888888-8888-4888-8888-888888888888"
+            )),
+        };
+
+        let result = <AlpacaBrokerApi as Executor>::place_limit_order(&executor, order)
+            .await
+            .unwrap();
+
+        asset_mock.assert();
+        order_mock.assert();
+        assert_eq!(result.order_id, "61e7b016-9c91-4a97-b912-615c9d365c9d");
+        assert_eq!(result.symbol, Symbol::new("AAPL").unwrap());
+        assert_eq!(
+            result.shares,
+            Positive::new(FractionalShares::new(float!(100))).unwrap()
+        );
+        assert_eq!(result.direction, Direction::Buy);
+        assert!(result.extended_hours);
+        assert_eq!(result.limit_price, Some(limit_price));
+    }
+
+    #[tokio::test]
+    async fn executor_place_limit_order_rejects_invalid_precision_before_placement() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        let account_mock = create_account_mock(&server);
+        let asset_mock = create_asset_mock(&server, "AAPL", "active", true);
+        let order_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": "61e7b016-9c91-4a97-b912-615c9d365c9d",
+                    "symbol": "AAPL",
+                    "qty": "100",
+                    "side": "buy",
+                    "status": "new",
+                    "filled_avg_price": null
+                }));
+        });
+
+        let executor = AlpacaBrokerApi::try_from_ctx(ctx).await.unwrap();
+        account_mock.assert();
+
+        let order = LimitOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
+            direction: Direction::Buy,
+            limit_price: Positive::new(Usd::new(float!(195.255))).unwrap(),
+            extended_hours: true,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "88888888-8888-4888-8888-888888888888"
+            )),
+        };
+
+        let error = <AlpacaBrokerApi as Executor>::place_limit_order(&executor, order)
+            .await
+            .unwrap_err();
+
+        asset_mock.assert();
+        order_mock.assert_calls(0);
+        assert!(
+            matches!(
+                error,
+                AlpacaBrokerApiError::InvalidLimitPricePrecision {
+                    limit_price,
+                    max_decimals: 2,
+                } if limit_price == Positive::new(Usd::new(float!(195.255))).unwrap()
+            ),
+            "expected InvalidLimitPricePrecision, got {error:?}"
+        );
     }
 
     #[tokio::test]
@@ -1169,9 +1359,10 @@ mod tests {
             )
             .unwrap(),
             extended_hours: true,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
 
-        let result = executor.place_limit_order(order).await;
+        let result = executor.place_alpaca_limit_order(order).await;
 
         asset_mock.assert();
         order_mock.assert_calls(0);
@@ -1210,9 +1401,10 @@ mod tests {
             )
             .unwrap(),
             extended_hours: true,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
 
-        let result = executor.place_limit_order(order).await;
+        let result = executor.place_alpaca_limit_order(order).await;
 
         asset_mock.assert();
         order_mock.assert_calls(0);
@@ -1223,6 +1415,286 @@ mod tests {
                 AlpacaBrokerApiError::AssetNotTradable { symbol } if *symbol == Symbol::new("AAPL").unwrap()
             ),
             "Expected AssetNotTradable error, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_surfaces_404_as_order_not_found() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let account_mock = create_account_mock(&server);
+        let order_id = "904837e3-3b76-47ec-b432-046db621571b".to_string();
+
+        let cancel_mock = server.mock(|when, then| {
+            when.method(DELETE).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(404)
+                .header("content-type", "application/json")
+                .json_body(json!({ "code": 40_410_000, "message": "order not found" }));
+        });
+
+        let executor = AlpacaBrokerApi::try_from_ctx(ctx).await.unwrap();
+        account_mock.assert();
+
+        let outcome = executor.cancel_order(&order_id).await.unwrap();
+
+        cancel_mock.assert();
+        assert_eq!(outcome, crate::CancellationOutcome::OrderNotFound);
+    }
+
+    #[tokio::test]
+    async fn cancel_order_surfaces_2xx_as_requested() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let account_mock = create_account_mock(&server);
+        let order_id = "904837e3-3b76-47ec-b432-046db621571b".to_string();
+
+        let cancel_mock = server.mock(|when, then| {
+            when.method(DELETE).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(204);
+        });
+
+        let executor = AlpacaBrokerApi::try_from_ctx(ctx).await.unwrap();
+        account_mock.assert();
+
+        let outcome = executor.cancel_order(&order_id).await.unwrap();
+
+        cancel_mock.assert();
+        assert_eq!(outcome, crate::CancellationOutcome::Requested);
+    }
+
+    #[tokio::test]
+    async fn get_order_status_maps_cancelled_broker_order_with_fill_to_order_state() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let account_mock = create_account_mock(&server);
+        let order_id = "61e7b016-9c91-4a97-b912-615c9d365c9d".to_string();
+
+        let status_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "AAPL",
+                    "qty": "100",
+                    "filled_qty": "40.5",
+                    "side": "buy",
+                    "status": "canceled",
+                    "filled_avg_price": "199.50",
+                    "canceled_at": "2025-01-06T14:32:01.111111Z"
+                }));
+        });
+
+        let executor = AlpacaBrokerApi::try_from_ctx(ctx).await.unwrap();
+        account_mock.assert();
+
+        let state = executor.get_order_status(&order_id).await.unwrap();
+
+        status_mock.assert();
+        let OrderState::Cancelled {
+            shares_filled,
+            avg_price,
+            cancelled_at,
+            ..
+        } = state
+        else {
+            panic!("expected OrderState::Cancelled, got {state:?}");
+        };
+        assert_eq!(shares_filled, FractionalShares::new(float!(40.5)));
+        assert_eq!(avg_price, Some(Usd::new(float!(199.50))));
+        // Broker cancellation time, not the local observation time.
+        assert_eq!(
+            cancelled_at,
+            "2025-01-06T14:32:01.111111Z"
+                .parse::<chrono::DateTime<chrono::Utc>>()
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn get_order_status_cancelled_without_filled_qty_errors() {
+        // The Cancelled arm fails closed on a missing filled_qty: a payload
+        // claiming a cancellation without the quantity is malformed (Alpaca
+        // always includes filled_qty, "0" when unfilled), and passing None
+        // through would silently drop any partial fill.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let account_mock = create_account_mock(&server);
+        let order_id = "61e7b016-9c91-4a97-b912-615c9d365c9d".to_string();
+
+        let status_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "AAPL",
+                    "qty": "100",
+                    "side": "buy",
+                    "status": "canceled",
+                    "filled_avg_price": "199.50",
+                    "canceled_at": "2025-01-06T14:32:01.111111Z"
+                }));
+        });
+
+        let executor = AlpacaBrokerApi::try_from_ctx(ctx).await.unwrap();
+        account_mock.assert();
+
+        let error = executor.get_order_status(&order_id).await.unwrap_err();
+
+        status_mock.assert();
+        assert!(
+            matches!(
+                &error,
+                AlpacaBrokerApiError::IncompleteOrder { order_id: id, field: MissingOrderField::FilledQty }
+                    if *id == ExecutorOrderId::new(&order_id)
+            ),
+            "expected IncompleteOrder for FilledQty, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_order_status_rejected_without_filled_qty_maps_to_failed() {
+        // Rejected-order payloads have been observed without filled_qty.
+        // Failing closed here would wedge rejection handling: the poll
+        // would retry the same erroring status read forever and the
+        // position would never release its pending slot.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let account_mock = create_account_mock(&server);
+        let order_id = "61e7b016-9c91-4a97-b912-615c9d365c9d".to_string();
+
+        let status_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "AAPL",
+                    "qty": "100",
+                    "side": "buy",
+                    "status": "rejected"
+                }));
+        });
+
+        let executor = AlpacaBrokerApi::try_from_ctx(ctx).await.unwrap();
+        account_mock.assert();
+
+        let state = executor.get_order_status(&order_id).await.unwrap();
+
+        status_mock.assert();
+        let OrderState::Failed {
+            shares_filled,
+            avg_price,
+            ..
+        } = state
+        else {
+            panic!("expected OrderState::Failed, got {state:?}");
+        };
+        assert_eq!(shares_filled, None);
+        assert_eq!(avg_price, None);
+    }
+
+    #[tokio::test]
+    async fn get_order_status_partially_filled_without_filled_qty_errors() {
+        // The PartiallyFilled arm requires filled_qty: a broker payload
+        // claiming a partial fill without the quantity must fail fast rather
+        // than fabricate a fill amount.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let account_mock = create_account_mock(&server);
+        let order_id = "61e7b016-9c91-4a97-b912-615c9d365c9d".to_string();
+
+        let status_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "AAPL",
+                    "qty": "100",
+                    "side": "buy",
+                    "status": "partially_filled",
+                    "filled_avg_price": "199.50"
+                }));
+        });
+
+        let executor = AlpacaBrokerApi::try_from_ctx(ctx).await.unwrap();
+        account_mock.assert();
+
+        let error = executor.get_order_status(&order_id).await.unwrap_err();
+
+        status_mock.assert();
+        assert!(
+            matches!(
+                &error,
+                AlpacaBrokerApiError::IncompleteOrder { order_id: id, field: MissingOrderField::FilledQty }
+                    if *id == ExecutorOrderId::new(&order_id)
+            ),
+            "expected IncompleteOrder for FilledQty, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_order_status_maps_partially_filled_broker_order_to_order_state() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let account_mock = create_account_mock(&server);
+        let order_id = "61e7b016-9c91-4a97-b912-615c9d365c9d".to_string();
+
+        let status_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "AAPL",
+                    "qty": "100",
+                    "filled_qty": "40.5",
+                    "side": "buy",
+                    "status": "partially_filled",
+                    "filled_avg_price": "199.50",
+                    "updated_at": "2025-01-06T14:32:01.111111Z"
+                }));
+        });
+
+        let executor = AlpacaBrokerApi::try_from_ctx(ctx).await.unwrap();
+        account_mock.assert();
+
+        let state = executor.get_order_status(&order_id).await.unwrap();
+
+        status_mock.assert();
+        let OrderState::PartiallyFilled {
+            shares_filled,
+            avg_price,
+            partially_filled_at,
+            ..
+        } = state
+        else {
+            panic!("expected OrderState::PartiallyFilled, got {state:?}");
+        };
+        assert_eq!(shares_filled, FractionalShares::new(float!(40.5)));
+        assert_eq!(avg_price, Some(Usd::new(float!(199.50))));
+        // Partial-fill time comes from the broker's updated_at timestamp.
+        assert_eq!(
+            partially_filled_at,
+            "2025-01-06T14:32:01.111111Z"
+                .parse::<chrono::DateTime<chrono::Utc>>()
+                .unwrap()
         );
     }
 }

--- a/crates/execution/src/alpaca_broker_api/market_hours.rs
+++ b/crates/execution/src/alpaca_broker_api/market_hours.rs
@@ -1,20 +1,48 @@
+use std::cmp::Ordering;
+
 use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
 use chrono_tz::America::New_York;
 use serde::Deserialize;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::AlpacaBrokerApiError;
 use super::client::AlpacaBrokerApiClient;
 
-/// Response from the calendar endpoint for regular market hours.
-/// We use regular hours (open/close) because Alpaca only allows extended_hours
-/// with limit orders, not market orders.
+use crate::MarketSession;
+
+/// Response from the Alpaca calendar endpoint
+/// (https://docs.alpaca.markets/reference/getcalendar-1).
+///
+/// `date` identifies the trading day the entry describes, so callers can
+/// verify the broker answered for the day they actually queried.
+/// `open`/`close` are the regular trading hours (typically 09:30-16:00 ET).
+/// `session_open`/`session_close` span the full extended session including
+/// pre-market and after-hours (typically 04:00-20:00 ET). Alpaca only allows
+/// `extended_hours: true` on limit orders, not market orders.
+///
+/// CONTRACT RISK: Alpaca's reference does not define `session_open`/
+/// `session_close` semantics, and their observed values have changed over
+/// time (community reports show 07:00/19:00 historically, 04:00/20:00
+/// currently -- forum.alpaca.markets/t/2400). This module assumes they span
+/// exactly the window in which Alpaca accepts `extended_hours: true` limit
+/// orders, i.e. the 4:00-9:30/16:00-20:00 windows described in
+/// https://docs.alpaca.markets/docs/orders-at-alpaca#extended-hours-trading.
+/// If Alpaca redefines the session bounds (e.g. for 24/5 overnight trading),
+/// `Extended` classification may cover times where extended-hours limit
+/// orders are rejected; the failure mode is broker rejections of the hedge
+/// order, retried by the hedge job, not silent misclassification of money
+/// amounts.
 #[derive(Debug, Clone, Deserialize)]
 struct CalendarDay {
+    date: NaiveDate,
     #[serde(deserialize_with = "deserialize_time")]
     open: NaiveTime,
     #[serde(deserialize_with = "deserialize_time")]
     close: NaiveTime,
+    #[serde(deserialize_with = "deserialize_time")]
+    session_open: NaiveTime,
+    #[serde(deserialize_with = "deserialize_time")]
+    session_close: NaiveTime,
 }
 
 fn deserialize_time<'de, D>(deserializer: D) -> Result<NaiveTime, D::Error>
@@ -22,7 +50,9 @@ where
     D: serde::Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    NaiveTime::parse_from_str(&s, "%H:%M").map_err(serde::de::Error::custom)
+    NaiveTime::parse_from_str(&s, "%H:%M")
+        .or_else(|_| NaiveTime::parse_from_str(&s, "%H%M"))
+        .map_err(serde::de::Error::custom)
 }
 
 /// Returns true if the market is currently open for trading.
@@ -32,11 +62,18 @@ pub(super) async fn is_market_open(
     is_market_open_at(client, Utc::now()).await
 }
 
-/// Returns true if the market is open at the given time.
-async fn is_market_open_at(
+/// Returns the current market session (regular, extended, or closed).
+pub(super) async fn market_session(
+    client: &AlpacaBrokerApiClient,
+) -> Result<MarketSession, AlpacaBrokerApiError> {
+    market_session_at(client, Utc::now()).await
+}
+
+/// Returns the market session at the given time.
+pub(super) async fn market_session_at(
     client: &AlpacaBrokerApiClient,
     now: DateTime<Utc>,
-) -> Result<bool, AlpacaBrokerApiError> {
+) -> Result<MarketSession, AlpacaBrokerApiError> {
     let now_et = now.with_timezone(&New_York);
     let today = now_et.date_naive();
 
@@ -44,21 +81,97 @@ async fn is_market_open_at(
 
     let Some(today_calendar) = calendar.into_iter().next() else {
         debug!("Today is not a trading day");
-        return Ok(false);
+        return Ok(MarketSession::Closed);
     };
 
+    // The broker may answer a non-trading-day query with the NEAREST trading
+    // day instead of an empty list. A LATER date is positive evidence the
+    // queried day has no trading session, so classify it Closed -- erroring
+    // here would turn every weekend/holiday tick into a multi-day error storm
+    // (failed scans, burned hedge-job retries) instead of the spec'd
+    // "Closed: leave the exposure for the next scan". An EARLIER date proves
+    // nothing about today and indicates a broken response, so fail fast
+    // rather than classify against another day's session windows.
+    match today_calendar.date.cmp(&today) {
+        Ordering::Greater => {
+            debug!(
+                queried = %today,
+                returned = %today_calendar.date,
+                "Calendar returned a later trading day; queried day is not a trading day"
+            );
+            return Ok(MarketSession::Closed);
+        }
+        Ordering::Less => {
+            return Err(AlpacaBrokerApiError::CalendarDateMismatch {
+                queried: today,
+                returned: today_calendar.date,
+            });
+        }
+        Ordering::Equal => {}
+    }
+
+    // Detect a silent redefinition of the undocumented session bounds (see
+    // the CONTRACT RISK note on `CalendarDay`). A NARROWED window is the
+    // dangerous direction -- fills landing inside the assumed 04:00-20:00
+    // extended window but outside Alpaca's would classify Closed and sit
+    // unhedged with no broker rejection to surface it -- so warn loudly when
+    // the broker's bounds differ from the documented extended-hours window.
+    let expected_session_open = NaiveTime::from_hms_opt(4, 0, 0);
+    let expected_session_close = NaiveTime::from_hms_opt(20, 0, 0);
+    if Some(today_calendar.session_open) != expected_session_open {
+        warn!(
+            session_open = %today_calendar.session_open,
+            "Alpaca calendar session_open differs from the assumed 04:00 ET \
+             extended-hours open; session classification may not match \
+             extended-hours order eligibility"
+        );
+    }
+    // session_close legitimately narrows on early-close trading days
+    // (half days end the post-market session early), so a mismatch there is
+    // expected several days a year -- log it for visibility without paging
+    // anyone. A redefinition narrowing REGULAR days would also surface in
+    // hedge behavior (orders deferred to the next scan).
+    if Some(today_calendar.session_close) != expected_session_close {
+        debug!(
+            session_close = %today_calendar.session_close,
+            "Alpaca calendar session_close differs from the typical 20:00 ET \
+             extended-hours close (expected on early-close days)"
+        );
+    }
+
     let now_time = now_et.time();
-    let is_open = now_time >= today_calendar.open && now_time < today_calendar.close;
+
+    let session = if now_time >= today_calendar.open && now_time < today_calendar.close {
+        MarketSession::Regular
+    } else if now_time >= today_calendar.session_open && now_time < today_calendar.session_close {
+        MarketSession::Extended
+    } else {
+        MarketSession::Closed
+    };
 
     debug!(
-        open = %today_calendar.open,
-        close = %today_calendar.close,
+        regular_open = %today_calendar.open,
+        regular_close = %today_calendar.close,
+        session_open = %today_calendar.session_open,
+        session_close = %today_calendar.session_close,
         now = %now_time,
-        is_open,
-        "Checked market hours"
+        ?session,
+        "Checked market session"
     );
 
-    Ok(is_open)
+    Ok(session)
+}
+
+/// Returns true if the market is open for regular trading at the given time.
+///
+/// Derived from [`market_session_at`] so the regular-hours predicate cannot
+/// drift from the session classification: `is_market_open` is true exactly
+/// when the session is [`MarketSession::Regular`].
+async fn is_market_open_at(
+    client: &AlpacaBrokerApiClient,
+    now: DateTime<Utc>,
+) -> Result<bool, AlpacaBrokerApiError> {
+    Ok(market_session_at(client, now).await? == MarketSession::Regular)
 }
 
 async fn get_calendar(
@@ -121,7 +234,9 @@ mod tests {
                     {
                         "date": "2025-01-06",
                         "open": "09:30",
-                        "close": "16:00"
+                        "close": "16:00",
+                        "session_open": "0400",
+                        "session_close": "2000"
                     }
                 ]));
         });
@@ -144,27 +259,40 @@ mod tests {
         let json = r#"{
             "date": "2025-01-06",
             "open": "09:30",
-            "close": "16:00"
+            "close": "16:00",
+            "session_open": "0400",
+            "session_close": "2000"
         }"#;
 
         let day: CalendarDay = serde_json::from_str(json).unwrap();
 
         assert_eq!(day.open, NaiveTime::from_hms_opt(9, 30, 0).unwrap());
         assert_eq!(day.close, NaiveTime::from_hms_opt(16, 0, 0).unwrap());
+        assert_eq!(day.session_open, NaiveTime::from_hms_opt(4, 0, 0).unwrap());
+        assert_eq!(
+            day.session_close,
+            NaiveTime::from_hms_opt(20, 0, 0).unwrap()
+        );
     }
 
     #[test]
-    fn test_calendar_day_rejects_hhmm_format_without_colon() {
+    fn test_calendar_day_accepts_hhmm_format_without_colon() {
         let json = r#"{
             "date": "2025-01-06",
             "open": "0930",
-            "close": "1600"
+            "close": "1600",
+            "session_open": "0400",
+            "session_close": "2000"
         }"#;
 
-        let err = serde_json::from_str::<CalendarDay>(json).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid"),
-            "expected parse error for missing colon, got: {err}"
+        let day: CalendarDay = serde_json::from_str(json).unwrap();
+
+        assert_eq!(day.open, NaiveTime::from_hms_opt(9, 30, 0).unwrap());
+        assert_eq!(day.close, NaiveTime::from_hms_opt(16, 0, 0).unwrap());
+        assert_eq!(day.session_open, NaiveTime::from_hms_opt(4, 0, 0).unwrap());
+        assert_eq!(
+            day.session_close,
+            NaiveTime::from_hms_opt(20, 0, 0).unwrap()
         );
     }
 
@@ -173,7 +301,9 @@ mod tests {
         let json = r#"{
             "date": "2025-01-06",
             "open": "25:30",
-            "close": "16:00"
+            "close": "16:00",
+            "session_open": "0400",
+            "session_close": "2000"
         }"#;
 
         let err = serde_json::from_str::<CalendarDay>(json).unwrap_err();
@@ -188,17 +318,27 @@ mod tests {
         let json = r#"{
             "date": "2025-01-06",
             "open": "09:60",
-            "close": "16:00"
+            "close": "16:00",
+            "session_open": "0400",
+            "session_close": "2000"
         }"#;
 
         let err = serde_json::from_str::<CalendarDay>(json).unwrap_err();
         assert!(
-            err.to_string().contains("out of range"),
-            "expected out of range error for minute 60, got: {err}"
+            err.to_string().contains("out of range")
+                || err.to_string().contains("invalid characters"),
+            "expected parse error for minute 60, got: {err}"
         );
     }
 
-    fn mock_trading_day(server: &MockServer, date: &str) {
+    fn mock_calendar_day(
+        server: &MockServer,
+        date: &str,
+        open: &str,
+        close: &str,
+        session_open: &str,
+        session_close: &str,
+    ) {
         server.mock(|when, then| {
             when.method(GET)
                 .path("/v1/calendar")
@@ -209,11 +349,17 @@ mod tests {
                 .json_body(json!([
                     {
                         "date": date,
-                        "open": "09:30",
-                        "close": "16:00"
+                        "open": open,
+                        "close": close,
+                        "session_open": session_open,
+                        "session_close": session_close
                     }
                 ]));
         });
+    }
+
+    fn mock_trading_day(server: &MockServer, date: &str) {
+        mock_calendar_day(server, date, "09:30", "16:00", "0400", "2000");
     }
 
     fn mock_non_trading_day(server: &MockServer, date: &str) {
@@ -289,6 +435,138 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn is_market_open_false_during_extended_hours() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        mock_trading_day(&server, "2025-01-06");
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let pre_market = et_time_as_utc("2025-01-06", 7, 0);
+
+        assert!(
+            !is_market_open_at(&client, pre_market).await.unwrap(),
+            "is_market_open must be true only during the Regular session, not pre-market"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_session_is_closed_when_calendar_returns_a_later_trading_day() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        // Saturday query answered with Monday's entry (the nearest trading
+        // day). A later date is positive evidence Saturday has no trading
+        // session, so the session is Closed -- NOT an error, which would
+        // storm every weekend tick, and NOT a classification against
+        // Monday's session windows.
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/calendar")
+                .query_param("start", "2025-01-04")
+                .query_param("end", "2025-01-04");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([
+                    {
+                        "date": "2025-01-06",
+                        "open": "09:30",
+                        "close": "16:00",
+                        "session_open": "0400",
+                        "session_close": "2000"
+                    }
+                ]));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        // 18:00 ET Saturday would classify Extended against Monday's
+        // session windows if the date guard were missing.
+        let saturday_evening = et_time_as_utc("2025-01-04", 18, 0);
+
+        let session = market_session_at(&client, saturday_evening).await.unwrap();
+
+        assert_eq!(session, MarketSession::Closed);
+    }
+
+    #[tokio::test]
+    async fn market_session_errors_when_calendar_returns_an_earlier_date() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        // An EARLIER date proves nothing about the queried day -- the
+        // response is broken, so classification must fail fast rather than
+        // trust another day's session windows.
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/calendar")
+                .query_param("start", "2025-01-07")
+                .query_param("end", "2025-01-07");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([
+                    {
+                        "date": "2025-01-06",
+                        "open": "09:30",
+                        "close": "16:00",
+                        "session_open": "0400",
+                        "session_close": "2000"
+                    }
+                ]));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let tuesday_midday = et_time_as_utc("2025-01-07", 12, 0);
+
+        let error = market_session_at(&client, tuesday_midday)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AlpacaBrokerApiError::CalendarDateMismatch { queried, returned }
+                    if queried == NaiveDate::from_ymd_opt(2025, 1, 7).unwrap()
+                        && returned == NaiveDate::from_ymd_opt(2025, 1, 6).unwrap()
+            ),
+            "expected CalendarDateMismatch, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn is_market_open_is_false_when_calendar_returns_a_later_trading_day() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        // Saturday answered with Monday's entry: a later trading day means
+        // the queried day is closed, so the regular-hours predicate is
+        // false -- 12:00 ET would be inside Monday's regular hours if the
+        // date guard were missing.
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/calendar")
+                .query_param("start", "2025-01-04")
+                .query_param("end", "2025-01-04");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([
+                    {
+                        "date": "2025-01-06",
+                        "open": "09:30",
+                        "close": "16:00",
+                        "session_open": "0400",
+                        "session_close": "2000"
+                    }
+                ]));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let saturday_noon = et_time_as_utc("2025-01-04", 12, 0);
+
+        let open = is_market_open_at(&client, saturday_noon).await.unwrap();
+
+        assert!(!open, "a non-trading day must report the market as closed");
+    }
+
+    #[tokio::test]
     async fn is_market_closed_on_non_trading_day() {
         let server = MockServer::start();
         let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
@@ -298,5 +576,187 @@ mod tests {
         let saturday = et_time_as_utc("2025-01-04", 12, 0);
 
         assert!(!is_market_open_at(&client, saturday).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn market_session_regular_during_trading_hours() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        mock_trading_day(&server, "2025-01-06");
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let midday = et_time_as_utc("2025-01-06", 12, 0);
+
+        assert_eq!(
+            market_session_at(&client, midday).await.unwrap(),
+            MarketSession::Regular
+        );
+    }
+
+    #[tokio::test]
+    async fn market_session_extended_pre_market() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        mock_trading_day(&server, "2025-01-06");
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let pre_market = et_time_as_utc("2025-01-06", 7, 0);
+
+        assert_eq!(
+            market_session_at(&client, pre_market).await.unwrap(),
+            MarketSession::Extended,
+            "7:00 AM ET is pre-market (between session_open 4:00 and open 9:30)"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_session_extended_after_hours() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        mock_trading_day(&server, "2025-01-06");
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let after_hours = et_time_as_utc("2025-01-06", 18, 0);
+
+        assert_eq!(
+            market_session_at(&client, after_hours).await.unwrap(),
+            MarketSession::Extended,
+            "6:00 PM ET is after-hours (between close 16:00 and session_close 20:00)"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_session_closed_before_extended_session() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        mock_trading_day(&server, "2025-01-06");
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let overnight = et_time_as_utc("2025-01-06", 3, 0);
+
+        assert_eq!(
+            market_session_at(&client, overnight).await.unwrap(),
+            MarketSession::Closed,
+            "3:00 AM ET is before session_open (4:00), should be Closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_session_closed_after_extended_session() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        mock_trading_day(&server, "2025-01-06");
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let late_night = et_time_as_utc("2025-01-06", 21, 0);
+
+        assert_eq!(
+            market_session_at(&client, late_night).await.unwrap(),
+            MarketSession::Closed,
+            "9:00 PM ET is after session_close (20:00), should be Closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_session_closed_at_session_close_boundary() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        mock_trading_day(&server, "2025-01-06");
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let session_close = et_time_as_utc("2025-01-06", 20, 0);
+
+        assert_eq!(
+            market_session_at(&client, session_close).await.unwrap(),
+            MarketSession::Closed,
+            "Exactly at session_close should be Closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_session_uses_early_close_calendar_boundaries() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        mock_calendar_day(&server, "2025-07-03", "09:30", "13:00", "0400", "1700");
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let after_regular_close = et_time_as_utc("2025-07-03", 13, 1);
+        let session_close = et_time_as_utc("2025-07-03", 17, 0);
+
+        assert_eq!(
+            market_session_at(&client, after_regular_close)
+                .await
+                .unwrap(),
+            MarketSession::Extended,
+            "After an early regular close should be Extended until session_close"
+        );
+        assert_eq!(
+            market_session_at(&client, session_close).await.unwrap(),
+            MarketSession::Closed,
+            "Exactly at early session_close should be Closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_session_closed_on_non_trading_day() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        mock_non_trading_day(&server, "2025-01-04");
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let saturday = et_time_as_utc("2025-01-04", 12, 0);
+
+        assert_eq!(
+            market_session_at(&client, saturday).await.unwrap(),
+            MarketSession::Closed
+        );
+    }
+
+    #[tokio::test]
+    async fn market_session_extended_at_session_open_boundary() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        mock_trading_day(&server, "2025-01-06");
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let at_session_open = et_time_as_utc("2025-01-06", 4, 0);
+
+        assert_eq!(
+            market_session_at(&client, at_session_open).await.unwrap(),
+            MarketSession::Extended,
+            "Exactly at session_open should be Extended"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_session_regular_at_regular_open_boundary() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        mock_trading_day(&server, "2025-01-06");
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let at_open = et_time_as_utc("2025-01-06", 9, 30);
+
+        assert_eq!(
+            market_session_at(&client, at_open).await.unwrap(),
+            MarketSession::Regular,
+            "Exactly at regular open should be Regular"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_session_extended_at_regular_close_boundary() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        mock_trading_day(&server, "2025-01-06");
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let at_close = et_time_as_utc("2025-01-06", 16, 0);
+
+        assert_eq!(
+            market_session_at(&client, at_close).await.unwrap(),
+            MarketSession::Extended,
+            "Exactly at regular close transitions to Extended (after-hours)"
+        );
     }
 }

--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -15,6 +15,7 @@ use alloy::sol;
 use alloy::sol_types::SolEvent;
 use bon::bon;
 use chrono::Utc;
+use chrono_tz::America::New_York;
 use httpmock::prelude::*;
 use serde_json::{Value, json};
 use tokio::task::JoinHandle;
@@ -106,10 +107,33 @@ struct MockOrder {
 }
 
 /// A single calendar entry controlling market open/close times.
+///
+/// Mirrors the real Alpaca calendar payload: `open`/`close` are the regular
+/// trading hours and `session_open`/`session_close` span the full extended
+/// session. All four are required by the `CalendarDay` parser.
 struct CalendarEntry {
     pub date: String,
     pub open: String,
     pub close: String,
+    pub session_open: String,
+    pub session_close: String,
+}
+
+/// Builds a calendar entry that keeps the regular session open all day.
+///
+/// The date is computed in Eastern Time because the market-hours client
+/// queries the calendar with today's ET date and rejects entries for any
+/// other day; a UTC date would mismatch between 19:00 and 24:00 ET.
+fn market_open_calendar_entry() -> CalendarEntry {
+    let today = Utc::now().with_timezone(&New_York).format("%Y-%m-%d");
+
+    CalendarEntry {
+        date: today.to_string(),
+        open: "00:00".to_string(),
+        close: "23:59".to_string(),
+        session_open: "00:00".to_string(),
+        session_close: "23:59".to_string(),
+    }
 }
 
 /// A mock wallet transfer tracked in shared state.
@@ -293,13 +317,7 @@ impl AlpacaBrokerMock {
         symbol_positions: Vec<MockPosition>,
         initial_cash: Option<Float>,
     ) -> Self {
-        let today = Utc::now().format("%Y-%m-%d").to_string();
-
-        let calendar_entries = vec![CalendarEntry {
-            date: today,
-            open: "00:00".to_string(),
-            close: "23:59".to_string(),
-        }];
+        let calendar_entries = vec![market_open_calendar_entry()];
 
         let symbol_fill_prices = symbol_fill_prices.into_iter().collect();
         let positions = symbol_positions
@@ -410,22 +428,16 @@ impl AlpacaBrokerMock {
 
     /// Switches the calendar to market-open (all day) for today.
     pub fn set_market_open(&self) {
-        let today = Utc::now().format("%Y-%m-%d").to_string();
-        lock(&self.state).calendar_entries = vec![CalendarEntry {
-            date: today,
-            open: "00:00".to_string(),
-            close: "23:59".to_string(),
-        }];
+        lock(&self.state).calendar_entries = vec![market_open_calendar_entry()];
     }
 
     /// Switches the calendar to market-closed for today.
     pub fn set_market_closed(&self) {
-        let today = Utc::now().format("%Y-%m-%d").to_string();
-        lock(&self.state).calendar_entries = vec![CalendarEntry {
-            date: today,
-            open: "04:00".to_string(),
-            close: "04:01".to_string(),
-        }];
+        // An empty calendar is how the real API reports a non-trading day
+        // and is the only representation with no open window at all -- a
+        // tiny synthetic session window would still classify as open if a
+        // test happened to run inside it.
+        lock(&self.state).calendar_entries = Vec::new();
     }
 
     /// Sets the USDC balance reported by the Alpaca crypto wallet endpoints.
@@ -825,7 +837,9 @@ fn register_calendar_endpoint(server: &MockServer, state: &Arc<Mutex<MockState>>
                     json!({
                         "date": entry.date,
                         "open": entry.open,
-                        "close": entry.close
+                        "close": entry.close,
+                        "session_open": entry.session_open,
+                        "session_close": entry.session_close
                     })
                 })
                 .collect();
@@ -1358,14 +1372,22 @@ fn register_order_status_endpoint(server: &MockServer, state: &Arc<Mutex<MockSta
                 }
 
                 let order = &state.orders[&order_id];
+                // The real API always reports filled_qty ("0" when unfilled);
+                // the client fails closed on terminal responses without it.
                 let filled_quantity = if order.status == OrderStatus::Filled {
-                    Some(format_float_with_fallback(&order.quantity))
+                    format_float_with_fallback(&order.quantity)
                 } else {
-                    None
+                    "0".to_string()
                 };
                 let filled_price: Option<String> =
                     order.filled_price.as_ref().map(format_float_with_fallback);
                 let quantity = format_float_with_fallback(&order.quantity);
+                // The real API stamps per-status timestamps; the client fails
+                // fast when a terminal status lacks its specific timestamp.
+                let filled_at =
+                    (order.status == OrderStatus::Filled).then_some("2025-01-01T00:00:01Z");
+                let failed_at =
+                    (order.status == OrderStatus::Rejected).then_some("2025-01-01T00:00:01Z");
                 let body = json!({
                     "id": order_id,
                     "symbol": order.symbol,
@@ -1375,6 +1397,9 @@ fn register_order_status_endpoint(server: &MockServer, state: &Arc<Mutex<MockSta
                     "filled_avg_price": filled_price,
                     "filled_qty": filled_quantity,
                     "created_at": "2025-01-01T00:00:00Z",
+                    "updated_at": "2025-01-01T00:00:01Z",
+                    "filled_at": filled_at,
+                    "failed_at": failed_at,
                 });
                 drop(state);
                 body
@@ -1830,14 +1855,80 @@ fn json_response(status: u16, body: &Value) -> HttpMockResponse {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::time::Duration;
 
     use alloy::primitives::{Address, U256};
+    use chrono::{NaiveTime, Utc};
+    use chrono_tz::America::New_York;
+    use uuid::Uuid;
 
     use super::{
-        MockAccount, MockMode, MockState, OrderSide, format_u256_as_usdc, handle_crypto_order,
+        AlpacaBrokerMock, MockAccount, MockMode, MockState, OrderSide, TEST_ACCOUNT_ID,
+        TEST_API_KEY, TEST_API_SECRET, format_u256_as_usdc, handle_crypto_order,
     };
-    use crate::Symbol;
+    use crate::alpaca_broker_api::auth::{
+        AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode,
+    };
+    use crate::alpaca_broker_api::client::AlpacaBrokerApiClient;
+    use crate::alpaca_broker_api::{TimeInForce, market_hours};
+    use crate::{MarketSession, Symbol};
     use st0x_float_macro::float;
+
+    /// Regression test for the calendar contract between `AlpacaBrokerMock`
+    /// and the market-hours parser: `CalendarDay` requires `session_open` /
+    /// `session_close`, so the mock's `/v1/calendar` payload must include
+    /// them or every `is_market_open()` / `market_session()` call against
+    /// the mock fails deserialization.
+    #[tokio::test]
+    async fn market_hours_parse_the_mock_calendar() {
+        let mock = AlpacaBrokerMock::start()
+            .symbol_fill_prices(vec![])
+            .symbol_positions(vec![])
+            .call()
+            .await;
+
+        let ctx = AlpacaBrokerApiCtx {
+            api_key: TEST_API_KEY.to_string(),
+            api_secret: TEST_API_SECRET.to_string(),
+            account_id: AlpacaAccountId::new(Uuid::parse_str(TEST_ACCOUNT_ID).unwrap()),
+            mode: Some(AlpacaBrokerApiMode::Mock(mock.base_url())),
+            asset_cache_ttl: Duration::from_secs(3600),
+            time_in_force: TimeInForce::Day,
+            counter_trade_slippage_bps: crate::DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,
+        };
+
+        // Use market_session_at with a pinned noon-ET timestamp so the test is
+        // deterministic regardless of when it runs. The mock's calendar entry
+        // uses today's ET date with regular hours [00:00, 23:59), so noon ET
+        // always falls within the regular window -- unlike Utc::now() which
+        // would hit the 1-minute gap at 23:59 ET.
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let today_et = Utc::now().with_timezone(&New_York).date_naive();
+        let noon_et = today_et
+            .and_time(NaiveTime::from_hms_opt(12, 0, 0).unwrap())
+            .and_local_timezone(New_York)
+            .single()
+            .unwrap()
+            .with_timezone(&Utc);
+
+        mock.set_market_open();
+        assert_eq!(
+            market_hours::market_session_at(&client, noon_et)
+                .await
+                .unwrap(),
+            MarketSession::Regular,
+            "market_session_at must return Regular at noon ET when the calendar is set open"
+        );
+
+        mock.set_market_closed();
+        assert_eq!(
+            market_hours::market_session_at(&client, noon_et)
+                .await
+                .unwrap(),
+            MarketSession::Closed,
+            "market_session_at must return Closed when the calendar is set closed"
+        );
+    }
 
     #[test]
     fn format_u256_as_usdc_cases() {

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -1,3 +1,4 @@
+use chrono::NaiveDate;
 use rain_math_float::Float;
 use rain_math_float::FloatError;
 use serde::Deserialize;
@@ -8,7 +9,9 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use crate::alpaca_market_data::AlpacaMarketDataError;
-use crate::{ClientOrderId, CounterTradeCostError, FractionalShares, Positive, Symbol, Usd};
+use crate::{
+    ClientOrderId, CounterTradeCostError, ExecutorOrderId, FractionalShares, Positive, Symbol, Usd,
+};
 
 /// Time-in-force specifies how long an order remains active before it expires.
 ///
@@ -129,6 +132,19 @@ pub enum CryptoOrderFailureReason {
     Calculated,
 }
 
+/// A field absent from a broker order response that the reported order
+/// status requires.
+///
+/// A closed enum (not a string) so call sites and tests cannot drift on
+/// spelling and new fields force exhaustive handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MissingOrderField {
+    FilledQty,
+    Price,
+    FilledAt,
+    CanceledAt,
+}
+
 #[derive(Debug, Error)]
 pub enum AlpacaBrokerApiError {
     #[error("HTTP client error: {0}")]
@@ -152,8 +168,11 @@ pub enum AlpacaBrokerApiError {
     #[error("Invalid order ID: {0}")]
     InvalidOrderId(#[from] uuid::Error),
 
-    #[error("Filled order {order_id} is missing required field: {field}")]
-    IncompleteFilledOrder { order_id: String, field: String },
+    #[error("Order {order_id} is missing required field {field:?} for its reported state")]
+    IncompleteOrder {
+        order_id: ExecutorOrderId,
+        field: MissingOrderField,
+    },
 
     #[error("Account {account_id} is not active (status: {status:?})")]
     AccountNotActive {
@@ -176,6 +195,15 @@ pub enum AlpacaBrokerApiError {
 
     #[error("Internal error: calendar was non-empty but iteration returned None")]
     CalendarIterationInvariantViolation,
+
+    #[error(
+        "Calendar endpoint returned an entry for {returned} when {queried} was \
+         requested; refusing to classify the market session from another day's hours"
+    )]
+    CalendarDateMismatch {
+        queried: NaiveDate,
+        returned: NaiveDate,
+    },
 
     #[error("Asset {symbol} is not active (status: {status:?})")]
     AssetNotActive { symbol: Symbol, status: AssetStatus },
@@ -229,6 +257,9 @@ pub enum AlpacaBrokerApiError {
 
     #[error(transparent)]
     NotPositive(#[from] st0x_finance::NotPositive<FractionalShares>),
+
+    #[error(transparent)]
+    NotPositiveLimitPrice(#[from] st0x_finance::NotPositive<Usd>),
 
     #[error("Float conversion error: {0}")]
     FloatConversion(#[from] FloatError),

--- a/crates/execution/src/alpaca_broker_api/order.rs
+++ b/crates/execution/src/alpaca_broker_api/order.rs
@@ -3,14 +3,14 @@ use rain_math_float::Float;
 use serde::{Deserialize, Serialize};
 use st0x_float_macro::float;
 use std::str::FromStr;
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 use uuid::Uuid;
 
 use super::client::AlpacaBrokerApiClient;
-use super::{AlpacaBrokerApiError, CryptoOrderFailureReason, TimeInForce};
+use super::{AlpacaBrokerApiError, CryptoOrderFailureReason, MissingOrderField, TimeInForce};
 use crate::{
-    ClientOrderId, Direction, FractionalShares, MarketOrder, OrderPlacement, OrderStatus,
-    OrderUpdate, Positive, Symbol, Usd, deserialize_float_from_number_or_string,
+    ClientOrderId, Direction, ExecutorOrderId, FractionalShares, MarketOrder, OrderPlacement,
+    OrderStatus, OrderUpdate, Positive, Symbol, Usd, deserialize_float_from_number_or_string,
     deserialize_option_float_from_number_or_string, serialize_float_as_string,
 };
 
@@ -62,6 +62,7 @@ pub struct AlpacaLimitOrder {
     pub direction: Direction,
     pub limit_price: AlpacaLimitPrice,
     pub extended_hours: bool,
+    pub client_order_id: ClientOrderId,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -139,6 +140,7 @@ pub(super) struct LimitOrderRequest {
     pub limit_price: AlpacaLimitPrice,
     pub time_in_force: &'static str,
     pub extended_hours: bool,
+    pub client_order_id: ClientOrderId,
 }
 
 fn serialize_symbol<S>(symbol: &Symbol, serializer: S) -> Result<S::Ok, S::Error>
@@ -189,6 +191,38 @@ pub(super) struct OrderResponse {
         deserialize_with = "deserialize_option_float_from_number_or_string"
     )]
     pub filled_average_price: Option<Float>,
+    /// Whether the broker holds this as an extended-hours order. Part of the
+    /// documented order entity
+    /// (https://docs.alpaca.markets/reference/getorderforaccount). Needed so
+    /// the duplicate-`client_order_id` adoption path reports the ADOPTED
+    /// order's session terms, which may differ from the current request's.
+    /// `Option` so an omitted echo is distinguishable from a real `false`:
+    /// adoption paths fall back to the request's terms when the broker omits
+    /// the field.
+    #[serde(default)]
+    pub extended_hours: Option<bool>,
+    /// The broker-held limit price, present for limit orders
+    /// (https://docs.alpaca.markets/reference/getorderforaccount). Same
+    /// adoption rationale as `extended_hours`.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_option_float_from_number_or_string"
+    )]
+    pub limit_price: Option<Float>,
+    /// Broker-side timestamps from the documented order entity
+    /// (https://docs.alpaca.markets/reference/getorderforaccount). Filled and
+    /// canceled states use these event times downstream in
+    /// `Position.last_updated` and recency logic -- never substitute the local
+    /// observation time for those terminal timestamps. Rejected orders may fall
+    /// back to observation time when Alpaca omits `failed_at`.
+    #[serde(default)]
+    pub updated_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub filled_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub canceled_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub failed_at: Option<DateTime<Utc>>,
 }
 
 /// Order request for crypto trading (e.g., USDC/USD conversion).
@@ -357,8 +391,15 @@ pub(super) async fn place_market_order(
     // adopted order's quantity is the broker's recorded intent, which may differ
     // from this attempt's recomputed `placed_shares`; any residual is picked up
     // by the next position scan.
-    let (order_id, shares) = match client.place_order(&request).await {
-        Ok(response) => (response.id, placed_shares),
+    // A fresh placement's terms are the REQUEST's terms (the broker created
+    // exactly what was asked; its response may even omit the echo fields). A
+    // duplicate-key adoption instead reports the ADOPTED order's terms from
+    // the lookup response: the broker may hold a prior attempt's
+    // extended-hours limit order (e.g. a regular-hours market retry after a
+    // lost extended-hours placement response), and the caller's convergence
+    // sweep keys off the recorded `extended_hours` flag.
+    let (order_id, shares, extended_hours, limit_price) = match client.place_order(&request).await {
+        Ok(response) => (response.id, placed_shares, false, None),
         Err(error) if is_duplicate_client_order_id(&error) => {
             debug!(
                 client_order_id = %market_order.client_order_id,
@@ -370,7 +411,14 @@ pub(super) async fn place_market_order(
                 .ok_or_else(|| AlpacaBrokerApiError::DuplicateOrderNotFound {
                     client_order_id: market_order.client_order_id.clone(),
                 })?;
-            (existing.id, existing.quantity)
+            (
+                existing.id,
+                existing.quantity,
+                // No request terms to fall back to for a market request: an
+                // omitted echo most plausibly means a plain market order.
+                existing.extended_hours.unwrap_or(false),
+                parse_limit_price(existing.limit_price)?,
+            )
         }
         Err(error) => return Err(error),
     };
@@ -381,7 +429,20 @@ pub(super) async fn place_market_order(
         shares,
         direction: market_order.direction,
         placed_at: Utc::now(),
+        extended_hours,
+        limit_price,
     })
+}
+
+/// Converts the broker-reported limit price into the domain type, failing
+/// fast on a non-positive value rather than silently dropping it.
+fn parse_limit_price(
+    limit_price: Option<Float>,
+) -> Result<Option<Positive<Usd>>, AlpacaBrokerApiError> {
+    limit_price
+        .map(|price| Positive::new(Usd::new(price)))
+        .transpose()
+        .map_err(Into::into)
 }
 
 /// Alpaca returns a 422 with "client_order_id must be unique" when a placement
@@ -402,11 +463,12 @@ fn is_duplicate_client_order_id(error: &AlpacaBrokerApiError) -> bool {
         | JsonParse(_)
         | InvalidHeader(_)
         | InvalidOrderId(_)
-        | IncompleteFilledOrder { .. }
+        | IncompleteOrder { .. }
         | AccountNotActive { .. }
         | CryptoOrderFailed { .. }
         | DuplicateOrderNotFound { .. }
         | CalendarIterationInvariantViolation
+        | CalendarDateMismatch { .. }
         | AssetNotActive { .. }
         | AssetNotTradable { .. }
         | InvalidLimitPricePrecision { .. }
@@ -418,6 +480,7 @@ fn is_duplicate_client_order_id(error: &AlpacaBrokerApiError) -> bool {
         | UsdcBelowPrecision { .. }
         | UsdcPrecisionExceeded { .. }
         | NotPositive(_)
+        | NotPositiveLimitPrice(_)
         | FloatConversion(_)
         | LatestTrade(_)
         | CounterTradeCost(_) => false,
@@ -452,16 +515,64 @@ pub(super) async fn place_limit_order(
         limit_price: limit_order.limit_price.clone(),
         time_in_force: TimeInForce::Day.as_api_str(),
         extended_hours: limit_order.extended_hours,
+        client_order_id: limit_order.client_order_id.clone(),
     };
 
-    let response = client.place_limit_order(&request).await?;
+    // Same lost-response reconciliation as place_market_order: a re-used
+    // client_order_id rejected with a 422 means the broker already accepted a
+    // prior attempt whose response was lost. Adopt the order it accepted so the
+    // apalis retry is idempotent instead of double-submitting a live limit
+    // order during thin extended-hours liquidity.
+    // Fresh placements report the REQUEST's terms; adoptions report the
+    // ADOPTED order's terms -- see the matching comment in
+    // `place_market_order`.
+    let (order_id, shares, extended_hours, limit_price) = match client
+        .place_limit_order(&request)
+        .await
+    {
+        Ok(response) => (
+            response.id,
+            placed_shares,
+            limit_order.extended_hours,
+            Some(*limit_order.limit_price.as_price()),
+        ),
+        Err(error) if is_duplicate_client_order_id(&error) => {
+            debug!(
+                client_order_id = %limit_order.client_order_id,
+                "Broker rejected duplicate client_order_id; reconciling the order it already accepted"
+            );
+            let existing = client
+                .get_order_by_client_order_id(&limit_order.client_order_id)
+                .await?
+                .ok_or_else(|| AlpacaBrokerApiError::DuplicateOrderNotFound {
+                    client_order_id: limit_order.client_order_id.clone(),
+                })?;
+            (
+                existing.id,
+                existing.quantity,
+                // An omitted echo falls back to the REQUEST's terms: the
+                // adopted order under this client_order_id was created by a
+                // prior attempt of this same extended-hours placement, and
+                // recording it as regular would hide it from the regular-open
+                // cancel-and-replace sweep.
+                existing
+                    .extended_hours
+                    .unwrap_or(limit_order.extended_hours),
+                parse_limit_price(existing.limit_price)?
+                    .or(Some(*limit_order.limit_price.as_price())),
+            )
+        }
+        Err(error) => return Err(error),
+    };
 
     Ok(OrderPlacement {
-        order_id: response.id.to_string(),
+        order_id: order_id.to_string(),
         symbol: limit_order.symbol,
-        shares: placed_shares,
+        shares,
         direction: limit_order.direction,
         placed_at: Utc::now(),
+        extended_hours,
+        limit_price,
     })
 }
 
@@ -484,16 +595,51 @@ pub(super) async fn get_order_status(
 
     let status = map_broker_status_to_order_status(response.status);
     let price = response.filled_average_price;
+    let shares_filled = response.filled_quantity.map(FractionalShares::new);
 
     if response.status == BrokerOrderStatus::PartiallyFilled {
         debug!(
             order_id,
             symbol = %response.symbol,
             ordered_qty = %response.quantity.inner(),
-            filled_qty = ?response.filled_quantity,
+            filled_qty = ?shares_filled,
             "Order is partially filled"
         );
     }
+
+    // The broker's event time for the mapped status, not the local
+    // observation time: queue delays, polling intervals, and retries would
+    // otherwise rewrite broker event time downstream
+    // (`Position.last_updated`, fill/cancel timestamps). Filled and
+    // Cancelled must carry their specific broker timestamps; Failed covers
+    // several broker statuses (expired, replaced, ...) that only reliably
+    // carry `updated_at`, so it falls back through `failed_at`.
+    // The order entity marks every timestamp nullable
+    // (https://docs.alpaca.markets/reference/getorderforaccount), so terminal
+    // states prefer their specific timestamp but fall back through
+    // `updated_at` (warned, not silent) rather than blocking fill/cancel
+    // recording on a missing echo. Only a response with no usable timestamp
+    // at all fails.
+    let updated_at = match status {
+        OrderStatus::Filled => terminal_broker_time(
+            response.filled_at,
+            response.updated_at,
+            order_id,
+            MissingOrderField::FilledAt,
+        )?,
+        OrderStatus::Cancelled => terminal_broker_time(
+            response.canceled_at,
+            response.updated_at,
+            order_id,
+            MissingOrderField::CanceledAt,
+        )?,
+        OrderStatus::Failed => {
+            broker_time_or_observation(response.failed_at.or(response.updated_at), order_id)
+        }
+        OrderStatus::Pending | OrderStatus::Submitted | OrderStatus::PartiallyFilled => {
+            broker_time_or_observation(response.updated_at, order_id)
+        }
+    };
 
     Ok(OrderUpdate {
         order_id: order_id.to_string(),
@@ -501,8 +647,51 @@ pub(super) async fn get_order_status(
         shares: response.quantity,
         direction,
         status,
-        updated_at: Utc::now(),
+        updated_at,
         price,
+        shares_filled,
+    })
+}
+
+/// Picks the broker event time for a terminal state: the status-specific
+/// timestamp when present, else `updated_at` with a warning (the doc marks
+/// both nullable). A terminal response carrying NEITHER is unusable --
+/// `Position.last_updated` and fill/cancel records need a broker time -- so
+/// that fails rather than silently substituting the observation clock.
+fn terminal_broker_time(
+    specific: Option<DateTime<Utc>>,
+    updated_at: Option<DateTime<Utc>>,
+    order_id: &str,
+    field: MissingOrderField,
+) -> Result<DateTime<Utc>, AlpacaBrokerApiError> {
+    if let Some(time) = specific {
+        return Ok(time);
+    }
+    if let Some(time) = updated_at {
+        warn!(
+            order_id,
+            ?field,
+            "Terminal order response omitted its status timestamp; using updated_at"
+        );
+        return Ok(time);
+    }
+    Err(AlpacaBrokerApiError::IncompleteOrder {
+        order_id: ExecutorOrderId::new(order_id),
+        field,
+    })
+}
+
+/// Falls back to the local observation time -- loudly, never silently --
+/// when the broker response omits the relevant timestamp. Only acceptable
+/// for non-terminal-specific timestamps; `filled_at`/`canceled_at` for
+/// terminal states must fail instead (see `terminal_broker_time`).
+fn broker_time_or_observation(broker_time: Option<DateTime<Utc>>, order_id: &str) -> DateTime<Utc> {
+    broker_time.unwrap_or_else(|| {
+        warn!(
+            order_id,
+            "Broker response omitted the status timestamp; using observation time"
+        );
+        Utc::now()
     })
 }
 
@@ -512,18 +701,23 @@ fn map_broker_status_to_order_status(status: BrokerOrderStatus) -> OrderStatus {
         BrokerOrderStatus::New
         | BrokerOrderStatus::Accepted
         | BrokerOrderStatus::PendingNew
-        | BrokerOrderStatus::PartiallyFilled
         | BrokerOrderStatus::AcceptedForBidding
         | BrokerOrderStatus::PendingCancel
         | BrokerOrderStatus::PendingReplace
         | BrokerOrderStatus::Stopped => OrderStatus::Submitted,
 
+        // Partially filled -- distinct from Submitted so the poll loop can
+        // drive `UpdatePartialFill` on the aggregate before any cancel.
+        BrokerOrderStatus::PartiallyFilled => OrderStatus::PartiallyFilled,
+
         // Successfully filled
         BrokerOrderStatus::Filled => OrderStatus::Filled,
 
+        // Cancelled by the broker after a cancel request was accepted.
+        BrokerOrderStatus::Canceled => OrderStatus::Cancelled,
+
         // Failed/terminal statuses
-        BrokerOrderStatus::Canceled
-        | BrokerOrderStatus::Expired
+        BrokerOrderStatus::Expired
         | BrokerOrderStatus::DoneForDay
         | BrokerOrderStatus::Rejected
         | BrokerOrderStatus::Replaced
@@ -835,6 +1029,9 @@ mod tests {
         assert_eq!(placement.symbol.to_string(), "TSLA");
         assert_eq!(placement.shares.inner(), FractionalShares::new(float!(50)));
         assert_eq!(placement.direction, Direction::Sell);
+        // A fresh market placement carries no session terms.
+        assert!(!placement.extended_hours);
+        assert_eq!(placement.limit_price, None);
     }
 
     #[tokio::test]
@@ -896,6 +1093,312 @@ mod tests {
         assert_eq!(placement.order_id, existing_order_id);
         assert_eq!(placement.shares.inner(), FractionalShares::new(float!(7)));
         assert_eq!(placement.direction, Direction::Buy);
+        // A fresh adoption of a plain market order carries no session terms.
+        assert!(!placement.extended_hours);
+        assert_eq!(placement.limit_price, None);
+    }
+
+    #[tokio::test]
+    async fn place_market_order_adoption_reports_adopted_extended_hours_terms() {
+        // Lost-response scenario the convergence sweep depends on: an
+        // extended-hours limit order was accepted but its 2xx was lost, the
+        // retry runs after the regular open as a MARKET order under the same
+        // client_order_id, and the broker 422s. The adoption must report the
+        // ADOPTED order's extended-hours flag and limit price -- not this
+        // attempt's market terms -- so the aggregate records broker reality
+        // and the regular-open cancel-and-replace sweep can converge it.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let client_order_uuid = uuid!("99999999-9999-4999-8999-999999999999");
+        let client_order_id = client_order_uuid.to_string();
+        let existing_order_id = "904837e3-3b76-47ec-b432-046db621571b";
+
+        let place_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(422)
+                .header("content-type", "application/json")
+                .json_body(json!({"message": "client_order_id must be unique"}));
+        });
+
+        let lookup_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path(
+                    "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders:by_client_order_id",
+                )
+                .query_param("client_order_id", client_order_id.as_str());
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": existing_order_id,
+                    "symbol": "AAPL",
+                    "qty": "7",
+                    "side": "buy",
+                    "status": "new",
+                    "filled_avg_price": null,
+                    "type": "limit",
+                    "limit_price": "195.25",
+                    "extended_hours": true
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let market_order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(client_order_uuid),
+        };
+
+        let placement = place_market_order(&client, market_order, TimeInForce::Day)
+            .await
+            .unwrap();
+
+        place_mock.assert();
+        lookup_mock.assert();
+        assert_eq!(placement.order_id, existing_order_id);
+        assert!(placement.extended_hours);
+        assert_eq!(
+            placement.limit_price,
+            Some(Positive::new(Usd::new(float!(195.25))).unwrap())
+        );
+    }
+
+    #[tokio::test]
+    async fn place_market_order_adoption_errors_on_non_positive_limit_price() {
+        // Broker holds an existing order under this client_order_id (lost-response
+        // adoption), but reports a zero limit_price in the lookup response.
+        // parse_limit_price must fail fast rather than silently passing None.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let client_order_uuid = uuid!("aaaabbbb-aaaa-4aaa-8aaa-aaaaaaaabbbb");
+        let client_order_id = client_order_uuid.to_string();
+        let existing_order_id = "904837e3-3b76-47ec-b432-046db621571b";
+
+        let place_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(422)
+                .header("content-type", "application/json")
+                .json_body(json!({"message": "client_order_id must be unique"}));
+        });
+
+        let lookup_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path(
+                    "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders:by_client_order_id",
+                )
+                .query_param("client_order_id", client_order_id.as_str());
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": existing_order_id,
+                    "symbol": "AAPL",
+                    "qty": "7",
+                    "side": "buy",
+                    "status": "new",
+                    "filled_avg_price": null,
+                    "type": "limit",
+                    "limit_price": "0",
+                    "extended_hours": true
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let market_order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(client_order_uuid),
+        };
+
+        let err = place_market_order(&client, market_order, TimeInForce::Day)
+            .await
+            .unwrap_err();
+
+        place_mock.assert();
+        lookup_mock.assert();
+        assert!(
+            matches!(err, AlpacaBrokerApiError::NotPositiveLimitPrice(_)),
+            "Expected NotPositiveLimitPrice error on zero limit_price, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn place_limit_order_reconciles_duplicate_client_order_id() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let client_order_uuid = uuid!("88888888-8888-4888-8888-888888888888");
+        let client_order_id = client_order_uuid.to_string();
+        let existing_order_id = "904837e3-3b76-47ec-b432-046db621571b";
+
+        // Same lost-response case as the market path: the broker rejects the
+        // re-used client_order_id with a 422 because it already recorded the
+        // original extended-hours limit order whose 2xx was lost in flight.
+        let place_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(422)
+                .header("content-type", "application/json")
+                .json_body(json!({"message": "client_order_id must be unique"}));
+        });
+
+        let lookup_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path(
+                    "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders:by_client_order_id",
+                )
+                .query_param("client_order_id", client_order_id.as_str());
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": existing_order_id,
+                    "symbol": "AAPL",
+                    "qty": "7",
+                    "side": "buy",
+                    "status": "new",
+                    "filled_avg_price": null
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let limit_order = AlpacaLimitOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            // Recomputed intent is 10 shares, but the broker already holds the
+            // original 7-share limit order under this key; we adopt it.
+            shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
+            direction: Direction::Buy,
+            limit_price: AlpacaLimitPrice::try_new(
+                Positive::new(Usd::new(float!(195.25))).unwrap(),
+            )
+            .unwrap(),
+            extended_hours: true,
+            client_order_id: ClientOrderId::from_uuid(client_order_uuid),
+        };
+
+        let placement = place_limit_order(&client, limit_order).await.unwrap();
+
+        place_mock.assert();
+        lookup_mock.assert();
+        assert_eq!(placement.order_id, existing_order_id);
+        assert_eq!(placement.shares.inner(), FractionalShares::new(float!(7)));
+        assert_eq!(placement.direction, Direction::Buy);
+        // The lookup response omitted the term echo fields; adoption must
+        // fall back to the REQUEST's terms (the adopted order was created by
+        // a prior attempt of this same extended-hours placement), or the
+        // regular-open cancel-and-replace sweep never sees the live order.
+        assert!(placement.extended_hours);
+        assert_eq!(
+            placement.limit_price,
+            Some(Positive::new(Usd::new(float!(195.25))).unwrap())
+        );
+    }
+
+    #[tokio::test]
+    async fn place_limit_order_adoption_errors_on_non_positive_limit_price() {
+        // Broker holds an existing order under this client_order_id (lost-response
+        // adoption), but reports a zero limit_price in the lookup response.
+        // parse_limit_price must fail fast rather than silently falling back to None.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let client_order_uuid = uuid!("bbbbcccc-bbbb-4bbb-8bbb-bbbbbbbbcccc");
+        let client_order_id = client_order_uuid.to_string();
+        let existing_order_id = "904837e3-3b76-47ec-b432-046db621571b";
+
+        let place_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(422)
+                .header("content-type", "application/json")
+                .json_body(json!({"message": "client_order_id must be unique"}));
+        });
+
+        let lookup_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path(
+                    "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders:by_client_order_id",
+                )
+                .query_param("client_order_id", client_order_id.as_str());
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": existing_order_id,
+                    "symbol": "AAPL",
+                    "qty": "7",
+                    "side": "buy",
+                    "status": "new",
+                    "filled_avg_price": null,
+                    "type": "limit",
+                    "limit_price": "0",
+                    "extended_hours": true
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let limit_order = AlpacaLimitOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
+            direction: Direction::Buy,
+            limit_price: AlpacaLimitPrice::try_new(
+                Positive::new(Usd::new(float!(195.25))).unwrap(),
+            )
+            .unwrap(),
+            extended_hours: true,
+            client_order_id: ClientOrderId::from_uuid(client_order_uuid),
+        };
+
+        let err = place_limit_order(&client, limit_order).await.unwrap_err();
+
+        place_mock.assert();
+        lookup_mock.assert();
+        assert!(
+            matches!(err, AlpacaBrokerApiError::NotPositiveLimitPrice(_)),
+            "Expected NotPositiveLimitPrice error on zero limit_price, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn place_limit_order_fresh_placement_records_request_terms() {
+        // A fresh extended-hours limit placement must record the REQUEST's
+        // terms even when the broker's placement response omits the echo
+        // fields -- otherwise the regular-open convergence sweep (keyed off
+        // extended_hours) never sees the order.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        let place_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": "904837e3-3b76-47ec-b432-046db621571b",
+                    "symbol": "AAPL",
+                    "qty": "10",
+                    "side": "buy",
+                    "status": "new",
+                    "filled_avg_price": null
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let limit_price = Positive::new(Usd::new(float!(195.25))).unwrap();
+        let limit_order = AlpacaLimitOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
+            direction: Direction::Buy,
+            limit_price: AlpacaLimitPrice::try_new(limit_price).unwrap(),
+            extended_hours: true,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+            )),
+        };
+
+        let placement = place_limit_order(&client, limit_order).await.unwrap();
+
+        place_mock.assert();
+        assert!(placement.extended_hours);
+        assert_eq!(placement.limit_price, Some(limit_price));
     }
 
     #[tokio::test]
@@ -1001,7 +1504,8 @@ mod tests {
                     "type": "limit",
                     "limit_price": "195.25",
                     "time_in_force": "day",
-                    "extended_hours": false
+                    "extended_hours": false,
+                    "client_order_id": "44444444-4444-4444-8444-444444444444"
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -1025,6 +1529,9 @@ mod tests {
             )
             .unwrap(),
             extended_hours: false,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "44444444-4444-4444-8444-444444444444"
+            )),
         };
 
         let placement = place_limit_order(&client, limit_order).await.unwrap();
@@ -1051,7 +1558,8 @@ mod tests {
                     "type": "limit",
                     "limit_price": "210",
                     "time_in_force": "day",
-                    "extended_hours": true
+                    "extended_hours": true,
+                    "client_order_id": "55555555-5555-4555-8555-555555555555"
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -1073,6 +1581,9 @@ mod tests {
             limit_price: AlpacaLimitPrice::try_new(Positive::new(Usd::new(float!(210))).unwrap())
                 .unwrap(),
             extended_hours: true,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "55555555-5555-4555-8555-555555555555"
+            )),
         };
 
         let placement = place_limit_order(&client, limit_order).await.unwrap();
@@ -1082,6 +1593,13 @@ mod tests {
         assert_eq!(placement.symbol.to_string(), "TSLA");
         assert_eq!(placement.shares.inner(), FractionalShares::new(float!(50)));
         assert_eq!(placement.direction, Direction::Sell);
+        // A fresh placement records the REQUEST's terms even when the broker
+        // response omits the echo fields.
+        assert!(placement.extended_hours);
+        assert_eq!(
+            placement.limit_price,
+            Some(Positive::new(Usd::new(float!(210))).unwrap())
+        );
     }
 
     #[test]
@@ -1133,7 +1651,8 @@ mod tests {
                     "type": "limit",
                     "limit_price": "0.1234",
                     "time_in_force": "day",
-                    "extended_hours": false
+                    "extended_hours": false,
+                    "client_order_id": "66666666-6666-4666-8666-666666666666"
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -1157,6 +1676,9 @@ mod tests {
             )
             .unwrap(),
             extended_hours: false,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "66666666-6666-4666-8666-666666666666"
+            )),
         };
 
         let placement = place_limit_order(&client, limit_order).await.unwrap();
@@ -1220,7 +1742,9 @@ mod tests {
                     "qty": "50",
                     "side": "sell",
                     "status": "filled",
-                    "filled_avg_price": "245.67"
+                    "filled_avg_price": "245.67",
+                    "updated_at": "2025-01-06T14:32:05.000000Z",
+                    "filled_at": "2025-01-06T14:32:01.111111Z"
                 }));
         });
 
@@ -1230,6 +1754,14 @@ mod tests {
         mock.assert();
         assert_eq!(order_update.order_id, order_id);
         assert_eq!(order_update.symbol.to_string(), "TSLA");
+        // The update must carry the broker's fill time, not the local
+        // observation time (and not the order's generic updated_at).
+        assert_eq!(
+            order_update.updated_at,
+            "2025-01-06T14:32:01.111111Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
         assert_eq!(
             order_update.shares.inner(),
             FractionalShares::new(float!(50))
@@ -1241,6 +1773,347 @@ mod tests {
                 .eq(Float::parse("245.67".to_string()).unwrap())
                 .unwrap()
         }));
+    }
+
+    #[tokio::test]
+    async fn test_get_order_status_partially_filled_parses_typed_fill() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = "0e9151b6-3b9f-4bf2-9f9b-1d6a8a1c1f0e";
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "AAPL",
+                    "qty": "100",
+                    "filled_qty": "40.5",
+                    "side": "buy",
+                    "status": "partially_filled",
+                    "filled_avg_price": "199.50"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let order_update = get_order_status(&client, order_id).await.unwrap();
+
+        mock.assert();
+        assert_eq!(order_update.status, OrderStatus::PartiallyFilled);
+        assert_eq!(
+            order_update.shares_filled,
+            Some(FractionalShares::new(float!(40.5)))
+        );
+        assert!(order_update.price.is_some_and(|price| {
+            price
+                .eq(Float::parse("199.50".to_string()).unwrap())
+                .unwrap()
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_get_order_status_cancelled_after_partial_fill_preserves_fill() {
+        // Full realistic Broker API order object for a limit order canceled
+        // after a partial fill, per the order entity reference
+        // (https://docs.alpaca.markets/reference/getorderforaccount-1):
+        // numeric fields are string-encoded ("filled_qty" is always present,
+        // "0" when unfilled) and absent values are null. The cancel-and-replace
+        // flow depends on this shape to preserve fills on cancellation.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = "61e7b016-9c91-4a97-b912-615c9d365c9d";
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "client_order_id": "33333333-3333-4333-8333-333333333333",
+                    "created_at": "2025-01-06T08:00:05.221046Z",
+                    "updated_at": "2025-01-06T14:32:01.118401Z",
+                    "submitted_at": "2025-01-06T08:00:05.211088Z",
+                    "filled_at": null,
+                    "expired_at": null,
+                    "canceled_at": "2025-01-06T14:32:01.111111Z",
+                    "failed_at": null,
+                    "replaced_at": null,
+                    "replaced_by": null,
+                    "replaces": null,
+                    "asset_id": "b0b6dd9d-8b9b-48a9-ba46-b9d54906e415",
+                    "symbol": "AAPL",
+                    "asset_class": "us_equity",
+                    "notional": null,
+                    "qty": "100",
+                    "filled_qty": "40.5",
+                    "filled_avg_price": "199.50",
+                    "order_class": "",
+                    "order_type": "limit",
+                    "type": "limit",
+                    "side": "buy",
+                    "time_in_force": "day",
+                    "limit_price": "200.00",
+                    "stop_price": null,
+                    "status": "canceled",
+                    "extended_hours": true,
+                    "legs": null,
+                    "trail_percent": null,
+                    "trail_price": null,
+                    "hwm": null
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let order_update = get_order_status(&client, order_id).await.unwrap();
+
+        mock.assert();
+        assert_eq!(order_update.status, OrderStatus::Cancelled);
+        assert_eq!(
+            order_update.shares_filled,
+            Some(FractionalShares::new(float!(40.5)))
+        );
+        assert!(order_update.price.is_some_and(|price| {
+            price
+                .eq(Float::parse("199.50".to_string()).unwrap())
+                .unwrap()
+        }));
+        // Broker cancellation time, not updated_at and not observation time.
+        assert_eq!(
+            order_update.updated_at,
+            "2025-01-06T14:32:01.111111Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_order_status_cancelled_without_fill() {
+        // Canceled before any fill: Alpaca reports filled_qty as the string
+        // "0" (the field is always present) and filled_avg_price as null.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = "7f3b1c2a-5d4e-4f6a-8b9c-0d1e2f3a4b5c";
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "client_order_id": "44444444-4444-4444-8444-444444444444",
+                    "created_at": "2025-01-06T08:00:05.221046Z",
+                    "updated_at": "2025-01-06T14:32:01.118401Z",
+                    "submitted_at": "2025-01-06T08:00:05.211088Z",
+                    "filled_at": null,
+                    "canceled_at": "2025-01-06T14:32:01.111111Z",
+                    "failed_at": null,
+                    "asset_id": "b0b6dd9d-8b9b-48a9-ba46-b9d54906e415",
+                    "symbol": "TSLA",
+                    "asset_class": "us_equity",
+                    "notional": null,
+                    "qty": "50",
+                    "filled_qty": "0",
+                    "filled_avg_price": null,
+                    "order_class": "",
+                    "order_type": "limit",
+                    "type": "limit",
+                    "side": "sell",
+                    "time_in_force": "day",
+                    "limit_price": "250.00",
+                    "stop_price": null,
+                    "status": "canceled",
+                    "extended_hours": true
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let order_update = get_order_status(&client, order_id).await.unwrap();
+
+        mock.assert();
+        assert_eq!(order_update.status, OrderStatus::Cancelled);
+        assert_eq!(
+            order_update.shares_filled,
+            Some(FractionalShares::new(float!(0)))
+        );
+        assert!(order_update.price.is_none());
+        // Broker cancellation time, not the local observation time.
+        assert_eq!(
+            order_update.updated_at,
+            "2025-01-06T14:32:01.111111Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn get_order_status_cancelled_with_null_canceled_at_uses_updated_at() {
+        // Branch 2 of terminal_broker_time: canceled_at absent but updated_at
+        // present -> warn and substitute updated_at.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "TSLA",
+                    "qty": "50",
+                    "side": "sell",
+                    "status": "canceled",
+                    "filled_qty": "0",
+                    "filled_avg_price": null,
+                    "updated_at": "2025-01-06T14:32:05.000000Z",
+                    "canceled_at": null
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let order_update = get_order_status(&client, order_id).await.unwrap();
+
+        mock.assert();
+        assert_eq!(order_update.status, OrderStatus::Cancelled);
+        // canceled_at is null so updated_at must be used as the fallback.
+        assert_eq!(
+            order_update.updated_at,
+            "2025-01-06T14:32:05.000000Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn get_order_status_cancelled_with_both_timestamps_null_errors() {
+        // Branch 3 of terminal_broker_time: both canceled_at and updated_at
+        // absent -> IncompleteOrder error rather than silent substitution.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e";
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "TSLA",
+                    "qty": "50",
+                    "side": "sell",
+                    "status": "canceled",
+                    "filled_qty": "0",
+                    "filled_avg_price": null
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let error = get_order_status(&client, order_id).await.unwrap_err();
+
+        mock.assert();
+        assert!(
+            matches!(
+                error,
+                AlpacaBrokerApiError::IncompleteOrder {
+                    field: MissingOrderField::CanceledAt,
+                    ..
+                }
+            ),
+            "expected IncompleteOrder with CanceledAt, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_order_status_filled_with_null_filled_at_uses_updated_at() {
+        // Branch 2 of terminal_broker_time: filled_at absent but updated_at
+        // present -> warn and substitute updated_at.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f";
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "TSLA",
+                    "qty": "50",
+                    "side": "sell",
+                    "status": "filled",
+                    "filled_qty": "50",
+                    "filled_avg_price": "200.00",
+                    "updated_at": "2025-01-06T14:32:05.000000Z",
+                    "filled_at": null
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let order_update = get_order_status(&client, order_id).await.unwrap();
+
+        mock.assert();
+        assert_eq!(order_update.status, OrderStatus::Filled);
+        // filled_at is null so updated_at must be used as the fallback.
+        assert_eq!(
+            order_update.updated_at,
+            "2025-01-06T14:32:05.000000Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn get_order_status_filled_with_both_timestamps_null_errors() {
+        // Branch 3 of terminal_broker_time: both filled_at and updated_at
+        // absent -> IncompleteOrder error rather than silent substitution.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = "d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a";
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "TSLA",
+                    "qty": "50",
+                    "side": "sell",
+                    "status": "filled",
+                    "filled_qty": "50",
+                    "filled_avg_price": "200.00"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let error = get_order_status(&client, order_id).await.unwrap_err();
+
+        mock.assert();
+        assert!(
+            matches!(
+                error,
+                AlpacaBrokerApiError::IncompleteOrder {
+                    field: MissingOrderField::FilledAt,
+                    ..
+                }
+            ),
+            "expected IncompleteOrder with FilledAt, got {error:?}"
+        );
     }
 
     #[tokio::test]
@@ -1273,6 +2146,89 @@ mod tests {
         assert_eq!(order_update.status, OrderStatus::Failed);
     }
 
+    #[tokio::test]
+    async fn get_order_status_failed_with_failed_at_uses_failed_at() {
+        // The Failed arm calls broker_time_or_observation(failed_at.or(updated_at)).
+        // When failed_at is present it takes priority over updated_at.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = "e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b";
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "AAPL",
+                    "qty": "25",
+                    "side": "buy",
+                    "status": "rejected",
+                    "filled_qty": "0",
+                    "filled_avg_price": null,
+                    "failed_at": "2025-01-06T14:32:01.000000Z",
+                    "updated_at": "2025-01-06T14:32:05.000000Z"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let order_update = get_order_status(&client, order_id).await.unwrap();
+
+        mock.assert();
+        assert_eq!(order_update.status, OrderStatus::Failed);
+        // failed_at is present so it must be used, not the later updated_at.
+        assert_eq!(
+            order_update.updated_at,
+            "2025-01-06T14:32:01.000000Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn get_order_status_failed_with_null_failed_at_uses_updated_at() {
+        // When failed_at is absent, the Failed arm falls back to updated_at
+        // via broker_time_or_observation (many rejected/expired payloads omit
+        // failed_at and only carry updated_at).
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = "f6a7b8c9-d0e1-4f2a-3b4c-5d6e7f8a9b0c";
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "AAPL",
+                    "qty": "25",
+                    "side": "buy",
+                    "status": "rejected",
+                    "filled_qty": "0",
+                    "filled_avg_price": null,
+                    "failed_at": null,
+                    "updated_at": "2025-01-06T14:32:05.000000Z"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let order_update = get_order_status(&client, order_id).await.unwrap();
+
+        mock.assert();
+        assert_eq!(order_update.status, OrderStatus::Failed);
+        // failed_at is null so updated_at must be used as the fallback.
+        assert_eq!(
+            order_update.updated_at,
+            "2025-01-06T14:32:05.000000Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
+    }
+
     #[test]
     fn test_map_broker_status_new() {
         assert_eq!(
@@ -1294,6 +2250,22 @@ mod tests {
         assert_eq!(
             map_broker_status_to_order_status(BrokerOrderStatus::Rejected),
             OrderStatus::Failed
+        );
+    }
+
+    #[test]
+    fn test_map_broker_status_partially_filled() {
+        assert_eq!(
+            map_broker_status_to_order_status(BrokerOrderStatus::PartiallyFilled),
+            OrderStatus::PartiallyFilled
+        );
+    }
+
+    #[test]
+    fn test_map_broker_status_cancelled() {
+        assert_eq!(
+            map_broker_status_to_order_status(BrokerOrderStatus::Canceled),
+            OrderStatus::Cancelled
         );
     }
 
@@ -1532,7 +2504,8 @@ mod tests {
                     "type": "limit",
                     "limit_price": "17.45",
                     "time_in_force": "day",
-                    "extended_hours": false
+                    "extended_hours": false,
+                    "client_order_id": "77777777-7777-4777-8777-777777777777"
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -1557,6 +2530,9 @@ mod tests {
             limit_price: AlpacaLimitPrice::try_new(Positive::new(Usd::new(float!(17.45))).unwrap())
                 .unwrap(),
             extended_hours: false,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "77777777-7777-4777-8777-777777777777"
+            )),
         };
 
         let placement = place_limit_order(&client, limit_order).await.unwrap();
@@ -1590,6 +2566,7 @@ mod tests {
             )
             .unwrap(),
             extended_hours: false,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
 
         let err = place_limit_order(&client, limit_order).await.unwrap_err();

--- a/crates/execution/src/alpaca_market_data.rs
+++ b/crates/execution/src/alpaca_market_data.rs
@@ -5,7 +5,7 @@ use reqwest::{Client, StatusCode};
 use serde::Deserialize;
 use tracing::trace;
 
-use crate::{Positive, Symbol, deserialize_float_from_number_or_string};
+use crate::{Positive, Symbol, Usd, deserialize_float_from_number_or_string};
 
 #[derive(Debug, thiserror::Error)]
 pub enum AlpacaMarketDataError {
@@ -42,7 +42,7 @@ pub(crate) async fn fetch_latest_trade_price(
     client: &Client,
     market_data_base_url: &str,
     symbol: &Symbol,
-) -> Result<Positive<Float>, AlpacaMarketDataError> {
+) -> Result<Positive<Usd>, AlpacaMarketDataError> {
     let response = client
         .get(format!(
             "{market_data_base_url}/v2/stocks/{symbol}/trades/latest"
@@ -77,9 +77,11 @@ pub(crate) async fn fetch_latest_trade_price(
     response
         .trade
         .map(|trade| {
-            Positive::new(trade.price).map_err(|error| AlpacaMarketDataError::NonPositivePrice {
-                symbol: symbol.clone(),
-                price: error.value,
+            Positive::new(Usd::new(trade.price)).map_err(|error| {
+                AlpacaMarketDataError::NonPositivePrice {
+                    symbol: symbol.clone(),
+                    price: error.value.inner(),
+                }
             })
         })
         .transpose()?
@@ -147,11 +149,9 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(
-            price
-                .inner()
-                .eq(Float::parse("123.45".to_string()).unwrap())
-                .unwrap()
+        assert_eq!(
+            price.inner(),
+            Usd::new(Float::parse("123.45".to_string()).unwrap())
         );
     }
 

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -31,8 +31,8 @@ pub use alpaca_broker_api::{
 pub use error::PersistenceError;
 pub use mock::{MockExecutor, MockExecutorCtx};
 pub use order::{
-    ClientOrderId, ClientOrderIdError, MarketOrder, OrderPlacement, OrderState, OrderStatus,
-    OrderUpdate,
+    CancellationOutcome, ClientOrderId, ClientOrderIdError, LimitOrder, MarketOrder,
+    OrderPlacement, OrderState, OrderStatus, OrderUpdate,
 };
 
 #[cfg(any(test, feature = "test-support"))]
@@ -76,6 +76,19 @@ pub(crate) fn truncate_to_decimal_places(
     }
 
     Float::from_fixed_decimal(fixed, max_decimals).map(Some)
+}
+
+/// Describes the current trading session, driving order-type selection.
+///
+/// - `Regular` -- standard market hours; market orders are used.
+/// - `Extended` -- pre-market or after-hours; only limit orders with
+///   `extended_hours: true` are allowed by the broker.
+/// - `Closed` -- outside all trading sessions (weekends, holidays, overnight).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MarketSession {
+    Regular,
+    Extended,
+    Closed,
 }
 
 #[async_trait]
@@ -155,6 +168,50 @@ pub trait Executor: Send + Sync + 'static {
     ) -> Result<CounterTradePreflight, Self::Error> {
         Ok(CounterTradePreflight::Allowed { reservation: None })
     }
+
+    /// Returns the current market session (regular, extended, or closed).
+    ///
+    /// Default implementation delegates to `is_market_open()`, mapping
+    /// `true -> Regular` and `false -> Closed`. Executors with extended-hours
+    /// support (e.g. Alpaca) override this to distinguish `Extended` sessions.
+    async fn market_session(&self) -> Result<MarketSession, Self::Error> {
+        if self.is_market_open().await? {
+            Ok(MarketSession::Regular)
+        } else {
+            Ok(MarketSession::Closed)
+        }
+    }
+
+    /// Fetches the latest trade price for a symbol from the broker's market
+    /// data feed. Used to determine limit prices for extended-hours
+    /// counter-trades. Returns `None` when not supported by the executor.
+    async fn fetch_latest_trade_price(
+        &self,
+        _symbol: &Symbol,
+    ) -> Result<Option<Positive<Usd>>, Self::Error> {
+        Ok(None)
+    }
+
+    /// Place a limit order for the specified symbol, quantity, and price.
+    ///
+    /// Used for counter-trading during extended hours when market orders
+    /// are not accepted.
+    async fn place_limit_order(
+        &self,
+        order: LimitOrder,
+    ) -> Result<OrderPlacement<Self::OrderId>, Self::Error>;
+
+    /// Cancel a previously placed order by its executor-assigned ID.
+    ///
+    /// Returns [`CancellationOutcome::Requested`] when the broker accepted
+    /// the cancel request, and [`CancellationOutcome::OrderNotFound`] when
+    /// the broker does not recognise the order id. The caller must resolve
+    /// `OrderNotFound` as terminal rather than retry: re-sending the cancel
+    /// can never succeed for an id the broker does not know.
+    async fn cancel_order(
+        &self,
+        order_id: &Self::OrderId,
+    ) -> Result<CancellationOutcome, Self::Error>;
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/execution/src/mock.rs
+++ b/crates/execution/src/mock.rs
@@ -13,9 +13,10 @@ use tracing::{debug, info};
 static MOCK_FILL_PRICE: LazyLock<Float> = LazyLock::new(|| float!(100));
 
 use crate::{
-    CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason,
-    DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS, Direction, ExecutionError, Executor, Inventory,
-    InventoryResult, MarketOrder, OrderPlacement, OrderState, SupportedExecutor, TryIntoExecutor,
+    CancellationOutcome, CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason,
+    DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS, Direction, ExecutionError, Executor,
+    ExecutorOrderId, Inventory, InventoryResult, LimitOrder, MarketOrder, MarketSession,
+    OrderPlacement, OrderState, SupportedExecutor, TryIntoExecutor, Usd,
     estimate_buffered_cost_cents,
 };
 
@@ -40,6 +41,7 @@ pub struct MockExecutor {
     inventory_result: InventoryResult,
     order_status_override: Option<OrderState>,
     market_open: bool,
+    market_session_override: Option<MarketSession>,
     preflight_price: Float,
 }
 
@@ -51,6 +53,7 @@ impl MockExecutor {
             inventory_result: InventoryResult::Unimplemented,
             order_status_override: None,
             market_open: true,
+            market_session_override: None,
             preflight_price: *MOCK_FILL_PRICE,
         }
     }
@@ -83,6 +86,15 @@ impl MockExecutor {
     #[must_use]
     pub fn with_market_closed(mut self) -> Self {
         self.market_open = false;
+        self
+    }
+
+    /// Configures the market session returned by `market_session()`.
+    /// When set, this takes precedence over `market_open` for the
+    /// `market_session()` method.
+    #[must_use]
+    pub fn with_market_session(mut self, session: MarketSession) -> Self {
+        self.market_session_override = Some(session);
         self
     }
 
@@ -152,6 +164,8 @@ impl Executor for MockExecutor {
             shares: order.shares,
             direction: order.direction,
             placed_at: chrono::Utc::now(),
+            extended_hours: false,
+            limit_price: None,
         })
     }
 
@@ -172,8 +186,8 @@ impl Executor for MockExecutor {
 
         Ok(OrderState::Filled {
             executed_at: chrono::Utc::now(),
-            order_id: order_id.clone(),
-            price,
+            order_id: ExecutorOrderId::new(order_id),
+            price: Usd::new(price),
         })
     }
 
@@ -239,6 +253,53 @@ impl Executor for MockExecutor {
                 }
             }
         }
+    }
+
+    async fn market_session(&self) -> Result<MarketSession, Self::Error> {
+        if let Some(session) = self.market_session_override {
+            return Ok(session);
+        }
+
+        if self.market_open {
+            Ok(MarketSession::Regular)
+        } else {
+            Ok(MarketSession::Closed)
+        }
+    }
+
+    async fn place_limit_order(
+        &self,
+        order: LimitOrder,
+    ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
+        self.fail_if_unhealthy()?;
+
+        let order_id = self.generate_order_id();
+
+        debug!(
+            target: "broker",
+            "[TEST] Would execute limit order: {} {} shares of {} at {} (order_id: {})",
+            order.direction, order.shares, order.symbol, order.limit_price, order_id
+        );
+
+        Ok(OrderPlacement {
+            order_id,
+            symbol: order.symbol,
+            shares: order.shares,
+            direction: order.direction,
+            placed_at: chrono::Utc::now(),
+            extended_hours: order.extended_hours,
+            limit_price: Some(order.limit_price),
+        })
+    }
+
+    async fn cancel_order(
+        &self,
+        order_id: &Self::OrderId,
+    ) -> Result<CancellationOutcome, Self::Error> {
+        self.fail_if_unhealthy()?;
+
+        debug!(target: "broker", "[TEST] Would cancel order: {}", order_id);
+        Ok(CancellationOutcome::Requested)
     }
 }
 

--- a/crates/execution/src/order/mod.rs
+++ b/crates/execution/src/order/mod.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use st0x_float_serde::DebugOptionFloat;
 
-use crate::{Direction, FractionalShares, Positive, Symbol};
+use crate::{Direction, FractionalShares, Positive, Symbol, Usd};
 
 pub mod state;
 pub mod status;
@@ -95,6 +95,17 @@ pub struct OrderPlacement<OrderId> {
     pub shares: Positive<FractionalShares>,
     pub direction: Direction,
     pub placed_at: DateTime<Utc>,
+    /// Whether the broker holds this as an extended-hours order. For a fresh
+    /// placement this echoes the request; when a duplicate `client_order_id`
+    /// placement adopts an order from a prior attempt, it is the ADOPTED
+    /// order's flag, which can differ from the request (e.g. a regular-hours
+    /// market retry adopting a still-live extended-hours limit order after a
+    /// lost placement response). Callers must record this value -- not the
+    /// request's -- so session-convergence logic sees broker reality.
+    pub extended_hours: bool,
+    /// The broker-held limit price, if the order is a limit order. Same
+    /// adoption semantics as `extended_hours`.
+    pub limit_price: Option<Positive<Usd>>,
 }
 
 pub struct OrderUpdate<OrderId> {
@@ -105,6 +116,14 @@ pub struct OrderUpdate<OrderId> {
     pub status: OrderStatus,
     pub updated_at: DateTime<Utc>,
     pub price: Option<Float>,
+    /// Cumulative quantity filled at the broker so far. `None` when the
+    /// broker response omitted the field; brokers that always report it
+    /// (Alpaca sends `filled_qty: "0"`) yield `Some(0)` for unfilled orders,
+    /// so consumers MUST treat `Some(0)` and `None` alike as "no fill" --
+    /// never branch on `is_some()` to detect a fill. Required for
+    /// `OrderStatus::PartiallyFilled` so the caller can reconcile the local
+    /// aggregate via `UpdatePartialFill`.
+    pub shares_filled: Option<FractionalShares>,
 }
 
 impl<OrderId: Debug> Debug for OrderUpdate<OrderId> {
@@ -117,8 +136,27 @@ impl<OrderId: Debug> Debug for OrderUpdate<OrderId> {
             .field("status", &self.status)
             .field("updated_at", &self.updated_at)
             .field("price", &DebugOptionFloat(&self.price))
+            .field("shares_filled", &self.shares_filled)
             .finish()
     }
+}
+
+/// Outcome of a broker cancel request.
+///
+/// Distinguishes "the broker accepted the cancel request" from "the broker
+/// no longer recognises the order id". The latter must not be reported as
+/// plain success (the caller would wait forever for a cancellation
+/// confirmation the broker will never produce) nor as a retryable error
+/// (re-sending the cancel can never succeed). Callers resolve `OrderNotFound`
+/// by treating the order as already terminal at the broker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancellationOutcome {
+    /// The broker accepted the cancel request; the order will reach a
+    /// terminal state observable via `get_order_status`.
+    Requested,
+    /// The broker does not recognise the order id (e.g. HTTP 404). No live
+    /// order exists under this id, so no further fills can occur.
+    OrderNotFound,
 }
 
 #[derive(Debug, Clone)]
@@ -130,6 +168,23 @@ pub struct MarketOrder {
     /// placement (e.g. apalis re-running a job after a transient 5xx whose
     /// response was lost in flight) are deduped by the broker rather than
     /// submitting a second order.
+    pub client_order_id: ClientOrderId,
+}
+
+/// Broker-agnostic limit order for automated counter-trading during extended
+/// hours. The executor implementation converts this to its broker-specific
+/// limit order type (e.g. `AlpacaLimitOrder`).
+#[derive(Debug, Clone)]
+pub struct LimitOrder {
+    pub symbol: Symbol,
+    pub shares: Positive<FractionalShares>,
+    pub direction: Direction,
+    pub limit_price: Positive<Usd>,
+    pub extended_hours: bool,
+    /// Forwarded to the broker so that retries of a logically identical
+    /// extended-hours placement (e.g. apalis re-running a job after a lost
+    /// placement response) are deduped by the broker rather than submitting a
+    /// second live limit order. Mirrors [`MarketOrder::client_order_id`].
     pub client_order_id: ClientOrderId,
 }
 

--- a/crates/execution/src/order/state.rs
+++ b/crates/execution/src/order/state.rs
@@ -1,101 +1,53 @@
 use chrono::{DateTime, Utc};
 
-use rain_math_float::Float;
+use crate::{ExecutorOrderId, FractionalShares, Usd};
 
 use super::OrderStatus;
 
 /// Runtime representation of an offchain order's lifecycle state.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OrderState {
     Pending,
     Submitted {
-        order_id: String,
+        order_id: ExecutorOrderId,
+    },
+    /// Broker reports a partial fill. Carries the executed quantity so far
+    /// and the average fill price so the local aggregate can record the
+    /// fill via `UpdatePartialFill` before the order is either filled,
+    /// cancelled, or fails.
+    PartiallyFilled {
+        order_id: ExecutorOrderId,
+        shares_filled: FractionalShares,
+        avg_price: Option<Usd>,
+        partially_filled_at: DateTime<Utc>,
     },
     Filled {
         executed_at: DateTime<Utc>,
-        order_id: String,
-        price: Float,
+        order_id: ExecutorOrderId,
+        price: Usd,
+    },
+    Cancelled {
+        cancelled_at: DateTime<Utc>,
+        order_id: ExecutorOrderId,
+        shares_filled: FractionalShares,
+        avg_price: Option<Usd>,
     },
     Failed {
         failed_at: DateTime<Utc>,
         error_reason: Option<String>,
+        shares_filled: Option<FractionalShares>,
+        avg_price: Option<Usd>,
     },
 }
-
-impl std::fmt::Debug for OrderState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Pending => write!(f, "Pending"),
-            Self::Submitted { order_id } => f
-                .debug_struct("Submitted")
-                .field("order_id", order_id)
-                .finish(),
-            Self::Filled {
-                executed_at,
-                order_id,
-                price,
-            } => f
-                .debug_struct("Filled")
-                .field("executed_at", executed_at)
-                .field("order_id", order_id)
-                .field("price", &st0x_float_serde::DebugFloat(price))
-                .finish(),
-            Self::Failed {
-                failed_at,
-                error_reason,
-            } => f
-                .debug_struct("Failed")
-                .field("failed_at", failed_at)
-                .field("error_reason", error_reason)
-                .finish(),
-        }
-    }
-}
-
-impl PartialEq for OrderState {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Pending, Self::Pending) => true,
-            (Self::Submitted { order_id: lhs }, Self::Submitted { order_id: rhs }) => lhs == rhs,
-            (
-                Self::Filled {
-                    executed_at: lhs_executed_at,
-                    order_id: lhs_order_id,
-                    price: lhs_price,
-                },
-                Self::Filled {
-                    executed_at: rhs_executed_at,
-                    order_id: rhs_order_id,
-                    price: rhs_price,
-                },
-            ) => {
-                lhs_executed_at == rhs_executed_at
-                    && lhs_order_id == rhs_order_id
-                    && lhs_price.eq(*rhs_price).unwrap_or(false)
-            }
-            (
-                Self::Failed {
-                    failed_at: lhs_failed_at,
-                    error_reason: lhs_error_reason,
-                },
-                Self::Failed {
-                    failed_at: rhs_failed_at,
-                    error_reason: rhs_error_reason,
-                },
-            ) => lhs_failed_at == rhs_failed_at && lhs_error_reason == rhs_error_reason,
-            _ => false,
-        }
-    }
-}
-
-impl Eq for OrderState {}
 
 impl OrderState {
     pub const fn status(&self) -> OrderStatus {
         match self {
             Self::Pending => OrderStatus::Pending,
             Self::Submitted { .. } => OrderStatus::Submitted,
+            Self::PartiallyFilled { .. } => OrderStatus::PartiallyFilled,
             Self::Filled { .. } => OrderStatus::Filled,
+            Self::Cancelled { .. } => OrderStatus::Cancelled,
             Self::Failed { .. } => OrderStatus::Failed,
         }
     }
@@ -103,14 +55,16 @@ impl OrderState {
 
 #[cfg(test)]
 mod tests {
+    use rain_math_float::Float;
+
     use super::*;
 
     #[test]
     fn filled_debug_formats_price_as_decimal() {
         let state = OrderState::Filled {
             executed_at: Utc::now(),
-            order_id: "ORDER123".to_string(),
-            price: Float::parse("150.00".to_string()).unwrap(),
+            order_id: ExecutorOrderId::new("ORDER123"),
+            price: Usd::new(Float::parse("150.00".to_string()).unwrap()),
         };
 
         let debug_output = format!("{state:?}");
@@ -129,7 +83,7 @@ mod tests {
         assert_eq!(OrderState::Pending.status(), OrderStatus::Pending);
         assert_eq!(
             OrderState::Submitted {
-                order_id: "ORDER123".to_string()
+                order_id: ExecutorOrderId::new("ORDER123")
             }
             .status(),
             OrderStatus::Submitted
@@ -137,16 +91,28 @@ mod tests {
         assert_eq!(
             OrderState::Filled {
                 executed_at: Utc::now(),
-                order_id: "ORDER123".to_string(),
-                price: Float::parse("150.00".to_string()).unwrap(),
+                order_id: ExecutorOrderId::new("ORDER123"),
+                price: Usd::new(Float::parse("150.00".to_string()).unwrap()),
             }
             .status(),
             OrderStatus::Filled
         );
         assert_eq!(
+            OrderState::Cancelled {
+                cancelled_at: Utc::now(),
+                order_id: ExecutorOrderId::new("ORDER123"),
+                shares_filled: FractionalShares::ZERO,
+                avg_price: None,
+            }
+            .status(),
+            OrderStatus::Cancelled
+        );
+        assert_eq!(
             OrderState::Failed {
                 failed_at: Utc::now(),
-                error_reason: None
+                error_reason: None,
+                shares_filled: None,
+                avg_price: None,
             }
             .status(),
             OrderStatus::Failed

--- a/crates/execution/src/order/status.rs
+++ b/crates/execution/src/order/status.rs
@@ -3,7 +3,9 @@
 pub enum OrderStatus {
     Pending,
     Submitted,
+    PartiallyFilled,
     Filled,
+    Cancelled,
     Failed,
 }
 
@@ -12,7 +14,9 @@ impl OrderStatus {
         match self {
             Self::Pending => "PENDING",
             Self::Submitted => "SUBMITTED",
+            Self::PartiallyFilled => "PARTIALLY_FILLED",
             Self::Filled => "FILLED",
+            Self::Cancelled => "CANCELLED",
             Self::Failed => "FAILED",
         }
     }
@@ -28,7 +32,7 @@ impl std::fmt::Display for OrderStatus {
 pub enum ParseOrderStatusError {
     #[error(
         "invalid order status: '{status_provided}'. Expected one of: \
-         PENDING, SUBMITTED, FILLED, FAILED"
+         PENDING, SUBMITTED, PARTIALLY_FILLED, FILLED, CANCELLED, FAILED"
     )]
     InvalidStatus { status_provided: String },
 }
@@ -40,11 +44,48 @@ impl std::str::FromStr for OrderStatus {
         match s {
             "PENDING" => Ok(Self::Pending),
             "SUBMITTED" => Ok(Self::Submitted),
+            "PARTIALLY_FILLED" => Ok(Self::PartiallyFilled),
             "FILLED" => Ok(Self::Filled),
+            "CANCELLED" => Ok(Self::Cancelled),
             "FAILED" => Ok(Self::Failed),
             _ => Err(ParseOrderStatusError::InvalidStatus {
                 status_provided: s.to_string(),
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_all_variants() {
+        let pairs = [
+            ("PENDING", OrderStatus::Pending),
+            ("SUBMITTED", OrderStatus::Submitted),
+            ("PARTIALLY_FILLED", OrderStatus::PartiallyFilled),
+            ("FILLED", OrderStatus::Filled),
+            ("CANCELLED", OrderStatus::Cancelled),
+            ("FAILED", OrderStatus::Failed),
+        ];
+
+        for (string, variant) in pairs {
+            assert_eq!(
+                string.parse::<OrderStatus>().unwrap(),
+                variant,
+                "parse failed for {string}"
+            );
+            assert_eq!(variant.as_str(), string, "as_str failed for {variant:?}");
+        }
+    }
+
+    #[test]
+    fn unknown_string_returns_invalid_status_error() {
+        let error = "NONSENSE".parse::<OrderStatus>().unwrap_err();
+        assert!(
+            matches!(error, ParseOrderStatusError::InvalidStatus { .. }),
+            "expected InvalidStatus, got {error:?}"
+        );
     }
 }

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -140,6 +140,12 @@ pub(super) async fn order_status_command<W: Write>(
 
     let state = get_broker_order_status(ctx, pool, order_id, stdout).await?;
 
+    write_order_status(stdout, state)?;
+
+    Ok(())
+}
+
+fn write_order_status<W: Write>(stdout: &mut W, state: OrderState) -> anyhow::Result<()> {
     match state {
         OrderState::Pending => {
             writeln!(stdout, "⏳ Order Status: PENDING")?;
@@ -156,6 +162,14 @@ pub(super) async fn order_status_command<W: Write>(
                 "   The order has been submitted and is waiting to be filled."
             )?;
         }
+        OrderState::PartiallyFilled { order_id, .. } => {
+            writeln!(stdout, "⏳ Order Status: PARTIALLY FILLED")?;
+            writeln!(stdout, "   Order ID: {order_id}")?;
+        }
+        OrderState::Cancelled { order_id, .. } => {
+            writeln!(stdout, "🚫 Order Status: CANCELLED")?;
+            writeln!(stdout, "   Order ID: {order_id}")?;
+        }
         OrderState::Filled {
             executed_at,
             order_id,
@@ -167,12 +181,13 @@ pub(super) async fn order_status_command<W: Write>(
             writeln!(
                 stdout,
                 "   Fill Price: ${}",
-                format_float_with_fallback(&price)
+                format_float_with_fallback(&price.into())
             )?;
         }
         OrderState::Failed {
             failed_at,
             error_reason,
+            ..
         } => {
             writeln!(stdout, "❌ Order Status: FAILED")?;
             writeln!(stdout, "   Failed At: {failed_at}")?;
@@ -300,12 +315,13 @@ async fn execute_alpaca_limit_order<W: Write>(
 
     let broker = alpaca_auth.clone().try_into_executor().await?;
     let placement = broker
-        .place_limit_order(AlpacaLimitOrder {
+        .place_alpaca_limit_order(AlpacaLimitOrder {
             symbol: request.symbol.clone(),
             shares: request.shares,
             direction: request.direction,
             limit_price,
             extended_hours,
+            client_order_id: ClientOrderId::cli(Uuid::new_v4()),
         })
         .await?;
 
@@ -502,7 +518,27 @@ async fn place_market_order_until_filled<Exec: Executor, W: Write>(
             OrderState::Failed { error_reason, .. } => {
                 anyhow::bail!("buy order failed: {error_reason:?}");
             }
-            OrderState::Pending | OrderState::Submitted { .. } => {
+            OrderState::Cancelled {
+                shares_filled,
+                avg_price,
+                ..
+            } => {
+                if shares_filled == FractionalShares::ZERO {
+                    anyhow::bail!("buy order was cancelled by the broker");
+                }
+
+                let Some(avg_price) = avg_price else {
+                    anyhow::bail!("buy order was cancelled after partial fill of {shares_filled}");
+                };
+
+                anyhow::bail!(
+                    "buy order was cancelled after partial fill of {shares_filled} \
+                     at average price ${avg_price}"
+                );
+            }
+            OrderState::PartiallyFilled { .. }
+            | OrderState::Pending
+            | OrderState::Submitted { .. } => {
                 if attempt % 10 == 0 {
                     writeln!(
                         stdout,
@@ -937,6 +973,8 @@ mod tests {
     use rain_math_float::Float;
     use regex::Regex;
     use serde_json::json;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::Mutex;
     use url::Url;
     use uuid::uuid;
@@ -947,7 +985,8 @@ mod tests {
         IngestionCutoff, LogLevel, OperationMode, TradingMode,
     };
     use st0x_execution::{
-        AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, SupportedExecutor,
+        AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, CancellationOutcome,
+        ExecutionError, InventoryResult, LimitOrder, SupportedExecutor,
     };
 
     use super::*;
@@ -998,6 +1037,102 @@ mod tests {
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
         AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
+
+    #[derive(Clone)]
+    struct SequencedStatusExecutor {
+        statuses: Arc<Vec<OrderState>>,
+        status_calls: Arc<AtomicUsize>,
+    }
+
+    impl SequencedStatusExecutor {
+        fn new(statuses: Vec<OrderState>) -> Self {
+            Self {
+                statuses: Arc::new(statuses),
+                status_calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn status_calls(&self) -> usize {
+            self.status_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Executor for SequencedStatusExecutor {
+        type Error = ExecutionError;
+        type OrderId = String;
+        type Ctx = ();
+
+        async fn try_from_ctx(_ctx: Self::Ctx) -> Result<Self, Self::Error> {
+            Ok(Self::new(vec![OrderState::Pending]))
+        }
+
+        async fn is_market_open(&self) -> Result<bool, Self::Error> {
+            Ok(true)
+        }
+
+        async fn place_market_order(
+            &self,
+            order: MarketOrder,
+        ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
+            Ok(OrderPlacement {
+                order_id: "sequenced-order-id".to_string(),
+                symbol: order.symbol,
+                shares: order.shares,
+                direction: order.direction,
+                placed_at: Utc::now(),
+                extended_hours: false,
+                limit_price: None,
+            })
+        }
+
+        async fn get_order_status(
+            &self,
+            _order_id: &Self::OrderId,
+        ) -> Result<OrderState, Self::Error> {
+            let call_index = self.status_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self
+                .statuses
+                .get(call_index)
+                .or_else(|| self.statuses.last())
+                .cloned()
+                .unwrap_or(OrderState::Pending))
+        }
+
+        fn to_supported_executor(&self) -> SupportedExecutor {
+            SupportedExecutor::DryRun
+        }
+
+        fn parse_order_id(&self, order_id_str: &str) -> Result<Self::OrderId, Self::Error> {
+            Ok(order_id_str.to_string())
+        }
+
+        async fn get_inventory(&self) -> Result<InventoryResult, Self::Error> {
+            Ok(InventoryResult::Unimplemented)
+        }
+
+        async fn place_limit_order(
+            &self,
+            order: LimitOrder,
+        ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
+            Ok(OrderPlacement {
+                order_id: "sequenced-limit-order-id".to_string(),
+                symbol: order.symbol,
+                shares: order.shares,
+                direction: order.direction,
+                placed_at: Utc::now(),
+                extended_hours: order.extended_hours,
+                limit_price: Some(order.limit_price),
+            })
+        }
+
+        async fn cancel_order(
+            &self,
+            _order_id: &Self::OrderId,
+        ) -> Result<CancellationOutcome, Self::Error> {
+            Ok(CancellationOutcome::Requested)
+        }
+    }
 
     fn create_base_test_ctx() -> Ctx {
         Ctx {
@@ -1205,18 +1340,31 @@ mod tests {
                 }));
         });
 
+        // The broker-side `client_order_id` is a fresh UUID per CLI invocation,
+        // so its exact value cannot be pinned. Assert the value is a well-formed
+        // CLI idempotency key (`cli-{uuid}`); `json_body_includes` covers the
+        // static fields.
+        let client_order_id_pattern = Regex::new(
+            r#""client_order_id":"cli-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}""#,
+        )
+        .unwrap();
+
         let order_mock = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders")
-                .json_body(json!({
-                    "symbol": "AAPL",
-                    "qty": "10",
-                    "side": "buy",
-                    "type": "limit",
-                    "limit_price": "195.25",
-                    "time_in_force": "day",
-                    "extended_hours": true
-                }));
+                .body_matches(client_order_id_pattern.clone())
+                .json_body_includes(
+                    json!({
+                        "symbol": "AAPL",
+                        "qty": "10",
+                        "side": "buy",
+                        "type": "limit",
+                        "limit_price": "195.25",
+                        "time_in_force": "day",
+                        "extended_hours": true
+                    })
+                    .to_string(),
+                );
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -1514,11 +1662,54 @@ mod tests {
         );
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn market_buy_keeps_polling_after_partial_fill_until_filled() {
+        let broker = SequencedStatusExecutor::new(vec![
+            OrderState::PartiallyFilled {
+                order_id: ExecutorOrderId::new("sequenced-order-id"),
+                shares_filled: FractionalShares::new(Float::parse("3.5".to_string()).unwrap()),
+                avg_price: Some(st0x_execution::Usd::new(
+                    Float::parse("195.25".to_string()).unwrap(),
+                )),
+                partially_filled_at: Utc::now(),
+            },
+            OrderState::Filled {
+                executed_at: Utc::now(),
+                order_id: ExecutorOrderId::new("sequenced-order-id"),
+                price: st0x_execution::Usd::new(Float::parse("195.30".to_string()).unwrap()),
+            },
+        ]);
+        let order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: positive_shares("10"),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::cli(Uuid::new_v4()),
+        };
+        let mut stdout = Vec::new();
+
+        place_market_order_until_filled(&broker, order, &mut stdout)
+            .await
+            .expect("partial fill should keep polling until the broker reports Filled");
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert_eq!(
+            broker.status_calls(),
+            2,
+            "the buy-fill wait must poll again after PartiallyFilled"
+        );
+        assert!(
+            output.contains("Buy filled"),
+            "the buy-fill wait must report the final fill, got: {output}"
+        );
+    }
+
     #[tokio::test]
     async fn market_buy_fails_when_the_broker_rejects_the_order() {
         let broker = MockExecutor::new().with_order_status(OrderState::Failed {
             failed_at: Utc::now(),
             error_reason: Some("rejected".to_string()),
+            shares_filled: None,
+            avg_price: None,
         });
         let order = MarketOrder {
             symbol: Symbol::new("AAPL").unwrap(),
@@ -2739,6 +2930,119 @@ mod tests {
         assert_eq!(
             fill_count, 1,
             "successful broker submission must account the onchain fill exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_buy_fails_when_the_broker_cancels_the_order() {
+        let broker = MockExecutor::new().with_order_status(OrderState::Cancelled {
+            cancelled_at: Utc::now(),
+            order_id: ExecutorOrderId::new("some-broker-order-id"),
+            shares_filled: FractionalShares::ZERO,
+            avg_price: None,
+        });
+        let order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: positive_shares("10"),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::cli(Uuid::new_v4()),
+        };
+        let mut stdout = Vec::new();
+
+        let error = place_market_order_until_filled(&broker, order, &mut stdout)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("buy order was cancelled"),
+            "a cancelled order must fail the buy-fill wait, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_buy_cancelled_after_partial_fill_reports_details() {
+        let broker = MockExecutor::new().with_order_status(OrderState::Cancelled {
+            cancelled_at: Utc::now(),
+            order_id: ExecutorOrderId::new("some-broker-order-id"),
+            shares_filled: FractionalShares::new(Float::parse("1.5".to_string()).unwrap()),
+            avg_price: Some(st0x_execution::Usd::new(
+                Float::parse("195.25".to_string()).unwrap(),
+            )),
+        });
+        let order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: positive_shares("10"),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::cli(Uuid::new_v4()),
+        };
+        let mut stdout = Vec::new();
+
+        let error = place_market_order_until_filled(&broker, order, &mut stdout)
+            .await
+            .unwrap_err();
+        let error = error.to_string();
+
+        assert!(
+            error.contains("cancelled after partial fill"),
+            "a cancelled partial fill must be explicit, got: {error}"
+        );
+        assert!(
+            error.contains("average price"),
+            "a cancelled partial fill with price must report it, got: {error}"
+        );
+    }
+
+    #[test]
+    fn write_order_status_displays_partially_filled_state() {
+        let mut stdout = Vec::new();
+
+        write_order_status(
+            &mut stdout,
+            OrderState::PartiallyFilled {
+                order_id: ExecutorOrderId::new("some-broker-order-id"),
+                shares_filled: FractionalShares::new(Float::parse("1.5".to_string()).unwrap()),
+                avg_price: Some(st0x_execution::Usd::new(
+                    Float::parse("195.25".to_string()).unwrap(),
+                )),
+                partially_filled_at: Utc::now(),
+            },
+        )
+        .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("PARTIALLY FILLED"),
+            "status output must include the partial-fill arm, got: {output}"
+        );
+        assert!(
+            output.contains("some-broker-order-id"),
+            "status output must include the broker order id, got: {output}"
+        );
+    }
+
+    #[test]
+    fn write_order_status_displays_cancelled_state() {
+        let mut stdout = Vec::new();
+
+        write_order_status(
+            &mut stdout,
+            OrderState::Cancelled {
+                cancelled_at: Utc::now(),
+                order_id: ExecutorOrderId::new("some-broker-order-id"),
+                shares_filled: FractionalShares::ZERO,
+                avg_price: None,
+            },
+        )
+        .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("CANCELLED"),
+            "status output must include the cancelled arm, got: {output}"
+        );
+        assert!(
+            output.contains("some-broker-order-id"),
+            "status output must include the broker order id, got: {output}"
         );
     }
 }

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -1268,6 +1268,8 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
 ) -> std::pin::Pin<
     Box<dyn std::future::Future<Output = anyhow::Result<RebalancingInfrastructure>> + Send>,
 > {
+    let rebalancing_ctx = Arc::new(rebalancing_ctx);
+
     Box::pin(async move {
         info!("Initializing rebalancing infrastructure");
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -249,6 +249,7 @@ where
 
     let poll_status_ctx = Arc::new(PollOrderStatusCtx {
         executor: context.executor.clone(),
+        offchain_order: context.frameworks.offchain_order.clone(),
         offchain_order_projection: context.frameworks.offchain_order_projection.clone(),
         poll_status_queue: poll_status_queue.clone(),
         reconcile_queue: reconcile_queue.clone(),

--- a/src/conductor/monitor/executor_maintenance.rs
+++ b/src/conductor/monitor/executor_maintenance.rs
@@ -109,6 +109,20 @@ mod tests {
             unreachable!("not used in maintenance tests")
         }
 
+        async fn place_limit_order(
+            &self,
+            _order: st0x_execution::LimitOrder,
+        ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
+            unreachable!("not used in maintenance tests")
+        }
+
+        async fn cancel_order(
+            &self,
+            _order_id: &Self::OrderId,
+        ) -> Result<st0x_execution::CancellationOutcome, Self::Error> {
+            unreachable!("not used in maintenance tests")
+        }
+
         async fn get_order_status(
             &self,
             _order_id: &Self::OrderId,

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -15,7 +15,7 @@ use alloy::providers::{Provider, ProviderBuilder};
 use alloy::rpc::types::Log;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::sol_types::SolEvent;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use rain_math_float::Float;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
@@ -29,7 +29,6 @@ use st0x_evm::{ReadOnlyEvm, USDC_BASE};
 use st0x_execution::{
     Direction, ExecutorOrderId, FractionalShares, MockExecutor, OrderState, Positive, Symbol,
 };
-use st0x_finance::Usd;
 use st0x_float_macro::float;
 use st0x_float_serde::format_float_with_fallback;
 
@@ -55,6 +54,13 @@ use crate::tokenization::alpaca::tests::setup_anvil;
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::TradeAccountingError;
 use crate::vault_registry::VaultRegistryId;
+
+struct RetainedPollFill {
+    shares_filled: Positive<FractionalShares>,
+    executor_order_id: ExecutorOrderId,
+    price: st0x_finance::Usd,
+    broker_timestamp: DateTime<Utc>,
+}
 
 const TEST_AAPL: &str = "AAPL";
 const TEST_MSFT: &str = "MSFT";
@@ -192,7 +198,7 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
             .await
             .map_err(|error| format!("get_order_status: {error}"))?;
 
-        use OrderState::{Failed, Filled, Pending, Submitted};
+        use OrderState::{Cancelled, Failed, Filled, PartiallyFilled, Pending, Submitted};
         match state {
             Filled {
                 price,
@@ -200,12 +206,7 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
                 executed_at,
             } => {
                 offchain_order
-                    .send(
-                        &order_id,
-                        OffchainOrderCommand::CompleteFill {
-                            price: Usd::new(price),
-                        },
-                    )
+                    .send(&order_id, OffchainOrderCommand::CompleteFill { price })
                     .await?;
 
                 position
@@ -216,16 +217,52 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
                             shares_filled: order.shares(),
                             direction: order.direction(),
                             executor_order_id: ExecutorOrderId::new(&broker_order_id),
-                            price: Usd::new(price),
+                            price,
                             broker_timestamp: executed_at,
                         },
                     )
                     .await?;
             }
 
-            Failed { error_reason, .. } => {
+            Failed {
+                error_reason,
+                shares_filled,
+                avg_price,
+                failed_at,
+            } => {
                 let error =
                     error_reason.unwrap_or_else(|| "Order failed with no error reason".to_string());
+                let partial_fill = match shares_filled {
+                    Some(shares_filled) => {
+                        record_poll_partial_fill(
+                            &order_id,
+                            executor_order_id,
+                            &order,
+                            offchain_order,
+                            shares_filled,
+                            avg_price,
+                            failed_at,
+                        )
+                        .await?
+                    }
+                    None => None,
+                };
+
+                if let Some(fill) = &partial_fill {
+                    position
+                        .send(
+                            order.symbol(),
+                            PositionCommand::CompleteOffChainOrder {
+                                offchain_order_id: order_id,
+                                shares_filled: fill.shares_filled,
+                                direction: order.direction(),
+                                executor_order_id: fill.executor_order_id.clone(),
+                                price: fill.price,
+                                broker_timestamp: fill.broker_timestamp,
+                            },
+                        )
+                        .await?;
+                }
 
                 offchain_order
                     .send(
@@ -236,15 +273,91 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
                     )
                     .await?;
 
-                position
+                if partial_fill.is_none() {
+                    position
+                        .send(
+                            order.symbol(),
+                            PositionCommand::FailOffChainOrder {
+                                offchain_order_id: order_id,
+                                error,
+                            },
+                        )
+                        .await?;
+                }
+            }
+
+            Cancelled {
+                shares_filled,
+                avg_price,
+                cancelled_at,
+                ..
+            } => {
+                let error = "Order cancelled by broker".to_string();
+                let partial_fill = record_poll_partial_fill(
+                    &order_id,
+                    executor_order_id,
+                    &order,
+                    offchain_order,
+                    shares_filled,
+                    avg_price,
+                    cancelled_at,
+                )
+                .await?;
+
+                if let Some(fill) = &partial_fill {
+                    position
+                        .send(
+                            order.symbol(),
+                            PositionCommand::CompleteOffChainOrder {
+                                offchain_order_id: order_id,
+                                shares_filled: fill.shares_filled,
+                                direction: order.direction(),
+                                executor_order_id: fill.executor_order_id.clone(),
+                                price: fill.price,
+                                broker_timestamp: fill.broker_timestamp,
+                            },
+                        )
+                        .await?;
+                }
+
+                offchain_order
                     .send(
-                        order.symbol(),
-                        PositionCommand::FailOffChainOrder {
-                            offchain_order_id: order_id,
-                            error,
+                        &order_id,
+                        OffchainOrderCommand::MarkFailed {
+                            error: error.clone(),
                         },
                     )
                     .await?;
+
+                if partial_fill.is_none() {
+                    position
+                        .send(
+                            order.symbol(),
+                            PositionCommand::FailOffChainOrder {
+                                offchain_order_id: order_id,
+                                error,
+                            },
+                        )
+                        .await?;
+                }
+            }
+
+            PartiallyFilled {
+                shares_filled,
+                avg_price,
+                partially_filled_at,
+                ..
+            } => {
+                record_poll_partial_fill(
+                    &order_id,
+                    executor_order_id,
+                    &order,
+                    offchain_order,
+                    shares_filled,
+                    avg_price,
+                    partially_filled_at,
+                )
+                .await?;
             }
 
             Pending | Submitted { .. } => {}
@@ -252,6 +365,51 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
     }
 
     Ok(())
+}
+
+async fn record_poll_partial_fill(
+    order_id: &OffchainOrderId,
+    executor_order_id: &ExecutorOrderId,
+    order: &OffchainOrder,
+    offchain_order: &Arc<Store<OffchainOrder>>,
+    shares_filled: FractionalShares,
+    avg_price: Option<st0x_finance::Usd>,
+    broker_timestamp: DateTime<Utc>,
+) -> Result<Option<RetainedPollFill>, Box<dyn std::error::Error>> {
+    if shares_filled == FractionalShares::ZERO {
+        return Ok(None);
+    }
+
+    let Some(avg_price) = avg_price else {
+        return Err(format!("order {order_id} reported shares_filled without avg_price").into());
+    };
+
+    if !matches!(
+        order,
+        OffchainOrder::PartiallyFilled {
+            shares_filled: current_shares_filled,
+            avg_price: current_avg_price,
+            ..
+        } if *current_shares_filled == shares_filled && *current_avg_price == avg_price
+    ) {
+        offchain_order
+            .send(
+                order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled,
+                    avg_price,
+                },
+            )
+            .await?;
+    }
+
+    Ok(Some(RetainedPollFill {
+        shares_filled: Positive::new(shares_filled)
+            .map_err(|error| format!("order {order_id} reported invalid partial fill: {error}"))?,
+        executor_order_id: executor_order_id.clone(),
+        price: avg_price,
+        broker_timestamp,
+    }))
 }
 
 /// Holds a deployed Rain OrderBook on a local Anvil node, ready to create real take-order events.
@@ -964,6 +1122,8 @@ async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std:
     let failed_executor = MockExecutor::new().with_order_status(OrderState::Failed {
         failed_at: Utc::now(),
         error_reason: Some("Broker rejected order".to_string()),
+        shares_filled: None,
+        avg_price: None,
     });
     poll_submitted_orders(
         &failed_executor,
@@ -1077,6 +1237,94 @@ async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std:
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderFilled"),
     ]);
     assert_events(&pool, &expected).await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn retains_terminal_partial_fill() -> Result<(), Box<dyn std::error::Error>> {
+    let mut orderbook = setup_anvil_orderbook().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
+    let (cqrs, position, position_query, offchain_order, offchain_order_projection) =
+        create_test_cqrs(&pool, &apalis_pool).await;
+    let symbol = Symbol::new(TEST_AAPL).unwrap();
+
+    let trade = orderbook
+        .take_order()
+        .symbol(TEST_AAPL)
+        .amount(float!(1.2))
+        .direction(Direction::Sell)
+        .price(AAPL_PRICE)
+        .call()
+        .await;
+    let order_id = trade.submit(&cqrs).await?.expect("Threshold crossed");
+
+    let partially_filled_executor =
+        MockExecutor::new().with_order_status(OrderState::PartiallyFilled {
+            order_id: ExecutorOrderId::new("broker-order-id"),
+            shares_filled: FractionalShares::new(float!(0.4)),
+            avg_price: Some(st0x_finance::Usd::new(float!(100.25))),
+            partially_filled_at: Utc::now(),
+        });
+    poll_submitted_orders(
+        &partially_filled_executor,
+        offchain_order_projection.as_ref(),
+        &offchain_order,
+        &position,
+    )
+    .await?;
+
+    let order = offchain_order
+        .load(&order_id)
+        .await?
+        .expect("offchain order should exist");
+    assert!(
+        matches!(order, OffchainOrder::PartiallyFilled { .. }),
+        "poll helper must retain partial fill details before terminal state"
+    );
+    assert_position()
+        .query(&position_query)
+        .symbol(&symbol)
+        .net(FractionalShares::new(float!(-1.2)))
+        .accumulated_long(FractionalShares::ZERO)
+        .accumulated_short(FractionalShares::new(float!(1.2)))
+        .pending(Some(order_id))
+        .last_price_usdc(float!(&AAPL_PRICE.to_string()))
+        .call()
+        .await;
+
+    let cancelled_executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
+        cancelled_at: Utc::now(),
+        order_id: ExecutorOrderId::new("broker-order-id"),
+        shares_filled: FractionalShares::new(float!(0.4)),
+        avg_price: Some(st0x_finance::Usd::new(float!(100.25))),
+    });
+    poll_submitted_orders(
+        &cancelled_executor,
+        offchain_order_projection.as_ref(),
+        &offchain_order,
+        &position,
+    )
+    .await?;
+
+    let order = offchain_order
+        .load(&order_id)
+        .await?
+        .expect("offchain order should exist");
+    assert!(
+        matches!(order, OffchainOrder::Failed { .. }),
+        "terminal partial fill must still mark the offchain order failed"
+    );
+    assert_position()
+        .query(&position_query)
+        .symbol(&symbol)
+        .net(FractionalShares::new(float!(-0.8)))
+        .accumulated_long(FractionalShares::ZERO)
+        .accumulated_short(FractionalShares::new(float!(1.2)))
+        .pending(None)
+        .last_price_usdc(float!(&AAPL_PRICE.to_string()))
+        .call()
+        .await;
 
     Ok(())
 }
@@ -2638,6 +2886,8 @@ async fn operational_limits_shares_cap_constrains_counter_trades_with_failure_an
     let failed_executor = MockExecutor::new().with_order_status(OrderState::Failed {
         failed_at: Utc::now(),
         error_reason: Some("Broker rejected".to_string()),
+        shares_filled: None,
+        avg_price: None,
     });
     poll_submitted_orders(
         &failed_executor,

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -44,7 +44,8 @@ use st0x_dto::{Direction, Trade, TradingVenue};
 use st0x_event_sorcery::{DomainEvent, EventSourced, SendError, Store, Table};
 use st0x_execution::{
     AlpacaBrokerApiError, ClientOrderId, ExecutionError, Executor, ExecutorOrderId,
-    FractionalShares, MarketOrder, PersistenceError, Positive, SupportedExecutor, Symbol,
+    FractionalShares, MarketOrder, NotPositive, PersistenceError, Positive, SupportedExecutor,
+    Symbol,
 };
 use st0x_finance::Usd;
 
@@ -78,6 +79,20 @@ pub(crate) enum JobError {
     PositionAggregate(#[from] st0x_event_sorcery::SendError<Position>),
     #[error("Failed to enqueue follow-up job: {0}")]
     Enqueue(#[from] QueuePushError),
+    #[error(
+        "Broker reported partial fill of {shares_filled} for offchain order \
+         {offchain_order_id} without an average price"
+    )]
+    MissingPartialFillPrice {
+        offchain_order_id: OffchainOrderId,
+        shares_filled: FractionalShares,
+    },
+    #[error("Broker reported invalid partial fill for offchain order {offchain_order_id}")]
+    InvalidPartialFill {
+        offchain_order_id: OffchainOrderId,
+        #[source]
+        source: NotPositive<FractionalShares>,
+    },
 }
 
 /// Drives one offchain order placement end to end: records intent via `Place`,

--- a/src/offchain/order/handle_rejection.rs
+++ b/src/offchain/order/handle_rejection.rs
@@ -9,10 +9,14 @@
 
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
+use st0x_dto::Direction;
 use st0x_event_sorcery::Store;
+use st0x_execution::{ExecutorOrderId, FractionalShares, NotPositive, Positive, Symbol};
+use st0x_finance::Usd;
 
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::offchain::order::{JobError, OffchainOrder, OffchainOrderCommand, OffchainOrderId};
@@ -31,6 +35,14 @@ pub(crate) struct HandleOrderRejectionCtx {
 pub(crate) struct HandleOrderRejection {
     pub(crate) offchain_order_id: OffchainOrderId,
     pub(crate) error: String,
+}
+
+struct RetainedPartialFill {
+    shares_filled: Positive<FractionalShares>,
+    direction: Direction,
+    executor_order_id: ExecutorOrderId,
+    price: Usd,
+    broker_timestamp: DateTime<Utc>,
 }
 
 impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
@@ -57,13 +69,29 @@ impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
         };
 
         let symbol = order.symbol().clone();
+        let retained_partial_fill =
+            retained_partial_fill(&order)
+                .transpose()
+                .map_err(|source| JobError::InvalidPartialFill {
+                    offchain_order_id: self.offchain_order_id,
+                    source,
+                })?;
 
-        // Retry-safe: the two writes (OffchainOrder MarkFailed +
-        // Position FailOffChainOrder) are not atomic. If a prior attempt
-        // completed step 1 but failed step 2, apalis re-runs us with the
-        // order already in `Failed`. Re-sending `MarkFailed` would surface
-        // `AlreadyCompleted` and stall the job forever, so we only run
-        // step 1 when the order has not yet been marked failed.
+        if let Some(fill) = &retained_partial_fill {
+            self.complete_position_for_partial_fill(ctx, &symbol, fill)
+                .await?;
+        }
+
+        // Retry-safe for no-fill rejections: the two writes (OffchainOrder
+        // MarkFailed + Position FailOffChainOrder) are not atomic. If a prior
+        // attempt completed step 1 but failed step 2, apalis re-runs us with
+        // the order already in `Failed`. Re-sending `MarkFailed` would surface
+        // `AlreadyCompleted` and stall the job forever, so we only run step 1
+        // when the order has not yet been marked failed.
+        //
+        // For retained partial fills, the position update runs first so a retry
+        // cannot lose the partial-fill quantity by loading an already-Failed
+        // OffchainOrder that no longer carries the partial-fill fields.
         use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
         match &order {
             Failed { .. } => {
@@ -91,6 +119,10 @@ impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
                 );
                 return Ok(());
             }
+        }
+
+        if retained_partial_fill.is_some() {
+            return Ok(());
         }
 
         // Retry-safe step 2: if a prior attempt or the startup recovery
@@ -123,6 +155,75 @@ impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
 
         Ok(())
     }
+}
+
+impl HandleOrderRejection {
+    async fn complete_position_for_partial_fill(
+        &self,
+        ctx: &HandleOrderRejectionCtx,
+        symbol: &Symbol,
+        fill: &RetainedPartialFill,
+    ) -> Result<(), JobError> {
+        let position_pending = ctx
+            .position
+            .load(symbol)
+            .await?
+            .and_then(|position| position.pending_offchain_order_id);
+        if position_pending != Some(self.offchain_order_id) {
+            info!(
+                offchain_order_id = %self.offchain_order_id,
+                ?position_pending,
+                "HandleOrderRejection: position no longer expecting this partial fill, skipping"
+            );
+            return Ok(());
+        }
+
+        ctx.position
+            .send(
+                symbol,
+                PositionCommand::CompleteOffChainOrder {
+                    offchain_order_id: self.offchain_order_id,
+                    shares_filled: fill.shares_filled,
+                    direction: fill.direction,
+                    executor_order_id: fill.executor_order_id.clone(),
+                    price: fill.price,
+                    broker_timestamp: fill.broker_timestamp,
+                },
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+fn retained_partial_fill(
+    order: &OffchainOrder,
+) -> Option<Result<RetainedPartialFill, NotPositive<FractionalShares>>> {
+    let OffchainOrder::PartiallyFilled {
+        shares_filled,
+        direction,
+        executor_order_id,
+        avg_price,
+        partially_filled_at,
+        ..
+    } = order
+    else {
+        return None;
+    };
+
+    if *shares_filled == FractionalShares::ZERO {
+        return None;
+    }
+
+    Some(
+        Positive::new(*shares_filled).map(|shares_filled| RetainedPartialFill {
+            shares_filled,
+            direction: *direction,
+            executor_order_id: executor_order_id.clone(),
+            price: *avg_price,
+            broker_timestamp: *partially_filled_at,
+        }),
+    )
 }
 
 #[cfg(test)]
@@ -230,6 +331,20 @@ mod tests {
             .await
             .unwrap();
 
+        infra
+            .ctx
+            .offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("test-broker-order-id"),
+                    placed_shares: shares,
+                    submitted_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
         offchain_order_id
     }
 
@@ -277,6 +392,76 @@ mod tests {
         assert_eq!(
             position.pending_offchain_order_id, None,
             "Position must clear pending state after rejection"
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_fill_rejection_retains_executed_quantity_on_position() {
+        let infra = build_test_infra().await;
+        let symbol = Symbol::new("TSLA").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+        let broker_timestamp = Utc::now();
+
+        infra
+            .ctx
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(0.75)),
+                    avg_price: Usd::new(float!(150.25)),
+                },
+            )
+            .await
+            .unwrap();
+
+        HandleOrderRejection {
+            offchain_order_id: order_id,
+            error: "broker cancelled after partial fill".to_string(),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let offchain = infra
+            .ctx
+            .offchain_order
+            .load(&order_id)
+            .await
+            .unwrap()
+            .expect("offchain order should exist");
+        assert!(
+            matches!(offchain, OffchainOrder::Failed { .. }),
+            "terminal partial rejection must still mark the offchain order failed"
+        );
+
+        let position = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.net,
+            FractionalShares::new(float!(1.25)),
+            "position must retain the partially executed sell quantity"
+        );
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "partial fill completion must clear pending state"
+        );
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "retained partial fills are completed, not marked as no-fill failures"
+        );
+        assert!(
+            position
+                .last_updated
+                .is_some_and(|updated| updated >= broker_timestamp),
+            "position timestamp should reflect the retained broker fill"
         );
     }
 

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -13,8 +13,10 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
-use st0x_event_sorcery::Projection;
-use st0x_execution::{Executor, ExecutorOrderId, OrderState, SupportedExecutor, Symbol};
+use st0x_event_sorcery::{Projection, Store};
+use st0x_execution::{
+    Executor, ExecutorOrderId, FractionalShares, OrderState, SupportedExecutor, Symbol,
+};
 use st0x_finance::Usd;
 
 use crate::conductor::job::{Job, JobQueue, Label};
@@ -22,7 +24,7 @@ use crate::offchain::order::handle_rejection::{
     HandleOrderRejection, HandleOrderRejectionJobQueue,
 };
 use crate::offchain::order::reconcile_fill::{ReconcileOrderFill, ReconcileOrderFillJobQueue};
-use crate::offchain::order::{JobError, OffchainOrder, OffchainOrderId};
+use crate::offchain::order::{JobError, OffchainOrder, OffchainOrderCommand, OffchainOrderId};
 
 pub(crate) type PollOrderStatusJobQueue = JobQueue<PollOrderStatus>;
 
@@ -32,6 +34,7 @@ pub(crate) type PollOrderStatusJobQueue = JobQueue<PollOrderStatus>;
 /// enqueues via their respective queues.
 pub(crate) struct PollOrderStatusCtx<E: Executor + Clone + Send + Sync + 'static> {
     pub(crate) executor: E,
+    pub(crate) offchain_order: Arc<Store<OffchainOrder>>,
     pub(crate) offchain_order_projection: Arc<Projection<OffchainOrder>>,
     pub(crate) poll_status_queue: PollOrderStatusJobQueue,
     pub(crate) reconcile_queue: ReconcileOrderFillJobQueue,
@@ -96,7 +99,7 @@ where
             PollAction::Drop => Ok(()),
             PollAction::Reschedule => reschedule_self(ctx, self.offchain_order_id).await,
             PollAction::Query { executor_order_id } => {
-                self.query_broker_and_dispatch(ctx, order.symbol(), executor_order_id)
+                self.query_broker_and_dispatch(ctx, &order, executor_order_id)
                     .await
             }
         }
@@ -107,7 +110,7 @@ impl PollOrderStatus {
     async fn query_broker_and_dispatch<E>(
         &self,
         ctx: &PollOrderStatusCtx<E>,
-        symbol: &Symbol,
+        order: &OffchainOrder,
         executor_order_id: ExecutorOrderId,
     ) -> Result<(), JobError>
     where
@@ -117,32 +120,78 @@ impl PollOrderStatus {
         let parsed_order_id = ctx.executor.parse_order_id(executor_order_id.as_ref())?;
         let order_state = ctx.executor.get_order_status(&parsed_order_id).await?;
 
-        self.dispatch_for_broker_state(ctx, symbol, order_state)
+        self.dispatch_for_broker_state(ctx, order, order_state)
             .await
     }
 
     async fn dispatch_for_broker_state<E>(
         &self,
         ctx: &PollOrderStatusCtx<E>,
-        symbol: &Symbol,
+        order: &OffchainOrder,
         order_state: OrderState,
     ) -> Result<(), JobError>
     where
         E: Executor + Clone + Send + Sync + 'static,
         JobError: From<E::Error>,
     {
-        use OrderState::{Failed, Filled, Pending, Submitted};
+        use OrderState::{Cancelled, Failed, Filled, PartiallyFilled, Pending, Submitted};
+        let symbol = order.symbol();
         match order_state {
             Filled {
                 price,
                 order_id,
                 executed_at,
             } => {
-                self.enqueue_reconcile(ctx, symbol, price, order_id, executed_at)
+                self.enqueue_reconcile(ctx, symbol, price.into(), order_id, executed_at)
                     .await
             }
 
-            Failed { error_reason, .. } => self.enqueue_rejection(ctx, symbol, error_reason).await,
+            Failed {
+                error_reason,
+                shares_filled,
+                avg_price,
+                ..
+            } => {
+                if let Some(shares_filled) = shares_filled {
+                    self.record_partial_fill(ctx, order, shares_filled, avg_price)
+                        .await?;
+                }
+
+                self.enqueue_rejection(ctx, symbol, error_reason).await
+            }
+
+            // The execution layer now surfaces broker-side cancellations as a
+            // distinct state; treat as a rejection until the aggregate learns
+            // to reconcile cancellations against the pending position.
+            Cancelled {
+                shares_filled,
+                avg_price,
+                ..
+            } => {
+                self.record_partial_fill(ctx, order, shares_filled, avg_price)
+                    .await?;
+
+                self.enqueue_rejection(ctx, symbol, Some("Order cancelled by broker".to_string()))
+                    .await
+            }
+
+            PartiallyFilled {
+                shares_filled,
+                avg_price,
+                ..
+            } => {
+                self.record_partial_fill(ctx, order, shares_filled, avg_price)
+                    .await?;
+
+                debug!(
+                    target: "broker",
+                    %symbol,
+                    offchain_order_id = %self.offchain_order_id,
+                    "PollOrderStatus: broker reports partial fill, re-enqueuing with delay"
+                );
+
+                reschedule_self(ctx, self.offchain_order_id).await
+            }
 
             Pending | Submitted { .. } => {
                 debug!(
@@ -162,7 +211,7 @@ impl PollOrderStatus {
         ctx: &PollOrderStatusCtx<E>,
         symbol: &Symbol,
         price: rain_math_float::Float,
-        order_id: String,
+        order_id: ExecutorOrderId,
         executed_at: DateTime<Utc>,
     ) -> Result<(), JobError>
     where
@@ -180,9 +229,59 @@ impl PollOrderStatus {
             .push(ReconcileOrderFill {
                 offchain_order_id: self.offchain_order_id,
                 price: Usd::new(price),
-                executor_order_id: ExecutorOrderId::new(&order_id),
+                executor_order_id: order_id,
                 broker_timestamp: executed_at,
             })
+            .await?;
+
+        Ok(())
+    }
+
+    async fn record_partial_fill<E>(
+        &self,
+        ctx: &PollOrderStatusCtx<E>,
+        order: &OffchainOrder,
+        shares_filled: FractionalShares,
+        avg_price: Option<Usd>,
+    ) -> Result<(), JobError>
+    where
+        E: Executor + Clone + Send + Sync + 'static,
+    {
+        if shares_filled == FractionalShares::ZERO {
+            return Ok(());
+        }
+
+        let Some(avg_price) = avg_price else {
+            return Err(JobError::MissingPartialFillPrice {
+                offchain_order_id: self.offchain_order_id,
+                shares_filled,
+            });
+        };
+
+        let already_recorded = match order {
+            OffchainOrder::PartiallyFilled {
+                shares_filled: current_shares_filled,
+                avg_price: current_avg_price,
+                ..
+            } => *current_shares_filled == shares_filled && *current_avg_price == avg_price,
+            OffchainOrder::Pending { .. }
+            | OffchainOrder::Submitted { .. }
+            | OffchainOrder::Filled { .. }
+            | OffchainOrder::Failed { .. } => false,
+        };
+
+        if already_recorded {
+            return Ok(());
+        }
+
+        ctx.offchain_order
+            .send(
+                &self.offchain_order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled,
+                    avg_price,
+                },
+            )
             .await?;
 
         Ok(())
@@ -389,6 +488,7 @@ mod tests {
 
         let ctx = PollOrderStatusCtx {
             executor,
+            offchain_order: offchain_order.clone(),
             offchain_order_projection,
             poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
             reconcile_queue: ReconcileOrderFillJobQueue::new(&apalis_pool),
@@ -533,6 +633,31 @@ mod tests {
         .unwrap()
     }
 
+    async fn assert_partially_filled_order<E: Executor + Clone + Send + Sync + 'static>(
+        infra: &TestInfra<E>,
+        order_id: OffchainOrderId,
+        expected_shares_filled: FractionalShares,
+        expected_avg_price: Usd,
+    ) {
+        let order = infra
+            .offchain_order
+            .load(&order_id)
+            .await
+            .unwrap()
+            .expect("offchain order should exist");
+        let OffchainOrder::PartiallyFilled {
+            shares_filled,
+            avg_price,
+            ..
+        } = order
+        else {
+            panic!("expected OffchainOrder::PartiallyFilled, got {order:?}");
+        };
+
+        assert_eq!(shares_filled, expected_shares_filled);
+        assert_eq!(avg_price, expected_avg_price);
+    }
+
     #[tokio::test]
     async fn poll_with_filled_broker_enqueues_reconcile_fill() {
         let infra = build_test_infra(MockExecutor::new()).await;
@@ -616,6 +741,8 @@ mod tests {
         let executor = MockExecutor::new().with_order_status(OrderState::Failed {
             failed_at: Utc::now(),
             error_reason: Some("broker rejected".to_string()),
+            shares_filled: None,
+            avg_price: None,
         });
         let infra = build_test_infra(executor).await;
         let symbol = Symbol::new("AAPL").unwrap();
@@ -644,6 +771,162 @@ mod tests {
             count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             0,
             "Terminal state must not re-enqueue PollOrderStatus"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_with_failed_partial_fill_records_fill_before_rejection() {
+        let shares_filled = FractionalShares::new(float!(1));
+        let avg_price = Usd::new(float!(150.0));
+        let executor = MockExecutor::new().with_order_status(OrderState::Failed {
+            failed_at: Utc::now(),
+            error_reason: Some("broker rejected after partial fill".to_string()),
+            shares_filled: Some(shares_filled),
+            avg_price: Some(avg_price),
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        assert_partially_filled_order(&infra, order_id, shares_filled, avg_price).await;
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
+            1,
+            "Failed partial fill must still enqueue HandleOrderRejection"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_with_cancelled_broker_enqueues_handle_rejection() {
+        let executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
+            cancelled_at: Utc::now(),
+            order_id: ExecutorOrderId::new("some-broker-order-id"),
+            shares_filled: FractionalShares::ZERO,
+            avg_price: None,
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
+            1,
+            "Cancelled broker state must enqueue exactly one HandleOrderRejection"
+        );
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, reconcile_order_fill_job_type()).await,
+            0,
+            "Cancelled state must not enqueue ReconcileOrderFill"
+        );
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            0,
+            "Terminal state must not re-enqueue PollOrderStatus"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_with_cancelled_partial_fill_records_fill_before_rejection() {
+        let shares_filled = FractionalShares::new(float!(1));
+        let avg_price = Usd::new(float!(150.0));
+        let executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
+            cancelled_at: Utc::now(),
+            order_id: ExecutorOrderId::new("some-broker-order-id"),
+            shares_filled,
+            avg_price: Some(avg_price),
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        assert_partially_filled_order(&infra, order_id, shares_filled, avg_price).await;
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
+            1,
+            "Cancelled partial fill must still enqueue HandleOrderRejection"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_with_partially_filled_broker_reschedules_self_with_delay() {
+        let shares_filled = FractionalShares::new(float!(1));
+        let avg_price = Usd::new(float!(150.0));
+        let executor = MockExecutor::new().with_order_status(OrderState::PartiallyFilled {
+            order_id: ExecutorOrderId::new("some-broker-order-id"),
+            shares_filled,
+            avg_price: Some(avg_price),
+            partially_filled_at: Utc::now(),
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        let before_now: i64 = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .try_into()
+            .unwrap();
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        assert_partially_filled_order(&infra, order_id, shares_filled, avg_price).await;
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            1,
+            "PartiallyFilled broker state must self-reschedule a PollOrderStatus job"
+        );
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, reconcile_order_fill_job_type()).await,
+            0,
+            "PartiallyFilled state must not enqueue ReconcileOrderFill"
+        );
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
+            0,
+            "PartiallyFilled state must not enqueue HandleOrderRejection"
+        );
+
+        let scheduled_at = min_run_at(&infra.apalis_pool, poll_order_status_job_type()).await;
+        let poll_interval_secs: i64 = TEST_POLL_INTERVAL.as_secs().try_into().unwrap();
+        let expected_min = before_now + poll_interval_secs;
+        assert!(
+            scheduled_at >= expected_min,
+            "Re-enqueued poll should run at >= now + poll_interval ({expected_min}s); got {scheduled_at}s"
         );
     }
 
@@ -678,6 +961,20 @@ mod tests {
                 order: st0x_execution::MarketOrder,
             ) -> Result<st0x_execution::OrderPlacement<Self::OrderId>, Self::Error> {
                 self.inner.place_market_order(order).await
+            }
+
+            async fn place_limit_order(
+                &self,
+                order: st0x_execution::LimitOrder,
+            ) -> Result<st0x_execution::OrderPlacement<Self::OrderId>, Self::Error> {
+                self.inner.place_limit_order(order).await
+            }
+
+            async fn cancel_order(
+                &self,
+                order_id: &Self::OrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Self::Error> {
+                self.inner.cancel_order(order_id).await
             }
 
             async fn get_order_status(

--- a/src/telemetry/executor.rs
+++ b/src/telemetry/executor.rs
@@ -14,8 +14,8 @@ use async_trait::async_trait;
 use chrono::Utc;
 
 use st0x_execution::{
-    CounterTradePreflight, Executor, InventoryResult, MarketOrder, OrderPlacement, OrderState,
-    SupportedExecutor,
+    CancellationOutcome, CounterTradePreflight, Executor, InventoryResult, LimitOrder, MarketOrder,
+    MarketSession, OrderPlacement, OrderState, Positive, SupportedExecutor, Symbol, Usd,
 };
 
 use super::{Dependency, DependencyCallSample, TelemetrySender, scrub_secrets};
@@ -133,6 +133,43 @@ impl<Inner: Executor + Clone> Executor for InstrumentedExecutor<Inner> {
         let started = Instant::now();
         let result = self.inner.preflight_counter_trade(order).await;
         self.record("preflight_counter_trade", started, &result);
+        result
+    }
+
+    async fn market_session(&self) -> Result<MarketSession, Self::Error> {
+        let started = Instant::now();
+        let result = self.inner.market_session().await;
+        self.record("market_session", started, &result);
+        result
+    }
+
+    async fn fetch_latest_trade_price(
+        &self,
+        symbol: &Symbol,
+    ) -> Result<Option<Positive<Usd>>, Self::Error> {
+        let started = Instant::now();
+        let result = self.inner.fetch_latest_trade_price(symbol).await;
+        self.record("fetch_latest_trade_price", started, &result);
+        result
+    }
+
+    async fn place_limit_order(
+        &self,
+        order: LimitOrder,
+    ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
+        let started = Instant::now();
+        let result = self.inner.place_limit_order(order).await;
+        self.record("place_limit_order", started, &result);
+        result
+    }
+
+    async fn cancel_order(
+        &self,
+        order_id: &Self::OrderId,
+    ) -> Result<CancellationOutcome, Self::Error> {
+        let started = Instant::now();
+        let result = self.inner.cancel_order(order_id).await;
+        self.record("cancel_order", started, &result);
         result
     }
 }


### PR DESCRIPTION
## What

- Add the `st0x-execution` crate groundwork for extended-hours counter-trading: a `MarketSession` (Regular/Extended/Closed) classification from the broker calendar, `place_limit_order` + `cancel_order` (-> `CancellationOutcome`) + `fetch_latest_trade_price` on the `Executor` trait, and the `LimitOrder` / `OrderPlacement` extensions.
- Represent broker order outcomes faithfully: `OrderState::PartiallyFilled` / `Cancelled`, `OrderUpdate.shares_filled`, and `client_order_id` idempotency; parse `filled_qty` and map broker `PartiallyFilled` / `Canceled` statuses instead of collapsing them; drive status updates from broker timestamps (`filled_at` / `canceled_at`) with a terminal-timestamp fallback.
- `OrderPlacement` now records `extended_hours` and `limit_price` -- on a duplicate-`client_order_id` 422 the *adopted* order's terms are reported (for both market and limit placements) so a later convergence sweep sees broker reality, falling back to the request's `extended_hours` / `limit_price` only when the broker lookup omits them (market adoption defaults an omitted `extended_hours` to `false`).
- Adapt the main crate at the execution-API boundary so the workspace still compiles: `poll_status` dispatch, the trading CLI (`place_alpaca_limit_order` + new `OrderState` arms), the telemetry `Executor` decorator, and the executor test mocks.

## Why

- First implementation PR of the extended-hours counter-trading stack (#915 -> **#916** -> #931 -> #932). Isolating the broker-facing primitives keeps the execution layer independently reviewable before the `OffchainOrder` aggregate (#931) and the hedge/sweep wiring (#932) build on it.

## How

- All of `crates/execution/**` at the feature version. `Executor` gains `place_limit_order` / `cancel_order` as newly required methods; `market_session` / `fetch_latest_trade_price` have default impls.
- Boundary glue is deliberately conservative and behaviour-preserving (finalized in #931/#932): `poll_status` re-polls `PartiallyFilled` exactly as the pre-feature `Submitted` path did and treats a broker `Cancelled` as a rejection; the CLI renders/handles the new states and the test mocks forward the new trait methods.

## Testing

- New execution-crate unit tests cover the added states, `filled_qty` parsing, the broker-timestamp status mapping, and `client_order_id` idempotency; the boundary-glue `poll_status` / `cli::trading` tests are updated. Verified locally on the stack tip: `cargo check --all-targets`, `cargo clippy --all-features`, `cargo fmt --check` clean. CI runs the full suite per PR.

## Anything else

- Breaking within the execution crate: `OrderState::Filled` price `Float` -> `Usd`, `order_id` `String` -> `ExecutorOrderId`, `OrderState::Failed` gains `shares_filled` / `avg_price`, `AlpacaLimitOrder` now requires `client_order_id`, `IncompleteFilledOrder` -> `IncompleteOrder`, and the Alpaca-specific helper `place_limit_order` is renamed `place_alpaca_limit_order` (the trait's new `place_limit_order` takes the broker-agnostic `LimitOrder` and owns that name).
- Stack: #915 (groundwork) -> **#916** (execution) -> #931 (aggregate) -> #932 (rest). The lower PRs carry conservative placeholder handling that the upper PRs replace; the feature ships disabled.
