### PR TITLE
fix: standing CCTP allowance so burns don't race a fresh approve

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2181,6 +2181,36 @@ enum BridgeStage { Burn, Attestation, Mint }
 - **Circle Attestation API**: Poll for attestation using CCTP nonce
 - **Rain OrderBook**: deposit2()/withdraw2() for vault operations
 
+##### CCTP Allowance (Standing U256::MAX Approval)
+
+Before each `depositForBurn`, the bridge checks the wallet's USDC allowance to
+the TokenMessenger. The bridge maintains a **standing `U256::MAX` allowance**
+rather than approving the exact burn amount each time.
+
+**Hot path (steady state):** If the allowance is at or above `U256::MAX / 2`
+(the threshold), no approve tx is submitted. This is the normal case.
+
+**Cold path (first use or allowance has been externally reduced):** An
+`approve(TokenMessenger, U256::MAX)` tx is submitted and confirmed. After
+confirmation, the bridge calls `wait_for_node_sync` to poll `eth_blockNumber`
+until at least one poll through the load-balanced endpoint returns a block at or
+above the approve block. This significantly reduces (but does not fully
+eliminate) the chance that the subsequent `depositForBurn` pre-flight `eth_call`
+hits a lagging node that reads allowance = 0 and reverts. The cross-node race is
+bounded by (a) the standing `U256::MAX` allowance meaning the cold path fires
+only on first use or a manual reset, and (b) the defense-in-depth retry below.
+
+**Defense-in-depth retry:** If `depositForBurn` reverts despite the above
+(structurally: re-read allowance < burn amount), the bridge re-runs the cold
+path and retries the burn exactly once. This handles rare cases where the
+node-sync poll window expires before a node catches up.
+
+Note: USDC (FiatToken v2.2) decrements even `U256::MAX` allowances in
+`transferFrom`. At realistic rebalancing sizes the allowance never drops below
+`U256::MAX / 2`, so the approve fires once at startup and not again. The
+single-USDC-rebalance-in-flight invariant ensures two concurrent burns cannot
+race the same allowance.
+
 ##### CCTP Flow (using V2 Fast Transfer)
 
 Alpaca to Base:
@@ -2205,37 +2235,41 @@ Alpaca to Base:
        USDC from a prior rebalance is present. Emits `FailBridging` (no burn
        attempted) and surfaces `WalletUsdcAmbientBalance` for operator
        reconciliation; the job treats this as a clean terminal (no redrive).
-5. Query Circle's `/v2/burn/USDC/fees` API for current fast transfer fee
-6. Submit depositForBurn() tx on Ethereum TokenMessenger (domain 0 -> domain 6)
+5. Ensure standing allowance to TokenMessenger (see above)
+6. Query Circle's `/v2/burn/USDC/fees` API for current fast transfer fee (after
+   allowance step to keep fee fresh across the cold-path ~30 s node-sync wait)
+7. Submit depositForBurn() tx on Ethereum TokenMessenger (domain 0 -> domain 6)
    with minFinalityThreshold=1000 and calculated maxFee for fast transfer
-7. Wait for burn tx confirmation and extract CCTP nonce from event logs
-8. Poll Circle attestation service for signature using CCTP nonce (~20 seconds
+8. Wait for burn tx confirmation and extract CCTP nonce from event logs
+9. Poll Circle attestation service for signature using CCTP nonce (~20 seconds
    for fast transfer)
-9. Submit receiveMessage() tx on Base MessageTransmitter with attestation
-10. Wait for mint tx confirmation (~8 seconds on Base)
-11. Submit deposit tx to Rain orderbook vault on Base
-12. Wait for deposit tx confirmation
+10. Submit receiveMessage() tx on Base MessageTransmitter with attestation
+11. Wait for mint tx confirmation (~8 seconds on Base)
+12. Submit deposit tx to Rain orderbook vault on Base
+13. Wait for deposit tx confirmation
 
 Base to Alpaca:
 
 1. Submit withdraw tx from Rain orderbook vault on Base
 2. Wait for withdraw tx confirmation
-3. Query Circle's `/v2/burn/USDC/fees` API for current fast transfer fee
-4. Submit depositForBurn() tx on Base TokenMessenger (domain 6 -> domain 0) with
+3. Ensure standing allowance to TokenMessenger on Base (see above)
+4. Query Circle's `/v2/burn/USDC/fees` API for current fast transfer fee (after
+   allowance step to keep fee fresh across the cold-path ~30 s node-sync wait)
+5. Submit depositForBurn() tx on Base TokenMessenger (domain 6 -> domain 0) with
    minFinalityThreshold=1000 and calculated maxFee for fast transfer
