### PR TITLE
refactor: make TokenizedEquityMint handlers pure (move tokenizer I/O to orchestrator)

### DIFF
--- a/crates/tokenization/src/mock.rs
+++ b/crates/tokenization/src/mock.rs
@@ -106,6 +106,8 @@ pub struct MockTokenizer {
     last_issuer_request_id: Mutex<Option<IssuerRequestId>>,
     /// Total number of tokenizer method calls made (across all methods).
     call_count: AtomicUsize,
+    /// Number of `request_mint` calls made (the provider-side mint requests).
+    request_mint_count: AtomicUsize,
     pending_requests: Vec<TokenizationRequest>,
     /// Override the token_symbol in completed mint responses.
     token_symbol_behavior: MockTokenSymbolBehavior,
@@ -129,6 +131,7 @@ impl MockTokenizer {
             list_pending_outcome: MockListPendingOutcome::Succeed,
             last_issuer_request_id: Mutex::new(None),
             call_count: AtomicUsize::new(0),
+            request_mint_count: AtomicUsize::new(0),
             token_symbol_behavior: MockTokenSymbolBehavior::Default,
             fees_override: None,
             pending_requests: Vec::new(),
@@ -138,6 +141,11 @@ impl MockTokenizer {
     /// Returns the total number of tokenizer method calls made since construction.
     pub fn call_count(&self) -> usize {
         self.call_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns how many times `request_mint` was called since construction.
+    pub fn request_mint_count(&self) -> usize {
+        self.request_mint_count.load(Ordering::Relaxed)
     }
 
     #[must_use]
@@ -252,6 +260,7 @@ impl Tokenizer for MockTokenizer {
         issuer_request_id: IssuerRequestId,
     ) -> Result<TokenizationRequest, TokenizerError> {
         self.call_count.fetch_add(1, Ordering::Relaxed);
+        self.request_mint_count.fetch_add(1, Ordering::Relaxed);
         *self
             .last_issuer_request_id
             .lock()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1865,17 +1865,12 @@ mod tests {
     use st0x_config::{EvmCtx, IngestionCutoff, InventoryMode};
     use st0x_event_sorcery::StoreBuilder;
     use st0x_float_macro::float;
-    use st0x_tokenization::IssuerRequestId;
-    use st0x_tokenization::mock::MockTokenizer;
-    use st0x_wrapper::MockWrapper;
+    use st0x_tokenization::{IssuerRequestId, tokenization_request_id};
 
     use super::*;
     use crate::offchain::order::OffchainOrderEvent;
-    use crate::onchain::mock::MockRaindex;
-    use crate::rebalancing::equity::EquityTransferServices;
     use crate::test_utils::{positive_shares, setup_test_db};
     use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintCommand};
-    use crate::vault_lookup::MockVaultLookup;
 
     fn create_test_ctx() -> Ctx {
         Ctx {
@@ -2657,28 +2652,23 @@ mod tests {
         let operation_id = Uuid::new_v4();
 
         // Seed a real TokenizedEquityMint event stream by sending the
-        // fixture-only `RequestMintAt` command through the aggregate's own
-        // store -- never a raw `events` INSERT -- so the replay path folds
-        // the exact event shapes/sequence the live system would produce.
-        // The default `MockTokenizer` accepts the request, so this emits
-        // both `MintRequested` and `MintAccepted`.
+        // fixture-only `RecordMintRequestedAt` command through the aggregate's
+        // own store -- never a raw `events` INSERT -- so the replay path folds
+        // the exact event shapes/sequence the live system would produce. It
+        // emits both `MintRequested` and `MintAccepted`.
         let store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-            .build(EquityTransferServices {
-                raindex: Arc::new(MockRaindex::new()),
-                vault_lookup: Arc::new(MockVaultLookup::new()),
-                tokenizer: Arc::new(MockTokenizer::new()),
-                wrapper: Arc::new(MockWrapper::new()),
-            })
+            .build(())
             .await
             .unwrap();
         store
             .send(
                 &IssuerRequestId(operation_id),
-                TokenizedEquityMintCommand::RequestMintAt {
+                TokenizedEquityMintCommand::RecordMintRequestedAt {
                     issuer_request_id: IssuerRequestId(operation_id),
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(5),
                     wallet: Address::repeat_byte(0x11),
+                    tokenization_request_id: tokenization_request_id("rebuild-view-tok"),
                     requested_at: Utc::now(),
                 },
             )

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -113,7 +113,7 @@ async fn build_equity_transfer_services(
     };
 
     let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-        .build(services.clone())
+        .build(())
         .await?;
 
     let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
@@ -1386,8 +1386,6 @@ pub(crate) async fn fail_transfer_command<W: Write>(
     id: &str,
     reason: &str,
 ) -> anyhow::Result<()> {
-    let services = EquityTransferServices::panicking();
-
     match transfer_type {
         TransferType::Mint => {
             let mint_id: IssuerRequestId = id
@@ -1424,16 +1422,18 @@ pub(crate) async fn fail_transfer_command<W: Write>(
                 }
             };
 
-            st0x_event_sorcery::send_command::<TokenizedEquityMint>(
-                pool, &mint_id, command, services,
-            )
-            .await
-            .map_err(|error| stale_state_context("Mint", id, error))?;
+            st0x_event_sorcery::send_command::<TokenizedEquityMint>(pool, &mint_id, command, ())
+                .await
+                .map_err(|error| stale_state_context("Mint", id, error))?;
 
             writeln!(stdout, "Mint {id} marked as failed")?;
         }
 
         TransferType::Redemption => {
+            // Only the redemption aggregate still takes `EquityTransferServices`;
+            // its failure commands never invoke them, so the panicking stub is safe.
+            let services = EquityTransferServices::panicking();
+
             let redemption_id: RedemptionAggregateId = id
                 .parse()
                 .map_err(|error| anyhow::anyhow!("Invalid redemption ID: {error}"))?;
@@ -1523,8 +1523,6 @@ pub(crate) async fn reconcile_equity_transfer_command<W: Write>(
     reason: String,
     pool: &SqlitePool,
 ) -> anyhow::Result<()> {
-    let services = EquityTransferServices::panicking();
-
     match transfer_type {
         TransferType::Mint => {
             let mint_id: IssuerRequestId = id.parse().map_err(|error| {
@@ -1547,7 +1545,7 @@ pub(crate) async fn reconcile_equity_transfer_command<W: Write>(
                 pool,
                 &mint_id,
                 TokenizedEquityMintCommand::Reconcile { reason },
-                services,
+                (),
             )
             .await?;
 
@@ -1555,6 +1553,10 @@ pub(crate) async fn reconcile_equity_transfer_command<W: Write>(
         }
 
         TransferType::Redemption => {
+            // Only the redemption aggregate still takes `EquityTransferServices`;
+            // Reconcile never invokes them, so the panicking stub is safe.
+            let services = EquityTransferServices::panicking();
+
             let redemption_id: RedemptionAggregateId = id.parse().map_err(|error| {
                 anyhow::anyhow!("transfer reconcile: invalid redemption id {id:?}: {error}")
             })?;
@@ -4160,21 +4162,22 @@ mod tests {
     }
 
     /// Drives a mint through the real command flow to its `Failed` terminal:
-    /// requested, then acceptance force-failed. (`redemption_services()` returns
-    /// the shared `EquityTransferServices`, used by both aggregate stores.)
+    /// requested, then acceptance force-failed. Uses `()` services because
+    /// `TokenizedEquityMint` performs no I/O in its handlers.
     async fn seed_mint_to_failed(pool: &SqlitePool, id: &IssuerRequestId) {
         let store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-            .build(redemption_services())
+            .build(())
             .await
             .unwrap();
         store
             .send(
                 id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(10),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("test-req-id"),
                 },
             )
             .await
@@ -4196,7 +4199,7 @@ mod tests {
         command: TokenizedEquityMintCommand,
     ) {
         let store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-            .build(redemption_services())
+            .build(())
             .await
             .unwrap();
         store.send(id, command).await.unwrap();
@@ -4230,11 +4233,12 @@ mod tests {
         send_mint_command(
             &pool,
             &id,
-            TokenizedEquityMintCommand::RequestMint {
+            TokenizedEquityMintCommand::RecordMintRequested {
                 issuer_request_id: id.clone(),
                 symbol: Symbol::new("AAPL").unwrap(),
                 quantity: float!(10),
                 wallet: Address::ZERO,
+                tokenization_request_id: tokenization_request_id("test-req-id"),
             },
         )
         .await;

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -3771,7 +3771,7 @@ mod tests {
             tokenizer: tokenizer.clone(),
             wrapper: wrapper.clone(),
         };
-        let mint_store = Arc::new(test_store(pool.clone(), services.clone()));
+        let mint_store = Arc::new(test_store(pool.clone(), ()));
         let redemption_store = Arc::new(test_store(pool, services));
 
         CrossVenueEquityTransfer::new(
@@ -3958,10 +3958,7 @@ mod tests {
             wrapper: wrapper.clone(),
         };
 
-        let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(
-            pool.clone(),
-            services.clone(),
-        ));
+        let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
         let seeding_redemption_store = Arc::new(test_store::<EquityRedemption>(
             pool.clone(),
             services.clone(),
@@ -3970,11 +3967,12 @@ mod tests {
         seeding_mint_store
             .send(
                 &mint_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: mint_id.clone(),
                     symbol: st0x_execution::Symbol::new("AAPL").unwrap(),
                     quantity: st0x_float_macro::float!(10.0),
                     wallet: alloy::primitives::Address::from([wallet_byte; 20]),
+                    tokenization_request_id: tokenization_request_id("TOK-interrupted-mint"),
                 },
             )
             .await
@@ -4068,10 +4066,7 @@ mod tests {
         // The recover function only calls store.load() (event replay); it does
         // not invoke tokenizer methods. Use the same services for the function
         // call -- MockTokenizer methods are never called during load().
-        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
-            pool.clone(),
-            services.clone(),
-        ));
+        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
         let redemption_store = Arc::new(test_store::<EquityRedemption>(
             pool.clone(),
             services.clone(),
@@ -4165,10 +4160,7 @@ mod tests {
             &pool,
             &rebalancing_service,
             inventory.as_ref(),
-            Arc::new(test_store::<TokenizedEquityMint>(
-                pool.clone(),
-                services.clone(),
-            )),
+            Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
             Arc::new(test_store::<EquityRedemption>(
                 pool.clone(),
                 services.clone(),
@@ -4189,10 +4181,7 @@ mod tests {
             &pool,
             &rebalancing_service,
             inventory.as_ref(),
-            Arc::new(test_store::<TokenizedEquityMint>(
-                pool.clone(),
-                services.clone(),
-            )),
+            Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
             Arc::new(test_store::<EquityRedemption>(
                 pool.clone(),
                 services.clone(),
@@ -4254,10 +4243,7 @@ mod tests {
             &pool,
             &rebalancing_service,
             inventory.as_ref(),
-            Arc::new(test_store::<TokenizedEquityMint>(
-                pool.clone(),
-                services.clone(),
-            )),
+            Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
             Arc::new(test_store::<EquityRedemption>(pool.clone(), services)),
             &mut resume_queue,
         )
@@ -4341,10 +4327,7 @@ mod tests {
             &pool,
             &rebalancing_service,
             inventory.as_ref(),
-            Arc::new(test_store::<TokenizedEquityMint>(
-                pool.clone(),
-                services.clone(),
-            )),
+            Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
             Arc::new(test_store::<EquityRedemption>(pool.clone(), services)),
             &mut resume_queue,
         )
@@ -4394,10 +4377,7 @@ mod tests {
             &pool,
             &rebalancing_service,
             inventory.as_ref(),
-            Arc::new(test_store::<TokenizedEquityMint>(
-                pool.clone(),
-                services.clone(),
-            )),
+            Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
             Arc::new(test_store::<EquityRedemption>(
                 pool.clone(),
                 services.clone(),
@@ -4422,10 +4402,7 @@ mod tests {
             &pool,
             &rebalancing_service,
             inventory.as_ref(),
-            Arc::new(test_store::<TokenizedEquityMint>(
-                pool.clone(),
-                services.clone(),
-            )),
+            Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
             Arc::new(test_store::<EquityRedemption>(
                 pool.clone(),
                 services.clone(),
@@ -4492,28 +4469,35 @@ mod tests {
             wrapper: wrapper.clone(),
         };
 
-        let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(
-            pool.clone(),
-            services.clone(),
-        ));
+        let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
 
-        // RequestMint (Pending) -> MintAccepted state.
-        // Poll with Completed outcome -> TokensReceived state (pre-wrap).
+        // RecordMintRequested -> MintAccepted state.
+        // RecordTokensReceived -> TokensReceived state (pre-wrap).
         seeding_mint_store
             .send(
                 &mint_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: mint_id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(5.0),
                     wallet: alloy::primitives::Address::from([3u8; 20]),
+                    tokenization_request_id: tokenization_request_id("TOK-pre-wrap-held"),
                 },
             )
             .await
             .unwrap();
 
         seeding_mint_store
-            .send(&mint_id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &mint_id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(fixed_bytes!(
+                        "0x1111111111111111111111111111111111111111111111111111111111111111"
+                    )),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -4550,10 +4534,7 @@ mod tests {
             Arc::new(crate::alerts::NoopNotifier),
         );
 
-        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
-            pool.clone(),
-            services.clone(),
-        ));
+        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
         let redemption_store = Arc::new(test_store::<EquityRedemption>(
             pool.clone(),
             services.clone(),
@@ -4589,26 +4570,33 @@ mod tests {
             wrapper: Arc::new(MockWrapper::new()),
         };
 
-        let seeding_mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(
-            pool2.clone(),
-            services2.clone(),
-        ));
+        let seeding_mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(pool2.clone(), ()));
 
         seeding_mint_store2
             .send(
                 &mint_id2,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: mint_id2.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(5.0),
                     wallet: alloy::primitives::Address::from([4u8; 20]),
+                    tokenization_request_id: tokenization_request_id("TOK-pre-wrap-active"),
                 },
             )
             .await
             .unwrap();
 
         seeding_mint_store2
-            .send(&mint_id2, TokenizedEquityMintCommand::Poll)
+            .send(
+                &mint_id2,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(fixed_bytes!(
+                        "0x2222222222222222222222222222222222222222222222222222222222222222"
+                    )),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -4645,10 +4633,7 @@ mod tests {
             Arc::new(crate::alerts::NoopNotifier),
         );
 
-        let mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(
-            pool2.clone(),
-            services2.clone(),
-        ));
+        let mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(pool2.clone(), ()));
         let redemption_store2 = Arc::new(test_store::<EquityRedemption>(
             pool2.clone(),
             services2.clone(),

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -1140,20 +1140,15 @@ mod tests {
     use st0x_event_sorcery::test_store;
     use st0x_execution::{FractionalShares, Symbol};
     use st0x_float_macro::float;
-    use st0x_raindex::Raindex;
     use st0x_tokenization::IssuerRequestId;
-    use st0x_tokenization::mock::MockTokenizer;
-    use st0x_wrapper::{MockWrapper, Wrapper};
 
     use super::*;
     use crate::equity_redemption::RedemptionAggregateId;
-    use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::{
-        EquityTransferServices, MintError, MintTransferError, RedemptionError,
-        ResumeEquityToHedging, ResumeEquityToMarketMaking,
+        MintError, MintTransferError, RedemptionError, ResumeEquityToHedging,
+        ResumeEquityToMarketMaking,
     };
     use crate::test_utils::{setup_test_apalis_pool, setup_test_pools};
-    use crate::vault_lookup::MockVaultLookup;
 
     struct PoisonThenHealthyRedemptionResume {
         poison_id: RedemptionAggregateId,
@@ -1230,19 +1225,10 @@ mod tests {
         transfer: Arc<dyn ResumeEquityToMarketMaking>,
         cqrs_pool: sqlx::SqlitePool,
     ) -> Arc<TransferEquityToMarketMakingCtx> {
-        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
-        let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
-        let services = EquityTransferServices {
-            raindex,
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper,
-        };
-
         Arc::new(TransferEquityToMarketMakingCtx {
             transfer,
             equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
-            mint_store: Arc::new(test_store(cqrs_pool, services)),
+            mint_store: Arc::new(test_store(cqrs_pool, ())),
             equities_config: EquitiesConfig::default(),
         })
     }

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -116,7 +116,7 @@ impl QueryManifest {
             .with(broadcaster.clone())
             .with(equity_timing.clone())
             .with(lifecycle_failure.clone())
-            .build(services.clone())
+            .build(())
             .await?;
 
         let redemption = StoreBuilder::<EquityRedemption>::new(pool.clone())

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -34,7 +34,7 @@ use st0x_finance::{Usd, Usdc};
 use st0x_float_macro::float;
 use st0x_raindex::{Raindex, RaindexVaultId};
 use st0x_tokenization::mock::MockTokenizer;
-use st0x_tokenization::{Tokenizer, issuer_request_id};
+use st0x_tokenization::{Tokenizer, issuer_request_id, tokenization_request_id};
 use st0x_wrapper::{MockWrapper, Wrapper};
 
 use super::{
@@ -469,10 +469,7 @@ fn build_equity_transfer_with_wrapper(
         tokenizer: Arc::clone(&tokenizer),
         wrapper: Arc::clone(&wrapper),
     };
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
-        pool.clone(),
-        equity_services.clone(),
-    ));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
     let redemption_store = Arc::new(test_store::<EquityRedemption>(
         pool.clone(),
         equity_services,
@@ -512,7 +509,7 @@ async fn build_equity_transfer_with_service(
 
     let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
         .with(Arc::clone(service))
-        .build(equity_services.clone())
+        .build(())
         .await
         .unwrap();
 
@@ -675,15 +672,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
             )]));
     });
 
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
-        pool.clone(),
-        EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        },
-    ));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
     let ctx = TransferEquityToMarketMakingCtx {
         transfer: equity_transfer,
         equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
@@ -1638,15 +1627,7 @@ async fn mint_api_failure_produces_rejected_event() {
     drain_pending_jobs(&service).await.unwrap();
 
     let job = fetch_pending_equity_mint_job(&apalis_pool).await;
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
-        pool.clone(),
-        EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        },
-    ));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
     let ctx = TransferEquityToMarketMakingCtx {
         transfer: equity_transfer,
         equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
@@ -1671,9 +1652,10 @@ async fn mint_api_failure_produces_rejected_event() {
     }
     .to_string();
 
-    // When the mint API returns HTTP 500, the TokenizedEquityMint aggregate
-    // returns Err(RequestFailed) without emitting any events, so no
-    // TokenizedEquityMint events appear.
+    // When the mint API returns HTTP 500, the orchestrator's request_mint call
+    // fails pre-receipt (MintTransferError::PreReceipt) before any
+    // RecordMintRequested command reaches the aggregate, so the aggregate never
+    // originates and no TokenizedEquityMint events appear.
     assert_events(
         &pool,
         &[
@@ -2226,15 +2208,7 @@ async fn mint_accepted_sets_offchain_inflight() {
     // The poll will return pending, so the mint aggregate will time out or loop,
     // but MintAccepted has already fired by then. We spawn and cancel to
     // get just the MintAccepted event through.
-    let mint_store_for_spawn = Arc::new(test_store::<TokenizedEquityMint>(
-        pool.clone(),
-        EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        },
-    ));
+    let mint_store_for_spawn = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
     let transfer_handle = tokio::spawn({
         let equity_transfer = Arc::clone(&equity_transfer);
         let mint_store = Arc::clone(&mint_store_for_spawn);
@@ -2440,15 +2414,7 @@ async fn completed_mint_clears_inflight_and_updates_inventory() {
     };
 
     // Execute the full mint lifecycle through the job's perform
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
-        pool.clone(),
-        EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        },
-    ));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
     let ctx = TransferEquityToMarketMakingCtx {
         transfer: Arc::clone(&equity_transfer) as _,
         equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
@@ -2647,10 +2613,7 @@ async fn wrapped_recovery_reschedules_when_held_for_recovery_but_no_balance() {
         tokenizer: Arc::clone(&tokenizer),
         wrapper: Arc::clone(&wrapper),
     };
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
-        pool.clone(),
-        equity_services.clone(),
-    ));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
     let redemption_store = Arc::new(test_store::<EquityRedemption>(
         pool.clone(),
         equity_services,
@@ -2765,10 +2728,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_landed_wrapped_equity_recovery()
         tokenizer: Arc::clone(&tokenizer),
         wrapper: Arc::clone(&wrapper),
     };
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
-        pool.clone(),
-        equity_services.clone(),
-    ));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
     let redemption_store = Arc::new(test_store::<EquityRedemption>(
         pool.clone(),
         equity_services,
@@ -2902,10 +2862,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_unwrapped_equity_recovery
         tokenizer: Arc::clone(&tokenizer),
         wrapper: Arc::clone(&wrapper),
     };
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
-        pool.clone(),
-        equity_services.clone(),
-    ));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
     let redemption_store = Arc::new(test_store::<EquityRedemption>(
         pool.clone(),
         equity_services,
@@ -3031,10 +2988,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_dispatches_active_mint() 
         tokenizer: Arc::clone(&tokenizer),
         wrapper: Arc::clone(&wrapper),
     };
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
-        pool.clone(),
-        equity_services.clone(),
-    ));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
     let redemption_store = Arc::new(test_store::<EquityRedemption>(
         pool.clone(),
         equity_services,
@@ -3065,19 +3019,27 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_dispatches_active_mint() 
     mint_store
         .send(
             &mint_id,
-            TokenizedEquityMintCommand::RequestMint {
+            TokenizedEquityMintCommand::RecordMintRequested {
                 issuer_request_id: mint_id.clone(),
                 symbol: symbol.clone(),
                 quantity: float!(5),
                 wallet: Address::ZERO,
+                tokenization_request_id: tokenization_request_id("active-mint-deadlock"),
             },
         )
         .await
-        .expect("RequestMint must persist");
+        .expect("RecordMintRequested must persist");
     mint_store
-        .send(&mint_id, TokenizedEquityMintCommand::Poll)
+        .send(
+            &mint_id,
+            TokenizedEquityMintCommand::RecordTokensReceived {
+                tx_hash: Some(TxHash::random()),
+                token_symbol: Some(format!("t{symbol}")),
+                fees: None,
+            },
+        )
         .await
-        .expect("Poll must transition the mint to TokensReceived");
+        .expect("RecordTokensReceived must transition the mint to TokensReceived");
 
     // Inventory reports UNWRAPPED balance AND an active mint, so decide_dispatch
     // resolves to ActiveMint (the prod path) instead of Orphan.

--- a/src/performance/equity_timing/mod.rs
+++ b/src/performance/equity_timing/mod.rs
@@ -993,13 +993,12 @@ impl From<StoredStageName> for EquityStageName {
 mod tests {
     use alloy::primitives::{Address, TxHash, U256};
     use chrono::TimeZone;
-    use std::sync::Arc;
     use uuid::Uuid;
 
     use st0x_dto::EquityOperationKind;
     use st0x_event_sorcery::{ReactorHarness, StoreBuilder};
     use st0x_float_macro::float;
-    use st0x_tokenization::{TokenizationRequestId, issuer_request_id};
+    use st0x_tokenization::{TokenizationRequestId, issuer_request_id, tokenization_request_id};
 
     use super::*;
     use crate::equity_redemption::redemption_aggregate_id;
@@ -1230,24 +1229,20 @@ mod tests {
 
         // Seed events directly through a store with NO projection attached,
         // simulating history that accumulated before this projection existed.
-        // `RequestMint`'s `initialize()` calls `services.tokenizer.request_mint`,
-        // so the panicking stub's tokenizer is swapped for a working mock --
-        // mirrors `simulated_transfers.rs`'s `FixtureTokenizer` wiring pattern.
-        let mut services = crate::rebalancing::equity::EquityTransferServices::panicking();
-        services.tokenizer = Arc::new(st0x_tokenization::mock::MockTokenizer::new());
         let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-            .build(services)
+            .build(())
             .await
             .unwrap();
         let operation_id = issuer_request_id("catch-up-mint");
         mint_store
             .send(
                 &operation_id,
-                TokenizedEquityMintCommand::RequestMintAt {
+                TokenizedEquityMintCommand::RecordMintRequestedAt {
                     issuer_request_id: operation_id.clone(),
                     symbol: symbol(),
                     quantity: float!(5),
                     wallet: Address::repeat_byte(0x11),
+                    tokenization_request_id: tokenization_request_id("catch-up-mint-tok"),
                     requested_at: timestamp(0),
                 },
             )
@@ -1256,8 +1251,8 @@ mod tests {
 
         let projection = EquityTimingProjection::new(pool.clone());
         let replayed = projection.catch_up().await.unwrap();
-        // `RequestMintAt` against a mock tokenizer that returns `Pending` (not
-        // `Rejected`) persists both `MintRequested` and `MintAccepted`.
+        // `RecordMintRequestedAt` persists both `MintRequested` and
+        // `MintAccepted`.
         assert_eq!(
             replayed, 2,
             "catch_up must replay exactly the two pre-existing events"

--- a/src/performance/simulated_transfers.rs
+++ b/src/performance/simulated_transfers.rs
@@ -60,8 +60,8 @@ use crate::vault_lookup::{VaultLookup, VaultLookupError};
 /// Minimal [`Tokenizer`] shared by [`seed_simulated_mint_history`]'s and
 /// [`seed_simulated_equity_redemption_history`]'s temporary stores.
 ///
-/// The mint fixture drives only the mint happy path (`RequestMintAt` ->
-/// `PollAt` -> `WrapTokensAt` -> `DepositToVaultAt`), which calls exactly
+/// The mint fixture drives only the mint happy path (`RecordMintRequestedAt` ->
+/// `RecordTokensReceivedAt` -> `WrapTokensAt` -> `DepositToVaultAt`), which calls exactly
 /// `request_mint`/`poll_mint_until_complete`. The redemption fixture drives
 /// only `wait_for_block`/`redemption_wallet`/`send_for_redemption` (its
 /// `Detect`/`Complete` steps are pure state transitions with no service
@@ -226,7 +226,8 @@ fn usdc(value: f64) -> anyhow::Result<Usdc> {
 /// Seeds deterministic equity-mint history for local dashboard simulation.
 ///
 /// Drives the `TokenizedEquityMint` aggregate's happy path
-/// (`RequestMintAt` -> `PollAt` -> `WrapTokensAt` -> `DepositToVaultAt`)
+/// (`RecordMintRequestedAt` -> `RecordTokensReceivedAt` -> `WrapTokensAt` ->
+/// `DepositToVaultAt`)
 /// through a temporary store, one mint per day alternating between the same
 /// dedicated fixture symbols (`AAPL.SIM`/`TSLA.SIM`) used by
 /// [`super::seed_simulated_hedge_latency_history`].
@@ -237,17 +238,11 @@ pub async fn seed_simulated_mint_history(
 ) -> anyhow::Result<()> {
     sqlx::migrate!().set_ignore_missing(true).run(pool).await?;
 
-    let mut services = EquityTransferServices::panicking();
-    // Mint's happy path never calls `redemption_wallet`/`send_for_redemption`;
-    // the address and day are meaningful only to
-    // `seed_simulated_equity_redemption_history`'s use of this same fixture.
-    services.tokenizer = Arc::new(FixtureTokenizer::new(Address::ZERO, 0));
-
     let mint = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
         .with(Arc::new(RetryOnBusy {
             inner: EquityTimingProjection::new(pool.clone()),
         }))
-        .build(services)
+        .build(())
         .await?;
 
     let range_start = now - Duration::days(i64::from(days)) - Duration::days(1);
@@ -267,19 +262,31 @@ pub async fn seed_simulated_mint_history(
 
         mint.send(
             &issuer_request_id,
-            TokenizedEquityMintCommand::RequestMintAt {
+            TokenizedEquityMintCommand::RecordMintRequestedAt {
                 issuer_request_id: issuer_request_id.clone(),
                 symbol: symbol.clone(),
                 quantity,
                 wallet,
+                tokenization_request_id: tokenization_request_id(&format!(
+                    "sim-mint-{issuer_request_id}"
+                )),
                 requested_at,
             },
         )
         .await?;
 
+        // Derived from the 16-byte `IssuerRequestId` uuid, matching the mint
+        // tx-hash convention of the redemption fixture's tokenizer.
+        let mint_tx_hash = TxHash::left_padding_from(issuer_request_id.0.as_bytes());
+
         mint.send(
             &issuer_request_id,
-            TokenizedEquityMintCommand::PollAt { received_at },
+            TokenizedEquityMintCommand::RecordTokensReceivedAt {
+                tx_hash: Some(mint_tx_hash),
+                token_symbol: Some(format!("t{symbol}")),
+                fees: None,
+                received_at,
+            },
         )
         .await?;
 

--- a/src/rebalancing/equity/job.rs
+++ b/src/rebalancing/equity/job.rs
@@ -438,17 +438,12 @@ mod tests {
     use st0x_config::{EquityAssetConfig, OperationMode};
     use st0x_event_sorcery::test_store;
     use st0x_float_macro::float;
-    use st0x_raindex::Raindex;
-    use st0x_tokenization::issuer_request_id;
-    use st0x_tokenization::mock::MockTokenizer;
-    use st0x_wrapper::{MockWrapper, Wrapper};
+    use st0x_tokenization::{issuer_request_id, tokenization_request_id};
 
     use super::*;
     use crate::equity_redemption::redemption_aggregate_id;
-    use crate::onchain::mock::MockRaindex;
-    use crate::rebalancing::equity::{EquityTransferServices, MintError};
+    use crate::rebalancing::equity::MintError;
     use crate::tokenized_equity_mint::TokenizedEquityMintCommand;
-    use crate::vault_lookup::MockVaultLookup;
 
     /// Builds a test ctx with recovery enabled for AAPL and an empty guard map.
     async fn test_ctx(
@@ -463,15 +458,7 @@ mod tests {
         recovery_mode: OperationMode,
     ) -> TransferEquityToMarketMakingCtx {
         let (pool, _apalis_pool) = crate::test_utils::setup_test_pools().await;
-        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
-        let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
-        let transfer_services = EquityTransferServices {
-            raindex: raindex.clone(),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: wrapper.clone(),
-        };
-        let mint_store = Arc::new(test_store(pool, transfer_services));
+        let mint_store = Arc::new(test_store(pool, ()));
 
         let aapl_config = EquityAssetConfig {
             tokenized_equity: Address::ZERO,
@@ -650,20 +637,28 @@ mod tests {
         ctx.mint_store
             .send(
                 issuer_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: issuer_id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(5),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("seed-tokens-wrapped"),
                 },
             )
             .await
-            .expect("RequestMint must persist");
+            .expect("RecordMintRequested must persist and accept the mint");
 
         ctx.mint_store
-            .send(issuer_id, TokenizedEquityMintCommand::Poll)
+            .send(
+                issuer_id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::repeat_byte(0x11)),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
-            .expect("Poll must transition to TokensReceived");
+            .expect("RecordTokensReceived must transition to TokensReceived");
 
         ctx.mint_store
             .send(
@@ -804,24 +799,33 @@ mod tests {
             .unwrap()
             .insert(symbol.clone(), GuardState::ActiveTransfer { generation: 0 });
 
-        // Drive the aggregate to TokensReceived (RequestMint + Poll) but do NOT wrap.
+        // Drive the aggregate to TokensReceived (RecordMintRequested +
+        // RecordTokensReceived) but do NOT wrap.
         ctx.mint_store
             .send(
                 &issuer_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: issuer_id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(5),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("seed-tokens-received"),
                 },
             )
             .await
-            .expect("RequestMint must persist");
+            .expect("RecordMintRequested must persist and accept the mint");
 
         ctx.mint_store
-            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::repeat_byte(0x11)),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
-            .expect("Poll must transition to TokensReceived");
+            .expect("RecordTokensReceived must transition to TokensReceived");
 
         let job = TransferEquityToMarketMaking {
             issuer_request_id: issuer_id.clone(),
@@ -861,20 +865,28 @@ mod tests {
         ctx.mint_store
             .send(
                 &issuer_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: issuer_id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(5),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("seed-tokens-received"),
                 },
             )
             .await
-            .expect("RequestMint must persist");
+            .expect("RecordMintRequested must persist and accept the mint");
 
         ctx.mint_store
-            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::repeat_byte(0x11)),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
-            .expect("Poll must transition to TokensReceived");
+            .expect("RecordTokensReceived must transition to TokensReceived");
 
         ctx.mint_store
             .send(
@@ -926,20 +938,28 @@ mod tests {
         ctx.mint_store
             .send(
                 &issuer_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: issuer_id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(5),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("seed-tokens-received"),
                 },
             )
             .await
-            .expect("RequestMint must persist");
+            .expect("RecordMintRequested must persist and accept the mint");
 
         ctx.mint_store
-            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::repeat_byte(0x11)),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
-            .expect("Poll must transition to TokensReceived");
+            .expect("RecordTokensReceived must transition to TokensReceived");
 
         // Simulate the timeout sweeper clearing this job's slot and a NEW
         // transfer reclaiming it with a fresh generation before PostReceipt runs.
@@ -991,20 +1011,28 @@ mod tests {
         ctx.mint_store
             .send(
                 &issuer_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: issuer_id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(5),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("seed-tokens-received"),
                 },
             )
             .await
-            .expect("RequestMint must persist");
+            .expect("RecordMintRequested must persist and accept the mint");
 
         ctx.mint_store
-            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::repeat_byte(0x11)),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
-            .expect("Poll must transition to TokensReceived");
+            .expect("RecordTokensReceived must transition to TokensReceived");
 
         let job = TransferEquityToMarketMaking {
             issuer_request_id: issuer_id.clone(),
@@ -1056,20 +1084,28 @@ mod tests {
         ctx.mint_store
             .send(
                 &issuer_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: issuer_id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(5),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("seed-tokens-received"),
                 },
             )
             .await
-            .expect("RequestMint must persist");
+            .expect("RecordMintRequested must persist and accept the mint");
 
         ctx.mint_store
-            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::repeat_byte(0x11)),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
-            .expect("Poll must transition to TokensReceived");
+            .expect("RecordTokensReceived must transition to TokensReceived");
 
         ctx.mint_store
             .send(
@@ -1129,20 +1165,28 @@ mod tests {
         ctx.mint_store
             .send(
                 &issuer_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: issuer_id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(5),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("seed-tokens-received"),
                 },
             )
             .await
-            .expect("RequestMint must persist");
+            .expect("RecordMintRequested must persist and accept the mint");
 
         ctx.mint_store
-            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::repeat_byte(0x11)),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
-            .expect("Poll must transition to TokensReceived");
+            .expect("RecordTokensReceived must transition to TokensReceived");
 
         let job = TransferEquityToMarketMaking {
             issuer_request_id: issuer_id.clone(),
@@ -1176,20 +1220,28 @@ mod tests {
         ctx.mint_store
             .send(
                 &issuer_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: issuer_id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(5),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("seed-tokens-received"),
                 },
             )
             .await
-            .expect("RequestMint must persist");
+            .expect("RecordMintRequested must persist and accept the mint");
 
         ctx.mint_store
-            .send(&issuer_id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &issuer_id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::repeat_byte(0x11)),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
-            .expect("Poll must transition to TokensReceived");
+            .expect("RecordTokensReceived must transition to TokensReceived");
 
         let job = TransferEquityToMarketMaking {
             issuer_request_id: issuer_id.clone(),

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -202,11 +202,12 @@ pub(crate) struct EquityTransferServices {
 impl EquityTransferServices {
     /// Constructs a services instance whose methods all panic.
     ///
-    /// Safe for sending commands that never invoke services (e.g., the
-    /// `FailWrapping`, `FailAcceptance`, `FailRaindexDeposit`, `FailTransfer`,
-    /// and `Reconcile` commands). Used by the CLI `transfer fail` and
-    /// `transfer reconcile` subcommands where no real broker/RPC connection
-    /// exists.
+    /// Only the redemption aggregate (`EquityRedemption`) still takes
+    /// `EquityTransferServices`; its failure and `Reconcile` commands never
+    /// invoke them, so the panicking stub is safe for the CLI `transfer fail`
+    /// and `transfer reconcile` subcommands where no real broker/RPC connection
+    /// exists. Mint commands use `()` services directly -- `TokenizedEquityMint`
+    /// performs no I/O in its handlers.
     pub(crate) fn panicking() -> Self {
         Self {
             raindex: Arc::new(PanickingRaindex),
@@ -432,6 +433,24 @@ pub(crate) enum MintError {
     VaultLookup(#[from] VaultLookupError),
     #[error("Onchain mint verification failed: {0}")]
     Verification(#[from] MintVerificationError),
+    #[error("Tokenization provider error: {0}")]
+    Tokenizer(#[from] TokenizerError),
+    #[error("Mint {tokenization_request_id} remained pending after polling")]
+    MintStillPending {
+        tokenization_request_id: TokenizationRequestId,
+    },
+    #[error("Completed mint {tokenization_request_id} is missing its onchain tx hash")]
+    CompletedMintMissingTxHash {
+        tokenization_request_id: TokenizationRequestId,
+    },
+    #[error(
+        "Completed mint {tokenization_request_id} returned token symbol {actual:?}; expected {expected}"
+    )]
+    CompletedMintTokenSymbolMismatch {
+        tokenization_request_id: TokenizationRequestId,
+        expected: String,
+        actual: Option<String>,
+    },
     #[error(
         "Entity not found after command: expected {expected_state} \
          for {issuer_request_id}"
@@ -882,11 +901,56 @@ impl CrossVenueEquityTransfer {
     ) -> Result<(), MintError> {
         loop {
             match self.load_mint_entity(issuer_request_id).await? {
-                TokenizedEquityMint::MintAccepted { .. } => {
-                    info!(%issuer_request_id, "Resuming accepted mint");
-                    self.mint_store
-                        .send(issuer_request_id, TokenizedEquityMintCommand::Poll)
-                        .await?;
+                TokenizedEquityMint::MintAccepted {
+                    symbol,
+                    tokenization_request_id,
+                    ..
+                } => {
+                    info!(%issuer_request_id, "Polling accepted mint");
+                    match self
+                        .tokenizer
+                        .poll_mint_until_complete(&tokenization_request_id)
+                        .await
+                    {
+                        Ok(completed) => match completed.status {
+                            TokenizationRequestStatus::Completed => {
+                                self.record_completed_mint(issuer_request_id, &symbol, completed)
+                                    .await?;
+                            }
+                            TokenizationRequestStatus::Rejected => {
+                                warn!(target: "rebalance", %symbol, "Mint rejected by Alpaca after acceptance");
+                                self.mint_store
+                                    .send(
+                                        issuer_request_id,
+                                        TokenizedEquityMintCommand::FailAcceptance {
+                                            reason: "Rejected by Alpaca after acceptance"
+                                                .to_string(),
+                                        },
+                                    )
+                                    .await?;
+                            }
+                            TokenizationRequestStatus::Pending => {
+                                warn!(
+                                    target: "rebalance",
+                                    %symbol,
+                                    %tokenization_request_id,
+                                    "Mint remained pending after polling; leaving it in flight for retry"
+                                );
+                                return Err(MintError::MintStillPending {
+                                    tokenization_request_id,
+                                });
+                            }
+                        },
+                        Err(error) => {
+                            warn!(
+                                target: "rebalance",
+                                %error,
+                                %symbol,
+                                "Mint polling failed; leaving the accepted mint in flight for retry"
+                            );
+                            return Err(error.into());
+                        }
+                    }
                 }
                 TokenizedEquityMint::TokensReceived { .. } => {
                     info!(%issuer_request_id, "Resuming received mint");
@@ -987,6 +1051,41 @@ impl CrossVenueEquityTransfer {
                 }
             }
         }
+    }
+
+    /// Records the provider's completion payload against the mint aggregate.
+    ///
+    /// An unusable completion payload must leave the accepted mint in flight.
+    /// The provider reported completion, so failing acceptance would restore
+    /// shares to available inventory even though tokens may already exist
+    /// onchain. Propagate the aggregate rejection for retry and operator alerting
+    /// instead of manufacturing a safe-to-remint terminal state.
+    async fn record_completed_mint(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+        symbol: &Symbol,
+        completed: TokenizationRequest,
+    ) -> Result<(), MintError> {
+        self.mint_store
+            .send(
+                issuer_request_id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: completed.tx_hash,
+                    token_symbol: completed.token_symbol,
+                    fees: completed.fees,
+                },
+            )
+            .await
+            .inspect_err(|error| {
+                warn!(
+                    target: "rebalance",
+                    %symbol,
+                    ?error,
+                    "Provider completion payload was unusable; leaving the accepted mint in flight"
+                );
+            })?;
+
+        Ok(())
     }
 
     /// Sends the Redeem command to submit vault withdrawal, then
@@ -1670,19 +1769,28 @@ impl CrossVenueEquityTransfer {
             Some(
                 TokenizedEquityMint::MintRequested { .. }
                 | TokenizedEquityMint::MintAccepted { .. },
-            ) => {
-                if let Err(error) = self.resume_mint(issuer_request_id).await {
-                    let reached = self.load_mint_entity(issuer_request_id).await;
-                    return Err(classify_mint_resume_error(reached, error));
-                }
-
-                Ok(())
-            }
+            ) => self.resume_mint_classified(issuer_request_id).await,
             Some(_) => self
                 .resume_mint(issuer_request_id)
                 .await
                 .map_err(MintTransferError::PostReceipt),
         }
+    }
+
+    /// Runs `resume_mint` and, on failure, reloads the aggregate to bucket the
+    /// error as pre- or post-receipt. `resume_mint`'s error is only actionable
+    /// once classified by how far the aggregate advanced, so the resume and the
+    /// classification are coupled here rather than repeated at each call site.
+    async fn resume_mint_classified(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+    ) -> Result<(), MintTransferError> {
+        if let Err(error) = self.resume_mint(issuer_request_id).await {
+            let reached = self.load_mint_entity(issuer_request_id).await;
+            return Err(classify_mint_resume_error(reached, error));
+        }
+
+        Ok(())
     }
 
     async fn start_mint(
@@ -1693,36 +1801,182 @@ impl CrossVenueEquityTransfer {
     ) -> Result<(), MintTransferError> {
         debug!(target: "rebalance", %issuer_request_id, wallet = %self.wallet, "Requesting mint");
 
-        // Pre-receipt: no tokens exist yet, safe to retry on failure.
+        // Pre-receipt I/O: no tokens exist yet, so this stage is safe to retry.
+        // issuer_request_id is the provider-side dedup key: if the process
+        // crashes after request_mint returns but before the RecordMintRequested
+        // commit, the retry re-enters start_mint and re-calls request_mint with
+        // the same id, and Alpaca deduplicates on issuer_request_id so no
+        // duplicate mint request is created.
+        let request = self
+            .tokenizer
+            .request_mint(
+                symbol.clone(),
+                quantity,
+                self.wallet,
+                issuer_request_id.clone(),
+            )
+            .await
+            .map_err(|error| MintTransferError::PreReceipt(error.into()))?;
+
+        if matches!(request.status, TokenizationRequestStatus::Rejected) {
+            warn!(target: "rebalance", %symbol, "Mint request rejected by Alpaca");
+            self.mint_store
+                .send(
+                    issuer_request_id,
+                    TokenizedEquityMintCommand::RejectMintRequest {
+                        symbol: symbol.clone(),
+                        quantity: quantity.inner(),
+                        wallet: self.wallet,
+                        reason: "Rejected by Alpaca".to_string(),
+                    },
+                )
+                .await
+                .map_err(|error| MintTransferError::PreReceipt(error.into()))?;
+
+            // Aggregate is now Failed; nothing further to drive.
+            return Ok(());
+        }
+
+        info!(target: "rebalance", %symbol, request_id = %request.id, "Mint request accepted, polling for completion");
+
+        // A concurrent worker or operator may advance the aggregate while the
+        // provider request is in flight. Reconcile every persisted state before
+        // recording the provider acceptance: blindly sending RecordMintRequested
+        // can lose an accepted provider request behind a terminal aggregate.
+        match self
+            .mint_store
+            .load(issuer_request_id)
+            .await
+            .map_err(|error| MintTransferError::PreReceipt(error.into()))?
+        {
+            Some(TokenizedEquityMint::MintAccepted {
+                tokenization_request_id: accepted,
+                ..
+            }) => {
+                if accepted != request.id {
+                    error!(
+                        target: "rebalance",
+                        %symbol,
+                        persisted_request_id = %accepted,
+                        duplicate_request_id = %request.id,
+                        "Alpaca returned a second tokenization_request_id for an already-accepted \
+                         mint; resuming the persisted request. The duplicate needs operator cleanup."
+                    );
+                }
+
+                return self.resume_mint_classified(issuer_request_id).await;
+            }
+            Some(TokenizedEquityMint::Failed { .. }) => {
+                return self
+                    .recover_racing_accepted_mint(issuer_request_id, symbol, request)
+                    .await;
+            }
+            Some(entity @ TokenizedEquityMint::Reconciled { .. }) => {
+                error!(
+                    target: "rebalance",
+                    %issuer_request_id,
+                    provider_request_id = %request.id,
+                    "Provider accepted a mint after the aggregate was reconciled; retaining the \
+                     guard for operator resolution"
+                );
+                return Err(MintTransferError::PostReceipt(MintError::UnexpectedState {
+                    issuer_request_id: issuer_request_id.clone(),
+                    expected_state: "non-terminal state after provider acceptance",
+                    entity: Box::new(entity),
+                }));
+            }
+            Some(
+                TokenizedEquityMint::TokensReceived { .. }
+                | TokenizedEquityMint::WrapSubmitted { .. }
+                | TokenizedEquityMint::TokensWrapped { .. }
+                | TokenizedEquityMint::VaultDepositSubmitted { .. }
+                | TokenizedEquityMint::DepositedIntoRaindex { .. },
+            ) => {
+                return self.resume_mint_classified(issuer_request_id).await;
+            }
+            None | Some(TokenizedEquityMint::MintRequested { .. }) => {}
+        }
+
         self.mint_store
             .send(
                 issuer_request_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: issuer_request_id.clone(),
                     symbol: symbol.clone(),
                     quantity: quantity.inner(),
                     wallet: self.wallet,
+                    tokenization_request_id: request.id,
                 },
             )
             .await
             .map_err(|error| MintTransferError::PreReceipt(error.into()))?;
 
-        info!(target: "rebalance", "Mint request accepted, polling for completion");
+        // resume_mint drives poll -> finalize; resume_mint_classified buckets
+        // its failure by how far the aggregate advanced (pre- vs post-receipt).
+        self.resume_mint_classified(issuer_request_id).await
+    }
+
+    /// A provider acceptance raced with a transition to terminal `Failed`.
+    /// Poll the accepted request under the same provider deduplication key and
+    /// recover completion into the aggregate instead of discarding the request
+    /// or permitting a fresh mint.
+    async fn recover_racing_accepted_mint(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+        symbol: &Symbol,
+        request: TokenizationRequest,
+    ) -> Result<(), MintTransferError> {
+        let provider_request_id = request.id;
+        let completed = self
+            .tokenizer
+            .poll_mint_until_complete(&provider_request_id)
+            .await
+            .map_err(|error| MintTransferError::PostReceipt(error.into()))?;
+
+        match completed.status {
+            TokenizationRequestStatus::Rejected => return Ok(()),
+            TokenizationRequestStatus::Pending => {
+                return Err(MintTransferError::PostReceipt(
+                    MintError::MintStillPending {
+                        tokenization_request_id: provider_request_id,
+                    },
+                ));
+            }
+            TokenizationRequestStatus::Completed => {}
+        }
+
+        let expected_token_symbol = format!("t{symbol}");
+        if completed.token_symbol.as_deref() != Some(expected_token_symbol.as_str()) {
+            return Err(MintTransferError::PostReceipt(
+                MintError::CompletedMintTokenSymbolMismatch {
+                    tokenization_request_id: provider_request_id,
+                    expected: expected_token_symbol,
+                    actual: completed.token_symbol,
+                },
+            ));
+        }
+
+        let tx_hash = completed.tx_hash.ok_or_else(|| {
+            MintTransferError::PostReceipt(MintError::CompletedMintMissingTxHash {
+                tokenization_request_id: provider_request_id.clone(),
+            })
+        })?;
 
         self.mint_store
-            .send(issuer_request_id, TokenizedEquityMintCommand::Poll)
+            .send(
+                issuer_request_id,
+                TokenizedEquityMintCommand::RecoverProviderCompletion {
+                    issuer_request_id: issuer_request_id.clone(),
+                    wallet: self.wallet,
+                    tokenization_request_id: provider_request_id,
+                    tx_hash,
+                    fees: completed.fees,
+                },
+            )
             .await
-            .map_err(|error| MintTransferError::PreReceipt(error.into()))?;
+            .map_err(|error| MintTransferError::PostReceipt(error.into()))?;
 
-        // Post-receipt: tokens exist in wallet from this point on.
-        let tokens_received = self
-            .load_tokens_received(issuer_request_id)
-            .await
-            .map_err(MintTransferError::PostReceipt)?;
-
-        self.finalize_received_mint(issuer_request_id, tokens_received)
-            .await
-            .map_err(MintTransferError::PostReceipt)
+        self.resume_mint_classified(issuer_request_id).await
     }
 }
 
@@ -1797,7 +2051,8 @@ mod tests {
     use st0x_config::{AssetsConfig, EquitiesConfig};
     use st0x_tokenization::issuer_request_id;
     use st0x_tokenization::mock::{
-        MockCompletionOutcome, MockDetectionOutcome, MockTokenizer, MockVerificationOutcome,
+        MockCompletionOutcome, MockDetectionOutcome, MockMintPollOutcome, MockMintRequestOutcome,
+        MockTokenizer, MockVerificationOutcome,
     };
     use st0x_tokenization::tokenization_request_id;
     use st0x_wrapper::MockWrapper;
@@ -1987,7 +2242,7 @@ mod tests {
         // events to the reactor's `on_mint`.
         let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
             .with(service.clone())
-            .build(mock_services())
+            .build(())
             .await
             .unwrap();
         let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
@@ -2134,7 +2389,7 @@ mod tests {
 
         let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
             .with(service.clone())
-            .build(mock_services())
+            .build(())
             .await
             .unwrap();
         let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
@@ -2207,11 +2462,12 @@ mod tests {
             .mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(10),
                     wallet: transfer.wallet,
+                    tokenization_request_id: tokenization_request_id("test-req-id"),
                 },
             )
             .await
@@ -2326,11 +2582,12 @@ mod tests {
             .mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(10),
                     wallet: transfer.wallet,
+                    tokenization_request_id: tokenization_request_id("test-req-id"),
                 },
             )
             .await
@@ -2461,7 +2718,7 @@ mod tests {
 
         let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
             .with(service.clone())
-            .build(mock_services())
+            .build(())
             .await
             .unwrap();
         let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
@@ -2509,10 +2766,8 @@ mod tests {
     ) -> (CrossVenueEquityTransfer, SqlitePool) {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
-        let services = mock_services();
-
-        let mint_store = Arc::new(test_store(pool.clone(), services.clone()));
-        let redemption_store = Arc::new(test_store(pool.clone(), services));
+        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
+        let redemption_store = Arc::new(test_store(pool.clone(), mock_services()));
         let vault_lookup = mock_vault_lookup();
 
         let transfer = CrossVenueEquityTransfer::new(
@@ -2548,6 +2803,473 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn start_mint_request_api_error_is_pre_receipt() {
+        let transfer = create_equity_transfer(
+            Arc::new(
+                MockTokenizer::new().with_mint_request_outcome(MockMintRequestOutcome::ApiError),
+            ),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let error = transfer
+            .resume_equity_to_market_making(
+                &issuer_request_id("ISS-REQ-ERR"),
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(10.0)),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                MintTransferError::PreReceipt(MintError::Tokenizer(_))
+            ),
+            "request_mint failure must be pre-receipt, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_mint_alpaca_rejection_records_failed_and_returns_ok() {
+        let transfer = create_equity_transfer(
+            Arc::new(
+                MockTokenizer::new().with_mint_request_outcome(MockMintRequestOutcome::Rejected),
+            ),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-REQ-REJECT");
+        // A fresh Alpaca rejection is terminal, not retryable: the job entry
+        // point returns Ok so apalis marks it done rather than retrying forever.
+        transfer
+            .resume_equity_to_market_making(
+                &id,
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(10.0)),
+            )
+            .await
+            .unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::Failed { .. }),
+            "rejected mint must be Failed, got: {entity:?}"
+        );
+    }
+
+    /// The issuer_request_id is the provider-side dedup key: a job retry must
+    /// resume the persisted aggregate rather than issue a second Alpaca mint
+    /// request for the same transfer. Proven by re-entering the entry point with
+    /// the same id and asserting request_mint ran exactly once.
+    #[tokio::test]
+    async fn retry_resumes_without_a_second_mint_request() {
+        let tokenizer = Arc::new(MockTokenizer::new());
+        let transfer = create_equity_transfer(
+            tokenizer.clone(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-DEDUP");
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        // First pass: a fresh transfer issues exactly one mint request, keyed by
+        // the issuer_request_id, and drives the mint to completion.
+        transfer
+            .resume_equity_to_market_making(&id, &symbol, FractionalShares::new(float!(10.0)))
+            .await
+            .unwrap();
+
+        assert_eq!(tokenizer.request_mint_count(), 1);
+        assert_eq!(tokenizer.last_issuer_request_id(), Some(id.clone()));
+
+        // Retry with the same id: the resume path takes over and must NOT issue a
+        // second Alpaca mint request -- otherwise the dedup key bought nothing.
+        transfer
+            .resume_equity_to_market_making(&id, &symbol, FractionalShares::new(float!(10.0)))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tokenizer.request_mint_count(),
+            1,
+            "a retry must resume the persisted mint, not request a duplicate"
+        );
+    }
+
+    /// A concurrent worker (or overlapping retry) can initialize the aggregate
+    /// while request_mint is in flight. If Alpaca then returns a different,
+    /// non-deduplicated tokenization_request_id, start_mint must resume the
+    /// persisted request rather than wedge on AlreadyInProgress.
+    #[tokio::test]
+    async fn start_mint_with_conflicting_request_id_resumes_persisted_mint() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-CONFLICT-ID");
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        // Stand in for the concurrent worker: the aggregate is already accepted
+        // under a different tokenization_request_id than the mock's request_mint
+        // hands back (MOCK_REQ_ID).
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordMintRequested {
+                    issuer_request_id: id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                    tokenization_request_id: tokenization_request_id("ORIGINAL_REQ"),
+                },
+            )
+            .await
+            .unwrap();
+
+        // start_mint requests a (duplicate) mint, sees the already-accepted
+        // aggregate, and resumes the persisted request rather than re-recording.
+        transfer
+            .start_mint(&id, &symbol, FractionalShares::new(float!(10)))
+            .await
+            .expect("a conflicting request id must resume, not wedge");
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        let TokenizedEquityMint::DepositedIntoRaindex {
+            tokenization_request_id: persisted_request_id,
+            ..
+        } = entity
+        else {
+            panic!("Expected the persisted mint to complete, got: {entity:?}");
+        };
+        assert_eq!(
+            persisted_request_id,
+            tokenization_request_id("ORIGINAL_REQ"),
+            "the persisted request id must survive -- the duplicate must not overwrite it"
+        );
+    }
+
+    /// If a failure command lands while request_mint is in flight, a provider
+    /// acceptance must be polled and recovered rather than discarded behind the
+    /// terminal aggregate.
+    #[tokio::test]
+    async fn start_mint_recovers_acceptance_that_raced_with_failed_state() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+        let id = issuer_request_id("ISS-FAILED-RACE");
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordMintRequested {
+                    issuer_request_id: id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                    tokenization_request_id: tokenization_request_id("STALE_REQ"),
+                },
+            )
+            .await
+            .unwrap();
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::FailAcceptance {
+                    reason: "operator timed out the request".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        transfer
+            .start_mint(&id, &symbol, FractionalShares::new(float!(10)))
+            .await
+            .expect("the accepted provider request must recover the raced failure");
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::DepositedIntoRaindex { .. }),
+            "the raced provider acceptance must complete, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_race_rejects_missing_or_wrong_provider_token_symbol() {
+        for (suffix, tokenizer) in [
+            ("missing", MockTokenizer::new().with_no_token_symbol()),
+            (
+                "wrong",
+                MockTokenizer::new().with_token_symbol_override("tMSFT"),
+            ),
+        ] {
+            let transfer = create_equity_transfer(
+                Arc::new(tokenizer),
+                Arc::new(MockRaindex::new()),
+                Arc::new(MockWrapper::new()),
+            )
+            .await;
+            let id = issuer_request_id(&format!("ISS-FAILED-RACE-{suffix}"));
+            let symbol = Symbol::new("AAPL").unwrap();
+
+            transfer
+                .mint_store
+                .send(
+                    &id,
+                    TokenizedEquityMintCommand::RecordMintRequested {
+                        issuer_request_id: id.clone(),
+                        symbol: symbol.clone(),
+                        quantity: float!(10),
+                        wallet: transfer.wallet,
+                        tokenization_request_id: tokenization_request_id("STALE_REQ"),
+                    },
+                )
+                .await
+                .unwrap();
+            transfer
+                .mint_store
+                .send(
+                    &id,
+                    TokenizedEquityMintCommand::FailAcceptance {
+                        reason: "operator timed out the request".to_string(),
+                    },
+                )
+                .await
+                .unwrap();
+
+            let error = transfer
+                .start_mint(&id, &symbol, FractionalShares::new(float!(10)))
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                error,
+                MintTransferError::PostReceipt(MintError::CompletedMintTokenSymbolMismatch { .. })
+            ));
+
+            let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+            assert!(
+                matches!(entity, TokenizedEquityMint::Failed { .. }),
+                "an invalid completion must not recover the failed aggregate: {entity:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn resume_mint_poll_rejected_records_failed() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new().with_mint_poll_outcome(MockMintPollOutcome::Rejected)),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-POLL-REJECT");
+        transfer
+            .resume_equity_to_market_making(
+                &id,
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(10.0)),
+            )
+            .await
+            .unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::Failed { .. }),
+            "poll rejection must mark the mint Failed, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_mint_poll_pending_keeps_accepted_mint_inflight_for_retry() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new().with_mint_poll_outcome(MockMintPollOutcome::Pending)),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-POLL-PENDING");
+        let error = transfer
+            .resume_equity_to_market_making(
+                &id,
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(10.0)),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            MintTransferError::PreReceipt(MintError::MintStillPending { .. })
+        ));
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::MintAccepted { .. }),
+            "a still-pending provider request must stay in flight, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_mint_poll_error_keeps_accepted_mint_inflight_for_retry() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new().with_mint_poll_outcome(MockMintPollOutcome::PollError)),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-POLL-ERR");
+        let error = transfer
+            .resume_equity_to_market_making(
+                &id,
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(10.0)),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            MintTransferError::PreReceipt(MintError::Tokenizer(_))
+        ));
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::MintAccepted { .. }),
+            "an unconfirmable provider outcome must stay in flight, got: {entity:?}"
+        );
+    }
+
+    /// After a poll rejection drives the mint to `Failed`, the apalis retry
+    /// re-enters the job entry point. A terminal aggregate must be a clean
+    /// no-op so the retry does not loop on the rejected mint.
+    #[tokio::test]
+    async fn resume_equity_to_market_making_is_noop_on_failed_mint() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new().with_mint_poll_outcome(MockMintPollOutcome::Rejected)),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-POLL-REJECT-NOOP");
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        transfer
+            .resume_equity_to_market_making(&id, &symbol, FractionalShares::new(float!(10.0)))
+            .await
+            .unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::Failed { .. }),
+            "poll rejection must mark the mint Failed, got: {entity:?}"
+        );
+
+        transfer
+            .resume_equity_to_market_making(&id, &symbol, FractionalShares::new(float!(10.0)))
+            .await
+            .expect("a Failed mint must be a clean no-op for the job retry");
+    }
+
+    #[tokio::test]
+    async fn resume_mint_poll_wrong_token_symbol_keeps_accepted_mint_inflight() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new().with_token_symbol_override("tGME")),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-WRONG-SYM");
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        transfer
+            .resume_equity_to_market_making(&id, &symbol, FractionalShares::new(float!(10.0)))
+            .await
+            .expect_err("an unusable completion payload must fail closed for retry and alerting");
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::MintAccepted { .. }),
+            "a reported completion may have minted tokens, so it must stay in flight: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_mint_poll_missing_token_symbol_keeps_accepted_mint_inflight() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new().with_no_token_symbol()),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-MISSING-SYM");
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        transfer
+            .resume_equity_to_market_making(&id, &symbol, FractionalShares::new(float!(10.0)))
+            .await
+            .expect_err("an unusable completion payload must fail closed for retry and alerting");
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::MintAccepted { .. }),
+            "a reported completion may have minted tokens, so it must stay in flight: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_mint_records_provider_fees() {
+        // Wrap fails so the flow halts right after TokensReceived is recorded,
+        // letting us inspect the persisted fees forwarded from the provider.
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new().with_fees(float!(0.25))),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::failing()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-FEES");
+        transfer
+            .resume_equity_to_market_making(
+                &id,
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(10.0)),
+            )
+            .await
+            .unwrap_err();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        let TokenizedEquityMint::TokensReceived {
+            fees: Some(fees), ..
+        } = entity
+        else {
+            panic!("expected TokensReceived carrying fees, got: {entity:?}");
+        };
+        assert!(
+            fees.eq(float!(0.25)).unwrap(),
+            "provider fees must propagate to TokensReceived"
+        );
+    }
+
+    #[tokio::test]
     async fn resume_mint_from_accepted_completes_workflow() {
         let transfer = create_equity_transfer(
             Arc::new(MockTokenizer::new()),
@@ -2561,11 +3283,12 @@ mod tests {
             .mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(10),
                     wallet: transfer.wallet,
+                    tokenization_request_id: tokenization_request_id("tok-1"),
                 },
             )
             .await
@@ -2601,18 +3324,19 @@ mod tests {
             .mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(10),
                     wallet: transfer.wallet,
+                    tokenization_request_id: tokenization_request_id("tok-1"),
                 },
             )
             .await
             .unwrap();
 
         // The re-enqueued job runs the same entry point with the same id; a
-        // fresh RequestMint here would fail with AlreadyInProgress, so
+        // fresh RecordMintRequested here would fail with AlreadyInProgress, so
         // completing proves the resume path was taken.
         transfer
             .resume_equity_to_market_making(&id, &symbol, FractionalShares::new(float!(10)))
@@ -3453,26 +4177,34 @@ mod tests {
         let id = issuer_request_id("ISS-REVERT-RECOVERY");
 
         // Advance the aggregate to TokensWrapped state manually:
-        // RequestMint -> MintAccepted -> TokensReceived -> WrapSubmitted
-        // -> TokensWrapped
+        // RecordMintRequested -> MintAccepted -> RecordTokensReceived ->
+        // TokensReceived -> WrapSubmitted -> TokensWrapped
         transfer
             .mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(10),
                     wallet: transfer.wallet,
+                    tokenization_request_id: tokenization_request_id("tok-1"),
                 },
             )
             .await
             .unwrap();
 
-        // Poll advances to TokensReceived
+        // RecordTokensReceived advances to TokensReceived
         transfer
             .mint_store
-            .send(&id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::ZERO),
+                    token_symbol: Some("tAAPL".to_string()),
+                    fees: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -3548,16 +4280,18 @@ mod tests {
         let id = issuer_request_id("ISS-WRAP-SUBMITTED-RECOVERY");
 
         // Advance aggregate to WrapSubmitted state:
-        // RequestMint -> MintAccepted -> TokensReceived -> WrapSubmitted
+        // RecordMintRequested -> MintAccepted -> RecordTokensReceived ->
+        // TokensReceived -> WrapSubmitted
         transfer
             .mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(10),
                     wallet: transfer.wallet,
+                    tokenization_request_id: tokenization_request_id("tok-1"),
                 },
             )
             .await
@@ -3565,7 +4299,14 @@ mod tests {
 
         transfer
             .mint_store
-            .send(&id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::ZERO),
+                    token_symbol: Some("tAAPL".to_string()),
+                    fees: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -3636,11 +4377,12 @@ mod tests {
             .mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(10),
                     wallet: transfer.wallet,
+                    tokenization_request_id: tokenization_request_id("tok-1"),
                 },
             )
             .await
@@ -3648,7 +4390,14 @@ mod tests {
 
         transfer
             .mint_store
-            .send(&id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::ZERO),
+                    token_symbol: Some("tAAPL".to_string()),
+                    fees: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -3729,11 +4478,12 @@ mod tests {
             .mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(10),
                     wallet: transfer.wallet,
+                    tokenization_request_id: tokenization_request_id("tok-1"),
                 },
             )
             .await
@@ -3741,7 +4491,14 @@ mod tests {
 
         transfer
             .mint_store
-            .send(&id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::ZERO),
+                    token_symbol: Some("tAAPL".to_string()),
+                    fees: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -3836,11 +4593,12 @@ mod tests {
             .mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(10),
                     wallet: transfer.wallet,
+                    tokenization_request_id: tokenization_request_id("tok-1"),
                 },
             )
             .await
@@ -3848,7 +4606,14 @@ mod tests {
 
         transfer
             .mint_store
-            .send(&id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::ZERO),
+                    token_symbol: Some("tAAPL".to_string()),
+                    fees: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -3926,16 +4691,18 @@ mod tests {
 
         let id = issuer_request_id("ISS-WRAP-SUBMITTED-WAIT-FAIL");
 
-        // Advance to WrapSubmitted: RequestMint -> Poll -> SubmitWrap
+        // Advance to WrapSubmitted: RecordMintRequested ->
+        // RecordTokensReceived -> SubmitWrap
         transfer
             .mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(10),
                     wallet: transfer.wallet,
+                    tokenization_request_id: tokenization_request_id("tok-1"),
                 },
             )
             .await
@@ -3943,7 +4710,14 @@ mod tests {
 
         transfer
             .mint_store
-            .send(&id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::ZERO),
+                    token_symbol: Some("tAAPL".to_string()),
+                    fees: None,
+                },
+            )
             .await
             .unwrap();
 

--- a/src/rebalancing/equity/resume_job.rs
+++ b/src/rebalancing/equity/resume_job.rs
@@ -94,7 +94,7 @@ impl Job<ResumeTokenizationCtx> for ResumeTokenizationAggregate {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Address, B256, TxHash, U256};
+    use alloy::primitives::{Address, B256, TxHash, U256, b256};
     use serde_json::json;
     use st0x_event_sorcery::test_store;
     use st0x_float_macro::float;
@@ -147,7 +147,7 @@ mod tests {
             wrapper: wrapper.clone(),
         };
 
-        let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
+        let mint_store = Arc::new(test_store(pool.clone(), ()));
         let redemption_store = Arc::new(test_store(pool, transfer_services));
 
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
@@ -173,22 +173,33 @@ mod tests {
         let symbol = st0x_execution::Symbol::new("AAPL").unwrap();
 
         // Drive mint to DepositedIntoRaindex (terminal) via command chain.
-        // MockTokenizer returns tokens immediately so Poll succeeds.
+        // RecordMintRequested lands in MintAccepted; RecordTokensReceived with a
+        // matching wrapped symbol drives MintAccepted -> TokensReceived.
         mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(1.0),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("resume-mint-terminal-req"),
                 },
             )
             .await
             .unwrap();
 
         mint_store
-            .send(&id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(b256!(
+                        "0x0000000000000000000000000000000000000000000000000000000000000001"
+                    )),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -241,22 +252,32 @@ mod tests {
         let id = issuer_request_id("resume-mint-failed");
         let symbol = st0x_execution::Symbol::new("AAPL").unwrap();
 
-        // Drive to Failed via RequestMint + Poll + FailWrapping.
+        // Drive to Failed via RecordMintRequested + RecordTokensReceived + FailWrapping.
         mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(1.0),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("resume-mint-failed-req"),
                 },
             )
             .await
             .unwrap();
 
         mint_store
-            .send(&id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(b256!(
+                        "0x0000000000000000000000000000000000000000000000000000000000000001"
+                    )),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -375,16 +396,17 @@ mod tests {
         let id = issuer_request_id("resume-mint-interrupted");
         let symbol = st0x_execution::Symbol::new("AAPL").unwrap();
 
-        // RequestMint emits MintRequested + MintAccepted (MockTokenizer accepts),
-        // leaving a non-terminal MintAccepted aggregate -- the interrupted state.
+        // RecordMintRequested emits MintRequested + MintAccepted, leaving a
+        // non-terminal MintAccepted aggregate -- the interrupted state.
         mint_store
             .send(
                 &id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(1.0),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("resume-mint-interrupted-req"),
                 },
             )
             .await

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -5244,7 +5244,6 @@ mod tests {
     };
     use st0x_finance::{Usd, Usdc};
     use st0x_float_macro::float;
-    use st0x_tokenization::mock::MockTokenizer;
     use st0x_tokenization::{issuer_request_id, tokenization_request_id};
     use st0x_wrapper::MockWrapper;
 
@@ -5260,7 +5259,6 @@ mod tests {
     use crate::inventory::view::{InFlightEquityLocation, Operator};
     use crate::inventory::{InventoryError, InventoryView, TransferOp, Venue};
     use crate::offchain::order::OffchainOrderId;
-    use crate::onchain::mock::MockRaindex;
     use crate::position::{Position, PositionCommand, PositionEvent, TradeId, TriggerReason};
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::test_utils::rebalancing_enabled_equities;
@@ -5268,7 +5266,6 @@ mod tests {
     use crate::usdc_rebalance::{
         ConversionAmounts, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
     };
-    use crate::vault_lookup::MockVaultLookup;
     use crate::vault_registry::VaultRegistryCommand;
 
     #[test]
@@ -13428,10 +13425,7 @@ mod tests {
     ) {
         service
             .set_stores(
-                Arc::new(test_store::<TokenizedEquityMint>(
-                    pool.clone(),
-                    EquityTransferServices::panicking(),
-                )),
+                Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
                 Arc::new(test_store::<EquityRedemption>(
                     pool,
                     EquityTransferServices::panicking(),
@@ -14022,26 +14016,19 @@ mod tests {
 
     /// Drives a `TokenizedEquityMint` aggregate to `Failed` state (terminal).
     ///
-    /// Uses `MockTokenizer` so `RequestMint` succeeds (returns `MintAccepted`),
-    /// then `FailAcceptance` drives it to `Failed` without calling any other service.
+    /// `RecordMintRequested` emits `MintRequested` + `MintAccepted` without
+    /// calling any service, then `FailAcceptance` drives it to `Failed`.
     async fn seed_terminal_mint_aggregate(pool: &SqlitePool, mint_id: &IssuerRequestId) {
-        let store = test_store::<TokenizedEquityMint>(
-            pool.clone(),
-            EquityTransferServices {
-                raindex: Arc::new(MockRaindex::new()),
-                vault_lookup: Arc::new(MockVaultLookup::new()),
-                tokenizer: Arc::new(MockTokenizer::new()),
-                wrapper: Arc::new(MockWrapper::new()),
-            },
-        );
+        let store = test_store::<TokenizedEquityMint>(pool.clone(), ());
         store
             .send(
                 mint_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: mint_id.clone(),
                     symbol: Symbol::new("tAAPL").unwrap(),
                     quantity: float!(1),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("terminal-mint-tok"),
                 },
             )
             .await
@@ -14059,26 +14046,19 @@ mod tests {
 
     /// Drives a `TokenizedEquityMint` aggregate to `MintAccepted` state (non-terminal).
     ///
-    /// Same services as `seed_terminal_mint_aggregate`; stops before the failure
+    /// Same seeding as `seed_terminal_mint_aggregate`; stops before the failure
     /// so the aggregate is still live and holds the duplicate-protection guard.
     async fn seed_nonterminal_mint_aggregate(pool: &SqlitePool, mint_id: &IssuerRequestId) {
-        let store = test_store::<TokenizedEquityMint>(
-            pool.clone(),
-            EquityTransferServices {
-                raindex: Arc::new(MockRaindex::new()),
-                vault_lookup: Arc::new(MockVaultLookup::new()),
-                tokenizer: Arc::new(MockTokenizer::new()),
-                wrapper: Arc::new(MockWrapper::new()),
-            },
-        );
+        let store = test_store::<TokenizedEquityMint>(pool.clone(), ());
         store
             .send(
                 mint_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: mint_id.clone(),
                     symbol: Symbol::new("tAAPL").unwrap(),
                     quantity: float!(1),
                     wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("nonterminal-mint-tok"),
                 },
             )
             .await
@@ -14260,7 +14240,7 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<TokenizedEquityMint>(pool.clone(), ()),
             test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
         )
         .await;
@@ -14318,7 +14298,7 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<TokenizedEquityMint>(pool.clone(), ()),
             test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
         )
         .await;
@@ -14376,7 +14356,7 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<TokenizedEquityMint>(pool.clone(), ()),
             test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
         )
         .await;
@@ -14430,7 +14410,7 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<TokenizedEquityMint>(pool.clone(), ()),
             test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
         )
         .await;
@@ -14523,7 +14503,7 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<TokenizedEquityMint>(pool.clone(), ()),
             test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
         )
         .await;
@@ -14584,7 +14564,7 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<TokenizedEquityMint>(pool.clone(), ()),
             test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
         )
         .await;
@@ -14636,7 +14616,7 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<TokenizedEquityMint>(pool.clone(), ()),
             test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
         )
         .await;
@@ -14688,7 +14668,7 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<TokenizedEquityMint>(pool.clone(), ()),
             test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
         )
         .await;
@@ -14765,7 +14745,7 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<TokenizedEquityMint>(pool.clone(), ()),
             test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
         )
         .await;
@@ -15042,10 +15022,7 @@ mod tests {
 
         trigger
             .set_stores(
-                Arc::new(test_store::<TokenizedEquityMint>(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
                 Arc::new(test_store::<EquityRedemption>(
                     pool.clone(),
                     crate::rebalancing::equity::EquityTransferServices::panicking(),
@@ -15168,10 +15145,7 @@ mod tests {
 
         trigger
             .set_stores(
-                Arc::new(test_store::<TokenizedEquityMint>(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
                 Arc::new(test_store::<EquityRedemption>(
                     pool.clone(),
                     crate::rebalancing::equity::EquityTransferServices::panicking(),
@@ -15269,10 +15243,7 @@ mod tests {
 
         trigger
             .set_stores(
-                Arc::new(test_store::<TokenizedEquityMint>(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
                 Arc::new(test_store::<EquityRedemption>(
                     pool.clone(),
                     crate::rebalancing::equity::EquityTransferServices::panicking(),
@@ -15441,10 +15412,7 @@ mod tests {
         let store = Arc::new(store);
         trigger
             .set_stores(
-                Arc::new(test_store::<TokenizedEquityMint>(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
                 Arc::new(test_store::<EquityRedemption>(
                     pool.clone(),
                     crate::rebalancing::equity::EquityTransferServices::panicking(),
@@ -15546,10 +15514,7 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(
-                    unmigrated_pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                >(unmigrated_pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     unmigrated_pool.clone(),
                     crate::rebalancing::equity::EquityTransferServices::panicking(),
@@ -15621,10 +15586,7 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(
-                    unmigrated_pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                >(unmigrated_pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     unmigrated_pool.clone(),
                     crate::rebalancing::equity::EquityTransferServices::panicking(),
@@ -15738,10 +15700,7 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                >(pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
                     crate::rebalancing::equity::EquityTransferServices::panicking(),
@@ -16088,10 +16047,7 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                >(pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
                     crate::rebalancing::equity::EquityTransferServices::panicking(),
@@ -16288,10 +16244,7 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                >(pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
                     crate::rebalancing::equity::EquityTransferServices::panicking(),
@@ -16442,10 +16395,7 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                >(pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
                     crate::rebalancing::equity::EquityTransferServices::panicking(),
@@ -17019,10 +16969,7 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                >(pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
                     crate::rebalancing::equity::EquityTransferServices::panicking(),

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -13,8 +13,12 @@
 //!     Failed          Failed          Failed           Failed
 //! ```
 //!
-//! - `MintRequested` can be rejected by Alpaca during `RequestMint`
-//! - `MintAccepted` can fail via `Poll` (rejection/timeout/error)
+//! - The handlers are pure: the tokenizer I/O lives in the orchestrator
+//!   (`CrossVenueEquityTransfer::{start_mint, resume_mint}`), which sends the
+//!   aggregate pure outcome commands.
+//! - A request Alpaca rejects is recorded via `RejectMintRequest` (-> `Failed`)
+//! - `MintAccepted` can fail via `FailAcceptance` when the orchestrator's poll
+//!   returns rejection/timeout/error (-> `Failed`)
 //! - `DepositedIntoRaindex` and `Failed` are terminal states
 //!
 //! # Alpaca API Integration
@@ -50,9 +54,7 @@ use st0x_dto::{EquityMintOperation, EquityMintStatus, TransferOperation};
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
 use st0x_execution::{FractionalShares, Symbol};
 use st0x_finance::Id;
-use st0x_tokenization::{IssuerRequestId, TokenizationRequestId, TokenizationRequestStatus};
-
-use crate::rebalancing::equity::EquityTransferServices;
+use st0x_tokenization::{IssuerRequestId, TokenizationRequestId};
 
 /// Errors that can occur during tokenized equity mint operations.
 ///
@@ -60,8 +62,8 @@ use crate::rebalancing::equity::EquityTransferServices;
 /// invalid transitions.
 #[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error)]
 pub(crate) enum TokenizedEquityMintError {
-    /// Command sent to a non-existent aggregate (must use RequestMint to initialize)
-    #[error("Aggregate not initialized: use RequestMint to start a new mint")]
+    /// Command sent to a non-existent aggregate (must use RecordMintRequested to initialize)
+    #[error("Aggregate not initialized: use RecordMintRequested to start a new mint")]
     NotInitialized,
     /// Attempted to request mint when already in progress
     #[error("Mint already in progress")]
@@ -90,12 +92,6 @@ pub(crate) enum TokenizedEquityMintError {
     /// Attempted to reconcile without an operator-supplied reason.
     #[error("Cannot reconcile: reason is required")]
     ReconcileReasonRequired,
-    /// Tokenizer API failed to submit the mint request.
-    /// Tokenizer errors can't be wrapped with #[from] because they may
-    /// contain types that don't implement Serialize/Deserialize (required
-    /// by DomainError).
-    #[error("Mint request failed: {error_message}")]
-    RequestFailed { error_message: String },
     /// Completed mint response missing tx_hash
     #[error("Missing tx_hash in completed mint response")]
     MissingTxHash,
@@ -149,11 +145,7 @@ impl PartialEq for TokenizedEquityMintError {
             | (Self::ReconcileReasonRequired, Self::ReconcileReasonRequired)
             | (Self::MissingTxHash, Self::MissingTxHash)
             | (Self::VaultDepositFailed, Self::VaultDepositFailed) => true,
-            (
-                Self::RequestFailed { error_message: a },
-                Self::RequestFailed { error_message: b },
-            )
-            | (Self::Float(a), Self::Float(b)) => a == b,
+            (Self::Float(a), Self::Float(b)) => a == b,
             (Self::VaultLookupFailed(a), Self::VaultLookupFailed(b))
             | (
                 Self::MissingTokenSymbol { expected_symbol: a },
@@ -188,43 +180,58 @@ impl From<FloatError> for TokenizedEquityMintError {
 /// Commands for the TokenizedEquityMint aggregate.
 #[derive(Debug, Clone)]
 pub(crate) enum TokenizedEquityMintCommand {
-    /// Request tokenization from Alpaca and poll until tokens arrive or failure.
+    /// Record that the orchestrator's `request_mint` call was accepted by the
+    /// provider. Pure: the handler emits MintRequested + MintAccepted.
     ///
     /// Flow: MintRequested -> MintAccepted -> TokensReceived (success)
-    ///                     or MintRejected (immediate failure)
     ///                     or MintAcceptanceFailed (failure after acceptance)
-    /// Calls `request_mint()` on the tokenizer service.
-    ///
-    /// Emits MintRequested + MintAccepted (success)
-    ///     or MintRequested + MintRejected (immediate rejection)
-    RequestMint {
+    RecordMintRequested {
         issuer_request_id: IssuerRequestId,
         symbol: Symbol,
         quantity: Float,
         wallet: Address,
+        tokenization_request_id: TokenizationRequestId,
     },
-    /// Test/fixture-only: identical to `RequestMint` but takes `requested_at`
-    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
-    /// backdate synthetic history.
+    /// Record that the orchestrator's `request_mint` call was rejected by the
+    /// provider before acceptance. Pure: the handler emits MintRequested +
+    /// MintRejected. Shares were never moved.
+    RejectMintRequest {
+        symbol: Symbol,
+        quantity: Float,
+        wallet: Address,
+        reason: String,
+    },
+    /// Record the provider's completed-mint poll result. Pure: the handler
+    /// validates the returned token symbol/tx hash against aggregate state and
+    /// emits TokensReceived. Carries the raw `Option` fields so the
+    /// missing-tx-hash / missing-or-mismatched-token-symbol invariants stay
+    /// enforced at the aggregate boundary. The orchestrator routes
+    /// rejection/timeout/error poll outcomes through `FailAcceptance` instead.
+    RecordTokensReceived {
+        tx_hash: Option<TxHash>,
+        token_symbol: Option<String>,
+        fees: Option<Float>,
+    },
+    /// Test/fixture-only: identical to `RecordMintRequested` but takes
+    /// `requested_at` explicitly instead of stamping `Utc::now()`, so fixture
+    /// seeding can backdate synthetic history.
     #[cfg(any(test, feature = "test-support"))]
-    RequestMintAt {
+    RecordMintRequestedAt {
         issuer_request_id: IssuerRequestId,
         symbol: Symbol,
         quantity: Float,
         wallet: Address,
+        tokenization_request_id: TokenizationRequestId,
         requested_at: DateTime<Utc>,
     },
-    /// Calls `poll_mint_until_complete()` on the tokenizer service.
-    ///
-    /// Emits TokensReceived (success)
-    ///     or MintAcceptanceFailed (rejection/timeout/error)
-    Poll,
-    /// Test/fixture-only: identical to `Poll` but takes `received_at`
-    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
-    /// backdate synthetic history. Only the success (`TokensReceived`) path
-    /// honours the timestamp; the fixture never drives a rejection.
+    /// Test/fixture-only: identical to `RecordTokensReceived` but takes
+    /// `received_at` explicitly instead of stamping `Utc::now()`, so fixture
+    /// seeding can backdate synthetic history.
     #[cfg(any(test, feature = "test-support"))]
-    PollAt {
+    RecordTokensReceivedAt {
+        tx_hash: Option<TxHash>,
+        token_symbol: Option<String>,
+        fees: Option<Float>,
         received_at: DateTime<Utc>,
     },
     /// Record that a wrap transaction has been submitted (before confirmation).
@@ -1402,7 +1409,7 @@ impl EventSourced for TokenizedEquityMint {
     type Event = TokenizedEquityMintEvent;
     type Command = TokenizedEquityMintCommand;
     type Error = TokenizedEquityMintError;
-    type Services = EquityTransferServices;
+    type Services = ();
     type Materialized = Nil;
 
     const AGGREGATE_TYPE: &'static str = "TokenizedEquityMint";
@@ -1818,119 +1825,168 @@ impl EventSourced for TokenizedEquityMint {
 
     async fn initialize(
         command: Self::Command,
-        services: &Self::Services,
+        _services: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use TokenizedEquityMintEvent::*;
 
-        let (issuer_request_id, symbol, quantity, wallet, now) = match command {
-            TokenizedEquityMintCommand::RequestMint {
-                issuer_request_id,
-                symbol,
-                quantity,
-                wallet,
-            } => (issuer_request_id, symbol, quantity, wallet, Utc::now()),
+        let now = Utc::now();
+
+        match command {
             #[cfg(any(test, feature = "test-support"))]
-            TokenizedEquityMintCommand::RequestMintAt {
+            TokenizedEquityMintCommand::RecordMintRequestedAt {
                 issuer_request_id,
                 symbol,
                 quantity,
                 wallet,
+                tokenization_request_id,
                 requested_at,
-            } => (issuer_request_id, symbol, quantity, wallet, requested_at),
-            _ => return Err(TokenizedEquityMintError::NotInitialized),
-        };
+            } => {
+                if quantity.lt(Float::zero()?)? {
+                    return Err(TokenizedEquityMintError::NegativeQuantity { value: quantity });
+                }
 
-        if quantity.lt(Float::zero()?)? {
-            return Err(TokenizedEquityMintError::NegativeQuantity { value: quantity });
-        }
-
-        info!(
-            target: "tokenization",
-            %symbol,
-            ?quantity,
-            %wallet,
-            "Initiating mint request"
-        );
-
-        let mint_requested = MintRequested {
-            symbol: symbol.clone(),
-            quantity,
-            wallet,
-            requested_at: now,
-        };
-
-        let alpaca_request = match services
-            .tokenizer
-            .request_mint(
-                symbol,
-                FractionalShares::new(quantity),
-                wallet,
-                issuer_request_id.clone(),
-            )
-            .await
-        {
-            Ok(req) => req,
-            Err(error) => {
-                return Err(TokenizedEquityMintError::RequestFailed {
-                    error_message: error.to_string(),
-                });
+                Ok(vec![
+                    MintRequested {
+                        symbol,
+                        quantity,
+                        wallet,
+                        requested_at,
+                    },
+                    MintAccepted {
+                        issuer_request_id,
+                        tokenization_request_id,
+                        accepted_at: requested_at,
+                    },
+                ])
             }
-        };
 
-        if matches!(alpaca_request.status, TokenizationRequestStatus::Rejected) {
-            warn!(
-                target: "tokenization",
-                symbol = %alpaca_request.underlying_symbol,
-                "Mint request rejected by Alpaca"
-            );
-            return Ok(vec![
-                mint_requested,
-                MintRejected {
-                    reason: "Rejected by Alpaca".to_string(),
-                    rejected_at: now,
-                },
-            ]);
-        }
-
-        info!(
-            target: "tokenization",
-            symbol = %alpaca_request.underlying_symbol,
-            request_id = %alpaca_request.id,
-            "Mint request accepted by Alpaca"
-        );
-
-        Ok(vec![
-            mint_requested,
-            MintAccepted {
+            TokenizedEquityMintCommand::RecordMintRequested {
                 issuer_request_id,
-                tokenization_request_id: alpaca_request.id,
-                accepted_at: now,
-            },
-        ])
+                symbol,
+                quantity,
+                wallet,
+                tokenization_request_id,
+            } => {
+                if quantity.lt(Float::zero()?)? {
+                    return Err(TokenizedEquityMintError::NegativeQuantity { value: quantity });
+                }
+
+                info!(
+                    target: "tokenization",
+                    %symbol,
+                    ?quantity,
+                    %wallet,
+                    "Recording accepted mint request"
+                );
+
+                Ok(vec![
+                    MintRequested {
+                        symbol,
+                        quantity,
+                        wallet,
+                        requested_at: now,
+                    },
+                    MintAccepted {
+                        issuer_request_id,
+                        tokenization_request_id,
+                        accepted_at: now,
+                    },
+                ])
+            }
+
+            TokenizedEquityMintCommand::RejectMintRequest {
+                symbol,
+                quantity,
+                wallet,
+                reason,
+            } => {
+                if quantity.lt(Float::zero()?)? {
+                    return Err(TokenizedEquityMintError::NegativeQuantity { value: quantity });
+                }
+
+                warn!(
+                    target: "tokenization",
+                    %symbol,
+                    %reason,
+                    "Recording rejected mint request"
+                );
+
+                Ok(vec![
+                    MintRequested {
+                        symbol,
+                        quantity,
+                        wallet,
+                        requested_at: now,
+                    },
+                    MintRejected {
+                        reason,
+                        rejected_at: now,
+                    },
+                ])
+            }
+
+            _ => Err(TokenizedEquityMintError::NotInitialized),
+        }
     }
 
     #[allow(clippy::too_many_lines)]
     async fn transition(
         &self,
         command: Self::Command,
-        services: &Self::Services,
+        _services: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use TokenizedEquityMintEvent::*;
         match command {
-            TokenizedEquityMintCommand::RequestMint { .. } => {
-                Err(TokenizedEquityMintError::AlreadyInProgress)
-            }
+            // Idempotent re-delivery of the accept outcome (jobs are
+            // at-least-once): the aggregate already originated, so this lands in
+            // transition, not initialize.
+            TokenizedEquityMintCommand::RecordMintRequested {
+                tokenization_request_id,
+                ..
+            } => match self {
+                Self::MintAccepted {
+                    tokenization_request_id: existing,
+                    ..
+                } if *existing == tokenization_request_id => Ok(vec![]),
+                Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+                _ => Err(TokenizedEquityMintError::AlreadyInProgress),
+            },
             #[cfg(any(test, feature = "test-support"))]
-            TokenizedEquityMintCommand::RequestMintAt { .. } => {
+            TokenizedEquityMintCommand::RecordMintRequestedAt { .. } => {
                 Err(TokenizedEquityMintError::AlreadyInProgress)
             }
 
-            TokenizedEquityMintCommand::Poll => self.transition_poll(services, None).await,
+            // Idempotent re-delivery of the reject outcome.
+            TokenizedEquityMintCommand::RejectMintRequest { .. } => match self {
+                Self::Failed { .. } => Ok(vec![]),
+                Self::DepositedIntoRaindex { .. } => {
+                    Err(TokenizedEquityMintError::AlreadyCompleted)
+                }
+                _ => Err(TokenizedEquityMintError::AlreadyInProgress),
+            },
 
+            TokenizedEquityMintCommand::RecordTokensReceived {
+                tx_hash,
+                token_symbol,
+                fees,
+            } => self.transition_record_tokens_received(
+                tx_hash,
+                token_symbol.as_deref(),
+                fees,
+                Utc::now(),
+            ),
             #[cfg(any(test, feature = "test-support"))]
-            TokenizedEquityMintCommand::PollAt { received_at } => {
-                self.transition_poll(services, Some(received_at)).await
-            }
+            TokenizedEquityMintCommand::RecordTokensReceivedAt {
+                tx_hash,
+                token_symbol,
+                fees,
+                received_at,
+            } => self.transition_record_tokens_received(
+                tx_hash,
+                token_symbol.as_deref(),
+                fees,
+                received_at,
+            ),
 
             TokenizedEquityMintCommand::SubmitWrap { wrap_tx_hash } => match self {
                 Self::TokensReceived { .. } => Ok(vec![WrapSubmitted {
@@ -2107,6 +2163,92 @@ impl EventSourced for TokenizedEquityMint {
 }
 
 impl TokenizedEquityMint {
+    /// Shared body for `RecordTokensReceived`/`RecordTokensReceivedAt`.
+    fn transition_record_tokens_received(
+        &self,
+        tx_hash: Option<TxHash>,
+        token_symbol: Option<&str>,
+        fees: Option<Float>,
+        received_at: DateTime<Utc>,
+    ) -> Result<Vec<TokenizedEquityMintEvent>, TokenizedEquityMintError> {
+        use TokenizedEquityMintEvent::*;
+
+        match self {
+            Self::MintAccepted {
+                symbol, quantity, ..
+            } => {
+                let tx_hash = tx_hash.ok_or(TokenizedEquityMintError::MissingTxHash)?;
+
+                // Validate that Alpaca returned the expected tokenized symbol
+                // (e.g. "tAAPL" for AAPL). This cross-system consistency check
+                // stays in the aggregate, at the consistency boundary.
+                let expected_token_symbol = format!("t{symbol}");
+                match token_symbol {
+                    Some(actual) if actual == expected_token_symbol => {}
+                    Some(actual) => {
+                        return Err(TokenizedEquityMintError::TokenSymbolMismatch {
+                            expected_symbol: symbol.clone(),
+                            actual_token_symbol: actual.to_string(),
+                        });
+                    }
+                    None => {
+                        return Err(TokenizedEquityMintError::MissingTokenSymbol {
+                            expected_symbol: symbol.clone(),
+                        });
+                    }
+                }
+
+                let shares_minted = quantity_to_u256_18_decimals(*quantity)?;
+
+                info!(
+                    target: "tokenization",
+                    %symbol,
+                    %tx_hash,
+                    "Recording received tokens"
+                );
+
+                Ok(vec![TokensReceived {
+                    tx_hash,
+                    shares_minted,
+                    fees,
+                    received_at,
+                }])
+            }
+            // Idempotent re-delivery of the same poll outcome. Also covers a
+            // recovery-produced TokensReceived (ProviderCompletionRecovered
+            // evolves Failed -> TokensReceived).
+            Self::TokensReceived {
+                tx_hash: existing,
+                fees: existing_fees,
+                ..
+            } if tx_hash == Some(*existing) => {
+                let fees_match = match (&fees, existing_fees) {
+                    (Some(new_fees), Some(old_fees)) => new_fees.eq(*old_fees)?,
+                    (None, None) => true,
+                    _ => false,
+                };
+                if !fees_match {
+                    warn!(
+                        target: "tokenization",
+                        ?fees,
+                        existing_fees = ?existing_fees,
+                        %existing,
+                        "RecordTokensReceived re-delivered with different fees; keeping recorded value"
+                    );
+                }
+                Ok(vec![])
+            }
+            Self::MintRequested { .. } => Err(TokenizedEquityMintError::NotAccepted),
+            Self::TokensReceived { .. }
+            | Self::WrapSubmitted { .. }
+            | Self::TokensWrapped { .. }
+            | Self::VaultDepositSubmitted { .. }
+            | Self::DepositedIntoRaindex { .. } => Err(TokenizedEquityMintError::AlreadyCompleted),
+            Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
+        }
+    }
+
     /// Shared body for `WrapTokens`/`WrapTokensAt`.
     fn transition_wrap_tokens(
         &self,
@@ -2159,151 +2301,33 @@ impl TokenizedEquityMint {
             Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
         }
     }
-
-    /// Shared body for `Poll`/`PollAt`: only `received_at` (the success
-    /// path's timestamp) is parameterized -- the failure paths keep
-    /// `Utc::now()` since fixture seeding only ever drives the happy path.
-    async fn transition_poll(
-        &self,
-        services: &EquityTransferServices,
-        override_received_at: Option<DateTime<Utc>>,
-    ) -> Result<Vec<TokenizedEquityMintEvent>, TokenizedEquityMintError> {
-        use TokenizedEquityMintEvent::*;
-
-        match self {
-            Self::MintAccepted {
-                symbol,
-                quantity,
-                tokenization_request_id,
-                ..
-            } => {
-                let completed = match services
-                    .tokenizer
-                    .poll_mint_until_complete(tokenization_request_id)
-                    .await
-                {
-                    Ok(req) => req,
-                    Err(error) => {
-                        warn!(target: "tokenization", %error, %symbol, %tokenization_request_id, "Polling failed");
-                        return Ok(vec![MintAcceptanceFailed {
-                            reason: format!("Polling failed: {error}"),
-                            failed_at: Utc::now(),
-                        }]);
-                    }
-                };
-
-                match completed.status {
-                    TokenizationRequestStatus::Completed => {
-                        let tx_hash = completed
-                            .tx_hash
-                            .ok_or(TokenizedEquityMintError::MissingTxHash)?;
-
-                        // Validate that Alpaca returned the expected
-                        // tokenized symbol (e.g. "tAAPL" for AAPL).
-                        let expected_token_symbol = format!("t{symbol}");
-                        match &completed.token_symbol {
-                            Some(actual) if *actual == expected_token_symbol => {}
-                            Some(actual) => {
-                                return Err(TokenizedEquityMintError::TokenSymbolMismatch {
-                                    expected_symbol: symbol.clone(),
-                                    actual_token_symbol: actual.clone(),
-                                });
-                            }
-                            None => {
-                                return Err(TokenizedEquityMintError::MissingTokenSymbol {
-                                    expected_symbol: symbol.clone(),
-                                });
-                            }
-                        }
-
-                        let shares_minted = quantity_to_u256_18_decimals(*quantity)?;
-
-                        info!(
-                            target: "tokenization",
-                            %symbol,
-                            %tx_hash,
-                            "Mint polling completed: tokens received"
-                        );
-
-                        Ok(vec![TokensReceived {
-                            tx_hash,
-                            shares_minted,
-                            fees: completed.fees,
-                            received_at: override_received_at.unwrap_or_else(Utc::now),
-                        }])
-                    }
-                    TokenizationRequestStatus::Rejected => {
-                        warn!(
-                            target: "tokenization",
-                            %symbol,
-                            "Mint rejected by Alpaca after acceptance"
-                        );
-                        Ok(vec![MintAcceptanceFailed {
-                            reason: "Rejected by Alpaca after acceptance".to_string(),
-                            failed_at: Utc::now(),
-                        }])
-                    }
-                    TokenizationRequestStatus::Pending => {
-                        warn!(
-                            target: "tokenization",
-                            %symbol,
-                            "Unexpected pending status after polling"
-                        );
-                        Ok(vec![MintAcceptanceFailed {
-                            reason: "Unexpected Pending status after polling".to_string(),
-                            failed_at: Utc::now(),
-                        }])
-                    }
-                }
-            }
-            Self::MintRequested { .. } => Err(TokenizedEquityMintError::NotAccepted),
-            Self::TokensReceived { .. }
-            | Self::WrapSubmitted { .. }
-            | Self::TokensWrapped { .. }
-            | Self::VaultDepositSubmitted { .. }
-            | Self::DepositedIntoRaindex { .. } => Err(TokenizedEquityMintError::AlreadyCompleted),
-            Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
-            Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::B256;
     use sqlx::SqlitePool;
-    use std::sync::Arc;
 
     use st0x_event_sorcery::{AggregateError, LifecycleError, TestHarness, TestStore, replay};
     use st0x_float_macro::float;
-    use st0x_raindex::RaindexVaultId;
-    use st0x_tokenization::mock::{MockMintPollOutcome, MockMintRequestOutcome, MockTokenizer};
-    use st0x_tokenization::{Tokenizer, issuer_request_id, tokenization_request_id};
-    use st0x_wrapper::MockWrapper;
+    use st0x_tokenization::{issuer_request_id, tokenization_request_id};
 
     use super::*;
-    use crate::onchain::mock::MockRaindex;
-    use crate::vault_lookup::MockVaultLookup;
-
-    fn mock_vault_lookup() -> MockVaultLookup {
-        MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO))
-    }
-
-    fn mint_services(tokenizer: MockTokenizer) -> EquityTransferServices {
-        EquityTransferServices {
-            tokenizer: Arc::new(tokenizer),
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            wrapper: Arc::new(MockWrapper::new()),
-        }
-    }
 
     fn mint_command() -> TokenizedEquityMintCommand {
-        TokenizedEquityMintCommand::RequestMint {
+        TokenizedEquityMintCommand::RecordMintRequested {
             issuer_request_id: issuer_request_id("ISS001"),
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: float!(10),
             wallet: Address::ZERO,
+            tokenization_request_id: tokenization_request_id("MOCK_REQ_ID"),
+        }
+    }
+
+    fn record_tokens_received() -> TokenizedEquityMintCommand {
+        TokenizedEquityMintCommand::RecordTokensReceived {
+            tx_hash: Some(TxHash::ZERO),
+            token_symbol: Some(format!("t{}", Symbol::new("AAPL").unwrap())),
+            fees: None,
         }
     }
 
@@ -2385,7 +2409,7 @@ mod tests {
 
     #[tokio::test]
     async fn initialize_emits_requested_and_accepted() {
-        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let events = TestHarness::<TokenizedEquityMint>::with(())
             .given_no_previous_events()
             .when(mint_command())
             .await
@@ -2409,15 +2433,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_after_acceptance_emits_tokens_received() {
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+    async fn record_tokens_received_after_acceptance_emits_tokens_received() {
+        let store = TestStore::<TokenizedEquityMint>::new(());
 
         let id = issuer_request_id("ISS001");
         store.send(&id, mint_command()).await.unwrap();
-        store
-            .send(&id, TokenizedEquityMintCommand::Poll)
-            .await
-            .unwrap();
+        store.send(&id, record_tokens_received()).await.unwrap();
 
         let entity = store.load(&id).await.unwrap().unwrap();
         assert!(
@@ -2427,15 +2448,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_completed_with_fees_propagates_to_tokens_received() {
+    async fn record_tokens_received_with_fees_propagates_to_tokens_received() {
         let expected_fees = float!("0.25");
-        let tokenizer = MockTokenizer::new().with_fees(expected_fees);
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
+        let store = TestStore::<TokenizedEquityMint>::new(());
 
         let id = issuer_request_id("ISS001");
         store.send(&id, mint_command()).await.unwrap();
         store
-            .send(&id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::ZERO),
+                    token_symbol: Some(format!("t{}", Symbol::new("AAPL").unwrap())),
+                    fees: Some(expected_fees),
+                },
+            )
             .await
             .unwrap();
 
@@ -2454,14 +2481,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_completed_with_wrong_token_symbol_errors() {
-        let tokenizer = MockTokenizer::new().with_token_symbol_override("tGME");
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
+    async fn record_tokens_received_with_wrong_token_symbol_errors() {
+        let store = TestStore::<TokenizedEquityMint>::new(());
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
         let error = store
-            .send(&id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::ZERO),
+                    token_symbol: Some("tGME".to_string()),
+                    fees: None,
+                },
+            )
             .await
             .unwrap_err();
 
@@ -2487,14 +2520,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_completed_with_missing_token_symbol_errors() {
-        let tokenizer = MockTokenizer::new().with_no_token_symbol();
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
+    async fn record_tokens_received_with_missing_token_symbol_errors() {
+        let store = TestStore::<TokenizedEquityMint>::new(());
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
         let error = store
-            .send(&id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::ZERO),
+                    token_symbol: None,
+                    fees: None,
+                },
+            )
             .await
             .unwrap_err();
 
@@ -2518,21 +2557,272 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_rejected_emits_acceptance_failed() {
-        let tokenizer = MockTokenizer::new().with_mint_poll_outcome(MockMintPollOutcome::Rejected);
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
+    async fn record_tokens_received_with_missing_tx_hash_errors() {
+        let store = TestStore::<TokenizedEquityMint>::new(());
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
-        store
-            .send(&id, TokenizedEquityMintCommand::Poll)
+        let error = store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: None,
+                    token_symbol: Some(format!("t{}", Symbol::new("AAPL").unwrap())),
+                    fees: None,
+                },
+            )
             .await
-            .unwrap();
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AggregateError::UserError(LifecycleError::Apply(
+                    TokenizedEquityMintError::MissingTxHash
+                ))
+            ),
+            "Expected MissingTxHash, got: {error:?}"
+        );
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::MintAccepted { .. }),
+            "Expected MintAccepted after validation error, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_mint_requested_is_idempotent_when_redelivered() {
+        let store = TestStore::<TokenizedEquityMint>::new(());
+        let id = issuer_request_id("ISS001");
+
+        // At-least-once jobs can re-deliver the accept outcome after the
+        // aggregate already originated; the same tokenization request id is a
+        // no-op rather than an error.
+        store.send(&id, mint_command()).await.unwrap();
+        store.send(&id, mint_command()).await.unwrap();
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::MintAccepted { .. }),
+            "Re-delivered RecordMintRequested must keep MintAccepted, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_mint_requested_with_conflicting_request_id_errors() {
+        let store = TestStore::<TokenizedEquityMint>::new(());
+        let id = issuer_request_id("ISS001");
+
+        store.send(&id, mint_command()).await.unwrap();
+        let error = store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordMintRequested {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: Address::ZERO,
+                    tokenization_request_id: tokenization_request_id("DIFFERENT"),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AggregateError::UserError(LifecycleError::Apply(
+                    TokenizedEquityMintError::AlreadyInProgress
+                ))
+            ),
+            "A conflicting request id must not overwrite acceptance, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_tokens_received_is_idempotent_when_redelivered() {
+        let store = TestStore::<TokenizedEquityMint>::new(());
+        let id = issuer_request_id("ISS001");
+
+        store.send(&id, mint_command()).await.unwrap();
+        store.send(&id, record_tokens_received()).await.unwrap();
+        // Re-delivery with the same tx hash is a no-op.
+        store.send(&id, record_tokens_received()).await.unwrap();
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::TokensReceived { .. }),
+            "Re-delivered RecordTokensReceived must keep TokensReceived, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_tokens_received_redelivered_with_different_tx_hash_errors() {
+        let store = TestStore::<TokenizedEquityMint>::new(());
+        let id = issuer_request_id("ISS001");
+
+        store.send(&id, mint_command()).await.unwrap();
+        // record_tokens_received() records tx_hash ZERO.
+        store.send(&id, record_tokens_received()).await.unwrap();
+
+        // A re-delivery carrying a different tx hash is not idempotent: it would
+        // mean two distinct completion events for the same mint, so the
+        // aggregate must reject it rather than overwrite the recorded hash.
+        let conflicting_tx_hash = TxHash::repeat_byte(0x11);
+        let error = store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(conflicting_tx_hash),
+                    token_symbol: Some(format!("t{}", Symbol::new("AAPL").unwrap())),
+                    fees: None,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AggregateError::UserError(LifecycleError::Apply(
+                    TokenizedEquityMintError::AlreadyCompleted
+                ))
+            ),
+            "A conflicting tx hash must not overwrite the recorded receipt, got: {error:?}"
+        );
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        let TokenizedEquityMint::TokensReceived { tx_hash, .. } = entity else {
+            panic!("Expected TokensReceived state, got: {entity:?}");
+        };
+        assert_eq!(
+            tx_hash,
+            TxHash::ZERO,
+            "The originally recorded tx hash must remain unchanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn reject_mint_request_is_idempotent_when_already_failed() {
+        let store = TestStore::<TokenizedEquityMint>::new(());
+        let id = issuer_request_id("ISS001");
+
+        let reject = || TokenizedEquityMintCommand::RejectMintRequest {
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: float!(10),
+            wallet: Address::ZERO,
+            reason: "Rejected by Alpaca".to_string(),
+        };
+
+        store.send(&id, reject()).await.unwrap();
+        // Re-delivery of the reject outcome against an already-Failed mint is a
+        // no-op.
+        store.send(&id, reject()).await.unwrap();
 
         let entity = store.load(&id).await.unwrap().unwrap();
         assert!(
             matches!(entity, TokenizedEquityMint::Failed { .. }),
-            "Expected Failed state after rejected poll, got: {entity:?}"
+            "Re-delivered RejectMintRequest must keep Failed, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reject_mint_request_on_accepted_mint_errors_already_in_progress() {
+        let store = TestStore::<TokenizedEquityMint>::new(());
+        let id = issuer_request_id("ISS001");
+
+        store.send(&id, mint_command()).await.unwrap();
+
+        // A reject re-delivery that races an already-accepted mint must not
+        // overwrite the in-progress aggregate; it errors and leaves state intact.
+        let error = store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RejectMintRequest {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: Address::ZERO,
+                    reason: "Rejected by Alpaca".to_string(),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AggregateError::UserError(LifecycleError::Apply(
+                    TokenizedEquityMintError::AlreadyInProgress
+                ))
+            ),
+            "A reject against an accepted mint must error AlreadyInProgress, got: {error:?}"
+        );
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::MintAccepted { .. }),
+            "A rejected reject must leave the mint in MintAccepted, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reject_mint_request_on_completed_mint_errors_already_completed() {
+        let store = TestStore::<TokenizedEquityMint>::new(());
+        let id = issuer_request_id("ISS001");
+
+        store.send(&id, mint_command()).await.unwrap();
+        store.send(&id, record_tokens_received()).await.unwrap();
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::WrapTokens {
+                    wrap_tx_hash: TxHash::random(),
+                    wrapped_shares: U256::from(10_000_000_000_000_000_000_u128),
+                    wrap_block: 1,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::DepositToVault {
+                    vault_deposit_tx_hash: TxHash::random(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // A reject re-delivery against a fully completed mint is a contradiction:
+        // the deposit already happened, so it errors rather than no-ops.
+        let error = store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RejectMintRequest {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: Address::ZERO,
+                    reason: "Rejected by Alpaca".to_string(),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AggregateError::UserError(LifecycleError::Apply(
+                    TokenizedEquityMintError::AlreadyCompleted
+                ))
+            ),
+            "A reject against a deposited mint must error AlreadyCompleted, got: {error:?}"
+        );
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::DepositedIntoRaindex { .. }),
+            "A rejected reject must leave the mint in DepositedIntoRaindex, got: {entity:?}"
         );
     }
 
@@ -2734,93 +3024,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn request_mint_rejected_by_alpaca_emits_rejected() {
-        let tokenizer =
-            MockTokenizer::new().with_mint_request_outcome(MockMintRequestOutcome::Rejected);
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
+    async fn reject_mint_request_emits_rejected() {
+        let store = TestStore::<TokenizedEquityMint>::new(());
         let id = issuer_request_id("ISS001");
 
-        store.send(&id, mint_command()).await.unwrap();
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RejectMintRequest {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: Address::ZERO,
+                    reason: "Rejected by Alpaca".to_string(),
+                },
+            )
+            .await
+            .unwrap();
 
         let entity = store.load(&id).await.unwrap().unwrap();
         assert!(
             matches!(entity, TokenizedEquityMint::Failed { .. }),
             "Expected Failed state after rejection, got: {entity:?}"
         );
-    }
-
-    #[tokio::test]
-    async fn request_mint_api_error_returns_error() {
-        let tokenizer =
-            MockTokenizer::new().with_mint_request_outcome(MockMintRequestOutcome::ApiError);
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
-        let id = issuer_request_id("ISS001");
-
-        let error = store.send(&id, mint_command()).await.unwrap_err();
-        assert!(
-            matches!(
-                error,
-                AggregateError::UserError(LifecycleError::Apply(
-                    TokenizedEquityMintError::RequestFailed { .. }
-                ))
-            ),
-            "Expected RequestFailed, got: {error:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn poll_pending_emits_acceptance_failed() {
-        let tokenizer = MockTokenizer::new().with_mint_poll_outcome(MockMintPollOutcome::Pending);
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
-        let id = issuer_request_id("ISS001");
-
-        store.send(&id, mint_command()).await.unwrap();
-        store
-            .send(&id, TokenizedEquityMintCommand::Poll)
-            .await
-            .unwrap();
-
-        let entity = store.load(&id).await.unwrap().unwrap();
-        assert!(
-            matches!(entity, TokenizedEquityMint::Failed { .. }),
-            "Expected Failed state after pending poll, got: {entity:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn poll_error_emits_acceptance_failed() {
-        let tokenizer = MockTokenizer::new().with_mint_poll_outcome(MockMintPollOutcome::PollError);
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
-        let id = issuer_request_id("ISS001");
-
-        store.send(&id, mint_command()).await.unwrap();
-        store
-            .send(&id, TokenizedEquityMintCommand::Poll)
-            .await
-            .unwrap();
-
-        let entity = store.load(&id).await.unwrap().unwrap();
-        assert!(
-            matches!(entity, TokenizedEquityMint::Failed { .. }),
-            "Expected Failed state after poll error, got: {entity:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn request_mint_passes_issuer_request_id_to_tokenizer() {
-        let tokenizer: Arc<MockTokenizer> = Arc::new(MockTokenizer::new());
-        let store = TestStore::<TokenizedEquityMint>::new(EquityTransferServices {
-            tokenizer: Arc::clone(&tokenizer) as Arc<dyn Tokenizer>,
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            wrapper: Arc::new(MockWrapper::new()),
-        });
-        let id = issuer_request_id("ISS001");
-
-        store.send(&id, mint_command()).await.unwrap();
-
-        let recorded_id = tokenizer.last_issuer_request_id().unwrap();
-        assert_eq!(recorded_id, issuer_request_id("ISS001"));
     }
 
     #[test]
@@ -2880,14 +3105,11 @@ mod tests {
 
     #[tokio::test]
     async fn wrap_tokens_is_pure_state_transition() {
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let store = TestStore::<TokenizedEquityMint>::new(());
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
-        store
-            .send(&id, TokenizedEquityMintCommand::Poll)
-            .await
-            .unwrap();
+        store.send(&id, record_tokens_received()).await.unwrap();
         store
             .send(
                 &id,
@@ -2909,14 +3131,11 @@ mod tests {
 
     #[tokio::test]
     async fn deposit_to_vault_is_pure_state_transition() {
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let store = TestStore::<TokenizedEquityMint>::new(());
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
-        store
-            .send(&id, TokenizedEquityMintCommand::Poll)
-            .await
-            .unwrap();
+        store.send(&id, record_tokens_received()).await.unwrap();
         store
             .send(
                 &id,
@@ -2946,12 +3165,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_at_uses_supplied_timestamp() {
+    async fn record_tokens_received_at_uses_supplied_timestamp() {
         let received_at = Utc::now() - chrono::Duration::hours(2);
 
-        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let events = TestHarness::<TokenizedEquityMint>::with(())
             .given(vec![mint_requested_event(), mint_accepted_event()])
-            .when(TokenizedEquityMintCommand::PollAt { received_at })
+            .when(TokenizedEquityMintCommand::RecordTokensReceivedAt {
+                tx_hash: Some(TxHash::ZERO),
+                token_symbol: Some("tAAPL".to_string()),
+                fees: None,
+                received_at,
+            })
             .await
             .events();
 
@@ -2970,7 +3194,7 @@ mod tests {
     async fn wrap_tokens_at_uses_supplied_timestamp() {
         let wrapped_at = Utc::now() - chrono::Duration::hours(3);
 
-        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let events = TestHarness::<TokenizedEquityMint>::with(())
             .given(vec![
                 mint_requested_event(),
                 mint_accepted_event(),
@@ -3000,7 +3224,7 @@ mod tests {
     async fn deposit_to_vault_at_uses_supplied_timestamp() {
         let deposited_at = Utc::now() - chrono::Duration::hours(4);
 
-        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let events = TestHarness::<TokenizedEquityMint>::with(())
             .given(vec![
                 mint_requested_event(),
                 mint_accepted_event(),
@@ -3026,16 +3250,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn request_mint_at_uses_supplied_timestamp() {
+    async fn record_mint_requested_at_uses_supplied_timestamp() {
         let requested_at = Utc::now() - chrono::Duration::hours(5);
 
-        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let events = TestHarness::<TokenizedEquityMint>::with(())
             .given_no_previous_events()
-            .when(TokenizedEquityMintCommand::RequestMintAt {
+            .when(TokenizedEquityMintCommand::RecordMintRequestedAt {
                 issuer_request_id: issuer_request_id("ISS001"),
                 symbol: Symbol::new("AAPL").unwrap(),
                 quantity: float!(10),
                 wallet: Address::ZERO,
+                tokenization_request_id: tokenization_request_id("MOCK_REQ_ID"),
                 requested_at,
             })
             .await
@@ -3360,7 +3585,7 @@ mod tests {
 
     #[tokio::test]
     async fn recover_provider_completion_rejected_for_active_mint() {
-        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let error = TestHarness::<TokenizedEquityMint>::with(())
             .given(vec![mint_requested_event()])
             .when(TokenizedEquityMintCommand::RecoverProviderCompletion {
                 issuer_request_id: issuer_request_id("ISS001"),
@@ -3383,7 +3608,7 @@ mod tests {
 
     #[tokio::test]
     async fn recover_provider_completion_rejected_for_completed_mint() {
-        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let error = TestHarness::<TokenizedEquityMint>::with(())
             .given(vec![
                 mint_requested_event(),
                 mint_accepted_event(),
@@ -3418,7 +3643,7 @@ mod tests {
             reconciled_at: Utc::now(),
         });
 
-        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let error = TestHarness::<TokenizedEquityMint>::with(())
             .given(history)
             .when(TokenizedEquityMintCommand::RecoverProviderCompletion {
                 issuer_request_id: issuer_request_id("ISS001"),
@@ -3441,7 +3666,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_acceptance_from_accepted_transitions_to_failed() {
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let store = TestStore::<TokenizedEquityMint>::new(());
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -3471,7 +3696,7 @@ mod tests {
         let history = vec![mint_requested_event()];
 
         let reason = "stuck pre-acceptance; operator force-fail";
-        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let events = TestHarness::<TokenizedEquityMint>::with(())
             .given(history.clone())
             .when(TokenizedEquityMintCommand::FailAcceptance {
                 reason: reason.to_string(),
@@ -3510,7 +3735,7 @@ mod tests {
         // FailAcceptance broadened to accept MintRequested/MintAccepted; a mint
         // that moved past acceptance (TokensReceived) must still be rejected, so
         // the success arm did not over-widen.
-        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let error = TestHarness::<TokenizedEquityMint>::with(())
             .given(vec![
                 mint_requested_event(),
                 mint_accepted_event(),
@@ -3533,14 +3758,11 @@ mod tests {
 
     #[tokio::test]
     async fn fail_wrapping_from_tokens_received_transitions_to_failed() {
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let store = TestStore::<TokenizedEquityMint>::new(());
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
-        store
-            .send(&id, TokenizedEquityMintCommand::Poll)
-            .await
-            .unwrap();
+        store.send(&id, record_tokens_received()).await.unwrap();
 
         store
             .send(
@@ -3561,14 +3783,11 @@ mod tests {
 
     #[tokio::test]
     async fn fail_raindex_deposit_from_tokens_wrapped_transitions_to_failed() {
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let store = TestStore::<TokenizedEquityMint>::new(());
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
-        store
-            .send(&id, TokenizedEquityMintCommand::Poll)
-            .await
-            .unwrap();
+        store.send(&id, record_tokens_received()).await.unwrap();
         store
             .send(
                 &id,
@@ -3600,7 +3819,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_wrapping_rejected_from_wrong_state() {
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let store = TestStore::<TokenizedEquityMint>::new(());
         let id = issuer_request_id("ISS001");
 
         // MintAccepted state -- FailWrapping requires TokensReceived
@@ -3623,7 +3842,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_acceptance_rejected_from_terminal_state() {
-        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let store = TestStore::<TokenizedEquityMint>::new(());
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -3667,7 +3886,7 @@ mod tests {
     async fn reconcile_from_failed_emits_operator_reconciled_and_replays_to_reconciled() {
         let history = failed_mint_history();
 
-        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let events = TestHarness::<TokenizedEquityMint>::with(())
             .given(history.clone())
             .when(TokenizedEquityMintCommand::Reconcile {
                 reason: "wrapped manually via wrap-equity".to_string(),
@@ -3732,7 +3951,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_from_non_failed_is_rejected() {
-        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let error = TestHarness::<TokenizedEquityMint>::with(())
             .given(vec![mint_requested_event(), mint_accepted_event()])
             .when(TokenizedEquityMintCommand::Reconcile {
                 reason: "should be rejected".to_string(),
@@ -3751,7 +3970,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_with_blank_reason_is_rejected() {
-        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let error = TestHarness::<TokenizedEquityMint>::with(())
             .given(failed_mint_history())
             .when(TokenizedEquityMintCommand::Reconcile {
                 reason: "   ".to_string(),
@@ -3776,7 +3995,7 @@ mod tests {
             reconciled_at: Utc::now(),
         });
 
-        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+        let error = TestHarness::<TokenizedEquityMint>::with(())
             .given(history)
             .when(TokenizedEquityMintCommand::Reconcile {
                 reason: "second attempt".to_string(),

--- a/src/unwrapped_equity_recovery/aggregate.rs
+++ b/src/unwrapped_equity_recovery/aggregate.rs
@@ -932,10 +932,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
         };
-        let mint_store = Arc::new(st0x_event_sorcery::test_store(
-            pool.clone(),
-            services.clone(),
-        ));
+        let mint_store = Arc::new(st0x_event_sorcery::test_store(pool.clone(), ()));
         let redemption_store = Arc::new(st0x_event_sorcery::test_store(pool, services));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -702,8 +702,8 @@ mod tests {
     use st0x_event_sorcery::test_store;
     use st0x_raindex::{Raindex, RaindexVaultId};
     use st0x_tokenization::Tokenizer;
-    use st0x_tokenization::issuer_request_id;
     use st0x_tokenization::mock::{MockCompletionOutcome, MockDetectionOutcome, MockTokenizer};
+    use st0x_tokenization::{issuer_request_id, tokenization_request_id};
     use st0x_wrapper::{MockWrapper, Wrapper};
 
     use crate::equity_redemption::{
@@ -751,7 +751,7 @@ mod tests {
             tokenizer: tokenizer.clone(),
             wrapper: wrapper.clone(),
         };
-        let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
+        let mint_store = Arc::new(test_store(pool.clone(), ()));
         let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
@@ -824,7 +824,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
         };
-        let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
+        let mint_store = Arc::new(test_store(pool.clone(), ()));
         let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
@@ -905,7 +905,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
         };
-        let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
+        let mint_store = Arc::new(test_store(pool.clone(), ()));
         let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
@@ -1221,15 +1221,16 @@ mod tests {
         ctx.mint_store
             .send(
                 &mint_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: mint_id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(5),
                     wallet: Address::random(),
+                    tokenization_request_id: tokenization_request_id("tok-req-accept"),
                 },
             )
             .await
-            .expect("RequestMint should persist a mint aggregate");
+            .expect("RecordMintRequested should persist a mint aggregate");
 
         let snapshot = RecoverySnapshot {
             shares: FractionalShares::new(float!(5)),
@@ -1249,15 +1250,16 @@ mod tests {
         ctx.mint_store
             .send(
                 &mint_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: mint_id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(3),
                     wallet: Address::random(),
+                    tokenization_request_id: tokenization_request_id("tok-req-mismatch"),
                 },
             )
             .await
-            .expect("RequestMint should persist a mint aggregate");
+            .expect("RecordMintRequested should persist a mint aggregate");
 
         let snapshot = RecoverySnapshot {
             shares: FractionalShares::new(float!(5)),
@@ -1647,21 +1649,29 @@ mod tests {
 
         // Seed the mint to `TokensWrapped` so `resume_mint` runs to completion
         // under the succeeding mocks:
-        // RequestMint -> (Poll) TokensReceived -> WrapSubmitted -> TokensWrapped.
+        // RecordMintRequested -> RecordTokensReceived -> WrapSubmitted -> TokensWrapped.
         ctx.mint_store
             .send(
                 &mint_id,
-                TokenizedEquityMintCommand::RequestMint {
+                TokenizedEquityMintCommand::RecordMintRequested {
                     issuer_request_id: mint_id.clone(),
                     symbol: symbol.clone(),
                     quantity: float!(5),
                     wallet: Address::random(),
+                    tokenization_request_id: tokenization_request_id("tok-req-dispatch"),
                 },
             )
             .await
             .unwrap();
         ctx.mint_store
-            .send(&mint_id, TokenizedEquityMintCommand::Poll)
+            .send(
+                &mint_id,
+                TokenizedEquityMintCommand::RecordTokensReceived {
+                    tx_hash: Some(TxHash::repeat_byte(0x11)),
+                    token_symbol: Some(format!("t{symbol}")),
+                    fees: None,
+                },
+            )
             .await
             .unwrap();
         let wrap_tx = TxHash::random();

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -630,10 +630,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
         };
-        let mint_store = Arc::new(st0x_event_sorcery::test_store(
-            pool.clone(),
-            services.clone(),
-        ));
+        let mint_store = Arc::new(st0x_event_sorcery::test_store(pool.clone(), ()));
         let redemption_store = Arc::new(st0x_event_sorcery::test_store(pool, services));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
@@ -826,10 +823,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
         };
-        let mint_store = Arc::new(st0x_event_sorcery::test_store(
-            pool.clone(),
-            inner_services.clone(),
-        ));
+        let mint_store = Arc::new(st0x_event_sorcery::test_store(pool.clone(), ()));
         let redemption_store = Arc::new(st0x_event_sorcery::test_store(pool, inner_services));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -488,7 +488,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
         };
-        let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
+        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
         let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -860,7 +860,7 @@ pub(crate) async fn assert_initial_base_wallet_unwrapped_and_wrapped_equity_snap
     expected_unwrapped_balance: FractionalShares,
     expected_wrapped_balance: FractionalShares,
 ) -> anyhow::Result<()> {
-    let timeout = Duration::from_secs(DEFAULT_POLL_TIMEOUT_SECS);
+    let timeout = Duration::from_secs(120);
     let deadline = tokio::time::Instant::now() + timeout;
     let context = format!(
         "Base-wallet unwrapped and wrapped equity snapshots for {symbol} matching unwrapped \


### PR DESCRIPTION
## What

[RAI-928](https://linear.app/makeitrain/issue/RAI-928)

Make `TokenizedEquityMint` command handlers pure by moving tokenizer request/poll I/O into the existing durable orchestrator and recording provider outcomes through idempotent commands.

## Why

The event-sorcery jobs model requires synchronous handlers, and external mint calls inside handlers leave a crash window between provider acceptance and event persistence. Retrying that window must adopt the accepted mint rather than create another request or lose a valid completion.

## How

- Replace I/O commands with pure request-accepted, request-rejected, and tokens-received outcome commands.
- Move `request_mint` and provider polling into `CrossVenueEquityTransfer`.
- Reuse the durable issuer request ID as the provider idempotency key.
- Reconcile provider acceptance that races with local `Failed` persistence through explicit `Failed` and `Reconciled` states plus `RecoverProviderCompletion`.
- Validate provider completion against the expected token symbol and require its transaction hash.
- Persist provider fees in the existing completion event.
- Make repeated matching outcomes no-ops while rejecting conflicting request IDs, transaction hashes, and completion symbols.

## Testing

Added aggregate and orchestrator coverage for:

- request API failures and provider rejection;
- retry without a second mint request;
- conflicting local versus provider request IDs;
- provider acceptance racing with local failure;
- recovery of an accepted request through reconciliation;
- missing or wrong completion symbols and transaction hashes;
- pending, rejected, and failed polling;
- provider-fee persistence; and
- idempotent and conflicting outcome redelivery.

GitHub Actions static checks and backend build/test matrix pass.

## Screenshots

Not applicable.

## Anything else

Stacked on the shared onchain-step extraction in #923 and ADR 0013 in #922. This PR closes the mint-provider acceptance window through provider-key reuse and adoption; equivalent adoption guarantees remain required for the later withdrawal, wrap, deposit, and redemption slices.
