### PR TITLE
feat: show USDC bridge direction in dashboard transfer rows

### DIFF
--- a/dashboard/src/lib/components/transfer-panel.svelte
+++ b/dashboard/src/lib/components/transfer-panel.svelte
@@ -5,6 +5,7 @@
   import * as Table from '$lib/components/ui/table'
   import HoverTooltip from '$lib/components/hover-tooltip.svelte'
   import type { Position } from '$lib/api/Position'
+  import type { UsdcBridgeDirection } from '$lib/api/UsdcBridgeDirection'
   import MultiSelect from '$lib/components/multi-select.svelte'
   import { reactive } from '$lib/frp.svelte'
   import {
@@ -18,6 +19,7 @@
   import { cashUsdTooltip, equityUsdTooltip } from '$lib/inventory-value'
   import {
     kindLabel,
+    transferTypeLabel,
     statusStyle,
     humanizeStatus,
     humanizeStep,
@@ -53,7 +55,7 @@
     symbol?: string
     quantity?: string
     amount?: string
-    direction?: string
+    direction?: UsdcBridgeDirection
     status: { status: string }
     startedAt: string
     updatedAt: string
@@ -444,7 +446,7 @@
                 {formatUtc(transfer.startedAt)}
               </Table.Cell>
               <Table.Cell class="font-mono text-xs font-medium">
-                {kindLabel(transfer.kind)}
+                {transferTypeLabel(transfer)}
               </Table.Cell>
               <Table.Cell class="font-mono text-xs">
                 {transfer.kind === 'usdc_bridge' ? 'USDC' : (transfer.symbol ?? '')}
@@ -550,7 +552,7 @@
     {@const amount = transferAmount(transfer)}
     <div class="flex items-center justify-between border-b px-5 py-3">
       <div class="flex items-center gap-2 text-sm font-semibold">
-        <span>{kindLabel(transfer.kind)}</span>
+        <span>{transferTypeLabel(transfer)}</span>
         <span class="font-mono text-xs font-normal text-muted-foreground">
           {transfer.kind === 'usdc_bridge' ? 'USDC' : (transfer.symbol ?? '')}
         </span>

--- a/dashboard/src/lib/transfer.test.ts
+++ b/dashboard/src/lib/transfer.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
+  kindLabel,
+  transferTypeLabel,
   statusStyle,
   isTxHash,
   formatNumericDetailValue,
@@ -10,6 +12,28 @@ import {
   stuckReasonLabel,
   recoveryCommand,
 } from './transfer'
+
+describe('transferTypeLabel', () => {
+  it('spells out the destination venue for each bridge direction', () => {
+    expect(transferTypeLabel({ kind: 'usdc_bridge', direction: 'alpaca_to_base' })).toBe(
+      'Alpaca → Raindex'
+    )
+    expect(transferTypeLabel({ kind: 'usdc_bridge', direction: 'base_to_alpaca' })).toBe(
+      'Raindex → Alpaca'
+    )
+  })
+
+  it('falls back to the bare kind label for equity transfers', () => {
+    expect(transferTypeLabel({ kind: 'equity_mint' })).toBe('Mint')
+    expect(transferTypeLabel({ kind: 'equity_redemption' })).toBe('Redeem')
+  })
+
+  it('falls back to "USDC Bridge" when a bridge has no direction', () => {
+    // The DTO always carries a direction; this guards the optional-field path
+    // so a missing direction degrades to the generic label rather than blank.
+    expect(transferTypeLabel({ kind: 'usdc_bridge' })).toBe(kindLabel('usdc_bridge'))
+  })
+})
 
 describe('statusStyle', () => {
   it('matches completed substring case-insensitively', () => {

--- a/dashboard/src/lib/transfer.ts
+++ b/dashboard/src/lib/transfer.ts
@@ -1,3 +1,4 @@
+import type { UsdcBridgeDirection } from './api/UsdcBridgeDirection'
 import { formatDecimal } from './decimal'
 import { formatBalance } from './format'
 
@@ -17,6 +18,28 @@ export const kindLabel = (kind: string): string => {
     default:
       return kind
   }
+}
+
+// Routing the Record through `UsdcBridgeDirection` makes a new direction variant
+// fail compilation here, mirroring performance-panel.svelte's direction labels.
+const USDC_BRIDGE_DIRECTION_LABELS: Record<UsdcBridgeDirection, string> = {
+  alpaca_to_base: 'Alpaca → Raindex',
+  base_to_alpaca: 'Raindex → Alpaca'
+}
+
+/// Row/detail label for a transfer's type. A USDC bridge spells out its
+/// direction ("Alpaca → Raindex" / "Raindex → Alpaca") since the asset column
+/// already reads "USDC"; the bare `kindLabel` ("USDC Bridge") still backs the
+/// kind filter, where direction is not a selectable dimension.
+export const transferTypeLabel = (transfer: {
+  kind: string
+  direction?: UsdcBridgeDirection
+}): string => {
+  if (transfer.kind === 'usdc_bridge' && transfer.direction !== undefined) {
+    return USDC_BRIDGE_DIRECTION_LABELS[transfer.direction]
+  }
+
+  return kindLabel(transfer.kind)
 }
 
 /// Maps a status string to colour classes.  Works for both DTO statuses


### PR DESCRIPTION
## What

- USDC bridge rows in the Cross-venue Transfers panel now spell out their direction in the **Type** column and the detail-modal header: `alpaca_to_base` → "Alpaca → Raindex", `base_to_alpaca` → "Raindex → Alpaca". Previously both rendered the generic "USDC Bridge".
- The kind filter, status-flow legend, and panel tooltip stay as the generic "USDC Bridge" category.

## Why

- Operators couldn't tell which way USDC was moving without opening the per-row info modal. The Asset column already reads "USDC", so the word in the Type column was redundant — replacing it with the direction makes the row self-explanatory.
- Closes [RAI-1149](https://linear.app/makeitrain/issue/RAI-1149).

## How

- New `transferTypeLabel(transfer)` in `dashboard/src/lib/transfer.ts` returns the directional label for `usdc_bridge` rows and falls back to `kindLabel` for everything else. The label map is a `Record<UsdcBridgeDirection, string>`, so adding a new direction variant fails compilation here.
- `kindLabel` is unchanged and still backs the kind filter dropdown, where direction is not a selectable dimension.
- `transfer-panel.svelte` calls `transferTypeLabel(transfer)` at the two label sites (table row + modal header) and types `TransferEntry.direction` as `UsdcBridgeDirection` (was `string`).
- No backend/DTO change — each row's JSON already carries `direction` because the `TransferOperation` union is `kind`-tagged.

## Testing

- New unit tests in `transfer.test.ts` cover both bridge directions, the equity fallback (Mint/Redeem), and the missing-direction fallback to "USDC Bridge".
- `bun run test`, `svelte-check` (0 errors/0 warnings), and `eslint --max-warnings 0` pass locally.

## Anything else

- The "Alpaca → Raindex" / "Raindex → Alpaca" wording mirrors the existing direction labels in `performance-panel.svelte`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784925863&installation_id=125569124&pr_number=918&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F918&signature=6e5cb7993b2404447915290ec40d9bdb58ee39c89ba1b05e31adaab73aada0e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
