### PR TITLE
fix: self-heal stalled USDC transfers with bounded burn-revert redrive

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2203,7 +2203,78 @@ only on first use or a manual reset, and (b) the defense-in-depth retry below.
 **Defense-in-depth retry:** If `depositForBurn` reverts despite the above
 (structurally: re-read allowance < burn amount), the bridge re-runs the cold
 path and retries the burn exactly once. This handles rare cases where the
-node-sync poll window expires before a node catches up.
+node-sync poll window expires before a node catches up. If the bridge-level
+one-shot retry also fails, the job-level bounded redrive (described below) takes
+over.
+
+#### Self-Healing and Alerting
+
+##### Transient burn-revert self-heal (bounded redrive)
+
+A Base->Alpaca transfer job that receives a revert-class CCTP burn error (where
+`CctpError::is_revert()` is true, indicating a pre-submission chain revert with
+no on-chain effect) is reclassified as a safe redrive rather than a
+circuit-breaker trip. The job returns `Ok` and re-enqueues itself with a 15 s
+delay, re-entering the `resume_bridging_submitting` scan-or-reburn path on the
+next pickup.
+
+The double-burn safety guarantee is NOT `is_revert()` classification -- it is
+the `resume_bridging_submitting` scan: `find_recent_burn` scans for an existing
+burn before re-attempting, using the `from_block` lower bound durably recorded
+in the `BridgingSubmitting` aggregate event before the burn call. Even a
+misclassified error cannot cause a double-burn because the scan adopts any
+existing burn.
+
+A per-attempt wall-clock timeout is similarly reclassified: the hung attempt is
+aborted and the job re-enqueues with a 30 s delay. On re-pickup, if the burn
+landed during the timeout, the scan adopts it rather than re-burning.
+
+**Bound**: Both revert and timeout redrives count against a shared
+`max_burn_revert_redrives` counter persisted in the job payload (durable across
+restarts). Once the bound is reached, the job propagates a
+`BurnRevertLimitReached` error so the circuit opens and the operator is alerted.
+Genuinely ambiguous failures (where the burn may have landed and `is_revert()`
+returns false, e.g. `MessageSentEventNotFound`) are never reclassified and
+always halt for operator review.
+
+**Alerting**: A Telegram alert fires at the warn threshold (`max / 2 + 1`
+redrives), at the limit, and before any terminal non-redriven error propagates.
+
+##### Startup re-arm for `BridgingSubmitting` and `WithdrawalSubmitting{BaseToAlpaca}`
+
+On startup, `recover_usdc_guard` re-arms transfer jobs for aggregates at
+`BridgingSubmitting` (both directions) or `WithdrawalSubmitting{BaseToAlpaca}`
+state that have no pending job row. These states are non-terminal and resumable:
+the process either crashed before the burn tx was submitted, or before the
+apalis enqueue committed. The re-arm is idempotent (suppressed if a job row
+exists) and runs before the apalis monitor starts so there is no live-job race.
+
+`WithdrawalSubmitting{AlpacaToBase}` is **NOT** auto-re-armed: the withdrawal
+transfer ID has not yet been persisted in that state (it is persisted only when
+`Withdrawing` is entered), so `resume_alpaca_to_base` returns
+`ResumeDirectionMismatch` and cannot reconstruct which Alpaca withdrawal to
+poll. When a crash leaves an aggregate in this state, `recover_usdc_guard`
+latches `usdc_in_progress` (no USDC rebalancing proceeds) and fires an operator
+alert via `self.notifier` so the operator is paged to run `resume-usdc-transfer`
+or `reconcile-usdc-transfer` manually.
+
+These states do NOT receive a tracking seed (unlike `DepositFailed` /
+`ConversionFailed` / `BridgingFailed{burn_tx=Some}`): seeding tracking for a
+mid-flight resumable state would wedge the `DepositConfirmed` path which
+requires `bridged_amount_received` that the seed cannot supply. The re-arm path
+(job re-enqueue) handles them; the sweep path is for manually-reconcilable
+terminal states only.
+
+###### Known limitations / follow-ups
+
+- **`WithdrawalSubmitting{AlpacaToBase}` is not auto-resumable**: Making this
+  state resumable requires persisting the withdrawal identity (Alpaca transfer
+  ID) before entering `WithdrawalSubmitting` and adding a corresponding resume
+  arm in `resume_alpaca_to_base`. This is deferred work; for now the operator is
+  alerted and must reconcile manually.
+- **Unresolved/unparseable aggregate IDs**: Aggregates that are missing from the
+  store or have unparseable IDs also latch the guard with an operator alert.
+  These indicate store inconsistency and require manual investigation.
 
 Note: USDC (FiatToken v2.2) decrements even `U256::MAX` allowances in
 `transferFrom`. At realistic rebalancing sizes the allowance never drops below

--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -54,6 +54,7 @@ redemption_wallet = "0x1c66D6708914C40239D54919320b4C48cAE3D1A9"
 transfer_timeout_secs = 1800
 transfer_attempt_timeout_secs = 3600
 attestation_retry_deadline_secs = 86400
+max_burn_revert_redrives = 5
 
 [rebalancing.usdc]
 mode = "enabled"

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -53,6 +53,7 @@ redemption_wallet = "0x1c66D6708914C40239D54919320b4C48cAE3D1A9"
 transfer_timeout_secs = 1800
 transfer_attempt_timeout_secs = 3600
 attestation_retry_deadline_secs = 86400