-5. Wait for burn tx confirmation and extract CCTP nonce from event logs
-6. Poll Circle attestation service for signature using CCTP nonce (~8 seconds
+6. Wait for burn tx confirmation and extract CCTP nonce from event logs
+7. Poll Circle attestation service for signature using CCTP nonce (~8 seconds
    for fast transfer)
-7. Submit receiveMessage() tx on Ethereum MessageTransmitter with attestation
+8. Submit receiveMessage() tx on Ethereum MessageTransmitter with attestation
    (mints USDC to the bot's own Ethereum wallet)
-8. Wait for mint tx confirmation (~20 seconds on Ethereum)
-9. Send the minted USDC from the bot wallet to Alpaca's deposit address (see
-   "BaseToAlpaca deposit send"; fresh sends directly, resume adopts an existing
-   send)
-10. Poll Alpaca API by the send tx until deposit status is COMPLETE
-11. **Convert USDC to USD**: Place market sell order on USDC/USD pair (sell
+9. Wait for mint tx confirmation (~20 seconds on Ethereum)
+10. Send the minted USDC from the bot wallet to Alpaca's deposit address (see
+    "BaseToAlpaca deposit send"; fresh sends directly, resume adopts an existing
+    send)
+11. Poll Alpaca API by the send tx until deposit status is COMPLETE
+12. **Convert USDC to USD**: Place market sell order on USDC/USD pair (sell
     USDC)
-12. Poll Alpaca until conversion order is filled
+13. Poll Alpaca until conversion order is filled
 
 ###### Fast Transfer Benefits
 

--- a/crates/bridge/src/cctp/evm.rs
+++ b/crates/bridge/src/cctp/evm.rs
@@ -1,5 +1,7 @@
 //! Single-chain CCTP operations.
 
+use std::time::Duration;
+
 use alloy::primitives::{Address, B256, Bytes, FixedBytes, TxHash, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::{Filter, TransactionReceipt};
@@ -9,7 +11,10 @@ use tracing::{debug, info, trace, warn};
 
 #[cfg(test)]
 use st0x_evm::Evm;
-use st0x_evm::{EvmError, IntoErrorRegistry, Wallet};
+use st0x_evm::{
+    EvmError, IntoErrorRegistry, NODE_SYNC_MAX_ATTEMPTS, NODE_SYNC_POLL_INTERVAL, Wallet,
+    wait_for_node_sync,
+};
 
 use super::{
     CctpError, FAST_TRANSFER_THRESHOLD, MessageTransmitterV2, MintReceipt, TokenMessengerV2,
@@ -18,6 +23,38 @@ use super::{
 use crate::BridgeDirection;
 
 const CCTP_RECOVERY_LOG_BLOCK_CHUNK: u64 = 20_000;
+
+/// Approve this amount to the CCTP TokenMessenger as the standing allowance.
+///
+/// `U256::MAX` is the Circle-standard CCTP integration pattern.
+///
+/// Note: FiatToken v2.2 (Circle's USDC implementation) unconditionally
+/// decrements allowances in `_transferFrom` with no `type(uint256).max`
+/// shortcut, so `U256::MAX` is decremented on every burn. This makes the
+/// threshold top-up in [`ensure_standing_allowance`] a real code path, not
+/// dead code. That said, the `TARGET / 2` threshold means correctness does not
+/// depend solely on this assumption: even if a future USDC version added a
+/// max-allowance shortcut the approve fires at most once per cold path anyway.
+/// At realistic rebalancing sizes the allowance never drops below
+/// [`STANDING_ALLOWANCE_THRESHOLD`], so the approve fires exactly once (at first
+/// use or after a manual reset) and never on the hot path.
+const STANDING_ALLOWANCE_TARGET: U256 = U256::MAX;
+
+/// Top up the standing allowance when it falls below this threshold.
+///
+/// Equal to `STANDING_ALLOWANCE_TARGET / 2` = `U256::MAX / 2`. The standing
+/// allowance model is safe because the SPEC guarantees a single USDC rebalance
+/// in flight at a time (one burn at a time), so two concurrent burns cannot race
+/// the same allowance. With that invariant, and at realistic rebalancing sizes,
+/// this threshold is never reached in normal operation.
+///
+/// Expressed as `U256::from_limbs(...)` because `ruint`'s `Div` is not `const
+/// fn`. A test pins `STANDING_ALLOWANCE_TARGET` against an independent
+/// `from_limbs` literal and `STANDING_ALLOWANCE_THRESHOLD` against a runtime
+/// `U256::MAX / 2` computation, so any divergence between the encoding and
+/// mathematical intent is caught.
+const STANDING_ALLOWANCE_THRESHOLD: U256 =
+    U256::from_limbs([u64::MAX, u64::MAX, u64::MAX, u64::MAX >> 1]);
 
 sol!(
     #![sol(all_derives = true, rpc)]
@@ -37,6 +74,24 @@ const SCAN_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis
 /// trusted as a true absence (the burn lands at/after `from_block`).
 const SCAN_FINALITY_MARGIN: u64 = 2;
 
+/// Maps a sync result during the allowance retry to the error returned on
+/// failure, preserving the original burn error as the actionable root cause.
+///
+/// On sync failure (`Err(sync_err)`), returns `Err(original_error)` — the
+/// original burn revert is what the job retry queue and operator logs need to
+/// diagnose, not the sync error. The sync error is already logged by the caller.
+///
+/// On sync success (`Ok(())`), returns `Ok(())` so the retry burn can proceed.
+///
+/// This pure function exists to make the error-selection logic unit-testable
+/// independently of the async I/O path.
+pub(super) fn apply_sync_result(
+    original_error: CctpError,
+    sync_result: Result<(), CctpError>,
+) -> Result<(), CctpError> {
+    sync_result.map_err(|_sync_err| original_error)
+}
+
 /// Single-chain CCTP endpoint with contract instances for cross-chain operations.
 ///
 /// The wallet's provider is used for read-only view calls (e.g. allowance
@@ -50,6 +105,11 @@ pub(crate) struct CctpEndpoint<W: Wallet> {
     message_transmitter_address: Address,
     /// Wallet for submitting write transactions
     wallet: W,
+    /// Poll interval between `eth_blockNumber` calls in [`wait_for_node_sync`].
+    ///
+    /// Production always uses [`NODE_SYNC_POLL_INTERVAL`]. Tests override it to
+    /// `Duration::ZERO` to avoid sleeping through the 30-attempt budget.
+    node_sync_poll_interval: Duration,
 }
 
 impl<W: Wallet> CctpEndpoint<W> {
@@ -68,12 +128,24 @@ impl<W: Wallet> CctpEndpoint<W> {
             token_messenger_address: token_messenger,
             message_transmitter_address: message_transmitter,
             wallet,
+            node_sync_poll_interval: NODE_SYNC_POLL_INTERVAL,
         }
     }
 
-    pub(super) async fn ensure_usdc_approval<Registry: IntoErrorRegistry>(
+    /// Ensures a standing `U256::MAX` allowance from the wallet to the
+    /// TokenMessenger. This is a no-op (fast path) when the allowance is at or
+    /// above [`STANDING_ALLOWANCE_THRESHOLD`]; on the slow path it approves
+    /// `STANDING_ALLOWANCE_TARGET` and waits until at least one poll through the
+    /// load-balanced endpoint returns a block at or above the approve block before
+    /// returning, reducing (but not eliminating) the chance that a subsequent
+    /// `depositForBurn` pre-flight hits a lagging node.
+    ///
+    /// The node-sync wait significantly reduces the dRPC load-balancing race
+    /// window: a `depositForBurn` pre-flight `eth_call` can still hit a lagging
+    /// node, but the defense-in-depth retry in
+    /// [`deposit_for_burn_with_allowance_retry`] handles that case.
+    pub(super) async fn ensure_standing_allowance<Registry: IntoErrorRegistry>(
         &self,
-        amount: U256,
     ) -> Result<(), CctpError> {
         let allowance = self
             .wallet
@@ -86,22 +158,126 @@ impl<W: Wallet> CctpEndpoint<W> {
             )
             .await?;
 
-        trace!(target: "bridge", ?allowance, %amount, "Checking USDC allowance");
-
-        if allowance < amount {
-            self.wallet
-                .submit::<Registry, _>(
-                    self.usdc_address,
-                    IERC20::approveCall {
-                        spender: self.token_messenger_address,
-                        amount,
-                    },
-                    "USDC approve for CCTP",
-                )
-                .await?;
+        if allowance >= STANDING_ALLOWANCE_THRESHOLD {
+            trace!(
+                target: "bridge",
+                ?allowance,
+                "USDC allowance at or above standing threshold; skipping approve"
+            );
+            return Ok(());
         }
 
+        info!(
+            target: "bridge",
+            ?allowance,
+            standing_target = ?STANDING_ALLOWANCE_TARGET,
+            "USDC allowance below standing threshold; approving U256::MAX to TokenMessenger"
+        );
+
+        let receipt = self
+            .wallet
+            .submit::<Registry, _>(
+                self.usdc_address,
+                IERC20::approveCall {
+                    spender: self.token_messenger_address,
+                    amount: STANDING_ALLOWANCE_TARGET,
+                },
+                "USDC standing allowance approve for CCTP",
+            )
+            .await?;
+
+        let approve_block = receipt
+            .block_number
+            .ok_or(CctpError::TxReceiptMissingBlock {
+                tx_hash: receipt.transaction_hash,
+            })?;
+
+        // Wait until at least one poll through the load-balanced endpoint returns
+        // a block at or above the approve block. This reduces (but does not
+        // eliminate) the chance that the subsequent depositForBurn pre-flight
+        // eth_call hits a lagging node; the defense-in-depth retry handles
+        // the residual race.
+        wait_for_node_sync(
+            self.wallet.provider(),
+            approve_block,
+            self.node_sync_poll_interval,
+            NODE_SYNC_MAX_ATTEMPTS,
+        )
+        .await?;
+
         Ok(())
+    }
+
+    /// Submits a `depositForBurn` and retries once if it reverts.
+    ///
+    /// Test-only helper that exercises the endpoint-level retry path in isolation
+    /// (without the fee re-query that `CctpBridge::retry_burn_if_revert` performs).
+    /// Production callers use `CctpBridge::burn_internal`, which re-queries the
+    /// Circle fast-transfer fee before the retry burn to avoid a stale fee bound.
+    ///
+    /// The retry is triggered by any revert-class failure (not by a post-revert
+    /// allowance re-read). On a revert-class error nothing was minted, so one retry
+    /// cannot double-burn. The one-shot bound prevents loops. If the second burn
+    /// also reverts that error is final and propagates to the caller.
+    ///
+    /// Non-revert errors (transport timeouts, RPC connection failures) are NOT
+    /// retried — `is_revert()` distinguishes them from EVM reverts.
+    ///
+    /// Note: `max_fee` is used as-is for the retry burn. On the cold
+    /// `ensure_standing_allowance` path (~30 s sync wait), a Circle fee spike
+    /// could make this stale. Production code re-queries the fee; this helper
+    /// does not, which is acceptable for the unit-test scenarios it covers.
+    ///
+    /// If `ensure_standing_allowance` fails during the retry, the original burn
+    /// revert is returned rather than the sync error — the burn revert is the
+    /// actionable root cause that the job retry queue and operator logs need to see.
+    #[cfg(test)]
+    pub(super) async fn deposit_for_burn_with_allowance_retry<Registry: IntoErrorRegistry>(
+        &self,
+        amount: U256,
+        recipient: Address,
+        direction: BridgeDirection,
+        max_fee: U256,
+    ) -> Result<crate::BurnReceipt, CctpError> {
+        let first_result = self
+            .deposit_for_burn::<Registry>(amount, recipient, direction, max_fee)
+            .await;
+
+        let Err(original_error) = first_result else {
+            return first_result;
+        };
+
+        // Only retry on revert-class errors. Transport or non-revert errors are
+        // not allowance-related; propagate immediately.
+        if !original_error.is_revert() {
+            return Err(original_error);
+        }
+
+        warn!(
+            target: "bridge",
+            ?original_error,
+            "depositForBurn reverted; re-running ensure_standing_allowance and retrying once"
+        );
+
+        // Re-run ensure_standing_allowance (cheap no-op on the hot path when
+        // allowance is already MAX; approves and syncs on the cold path). If sync
+        // fails, return the original burn revert — not the sync error — so the
+        // caller and operator logs see the actionable root cause.
+        let sync_result = self.ensure_standing_allowance::<Registry>().await;
+
+        if let Err(sync_err) = &sync_result {
+            warn!(
+                target: "bridge",
+                ?sync_err,
+                ?original_error,
+                "node-sync gate failed during allowance retry; returning original burn revert"
+            );
+        }
+
+        apply_sync_result(original_error, sync_result)?;
+
+        self.deposit_for_burn::<Registry>(amount, recipient, direction, max_fee)
+            .await
     }
 
     pub(super) async fn deposit_for_burn<Registry: IntoErrorRegistry>(
@@ -697,6 +873,15 @@ impl<W: Wallet> CctpEndpoint<W> {
     pub(super) fn token_messenger_address(&self) -> Address {
         self.token_messenger_address
     }
+
+    /// Sets a custom node-sync poll interval. Test-only: lets node-sync
+    /// exhaustion paths run without sleeping at the production one-second
+    /// cadence.
+    #[cfg(test)]
+    pub(super) fn with_node_sync_poll_interval(mut self, interval: Duration) -> Self {
+        self.node_sync_poll_interval = interval;
+        self
+    }
 }
 
 fn parse_mint_receipt(receipt: &TransactionReceipt) -> Option<MintReceipt> {
@@ -772,6 +957,35 @@ mod tests {
     use alloy::rpc::types::Log;
 
     use super::*;
+
+    /// Guards the values of the allowance constants against accidental change.
+    ///
+    /// `STANDING_ALLOWANCE_TARGET` is pinned against a concrete four-limb
+    /// `U256::MAX` literal. `STANDING_ALLOWANCE_THRESHOLD` is pinned against
+    /// `U256::MAX / U256::from(2u8)` computed at runtime -- an independent
+    /// derivation that does not share the `from_limbs` expression used in the
+    /// constant definition, so any divergence between the two formulas is caught.
+    #[test]
+    fn allowance_constants_have_expected_values() {
+        // U256::MAX: all 256 bits set, represented as four 64-bit limbs of
+        // 0xFFFF_FFFF_FFFF_FFFF (Rust uint uses little-endian limb order).
+        assert_eq!(
+            STANDING_ALLOWANCE_TARGET,
+            U256::from_limbs([u64::MAX, u64::MAX, u64::MAX, u64::MAX]),
+            "STANDING_ALLOWANCE_TARGET must be U256::MAX"
+        );
+
+        // Cross-check the constant against an independent runtime computation
+        // (U256::MAX / 2) rather than duplicating the from_limbs expression.
+        // If the constant's from_limbs encoding drifts from the mathematical
+        // intention, this assertion will fail even if both sides use different
+        // literal representations.
+        assert_eq!(
+            STANDING_ALLOWANCE_THRESHOLD,
+            U256::MAX / U256::from(2u8),
+            "STANDING_ALLOWANCE_THRESHOLD must be U256::MAX / 2"
+        );
+    }
 
     fn mint_log(log_index: u64, amount: u64) -> Log {
         let event = TokenMessengerV2::MintAndWithdraw {
@@ -855,5 +1069,49 @@ mod tests {
             parse_mint_receipt_for_message(&receipt, 0).is_none(),
             "no MintAndWithdraw below the MessageReceived log must yield None, not a later mint"
         );
+    }
+
+    // --- apply_sync_result unit tests ---
+
+    /// Helper that constructs a representative non-revert `CctpError` for use as
+    /// the `original_error` sentinel in `apply_sync_result` tests.
+    fn sentinel_original_error() -> CctpError {
+        CctpError::ScanInconclusive { from_block: 42 }
+    }
+
+    /// Helper that constructs a different `CctpError` to use as the sync error,
+    /// distinct from the sentinel so tests can verify which error was returned.
+    fn sentinel_sync_error() -> CctpError {
+        CctpError::ScanInconclusive { from_block: 99 }
+    }
+
+    /// When `ensure_standing_allowance` fails during the retry, `apply_sync_result`
+    /// returns the original burn error so operator logs see the actionable root cause.
+    ///
+    /// This covers the branch in `deposit_for_burn_with_allowance_retry` (and
+    /// `retry_burn_if_revert`) where sync fails: the sync error is logged but the
+    /// original error is what propagates.
+    #[test]
+    fn apply_sync_result_on_sync_failure_returns_original_error() {
+        let original = sentinel_original_error();
+        let sync_result: Result<(), CctpError> = Err(sentinel_sync_error());
+
+        let result = apply_sync_result(original, sync_result);
+
+        // Must return Err with the original error (from_block: 42), not the sync
+        // error (from_block: 99).
+        let CctpError::ScanInconclusive { from_block: 42 } = result.unwrap_err() else {
+            panic!("expected original_error (from_block: 42) to be returned on sync failure");
+        };
+    }
+
+    /// When `ensure_standing_allowance` succeeds during the retry, `apply_sync_result`
+    /// returns `Ok(())` so the caller can proceed to issue the retry burn.
+    #[test]
+    fn apply_sync_result_on_sync_success_returns_ok() {
+        let original = sentinel_original_error();
+        let sync_result: Result<(), CctpError> = Ok(());
+
+        apply_sync_result(original, sync_result).unwrap();
     }
 }

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -427,6 +427,67 @@ pub enum CctpError {
     FeeValueParse(#[from] std::num::ParseIntError),
 }
 
+impl CctpError {
+    /// Returns `true` if this error represents a transaction revert (as opposed
+    /// to a transport failure or other non-revert EVM error).
+    ///
+    /// Used by `burn_internal` to gate the allowance-check retry: only reverts
+    /// can be allowance-related; transport errors and other non-revert errors
+    /// are not.
+    ///
+    /// For `CctpError::Evm` variants, delegates to [`EvmError::is_revert()`],
+    /// which is exhaustive over all `EvmError` variants (including feature-gated
+    /// ones). See that method for the full revert-classification rules.
+    ///
+    /// For `CctpError::Contract` (top-level, from `#[from] alloy::contract::Error`):
+    /// only revert-class when the inner error carries actual revert data (same
+    /// reasoning as `EvmError::Contract` — a network blip wraps as Contract with
+    /// no revert data and must not trigger the retry).
+    pub(crate) fn is_revert(&self) -> bool {
+        match self {
+            // Delegate to EvmError::is_revert(), which is exhaustive over all
+            // EvmError variants (including feature-gated ones) and lives in
+            // crates/evm where the feature flags are visible. This gives
+            // compile-time enforcement: a new EvmError variant forces an explicit
+            // revert/non-revert classification in EvmError::is_revert() before
+            // it can compile.
+            Self::Evm(evm_err) => evm_err.is_revert(),
+            // `CctpError::Contract` (from `#[from] alloy::contract::Error`):
+            // only revert-class when the inner error carries actual revert data.
+            // A pure transport failure (connection reset, timeout) produces a
+            // Contract error with no revert data and must not trigger the retry.
+            Self::Contract(contract_err) => contract_err.as_revert_data().is_some(),
+            // `CctpError::RpcTransport` is produced exclusively by direct provider
+            // calls (get_logs, get_block_number) in scan/recovery paths — never by
+            // the depositForBurn submission path. It cannot carry an EVM revert.
+            Self::RpcTransport(_)
+            | Self::SolType(_)
+            | Self::ScanInconclusive { .. }
+            | Self::Http(_)
+            | Self::AttestationTimeout { .. }
+            | Self::MalformedAttestation { .. }
+            | Self::MessageSentEventNotFound { .. }
+            | Self::MintAndWithdrawEventNotFound
+            | Self::TxReceiptMissingBlock { .. }
+            | Self::MessageTooShort { .. }
+            | Self::MessageTooShortForRecovery { .. }
+            | Self::MessageDestinationDomainMismatch { .. }
+            | Self::AlreadyMintedMessageNotFound { .. }
+            | Self::RecoveredMintMessageMismatch { .. }
+            | Self::RecoveredMintLogMissingTxHash { .. }
+            | Self::RecoveredMintReceiptReverted { .. }
+            | Self::RecoveredMintAndWithdrawEventNotFound { .. }
+            | Self::PlaceholderNonce
+            | Self::FeeCalculationOverflow
+            | Self::Float(_)
+            | Self::AmountConversion(_)
+            | Self::FastTransferFeeNotAvailable { .. }
+            | Self::HexDecode(_)
+            | Self::FeeValueParse(_) => false,
+        }
+    }
+}
+
 /// Errors specific to attestation polling from Circle's API.
 #[derive(Debug, thiserror::Error)]
 pub enum AttestationError {
@@ -729,30 +790,120 @@ impl<EthWallet: Wallet, BaseWallet: Wallet> CctpBridge<EthWallet, BaseWallet> {
     }
 
     /// Burns USDC on the source chain for the given bridge direction.
+    ///
+    /// Internal retry logic: if the first `depositForBurn` reverts, `ensure_standing_allowance`
+    /// is re-run on the endpoint and the Circle fee is re-queried immediately before the
+    /// retry burn. This avoids a stale fee from a Circle fee spike that occurs during the
+    /// ~30 s `wait_for_node_sync` window on the cold allowance path.
+    ///
+    /// The retry is one-shot: if the second burn also fails, the error propagates to the
+    /// job retry queue. Retrying on any revert-class failure (not just allowance reverts)
+    /// is intentional: the dRPC load-balancing race can route the post-revert allowance
+    /// re-read to a fresh node, making the allowance appear sufficient and incorrectly
+    /// skipping the retry. One-shot bounds the cost for non-allowance reverts.
     async fn burn_internal<Registry: IntoErrorRegistry>(
         &self,
         direction: BridgeDirection,
         amount: U256,
         recipient: Address,
     ) -> Result<crate::BurnReceipt, CctpError> {
-        let max_fee = self.query_fast_transfer_fee(amount, direction).await?;
-
+        // ensure_standing_allowance runs first: on the cold path it submits an
+        // approve and then spins wait_for_node_sync (~30 s worst case). Fetching
+        // max_fee afterward keeps the Circle fee fresh immediately before the burn
+        // and avoids a stale bound from a spike that occurs during the sync window.
         match direction {
             BridgeDirection::EthereumToBase => {
                 self.ethereum
-                    .ensure_usdc_approval::<Registry>(amount)
+                    .ensure_standing_allowance::<Registry>()
                     .await?;
-                self.ethereum
+                let max_fee = self.query_fast_transfer_fee(amount, direction).await?;
+                let first = self
+                    .ethereum
                     .deposit_for_burn::<Registry>(amount, recipient, direction, max_fee)
-                    .await
+                    .await;
+                self.retry_burn_if_revert::<Registry, _>(
+                    &self.ethereum,
+                    first,
+                    amount,
+                    recipient,
+                    direction,
+                )
+                .await
             }
             BridgeDirection::BaseToEthereum => {
-                self.base.ensure_usdc_approval::<Registry>(amount).await?;
-                self.base
+                self.base.ensure_standing_allowance::<Registry>().await?;
+                let max_fee = self.query_fast_transfer_fee(amount, direction).await?;
+                let first = self
+                    .base
                     .deposit_for_burn::<Registry>(amount, recipient, direction, max_fee)
-                    .await
+                    .await;
+                self.retry_burn_if_revert::<Registry, _>(
+                    &self.base, first, amount, recipient, direction,
+                )
+                .await
             }
         }
+    }
+
+    /// Performs the one-shot retry burn if `first_result` is a revert-class error.
+    ///
+    /// Re-runs `ensure_standing_allowance` on `endpoint` and re-queries the Circle
+    /// fast-transfer fee immediately before the retry burn, so the retry uses a
+    /// fresh fee bound rather than the potentially-stale one from the first attempt.
+    ///
+    /// If `ensure_standing_allowance` fails during the retry, returns the original
+    /// burn error (not the sync error) as the actionable root cause.
+    ///
+    /// Retrying on any revert-class failure is intentional (see `burn_internal` doc).
+    /// The one-shot bound prevents double-burning: a pre-flight revert or confirmed
+    /// on-chain revert rolls back state, so one retry cannot double-burn.
+    async fn retry_burn_if_revert<Registry: IntoErrorRegistry, EndpointWallet: Wallet>(
+        &self,
+        endpoint: &evm::CctpEndpoint<EndpointWallet>,
+        first_result: Result<crate::BurnReceipt, CctpError>,
+        amount: U256,
+        recipient: Address,
+        direction: BridgeDirection,
+    ) -> Result<crate::BurnReceipt, CctpError> {
+        let Err(original_error) = first_result else {
+            return first_result;
+        };
+
+        if !original_error.is_revert() {
+            return Err(original_error);
+        }
+
+        warn!(
+            target: "bridge",
+            ?original_error,
+            "depositForBurn reverted; re-running ensure_standing_allowance and retrying once"
+        );
+
+        let sync_result = endpoint.ensure_standing_allowance::<Registry>().await;
+
+        if let Err(sync_err) = &sync_result {
+            // Note: a TxReceiptMissingBlock sync_err here means the approve tx
+            // was mined (a receipt was returned) but lacked a block number in
+            // the receipt. The allowance is live on-chain; the next job-level
+            // retry will find allowance >= threshold and skip the approve.
+            warn!(
+                target: "bridge",
+                ?sync_err,
+                ?original_error,
+                "node-sync gate failed during allowance retry; returning original burn revert"
+            );
+        }
+
+        evm::apply_sync_result(original_error, sync_result)?;
+
+        // Re-query the fee immediately before the retry burn so a Circle fee
+        // spike during the sync window does not cause the retry to fail with a
+        // stale fee bound.
+        let retry_max_fee = self.query_fast_transfer_fee(amount, direction).await?;
+
+        endpoint
+            .deposit_for_burn::<Registry>(amount, recipient, direction, retry_max_fee)
+            .await
     }
 
     /// Mints USDC on the destination chain for the given bridge direction.
@@ -1036,25 +1187,238 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloy::contract::Error as ContractError;
     use alloy::network::EthereumWallet;
     use alloy::node_bindings::{Anvil, AnvilInstance};
     use alloy::primitives::address;
-    use alloy::primitives::{B256, b256, keccak256};
+    use alloy::primitives::{B256, Bytes, b256, keccak256};
     use alloy::providers::ext::AnvilApi as _;
     use alloy::providers::{Provider, ProviderBuilder};
+    use alloy::rpc::json_rpc::ErrorPayload;
     use alloy::signers::Signer;
     use alloy::signers::local::PrivateKeySigner;
     use alloy::sol_types::{SolCall, SolEvent};
+    use alloy::transports::{RpcError, TransportError};
     use httpmock::prelude::*;
     use itertools::Itertools;
     use proptest::prelude::*;
     use rand::Rng;
+    use serde_json::value::to_raw_value;
+    use std::borrow::Cow;
+    use std::time::Duration;
+
+    use st0x_evm::AbiDecodedErrorType;
     use st0x_evm::NoOpErrorRegistry;
     use st0x_evm::local::RawPrivateKeyWallet;
     use st0x_evm::{USDC_BASE, USDC_ETHEREUM};
 
     use super::*;
     use crate::{Attestation, Bridge};
+
+    // --- is_revert unit tests ---
+
+    fn transport_error(code: i64, message: &'static str) -> CctpError {
+        CctpError::Evm(EvmError::Transport(RpcError::ErrorResp(ErrorPayload {
+            code,
+            message: Cow::Borrowed(message),
+            data: None,
+        })))
+    }
+
+    /// Code 3 (Ethereum JSON-RPC spec, Anvil simulation mode) is revert-class
+    /// regardless of the message content. This test uses a non-matching message to
+    /// prove the `code == 3` branch fires independently of the message fallback.
+    #[test]
+    fn is_revert_true_for_transport_code_3() {
+        assert!(transport_error(3, "some unrelated error").is_revert());
+    }
+
+    /// Code -32000 + "execution reverted" message (Geth/Infura/Alchemy/dRPC
+    /// preflight; repo submit.rs mock) is revert-class.
+    #[test]
+    fn is_revert_true_for_transport_code_minus_32000_execution_reverted() {
+        assert!(transport_error(-32000, "execution reverted").is_revert());
+    }
+
+    /// Code -32003 + "execution reverted" message (some Alchemy endpoints) is
+    /// revert-class.
+    #[test]
+    fn is_revert_true_for_transport_code_minus_32003_execution_reverted() {
+        assert!(transport_error(-32003, "execution reverted").is_revert());
+    }
+
+    /// Message-based detection: any code with `"execution reverted"` in the
+    /// message is revert-class.
+    #[test]
+    fn is_revert_true_for_transport_message_execution_reverted() {
+        assert!(
+            transport_error(-32099, "execution reverted: ERC20: insufficient allowance")
+                .is_revert()
+        );
+    }
+
+    /// Code -32000 + "nonce too low" is NOT revert-class: the code is shared by
+    /// multiple failure types; only the message distinguishes them.
+    #[test]
+    fn is_revert_false_for_transport_nonce_too_low() {
+        assert!(!transport_error(-32000, "nonce too low").is_revert());
+    }
+
+    /// Code -32001 with no revert message is NOT revert-class.
+    #[test]
+    fn is_revert_false_for_transport_unrelated_code() {
+        assert!(!transport_error(-32001, "some other error").is_revert());
+    }
+
+    /// `ScanInconclusive` is not revert-class.
+    #[test]
+    fn is_revert_false_for_scan_inconclusive() {
+        assert!(!CctpError::ScanInconclusive { from_block: 0 }.is_revert());
+    }
+
+    /// `PlaceholderNonce` is not revert-class.
+    #[test]
+    fn is_revert_false_for_placeholder_nonce() {
+        assert!(!CctpError::PlaceholderNonce.is_revert());
+    }
+
+    /// `TxReceiptMissingBlock` is not revert-class: it is a post-mining
+    /// infrastructure error, not an on-chain revert.
+    #[test]
+    fn is_revert_false_for_tx_receipt_missing_block() {
+        assert!(
+            !CctpError::TxReceiptMissingBlock {
+                tx_hash: TxHash::ZERO
+            }
+            .is_revert()
+        );
+    }
+
+    /// `MessageSentEventNotFound` is not revert-class: it is a post-commit
+    /// receipt-parsing error, not an on-chain revert.
+    #[test]
+    fn is_revert_false_for_message_sent_event_not_found() {
+        assert!(
+            !CctpError::MessageSentEventNotFound {
+                tx_hash: TxHash::ZERO
+            }
+            .is_revert()
+        );
+    }
+
+    /// `Http` (reqwest) is not revert-class: network transport errors must not
+    /// trigger the allowance retry.
+    #[test]
+    fn is_revert_false_for_http_error() {
+        // Construct a reqwest error from a known-bad URL via the blocking client.
+        let err = reqwest::blocking::get("http://0.0.0.0:0").unwrap_err();
+        assert!(!CctpError::Http(err.without_url()).is_revert());
+    }
+
+    /// `EvmError::Transaction` (PendingTransactionError) is not revert-class:
+    /// it covers errors while WAITING for a submitted tx to confirm (not a
+    /// pre-flight simulation reject). Ensures the unconditional non-revert arm
+    /// in `EvmError::is_revert()` covers this variant.
+    #[test]
+    fn is_revert_false_for_evm_transaction() {
+        use alloy::providers::PendingTransactionError;
+        let err = CctpError::Evm(EvmError::Transaction(
+            PendingTransactionError::FailedToRegister,
+        ));
+        assert!(
+            !err.is_revert(),
+            "EvmError::Transaction must not be revert-class"
+        );
+    }
+
+    /// `EvmError::NodeBehindRequiredBlock` is not revert-class: it is a
+    /// node-sync timeout, not an EVM revert. Ensures the unconditional
+    /// non-revert arm in `EvmError::is_revert()` covers this variant.
+    #[test]
+    fn is_revert_false_for_evm_node_behind_required_block() {
+        let err = CctpError::Evm(EvmError::NodeBehindRequiredBlock {
+            observed_tip: 10,
+            required_block: 20,
+            attempts: 30,
+        });
+        assert!(
+            !err.is_revert(),
+            "EvmError::NodeBehindRequiredBlock must not be revert-class"
+        );
+    }
+
+    /// `EvmError::Reverted` (confirmed on-chain revert, post-mining) is
+    /// revert-class. This is the primary production path the retry defends against.
+    #[test]
+    fn is_revert_true_for_evm_reverted() {
+        assert!(
+            CctpError::Evm(EvmError::Reverted {
+                tx_hash: TxHash::ZERO
+            })
+            .is_revert()
+        );
+    }
+
+    /// `EvmError::DecodedRevert` (decoded Solidity error from a confirmed revert)
+    /// is revert-class.
+    #[test]
+    fn is_revert_true_for_evm_decoded_revert() {
+        assert!(
+            CctpError::Evm(EvmError::DecodedRevert(AbiDecodedErrorType::Unknown(
+                vec![]
+            )))
+            .is_revert()
+        );
+    }
+
+    /// `EvmError::Contract` carrying actual EVM revert data (a `TransportError::ErrorResp`
+    /// with message containing "revert" and hex-encoded data) is revert-class.
+    #[test]
+    fn is_revert_true_for_evm_contract_with_revert_data() {
+        let raw = to_raw_value(&"0x1234").expect("valid json");
+        let payload = ErrorPayload {
+            code: 3,
+            message: Cow::Borrowed("execution reverted"),
+            data: Some(raw),
+        };
+        let contract_err = ContractError::TransportError(TransportError::ErrorResp(payload));
+        assert!(CctpError::Evm(EvmError::Contract(contract_err)).is_revert());
+    }
+
+    /// `EvmError::Contract` from a transport failure (no revert data) is NOT
+    /// revert-class. This is the path that `decode_rpc_revert` produces for
+    /// network errors -- see `error_decoding.rs::decode_rpc_revert_returns_contract_for_non_revert`.
+    #[test]
+    fn is_revert_false_for_evm_contract_without_revert_data() {
+        let contract_err =
+            ContractError::TransportError(TransportError::local_usage_str("connection refused"));
+        assert!(!CctpError::Evm(EvmError::Contract(contract_err)).is_revert());
+    }
+
+    /// `CctpError::Contract` with actual revert data is revert-class.
+    #[test]
+    fn is_revert_true_for_top_level_contract_error_with_revert_data() {
+        let raw = to_raw_value(&"0x1234").expect("valid json");
+        let payload = ErrorPayload {
+            code: 3,
+            message: Cow::Borrowed("execution reverted"),
+            data: Some(raw),
+        };
+        let contract_err = ContractError::TransportError(TransportError::ErrorResp(payload));
+        assert!(CctpError::Contract(contract_err).is_revert());
+    }
+
+    /// `CctpError::Contract` from a pure transport failure (no revert data) is NOT
+    /// revert-class. A local client error or network blip must not trigger the
+    /// allowance retry.
+    #[test]
+    fn is_revert_false_for_top_level_contract_error_without_revert_data() {
+        let contract_err =
+            ContractError::TransportError(TransportError::local_usage_str("connection refused"));
+        assert!(!CctpError::Contract(contract_err).is_revert());
+    }
+
+    // --- end is_revert unit tests ---
 
     fn setup_anvil() -> (AnvilInstance, String, B256) {
         let anvil = Anvil::new().spawn();
@@ -1087,14 +1451,16 @@ mod tests {
             TOKEN_MESSENGER_V2,
             MESSAGE_TRANSMITTER_V2,
             ethereum_wallet,
-        );
+        )
+        .with_node_sync_poll_interval(Duration::ZERO);
 
         let base = CctpEndpoint::new(
             USDC_BASE,
             TOKEN_MESSENGER_V2,
             MESSAGE_TRANSMITTER_V2,
             base_wallet,
-        );
+        )
+        .with_node_sync_poll_interval(Duration::ZERO);
 
         Ok(CctpBridge::new(ethereum, base)?)
     }
@@ -1575,7 +1941,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_ensure_usdc_approval_ethereum_with_zero_allowance() {
+    async fn ensure_standing_allowance_sets_max_when_allowance_is_zero_ethereum() {
         let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
         let (_base_anvil, base_endpoint, _) = setup_anvil();
 
@@ -1592,7 +1958,6 @@ mod tests {
         .await
         .unwrap();
 
-        let amount = U256::from(1_000_000u64);
         let owner = bridge.ethereum.owner();
         let spender = bridge.ethereum.token_messenger_address();
 
@@ -1603,11 +1968,15 @@ mod tests {
             .call()
             .await
             .unwrap();
-        assert_eq!(initial_allowance, U256::ZERO);
+        assert_eq!(
+            initial_allowance,
+            U256::ZERO,
+            "initial allowance should be zero"
+        );
 
         bridge
             .ethereum
-            .ensure_usdc_approval::<NoOpErrorRegistry>(amount)
+            .ensure_standing_allowance::<NoOpErrorRegistry>()
             .await
             .unwrap();
 
@@ -1618,11 +1987,15 @@ mod tests {
             .call()
             .await
             .unwrap();
-        assert_eq!(final_allowance, amount);
+        assert_eq!(
+            final_allowance,
+            U256::MAX,
+            "standing allowance must be set to U256::MAX"
+        );
     }
 
     #[tokio::test]
-    async fn test_ensure_usdc_approval_ethereum_with_sufficient_allowance() {
+    async fn ensure_standing_allowance_no_op_when_above_threshold_ethereum() {
         let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
         let (_base_anvil, base_endpoint, _) = setup_anvil();
 
@@ -1639,31 +2012,41 @@ mod tests {
         .await
         .unwrap();
 
-        let amount = U256::from(1_000_000u64);
-        let higher_amount = U256::from(2_000_000u64);
         let owner = bridge.ethereum.owner();
         let spender = bridge.ethereum.token_messenger_address();
 
+        // Pre-set allowance to U256::MAX (the standing target).
         bridge
             .ethereum
-            .approve_usdc::<NoOpErrorRegistry>(spender, higher_amount)
+            .approve_usdc::<NoOpErrorRegistry>(spender, U256::MAX)
             .await
             .unwrap();
 
-        let initial_allowance = bridge
-            .ethereum
-            .usdc()
-            .allowance(owner, spender)
-            .call()
+        let ethereum_provider = ProviderBuilder::new()
+            .connect(&ethereum_endpoint)
             .await
             .unwrap();
-        assert_eq!(initial_allowance, higher_amount);
+
+        let tx_count_before = ethereum_provider
+            .get_transaction_count(owner)
+            .await
+            .unwrap();
 
         bridge
             .ethereum
-            .ensure_usdc_approval::<NoOpErrorRegistry>(amount)
+            .ensure_standing_allowance::<NoOpErrorRegistry>()
             .await
             .unwrap();
+
+        let tx_count_after = ethereum_provider
+            .get_transaction_count(owner)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tx_count_before, tx_count_after,
+            "no approve tx must be submitted when allowance is at or above threshold"
+        );
 
         let final_allowance = bridge
             .ethereum
@@ -1672,11 +2055,15 @@ mod tests {
             .call()
             .await
             .unwrap();
-        assert_eq!(final_allowance, higher_amount);
+        assert_eq!(
+            final_allowance,
+            U256::MAX,
+            "allowance must remain U256::MAX"
+        );
     }
 
     #[tokio::test]
-    async fn test_ensure_usdc_approval_ethereum_with_insufficient_allowance() {
+    async fn ensure_standing_allowance_tops_up_when_below_threshold_ethereum() {
         let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
         let (_base_anvil, base_endpoint, _) = setup_anvil();
 
@@ -1693,14 +2080,13 @@ mod tests {
         .await
         .unwrap();
 
-        let initial_allowance_amount = U256::from(500_000u64);
-        let required_amount = U256::from(1_000_000u64);
         let owner = bridge.ethereum.owner();
         let spender = bridge.ethereum.token_messenger_address();
 
+        // Pre-set allowance to 1 (well below threshold).
         bridge
             .ethereum
-            .approve_usdc::<NoOpErrorRegistry>(spender, initial_allowance_amount)
+            .approve_usdc::<NoOpErrorRegistry>(spender, U256::from(1u8))
             .await
             .unwrap();
 
@@ -1711,11 +2097,15 @@ mod tests {
             .call()
             .await
             .unwrap();
-        assert_eq!(initial_allowance, initial_allowance_amount);
+        assert_eq!(
+            initial_allowance,
+            U256::from(1u8),
+            "initial allowance should be 1"
+        );
 
         bridge
             .ethereum
-            .ensure_usdc_approval::<NoOpErrorRegistry>(required_amount)
+            .ensure_standing_allowance::<NoOpErrorRegistry>()
             .await
             .unwrap();
 
@@ -1726,7 +2116,11 @@ mod tests {
             .call()
             .await
             .unwrap();
-        assert_eq!(final_allowance, required_amount);
+        assert_eq!(
+            final_allowance,
+            U256::MAX,
+            "allowance must be topped up to U256::MAX"
+        );
     }
 
     async fn create_bridge_with_base_usdc(
@@ -1753,20 +2147,22 @@ mod tests {
             TOKEN_MESSENGER_V2,
             MESSAGE_TRANSMITTER_V2,
             ethereum_wallet,
-        );
+        )
+        .with_node_sync_poll_interval(Duration::ZERO);
 
         let base = CctpEndpoint::new(
             base_usdc_address,
             TOKEN_MESSENGER_V2,
             MESSAGE_TRANSMITTER_V2,
             base_wallet,
-        );
+        )
+        .with_node_sync_poll_interval(Duration::ZERO);
 
         Ok(CctpBridge::new(ethereum, base)?)
     }
 
     #[tokio::test]
-    async fn test_ensure_usdc_approval_base_with_zero_allowance() {
+    async fn ensure_standing_allowance_sets_max_when_allowance_is_zero_base() {
         let (_ethereum_anvil, ethereum_endpoint, _) = setup_anvil();
         let (_base_anvil, base_endpoint, base_key) = setup_anvil();
 
@@ -1781,7 +2177,6 @@ mod tests {
         .await
         .unwrap();
 
-        let amount = U256::from(1_000_000u64);
         let owner = bridge.base.owner();
         let spender = bridge.base.token_messenger_address();
 
@@ -1792,11 +2187,15 @@ mod tests {
             .call()
             .await
             .unwrap();
-        assert_eq!(initial_allowance, U256::ZERO);
+        assert_eq!(
+            initial_allowance,
+            U256::ZERO,
+            "initial allowance should be zero"
+        );
 
         bridge
             .base
-            .ensure_usdc_approval::<NoOpErrorRegistry>(amount)
+            .ensure_standing_allowance::<NoOpErrorRegistry>()
             .await
             .unwrap();
 
@@ -1807,11 +2206,15 @@ mod tests {
             .call()
             .await
             .unwrap();
-        assert_eq!(final_allowance, amount);
+        assert_eq!(
+            final_allowance,
+            U256::MAX,
+            "standing allowance must be set to U256::MAX"
+        );
     }
 
     #[tokio::test]
-    async fn test_ensure_usdc_approval_base_with_sufficient_allowance() {
+    async fn ensure_standing_allowance_no_op_when_above_threshold_base() {
         let (_ethereum_anvil, ethereum_endpoint, _) = setup_anvil();
         let (_base_anvil, base_endpoint, base_key) = setup_anvil();
 
@@ -1826,31 +2229,35 @@ mod tests {
         .await
         .unwrap();
 
-        let amount = U256::from(1_000_000u64);
-        let higher_amount = U256::from(2_000_000u64);
         let owner = bridge.base.owner();
         let spender = bridge.base.token_messenger_address();
 
+        // Pre-set allowance to U256::MAX (the standing target).
         bridge
             .base
-            .approve_usdc::<NoOpErrorRegistry>(spender, higher_amount)
+            .approve_usdc::<NoOpErrorRegistry>(spender, U256::MAX)
             .await
             .unwrap();
 
-        let initial_allowance = bridge
-            .base
-            .usdc()
-            .allowance(owner, spender)
-            .call()
+        let base_provider = ProviderBuilder::new()
+            .connect(&base_endpoint)
             .await
             .unwrap();
-        assert_eq!(initial_allowance, higher_amount);
+
+        let tx_count_before = base_provider.get_transaction_count(owner).await.unwrap();
 
         bridge
             .base
-            .ensure_usdc_approval::<NoOpErrorRegistry>(amount)
+            .ensure_standing_allowance::<NoOpErrorRegistry>()
             .await
             .unwrap();
+
+        let tx_count_after = base_provider.get_transaction_count(owner).await.unwrap();
+
+        assert_eq!(
+            tx_count_before, tx_count_after,
+            "no approve tx must be submitted when allowance is at or above threshold"
+        );
 
         let final_allowance = bridge
             .base
@@ -1859,11 +2266,142 @@ mod tests {
             .call()
             .await
             .unwrap();
-        assert_eq!(final_allowance, higher_amount);
+        assert_eq!(
+            final_allowance,
+            U256::MAX,
+            "allowance must remain U256::MAX"
+        );
+    }
+
+    /// The threshold is `U256::MAX / 2`. At exactly this value the condition is
+    /// `allowance >= threshold`, so no approve must fire.
+    #[tokio::test]
+    async fn ensure_standing_allowance_no_op_at_exact_threshold() {
+        let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
+        let (_base_anvil, base_endpoint, _) = setup_anvil();
+
+        let usdc_address = deploy_mock_usdc(&ethereum_endpoint, &private_key)
+            .await
+            .unwrap();
+
+        let bridge = create_bridge(
+            &ethereum_endpoint,
+            &base_endpoint,
+            &private_key,
+            usdc_address,
+        )
+        .await
+        .unwrap();
+
+        let owner = bridge.ethereum.owner();
+        let spender = bridge.ethereum.token_messenger_address();
+
+        // STANDING_ALLOWANCE_THRESHOLD = U256::MAX / 2 (defined in evm.rs)
+        let threshold = U256::MAX / U256::from(2u8);
+
+        bridge
+            .ethereum
+            .approve_usdc::<NoOpErrorRegistry>(spender, threshold)
+            .await
+            .unwrap();
+
+        let ethereum_provider = ProviderBuilder::new()
+            .connect(&ethereum_endpoint)
+            .await
+            .unwrap();
+
+        let tx_count_before = ethereum_provider
+            .get_transaction_count(owner)
+            .await
+            .unwrap();
+
+        bridge
+            .ethereum
+            .ensure_standing_allowance::<NoOpErrorRegistry>()
+            .await
+            .unwrap();
+
+        let tx_count_after = ethereum_provider
+            .get_transaction_count(owner)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tx_count_before, tx_count_after,
+            "no approve tx must fire when allowance equals the threshold exactly"
+        );
+
+        let final_allowance = bridge
+            .ethereum
+            .usdc()
+            .allowance(owner, spender)
+            .call()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            final_allowance, threshold,
+            "allowance must remain unchanged at exactly the threshold"
+        );
+    }
+
+    /// One below the threshold (`U256::MAX / 2 - 1`) must trigger a top-up to
+    /// `U256::MAX`: guards the `>=` boundary condition in
+    /// `ensure_standing_allowance`.
+    #[tokio::test]
+    async fn ensure_standing_allowance_tops_up_at_threshold_minus_one() {
+        let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
+        let (_base_anvil, base_endpoint, _) = setup_anvil();
+
+        let usdc_address = deploy_mock_usdc(&ethereum_endpoint, &private_key)
+            .await
+            .unwrap();
+
+        let bridge = create_bridge(
+            &ethereum_endpoint,
+            &base_endpoint,
+            &private_key,
+            usdc_address,
+        )
+        .await
+        .unwrap();
+
+        let owner = bridge.ethereum.owner();
+        let spender = bridge.ethereum.token_messenger_address();
+
+        // STANDING_ALLOWANCE_THRESHOLD = U256::MAX / 2 (defined in evm.rs).
+        // One below it must trigger a top-up.
+        let below_threshold = U256::MAX / U256::from(2u8) - U256::from(1u8);
+
+        bridge
+            .ethereum
+            .approve_usdc::<NoOpErrorRegistry>(spender, below_threshold)
+            .await
+            .unwrap();
+
+        bridge
+            .ethereum
+            .ensure_standing_allowance::<NoOpErrorRegistry>()
+            .await
+            .unwrap();
+
+        let final_allowance = bridge
+            .ethereum
+            .usdc()
+            .allowance(owner, spender)
+            .call()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            final_allowance,
+            U256::MAX,
+            "allowance one below threshold must be topped up to U256::MAX"
+        );
     }
 
     #[tokio::test]
-    async fn test_ensure_usdc_approval_base_with_insufficient_allowance() {
+    async fn ensure_standing_allowance_tops_up_when_below_threshold_base() {
         let (_ethereum_anvil, ethereum_endpoint, _) = setup_anvil();
         let (_base_anvil, base_endpoint, base_key) = setup_anvil();
 
@@ -1878,14 +2416,13 @@ mod tests {
         .await
         .unwrap();
 
-        let initial_allowance_amount = U256::from(500_000u64);
-        let required_amount = U256::from(1_000_000u64);
         let owner = bridge.base.owner();
         let spender = bridge.base.token_messenger_address();
 
+        // Pre-set allowance to 1 (well below threshold).
         bridge
             .base
-            .approve_usdc::<NoOpErrorRegistry>(spender, initial_allowance_amount)
+            .approve_usdc::<NoOpErrorRegistry>(spender, U256::from(1u8))
             .await
             .unwrap();
 
@@ -1896,11 +2433,15 @@ mod tests {
             .call()
             .await
             .unwrap();
-        assert_eq!(initial_allowance, initial_allowance_amount);
+        assert_eq!(
+            initial_allowance,
+            U256::from(1u8),
+            "initial allowance should be 1"
+        );
 
         bridge
             .base
-            .ensure_usdc_approval::<NoOpErrorRegistry>(required_amount)
+            .ensure_standing_allowance::<NoOpErrorRegistry>()
             .await
             .unwrap();
 
@@ -1911,7 +2452,11 @@ mod tests {
             .call()
             .await
             .unwrap();
-        assert_eq!(final_allowance, required_amount);
+        assert_eq!(
+            final_allowance,
+            U256::MAX,
+            "allowance must be topped up to U256::MAX"
+        );
     }
 
     // Committed ABI: CCTP contracts use solc 0.7.6 which solc.nix doesn't have for aarch64-darwin
@@ -2292,14 +2837,16 @@ mod tests {
                 self.ethereum.token_messenger,
                 self.ethereum.message_transmitter,
                 ethereum_wallet,
-            );
+            )
+            .with_node_sync_poll_interval(Duration::ZERO);
 
             let base = CctpEndpoint::new(
                 self.base.usdc,
                 self.base.token_messenger,
                 self.base.message_transmitter,
                 base_wallet,
-            );
+            )
+            .with_node_sync_poll_interval(Duration::ZERO);
 
             Ok(CctpBridge::new(ethereum, base)?
                 .with_circle_api_base(self.fee_mock_server.base_url()))
@@ -3109,7 +3656,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ensure_usdc_approval_approves_when_existing_allowance_is_lower() {
+    async fn standing_allowance_set_on_first_burn_and_persists_across_burns() {
         let cctp = LocalCctp::new().await.unwrap();
         let bridge = cctp.create_bridge().await.unwrap();
 
@@ -3117,7 +3664,6 @@ mod tests {
         let owner = bridge.ethereum.owner();
         let spender = bridge.ethereum.token_messenger_address();
 
-        // Check initial allowance is 0
         let initial_allowance = bridge
             .ethereum
             .usdc()
@@ -3128,10 +3674,10 @@ mod tests {
         assert_eq!(
             initial_allowance,
             U256::ZERO,
-            "Initial allowance should be 0"
+            "initial allowance should be 0 before first burn"
         );
 
-        // First burn sets allowance to 1 USDC
+        // First burn: ensure_standing_allowance sets U256::MAX, then burn succeeds.
         let small_amount = U256::from(1_000_000u64); // 1 USDC
         bridge
             .burn_internal::<NoOpErrorRegistry>(
@@ -3142,7 +3688,6 @@ mod tests {
             .await
             .unwrap();
 
-        // After burn, allowance should be consumed (0) since we approved exactly what we needed
         let after_first_burn = bridge
             .ethereum
             .usdc()
@@ -3152,11 +3697,12 @@ mod tests {
             .unwrap();
         assert_eq!(
             after_first_burn,
-            U256::ZERO,
-            "Allowance should be 0 after burn consumed it"
+            U256::MAX - U256::from(small_amount),
+            "allowance must be U256::MAX minus the burned amount"
         );
 
-        // Second burn with larger amount should update allowance and succeed
+        // Second burn: allowance is still far above threshold, so ensure_standing_allowance
+        // is a no-op. The burn succeeds without re-approving.
         let large_amount = U256::from(100_000_000u64); // 100 USDC
         let receipt = bridge
             .burn_internal::<NoOpErrorRegistry>(
@@ -3167,7 +3713,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(!receipt.tx.is_zero(), "Second burn should succeed");
+        assert!(!receipt.tx.is_zero(), "second burn should succeed");
         assert_eq!(receipt.amount, large_amount);
     }
 
@@ -3813,7 +4359,7 @@ mod tests {
         let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
         let (_base_anvil, base_endpoint, _) = setup_anvil();
 
-        // Deploy real USDC so ensure_usdc_approval succeeds.
+        // Deploy real USDC so ensure_standing_allowance succeeds.
         let usdc_address = deploy_mock_usdc(&ethereum_endpoint, &private_key)
             .await
             .unwrap();
@@ -3863,6 +4409,275 @@ mod tests {
             matches!(error, CctpError::MessageSentEventNotFound { .. }),
             "burn must return MessageSentEventNotFound when the receipt has no \
              MessageSent event (post-commit error); got: {error:?}"
+        );
+    }
+
+    /// Verifies that `deposit_for_burn_with_allowance_retry` retries exactly once
+    /// when the first `depositForBurn` reverts due to insufficient allowance (zero
+    /// allowance at the token messenger).
+    ///
+    /// This exercises the defense-in-depth retry path. The retry calls
+    /// `ensure_standing_allowance`, which sets allowance to `U256::MAX`, and then
+    /// the second `depositForBurn` succeeds.
+    #[tokio::test]
+    async fn deposit_for_burn_retries_once_on_allowance_revert() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let owner = bridge.ethereum.owner();
+        let spender = bridge.ethereum.token_messenger_address();
+        let amount = U256::from(1_000_000u64); // 1 USDC
+
+        // Start with zero allowance to guarantee the first depositForBurn reverts.
+        let initial_allowance = bridge
+            .ethereum
+            .usdc()
+            .allowance(owner, spender)
+            .call()
+            .await
+            .unwrap();
+        assert_eq!(
+            initial_allowance,
+            U256::ZERO,
+            "test precondition: allowance must be zero"
+        );
+
+        let max_fee = bridge
+            .query_fast_transfer_fee(amount, BridgeDirection::EthereumToBase)
+            .await
+            .unwrap();
+
+        // Call the retry wrapper directly, bypassing ensure_standing_allowance.
+        // The first depositForBurn should revert (zero allowance), the retry should
+        // re-approve to U256::MAX via ensure_standing_allowance, then succeed.
+        let burn_receipt = bridge
+            .ethereum
+            .deposit_for_burn_with_allowance_retry::<NoOpErrorRegistry>(
+                amount,
+                recipient,
+                BridgeDirection::EthereumToBase,
+                max_fee,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !burn_receipt.tx.is_zero(),
+            "retry must produce a valid burn tx"
+        );
+        assert_eq!(burn_receipt.amount, amount, "burn amount must match");
+
+        // Verify that the approve tx was submitted during the retry path.
+        let final_allowance = bridge
+            .ethereum
+            .usdc()
+            .allowance(owner, spender)
+            .call()
+            .await
+            .unwrap();
+        assert_eq!(
+            final_allowance,
+            U256::MAX - U256::from(amount),
+            "after a successful retry, allowance must be U256::MAX minus the burn amount"
+        );
+    }
+
+    /// Verifies that `deposit_for_burn_with_allowance_retry` retries exactly once
+    /// on any revert-class error, and terminates after the second attempt regardless
+    /// of why the burn reverted.
+    ///
+    /// Uses `Address::ZERO` as an invalid `mintRecipient`: Circle's TokenMessenger
+    /// V2 reverts with `InvalidMintRecipient` on both the first and second attempts.
+    /// With `U256::MAX` allowance, `ensure_standing_allowance` is a no-op (no
+    /// approve tx mined). Both deposit attempts are pre-flight reverts in Anvil
+    /// simulation mode, so no transactions are mined and the nonce does not advance.
+    /// The returned error is a revert-class error.
+    #[tokio::test]
+    async fn deposit_for_burn_retries_once_on_any_revert_then_propagates() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let owner = bridge.ethereum.owner();
+        let spender = bridge.ethereum.token_messenger_address();
+        let amount = U256::from(1_000_000u64); // 1 USDC
+
+        // Pre-set allowance to U256::MAX so ensure_standing_allowance is a no-op.
+        bridge
+            .ethereum
+            .approve_usdc::<NoOpErrorRegistry>(spender, U256::MAX)
+            .await
+            .unwrap();
+
+        let max_fee = bridge
+            .query_fast_transfer_fee(amount, BridgeDirection::EthereumToBase)
+            .await
+            .unwrap();
+
+        // Take the tx count after the approve so the subsequent deposit_for_burn
+        // call is the baseline for measuring retry attempts.
+        let ethereum_provider = ProviderBuilder::new()
+            .connect(&cctp.ethereum_endpoint)
+            .await
+            .unwrap();
+        let tx_count_before = ethereum_provider
+            .get_transaction_count(owner)
+            .await
+            .unwrap();
+
+        let zero_recipient = Address::ZERO;
+        let result = bridge
+            .ethereum
+            .deposit_for_burn_with_allowance_retry::<NoOpErrorRegistry>(
+                amount,
+                zero_recipient,
+                BridgeDirection::EthereumToBase,
+                max_fee,
+            )
+            .await;
+
+        // The second depositForBurn revert propagates; it is revert-class.
+        let error = result.unwrap_err();
+        assert!(
+            error.is_revert(),
+            "revert error must propagate after one retry; got: {error:?}"
+        );
+
+        // PRIMARY proof: no transactions were mined. Both depositForBurn calls
+        // reverted as pre-flight in Anvil simulation; ensure_standing_allowance was
+        // a no-op (allowance already MAX, no approve tx). No nonce was consumed.
+        let tx_count_after = ethereum_provider
+            .get_transaction_count(owner)
+            .await
+            .unwrap();
+        assert_eq!(
+            tx_count_after,
+            tx_count_before,
+            "no transactions must have been mined (both burns pre-flight revert, \
+             ensure_standing_allowance no-op); got {} unexpected additional txs",
+            tx_count_after.saturating_sub(tx_count_before)
+        );
+
+        // The allowance must be unchanged (ensure_standing_allowance was a no-op).
+        let final_allowance = bridge
+            .ethereum
+            .usdc()
+            .allowance(owner, spender)
+            .call()
+            .await
+            .unwrap();
+        assert_eq!(
+            final_allowance,
+            U256::MAX,
+            "allowance must be unchanged when ensure_standing_allowance is a no-op"
+        );
+    }
+
+    // NOTE: Integration-level tests for the two remaining paths from finding #5
+    // are skipped as not cheaply constructible:
+    //
+    // 1. "sync-failure branch" (wait_for_node_sync exhausts during retry):
+    //    Requires a provider that always returns a stale block number for the
+    //    sync wait while still supporting real `submit()` calls for the approve.
+    //    CctpEndpoint uses a single wallet/provider for both, so there is no
+    //    injection point short of introducing a split-provider wrapper that
+    //    does not exist in the current test infrastructure.
+    //
+    // 2. "non-revert transport error no-retry" at the integration level:
+    //    Requires injecting a transport error into wallet.submit() inside
+    //    deposit_for_burn. No mock wallet exists; the Wallet trait has no
+    //    error-injection hook. The property IS covered at the unit level:
+    //    `is_revert_false_for_transport_nonce_too_low` and related tests prove
+    //    that transport errors return false from is_revert(), and the guard
+    //    `if !original_error.is_revert() { return Err(original_error); }` in
+    //    deposit_for_burn_with_allowance_retry returns immediately.
+
+    /// Verifies the exactly-once retry guarantee: when the first `depositForBurn`
+    /// reverts with insufficient allowance, the retry re-approves and fires a
+    /// second burn, but if that second burn also reverts, the error is returned
+    /// immediately with no third attempt.
+    #[tokio::test]
+    async fn deposit_for_burn_retry_fires_exactly_once_on_second_revert() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let owner = bridge.ethereum.owner();
+        let spender = bridge.ethereum.token_messenger_address();
+
+        // Start with zero allowance so the first depositForBurn reverts with an
+        // allowance-class error, triggering the retry path.
+        let initial_allowance = bridge
+            .ethereum
+            .usdc()
+            .allowance(owner, spender)
+            .call()
+            .await
+            .unwrap();
+        assert_eq!(
+            initial_allowance,
+            U256::ZERO,
+            "test precondition: allowance must be zero"
+        );
+
+        let amount = U256::from(1_000_000u64); // 1 USDC
+        let max_fee = bridge
+            .query_fast_transfer_fee(amount, BridgeDirection::EthereumToBase)
+            .await
+            .unwrap();
+
+        // Take tx count after setup so we can count only retry-path txs.
+        let ethereum_provider = ProviderBuilder::new()
+            .connect(&cctp.ethereum_endpoint)
+            .await
+            .unwrap();
+        let tx_count_before = ethereum_provider
+            .get_transaction_count(owner)
+            .await
+            .unwrap();
+
+        // Use zero recipient for the second burn to cause a non-allowance revert:
+        // TokenMessenger V2 reverts with `InvalidMintRecipient` on Address::ZERO,
+        // which is not allowance-related, so no third attempt must fire.
+        let zero_recipient = Address::ZERO;
+        let result = bridge
+            .ethereum
+            .deposit_for_burn_with_allowance_retry::<NoOpErrorRegistry>(
+                amount,
+                zero_recipient,
+                BridgeDirection::EthereumToBase,
+                max_fee,
+            )
+            .await;
+
+        // The second burn reverted for a non-allowance reason; that error propagates.
+        let error = result.unwrap_err();
+        assert!(
+            error.is_revert(),
+            "second burn revert must propagate; got: {error:?}"
+        );
+
+        // PRIMARY proof of exactly-once: exactly one tx was mined (the approve
+        // from ensure_standing_allowance). The first and second depositForBurn
+        // calls both revert as pre-flight (Anvil simulation), so they do not mine
+        // a transaction or advance the nonce. No third depositForBurn was issued.
+        //
+        // Note: the "no nonce advance on revert" property is specific to Anvil's
+        // simulation mode (failed `eth_sendRawTransaction` pre-flights are rejected
+        // before mining). On a live network, a reverting transaction that makes it
+        // into a block DOES advance the nonce. The `is_revert()` check above is a
+        // secondary sanity check confirming the error kind is preserved across the
+        // retry chain — it cannot prove exactly-once because it would also pass if
+        // three deposit attempts were made and the final one reverted.
+        let tx_count_after = ethereum_provider
+            .get_transaction_count(owner)
+            .await
+            .unwrap();
+        assert_eq!(
+            tx_count_after,
+            tx_count_before + 1,
+            "exactly one tx (the approve) must have been mined; \
+             got {} additional txs",
+            tx_count_after.saturating_sub(tx_count_before)
         );
     }
 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -22,7 +22,6 @@ use alloy::providers::Provider;
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use alloy::sol_types::SolCall;
 use async_trait::async_trait;
-use rain_error_decoding::AbiDecodedErrorType;
 use serde::Deserialize;
 use std::sync::Arc;
 use std::time::Duration;
@@ -34,6 +33,7 @@ use tracing::{debug, warn};
 pub mod error_decoding;
 pub use error_decoding::{IntoErrorRegistry, NoOpErrorRegistry, OpenChainErrorRegistry};
 use error_decoding::{decode_reverted_receipt, decode_rpc_revert};
+pub use rain_error_decoding::AbiDecodedErrorType;
 
 pub mod nonce;
 pub use nonce::ResettableNonceManager;
@@ -237,6 +237,50 @@ pub enum EvmError {
 }
 
 impl EvmError {
+    /// `true` if this error represents an EVM transaction revert (as opposed
+    /// to a transport failure or other non-revert error).
+    ///
+    /// Handles both post-mining reverts ([`Self::Reverted`],
+    /// [`Self::DecodedRevert`], [`Self::Contract`] with actual revert data)
+    /// and pre-mining preflight rejections via [`Self::Transport`]:
+    ///
+    /// - Code 3: the Ethereum JSON-RPC spec execution-revert code; Anvil uses
+    ///   this in simulation mode. Unambiguously a revert regardless of message.
+    /// - Codes -32000 / -32003: shared by multiple failure types ("nonce too
+    ///   low", "underpriced", "execution reverted"). Only classified as revert
+    ///   when the message contains `"execution reverted"`.
+    ///
+    /// All other variants (`Transaction`, `AbiDecode`, `WalletConfigParse`,
+    /// `NodeBehindRequiredBlock`, and all feature-gated variants) are
+    /// non-revert by definition.
+    pub fn is_revert(&self) -> bool {
+        match self {
+            Self::Reverted { .. } | Self::DecodedRevert(_) => true,
+            // Contract wraps alloy::contract::Error, which is also produced for
+            // pure transport failures (connection reset, timeout) when revert
+            // data cannot be decoded. Only classify as revert when actual EVM
+            // revert data is present.
+            Self::Contract(contract_err) => contract_err.as_revert_data().is_some(),
+            Self::Transport(rpc_error) => rpc_error.as_error_resp().is_some_and(|payload| {
+                payload.code == 3 || payload.message.contains("execution reverted")
+            }),
+            Self::Transaction(_) | Self::AbiDecode(_) | Self::WalletConfigParse(_) => false,
+            #[cfg(any(feature = "turnkey", feature = "local-signer"))]
+            Self::ReceiptTimeout { .. } => false,
+            #[cfg(any(feature = "turnkey", feature = "local-signer"))]
+            Self::TransactionDropped { .. } => false,
+            #[cfg(any(feature = "turnkey", feature = "local-signer"))]
+            Self::ReplacementUnderpriced { .. } => false,
+            #[cfg(any(feature = "turnkey", feature = "local-signer"))]
+            Self::ReplacementFeeOverflow => false,
+            #[cfg(feature = "local-signer")]
+            Self::InvalidPrivateKey(_) => false,
+            #[cfg(feature = "turnkey")]
+            Self::Turnkey(_) => false,
+            Self::NodeBehindRequiredBlock { .. } => false,
+        }
+    }
+
     /// `true` if this reports a transaction dropped from the mempool (it will
     /// never mine) -- a terminal failure, distinct from a still-pending tx that
     /// merely has not confirmed yet. Only the wallet builds (`turnkey` /


### PR DESCRIPTION
## What

Fixes a prod incident: a dRPC load-balancing race between a just-submitted USDC
`approve` and the subsequent `depositForBurn` pre-flight `eth_call` caused CCTP
burns to revert with "ERC20: transfer amount exceeds allowance", permanently
latching USDC rebalancing. [RAI-1151](https://linear.app/makeitrain/issue/RAI-1151)

## Why

- The previous code approved the exact burn amount immediately before each
  `depositForBurn`. Under dRPC load balancing, a lagging node could serve the
  `depositForBurn` pre-flight `eth_call` before it saw the approve block, reading
  allowance = 0 and reverting.
- A CCTP burn revert with no retry caused the apalis job to fail permanently,
  latching `usdc_in_progress` and blocking all future rebalances until manual
  operator intervention.

## How

- **Standing `U256::MAX` allowance** (`ensure_standing_allowance`): the burn path
  checks allowance against a `U256::MAX / 2` threshold and only submits a new
  `approve(TokenMessenger, U256::MAX)` when it drops below that line. On the
  steady-state hot path (allowance >> threshold) no approve tx is sent.
- **`wait_for_node_sync` gate after approve**: after the cold-path approve
  confirms, the bridge polls `eth_blockNumber` through the load-balanced endpoint
  until it observes a block at or above the approve block, shrinking the race
  window before the burn.
- **One-shot retry** (`retry_burn_if_revert`): if `depositForBurn` still reverts,
  the bridge re-runs `ensure_standing_allowance`, re-queries the Circle
  fast-transfer fee (to avoid a stale fee from a spike during the ~30 s sync
  window), then retries exactly once. Non-revert errors (transport timeouts,
  connection failures) are NOT retried. The `#[cfg(test)]`
  `deposit_for_burn_with_allowance_retry` helper exercises the endpoint-level
  path without a fee re-query; production callers always use `burn_internal` which
  does re-query via `retry_burn_if_revert`.
- **`EvmError::is_revert()` + `CctpError::is_revert()`**: exhaustive
  compile-enforced classifiers. A new `EvmError` variant forces an explicit
  revert/non-revert decision before the code compiles. `CctpError::is_revert()`
  delegates to `EvmError::is_revert()` for `Evm` variants and checks
  `as_revert_data()` for bare `Contract` variants.
- **`apply_sync_result`**: pure function that maps sync failure to the original
  burn error (not the sync error), so operator logs and the job retry queue see
  the actionable root cause. `pub(super)` for unit testability.
- **Fee query moved after allowance**: `query_fast_transfer_fee` now runs after
  `ensure_standing_allowance` so the Circle fee is fresh even if the cold-path
  sync took ~30 s.
- **`AbiDecodedErrorType` re-exported** from `st0x-evm` so bridge tests can
  construct `EvmError::DecodedRevert` without a direct `rain_error_decoding`
  dependency.
- **SPEC.md updated**: CCTP allowance section added; flow step numbering updated
  for both Alpaca-to-Base and Base-to-Alpaca directions.

## Testing

~27 new tests across `st0x-bridge` and `st0x-evm`; `cargo clippy` clean on both.

- **Constant pins**: `allowance_constants_have_expected_values` — `U256::MAX` and
  `U256::MAX / 2` against independent derivations.
- **`is_revert` matrix** (18 tests): code 3, `-32000`/`-32003` + "execution
  reverted" (true); `-32000` + "nonce too low", transport without revert data,
  `EvmError::Transaction`/`NodeBehindRequiredBlock`, `Http`/`ScanInconclusive`/
  `PlaceholderNonce` (all false); `EvmError::Reverted`/`DecodedRevert`,
  `Contract` with revert data (true).
- **`apply_sync_result`** (2 unit tests): sync failure returns original error;
  sync success returns `Ok(())`.
- **Standing allowance** (Ethereum + Base, 8 Anvil tests): zero -> sets `U256::MAX`;
  above-threshold -> no-op; below-threshold -> tops up to `U256::MAX`; exact
  threshold -> no-op; threshold - 1 -> tops up.
- **Retry path** (3 Anvil tests): zero allowance -> first burn reverts -> retry
  approves + succeeds; `U256::MAX` pre-set + `Address::ZERO` recipient -> both
  burns revert, no extra txs mined, allowance unchanged; exactly-once proof
  (zero allowance -> first burn reverts -> approve mined -> second burn reverts
  -> exactly 1 tx total).

## Anything else

- The `wait_for_node_sync` race is not fully eliminated, but the standing
  allowance means the cold path (sync wait) fires only on first use or a manual
  reset, and the one-shot retry handles the residual race.
- USDC (FiatToken v2.2) decrements even `U256::MAX` allowances; at realistic
  rebalancing sizes the allowance never drops below `U256::MAX / 2`, so the
  approve fires once at startup.
- The apalis-job-level self-heal path is tracked separately in
  [RAI-1152](https://linear.app/makeitrain/issue/RAI-1152).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more reliable CCTP transfer flow with automatic allowance maintenance before burns.
  * Transfers now retry once when a burn reverts, improving success rates during temporary chain-sync delays.

* **Bug Fixes**
  * Improved handling of approval timing so transfers wait for network confirmation before continuing.
  * Reduced failed transfers caused by allowance observation issues and transient revert errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->