+max_burn_revert_redrives = 5
 equity = { target = 0.5, deviation = 0.2 }
 usdc = { mode = "disabled" }
 

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -431,6 +431,11 @@ impl CctpError {
     /// Returns `true` if this error represents a transaction revert (as opposed
     /// to a transport failure or other non-revert EVM error).
     ///
+    /// Revert classification is an intentional, supported part of `CctpError`'s
+    /// public contract: the main crate's burn paths (`burn_on_base` /
+    /// `burn_on_ethereum`) call it to distinguish a redrivable revert-class burn
+    /// failure from a terminal one.
+    ///
     /// Used by `burn_internal` to gate the allowance-check retry: only reverts
     /// can be allowance-related; transport errors and other non-revert errors
     /// are not.
@@ -443,7 +448,7 @@ impl CctpError {
     /// only revert-class when the inner error carries actual revert data (same
     /// reasoning as `EvmError::Contract` — a network blip wraps as Contract with
     /// no revert data and must not trigger the retry).
-    pub(crate) fn is_revert(&self) -> bool {
+    pub fn is_revert(&self) -> bool {
         match self {
             // Delegate to EvmError::is_revert(), which is exhaustive over all
             // EvmError variants (including feature-gated ones) and lives in

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -2319,6 +2319,7 @@ mod tests {
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
             attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 5
 
             [wallet]
             kind = "private-key"
@@ -2431,6 +2432,7 @@ mod tests {
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
             attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 5
 
             [wallet]
             kind = "private-key"
@@ -2646,6 +2648,7 @@ mod tests {
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
             attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 5
 
             [rebalancing.equity]
             target = "0.5"
@@ -2708,6 +2711,7 @@ mod tests {
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
             attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 5
 
             [rebalancing.equity]
             target = "0.5"
@@ -2772,6 +2776,7 @@ mod tests {
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
             attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 5
 
             [rebalancing.equity]
             target = "0.5"
@@ -3344,6 +3349,7 @@ mod tests {
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
             attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 5
 
             [wallet]
             kind = "private-key"

--- a/crates/config/src/rebalancing.rs
+++ b/crates/config/src/rebalancing.rs
@@ -30,6 +30,12 @@ pub enum RebalancingCtxError {
     ZeroTransferAttemptTimeout,
     #[error("rebalancing attestation_retry_deadline_secs must be non-zero")]
     ZeroAttestationRetryDeadline,
+    #[error(
+        "rebalancing max_burn_revert_redrives must be non-zero when USDC rebalancing \
+         is enabled; set it to the maximum number of burn-revert redrive attempts \
+         before the circuit opens (suggested value: 5)"
+    )]
+    ZeroMaxBurnRevertRedrives,
     #[error("invalid wallet config: {0}")]
     WalletConfig(#[from] toml::de::Error),
     #[error(transparent)]
@@ -70,6 +76,20 @@ pub struct RebalancingConfig {
     /// At the production default (24h) the overshoot is negligible; set with
     /// that granularity in mind, not as a hard millisecond cutoff.
     pub attestation_retry_deadline_secs: u64,
+    /// Maximum number of burn-revert redrive attempts for a single Base->Alpaca
+    /// USDC transfer job before the circuit-breaker opens and the operator is
+    /// alerted.
+    ///
+    /// A revert-class CCTP burn failure (where no EVM state change occurred)
+    /// is reclassified as a safe redrive: the job returns Ok and re-enqueues
+    /// itself, re-entering the scan-or-reburn path. After this many consecutive
+    /// revert redrives the transfer stalls for operator review instead of
+    /// looping forever. Required when `usdc.mode = "enabled"`; must be non-zero.
+    ///
+    /// Suggested value: 5. Covers transient load-balanced-RPC oscillation
+    /// while halting for permanent contract reverts (USDC blocklist, paused
+    /// TokenMessenger, etc.).
+    pub max_burn_revert_redrives: u32,
 }
 
 /// Runtime configuration for rebalancing operations.
@@ -87,6 +107,9 @@ pub struct RebalancingCtx {
     /// [`RebalancingConfig::transfer_attempt_timeout_secs`].
     pub transfer_attempt_timeout: Duration,
     pub attestation_retry_deadline: Duration,
+    /// Maximum consecutive burn-revert redrives before the circuit opens.
+    /// See [`RebalancingConfig::max_burn_revert_redrives`].
+    pub max_burn_revert_redrives: u32,
     /// Circle attestation/fee API base URL (test-only override).
     #[cfg(feature = "test-support")]
     pub circle_api_base: String,
@@ -120,12 +143,17 @@ impl RebalancingCtx {
             UsdcRebalancing::Disabled => None,
         };
 
+        if usdc.is_some() && config.max_burn_revert_redrives == 0 {
+            return Err(RebalancingCtxError::ZeroMaxBurnRevertRedrives);
+        }
+
         Ok(Self {
             equity: config.equity,
             usdc,
             transfer_timeout: Duration::from_secs(config.transfer_timeout_secs),
             transfer_attempt_timeout: Duration::from_secs(config.transfer_attempt_timeout_secs),
             attestation_retry_deadline: Duration::from_secs(config.attestation_retry_deadline_secs),
+            max_burn_revert_redrives: config.max_burn_revert_redrives,
             #[cfg(feature = "test-support")]
             circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
             #[cfg(feature = "test-support")]
@@ -151,6 +179,7 @@ impl RebalancingCtx {
         #[builder(default = Duration::from_secs(60 * 60))] transfer_attempt_timeout: Duration,
         #[builder(default = Duration::from_secs(24 * 60 * 60))]
         attestation_retry_deadline: Duration,
+        #[builder(default = 5)] max_burn_revert_redrives: u32,
     ) -> Self {
         Self {
             equity,
@@ -158,6 +187,7 @@ impl RebalancingCtx {
             transfer_timeout,
             transfer_attempt_timeout,
             attestation_retry_deadline,
+            max_burn_revert_redrives,
             #[cfg(feature = "test-support")]
             circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
             #[cfg(feature = "test-support")]
@@ -181,6 +211,7 @@ impl RebalancingCtx {
         #[builder(default = Duration::from_secs(60 * 60))] transfer_attempt_timeout: Duration,
         #[builder(default = Duration::from_secs(24 * 60 * 60))]
         attestation_retry_deadline: Duration,
+        #[builder(default = 5)] max_burn_revert_redrives: u32,
     ) -> Self {
         let usdc = match usdc {
             UsdcRebalancing::Enabled { target, deviation } => {
@@ -195,6 +226,7 @@ impl RebalancingCtx {
             transfer_timeout,
             transfer_attempt_timeout,
             attestation_retry_deadline,
+            max_burn_revert_redrives,
             circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
             token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
             message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
@@ -242,6 +274,7 @@ mod tests {
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
             attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 5
 
             [equity]
             target = "0.5"
@@ -269,6 +302,7 @@ mod tests {
         assert_eq!(config.transfer_timeout_secs, 1800);
         assert_eq!(config.transfer_attempt_timeout_secs, 3600);
         assert_eq!(config.attestation_retry_deadline_secs, 86400);
+        assert_eq!(config.max_burn_revert_redrives, 5);
     }
 
     #[test]
@@ -278,6 +312,7 @@ mod tests {
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
             attestation_retry_deadline_secs = 7200
+            max_burn_revert_redrives = 3
 
             [equity]
             target = "0.6"
@@ -300,11 +335,16 @@ mod tests {
         assert!(target.eq(float!(0.4)).unwrap());
         assert!(deviation.eq(float!(0.15)).unwrap());
         assert_eq!(config.attestation_retry_deadline_secs, 7200);
+        assert_eq!(config.max_burn_revert_redrives, 3);
     }
 
     #[test]
     fn deserialize_missing_transfer_timeout_secs_fails() {
         let toml_str = r#"
+            transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 5
+
             [equity]
             target = "0.5"
             deviation = "0.2"
@@ -327,6 +367,7 @@ mod tests {
         let toml_str = r#"
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
+            max_burn_revert_redrives = 5
 
             [equity]
             target = "0.5"
@@ -352,6 +393,7 @@ mod tests {
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
             attestation_retry_deadline_secs = 0
+            max_burn_revert_redrives = 5
 
             [equity]
             target = "0.5"
@@ -376,7 +418,9 @@ mod tests {
     fn deserialize_missing_equity_fails() {
         let toml_str = r#"
             transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
             attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 5
 
             [usdc]
             mode = "enabled"
@@ -395,7 +439,9 @@ mod tests {
     fn deserialize_missing_usdc_fails() {
         let toml_str = r#"
             transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
             attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 5
 
             [equity]
             target = "0.5"
@@ -413,6 +459,8 @@ mod tests {
     fn deserialize_missing_transfer_attempt_timeout_secs_fails() {
         let toml_str = r#"
             transfer_timeout_secs = 1800
+            attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 5
 
             [equity]
             target = "0.5"
@@ -438,6 +486,7 @@ mod tests {
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 0
             attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 5
 
             [equity]
             target = "0.5"
@@ -456,5 +505,80 @@ mod tests {
             error,
             RebalancingCtxError::ZeroTransferAttemptTimeout
         ));
+    }
+
+    #[test]
+    fn zero_max_burn_revert_redrives_fails_validation_when_usdc_enabled() {
+        let config: RebalancingConfig = toml::from_str(
+            r#"
+            transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 0
+
+            [equity]
+            target = "0.5"
+            deviation = "0.2"
+
+            [usdc]
+            mode = "enabled"
+            target = "0.5"
+            deviation = "0.3"
+        "#,
+        )
+        .unwrap();
+
+        let error = RebalancingCtx::new(&config).unwrap_err();
+        assert!(matches!(
+            error,
+            RebalancingCtxError::ZeroMaxBurnRevertRedrives
+        ));
+    }
+
+    #[test]
+    fn zero_max_burn_revert_redrives_is_ok_when_usdc_disabled() {
+        let config: RebalancingConfig = toml::from_str(
+            r#"
+            transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 86400
+            max_burn_revert_redrives = 0
+
+            [equity]
+            target = "0.5"
+            deviation = "0.2"
+
+            [usdc]
+            mode = "disabled"
+        "#,
+        )
+        .unwrap();
+
+        // USDC is disabled so the zero-check is skipped.
+        RebalancingCtx::new(&config).unwrap();
+    }
+
+    #[test]
+    fn deserialize_missing_max_burn_revert_redrives_fails() {
+        let toml_str = r#"
+            transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 86400
+
+            [equity]
+            target = "0.5"
+            deviation = "0.2"
+
+            [usdc]
+            mode = "enabled"
+            target = "0.5"
+            deviation = "0.3"
+        "#;
+
+        let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
+        assert!(
+            error.message().contains("max_burn_revert_redrives"),
+            "Expected missing max_burn_revert_redrives error, got: {error}"
+        );
     }
 }

--- a/example.config.toml
+++ b/example.config.toml
@@ -77,6 +77,12 @@ transfer_attempt_timeout_secs = 3600
 # CCTP attestation polling timeouts stay retryable until this deadline.
 # 86400 = 24 hours.
 attestation_retry_deadline_secs = 86400
+# Maximum number of consecutive revert-class CCTP burn failures that will be
+# reclassified as safe redrives (scan-or-reburn path) before the circuit
+# opens and the operator is alerted. Required when usdc.mode = "enabled".
+# Suggested value: 5 (covers transient RPC oscillation; halts for permanent
+# contract reverts such as USDC blocklist or paused TokenMessenger).
+max_burn_revert_redrives = 5
 equity = { target = 0.5, deviation = 0.2 }
 usdc = { mode = "enabled", target = 0.5, deviation = 0.3 }
 

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -5,7 +5,84 @@
 //! is the only implementation today. Monitors that raise alerts (see
 //! `crate::conductor::monitor::gas`) depend on the trait so they stay testable
 //! against a capturing mock.
+//!
+//! [`NoopNotifier`] is the explicit absence implementation: used when the
+//! `[alerts]` config section is omitted. Its presence in the type system makes
+//! the absence of alerting intentional and visible rather than silently skipped
+//! via `Option`.
 
 pub(crate) mod telegram;
 
-pub(crate) use telegram::{Notifier, TelegramNotifier};
+pub(crate) use telegram::TelegramNotifier;
+
+use async_trait::async_trait;
+use reqwest::StatusCode;
+
+/// Sends an operational alert over some channel.
+///
+/// Kept as a trait so monitors depend on the capability, not the concrete
+/// Telegram transport, which keeps them unit-testable with a capturing mock.
+#[async_trait]
+pub(crate) trait Notifier: Send + Sync {
+    async fn notify(&self, message: &str) -> Result<(), NotifierError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum NotifierError {
+    #[error("failed to build Telegram HTTP client")]
+    ClientBuild(#[source] reqwest::Error),
+    #[error("Telegram sendMessage request failed")]
+    Request(#[source] reqwest::Error),
+    #[error("Telegram API returned error status {status}: {body}")]
+    ApiError { status: StatusCode, body: String },
+}
+
+/// A [`Notifier`] that discards every message without error.
+///
+/// Used when the `[alerts]` config section is absent: the caller receives an
+/// `Arc<dyn Notifier>` pointing at this type, making the absence explicit
+/// (no `Option` branch, no silent skip). The no-op path is visible in the
+/// type system and in startup logs.
+pub(crate) struct NoopNotifier;
+
+#[async_trait]
+impl Notifier for NoopNotifier {
+    async fn notify(&self, _message: &str) -> Result<(), NotifierError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) use test_support::CapturingNotifier;
+
+/// Test-only notifier helpers. Lives in a `#[cfg(test)]` module (rather than
+/// bare `#[cfg(test)]` items) so clippy's `allow-unwrap-in-tests` applies to the
+/// `Mutex`-lock unwraps below, matching the crate's `test_utils` pattern.
+#[cfg(test)]
+mod test_support {
+    use async_trait::async_trait;
+
+    use super::{Notifier, NotifierError};
+
+    /// A [`Notifier`] that captures every message passed to `notify()`, for tests
+    /// that assert operator alerts fire at the right moments without a real
+    /// delivery channel. Shared across the crate's test modules.
+    #[derive(Default)]
+    pub(crate) struct CapturingNotifier {
+        captured: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl CapturingNotifier {
+        pub(crate) fn messages(&self) -> Vec<String> {
+            self.captured.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl Notifier for CapturingNotifier {
+        async fn notify(&self, message: &str) -> Result<(), NotifierError> {
+            self.captured.lock().unwrap().push(message.to_string());
+            Ok(())
+        }
+    }
+}

--- a/src/alerts/telegram.rs
+++ b/src/alerts/telegram.rs
@@ -5,17 +5,9 @@
 //! monitor can be exercised against a capturing mock in tests.
 
 use async_trait::async_trait;
-use reqwest::StatusCode;
 use serde_json::json;
 
-/// Sends an operational alert over some channel.
-///
-/// Kept as a trait so monitors depend on the capability, not the concrete
-/// Telegram transport, which keeps them unit-testable with a capturing mock.
-#[async_trait]
-pub(crate) trait Notifier: Send + Sync {
-    async fn notify(&self, message: &str) -> Result<(), NotifierError>;
-}
+use super::{Notifier, NotifierError};
 
 /// Telegram Bot API client that posts alerts to a fixed chat.
 pub(crate) struct TelegramNotifier {
@@ -107,20 +99,11 @@ impl Notifier for TelegramNotifier {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum NotifierError {
-    #[error("failed to build Telegram HTTP client")]
-    ClientBuild(#[source] reqwest::Error),
-    #[error("Telegram sendMessage request failed")]
-    Request(#[source] reqwest::Error),
-    #[error("Telegram API returned error status {status}: {body}")]
-    ApiError { status: StatusCode, body: String },
-}
-
 #[cfg(test)]
 mod tests {
     use httpmock::Method::POST;
     use httpmock::MockServer;
+    use reqwest::StatusCode;
     use serde_json::{Value, json};
 
     use super::*;

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -46,6 +46,7 @@ use st0x_execution::{
 use st0x_raindex::{RaindexService, RaindexVaultId};
 use st0x_wrapper::WrapperService;
 
+use crate::alerts::{NoopNotifier, NotifierError, TelegramNotifier};
 use crate::conductor::exit::{ConductorExit, MonitorTaskError};
 use crate::conductor::monitor::order_fills::{CutoffProbe, probe_cutoff_block_support};
 use crate::dashboard::Broadcaster;
@@ -78,7 +79,8 @@ use crate::rebalancing::equity::{
 };
 use crate::rebalancing::trigger::GuardState;
 use crate::rebalancing::usdc::{
-    TransferUsdcToHedgingCtx, TransferUsdcToMarketMakingCtx, UsdcSettlementParams,
+    TransferUsdcToHedging, TransferUsdcToHedgingCtx, TransferUsdcToMarketMaking,
+    TransferUsdcToMarketMakingCtx, UsdcSettlementParams,
 };
 use crate::rebalancing::{
     RebalancerServices, RebalancingSchedulers, RebalancingService, RebalancingServiceConfig,
@@ -978,12 +980,24 @@ fn spawn_finished_job_cleanup(
         loop {
             interval.tick().await;
 
+            // USDC transfer-job rows are the durable startup re-arm
+            // idempotency + redrive-budget signal. Pruning them while the
+            // aggregate is still mid-flight (e.g. `BridgingSubmitting`) resets
+            // the redrive bound to a fresh budget on restart and silences the
+            // stranded-transfer operator alert. Transfer jobs are low-volume,
+            // so retaining their finished rows is cheap; exclude both transfer
+            // job types from cleanup.
             let cleanup_result = sqlx_apalis::query(
                 "DELETE FROM Jobs \
-                 WHERE status = ? \
-                 OR status = ? \
-                 OR (status = ? AND max_attempts <= attempts)",
+                 WHERE job_type NOT IN (?, ?) \
+                 AND ( \
+                     status = ? \
+                     OR status = ? \
+                     OR (status = ? AND max_attempts <= attempts) \
+                 )",
             )
+            .bind(std::any::type_name::<TransferUsdcToHedging>())
+            .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
             .bind(Status::Done.to_string())
             .bind(Status::Killed.to_string())
             .bind(Status::Failed.to_string())
@@ -1205,6 +1219,29 @@ impl PositionAndRebalancing {
     }
 }
 
+/// Builds the USDC alerting notifier.
+///
+/// Returns `Ok(Arc<NoopNotifier>)` when `[alerts]` is absent — silence is
+/// the correct behaviour for an unconfigured optional channel.
+///
+/// Returns `Err` when `[alerts]` IS present but `TelegramNotifier` fails to
+/// initialise. The caller must propagate this so the server fails to start:
+/// an operator who configured `[alerts]` believes alerts are active; silently
+/// falling back to Noop would suppress all redrive-limit and terminal-error
+/// pages with no runtime indication.
+fn build_usdc_notifier(
+    alerts: Option<&st0x_config::AlertsCtx>,
+) -> Result<Arc<dyn crate::alerts::Notifier>, NotifierError> {
+    let Some(alerts) = alerts else {
+        debug!("USDC alerting: [alerts] section absent, using NoopNotifier");
+        return Ok(Arc::new(NoopNotifier));
+    };
+    let notifier =
+        TelegramNotifier::new(&alerts.bot_token, alerts.chat_id, alerts.message_thread_id)?;
+    info!("USDC alerting: Telegram notifier configured");
+    Ok(Arc::new(notifier))
+}
+
 fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
     rebalancing_ctx: RebalancingCtx,
     redemption_wallet: Address,
@@ -1267,6 +1304,8 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             deps.ctx.issuance.api_key.header_value(),
         )?);
 
+        let usdc_notifier = build_usdc_notifier(deps.ctx.alerts.as_ref())?;
+
         let rebalancing_service = Arc::new(RebalancingService::new(
             RebalancingServiceConfig {
                 equity: rebalancing_ctx.equity,
@@ -1280,6 +1319,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             deps.inventory.clone(),
             wrapper.clone(),
             deps.schedulers,
+            usdc_notifier.clone(),
         ));
 
         rebalancing_service
@@ -1295,11 +1335,8 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         // live path missed in the previous run. Reads only the un-folded tail
         // past each operation's checkpoint, so this does not re-fold history.
         let rebalance_timing_replayed = rebalance_timing.catch_up().await?;
-        info!(
-            target: "rebalance",
-            replayed = rebalance_timing_replayed,
-            "Rebalance stage-timing read model caught up to the event log at startup"
-        );
+        info!(target: "rebalance", replayed = rebalance_timing_replayed,
+            "Rebalance stage-timing read model caught up to the event log at startup");
 
         let manifest = QueryManifest::new(
             rebalancing_service.clone(),
@@ -1335,9 +1372,8 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             built.redemption.clone(),
         ));
 
-        // Built outside `QueryManifest` because the recovery aggregate's
-        // services include `recovery_transfer`, which depends on the
-        // mint/redemption stores produced by the manifest above.
+        // Built outside `QueryManifest`: services depend on mint/redemption stores
+        // that the manifest produces.
         let (wrapped_equity_recovery_store, unwrapped_equity_recovery_store) =
             build_equity_recovery_stores(
                 &deps.pool,
@@ -1372,11 +1408,8 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             alpaca_auth.api_secret.clone(),
         ));
 
-        // Build the broker here (not inside `RebalancerServices::new`) so it can
-        // be wrapped in the telemetry decorator before being threaded down. This
-        // mirrors how the hedge executor is wrapped in `Conductor::run` before
-        // use, so the rebalancer's Alpaca conversion calls emit broker dependency
-        // samples alongside the hedge path.
+        // Wrap with telemetry before threading down so rebalancer Alpaca calls
+        // emit broker dependency samples (mirrors hedge executor wrapping).
         let broker = InstrumentedAlpacaBroker::new(
             AlpacaBrokerApi::try_from_ctx(alpaca_auth.clone()).await?,
             deps.telemetry.clone(),
@@ -1408,30 +1441,31 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             .and_then(|cash| cash.vault_ids.first().copied())
             .ok_or(CtxError::MissingCashVaultId)?;
 
-        let mint_store = built.mint;
-        let redemption_store = built.redemption;
-
         let usdc_handles = services.into_usdc_transfer_handles(
             market_maker_wallet,
             RaindexVaultId(usdc_vault_id),
             built.usdc,
         );
 
+        let transfer_usdc_to_market_making_ctx = Arc::new(TransferUsdcToMarketMakingCtx {
+            transfer: usdc_handles.resume_alpaca_to_base,
+            job_queue: transfer_usdc_to_market_making_queue,
+            max_burn_revert_redrives: rebalancing_ctx.max_burn_revert_redrives,
+            notifier: usdc_notifier.clone(),
+        });
+
         let transfer_usdc_to_hedging_ctx = Arc::new(TransferUsdcToHedgingCtx {
             transfer: usdc_handles.resume_base_to_alpaca,
             timeout: rebalancing_ctx.transfer_attempt_timeout,
             job_queue: transfer_usdc_to_hedging_queue,
-        });
-
-        let transfer_usdc_to_market_making_ctx = Arc::new(TransferUsdcToMarketMakingCtx {
-            transfer: usdc_handles.resume_alpaca_to_base,
-            job_queue: transfer_usdc_to_market_making_queue,
+            max_burn_revert_redrives: rebalancing_ctx.max_burn_revert_redrives,
+            notifier: usdc_notifier,
         });
 
         let transfer_equity_to_market_making_ctx = Arc::new(TransferEquityToMarketMakingCtx {
             transfer: recovery_transfer.clone(),
             equity_in_progress: rebalancing_service.equity_in_progress.clone(),
-            mint_store: mint_store.clone(),
+            mint_store: built.mint.clone(),
             equities_config: deps.ctx.assets.equities.clone(),
         });
 
@@ -1448,8 +1482,8 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             recovery_transfer,
             wrapped_equity_recovery_store,
             unwrapped_equity_recovery_store,
-            mint_store,
-            redemption_store,
+            mint_store: built.mint,
+            redemption_store: built.redemption,
             transfer_usdc_to_hedging_ctx,
             transfer_usdc_to_market_making_ctx,
             transfer_equity_to_market_making_ctx,
@@ -2843,6 +2877,30 @@ mod tests {
         .unwrap();
     }
 
+    async fn insert_job_row(
+        apalis_pool: &apalis_sqlite::SqlitePool,
+        id: &str,
+        job_type: &str,
+        status: Status,
+        attempts: i64,
+        max_attempts: i64,
+    ) {
+        sqlx_apalis::query(
+            "INSERT INTO Jobs \
+             (job, id, job_type, status, attempts, max_attempts, run_at, priority) \
+             VALUES (?, ?, ?, ?, ?, ?, 0, 0)",
+        )
+        .bind(vec![0_u8])
+        .bind(id)
+        .bind(job_type)
+        .bind(status.to_string())
+        .bind(attempts)
+        .bind(max_attempts)
+        .execute(apalis_pool)
+        .await
+        .unwrap();
+    }
+
     #[tokio::test]
     async fn requeue_recovery_orphans_resets_unwrapped_recovery_rows() {
         let (_pool, apalis_pool) = setup_test_pools().await;
@@ -2976,6 +3034,7 @@ mod tests {
             inventory.clone(),
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         );
 
         let resume_queue = ResumeTokenizationJobQueue::new(&apalis_pool);
@@ -3342,6 +3401,7 @@ mod tests {
             inventory.clone(),
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         );
 
         let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
@@ -3433,6 +3493,7 @@ mod tests {
             inventory2.clone(),
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool2),
+            Arc::new(crate::alerts::NoopNotifier),
         );
 
         let mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(
@@ -3600,6 +3661,57 @@ mod tests {
         assert!(
             join_error.is_cancelled(),
             "expected cleanup task to be cancelled, got: {join_error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_finished_job_cleanup_retains_usdc_transfer_rows() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let hedging_type = std::any::type_name::<TransferUsdcToHedging>();
+        let market_making_type = std::any::type_name::<TransferUsdcToMarketMaking>();
+
+        // Non-transfer finished rows must be pruned (Done and exhausted Failed).
+        insert_job_row(&apalis_pool, "other-done", "test", Status::Done, 1, 25).await;
+        insert_job_row(&apalis_pool, "other-failed", "test", Status::Failed, 25, 25).await;
+
+        // USDC transfer finished rows must survive cleanup: they are the durable
+        // startup re-arm idempotency + redrive-budget signal.
+        insert_job_row(
+            &apalis_pool,
+            "hedging-done",
+            hedging_type,
+            Status::Done,
+            1,
+            25,
+        )
+        .await;
+        insert_job_row(
+            &apalis_pool,
+            "market-making-failed",
+            market_making_type,
+            Status::Failed,
+            25,
+            25,
+        )
+        .await;
+
+        let handle =
+            spawn_finished_job_cleanup(pool.clone(), apalis_pool.clone(), Duration::from_secs(60));
+
+        // The two non-transfer finished rows are pruned; the two transfer rows remain.
+        wait_for_job_count(&apalis_pool, 2).await;
+        handle.abort();
+
+        let mut remaining: Vec<String> = sqlx_apalis::query_scalar("SELECT job_type FROM Jobs")
+            .fetch_all(&apalis_pool)
+            .await
+            .unwrap();
+        remaining.sort();
+        let mut expected = vec![hedging_type.to_string(), market_making_type.to_string()];
+        expected.sort();
+        assert_eq!(
+            remaining, expected,
+            "USDC transfer finished rows must survive cleanup regardless of Done/Failed status"
         );
     }
 
@@ -5952,6 +6064,7 @@ mod tests {
             inventory,
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
         let reactor = trigger.clone();
 
@@ -6060,6 +6173,7 @@ mod tests {
             Arc::clone(&inventory),
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
         let reactor = trigger.clone();
 
@@ -6178,6 +6292,7 @@ mod tests {
             inventory,
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
         let reactor = trigger.clone();
 
@@ -6314,6 +6429,7 @@ mod tests {
             inventory,
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
         let reactor = trigger.clone();
 
@@ -7713,5 +7829,42 @@ mod tests {
             !is_pre_wrap_held_for_recovery(&tokens_wrapped, &equity_in_progress),
             "TokensWrapped must NEVER be excluded (deposit idempotent)"
         );
+    }
+
+    /// When `[alerts]` is absent, `build_usdc_notifier` returns a `NoopNotifier`
+    /// that silently discards notifications without error.
+    #[tokio::test]
+    async fn build_usdc_notifier_returns_ok_noop_when_alerts_absent() {
+        let notifier = build_usdc_notifier(None).unwrap();
+        notifier
+            .notify("test message")
+            .await
+            .expect("NoopNotifier must not error on notify");
+    }
+
+    /// When `[alerts]` IS present, `build_usdc_notifier` constructs a real
+    /// Telegram notifier and returns `Ok` -- it must NOT fail startup for a
+    /// well-formed config, and it must NOT silently fall back to `NoopNotifier`
+    /// (which would suppress every redrive-limit and terminal-error page).
+    ///
+    /// The error branch (`Err(NotifierError::ClientBuild)`) is only reachable on
+    /// a reqwest/TLS backend init failure; it cannot be triggered deterministically
+    /// from the `AlertsCtx` inputs, so it is not unit-testable here. At the call
+    /// site the `?` propagation fails startup, which is the behaviour that matters.
+    /// `notify()` is deliberately not exercised: the present-branch notifier posts
+    /// to the live Telegram API, which a unit test must never reach.
+    #[tokio::test]
+    async fn build_usdc_notifier_returns_ok_telegram_when_alerts_present() {
+        let alerts = st0x_config::AlertsCtx {
+            chat_id: 123,
+            bot_token: "test-bot-token".to_string(),
+            low_balance_threshold_wei: U256::from(0u64),
+            poll_interval: std::time::Duration::from_secs(60),
+            realert_interval: std::time::Duration::from_secs(3600),
+            message_thread_id: Some(42),
+        };
+
+        build_usdc_notifier(Some(&alerts))
+            .expect("a well-formed [alerts] config must yield a notifier, not a startup error");
     }
 }

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -207,6 +207,7 @@ mod tests {
             inventory.clone(),
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
 
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
@@ -265,6 +266,7 @@ mod tests {
             inventory.clone(),
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
@@ -381,6 +383,7 @@ mod tests {
             inventory,
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));

--- a/src/conductor/monitor/gas.rs
+++ b/src/conductor/monitor/gas.rs
@@ -285,10 +285,7 @@ mod tests {
 
     #[async_trait]
     impl Notifier for CapturingNotifier {
-        async fn notify(
-            &self,
-            message: &str,
-        ) -> Result<(), crate::alerts::telegram::NotifierError> {
+        async fn notify(&self, message: &str) -> Result<(), crate::alerts::NotifierError> {
             self.messages.lock().unwrap().push(message.to_owned());
             Ok(())
         }

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -288,6 +288,7 @@ async fn setup_equity_trigger() -> EquityTriggerFixture {
         Arc::clone(&inventory),
         wrapper,
         RebalancingSchedulers::new(&apalis_pool),
+        Arc::new(crate::alerts::NoopNotifier),
     ));
 
     let position_cqrs = build_position_cqrs_with_service(&pool, &service).await;
@@ -1158,6 +1159,7 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
         Arc::clone(&inventory),
         wrapper,
         RebalancingSchedulers::new(&apalis_pool),
+        Arc::new(crate::alerts::NoopNotifier),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1242,6 +1244,7 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
         Arc::clone(&inventory),
         wrapper,
         RebalancingSchedulers::new(&apalis_pool),
+        Arc::new(crate::alerts::NoopNotifier),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1344,6 +1347,7 @@ async fn cash_reserve_does_not_shift_rebalancing_ratio() {
         Arc::clone(&inventory),
         wrapper,
         RebalancingSchedulers::new(&apalis_pool),
+        Arc::new(crate::alerts::NoopNotifier),
     ));
 
     // Build snapshot store with the service as the CQRS subscriber — mirrors
@@ -1487,6 +1491,7 @@ async fn balanced_usdc_without_reserve_triggers_no_rebalancing() {
         Arc::clone(&inventory),
         wrapper,
         RebalancingSchedulers::new(&apalis_pool),
+        Arc::new(crate::alerts::NoopNotifier),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1543,6 +1548,7 @@ async fn usdc_alpaca_to_base_skips_when_withdrawable_cash_missing_with_reserve()
         Arc::clone(&inventory),
         wrapper,
         RebalancingSchedulers::new(&apalis_pool),
+        Arc::new(crate::alerts::NoopNotifier),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1589,6 +1595,7 @@ async fn usdc_none_disables_usdc_rebalancing() {
         Arc::clone(&inventory),
         wrapper,
         RebalancingSchedulers::new(&apalis_pool),
+        Arc::new(crate::alerts::NoopNotifier),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1802,6 +1809,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
         Arc::clone(&inventory),
         wrapper,
         RebalancingSchedulers::new(&apalis_pool),
+        Arc::new(crate::alerts::NoopNotifier),
     );
 
     // Cycle 1: excess = 450, capped to 100
@@ -1929,6 +1937,7 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
         Arc::clone(&inventory),
         wrapper,
         RebalancingSchedulers::new(&apalis_pool),
+        Arc::new(crate::alerts::NoopNotifier),
     );
 
     // First trigger fires: excess = 400, capped to 100
@@ -2025,6 +2034,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
             Arc::clone(&inventory),
             wrapper,
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         );
 
         trigger.check_and_trigger_usdc().await;
@@ -2083,6 +2093,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
             Arc::clone(&inventory),
             wrapper,
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         );
 
         trigger.check_and_trigger_usdc().await;

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -1871,6 +1871,7 @@ mod tests {
             inventory.clone(),
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
 
         // Reactor-wired stores -- the production wiring that dispatches committed
@@ -2016,6 +2017,7 @@ mod tests {
             inventory.clone(),
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
 
         let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
@@ -2339,6 +2341,7 @@ mod tests {
             inventory,
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
 
         let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -491,6 +491,7 @@ pub(crate) struct RebalancingService {
     pub(crate) equity_in_progress: Arc<std::sync::RwLock<HashMap<Symbol, equity::GuardState>>>,
     pending_offchain_order_symbols: Arc<RwLock<HashSet<Symbol>>>,
     pub(crate) usdc_in_progress: Arc<AtomicBool>,
+    notifier: Arc<dyn crate::alerts::Notifier>,
     wrapper: Arc<dyn Wrapper>,
     pub(super) equity_scheduler: EquityRebalancingCheckScheduler,
     pub(super) usdc_scheduler: UsdcRebalancingCheckScheduler,
@@ -523,6 +524,12 @@ pub(crate) struct RebalancingService {
     /// `last_progress_at` never advances, so every sweep re-selects it. This
     /// set deduplicates the error log to once per stuck transfer.
     post_burn_timeout_logged: Arc<RwLock<HashSet<UsdcRebalanceId>>>,
+    /// Ids of post-burn-stuck USDC rebalances whose operator alert has been
+    /// delivered successfully. Tracked separately from `post_burn_timeout_logged`
+    /// so a transient notifier failure on the first sweep does not permanently
+    /// silence the page about stranded funds: the alert is re-attempted on every
+    /// sweep until one delivery succeeds, while the error log stays one-shot.
+    post_burn_timeout_alerted: Arc<RwLock<HashSet<UsdcRebalanceId>>>,
     mint_event_sync: Arc<Mutex<()>>,
     redemption_event_sync: Arc<Mutex<()>>,
     usdc_event_sync: Arc<Mutex<()>>,
@@ -559,15 +566,33 @@ enum UsdcTimeoutCleanup {
     },
 }
 
-/// A stranded post-burn USDC rebalance to re-arm on startup. `recoverable_failure`
-/// distinguishes a post-burn `BridgingFailed` (recoverable via the RAI-909 resume
-/// path, so a terminal job row must not block re-arm) from the pre-mint-confirmation
-/// states (where any job row blocks). See [`RebalancingService::rearm_stranded_transfers`].
+/// How [`RebalancingService::rearm_stranded_transfers`] gates re-arm for a
+/// candidate, by the aggregate's recovery semantics.
+enum RearmPolicy {
+    /// Post-burn `BridgingFailed` (RAI-909): re-checking the mint is NEW work,
+    /// so a terminal `Failed`/`Done` row must NOT block -- gate on a live job
+    /// only.
+    RecoverableFailure,
+    /// Post-burn pre-mint resumable (`Bridging`/`AwaitingAttestation`/
+    /// `Attested`): any job row -- in-flight or terminal -- blocks re-arm so an
+    /// exhausted retry budget is never bypassed.
+    PostBurnResumable,
+    /// Pre-burn mid-flight (`BridgingSubmitting` /
+    /// `WithdrawalSubmitting{BaseToAlpaca}`): re-arm only when NO job row exists.
+    /// A live row means apalis is still driving it (skip). A terminal-only row
+    /// means the redrive budget is exhausted with no driver -- strand it for an
+    /// operator alert rather than silently resetting the counter to zero.
+    MidFlightPreBurn,
+}
+
+/// A stranded USDC rebalance to re-arm on startup, with the [`RearmPolicy`] that
+/// governs how a pre-existing job row gates the re-arm. See
+/// [`RebalancingService::rearm_stranded_transfers`].
 struct RearmCandidate {
     id: UsdcRebalanceId,
     direction: RebalanceDirection,
     amount: Usdc,
-    recoverable_failure: bool,
+    policy: RearmPolicy,
 }
 
 impl RebalancingService {
@@ -579,6 +604,7 @@ impl RebalancingService {
         inventory: Arc<BroadcastingInventory>,
         wrapper: Arc<dyn Wrapper>,
         schedulers: RebalancingSchedulers,
+        notifier: Arc<dyn crate::alerts::Notifier>,
     ) -> Self {
         let RebalancingSchedulers {
             equity: equity_scheduler,
@@ -600,6 +626,7 @@ impl RebalancingService {
             equity_in_progress: Arc::new(std::sync::RwLock::new(HashMap::new())),
             pending_offchain_order_symbols: Arc::new(RwLock::new(HashSet::new())),
             usdc_in_progress: Arc::new(AtomicBool::new(false)),
+            notifier,
             wrapper,
             equity_scheduler,
             usdc_scheduler,
@@ -617,6 +644,7 @@ impl RebalancingService {
             timed_out_redemptions: Arc::new(RwLock::new(HashMap::new())),
             timed_out_usdc_rebalances: Arc::new(RwLock::new(HashMap::new())),
             post_burn_timeout_logged: Arc::new(RwLock::new(HashSet::new())),
+            post_burn_timeout_alerted: Arc::new(RwLock::new(HashSet::new())),
             mint_event_sync: Arc::new(Mutex::new(())),
             redemption_event_sync: Arc::new(Mutex::new(())),
             usdc_event_sync: Arc::new(Mutex::new(())),
@@ -1000,6 +1028,31 @@ impl RebalancingService {
                             ?elapsed,
                             "USDC transfer timed out after CCTP burn; preserving trigger guard and inventory inflight"
                         );
+                    }
+
+                    // Alert delivery is deduped separately from the one-shot log:
+                    // a transient notifier failure must NOT permanently silence the
+                    // operator page about stranded funds. Re-attempt on every sweep
+                    // until one delivery succeeds, then record it so it is not re-sent.
+                    let already_alerted = self.post_burn_timeout_alerted.read().await.contains(&id);
+
+                    if !already_alerted {
+                        match self.notifier.notify(&format!(
+                            "USDC transfer {id} timed out after CCTP burn and is stalled. \
+                             Guard preserved. Stage: {}. Elapsed: {elapsed:?}. Manual operator action required.",
+                            tracking.stage,
+                        )).await {
+                            Ok(()) => {
+                                self.post_burn_timeout_alerted.write().await.insert(id.clone());
+                            }
+                            Err(error) => {
+                                warn!(
+                                    target: "rebalance",
+                                    ?error,
+                                    "Failed to deliver USDC post-burn stall alert; will retry next sweep"
+                                );
+                            }
+                        }
                     }
                 }
             }
@@ -2755,6 +2808,7 @@ impl RebalancingService {
             .push(TransferUsdcToHedging {
                 id: id.clone(),
                 amount,
+                revert_redrive_attempts: 0,
             })
             .await;
 
@@ -2823,6 +2877,7 @@ impl RebalancingService {
             .push(TransferUsdcToMarketMaking {
                 id: id.clone(),
                 amount,
+                revert_redrive_attempts: 0,
             })
             .await;
 
@@ -3195,6 +3250,11 @@ impl RebalancingService {
 
         let mut held_ids = Vec::new();
         let mut held_tracking = Vec::new();
+        // Guard-holding aggregates with no tracking seed AND no re-arm path
+        // (e.g. WithdrawalSubmitting{AlpacaToBase}): the sweep never selects
+        // them, so there is no automated recovery. The operator must be paged
+        // so they know to run manual reconciliation.
+        let mut stranded_held_ids: Vec<UsdcRebalanceId> = Vec::new();
         let mut unresolved_ids = Vec::new();
         let mut rearm_candidates = Vec::new();
         for id in candidate_ids {
@@ -3249,14 +3309,70 @@ impl RebalancingService {
 
                     if let Some((direction, amount)) = entity.resumable_post_burn_transfer() {
                         rearm_candidates.push(RearmCandidate {
-                            recoverable_failure: matches!(
-                                &entity,
-                                UsdcRebalance::BridgingFailed { .. }
-                            ),
+                            policy: if matches!(&entity, UsdcRebalance::BridgingFailed { .. }) {
+                                RearmPolicy::RecoverableFailure
+                            } else {
+                                RearmPolicy::PostBurnResumable
+                            },
                             id,
                             direction,
                             amount,
                         });
+                    } else if let Some((direction, amount)) = entity.is_resumable_mid_flight_data()
+                    {
+                        // Pre-burn states (BridgingSubmitting / WithdrawalSubmitting{BaseToAlpaca})
+                        // with no job row: the process crashed before the enqueue
+                        // committed or before the tx was submitted. Safe to re-arm
+                        // because these states are non-terminal and resumable: the
+                        // resume path scans for any existing on-chain effect before
+                        // re-attempting.
+                        //
+                        // WithdrawalSubmitting{AlpacaToBase} is excluded by
+                        // is_resumable_mid_flight_data: resume_alpaca_to_base returns
+                        // ResumeDirectionMismatch for that state so it must not be re-armed.
+                        //
+                        // IMPORTANT: These states must NOT get a tracking seed (only
+                        // DepositFailed, ConversionFailed, and BridgingFailed{burn_tx=Some}
+                        // get tracking seeds). Adding tracking here would wedge the
+                        // DepositConfirmed path which requires bridged_amount_received
+                        // that the seed cannot supply.
+                        //
+                        // This re-arm runs BEFORE the apalis monitor spawns (see
+                        // conductor.rs startup order), so there is no live-worker race.
+                        // The transfer_has_job_row_for_id gate below provides idempotency
+                        // on the very first check; we collect here and gate in
+                        // rearm_stranded_transfers.
+                        rearm_candidates.push(RearmCandidate {
+                            policy: RearmPolicy::MidFlightPreBurn,
+                            id,
+                            direction,
+                            amount,
+                        });
+                    } else if entity.holds_rebalance_guard()
+                        && entity.guard_recovery_tracking_data().is_none()
+                        && !self.transfer_live_job_for_id(&id).await?
+                    {
+                        // This held aggregate has no tracking seed (so the
+                        // sweep never selects it), no re-arm path (so startup
+                        // recovery does not enqueue a job), AND no live apalis
+                        // job that already owns it. With no driver it latches
+                        // usdc_in_progress with no automated recovery. Collect
+                        // for operator alert so the blocked state is visible
+                        // immediately rather than surfacing only through log
+                        // monitoring.
+                        //
+                        // The live-job probe guards a false positive: when
+                        // apalis still owns a Pending/Running/retryable job for
+                        // this id (e.g. a Converting/Bridged/DepositInitiated
+                        // aggregate that the interrupted transfer job will
+                        // resume on its own), that job is the driver -- alerting
+                        // here would duplicate the page the live job itself
+                        // raises if it ultimately fails. Notably:
+                        // WithdrawalSubmitting{AlpacaToBase} ends up here (when
+                        // no live job remains) because resume_alpaca_to_base
+                        // returns ResumeDirectionMismatch for it (see
+                        // is_resumable_mid_flight_data).
+                        stranded_held_ids.push(id);
                     }
                 }
                 // The id came from the event log, so a missing or unreplayable
@@ -3291,7 +3407,8 @@ impl RebalancingService {
         // resumable aggregate always holds the guard, so this set is non-empty
         // only when `held_ids` is too. Propagates on failure so startup recovery
         // fails fast rather than coming up with a latched guard and no driving job.
-        self.rearm_stranded_transfers(rearm_candidates).await?;
+        let stranded_after_exhaustion = self.rearm_stranded_transfers(rearm_candidates).await?;
+        stranded_held_ids.extend(stranded_after_exhaustion);
 
         // An unparseable candidate aggregate_id cannot be loaded or classified,
         // so it joins the unresolved set: hold the guard rather than risk leaving
@@ -3319,32 +3436,66 @@ impl RebalancingService {
              new USDC rebalancing is blocked until they settle or are recovered"
         );
 
+        // Alert the operator for any aggregate that latches the guard with no
+        // automated recovery path (no tracking seed, no re-arm). This covers:
+        // - WithdrawalSubmitting{AlpacaToBase}: deliberately excluded from
+        //   is_resumable_mid_flight_data because resume_alpaca_to_base returns
+        //   ResumeDirectionMismatch for it. No job drives it forward.
+        // - unresolved: aggregates missing from the store or that failed to
+        //   load. Cannot be classified; guard held defensively.
+        // - unparseable: aggregate ids that could not be parsed. Same as above.
+        // Without this alert the operator would only discover the blocked state
+        // through log monitoring or by noticing USDC rebalancing has stopped.
+        let has_stranded =
+            !stranded_held_ids.is_empty() || !unresolved_ids.is_empty() || !unparseable.is_empty();
+        if has_stranded {
+            let message = format!(
+                "USDC rebalancing is LATCHED on startup with no automated recovery. \
+                 stranded={stranded_held_ids:?} unresolved={unresolved_ids:?} \
+                 unparseable={unparseable:?}. \
+                 Run `resume-usdc-transfer` or `reconcile-usdc-transfer` to unblock. \
+                 Rebalancing is blocked until manually resolved."
+            );
+            if let Err(error) = self.notifier.notify(&message).await {
+                warn!(target: "rebalance", ?error, "Failed to deliver USDC startup-stranded alert");
+            }
+        }
+
         Ok(())
     }
 
-    /// Re-enqueues a transfer job for each stranded post-burn rebalance, keyed by
-    /// the existing aggregate id so the resumed job hits the same aggregate.
+    /// Re-enqueues a transfer job for each stranded rebalance that still needs a
+    /// driver, keyed by the existing aggregate id so the resumed job hits the
+    /// same aggregate. Returns the ids of pre-burn mid-flight candidates whose
+    /// redrive budget is already exhausted (a terminal-only job row, no live
+    /// driver), so the caller can fold them into the startup operator alert
+    /// rather than silently resetting their counter.
     ///
-    /// The skip gate depends on the candidate's state:
+    /// The skip gate depends on the candidate's [`RearmPolicy`]:
     ///
-    /// - A pre-mint-confirmation post-burn state (`Bridging`/`AwaitingAttestation`/
-    ///   `Attested`) is re-armed only for the true "no job row at all" strand: any
-    ///   job row -- in-flight OR a terminal `Failed` awaiting operator
-    ///   reconciliation -- skips it via [`Self::transfer_has_job_row_for_id`], so
-    ///   re-arm never bypasses the retry budget of a job that already ran and gave
-    ///   up.
-    /// - A post-burn `BridgingFailed` (`recoverable_failure`) is recoverable
-    ///   (RAI-909): re-checking the mint on-chain and un-failing the aggregate is
-    ///   NEW work, not a continuation of the original transfer's exhausted budget,
-    ///   so a terminal `Failed`/`Done` row must NOT block it (that row is the
-    ///   normal artifact of the job that drove it to the failed state). Only a
-    ///   row apalis still owns -- in-flight OR a `Failed` row with retries
+    /// - [`RearmPolicy::RecoverableFailure`] (post-burn `BridgingFailed`,
+    ///   RAI-909): re-checking the mint on-chain and un-failing the aggregate is
+    ///   NEW work, not a continuation of the original transfer's exhausted
+    ///   budget, so a terminal `Failed`/`Done` row must NOT block it (that row is
+    ///   the normal artifact of the job that drove it to the failed state). Only
+    ///   a row apalis still owns -- in-flight OR a `Failed` row with retries
     ///   remaining -- skips it, via [`Self::transfer_live_job_for_id`], so we
     ///   never drive two concurrent resumes of the same id. A genuinely
     ///   unrecoverable transfer re-arms again on each restart once its retry
-    ///   budget is spent; that is acceptable for committed burned funds (and an
-    ///   operator alert should fire on the repeated failure) and is the price of
-    ///   not abandoning recoverable funds.
+    ///   budget is spent; that is acceptable for committed burned funds and is
+    ///   the price of not abandoning recoverable funds.
+    /// - [`RearmPolicy::PostBurnResumable`] (pre-mint-confirmation
+    ///   `Bridging`/`AwaitingAttestation`/`Attested`): re-armed only for the true
+    ///   "no job row at all" strand: any job row -- in-flight OR a terminal
+    ///   `Failed` awaiting operator reconciliation -- skips it via
+    ///   [`Self::transfer_has_job_row_for_id`], so re-arm never bypasses the
+    ///   retry budget of a job that already ran and gave up.
+    /// - [`RearmPolicy::MidFlightPreBurn`] (pre-burn `BridgingSubmitting` /
+    ///   `WithdrawalSubmitting{BaseToAlpaca}`): re-armed only when NO job row
+    ///   exists. A live row means apalis is still driving it (skip silently). A
+    ///   terminal-only row means the redrive budget is exhausted with no driver:
+    ///   rather than silently re-arming with a fresh budget, the id is stranded
+    ///   and returned for the operator alert.
     ///
     /// An enqueue failure (or a probe failure) is propagated so startup recovery
     /// fails fast and the supervisor retries -- consistent with the
@@ -3353,26 +3504,41 @@ impl RebalancingService {
     async fn rearm_stranded_transfers(
         &self,
         candidates: Vec<RearmCandidate>,
-    ) -> Result<(), RebalancingServiceError> {
+    ) -> Result<Vec<UsdcRebalanceId>, RebalancingServiceError> {
+        let mut stranded_after_exhaustion: Vec<UsdcRebalanceId> = Vec::new();
+
         for RearmCandidate {
             id,
             direction,
             amount,
-            recoverable_failure,
+            policy,
         } in candidates
         {
-            let blocked = if recoverable_failure {
-                self.transfer_live_job_for_id(&id).await?
-            } else {
-                self.transfer_has_job_row_for_id(&id).await?
+            let blocked = match policy {
+                RearmPolicy::RecoverableFailure => self.transfer_live_job_for_id(&id).await?,
+                RearmPolicy::PostBurnResumable => self.transfer_has_job_row_for_id(&id).await?,
+                RearmPolicy::MidFlightPreBurn => {
+                    let live = self.transfer_live_job_for_id(&id).await?;
+                    let stranded_by_exhaustion =
+                        !live && self.transfer_has_job_row_for_id(&id).await?;
+                    if stranded_by_exhaustion {
+                        warn!(
+                            target: "rebalance",
+                            %id,
+                            "Pre-burn mid-flight transfer has a terminal job row (redrive budget \
+                             exhausted) and no live driver; stranding for operator alert"
+                        );
+                        stranded_after_exhaustion.push(id.clone());
+                    }
+                    live || stranded_by_exhaustion
+                }
             };
 
             if blocked {
                 debug!(
                     target: "rebalance",
                     %id,
-                    recoverable_failure,
-                    "Post-burn transfer already has a blocking job row on startup; not re-arming",
+                    "Transfer already has a blocking job row on startup; not re-arming",
                 );
                 continue;
             }
@@ -3384,6 +3550,7 @@ impl RebalancingService {
                         .push(TransferUsdcToHedging {
                             id: id.clone(),
                             amount,
+                            revert_redrive_attempts: 0,
                         })
                         .await?;
                 }
@@ -3393,6 +3560,7 @@ impl RebalancingService {
                         .push(TransferUsdcToMarketMaking {
                             id: id.clone(),
                             amount,
+                            revert_redrive_attempts: 0,
                         })
                         .await?;
                 }
@@ -3403,11 +3571,11 @@ impl RebalancingService {
                 %id,
                 ?direction,
                 %amount,
-                "Re-armed a stranded post-burn USDC transfer with no job row on startup",
+                "Re-armed a stranded USDC transfer with no job row on startup",
             );
         }
 
-        Ok(())
+        Ok(stranded_after_exhaustion)
     }
 
     pub(crate) async fn recover_mint_state(
@@ -4301,6 +4469,7 @@ mod tests {
     use st0x_wrapper::MockWrapper;
 
     use super::*;
+    use crate::alerts::{CapturingNotifier, NoopNotifier};
     use crate::conductor::job::Job;
     use crate::equity_redemption::{DetectionFailure, redemption_aggregate_id};
     use crate::inventory::snapshot::{
@@ -4416,6 +4585,7 @@ mod tests {
             inventory,
             wrapper,
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ))
     }
 
@@ -4458,6 +4628,7 @@ mod tests {
             inventory,
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         );
 
         service.enqueue_recovery_for_current_wallet_balances().await;
@@ -4512,6 +4683,7 @@ mod tests {
             inventory,
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         );
 
         service.enqueue_recovery_for_current_wallet_balances().await;
@@ -4566,6 +4738,7 @@ mod tests {
             inventory,
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         );
 
         service.enqueue_recovery_for_current_wallet_balances().await;
@@ -4682,6 +4855,7 @@ mod tests {
             inventory,
             wrapper,
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ))
     }
 
@@ -6301,6 +6475,7 @@ mod tests {
             inventory,
             wrapper,
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         );
 
         trigger.check_and_trigger_usdc().await;
@@ -6691,6 +6866,15 @@ mod tests {
         inventory: InventoryView,
         config: RebalancingServiceConfig,
     ) -> Arc<RebalancingService> {
+        make_trigger_with_inventory_config_and_notifier(inventory, config, Arc::new(NoopNotifier))
+            .await
+    }
+
+    async fn make_trigger_with_inventory_config_and_notifier(
+        inventory: InventoryView,
+        config: RebalancingServiceConfig,
+        notifier: Arc<dyn crate::alerts::Notifier>,
+    ) -> Arc<RebalancingService> {
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
@@ -6703,6 +6887,7 @@ mod tests {
             inventory,
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            notifier,
         ))
     }
 
@@ -6925,6 +7110,7 @@ mod tests {
             inventory,
             wrapper,
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ))
     }
 
@@ -6995,6 +7181,7 @@ mod tests {
             inventory,
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
         let reactor = trigger.clone();
 
@@ -11038,6 +11225,7 @@ mod tests {
             .push(TransferUsdcToHedging {
                 id: id.clone(),
                 amount: usdc(400),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -11105,6 +11293,7 @@ mod tests {
             .push(TransferUsdcToHedging {
                 id: id.clone(),
                 amount: usdc(400),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -11138,6 +11327,7 @@ mod tests {
             .push(TransferUsdcToMarketMaking {
                 id: id.clone(),
                 amount: usdc(400),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -11166,6 +11356,7 @@ mod tests {
             .push(TransferUsdcToHedging {
                 id: id.clone(),
                 amount: usdc(400),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -11213,6 +11404,7 @@ mod tests {
             .push(TransferUsdcToHedging {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -11242,6 +11434,7 @@ mod tests {
             .push(TransferUsdcToMarketMaking {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -11280,6 +11473,7 @@ mod tests {
             .push(TransferUsdcToMarketMaking {
                 id: id.clone(),
                 amount: usdc(400),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -11386,6 +11580,59 @@ mod tests {
             count_pending_transfer_usdc_to_market_making_jobs(&trigger).await,
             0,
             "post-burn USDC timeout must not allow another rebalance dispatch"
+        );
+    }
+
+    /// The post-burn stall sweep arm must fire exactly one operator alert (carrying
+    /// the transfer id) so the latched guard is not silent. The test above asserts
+    /// the guard/inflight are preserved; this asserts the alert side-effect by
+    /// injecting a capturing notifier.
+    #[tokio::test]
+    async fn timed_out_post_burn_usdc_rebalance_alerts_operator() {
+        let now = Utc::now();
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(100), usdc(900))
+            .with_withdrawable_cash_cents(90_000)
+            .update_usdc(
+                Inventory::transfer(Venue::Hedging, TransferOp::Start, usdc(400)),
+                now,
+            )
+            .unwrap();
+        let notifier = Arc::new(CapturingNotifier::default());
+        let reactor = make_trigger_with_inventory_config_and_notifier(
+            inventory,
+            test_config_with_timeout(Duration::from_secs(1)),
+            notifier.clone(),
+        )
+        .await;
+        let trigger = reactor.clone();
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: usdc(400),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::BridgingInitiated,
+                last_progress_at: now - ChronoDuration::minutes(31),
+            },
+        );
+
+        trigger.check_and_trigger_usdc().await;
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "a timed-out post-burn USDC transfer must fire exactly one operator alert; \
+             got: {messages:?}"
+        );
+        assert!(
+            messages[0].contains(&id.to_string()),
+            "the post-burn stall alert must carry the transfer id; got: {:?}",
+            messages[0]
         );
     }
 
@@ -12701,6 +12948,108 @@ mod tests {
         );
     }
 
+    /// A [`Notifier`] that returns `Err` for its first `remaining_failures`
+    /// calls, then succeeds, capturing every successfully delivered message.
+    /// Lets a test prove the post-burn stall alert is re-attempted across sweeps
+    /// after a transient delivery failure rather than silenced forever.
+    struct FlakyNotifier {
+        remaining_failures: std::sync::atomic::AtomicUsize,
+        delivered: std::sync::Mutex<Vec<String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::alerts::Notifier for FlakyNotifier {
+        async fn notify(&self, message: &str) -> Result<(), crate::alerts::NotifierError> {
+            let should_fail = self
+                .remaining_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok();
+
+            if should_fail {
+                return Err(crate::alerts::NotifierError::ApiError {
+                    status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                    body: "simulated transient failure".to_string(),
+                });
+            }
+
+            self.delivered.lock().unwrap().push(message.to_string());
+            Ok(())
+        }
+    }
+
+    /// A transient notifier failure on the first sweep must not permanently
+    /// silence the operator page: the alert is re-attempted on the next sweep and
+    /// recorded once it succeeds, then never re-sent.
+    #[tokio::test]
+    async fn post_burn_usdc_timeout_alert_retries_after_transient_failure() {
+        let now = Utc::now();
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(100), usdc(900))
+            .with_withdrawable_cash_cents(90_000)
+            .update_usdc(
+                Inventory::transfer(Venue::Hedging, TransferOp::Start, usdc(400)),
+                now,
+            )
+            .unwrap();
+        let notifier = Arc::new(FlakyNotifier {
+            remaining_failures: std::sync::atomic::AtomicUsize::new(1),
+            delivered: std::sync::Mutex::new(Vec::new()),
+        });
+        let trigger = make_trigger_with_inventory_config_and_notifier(
+            inventory,
+            test_config_with_timeout(Duration::from_secs(1)),
+            notifier.clone(),
+        )
+        .await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: usdc(400),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::BridgingInitiated,
+                last_progress_at: now - ChronoDuration::minutes(31),
+            },
+        );
+
+        // First sweep: delivery fails, so the alert must not be recorded as sent
+        // and nothing is captured.
+        trigger.check_and_trigger_usdc().await;
+        assert!(
+            !trigger.post_burn_timeout_alerted.read().await.contains(&id),
+            "a failed alert delivery must not be recorded as alerted"
+        );
+        assert!(
+            notifier.delivered.lock().unwrap().is_empty(),
+            "no alert should be captured while delivery is failing"
+        );
+
+        // Second sweep: delivery succeeds, the alert lands and is recorded.
+        trigger.check_and_trigger_usdc().await;
+        assert_eq!(
+            notifier.delivered.lock().unwrap().len(),
+            1,
+            "the alert must be re-attempted on the next sweep and delivered once it succeeds"
+        );
+        assert!(
+            trigger.post_burn_timeout_alerted.read().await.contains(&id),
+            "a successful delivery must be recorded so it is not re-sent"
+        );
+
+        // Third sweep: already delivered, so no further attempts.
+        trigger.check_and_trigger_usdc().await;
+        assert_eq!(
+            notifier.delivered.lock().unwrap().len(),
+            1,
+            "a delivered alert must not be re-sent on subsequent sweeps"
+        );
+    }
+
     #[tokio::test]
     async fn recover_usdc_guard_reasserts_guard_for_post_burn_bridging_failure() {
         let pool = crate::test_utils::setup_test_db().await;
@@ -12809,6 +13158,716 @@ mod tests {
             service.usdc_in_progress.load(Ordering::SeqCst),
             "a crash at BridgingSubmitting (burn possibly already broadcast) must \
              re-assert the USDC guard on startup"
+        );
+    }
+
+    /// Drives a `UsdcRebalance` aggregate to `BridgingSubmitting` for the
+    /// Base->Alpaca direction. This is the pre-burn intent marker written
+    /// immediately before the irreversible CCTP burn call.
+    async fn seed_bridging_submitting_base_to_alpaca(
+        store: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        burn_tx: TxHash,
+    ) {
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount,
+                    withdrawal: TransferRef::OnchainTx(burn_tx),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::BeginBridging {
+                    from_block: 99,
+                    burn_amount: None,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    /// Drives a `UsdcRebalance` aggregate to `WithdrawalSubmitting` for the
+    /// Base->Alpaca direction. This is the pre-withdrawal-tx intent marker.
+    ///
+    /// Uses `BeginWithdrawal{BaseToAlpaca}` from the `Uninitialized` state,
+    /// which only accepts `BaseToAlpaca` (no conversion leg required).
+    async fn seed_withdrawal_submitting_base_to_alpaca(
+        store: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) {
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::BeginWithdrawal {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount,
+                    from_block: 10,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    /// Seeds a `WithdrawalSubmitting{AlpacaToBase}` aggregate. This requires the
+    /// conversion leg first (InitiateConversion -> ConfirmConversion) before
+    /// `BeginWithdrawal{AlpacaToBase}` is valid.
+    async fn seed_withdrawal_submitting_alpaca_to_base(
+        store: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) {
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::InitiateConversion {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount,
+                    order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::ConfirmConversion {
+                    filled_amount: amount,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::BeginWithdrawal {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount,
+                    from_block: 10,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    /// KNOWN LIMITATION: `WithdrawalSubmitting{AlpacaToBase}` is deliberately
+    /// excluded from the startup re-arm because `resume_alpaca_to_base` returns
+    /// `ResumeDirectionMismatch` for that state. The transfer must be recovered manually
+    /// via `resume-usdc-transfer` or `reconcile-usdc-transfer`. The operator is alerted
+    /// on startup (see `recover_usdc_guard_alerts_on_stranded_withdrawal_submitting_alpaca_to_base`).
+    /// This test asserts the deliberate exclusion is preserved -- a regression that
+    /// accidentally re-armed this state would immediately fail the market-making job.
+    #[tokio::test]
+    async fn recover_usdc_guard_does_not_rearm_withdrawal_submitting_alpaca_to_base() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(300);
+
+        seed_withdrawal_submitting_alpaca_to_base(&store, &id, amount).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&service).await,
+            0,
+            "WithdrawalSubmitting{{AlpacaToBase}} must NOT be re-armed as a hedging job",
+        );
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&service).await,
+            0,
+            "WithdrawalSubmitting{{AlpacaToBase}} must NOT be re-armed as a market-making job",
+        );
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress must remain latched (WithdrawalSubmitting holds the guard \
+             even without re-arming)",
+        );
+    }
+
+    /// `WithdrawalSubmitting{AlpacaToBase}` has no automated recovery path: the
+    /// sweep never selects it (no tracking seed) and it is not re-armed (excluded
+    /// from `is_resumable_mid_flight_data`). This test verifies the operator alert
+    /// fires so the blocked state is not silent.
+    #[tokio::test]
+    async fn recover_usdc_guard_alerts_on_stranded_withdrawal_submitting_alpaca_to_base() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(300);
+
+        seed_withdrawal_submitting_alpaca_to_base(&store, &id, amount).await;
+
+        let notifier = Arc::new(CapturingNotifier::default());
+        let service = make_trigger_with_inventory_config_and_notifier(
+            InventoryView::default(),
+            test_config(),
+            notifier.clone(),
+        )
+        .await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "exactly one operator alert must fire for a stranded WithdrawalSubmitting{{AlpacaToBase}}; got: {messages:?}",
+        );
+        assert!(
+            messages[0].contains("LATCHED"),
+            "alert must say the guard is LATCHED; got: {:?}",
+            messages[0]
+        );
+        assert!(
+            messages[0].contains("resume-usdc-transfer"),
+            "alert must mention the manual recovery command; got: {:?}",
+            messages[0]
+        );
+    }
+
+    /// A `BridgingSubmitting` (Base->Alpaca) aggregate with no job row
+    /// must be re-armed on startup: the process crashed before the enqueue
+    /// committed or before the burn tx was submitted. The resume path scans for
+    /// any existing burn before re-attempting.
+    #[tokio::test]
+    async fn recover_usdc_guard_rearms_bridging_submitting_base_to_alpaca() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let amount = usdc(500);
+
+        seed_bridging_submitting_base_to_alpaca(&store, &id, amount, burn_tx).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&service).await,
+            1,
+            "a BridgingSubmitting Base->Alpaca with no job row must be re-armed as a hedging job",
+        );
+
+        let payload: Vec<u8> = sqlx_apalis::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<TransferUsdcToHedging>())
+        .fetch_one(service.transfer_usdc_to_hedging_queue.pool())
+        .await
+        .unwrap();
+        let job: TransferUsdcToHedging = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            job.id, id,
+            "the re-armed job must resume the same aggregate id",
+        );
+        assert!(
+            job.amount.eq(&amount).unwrap(),
+            "the re-armed job must carry the same amount",
+        );
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress must be latched after re-arming a stranded BridgingSubmitting job",
+        );
+    }
+
+    /// Drives a `UsdcRebalance` aggregate to `BridgingSubmitting` for the
+    /// Alpaca->Base direction. This requires seeding through the full conversion
+    /// and withdrawal legs before `BeginBridging` is valid.
+    async fn seed_bridging_submitting_alpaca_to_base(
+        store: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        withdrawal_tx: TxHash,
+    ) {
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::InitiateConversion {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount,
+                    order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::ConfirmConversion {
+                    filled_amount: amount,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::BeginWithdrawal {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount,
+                    from_block: 10,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount,
+                    withdrawal: TransferRef::OnchainTx(withdrawal_tx),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: Some(withdrawal_tx),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::BeginBridging {
+                    from_block: 99,
+                    burn_amount: None,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    /// A `BridgingSubmitting` (Alpaca->Base) aggregate with no job row
+    /// must be re-armed on startup as a market-making job (not a hedging job).
+    #[tokio::test]
+    async fn recover_usdc_guard_rearms_bridging_submitting_alpaca_to_base() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let withdrawal_tx =
+            fixed_bytes!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let amount = usdc(500);
+
+        seed_bridging_submitting_alpaca_to_base(&store, &id, amount, withdrawal_tx).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&service).await,
+            1,
+            "a BridgingSubmitting Alpaca->Base with no job row must be re-armed as a market-making job",
+        );
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&service).await,
+            0,
+            "BridgingSubmitting Alpaca->Base must NOT be re-armed as a hedging job",
+        );
+
+        let payload: Vec<u8> = sqlx_apalis::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+        .fetch_one(service.transfer_usdc_to_market_making_queue.pool())
+        .await
+        .unwrap();
+        let job: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            job.id, id,
+            "the re-armed job must resume the same aggregate id",
+        );
+        assert!(
+            job.amount.eq(&amount).unwrap(),
+            "the re-armed job must carry the same amount",
+        );
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress must be latched after re-arming a stranded BridgingSubmitting job",
+        );
+    }
+
+    /// A `WithdrawalSubmitting{BaseToAlpaca}` aggregate with no job
+    /// row must be re-armed on startup as a HEDGING job (not market-making).
+    /// `resume_base_to_alpaca` handles `WithdrawalSubmitting`; `resume_alpaca_to_base`
+    /// does not, so `WithdrawalSubmitting{AlpacaToBase}` must NOT be re-armed at all.
+    #[tokio::test]
+    async fn recover_usdc_guard_rearms_withdrawal_submitting() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(300);
+
+        seed_withdrawal_submitting_base_to_alpaca(&store, &id, amount).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&service).await,
+            1,
+            "a WithdrawalSubmitting BaseToAlpaca with no job row must be re-armed as a hedging job",
+        );
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&service).await,
+            0,
+            "WithdrawalSubmitting BaseToAlpaca must NOT be re-armed as a market-making job",
+        );
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress must be latched after re-arming a stranded WithdrawalSubmitting job",
+        );
+    }
+
+    /// A `BridgingSubmitting` aggregate that already has a Pending
+    /// job row must NOT be re-armed -- the existing job will resume it; a second
+    /// job would drive two concurrent resumes of the same aggregate.
+    #[tokio::test]
+    async fn recover_usdc_guard_does_not_rearm_bridging_submitting_with_job_row() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let amount = usdc(500);
+
+        seed_bridging_submitting_base_to_alpaca(&store, &id, amount, burn_tx).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        // Pre-seed a Pending job row (as apalis would have if the enqueue succeeded).
+        service
+            .transfer_usdc_to_hedging_queue
+            .clone()
+            .push(TransferUsdcToHedging {
+                id: id.clone(),
+                amount,
+                revert_redrive_attempts: 0,
+            })
+            .await
+            .unwrap();
+
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&service).await,
+            1,
+            "a BridgingSubmitting aggregate with an existing Pending job row must NOT be re-armed again",
+        );
+    }
+
+    /// A `BridgingSubmitting` aggregate with a terminal `Failed` job
+    /// row must NOT be re-armed -- the failed row is the result of a real
+    /// circuit-breaker trip that requires operator attention.
+    #[tokio::test]
+    async fn recover_usdc_guard_does_not_rearm_bridging_submitting_with_failed_job_row() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
+        let amount = usdc(500);
+
+        seed_bridging_submitting_base_to_alpaca(&store, &id, amount, burn_tx).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        // Pre-seed a Failed job row (circuit opened after retries exhausted).
+        service
+            .transfer_usdc_to_hedging_queue
+            .clone()
+            .push(TransferUsdcToHedging {
+                id: id.clone(),
+                amount,
+                revert_redrive_attempts: 0,
+            })
+            .await
+            .unwrap();
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Failed' WHERE job_type = ?")
+            .bind(std::any::type_name::<TransferUsdcToHedging>())
+            .execute(service.transfer_usdc_to_hedging_queue.pool())
+            .await
+            .unwrap();
+
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&service).await,
+            0,
+            "a BridgingSubmitting aggregate with a terminal Failed job row \
+             must NOT be re-armed; it requires operator attention",
+        );
+    }
+
+    /// A `BridgingSubmitting` (Base->Alpaca) aggregate whose only job
+    /// row is a terminal, retry-budget-exhausted `Failed` (attempts ==
+    /// max_attempts, so apalis no longer owns it) must NOT be silently re-armed
+    /// with a fresh budget. It is stranded for an operator alert instead, so the
+    /// permanently latched guard is visible rather than silently resetting.
+    #[tokio::test]
+    async fn recover_usdc_guard_alerts_on_bridging_submitting_with_exhausted_failed_job_row() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd");
+        let amount = usdc(500);
+
+        seed_bridging_submitting_base_to_alpaca(&store, &id, amount, burn_tx).await;
+
+        let notifier = Arc::new(CapturingNotifier::default());
+        let service = make_trigger_with_inventory_config_and_notifier(
+            InventoryView::default(),
+            test_config(),
+            notifier.clone(),
+        )
+        .await;
+
+        // A terminal, retry-budget-exhausted Failed row: apalis no longer owns
+        // it (attempts == max_attempts), so no live driver remains.
+        service
+            .transfer_usdc_to_hedging_queue
+            .clone()
+            .push(TransferUsdcToHedging {
+                id: id.clone(),
+                amount,
+                revert_redrive_attempts: 0,
+            })
+            .await
+            .unwrap();
+        sqlx_apalis::query(
+            "UPDATE Jobs SET status = 'Failed', attempts = max_attempts WHERE job_type = ?",
+        )
+        .bind(std::any::type_name::<TransferUsdcToHedging>())
+        .execute(service.transfer_usdc_to_hedging_queue.pool())
+        .await
+        .unwrap();
+
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        // (b) No NEW live transfer job was enqueued -- the exhausted Failed row
+        // stays the only row; nothing was re-armed to Pending.
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&service).await,
+            0,
+            "a BridgingSubmitting aggregate with an exhausted Failed job row must NOT be re-armed",
+        );
+
+        // (a) Exactly one operator alert fired, naming the stranded transfer id.
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "exactly one operator alert must fire for a terminal-exhausted pre-burn mid-flight \
+             transfer; got: {messages:?}",
+        );
+        assert!(
+            messages[0].contains(&id.to_string()),
+            "alert must name the stranded transfer id {id}; got: {:?}",
+            messages[0]
+        );
+    }
+
+    /// A `BridgingSubmitting` (Alpaca->Base) aggregate whose only job
+    /// row is a terminal, retry-budget-exhausted `Failed` (attempts ==
+    /// max_attempts, so apalis no longer owns it) must NOT be silently re-armed
+    /// with a fresh budget. It is stranded for an operator alert instead, so the
+    /// permanently latched guard is visible rather than silently resetting.
+    #[tokio::test]
+    async fn recover_usdc_guard_alerts_on_bridging_submitting_alpaca_to_base_with_exhausted_failed_job_row()
+     {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let withdrawal_tx =
+            fixed_bytes!("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        let amount = usdc(500);
+
+        seed_bridging_submitting_alpaca_to_base(&store, &id, amount, withdrawal_tx).await;
+
+        let notifier = Arc::new(CapturingNotifier::default());
+        let service = make_trigger_with_inventory_config_and_notifier(
+            InventoryView::default(),
+            test_config(),
+            notifier.clone(),
+        )
+        .await;
+
+        // A terminal, retry-budget-exhausted Failed row: apalis no longer owns
+        // it (attempts == max_attempts), so no live driver remains.
+        service
+            .transfer_usdc_to_market_making_queue
+            .clone()
+            .push(TransferUsdcToMarketMaking {
+                id: id.clone(),
+                amount,
+                revert_redrive_attempts: 0,
+            })
+            .await
+            .unwrap();
+        sqlx_apalis::query(
+            "UPDATE Jobs SET status = 'Failed', attempts = max_attempts WHERE job_type = ?",
+        )
+        .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+        .execute(service.transfer_usdc_to_market_making_queue.pool())
+        .await
+        .unwrap();
+
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        // (b) No NEW live transfer job was enqueued -- the exhausted Failed row
+        // stays the only row; nothing was re-armed to Pending.
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&service).await,
+            0,
+            "a BridgingSubmitting Alpaca->Base with an exhausted Failed job row must NOT be re-armed",
+        );
+
+        // (a) Exactly one operator alert fired, naming the stranded transfer id.
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "exactly one operator alert must fire for a terminal-exhausted pre-burn mid-flight \
+             transfer; got: {messages:?}",
+        );
+        assert!(
+            messages[0].contains(&id.to_string()),
+            "alert must name the stranded transfer id {id}; got: {:?}",
+            messages[0]
+        );
+    }
+
+    /// A `BridgingSubmitting` (Base->Alpaca) aggregate whose only job row is a
+    /// `Failed` row that still has retries remaining (`attempts < max_attempts`)
+    /// is still apalis-owned: apalis re-fetches and re-runs it. So startup
+    /// recovery must neither re-arm a fresh job (which would bypass the retry
+    /// budget and drive a second concurrent resume) nor fire the stranded alert
+    /// (the live row is the driver). Contrast with
+    /// `recover_usdc_guard_alerts_on_bridging_submitting_with_exhausted_failed_job_row`,
+    /// where the exhausted-budget row is no longer owned, so it strands and alerts.
+    #[tokio::test]
+    async fn recover_usdc_guard_does_not_rearm_or_alert_bridging_submitting_with_retryable_failed_job_row()
+     {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+        let amount = usdc(500);
+
+        seed_bridging_submitting_base_to_alpaca(&store, &id, amount, burn_tx).await;
+
+        let notifier = Arc::new(CapturingNotifier::default());
+        let service = make_trigger_with_inventory_config_and_notifier(
+            InventoryView::default(),
+            test_config(),
+            notifier.clone(),
+        )
+        .await;
+
+        // A Failed row with retries remaining (attempts < max_attempts): apalis
+        // still owns it and will re-fetch it on its own.
+        service
+            .transfer_usdc_to_hedging_queue
+            .clone()
+            .push(TransferUsdcToHedging {
+                id: id.clone(),
+                amount,
+                revert_redrive_attempts: 0,
+            })
+            .await
+            .unwrap();
+        sqlx_apalis::query(
+            "UPDATE Jobs SET status = 'Failed', attempts = 1, max_attempts = 3 WHERE job_type = ?",
+        )
+        .bind(std::any::type_name::<TransferUsdcToHedging>())
+        .execute(service.transfer_usdc_to_hedging_queue.pool())
+        .await
+        .unwrap();
+
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&service).await,
+            0,
+            "a retryable Failed row is still apalis-owned; recovery must NOT re-arm a fresh job",
+        );
+        assert_eq!(
+            notifier.messages().len(),
+            0,
+            "a retryable Failed row is still apalis-owned; no stranded alert must fire; got: {:?}",
+            notifier.messages(),
+        );
+    }
+
+    /// A guard-holding aggregate that reaches the general "stranded" branch
+    /// (`WithdrawalSubmitting{AlpacaToBase}`: no tracking seed, no re-arm path)
+    /// must NOT fire the startup stranded alert while apalis still owns a live
+    /// (Pending) transfer job for the same id. The live job is the driver -- the
+    /// startup page would duplicate the terminal page the live job itself raises
+    /// if it ultimately fails. The guard stays latched either way.
+    #[tokio::test]
+    async fn recover_usdc_guard_does_not_alert_stranded_state_with_live_job_row() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(300);
+
+        seed_withdrawal_submitting_alpaca_to_base(&store, &id, amount).await;
+
+        let notifier = Arc::new(CapturingNotifier::default());
+        let service = make_trigger_with_inventory_config_and_notifier(
+            InventoryView::default(),
+            test_config(),
+            notifier.clone(),
+        )
+        .await;
+
+        // A live Pending transfer job for the same id (AlpacaToBase routes to the
+        // market-making queue): apalis still owns and will run it.
+        service
+            .transfer_usdc_to_market_making_queue
+            .clone()
+            .push(TransferUsdcToMarketMaking {
+                id: id.clone(),
+                amount,
+                revert_redrive_attempts: 0,
+            })
+            .await
+            .unwrap();
+
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            notifier.messages().len(),
+            0,
+            "no stranded alert must fire while a live job already owns the id; got: {:?}",
+            notifier.messages(),
+        );
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "the guard must still be latched -- the aggregate holds it regardless of the alert",
         );
     }
 
@@ -13056,6 +14115,7 @@ mod tests {
             .push(TransferUsdcToHedging {
                 id: id.clone(),
                 amount: usdc(400),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -13103,6 +14163,7 @@ mod tests {
             .push(TransferUsdcToHedging {
                 id: id.clone(),
                 amount: usdc(400),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -13199,6 +14260,7 @@ mod tests {
             .push(TransferUsdcToHedging {
                 id: id.clone(),
                 amount: usdc(400),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -13250,6 +14312,7 @@ mod tests {
             .push(TransferUsdcToHedging {
                 id: id.clone(),
                 amount: usdc(400),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -13295,6 +14358,7 @@ mod tests {
             .push(TransferUsdcToHedging {
                 id: id.clone(),
                 amount: usdc(400),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -13342,6 +14406,7 @@ mod tests {
             .push(TransferUsdcToHedging {
                 id: id.clone(),
                 amount: usdc(400),
+                revert_redrive_attempts: 0,
             })
             .await
             .unwrap();
@@ -13918,6 +14983,7 @@ mod tests {
             },
             wrapper,
             schedulers,
+            Arc::new(crate::alerts::NoopNotifier),
         );
 
         assert!(
@@ -14308,6 +15374,7 @@ mod tests {
             inventory,
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
 
         // Set in_progress flag
@@ -14531,6 +15598,7 @@ mod tests {
             inventory.clone(),
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
         let reactor = trigger.clone();
 
@@ -14597,6 +15665,7 @@ mod tests {
             inventory.clone(),
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
         let reactor = trigger.clone();
 
@@ -14673,6 +15742,7 @@ mod tests {
             inventory.clone(),
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
         let reactor = trigger.clone();
 
@@ -14733,6 +15803,7 @@ mod tests {
             inventory.clone(),
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
         let reactor = trigger.clone();
 
@@ -17756,6 +18827,7 @@ mod tests {
             inventory,
             wrapper,
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
 
         let id = issuer_request_id("held-for-recovery-timeout");
@@ -17836,6 +18908,7 @@ mod tests {
             inventory,
             wrapper,
             RebalancingSchedulers::new(&apalis_pool),
+            Arc::new(crate::alerts::NoopNotifier),
         ));
 
         // HeldForRecovery: recovery owns the slot -- must be left untouched and

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -22,17 +22,34 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::warn;
+use tracing::{error, warn};
 
 use st0x_evm::Wallet;
 use st0x_finance::Usdc;
 
 use super::UsdcTransferError;
 use super::manager::CrossVenueCashTransfer;
+use crate::alerts::Notifier;
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::usdc_rebalance::UsdcRebalanceId;
 
 const ATTESTATION_REDRIVE_DELAY: Duration = Duration::from_secs(60);
+
+/// Delay before re-enqueueing a Base->Alpaca job after a revert-class burn
+/// failure. 15 s is enough for a lagging load-balanced RPC node to catch up
+/// while keeping the recovery cadence tight.
+const BURN_REVERT_REDRIVE_DELAY: Duration = Duration::from_secs(15);
+
+/// Delay before re-enqueueing a Base->Alpaca job after a per-attempt timeout.
+/// 30 s gives a hung RPC time to settle before the job re-enters the
+/// scan-or-reburn path. NOTE: the scan (`find_recent_burn`) is a mempool-blind
+/// log scan -- it adopts only a MINED burn, not a still-pending (broadcast but
+/// unmined) one. So this delay must be long enough that a burn broadcast just
+/// before the timeout has mined (and become visible to the scan) or been evicted
+/// from the mempool before the redrive scans. Fully closing that residual
+/// double-burn window requires durably recording the in-flight burn tx hash; it
+/// is tracked as a dedicated follow-up.
+const TIMEOUT_REDRIVE_DELAY: Duration = Duration::from_secs(30);
 
 /// Delay before re-enqueueing an Alpaca->Base job when on-chain settlement has
 /// not yet completed. Two to three Ethereum block times (~30 s total) is enough
@@ -40,6 +57,22 @@ const ATTESTATION_REDRIVE_DELAY: Duration = Duration::from_secs(60);
 /// withdrawal "Complete", while keeping the redrive cadence tight enough to
 /// avoid materially delaying the transfer.
 const SETTLEMENT_REDRIVE_DELAY: Duration = Duration::from_secs(30);
+
+/// Returns the warn-threshold attempt count at which an early operator alert
+/// fires, or `None` when there is no room for a distinct early warning.
+///
+/// The threshold is set at `max/2 + 1` (integer division) so operators get
+/// time to investigate before the circuit opens. For `max >= 3` this always
+/// yields a threshold strictly less than `max`, giving one or more warn-only
+/// attempts before the limit alert. For `max <= 2` the formula would produce
+/// `threshold == max`, making the warn branch structurally unreachable (the
+/// limit branch fires first in the if/else-if chain). In that case we return
+/// `None` so callers skip the warn branch entirely rather than silently
+/// dropping it.
+fn warn_threshold(max_redrives: u32) -> Option<u32> {
+    let threshold = max_redrives / 2 + 1;
+    (threshold < max_redrives).then_some(threshold)
+}
 
 /// Apalis queue type for [`TransferUsdcToHedging`].
 pub(crate) type TransferUsdcToHedgingJobQueue = JobQueue<TransferUsdcToHedging>;
@@ -106,6 +139,13 @@ pub(crate) struct TransferUsdcToHedgingCtx {
     /// single-concurrency worker forever.
     pub(crate) timeout: Duration,
     pub(crate) job_queue: TransferUsdcToHedgingJobQueue,
+    /// Maximum consecutive revert-class burn failures reclassified as safe
+    /// redrives before the circuit opens. From `RebalancingConfig`.
+    pub(crate) max_burn_revert_redrives: u32,
+    /// Alerting channel. `NoopNotifier` when `[alerts]` is unconfigured;
+    /// `TelegramNotifier` otherwise. Never `None` — absence is explicit via
+    /// `NoopNotifier` rather than a silent skip.
+    pub(crate) notifier: Arc<dyn Notifier>,
 }
 
 /// Errors emitted by [`TransferUsdcToHedging::perform`].
@@ -113,21 +153,32 @@ pub(crate) struct TransferUsdcToHedgingCtx {
 pub(crate) enum TransferUsdcToHedgingJobError {
     #[error(transparent)]
     Transfer(#[from] UsdcTransferError),
-    #[error("Base->Alpaca transfer {id} attempt exceeded the {timeout:?} per-attempt timeout")]
-    Timeout {
-        id: UsdcRebalanceId,
-        timeout: Duration,
-    },
+    #[error(
+        "Base->Alpaca transfer {id} burn revert redrive limit reached; \
+         aggregate stalled at BridgingSubmitting, operator action required"
+    )]
+    BurnRevertLimitReached { id: UsdcRebalanceId },
+    #[error(
+        "Base->Alpaca transfer {id} per-attempt timeout redrive limit reached; \
+         RPC permanently wedged, operator action required"
+    )]
+    TimeoutLimitReached { id: UsdcRebalanceId },
     #[error(transparent)]
     Enqueue(#[from] QueuePushError),
 }
 
 /// Apalis job payload. The `id` is generated at enqueue time so retries
-/// resume the same aggregate.
+/// resume the same aggregate. `revert_redrive_attempts` is a durable counter
+/// so the redrive bound is preserved across restarts.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct TransferUsdcToHedging {
     pub(crate) id: UsdcRebalanceId,
     pub(crate) amount: Usdc,
+    /// Shared redrive budget covering both burn-revert and per-attempt timeout
+    /// redrives (hedging direction has both). Persisted in the apalis payload
+    /// so the bound is durable across restarts.
+    #[serde(default)]
+    pub(crate) revert_redrive_attempts: u32,
 }
 
 impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
@@ -150,14 +201,20 @@ impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
         // worker. The inner result is then classified for redrive/terminal
         // handling.
         let resume = ctx.transfer.resume_base_to_alpaca(&self.id, self.amount);
-        let result = match tokio::time::timeout(ctx.timeout, resume).await {
-            Ok(result) => result,
-            Err(_elapsed) => {
-                return Err(TransferUsdcToHedgingJobError::Timeout {
-                    id: self.id.clone(),
-                    timeout: ctx.timeout,
-                });
-            }
+        let Ok(result) = tokio::time::timeout(ctx.timeout, resume).await else {
+            // A timeout fires while a burn tx may have been broadcast -- the RPC
+            // just did not return the receipt in time. The redrive re-enters
+            // `resume_bridging_submitting`, whose `find_recent_burn` probe is a
+            // mempool-blind LOG SCAN: it adopts only a MINED burn, never a
+            // still-pending (broadcast-but-unmined) one. So double-burn safety on
+            // the timeout path depends on the per-attempt timeout plus
+            // `TIMEOUT_REDRIVE_DELAY` being long enough that a broadcast burn has
+            // mined (and become scan-visible) or been evicted before the redrive
+            // scans. Fully closing that residual window requires durably recording
+            // the in-flight burn tx hash and is tracked as a dedicated follow-up.
+            // Count against the shared redrive budget so repeated timeouts (e.g., a
+            // permanently hung RPC) eventually surface for operator review.
+            return self.handle_hedging_timeout_redrive(ctx).await;
         };
 
         match result {
@@ -181,6 +238,13 @@ impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
                     "Base->Alpaca USDC transfer attestation retry deadline elapsed; \
                      bridge marked failed for operator reconciliation"
                 );
+                let message = format!(
+                    "USDC transfer {id} attestation retry deadline elapsed. \
+                     Bridge marked failed; manual operator reconciliation required."
+                );
+                if let Err(error) = ctx.notifier.notify(&message).await {
+                    warn!(target: "rebalance", ?error, "Failed to deliver USDC hedging deadline-elapsed alert");
+                }
             }
             Err(UsdcTransferError::PreviouslyFailedAggregate { id }) => {
                 warn!(
@@ -190,9 +254,272 @@ impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
                      nothing to redrive, leaving for operator reconciliation"
                 );
             }
-            Err(error) => return Err(error.into()),
+            // Settlement-phase transient: the Base burn scan was inconclusive
+            // (chain head not yet far enough past the scan lower bound) or another
+            // settlement-phase RPC check failed transiently. The aggregate is in a
+            // durable state (`BridgingSubmitting`), so this must delayed-redrive
+            // rather than consume the apalis retry budget or trip the circuit --
+            // an inconclusive scan is a normal self-heal outcome. Re-pushing
+            // `self.clone()` unchanged means this redrive intentionally does NOT
+            // consume the burn-revert budget (`revert_redrive_attempts`) and is
+            // unbounded BY DESIGN: a scan-inconclusive / pending-settlement
+            // condition resolves as the chain advances, and failing a transfer
+            // for slow on-chain settlement would be wrong. Mirrors the
+            // market-making settlement-wait arm.
+            Err(UsdcTransferError::SettlementCheckTransient { id, .. }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    delay = ?SETTLEMENT_REDRIVE_DELAY,
+                    "Rescheduling Base->Alpaca USDC transfer: settlement-phase RPC check \
+                     failed transiently or burn scan inconclusive"
+                );
+                let mut job_queue = ctx.job_queue.clone();
+                job_queue
+                    .push_with_delay(self.clone(), SETTLEMENT_REDRIVE_DELAY)
+                    .await?;
+            }
+            // Revert-class burn failures: safe to redrive because
+            // `resume_bridging_submitting` scans for an existing burn before
+            // re-burning (the scan lower bound is durably recorded in the
+            // `BeginBridging` / `BridgingSubmitting` event). The safety
+            // guarantee is the scan, NOT this classification.
+            Err(UsdcTransferError::BurnRevert(_)) => {
+                return self.handle_hedging_burn_revert_redrive(ctx).await;
+            }
+            Err(error) => {
+                // Terminal non-redriven error: fire notifier before surfacing
+                // to apalis so the operator is alerted before the circuit opens.
+                //
+                // KNOWN LIMITATION: this arm fires on every apalis attempt (up
+                // to 4x with the default RetryPolicy::retries(3)). Because the
+                // apalis retry uses the same serialized payload and `perform`
+                // has no visibility into the current attempt number, suppressing
+                // duplicates here is not feasible without threading apalis
+                // attempt context through. The bounded-limit path
+                // (BurnRevertLimitReached / TimeoutLimitReached) already fires
+                // exactly once via the Ok-return redrive pattern; this generic
+                // terminal arm is a best-effort alert that may duplicate.
+                let id = &self.id;
+                error!(
+                    target: "rebalance",
+                    %id,
+                    %error,
+                    "Base->Alpaca USDC transfer failed terminally; circuit will open"
+                );
+                let message = format!(
+                    "USDC transfer {id} failed: {error}. \
+                     Check if apalis will retry before acting."
+                );
+                if let Err(error) = ctx.notifier.notify(&message).await {
+                    warn!(target: "rebalance", ?error, "Failed to deliver USDC hedging terminal-error alert");
+                }
+                return Err(error.into());
+            }
         }
 
+        Ok(())
+    }
+}
+
+impl TransferUsdcToHedging {
+    /// Handles a per-attempt timeout by either opening the circuit (when the
+    /// redrive limit is reached) or scheduling a delayed redrive attempt.
+    /// Extracted from `Job::perform` to mirror the market-making extraction and
+    /// keep the perform body under the line-count lint threshold.
+    async fn handle_hedging_timeout_redrive(
+        &self,
+        ctx: &TransferUsdcToHedgingCtx,
+    ) -> Result<(), TransferUsdcToHedgingJobError> {
+        let id = &self.id;
+
+        // Check the stored counter BEFORE incrementing: the budget is exhausted
+        // once the redrives already consumed reach the max, so the next attempt
+        // would exceed it. Incrementing first then comparing `>` is equivalent but
+        // obscures the boundary and leans on saturating arithmetic.
+        if self.revert_redrive_attempts >= ctx.max_burn_revert_redrives {
+            error!(
+                target: "rebalance",
+                %id,
+                attempts = self.revert_redrive_attempts,
+                timeout = ?ctx.timeout,
+                "Base->Alpaca USDC transfer per-attempt timeout redrive limit reached; \
+                 operator action required"
+            );
+            // Alert fires only on the last successful redrive (next_attempts == max),
+            // not here. Apalis retries this Err up to 3 more times with the same
+            // payload, so alerting here would fire up to 4x for the same event.
+            //
+            // The operator is paged for this exhausted-budget circuit-open via the
+            // startup `recover_usdc_guard` stranded-alert path (the aggregate is
+            // found at `BridgingSubmitting` with only an exhausted-`Failed` job
+            // row). A live (non-restart) page on circuit-open is a known gap,
+            // tracked as a follow-up.
+            return Err(TransferUsdcToHedgingJobError::TimeoutLimitReached { id: id.clone() });
+        }
+
+        // Bound already checked above, so a plain `+ 1` cannot overflow.
+        let next_attempts = self.revert_redrive_attempts + 1;
+
+        // Last allowed redrive: fire the limit alert BEFORE enqueuing so operators
+        // know the budget is exhausted. Returns Ok so apalis does not retry this
+        // attempt -- the alert fires exactly once.
+        if next_attempts == ctx.max_burn_revert_redrives {
+            warn!(
+                target: "rebalance",
+                %id,
+                attempts = next_attempts,
+                timeout = ?ctx.timeout,
+                "Base->Alpaca USDC transfer per-attempt timeout redrive limit reached; \
+                 last redrive enqueued, operator action will be needed"
+            );
+            let message = format!(
+                "USDC transfer {id} per-attempt timeout redrive limit reached after \
+                 {next_attempts} attempts. Base->Alpaca transfer stalled; \
+                 check aggregate state for current stage. Manual operator action required."
+            );
+            if let Err(error) = ctx.notifier.notify(&message).await {
+                warn!(target: "rebalance", ?error, "Failed to deliver USDC hedging timeout-limit alert");
+            }
+        } else if warn_threshold(ctx.max_burn_revert_redrives) == Some(next_attempts) {
+            warn!(
+                target: "rebalance",
+                %id,
+                attempts = next_attempts,
+                max = ctx.max_burn_revert_redrives,
+                delay = ?TIMEOUT_REDRIVE_DELAY,
+                "Base->Alpaca USDC transfer timeout has retried multiple times; \
+                 possible hung RPC or persistent network issue"
+            );
+            let message = format!(
+                "USDC transfer {id} per-attempt timeout has retried {next_attempts} times \
+                 (max: {}). Possible hung RPC or persistent network issue.",
+                ctx.max_burn_revert_redrives
+            );
+            if let Err(error) = ctx.notifier.notify(&message).await {
+                warn!(target: "rebalance", ?error, "Failed to deliver USDC hedging timeout-warn alert");
+            }
+        } else {
+            warn!(
+                target: "rebalance",
+                %id,
+                attempts = next_attempts,
+                delay = ?TIMEOUT_REDRIVE_DELAY,
+                "Base->Alpaca USDC transfer timed out; re-entering scan-or-reburn \
+                 path after delay (burn may have landed; resume will adopt it)"
+            );
+        }
+
+        let updated = Self {
+            revert_redrive_attempts: next_attempts,
+            ..self.clone()
+        };
+        ctx.job_queue
+            .clone()
+            .push_with_delay(updated, TIMEOUT_REDRIVE_DELAY)
+            .await?;
+        Ok(())
+    }
+
+    /// Handles a revert-class burn error by either opening the circuit (when the
+    /// redrive limit is reached) or scheduling a delayed redrive attempt. Symmetric
+    /// to [`TransferUsdcToMarketMaking::handle_mm_burn_revert_redrive`].
+    async fn handle_hedging_burn_revert_redrive(
+        &self,
+        ctx: &TransferUsdcToHedgingCtx,
+    ) -> Result<(), TransferUsdcToHedgingJobError> {
+        let id = &self.id;
+
+        // Check the stored counter BEFORE incrementing: the budget is exhausted
+        // once the redrives already consumed reach the max, so the next attempt
+        // would exceed it. Incrementing first then comparing `>` is equivalent but
+        // obscures the boundary and leans on saturating arithmetic.
+        if self.revert_redrive_attempts >= ctx.max_burn_revert_redrives {
+            error!(
+                target: "rebalance",
+                %id,
+                attempts = self.revert_redrive_attempts,
+                "Base->Alpaca USDC burn revert redrive limit reached; \
+                 operator action required"
+            );
+            // Alert fires only on the last successful redrive (next_attempts == max),
+            // not here. Apalis retries this Err up to 3 more times with the same
+            // payload, so alerting here would fire up to 4x for the same event.
+            //
+            // The operator is paged for this exhausted-budget circuit-open via the
+            // startup `recover_usdc_guard` stranded-alert path (the aggregate is
+            // found at `BridgingSubmitting` with only an exhausted-`Failed` job
+            // row). A live (non-restart) page on circuit-open is a known gap,
+            // tracked as a follow-up.
+            return Err(TransferUsdcToHedgingJobError::BurnRevertLimitReached { id: id.clone() });
+        }
+
+        // Bound already checked above, so a plain `+ 1` cannot overflow.
+        let next_attempts = self.revert_redrive_attempts + 1;
+
+        // Last allowed redrive: alert fires BEFORE enqueuing the final redrive
+        // so the operator is notified as early as possible. The next failure
+        // (next_attempts > max) returns BurnRevertLimitReached with no further
+        // alert (apalis would retry the Err up to 3x, causing duplicate pages).
+        // Returns Ok so apalis does not retry this attempt -- the alert fires
+        // exactly once at this boundary.
+        if next_attempts == ctx.max_burn_revert_redrives {
+            warn!(
+                target: "rebalance",
+                %id,
+                attempts = next_attempts,
+                delay = ?BURN_REVERT_REDRIVE_DELAY,
+                "Base->Alpaca USDC burn revert hit redrive limit; \
+                 attempting the final redrive, operator action will be needed if it fails"
+            );
+            let message = format!(
+                "USDC transfer {id} burn revert redrive limit reached after \
+                 {next_attempts} attempts (max: {max}). Attempting the final redrive now; \
+                 manual operator action will be required if it fails to enqueue or also reverts.",
+                max = ctx.max_burn_revert_redrives
+            );
+            if let Err(error) = ctx.notifier.notify(&message).await {
+                warn!(target: "rebalance", ?error, "Failed to deliver USDC hedging burn-revert-limit alert");
+            }
+        } else if warn_threshold(ctx.max_burn_revert_redrives) == Some(next_attempts) {
+            // Warn threshold: alert exactly once so operators can investigate
+            // before the limit is reached, avoiding a silent infinite loop.
+            warn!(
+                target: "rebalance",
+                %id,
+                attempts = next_attempts,
+                max = ctx.max_burn_revert_redrives,
+                delay = ?BURN_REVERT_REDRIVE_DELAY,
+                "Base->Alpaca USDC burn revert has retried multiple times; \
+                 possible persistent RPC or contract issue"
+            );
+            let message = format!(
+                "USDC transfer {id} burn revert has retried {next_attempts} times \
+                 (max: {}). Possible transient or persistent RPC/contract issue.",
+                ctx.max_burn_revert_redrives
+            );
+            if let Err(error) = ctx.notifier.notify(&message).await {
+                warn!(target: "rebalance", ?error, "Failed to deliver USDC hedging burn-revert-warn alert");
+            }
+        } else {
+            warn!(
+                target: "rebalance",
+                %id,
+                attempts = next_attempts,
+                delay = ?BURN_REVERT_REDRIVE_DELAY,
+                "Base->Alpaca USDC burn reverted (revert-class, no on-chain state \
+                 change); re-entering scan-or-reburn path after delay"
+            );
+        }
+
+        let updated = Self {
+            revert_redrive_attempts: next_attempts,
+            ..self.clone()
+        };
+        ctx.job_queue
+            .clone()
+            .push_with_delay(updated, BURN_REVERT_REDRIVE_DELAY)
+            .await?;
         Ok(())
     }
 }
@@ -202,6 +529,12 @@ impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
 pub(crate) struct TransferUsdcToMarketMakingCtx {
     pub(crate) transfer: Arc<dyn ResumeAlpacaToBase>,
     pub(crate) job_queue: TransferUsdcToMarketMakingJobQueue,
+    /// Maximum consecutive revert-class burn failures before circuit opens.
+    pub(crate) max_burn_revert_redrives: u32,
+    /// Alerting channel. `NoopNotifier` when `[alerts]` is unconfigured;
+    /// `TelegramNotifier` otherwise. Never `None` — absence is explicit via
+    /// `NoopNotifier` rather than a silent skip.
+    pub(crate) notifier: Arc<dyn Notifier>,
 }
 
 /// Errors emitted by [`TransferUsdcToMarketMaking::perform`].
@@ -209,16 +542,27 @@ pub(crate) struct TransferUsdcToMarketMakingCtx {
 pub(crate) enum TransferUsdcToMarketMakingJobError {
     #[error(transparent)]
     Transfer(#[from] UsdcTransferError),
+    #[error(
+        "Alpaca->Base transfer {id} burn revert redrive limit reached; \
+         aggregate stalled at BridgingSubmitting, operator action required"
+    )]
+    BurnRevertLimitReached { id: UsdcRebalanceId },
     #[error(transparent)]
     Enqueue(#[from] QueuePushError),
 }
 
 /// Apalis job payload for the Alpaca->Base direction. The `id` is generated
-/// at enqueue time so retries resume the same aggregate.
+/// at enqueue time so retries resume the same aggregate. `revert_redrive_attempts`
+/// is a durable counter so the redrive bound is preserved across restarts.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct TransferUsdcToMarketMaking {
     pub(crate) id: UsdcRebalanceId,
     pub(crate) amount: Usdc,
+    /// Burn-revert redrive budget (market-making direction: no per-attempt
+    /// timeout, so this counter covers only burn-revert redrives). Persisted in
+    /// the apalis payload so the bound is durable across restarts.
+    #[serde(default)]
+    pub(crate) revert_redrive_attempts: u32,
 }
 
 impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
@@ -239,11 +583,25 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
         &self,
         ctx: &TransferUsdcToMarketMakingCtx,
     ) -> Result<Self::Output, Self::Error> {
-        match ctx
+        // No per-attempt timeout here unlike the hedging direction. The
+        // AlpacaToBase resume can pass through a long-running broker Converting
+        // leg with no safe re-entry path if interrupted (unlike BaseToAlpaca
+        // which has resume_converting recovery). The burn-revert-redrive path
+        // below is the correct self-heal mechanism for the incident this PR
+        // targets.
+        //
+        // KNOWN LIMITATION: A wedged (not erroring) RPC during resume of the burn
+        // or attestation phase will stall this worker indefinitely with no
+        // per-attempt timeout bound. The burn-revert redrive above handles the case
+        // where the burn RETURNS a revert error; it does not handle a hung RPC that
+        // never returns. A burn-leg-only timeout (gated to post-Converting stages
+        // where re-entry is safe) is a follow-up.
+        let result = ctx
             .transfer
             .resume_alpaca_to_base(&self.id, self.amount)
-            .await
-        {
+            .await;
+
+        match result {
             Ok(()) => {}
             Err(UsdcTransferError::AttestationTimedOut { id }) => {
                 warn!(
@@ -306,6 +664,13 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
                     "Alpaca->Base USDC transfer attestation retry deadline elapsed; \
                      bridge marked failed for operator reconciliation"
                 );
+                let message = format!(
+                    "USDC transfer {id} attestation retry deadline elapsed. \
+                     Bridge marked failed; manual operator reconciliation required."
+                );
+                if let Err(error) = ctx.notifier.notify(&message).await {
+                    warn!(target: "rebalance", ?error, "Failed to deliver USDC market-making deadline-elapsed alert");
+                }
             }
             Err(UsdcTransferError::PreviouslyFailedAggregate { id }) => {
                 warn!(
@@ -332,10 +697,158 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
                     "Alpaca->Base USDC transfer failed: ambient USDC in market-maker wallet; \
                      bridge marked failed for operator reconciliation"
                 );
+                let message = format!(
+                    "USDC transfer {id} failed: ambient USDC ({balance}) exceeds nominal ({nominal}). \
+                     Wallet-empty invariant broken; bridge marked failed, manual operator reconciliation required."
+                );
+                if let Err(error) = ctx.notifier.notify(&message).await {
+                    warn!(target: "rebalance", ?error, "Failed to deliver USDC market-making ambient-balance alert");
+                }
             }
-            Err(error) => return Err(error.into()),
+            // Revert-class burn failures: safe to redrive because
+            // `resume_bridging_submitting` scans for an existing burn before
+            // re-burning (the scan lower bound is durably recorded). The safety
+            // guarantee is the scan, NOT this classification.
+            Err(UsdcTransferError::BurnRevert(_)) => {
+                return self.handle_mm_burn_revert_redrive(ctx).await;
+            }
+            Err(error) => {
+                // Terminal non-redriven error: fire notifier before surfacing
+                // to apalis so the operator is alerted before the circuit opens.
+                //
+                // KNOWN LIMITATION: this arm fires on every apalis attempt (up
+                // to 4x with the default RetryPolicy::retries(3)). Because the
+                // apalis retry uses the same serialized payload and `perform`
+                // has no visibility into the current attempt number, suppressing
+                // duplicates here is not feasible without threading apalis
+                // attempt context through. The bounded-limit path
+                // (BurnRevertLimitReached) already fires exactly once via the
+                // Ok-return redrive pattern; this generic terminal arm is a
+                // best-effort alert that may duplicate.
+                let id = &self.id;
+                error!(
+                    target: "rebalance",
+                    %id,
+                    %error,
+                    "Alpaca->Base USDC transfer failed terminally; circuit will open"
+                );
+                let message = format!(
+                    "USDC transfer {id} failed: {error}. \
+                     Check if apalis will retry before acting."
+                );
+                if let Err(error) = ctx.notifier.notify(&message).await {
+                    warn!(target: "rebalance", ?error, "Failed to deliver USDC market-making terminal-error alert");
+                }
+                return Err(error.into());
+            }
         }
 
+        Ok(())
+    }
+}
+
+impl TransferUsdcToMarketMaking {
+    /// Handles a revert-class burn error by either opening the circuit (when the
+    /// redrive limit is reached) or scheduling a delayed redrive attempt. Extracted
+    /// to keep `Job::perform` under the line-count lint threshold.
+    async fn handle_mm_burn_revert_redrive(
+        &self,
+        ctx: &TransferUsdcToMarketMakingCtx,
+    ) -> Result<(), TransferUsdcToMarketMakingJobError> {
+        let id = &self.id;
+
+        // Check the stored counter BEFORE incrementing: the budget is exhausted
+        // once the redrives already consumed reach the max, so the next attempt
+        // would exceed it. Incrementing first then comparing `>` is equivalent but
+        // obscures the boundary and leans on saturating arithmetic.
+        if self.revert_redrive_attempts >= ctx.max_burn_revert_redrives {
+            error!(
+                target: "rebalance",
+                %id,
+                attempts = self.revert_redrive_attempts,
+                "Alpaca->Base USDC burn revert redrive limit reached; \
+                 operator action required"
+            );
+            // Alert fires only on the last successful redrive (next_attempts == max),
+            // not here. Apalis retries this Err up to 3 more times with the same
+            // payload, so alerting here would fire up to 4x for the same event.
+            //
+            // The operator is paged for this exhausted-budget circuit-open via the
+            // startup `recover_usdc_guard` stranded-alert path (the aggregate is
+            // found at `BridgingSubmitting` with only an exhausted-`Failed` job
+            // row). A live (non-restart) page on circuit-open is a known gap,
+            // tracked as a follow-up.
+            return Err(TransferUsdcToMarketMakingJobError::BurnRevertLimitReached {
+                id: id.clone(),
+            });
+        }
+
+        // Bound already checked above, so a plain `+ 1` cannot overflow.
+        let next_attempts = self.revert_redrive_attempts + 1;
+
+        // Last allowed redrive: alert fires BEFORE enqueuing the final redrive
+        // so the operator is notified as early as possible. The next failure
+        // (next_attempts > max) returns BurnRevertLimitReached with no further
+        // alert (apalis would retry the Err up to 3x, causing duplicate pages).
+        // Returns Ok so apalis does not retry this attempt -- the alert fires
+        // exactly once at this boundary.
+        if next_attempts == ctx.max_burn_revert_redrives {
+            warn!(
+                target: "rebalance",
+                %id,
+                attempts = next_attempts,
+                delay = ?BURN_REVERT_REDRIVE_DELAY,
+                "Alpaca->Base USDC burn revert hit redrive limit; \
+                 attempting the final redrive, operator action will be needed if it fails"
+            );
+            let message = format!(
+                "USDC transfer {id} burn revert redrive limit reached after \
+                 {next_attempts} attempts (max: {max}). Attempting the final redrive now; \
+                 manual operator action will be required if it fails to enqueue or also reverts.",
+                max = ctx.max_burn_revert_redrives
+            );
+            if let Err(error) = ctx.notifier.notify(&message).await {
+                warn!(target: "rebalance", ?error, "Failed to deliver USDC market-making burn-revert-limit alert");
+            }
+        } else if warn_threshold(ctx.max_burn_revert_redrives) == Some(next_attempts) {
+            // Warn threshold: alert exactly once so operators can investigate
+            // before the limit is reached, avoiding a silent infinite loop.
+            warn!(
+                target: "rebalance",
+                %id,
+                attempts = next_attempts,
+                max = ctx.max_burn_revert_redrives,
+                delay = ?BURN_REVERT_REDRIVE_DELAY,
+                "Alpaca->Base USDC burn revert has retried multiple times; \
+                 possible persistent RPC or contract issue"
+            );
+            let message = format!(
+                "USDC transfer {id} burn revert has retried {next_attempts} times \
+                 (max: {}). Possible transient or persistent RPC/contract issue.",
+                ctx.max_burn_revert_redrives
+            );
+            if let Err(error) = ctx.notifier.notify(&message).await {
+                warn!(target: "rebalance", ?error, "Failed to deliver USDC market-making burn-revert-warn alert");
+            }
+        } else {
+            warn!(
+                target: "rebalance",
+                %id,
+                attempts = next_attempts,
+                delay = ?BURN_REVERT_REDRIVE_DELAY,
+                "Alpaca->Base USDC burn reverted (revert-class, no on-chain state \
+                 change); re-entering scan-or-reburn path after delay"
+            );
+        }
+
+        let updated = Self {
+            revert_redrive_attempts: next_attempts,
+            ..self.clone()
+        };
+        ctx.job_queue
+            .clone()
+            .push_with_delay(updated, BURN_REVERT_REDRIVE_DELAY)
+            .await?;
         Ok(())
     }
 }
@@ -344,12 +857,31 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
 mod tests {
     use alloy::primitives::TxHash;
     use chrono::Utc;
+    use reqwest::StatusCode;
+    use st0x_bridge::cctp::CctpError;
+    use st0x_evm::EvmError;
     use uuid::Uuid;
 
     use st0x_float_macro::float;
 
     use super::*;
+    use crate::alerts::{CapturingNotifier, NoopNotifier};
     use crate::test_utils::setup_test_apalis_pool;
+
+    /// Builds a `TransferUsdcToHedgingCtx` with test-safe defaults for the
+    /// notifier and redrive-limit fields.
+    fn hedging_ctx(
+        transfer: Arc<dyn ResumeBaseToAlpaca>,
+        pool: &apalis_sqlite::SqlitePool,
+    ) -> TransferUsdcToHedgingCtx {
+        TransferUsdcToHedgingCtx {
+            transfer,
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(pool),
+            max_burn_revert_redrives: 5,
+            notifier: Arc::new(NoopNotifier),
+        }
+    }
 
     struct TimeoutBaseToAlpaca;
 
@@ -479,15 +1011,11 @@ mod tests {
     #[tokio::test]
     async fn hedging_job_reschedules_attestation_timeout() {
         let pool = setup_queue_pool().await;
-        let job_queue = TransferUsdcToHedgingJobQueue::new(&pool);
-        let ctx = TransferUsdcToHedgingCtx {
-            transfer: Arc::new(TimeoutBaseToAlpaca),
-            timeout: Duration::from_secs(3600),
-            job_queue,
-        };
+        let ctx = hedging_ctx(Arc::new(TimeoutBaseToAlpaca), &pool);
         let job = TransferUsdcToHedging {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
         };
 
         let before = Utc::now().timestamp();
@@ -519,38 +1047,118 @@ mod tests {
         );
     }
 
+    /// A hung resume (RPC wedge) must be aborted by the per-attempt timeout
+    /// and reclassified as a safe redrive -- not propagated as a circuit-tripping
+    /// error -- because the scan-or-reburn path will adopt any burn that landed
+    /// during the hang. Verify Ok + one Pending row with TIMEOUT_REDRIVE_DELAY,
+    /// carrying `revert_redrive_attempts = 1`.
     #[tokio::test]
     async fn perform_times_out_when_resume_hangs() {
+        let pool = setup_queue_pool().await;
+        // Short timeout to make the test fast. hedging_ctx uses 3600s by
+        // default so override inline.
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(HangingResume),
+            timeout: Duration::from_millis(50),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: Arc::new(NoopNotifier),
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let before = Utc::now().timestamp();
+        Job::perform(&job, &ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            1,
+            "a per-attempt timeout must redrive rather than trip the circuit breaker"
+        );
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToHedging>(&pool).await;
+        let rescheduled: TransferUsdcToHedging = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.id, job.id,
+            "the rescheduled job must resume the same aggregate id"
+        );
+        assert!(
+            rescheduled.amount.eq(&job.amount).unwrap(),
+            "the rescheduled job must carry the same amount"
+        );
+        assert_eq!(
+            rescheduled.revert_redrive_attempts, 1,
+            "revert_redrive_attempts must be incremented to 1 in the redrive payload"
+        );
+        assert!(
+            run_at >= before + i64::try_from(TIMEOUT_REDRIVE_DELAY.as_secs()).unwrap() - 5
+                && run_at <= after + i64::try_from(TIMEOUT_REDRIVE_DELAY.as_secs()).unwrap() + 5,
+            "redrive must be delayed by ~{TIMEOUT_REDRIVE_DELAY:?} -- \
+             run_at={run_at} before={before} after={after}"
+        );
+    }
+
+    /// After `max_burn_revert_redrives` consecutive timeouts the job must
+    /// propagate `TimeoutLimitReached` so the circuit opens and the operator
+    /// is alerted. No new Pending row must be created.
+    #[tokio::test]
+    async fn hedging_job_hits_redrive_limit_on_repeated_timeout() {
         let pool = setup_queue_pool().await;
         let ctx = TransferUsdcToHedgingCtx {
             transfer: Arc::new(HangingResume),
             timeout: Duration::from_millis(50),
             job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 3,
+            notifier: Arc::new(NoopNotifier),
         };
+        // Simulate a job that has already used all its redrive budget.
         let job = TransferUsdcToHedging {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 3,
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
 
-        assert!(matches!(
-            error,
-            TransferUsdcToHedgingJobError::Timeout { .. }
-        ));
+        assert!(
+            matches!(
+                error,
+                TransferUsdcToHedgingJobError::TimeoutLimitReached { .. }
+            ),
+            "at the redrive limit a timeout must propagate TimeoutLimitReached, got {error:?}",
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            0,
+            "limit-reached must NOT enqueue a new pending job"
+        );
+    }
+
+    /// Builds a `TransferUsdcToMarketMakingCtx` with test-safe defaults.
+    fn market_making_ctx(
+        transfer: Arc<dyn ResumeAlpacaToBase>,
+        pool: &apalis_sqlite::SqlitePool,
+    ) -> TransferUsdcToMarketMakingCtx {
+        TransferUsdcToMarketMakingCtx {
+            transfer,
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(pool),
+            max_burn_revert_redrives: 5,
+            notifier: Arc::new(NoopNotifier),
+        }
     }
 
     #[tokio::test]
     async fn market_making_job_reschedules_attestation_timeout() {
         let pool = setup_queue_pool().await;
-        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
-        let ctx = TransferUsdcToMarketMakingCtx {
-            transfer: Arc::new(TimeoutAlpacaToBase),
-            job_queue,
-        };
+        let ctx = market_making_ctx(Arc::new(TimeoutAlpacaToBase), &pool);
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
         };
 
         let before = Utc::now().timestamp();
@@ -585,15 +1193,14 @@ mod tests {
     #[tokio::test]
     async fn hedging_job_treats_deadline_elapsed_as_clean_terminal() {
         let pool = setup_queue_pool().await;
-        let job_queue = TransferUsdcToHedgingJobQueue::new(&pool);
-        let ctx = TransferUsdcToHedgingCtx {
-            transfer: Arc::new(TerminalBaseToAlpaca(TerminalOutcome::DeadlineElapsed)),
-            timeout: Duration::from_secs(3600),
-            job_queue,
-        };
+        let ctx = hedging_ctx(
+            Arc::new(TerminalBaseToAlpaca(TerminalOutcome::DeadlineElapsed)),
+            &pool,
+        );
         let job = TransferUsdcToHedging {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
         };
 
         job.perform(&ctx)
@@ -610,15 +1217,14 @@ mod tests {
     #[tokio::test]
     async fn hedging_job_treats_previously_failed_as_clean_terminal() {
         let pool = setup_queue_pool().await;
-        let job_queue = TransferUsdcToHedgingJobQueue::new(&pool);
-        let ctx = TransferUsdcToHedgingCtx {
-            transfer: Arc::new(TerminalBaseToAlpaca(TerminalOutcome::PreviouslyFailed)),
-            timeout: Duration::from_secs(3600),
-            job_queue,
-        };
+        let ctx = hedging_ctx(
+            Arc::new(TerminalBaseToAlpaca(TerminalOutcome::PreviouslyFailed)),
+            &pool,
+        );
         let job = TransferUsdcToHedging {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
         };
 
         job.perform(&ctx).await.expect(
@@ -635,14 +1241,14 @@ mod tests {
     #[tokio::test]
     async fn market_making_job_treats_deadline_elapsed_as_clean_terminal() {
         let pool = setup_queue_pool().await;
-        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
-        let ctx = TransferUsdcToMarketMakingCtx {
-            transfer: Arc::new(TerminalAlpacaToBase(TerminalOutcome::DeadlineElapsed)),
-            job_queue,
-        };
+        let ctx = market_making_ctx(
+            Arc::new(TerminalAlpacaToBase(TerminalOutcome::DeadlineElapsed)),
+            &pool,
+        );
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
         };
 
         job.perform(&ctx)
@@ -659,14 +1265,14 @@ mod tests {
     #[tokio::test]
     async fn market_making_job_treats_previously_failed_as_clean_terminal() {
         let pool = setup_queue_pool().await;
-        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
-        let ctx = TransferUsdcToMarketMakingCtx {
-            transfer: Arc::new(TerminalAlpacaToBase(TerminalOutcome::PreviouslyFailed)),
-            job_queue,
-        };
+        let ctx = market_making_ctx(
+            Arc::new(TerminalAlpacaToBase(TerminalOutcome::PreviouslyFailed)),
+            &pool,
+        );
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
         };
 
         job.perform(&ctx).await.expect(
@@ -683,14 +1289,14 @@ mod tests {
     #[tokio::test]
     async fn market_making_job_treats_ambient_balance_as_clean_terminal() {
         let pool = setup_queue_pool().await;
-        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
-        let ctx = TransferUsdcToMarketMakingCtx {
-            transfer: Arc::new(TerminalAlpacaToBase(TerminalOutcome::AmbientBalance)),
-            job_queue,
-        };
+        let ctx = market_making_ctx(
+            Arc::new(TerminalAlpacaToBase(TerminalOutcome::AmbientBalance)),
+            &pool,
+        );
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
         };
 
         job.perform(&ctx)
@@ -736,15 +1342,13 @@ mod tests {
             fail: false,
             captured: std::sync::Mutex::new(None),
         });
-        let ctx = TransferUsdcToMarketMakingCtx {
-            transfer: stub.clone(),
-            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
-        };
+        let ctx = market_making_ctx(stub.clone(), &pool);
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = Usdc::new(float!(250));
         let job = TransferUsdcToMarketMaking {
             id: id.clone(),
             amount,
+            revert_redrive_attempts: 0,
         };
 
         Job::perform(&job, &ctx).await.unwrap();
@@ -760,16 +1364,17 @@ mod tests {
     #[tokio::test]
     async fn market_making_perform_returns_ok_on_successful_resume() {
         let pool = setup_queue_pool().await;
-        let ctx = TransferUsdcToMarketMakingCtx {
-            transfer: Arc::new(RecordingResume {
+        let ctx = market_making_ctx(
+            Arc::new(RecordingResume {
                 fail: false,
                 captured: std::sync::Mutex::new(None),
             }),
-            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
-        };
+            &pool,
+        );
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
         };
 
         Job::perform(&job, &ctx).await.unwrap();
@@ -778,16 +1383,17 @@ mod tests {
     #[tokio::test]
     async fn market_making_perform_propagates_resume_failure() {
         let pool = setup_queue_pool().await;
-        let ctx = TransferUsdcToMarketMakingCtx {
-            transfer: Arc::new(RecordingResume {
+        let ctx = market_making_ctx(
+            Arc::new(RecordingResume {
                 fail: true,
                 captured: std::sync::Mutex::new(None),
             }),
-            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
-        };
+            &pool,
+        );
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -799,6 +1405,47 @@ mod tests {
         assert!(
             matches!(error, TransferUsdcToMarketMakingJobError::Transfer(_)),
             "perform must propagate the resume failure as a Transfer error, got {error:?}",
+        );
+    }
+
+    /// The `#[serde(default)]` annotation on `revert_redrive_attempts` is
+    /// load-bearing: on first deploy, all in-flight apalis job rows will lack
+    /// the field in their serialized JSON payload. Verify that deserialization
+    /// of a legacy payload (missing field) defaults to 0, not a parse error.
+    #[test]
+    fn hedging_job_deserializes_legacy_payload_without_redrive_attempts() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = Usdc::new(float!(100));
+        let json = serde_json::json!({
+            "id": id,
+            "amount": amount
+        })
+        .to_string();
+
+        let job: TransferUsdcToHedging = serde_json::from_str(&json).unwrap();
+        assert_eq!(job.id, id, "deserialized id must match",);
+        assert_eq!(
+            job.revert_redrive_attempts, 0,
+            "missing revert_redrive_attempts must default to 0 (serde(default))"
+        );
+    }
+
+    /// Symmetric backward-compat test for the market-making direction.
+    #[test]
+    fn market_making_job_deserializes_legacy_payload_without_redrive_attempts() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = Usdc::new(float!(100));
+        let json = serde_json::json!({
+            "id": id,
+            "amount": amount
+        })
+        .to_string();
+
+        let job: TransferUsdcToMarketMaking = serde_json::from_str(&json).unwrap();
+        assert_eq!(job.id, id, "deserialized id must match",);
+        assert_eq!(
+            job.revert_redrive_attempts, 0,
+            "missing revert_redrive_attempts must default to 0 (serde(default))"
         );
     }
 
@@ -844,14 +1491,11 @@ mod tests {
     #[tokio::test]
     async fn market_making_job_reschedules_underconfirmed_withdrawal() {
         let pool = setup_queue_pool().await;
-        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
-        let ctx = TransferUsdcToMarketMakingCtx {
-            transfer: Arc::new(UnderconfirmedWithdrawal),
-            job_queue,
-        };
+        let ctx = market_making_ctx(Arc::new(UnderconfirmedWithdrawal), &pool);
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
         };
 
         let before = Utc::now().timestamp();
@@ -890,14 +1534,11 @@ mod tests {
     #[tokio::test]
     async fn market_making_job_reschedules_insufficient_usdc_balance() {
         let pool = setup_queue_pool().await;
-        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
-        let ctx = TransferUsdcToMarketMakingCtx {
-            transfer: Arc::new(InsufficientUsdcBalance),
-            job_queue,
-        };
+        let ctx = market_making_ctx(Arc::new(InsufficientUsdcBalance), &pool);
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
         };
 
         let before = Utc::now().timestamp();
@@ -941,7 +1582,6 @@ mod tests {
             id: &UsdcRebalanceId,
             _amount: Usdc,
         ) -> Result<(), UsdcTransferError> {
-            use st0x_bridge::cctp::CctpError;
             Err(UsdcTransferError::SettlementCheckTransient {
                 id: id.clone(),
                 source: Box::new(CctpError::ScanInconclusive { from_block: 42 }),
@@ -955,14 +1595,11 @@ mod tests {
     #[tokio::test]
     async fn market_making_job_reschedules_settlement_check_transient() {
         let pool = setup_queue_pool().await;
-        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
-        let ctx = TransferUsdcToMarketMakingCtx {
-            transfer: Arc::new(SettlementRpcFailure),
-            job_queue,
-        };
+        let ctx = market_making_ctx(Arc::new(SettlementRpcFailure), &pool);
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
         };
 
         let before = Utc::now().timestamp();
@@ -987,11 +1624,1166 @@ mod tests {
             rescheduled.amount,
             job.amount
         );
+        assert_eq!(
+            rescheduled.revert_redrive_attempts, job.revert_redrive_attempts,
+            "SettlementCheckTransient must not consume the revert-redrive budget"
+        );
         assert!(
             run_at >= before + i64::try_from(SETTLEMENT_REDRIVE_DELAY.as_secs()).unwrap() - 5
                 && run_at <= after + i64::try_from(SETTLEMENT_REDRIVE_DELAY.as_secs()).unwrap() + 5,
             "redrive must be delayed by ~{SETTLEMENT_REDRIVE_DELAY:?} -- \
              run_at={run_at} before={before} after={after}"
+        );
+    }
+
+    /// Stub for `SettlementCheckTransient` on the Base->Alpaca (hedging)
+    /// direction -- models an inconclusive Base burn scan or a settlement-phase
+    /// RPC failure surfaced by `resume_bridging_submitting`.
+    struct SettlementRpcFailureBaseToAlpaca;
+
+    #[async_trait]
+    impl ResumeBaseToAlpaca for SettlementRpcFailureBaseToAlpaca {
+        async fn resume_base_to_alpaca(
+            &self,
+            id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(UsdcTransferError::SettlementCheckTransient {
+                id: id.clone(),
+                source: Box::new(CctpError::ScanInconclusive { from_block: 42 }),
+            })
+        }
+    }
+
+    /// Hypothesis: SettlementCheckTransient on the hedging direction (e.g. an
+    /// inconclusive Base burn scan) re-enqueues with SETTLEMENT_REDRIVE_DELAY and
+    /// returns Ok -- the job delayed-redrives without tripping the circuit, so the
+    /// guard is not latched on a normal self-heal outcome.
+    #[tokio::test]
+    async fn hedging_job_reschedules_settlement_check_transient() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(SettlementRpcFailureBaseToAlpaca),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let before = Utc::now().timestamp();
+        Job::perform(&job, &ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            1,
+            "SettlementCheckTransient must re-enqueue a delayed replacement job"
+        );
+        assert_eq!(
+            notifier.messages().len(),
+            0,
+            "an inconclusive settlement check is a normal self-heal outcome and must not \
+             fire a terminal alert (which would page the operator and open the circuit)"
+        );
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToHedging>(&pool).await;
+        let rescheduled: TransferUsdcToHedging = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.id, job.id,
+            "the rescheduled job must resume the same aggregate id"
+        );
+        assert!(
+            rescheduled.amount.eq(&job.amount).unwrap(),
+            "the rescheduled job must carry the same amount, got {} vs {}",
+            rescheduled.amount,
+            job.amount
+        );
+        assert_eq!(
+            rescheduled.revert_redrive_attempts, job.revert_redrive_attempts,
+            "SettlementCheckTransient must not consume the revert-redrive budget"
+        );
+        assert!(
+            run_at >= before + i64::try_from(SETTLEMENT_REDRIVE_DELAY.as_secs()).unwrap() - 5
+                && run_at <= after + i64::try_from(SETTLEMENT_REDRIVE_DELAY.as_secs()).unwrap() + 5,
+            "redrive must be delayed by ~{SETTLEMENT_REDRIVE_DELAY:?} -- \
+             run_at={run_at} before={before} after={after}"
+        );
+    }
+
+    // --- Burn-revert redrive tests ------------------------------------------------
+
+    /// A notifier that always returns an error. Used to verify that a failing
+    /// notifier does not abort the job -- errors are swallowed with a warning.
+    struct FailingNotifier;
+
+    #[async_trait]
+    impl crate::alerts::Notifier for FailingNotifier {
+        async fn notify(&self, _message: &str) -> Result<(), crate::alerts::NotifierError> {
+            Err(crate::alerts::NotifierError::ApiError {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                body: "injected test failure".to_string(),
+            })
+        }
+    }
+
+    /// A failing notifier must not abort the job. The notifier error is swallowed
+    /// and logged as a warning; the job returns the same outcome it would have
+    /// with a working notifier.
+    #[tokio::test]
+    async fn hedging_job_failing_notifier_does_not_abort_job() {
+        let pool = setup_queue_pool().await;
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(BurnRevertResume),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 1,
+            notifier: Arc::new(FailingNotifier),
+        };
+        // attempts=0 -> next=1 == max=1: limit alert fires (and is swallowed), redrive enqueued
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        // A failing notifier must not prevent the redrive from being enqueued
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            1,
+            "failing notifier must not prevent the redrive job from being enqueued"
+        );
+    }
+
+    /// Returns a revert-class burn error. This simulates what `burn_on_base` /
+    /// `burn_on_ethereum` emit when the burn EVM call reverts: `BurnRevert`, not
+    /// `Cctp`. Only the burn call sites emit `BurnRevert`; the mint path and other
+    /// CCTP failures emit `Cctp`.
+    fn revert_burn_error() -> UsdcTransferError {
+        UsdcTransferError::BurnRevert(Box::new(CctpError::Evm(EvmError::Reverted {
+            tx_hash: TxHash::ZERO,
+        })))
+    }
+
+    /// Returns a non-revert `CctpError` (post-burn-success-but-undecodable).
+    fn non_revert_burn_error() -> UsdcTransferError {
+        UsdcTransferError::Cctp(Box::new(CctpError::MessageSentEventNotFound {
+            tx_hash: TxHash::ZERO,
+        }))
+    }
+
+    struct BurnRevertResume;
+
+    #[async_trait]
+    impl ResumeBaseToAlpaca for BurnRevertResume {
+        async fn resume_base_to_alpaca(
+            &self,
+            _id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(revert_burn_error())
+        }
+    }
+
+    struct NonRevertBurnErrorResume;
+
+    #[async_trait]
+    impl ResumeBaseToAlpaca for NonRevertBurnErrorResume {
+        async fn resume_base_to_alpaca(
+            &self,
+            _id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(non_revert_burn_error())
+        }
+    }
+
+    /// A revert-class burn error on the first attempt must return Ok and enqueue
+    /// a delayed replacement job with `revert_redrive_attempts = 1`.
+    /// The safety guarantee is `resume_bridging_submitting`'s scan-or-reburn
+    /// path, not this classification.
+    #[tokio::test]
+    async fn hedging_job_redrives_burn_revert_first_attempt() {
+        let pool = setup_queue_pool().await;
+        let ctx = hedging_ctx(Arc::new(BurnRevertResume), &pool);
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let before = Utc::now().timestamp();
+        Job::perform(&job, &ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            1,
+            "a revert-class burn error must redrive rather than trip the circuit breaker"
+        );
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToHedging>(&pool).await;
+        let rescheduled: TransferUsdcToHedging = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.id, job.id,
+            "the rescheduled job must resume the same aggregate id"
+        );
+        assert!(
+            rescheduled.amount.eq(&job.amount).unwrap(),
+            "the rescheduled job must carry the same amount"
+        );
+        assert_eq!(
+            rescheduled.revert_redrive_attempts, 1,
+            "revert_redrive_attempts must be incremented to 1 in the redrive payload"
+        );
+        assert!(
+            run_at >= before + i64::try_from(BURN_REVERT_REDRIVE_DELAY.as_secs()).unwrap() - 5
+                && run_at
+                    <= after + i64::try_from(BURN_REVERT_REDRIVE_DELAY.as_secs()).unwrap() + 5,
+            "redrive must be delayed by ~{BURN_REVERT_REDRIVE_DELAY:?} -- \
+             run_at={run_at} before={before} after={after}"
+        );
+    }
+
+    /// After `max_burn_revert_redrives` redrives the job must propagate
+    /// `BurnRevertLimitReached` so the circuit opens and the operator is alerted.
+    #[tokio::test]
+    async fn hedging_job_hits_redrive_limit_on_revert() {
+        let pool = setup_queue_pool().await;
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(BurnRevertResume),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 3,
+            notifier: Arc::new(NoopNotifier),
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 3,
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                TransferUsdcToHedgingJobError::BurnRevertLimitReached { .. }
+            ),
+            "at the redrive limit a burn revert must propagate BurnRevertLimitReached, got {error:?}",
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            0,
+            "limit-reached must NOT enqueue a new pending job"
+        );
+    }
+
+    /// A non-revert `CctpError` (e.g. `MessageSentEventNotFound`) is NOT a
+    /// safe-to-redrive error; it must propagate immediately as `Err` so the
+    /// circuit opens.
+    #[tokio::test]
+    async fn hedging_job_does_not_redrive_non_revert_cctp_error() {
+        let pool = setup_queue_pool().await;
+        let ctx = hedging_ctx(Arc::new(NonRevertBurnErrorResume), &pool);
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        assert!(
+            matches!(error, TransferUsdcToHedgingJobError::Transfer(_)),
+            "a non-revert CCTP error must propagate as Transfer, not redrive; got {error:?}",
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            0,
+            "a non-revert error must NOT enqueue a pending job"
+        );
+    }
+
+    /// A terminal non-redriven error must fire the notifier before the circuit
+    /// opens, so the operator receives an alert.
+    #[tokio::test]
+    async fn hedging_job_fires_alert_on_terminal_error() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(NonRevertBurnErrorResume),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        Job::perform(&job, &ctx).await.unwrap_err();
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "exactly one alert must fire on a terminal non-redriven error"
+        );
+        assert!(
+            messages[0].contains(&job.id.to_string()),
+            "alert message must include the transfer id; got: {:?}",
+            messages[0]
+        );
+    }
+
+    /// The notifier must fire exactly once when `revert_redrive_attempts`
+    /// reaches the warn threshold (max/2+1). With max=5, threshold=3: starting
+    /// at attempts=2, next=3 fires exactly one alert and enqueues one pending job.
+    #[tokio::test]
+    async fn hedging_job_fires_alert_at_warn_threshold() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(BurnRevertResume),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        // attempts=2 -> next=3 == 5/2+1 == 3: exactly at threshold
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 2,
+        };
+
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "exactly one alert must fire at the warn threshold"
+        );
+        assert!(
+            notifier.messages()[0].contains("retried"),
+            "warn-threshold message must mention retry count; got: {:?}",
+            notifier.messages()[0]
+        );
+        assert!(
+            notifier.messages()[0].contains(&job.id.to_string()),
+            "warn-threshold alert must include the transfer id; got: {:?}",
+            notifier.messages()[0]
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            1,
+            "a delayed pending job must still be enqueued at the warn threshold"
+        );
+    }
+
+    /// When `next_attempts == max_burn_revert_redrives` (last allowed redrive),
+    /// the job must fire exactly one alert and enqueue the final delayed job.
+    /// This ensures the alert fires exactly once (on the Ok-returning run, not on
+    /// the Err-returning run that apalis retries up to 3 times).
+    #[tokio::test]
+    async fn hedging_job_fires_alert_at_last_redrive() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(BurnRevertResume),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 3,
+            notifier: notifier.clone(),
+        };
+        // attempts=2 -> next=3 == max=3: last allowed redrive, alert fires
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 2,
+        };
+
+        // Returns Ok (last redrive enqueued), NOT Err
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "exactly one alert must fire on the last allowed redrive"
+        );
+        assert!(
+            notifier.messages()[0].contains("limit reached"),
+            "last-redrive message must say 'limit reached'; got: {:?}",
+            notifier.messages()[0]
+        );
+        assert!(
+            notifier.messages()[0].contains(&job.id.to_string()),
+            "alert must include the transfer id; got: {:?}",
+            notifier.messages()[0]
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            1,
+            "last redrive must enqueue one pending job"
+        );
+    }
+
+    /// After the last redrive the job must return `BurnRevertLimitReached`
+    /// with NO alert (apalis will retry this Err; alerting here fires multiple times).
+    #[tokio::test]
+    async fn hedging_job_errors_after_last_redrive_no_alert() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(BurnRevertResume),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 3,
+            notifier: notifier.clone(),
+        };
+        // attempts=3 -> next=4 > max=3: over-limit, returns Err, no alert
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 3,
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                TransferUsdcToHedgingJobError::BurnRevertLimitReached { .. }
+            ),
+            "over-limit must return BurnRevertLimitReached, got {error:?}",
+        );
+        assert_eq!(
+            notifier.messages().len(),
+            0,
+            "over-limit must NOT fire an alert (would fire 4x due to apalis retries)"
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            0,
+            "over-limit must NOT enqueue a new pending job"
+        );
+    }
+
+    /// With `max_burn_revert_redrives = 1`, `warn_threshold` returns `None` so
+    /// no early-warning alert fires. Only the limit alert fires (on the first
+    /// and only redrive attempt). Exactly one alert total, one pending job.
+    #[tokio::test]
+    async fn hedging_job_max_redrives_of_one_fires_exactly_one_limit_alert() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(BurnRevertResume),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 1,
+            notifier: notifier.clone(),
+        };
+        // attempts=0 -> next=1 == max=1: last allowed redrive, limit alert fires
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        Job::perform(&job, &ctx).await.unwrap();
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "max=1: exactly one alert (limit) must fire, not two; got: {messages:?}"
+        );
+        assert!(
+            messages[0].contains("limit reached"),
+            "max=1: alert must say 'limit reached'; got: {:?}",
+            messages[0]
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            1,
+            "max=1: the single redrive job must still be enqueued"
+        );
+    }
+
+    /// With `max_burn_revert_redrives = 2`, `warn_threshold` returns `None` so
+    /// no early-warning alert fires. The limit alert fires on attempt 2, the
+    /// warn-threshold branch is skipped entirely (no room for a distinct warn).
+    #[tokio::test]
+    async fn hedging_job_max_redrives_of_two_no_warn_alert() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(BurnRevertResume),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 2,
+            notifier: notifier.clone(),
+        };
+        // attempts=1 -> next=2 == max=2: last allowed redrive, limit alert fires
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 1,
+        };
+
+        Job::perform(&job, &ctx).await.unwrap();
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "max=2: exactly one alert (limit) must fire, no separate warn; got: {messages:?}"
+        );
+        assert!(
+            messages[0].contains("limit reached"),
+            "max=2: alert must say 'limit reached'; got: {:?}",
+            messages[0]
+        );
+    }
+
+    /// When `next_attempts == max_burn_revert_redrives` (last allowed timeout
+    /// redrive), the job must fire exactly one alert and enqueue the final
+    /// delayed job. Alert fires exactly once (Ok-path, not Err-path).
+    #[tokio::test]
+    async fn hedging_job_fires_alert_at_last_timeout_redrive() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(HangingResume),
+            timeout: Duration::from_millis(50),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 3,
+            notifier: notifier.clone(),
+        };
+        // attempts=2 -> next=3 == max=3: last allowed timeout redrive, alert fires
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 2,
+        };
+
+        // Returns Ok (last redrive enqueued), NOT Err
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "exactly one alert must fire on the last allowed timeout redrive"
+        );
+        assert!(
+            notifier.messages()[0].contains("limit reached"),
+            "last-timeout-redrive message must say 'limit reached'; got: {:?}",
+            notifier.messages()[0]
+        );
+        assert!(
+            notifier.messages()[0].contains(&job.id.to_string()),
+            "alert must include the transfer id; got: {:?}",
+            notifier.messages()[0]
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            1,
+            "last timeout redrive must enqueue one pending job"
+        );
+    }
+
+    /// After the last timeout redrive the job returns `TimeoutLimitReached`
+    /// with NO alert (would fire 4x due to apalis retries).
+    #[tokio::test]
+    async fn hedging_job_errors_after_last_timeout_redrive_no_alert() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(HangingResume),
+            timeout: Duration::from_millis(50),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 3,
+            notifier: notifier.clone(),
+        };
+        // attempts=3 -> next=4 > max=3: over-limit, returns Err, no alert
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 3,
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                TransferUsdcToHedgingJobError::TimeoutLimitReached { .. }
+            ),
+            "over-limit must return TimeoutLimitReached, got {error:?}",
+        );
+        assert_eq!(
+            notifier.messages().len(),
+            0,
+            "over-limit must NOT fire an alert (would fire 4x due to apalis retries)"
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            0,
+            "over-limit must NOT enqueue a new pending job"
+        );
+    }
+
+    /// The notifier must fire exactly once when a timeout hits the warn threshold.
+    /// With max=5, threshold=3: starting at attempts=2, next=3 fires exactly one alert.
+    #[tokio::test]
+    async fn hedging_job_fires_alert_at_timeout_warn_threshold() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(HangingResume),
+            timeout: Duration::from_millis(50),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        // attempts=2 -> next=3 == 5/2+1: exactly at threshold
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 2,
+        };
+
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "exactly one alert must fire at the timeout warn threshold"
+        );
+        assert!(
+            notifier.messages()[0].contains("retried"),
+            "warn-threshold message must mention retry count; got: {:?}",
+            notifier.messages()[0]
+        );
+        assert!(
+            notifier.messages()[0].contains(&job.id.to_string()),
+            "timeout warn-threshold alert must include the transfer id; got: {:?}",
+            notifier.messages()[0]
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            1,
+            "a delayed pending job must still be enqueued at the timeout warn threshold"
+        );
+    }
+
+    // --- Market-making burn-revert redrive tests ---------------------------------
+
+    /// Stub that returns a revert-class error from `resume_alpaca_to_base`.
+    struct BurnRevertAlpacaToBase;
+
+    #[async_trait]
+    impl ResumeAlpacaToBase for BurnRevertAlpacaToBase {
+        async fn resume_alpaca_to_base(
+            &self,
+            _id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(revert_burn_error())
+        }
+    }
+
+    /// A revert-class burn error on the first market-making attempt must return
+    /// Ok and enqueue a delayed replacement job with `revert_redrive_attempts = 1`.
+    #[tokio::test]
+    async fn market_making_job_redrives_burn_revert_first_attempt() {
+        let pool = setup_queue_pool().await;
+        let ctx = market_making_ctx(Arc::new(BurnRevertAlpacaToBase), &pool);
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let before = Utc::now().timestamp();
+        Job::perform(&job, &ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "a revert-class burn error must redrive rather than trip the circuit breaker"
+        );
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        let rescheduled: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.id, job.id,
+            "the rescheduled job must resume the same aggregate id"
+        );
+        assert!(
+            rescheduled.amount.eq(&job.amount).unwrap(),
+            "the rescheduled job must carry the same amount"
+        );
+        assert_eq!(
+            rescheduled.revert_redrive_attempts, 1,
+            "revert_redrive_attempts must be incremented to 1 in the redrive payload"
+        );
+        assert!(
+            run_at >= before + i64::try_from(BURN_REVERT_REDRIVE_DELAY.as_secs()).unwrap() - 5
+                && run_at
+                    <= after + i64::try_from(BURN_REVERT_REDRIVE_DELAY.as_secs()).unwrap() + 5,
+            "redrive must be delayed by ~{BURN_REVERT_REDRIVE_DELAY:?} -- \
+             run_at={run_at} before={before} after={after}"
+        );
+    }
+
+    /// After `max_burn_revert_redrives` redrives the market-making job must
+    /// propagate `BurnRevertLimitReached` so the circuit opens.
+    #[tokio::test]
+    async fn market_making_job_hits_redrive_limit_on_revert() {
+        let pool = setup_queue_pool().await;
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(BurnRevertAlpacaToBase),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 3,
+            notifier: Arc::new(NoopNotifier),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 3,
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                TransferUsdcToMarketMakingJobError::BurnRevertLimitReached { .. }
+            ),
+            "at the redrive limit a burn revert must propagate BurnRevertLimitReached, \
+             got {error:?}",
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            0,
+            "limit-reached must NOT enqueue a new pending job"
+        );
+    }
+
+    /// The notifier must fire exactly once when the market-making job hits the
+    /// revert warn threshold.
+    #[tokio::test]
+    async fn market_making_job_fires_alert_at_warn_threshold() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(BurnRevertAlpacaToBase),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        // attempts=2 -> next=3 == 5/2+1: exactly at threshold
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 2,
+        };
+
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "exactly one alert must fire at the warn threshold"
+        );
+        assert!(
+            notifier.messages()[0].contains("retried"),
+            "warn-threshold message must mention retry count; got: {:?}",
+            notifier.messages()[0]
+        );
+        assert!(
+            notifier.messages()[0].contains(&job.id.to_string()),
+            "warn-threshold alert must include the transfer id; got: {:?}",
+            notifier.messages()[0]
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "a delayed pending job must still be enqueued at the warn threshold"
+        );
+    }
+
+    /// When `next_attempts == max_burn_revert_redrives` (last allowed redrive),
+    /// the market-making job must fire exactly one alert and enqueue the final
+    /// delayed job. Alert fires exactly once (Ok-path).
+    #[tokio::test]
+    async fn market_making_job_fires_alert_at_last_redrive() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(BurnRevertAlpacaToBase),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 3,
+            notifier: notifier.clone(),
+        };
+        // attempts=2 -> next=3 == max=3: last allowed redrive, alert fires
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 2,
+        };
+
+        // Returns Ok (last redrive enqueued), NOT Err
+        Job::perform(&job, &ctx).await.unwrap();
+
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "exactly one alert must fire on the last allowed redrive"
+        );
+        assert!(
+            notifier.messages()[0].contains("limit reached"),
+            "last-redrive message must say 'limit reached'; got: {:?}",
+            notifier.messages()[0]
+        );
+        assert!(
+            notifier.messages()[0].contains(&job.id.to_string()),
+            "alert must include the transfer id; got: {:?}",
+            notifier.messages()[0]
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "last redrive must enqueue one pending job"
+        );
+    }
+
+    /// After the last redrive the market-making job must return
+    /// `BurnRevertLimitReached` with NO alert.
+    #[tokio::test]
+    async fn market_making_job_errors_after_last_redrive_no_alert() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(BurnRevertAlpacaToBase),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 3,
+            notifier: notifier.clone(),
+        };
+        // attempts=3 -> next=4 > max=3: over-limit, Err, no alert
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 3,
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                TransferUsdcToMarketMakingJobError::BurnRevertLimitReached { .. }
+            ),
+            "over-limit must return BurnRevertLimitReached, got {error:?}",
+        );
+        assert_eq!(
+            notifier.messages().len(),
+            0,
+            "over-limit must NOT fire an alert (would fire 4x due to apalis retries)"
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            0,
+            "over-limit must NOT enqueue a new pending job"
+        );
+    }
+
+    /// A terminal non-redriven error on the market-making job must fire the
+    /// notifier before the circuit opens.
+    #[tokio::test]
+    async fn market_making_job_fires_alert_on_terminal_error() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+
+        struct NonRevertAlpacaToBase;
+
+        #[async_trait]
+        impl ResumeAlpacaToBase for NonRevertAlpacaToBase {
+            async fn resume_alpaca_to_base(
+                &self,
+                _id: &UsdcRebalanceId,
+                _amount: Usdc,
+            ) -> Result<(), UsdcTransferError> {
+                Err(non_revert_burn_error())
+            }
+        }
+
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(NonRevertAlpacaToBase),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        Job::perform(&job, &ctx).await.unwrap_err();
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "exactly one alert must fire on a terminal non-redriven error"
+        );
+        assert!(
+            messages[0].contains(&job.id.to_string()),
+            "alert message must include the transfer id; got: {:?}",
+            messages[0]
+        );
+    }
+
+    /// AttestationRetryDeadlineElapsed (hedging) must fire a notifier alert
+    /// because it leaves the aggregate in an operator-reconciliation-bound state.
+    #[tokio::test]
+    async fn hedging_job_fires_alert_on_attestation_deadline_elapsed() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(TerminalBaseToAlpaca(TerminalOutcome::DeadlineElapsed)),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        job.perform(&ctx)
+            .await
+            .expect("deadline-elapsed is a clean terminal outcome");
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "attestation deadline elapsed must fire exactly one alert"
+        );
+        assert!(
+            messages[0].contains(&job.id.to_string()),
+            "alert must include the transfer id; got: {:?}",
+            messages[0]
+        );
+    }
+
+    /// AttestationRetryDeadlineElapsed (market-making) must fire a notifier alert.
+    #[tokio::test]
+    async fn market_making_job_fires_alert_on_attestation_deadline_elapsed() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(TerminalAlpacaToBase(TerminalOutcome::DeadlineElapsed)),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        job.perform(&ctx)
+            .await
+            .expect("deadline-elapsed is a clean terminal outcome");
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "attestation deadline elapsed must fire exactly one alert"
+        );
+        assert!(
+            messages[0].contains(&job.id.to_string()),
+            "alert must include the transfer id; got: {:?}",
+            messages[0]
+        );
+    }
+
+    /// A revert-class `CctpError` returned as `UsdcTransferError::Cctp` (as the
+    /// MINT path emits after calling `FailBridging`) must NOT enter the burn-redrive
+    /// path -- it must fall through to the terminal-error branch and propagate as Err.
+    /// This is the HIGH #1 regression: before the `BurnRevert` variant,
+    /// `is_burn_revert()` misrouted mint-side reverts into the redrive path,
+    /// silently swallowing the operator alert.
+    #[tokio::test]
+    async fn hedging_job_cctp_revert_from_mint_path_goes_to_terminal_not_redrive() {
+        struct MintPathRevert;
+
+        #[async_trait]
+        impl ResumeBaseToAlpaca for MintPathRevert {
+            async fn resume_base_to_alpaca(
+                &self,
+                _id: &UsdcRebalanceId,
+                _amount: Usdc,
+            ) -> Result<(), UsdcTransferError> {
+                // The mint path emits UsdcTransferError::Cctp(revert-class) after
+                // FailBridging. Critically: NOT UsdcTransferError::BurnRevert.
+                Err(UsdcTransferError::Cctp(Box::new(CctpError::Evm(
+                    EvmError::Reverted {
+                        tx_hash: TxHash::ZERO,
+                    },
+                ))))
+            }
+        }
+
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(MintPathRevert),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        // Must error (terminal), not Ok (redrive)
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        assert!(
+            matches!(error, TransferUsdcToHedgingJobError::Transfer(_)),
+            "a mint-path Cctp revert must propagate as terminal Transfer,              not redrive; got {error:?}",
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            0,
+            "a mint-path Cctp revert must NOT enqueue a redrive job"
+        );
+        // Operator alert must fire (terminal path fires alert)
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "exactly one alert must fire for a mint-path terminal error"
+        );
+        assert!(
+            notifier.messages()[0].contains(&job.id.to_string()),
+            "terminal alert must include the transfer id; got: {:?}",
+            notifier.messages()[0]
+        );
+    }
+
+    /// Symmetric to `hedging_job_cctp_revert_from_mint_path_goes_to_terminal_not_redrive`
+    /// for the market-making (Alpaca->Base) direction.
+    #[tokio::test]
+    async fn market_making_job_cctp_revert_from_mint_path_goes_to_terminal_not_redrive() {
+        struct MintPathRevertAlpacaToBase;
+
+        #[async_trait]
+        impl ResumeAlpacaToBase for MintPathRevertAlpacaToBase {
+            async fn resume_alpaca_to_base(
+                &self,
+                _id: &UsdcRebalanceId,
+                _amount: Usdc,
+            ) -> Result<(), UsdcTransferError> {
+                Err(UsdcTransferError::Cctp(Box::new(CctpError::Evm(
+                    EvmError::Reverted {
+                        tx_hash: TxHash::ZERO,
+                    },
+                ))))
+            }
+        }
+
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(MintPathRevertAlpacaToBase),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        assert!(
+            matches!(error, TransferUsdcToMarketMakingJobError::Transfer(_)),
+            "a mint-path Cctp revert in market-making must propagate as terminal Transfer;              got {error:?}",
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            0,
+            "a mint-path Cctp revert must NOT enqueue a redrive job"
+        );
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "exactly one alert must fire for a mint-path terminal error in market-making"
+        );
+        assert!(
+            notifier.messages()[0].contains(&job.id.to_string()),
+            "terminal alert must include the transfer id; got: {:?}",
+            notifier.messages()[0]
+        );
+    }
+
+    /// WalletUsdcAmbientBalance (market-making) must fire a notifier alert
+    /// because it leaves the aggregate in an operator-reconciliation-bound state.
+    #[tokio::test]
+    async fn market_making_job_fires_alert_on_ambient_balance() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(TerminalAlpacaToBase(TerminalOutcome::AmbientBalance)),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        job.perform(&ctx)
+            .await
+            .expect("ambient balance is a clean terminal outcome");
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "ambient balance must fire exactly one alert"
+        );
+        assert!(
+            messages[0].contains(&job.id.to_string()),
+            "alert must include the transfer id; got: {:?}",
+            messages[0]
         );
     }
 }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -2606,6 +2606,22 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 }
             }
             Ok(None) => self.burn_on_base(amount).await?,
+            // ScanInconclusive: the chain head hasn't advanced far enough past
+            // `from_block` to trust an empty scan result. The aggregate is at
+            // `BridgingSubmitting` (a durable state), so return
+            // `SettlementCheckTransient` so the job delayed-redrives instead of
+            // consuming the apalis retry budget.
+            Err(error @ CctpError::ScanInconclusive { .. }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    "CCTP burn scan on Base inconclusive; will retry after delay"
+                );
+                return Err(UsdcTransferError::SettlementCheckTransient {
+                    id: id.clone(),
+                    source: Box::new(error),
+                });
+            }
             Err(error) => {
                 warn!(target: "rebalance", "CCTP burn scan on Base failed: {error}");
                 return Err(UsdcTransferError::Cctp(Box::new(error)));
@@ -2629,7 +2645,11 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             .await
             .map_err(|error| {
                 warn!(target: "rebalance", "CCTP burn on Base failed: {error}");
-                UsdcTransferError::Cctp(Box::new(error))
+                if error.is_revert() {
+                    UsdcTransferError::BurnRevert(Box::new(error))
+                } else {
+                    UsdcTransferError::Cctp(Box::new(error))
+                }
             })
     }
 
@@ -2764,7 +2784,11 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             .await
             .map_err(|error| {
                 warn!(target: "rebalance", "CCTP burn on Ethereum failed: {error}");
-                UsdcTransferError::Cctp(Box::new(error))
+                if error.is_revert() {
+                    UsdcTransferError::BurnRevert(Box::new(error))
+                } else {
+                    UsdcTransferError::Cctp(Box::new(error))
+                }
             })
     }
 
@@ -7591,10 +7615,16 @@ mod tests {
         let (manager, cqrs) =
             build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
 
-        // Deploy a REVERT-only contract at TOKEN_MESSENGER_V2 so the burn
-        // attempt fails predictably: BeginBridging fires before the burn,
-        // leaving the aggregate at BridgingSubmitting (not BridgingFailed).
-        let revert_bytecode = alloy::primitives::Bytes::from(vec![0xFDu8]);
+        // Deploy a REVERT contract at TOKEN_MESSENGER_V2 so the burn fails
+        // predictably. The bytecode is PUSH1 0 PUSH1 0 REVERT (0x60 0x00 0x60
+        // 0x00 0xFD), which pushes two zero arguments for the REVERT opcode so
+        // the stack is not underflowed. This produces a proper EVM revert
+        // (error code 3 / "execution reverted"), recognized by is_revert().
+        // A bare 0xFD with empty stack would cause StackUnderflow (code -32603),
+        // which is_revert() does not classify as a revert-class error.
+        // BeginBridging fires before the burn attempt; the REVERT leaves the
+        // aggregate at BridgingSubmitting (not BridgingFailed).
+        let revert_bytecode = alloy::primitives::Bytes::from(vec![0x60u8, 0x00, 0x60, 0x00, 0xFD]);
         let provider = ProviderBuilder::new()
             .connect(&chain.endpoint)
             .await
@@ -7618,8 +7648,8 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            matches!(error, UsdcTransferError::Cctp(_)),
-            "Expected Cctp error, not a balance-gate wedge; got: {error:?}"
+            matches!(error, UsdcTransferError::BurnRevert(_)),
+            "Expected BurnRevert error from REVERT-bytecode burn (0xFD), got: {error:?}"
         );
 
         // Aggregate at BridgingSubmitting confirms BeginBridging was emitted
@@ -7726,8 +7756,12 @@ mod tests {
         let (manager, cqrs) =
             build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
 
-        // REVERT-only contract: confirms burn was attempted (not wedged).
-        let revert_bytecode = alloy::primitives::Bytes::from(vec![0xFDu8]);
+        // REVERT contract: confirms burn was attempted (not wedged by gates).
+        // The bytecode PUSH1 0 PUSH1 0 REVERT (0x60 0x00 0x60 0x00 0xFD)
+        // produces a proper EVM revert (code 3 / "execution reverted") so
+        // is_revert() classifies it as a BurnRevert. A bare 0xFD with empty
+        // stack causes StackUnderflow (code -32603), which is_revert() rejects.
+        let revert_bytecode = alloy::primitives::Bytes::from(vec![0x60u8, 0x00, 0x60, 0x00, 0xFD]);
         let provider = ProviderBuilder::new()
             .connect(&chain.endpoint)
             .await
@@ -7745,16 +7779,16 @@ mod tests {
         // withdrawal_tx = None: no confirmation gate is entered at all.
         // If the confirmation gate ran, the mock server would return 404 (no
         // tx-confirmation endpoint registered), producing SettlementCheckTransient.
-        // A Cctp error proves the gate was skipped and the burn was attempted.
+        // A BurnRevert error proves the gate was skipped and the burn was attempted.
         let error = manager
             .continue_alpaca_to_base_from_withdrawal_complete(&id, nominal, None)
             .await
             .unwrap_err();
 
         assert!(
-            matches!(error, UsdcTransferError::Cctp(_)),
-            "Expected Cctp error (burn attempted, tx-confirmation gate skipped); \
-             SettlementCheckTransient would indicate the confirmation gate incorrectly fired; \
+            matches!(error, UsdcTransferError::BurnRevert(_)),
+            "Expected BurnRevert error from REVERT-bytecode burn (0xFD, confirmation gate \
+             skipped); SettlementCheckTransient would indicate the gate incorrectly fired; \
              got: {error:?}"
         );
 
@@ -7923,9 +7957,13 @@ mod tests {
         let (manager, cqrs) =
             build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
 
-        // Deploy a REVERT-only contract at TOKEN_MESSENGER_V2 (0xFD = REVERT opcode)
-        // to ensure any call that reaches the contract level also reverts.
-        let revert_bytecode = alloy::primitives::Bytes::from(vec![0xFDu8]);
+        // Deploy a REVERT contract at TOKEN_MESSENGER_V2. The bytecode is
+        // PUSH1 0 PUSH1 0 REVERT (0x60 0x00 0x60 0x00 0xFD): two zero
+        // arguments for REVERT so the stack is not underflowed. This produces
+        // a proper EVM revert (code 3 / "execution reverted") recognized by
+        // is_revert(). A bare 0xFD with empty stack causes StackUnderflow
+        // (code -32603) which is_revert() does not classify as a revert.
+        let revert_bytecode = alloy::primitives::Bytes::from(vec![0x60u8, 0x00, 0x60, 0x00, 0xFD]);
         let provider = ProviderBuilder::new()
             .connect(&chain.endpoint)
             .await
@@ -7950,8 +7988,8 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            matches!(error, UsdcTransferError::Cctp(_)),
-            "Expected Cctp error from pre-commit burn failure, got: {error:?}"
+            matches!(error, UsdcTransferError::BurnRevert(_)),
+            "Expected BurnRevert error from REVERT-bytecode burn (0xFD pre-commit), got: {error:?}"
         );
 
         // Aggregate must be in BridgingSubmitting (BeginBridging was emitted before
@@ -8762,6 +8800,44 @@ mod tests {
             ),
             "BridgingSubmitting{{BaseToAlpaca}} must yield ResumeDirectionMismatch, \
              got: {error:?}"
+        );
+    }
+
+    /// `resume_bridging_submitting` (Base->Alpaca, burning via BaseToEthereum)
+    /// returns `SettlementCheckTransient` -- not `Cctp` -- when the burn scan is
+    /// inconclusive (chain head not yet `SCAN_FINALITY_MARGIN` blocks past
+    /// `from_block`). Mirrors the Ethereum counterpart so an inconclusive scan
+    /// delayed-redrives instead of tripping the terminal circuit. The aggregate
+    /// stays at `BridgingSubmitting`.
+    #[tokio::test]
+    async fn resume_bridging_submitting_base_scan_inconclusive_returns_settlement_transient() {
+        let server = MockServer::start();
+        let (manager, cqrs, anvil) = make_resume_test_manager(&server).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        let amount_u256 = usdc_to_u256(amount).unwrap();
+        let provider = ProviderBuilder::new().connect_http(anvil.endpoint().parse().unwrap());
+        let from_block = provider.get_block_number().await.unwrap();
+        advance_to_bridging_submitting_base_to_alpaca(&cqrs, &id, amount, from_block).await;
+        let error = manager
+            .resume_bridging_submitting(&id, amount_u256, from_block)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, UsdcTransferError::SettlementCheckTransient { .. }),
+            "an inconclusive Base burn scan must yield SettlementCheckTransient (delayed \
+             redrive), not Cctp (terminal); got: {error:?}"
+        );
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::BridgingSubmitting {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    ..
+                }
+            ),
+            "Aggregate must stay at BridgingSubmitting after an inconclusive scan; got: {state:?}"
         );
     }
 

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -38,6 +38,22 @@ pub(crate) enum UsdcTransferError {
     AlpacaBrokerApi(#[from] AlpacaBrokerApiError),
     #[error("CCTP bridge error: {0}")]
     Cctp(#[from] Box<CctpError>),
+    /// Emitted only by burn call sites (`burn_on_base`, `burn_on_ethereum`) when
+    /// the burn fails with a revert-class error: EVM execution reverts and
+    /// pre-flight rejections that produce no on-chain state change. Safe to
+    /// redrive via the scan-or-reburn path in `resume_bridging_submitting` /
+    /// `resume_bridging_submitting_ethereum`.
+    ///
+    /// IMPORTANT: The double-burn safety guarantee does NOT come from this
+    /// classification. It comes from `resume_bridging_submitting` /
+    /// `resume_bridging_submitting_ethereum` scanning for an existing burn (via
+    /// `find_recent_burn`) before attempting a new one, with the scan lower bound
+    /// (`from_block`) durably recorded in the `BeginBridging` / `BridgingSubmitting`
+    /// event before the burn call. This variant identifies errors where the EVM
+    /// produced no lasting state change (post-mining reverts, pre-flight rejections).
+    /// The safety guarantee is the scan, not this variant.
+    #[error("CCTP burn revert (no on-chain state change): {0}")]
+    BurnRevert(Box<CctpError>),
     #[error("Vault error: {0}")]
     Vault(#[from] RaindexError),
     #[error("Aggregate error: {0}")]

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -1278,6 +1278,52 @@ impl UsdcRebalance {
             | Self::Reconciled { amount, .. } => *amount,
         }
     }
+
+    /// Returns the `(direction, amount)` for a mid-flight resumable aggregate
+    /// that can be re-armed by `recover_usdc_guard`, or `None` otherwise.
+    ///
+    /// `BridgingSubmitting` is resumable for both directions.
+    /// `WithdrawalSubmitting` is resumable only for `BaseToAlpaca`:
+    /// `resume_base_to_alpaca` handles it; `resume_alpaca_to_base` returns
+    /// `ResumeDirectionMismatch` for `WithdrawalSubmitting{AlpacaToBase}`.
+    ///
+    /// This method covers ONLY pre-burn / pre-withdrawal-tx states: post-burn
+    /// states (`Bridging`, `AwaitingAttestation`, `Attested`) are already
+    /// handled by `resumable_post_burn_transfer`.
+    pub(crate) fn is_resumable_mid_flight_data(&self) -> Option<(RebalanceDirection, Usdc)> {
+        match self {
+            // WithdrawalSubmitting is only resumable for BaseToAlpaca:
+            // resume_base_to_alpaca handles it; resume_alpaca_to_base returns
+            // ResumeDirectionMismatch for this state regardless of direction.
+            Self::WithdrawalSubmitting {
+                direction: direction @ RebalanceDirection::BaseToAlpaca,
+                amount,
+                ..
+            }
+            | Self::BridgingSubmitting {
+                direction, amount, ..
+            } => Some((*direction, *amount)),
+            Self::WithdrawalSubmitting {
+                direction: RebalanceDirection::AlpacaToBase,
+                ..
+            }
+            | Self::Converting { .. }
+            | Self::ConversionComplete { .. }
+            | Self::ConversionFailed { .. }
+            | Self::Withdrawing { .. }
+            | Self::WithdrawalComplete { .. }
+            | Self::WithdrawalFailed { .. }
+            | Self::Bridging { .. }
+            | Self::AwaitingAttestation { .. }
+            | Self::Attested { .. }
+            | Self::Bridged { .. }
+            | Self::DepositInitiated { .. }
+            | Self::DepositConfirmed { .. }
+            | Self::DepositFailed { .. }
+            | Self::BridgingFailed { .. }
+            | Self::Reconciled { .. } => None,
+        }
+    }
 }
 
 /// Candidate `UsdcRebalance` aggregates whose latest event leaves them
@@ -8813,5 +8859,122 @@ mod tests {
         };
         assert_eq!(direction, RebalanceDirection::AlpacaToBase);
         assert_eq!(burn_tx_hash, burn_tx);
+    }
+
+    // --- is_resumable_mid_flight tests ---
+
+    fn bridging_submitting_base_to_alpaca() -> UsdcRebalance {
+        UsdcRebalance::BridgingSubmitting {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(100)),
+            from_block: 1,
+            initiated_at: Utc::now(),
+            burn_amount: None,
+        }
+    }
+
+    fn bridging_submitting_alpaca_to_base() -> UsdcRebalance {
+        UsdcRebalance::BridgingSubmitting {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: Usdc::new(float!(100)),
+            from_block: 1,
+            initiated_at: Utc::now(),
+            burn_amount: None,
+        }
+    }
+
+    fn withdrawal_submitting_base_to_alpaca() -> UsdcRebalance {
+        UsdcRebalance::WithdrawalSubmitting {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(100)),
+            from_block: 1,
+            initiated_at: Utc::now(),
+        }
+    }
+
+    fn withdrawal_submitting_alpaca_to_base() -> UsdcRebalance {
+        UsdcRebalance::WithdrawalSubmitting {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: Usdc::new(float!(100)),
+            from_block: 1,
+            initiated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn is_resumable_mid_flight_data_some_for_bridging_submitting_base_to_alpaca() {
+        let amount = Usdc::new(float!(100));
+        let result = bridging_submitting_base_to_alpaca().is_resumable_mid_flight_data();
+        assert_eq!(
+            result,
+            Some((RebalanceDirection::BaseToAlpaca, amount)),
+            "BridgingSubmitting BaseToAlpaca must be resumable"
+        );
+    }
+
+    #[test]
+    fn is_resumable_mid_flight_data_some_for_bridging_submitting_alpaca_to_base() {
+        let amount = Usdc::new(float!(100));
+        let result = bridging_submitting_alpaca_to_base().is_resumable_mid_flight_data();
+        assert_eq!(
+            result,
+            Some((RebalanceDirection::AlpacaToBase, amount)),
+            "BridgingSubmitting AlpacaToBase must be resumable"
+        );
+    }
+
+    #[test]
+    fn is_resumable_mid_flight_data_some_for_withdrawal_submitting_base_to_alpaca() {
+        let amount = Usdc::new(float!(100));
+        let result = withdrawal_submitting_base_to_alpaca().is_resumable_mid_flight_data();
+        assert_eq!(
+            result,
+            Some((RebalanceDirection::BaseToAlpaca, amount)),
+            "WithdrawalSubmitting BaseToAlpaca must be resumable (resume_base_to_alpaca handles it)"
+        );
+    }
+
+    #[test]
+    fn is_resumable_mid_flight_data_none_for_withdrawal_submitting_alpaca_to_base() {
+        let result = withdrawal_submitting_alpaca_to_base().is_resumable_mid_flight_data();
+        assert_eq!(
+            result, None,
+            "WithdrawalSubmitting AlpacaToBase must NOT be resumable \
+             (resume_alpaca_to_base returns ResumeDirectionMismatch)"
+        );
+    }
+
+    #[test]
+    fn is_resumable_mid_flight_data_none_for_post_burn_bridging() {
+        let state = UsdcRebalance::Bridging {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(100)),
+            burn_tx_hash: alloy::primitives::TxHash::ZERO,
+            initiated_at: Utc::now(),
+            burned_at: Utc::now(),
+        };
+        assert_eq!(
+            state.is_resumable_mid_flight_data(),
+            None,
+            "Bridging (post-burn) must not be mid-flight resumable"
+        );
+    }
+
+    #[test]
+    fn is_resumable_mid_flight_data_none_for_terminal_bridging_failed() {
+        let state = UsdcRebalance::BridgingFailed {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(100)),
+            burn_tx_hash: None,
+            cctp_nonce: None,
+            reason: "transient".to_string(),
+            initiated_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+        assert_eq!(
+            state.is_resumable_mid_flight_data(),
+            None,
+            "BridgingFailed (terminal) must not be mid-flight resumable"
+        );
     }
 }

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -367,6 +367,7 @@ redemption_wallet = "{redemption_wallet}"
 transfer_timeout_secs = 1800
 transfer_attempt_timeout_secs = 3600
 attestation_retry_deadline_secs = 86400
+max_burn_revert_redrives = 5
 equity = {{ target = 0.5, deviation = 0.1 }}
 usdc = {{ mode = "enabled", target = 0.5, deviation = 0.1 }}
 


### PR DESCRIPTION
## What

Self-heal transient CCTP burn reverts instead of latching the `usdc_in_progress`
guard permanently, and alert operators on any state that blocks USDC rebalancing
without an automated recovery path.

Stacks on [RAI-1151 / PR #920](https://github.com/ST0x-Technology/st0x.liquidity/pull/920)
(standing CCTP allowance).
Closes [RAI-1152](https://linear.app/makeitrain/issue/RAI-1152).

## Why

- A transient, provably-safe CCTP burn revert (EVM reverted — no on-chain state
  change) was treated as a terminal fail-stop, tripping the circuit breaker,
  latching `usdc_in_progress`, and blocking ALL USDC rebalancing until an
  operator manually ran `resume-usdc-transfer`. This was a real prod incident.
- Separately, if the process crashed between emitting `BridgingSubmitting` and
  committing the apalis job row, the guard was permanently latched on restart
  with no alert and no automated recovery.

## How

**Bounded burn-revert self-heal (both directions)**

- New `UsdcTransferError::BurnRevert` variant — emitted only by the two burn
  call sites (`burn_on_base`, `burn_on_ethereum`) when `CctpError::is_revert()`
  is true (revert-class failure with no successful burn/message state change).
  `Cctp` (from mint, attestation, etc.) remains terminal and is NOT rerouted.
  The double-burn safety guarantee comes from `find_recent_burn` in the
  `resume_bridging_submitting` scan-or-reburn path, not from this classification.
- `TransferUsdcToHedging` and `TransferUsdcToMarketMaking` jobs handle
  `BurnRevert` by re-enqueueing themselves via `push_with_delay` (15 s for burn
  reverts, 30 s for per-attempt timeouts on the hedging direction), re-entering
  the scan-or-reburn path on next pickup. Applied symmetrically to both
  directions.
- A durable `revert_redrive_attempts` counter (`#[serde(default)]` for backward
  compat with existing job rows) caps redrives at `max_burn_revert_redrives`
  (new REQUIRED config field; startup fails with a clear error if zero and USDC
  is enabled). Suggested value: 5.

**Startup reaper for `BridgingSubmitting` / `WithdrawalSubmitting{BaseToAlpaca}`**

- `recover_usdc_guard` now also re-arms aggregates at pre-burn mid-flight states
  (`BridgingSubmitting`, both directions; `WithdrawalSubmitting{BaseToAlpaca}`)
  that have no blocking job row (a `Failed` row also suppresses re-arm — those
  require operator attention). These are resumable: the process crashed before
  the burn tx was submitted or before the enqueue committed.
- `WithdrawalSubmitting{AlpacaToBase}` is deliberately NOT re-armed:
  `resume_alpaca_to_base` returns `ResumeDirectionMismatch` for that state. The
  operator is alerted instead (see below).
- Mid-flight states do NOT get a tracking seed (unlike `DepositFailed` etc.);
  seeding them would wedge the `DepositConfirmed` path.

**Notifier seam**

- `Notifier` trait moved to `alerts/mod.rs`; `NoopNotifier` added as the
  explicit-absence implementation (used when `[alerts]` is omitted).
- `build_usdc_notifier` in `conductor.rs` returns `NoopNotifier` when
  `[alerts]` is absent, or fails startup (not silently falls back) if the
  section is present but `TelegramNotifier` cannot init.
- Alerts fire on: warn-threshold redrive, last-allowed redrive, terminal
  non-redriven errors, post-burn stall, and startup stranded/unresolved aggregates.

## Testing

- `~1937` non-e2e tests pass; clippy clean.
- **`BurnRevert` routing**: hedging and market-making jobs redrive on
  `BurnRevert`, do NOT redrive on non-revert `Cctp` errors, and the
  `BurnRevert`/`Cctp` variants are distinct (mint reverts are not misrouted).
- **Bounded redrive**: warn-threshold fires once, last-redrive alert fires once
  then final redrive is enqueued, over-limit returns `BurnRevertLimitReached`
  with NO alert (suppresses duplicate apalis retry pages) — for both directions.
- **Timeout redrive** (hedging): same boundary logic; `TimeoutLimitReached` on
  over-limit.
- **Serde backward compat**: legacy job rows without `revert_redrive_attempts`
  deserialize with `default = 0`.
- **Startup reaper routing**: `BridgingSubmitting{BaseToAlpaca/AlpacaToBase}` and
  `WithdrawalSubmitting{BaseToAlpaca}` are re-armed; `WithdrawalSubmitting{AlpacaToBase}`
  is NOT re-armed (excluded by `is_resumable_mid_flight_data`); a `Failed` job
  row suppresses re-arm (idempotency).
- **Stranded-latch alert**: operator is notified on startup for any held
  aggregate with no automated recovery.
- **Notifier noop**: `build_usdc_notifier` returns `Ok(NoopNotifier)` when
  `[alerts]` is absent; propagates `NotifierError` (fails startup) when the
  section is present but `TelegramNotifier` cannot init — verified by
  `build_usdc_notifier_returns_ok_noop_when_alerts_absent`.

## Anything else

**Known limitations / follow-ups:**

1. `WithdrawalSubmitting{AlpacaToBase}` is not auto-resumable: the withdrawal
   identity (Alpaca transfer ID) is not yet persisted in that state.
   `resume_alpaca_to_base` returns `ResumeDirectionMismatch`. Operator alert
   fires on startup; manual `reconcile-usdc-transfer` required. Making it
   resumable is a follow-up.
2. The market-making direction has no wall-clock per-attempt timeout: its
   broker Converting leg has no safe re-entry. Relies on underlying RPC/broker
   timeouts and the startup re-arm.
3. Generic terminal-error alerts (non-redriven `Cctp` / other errors) on both
   hedging and market-making jobs may fire up to ~4x under apalis retries;
   limit-reached alerts fire exactly once (Ok-path design).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer USDC rebalance recovery with automatic restart of resumable in-flight transfers and clearer handling for stalled jobs.
  * Introduced configurable alerting for repeated burn failures, with operator notifications when limits are approached or reached.

* **Bug Fixes**
  * Improved classification of CCTP burn reverts so recoverable failures are retried instead of treated as hard errors.
  * Added startup recovery behavior to avoid leaving eligible transfers stuck after interruptions.

* **Documentation**
  * Expanded USDC rebalance guidance to cover recovery rules, restart behavior, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->