### PR TITLE
feat: surface reconciled transfers distinctly in the transfer DTO

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3133,9 +3133,11 @@ pre-send redemption failures settle inventory at failure time, so they need no
 such clearing. `Reconciled` is valid ONLY from `Failed`; every other state is
 rejected. The `Reconciled` state retains the identifying fields (symbol,
 quantity, original failure reason, request/redemption identifiers) so the
-dashboard projection still reports the real transfer, and maps to the existing
-terminal `Completed` DTO status (no new status). The CLI surface is
-`transfer reconcile --kind mint|redemption` (alongside `--kind usdc`).
+dashboard projection still reports the real transfer, and maps to a distinct
+terminal `Reconciled` DTO status carrying `reconciled_at`, `failure_reason`, and
+`reconcile_reason` -- distinguishable from genuine success (`Completed`) at the
+DTO level. The CLI surface is `transfer reconcile --kind mint|redemption`
+(alongside `--kind usdc`).
 
 The operator-facing verb vocabulary that this command and the rest of the
 recovery CLI follow is defined in the "Operator Recovery Surface" section below.

--- a/crates/dto/src/transfer.rs
+++ b/crates/dto/src/transfer.rs
@@ -53,8 +53,25 @@ pub enum EquityMintStatus {
     Minting,
     Wrapping,
     Depositing,
-    Completed { completed_at: DateTime<Utc> },
-    Failed { failed_at: DateTime<Utc> },
+    Completed {
+        completed_at: DateTime<Utc>,
+    },
+    Failed {
+        failed_at: DateTime<Utc>,
+    },
+    // Plain `//` comment, not `///` -- ts-rs propagates doc comments into the
+    // generated TS binding and a field-level doc trips the dashboard's
+    // type-aware eslint. Keep rationale here in Rust.
+    Reconciled {
+        reconciled_at: DateTime<Utc>,
+        // The mint aggregate's Failed.reason is always a non-optional String, so
+        // the DTO field is String (not Option<String>). Redemption and USDC
+        // reconciled variants use Option<String> because their failure paths can
+        // legitimately produce None (e.g. Timeout detection failure for
+        // redemption, pre-existing-field replays for USDC).
+        failure_reason: String,
+        reconcile_reason: String,
+    },
 }
 
 /// Redeeming tokenized equity back to real shares.
@@ -84,8 +101,20 @@ pub enum EquityRedemptionStatus {
     Unwrapping,
     Sending,
     PendingConfirmation,
-    Completed { completed_at: DateTime<Utc> },
-    Failed { failed_at: DateTime<Utc> },
+    Completed {
+        completed_at: DateTime<Utc>,
+    },
+    Failed {
+        failed_at: DateTime<Utc>,
+    },
+    // Plain `//` comment, not `///` -- ts-rs propagates doc comments into the
+    // generated TS binding and a field-level doc trips the dashboard's
+    // type-aware eslint. Keep rationale here in Rust.
+    Reconciled {
+        reconciled_at: DateTime<Utc>,
+        failure_reason: Option<String>,
+        reconcile_reason: String,
+    },
 }
 
 /// Direction for USDC bridge transfers.
@@ -138,10 +167,18 @@ pub enum UsdcBridgeStatus {
         // trips the dashboard's type-aware eslint. Keep the rationale here in Rust.
         post_burn: bool,
     },
+    // Plain `//` comment, not `///` -- ts-rs propagates doc comments into the
+    // generated TS binding and a field-level doc trips the dashboard's
+    // type-aware eslint. Keep rationale here in Rust.
+    Reconciled {
+        reconciled_at: DateTime<Utc>,
+        failure_reason: Option<String>,
+        reconcile_reason: String,
+    },
 }
 
 impl TransferOperation {
-    /// Whether this transfer is in a terminal state (completed or failed).
+    /// Whether this transfer is in a terminal state (completed, failed, or reconciled).
     #[must_use]
     pub fn is_terminal(&self) -> bool {
         match self {
@@ -149,7 +186,7 @@ impl TransferOperation {
                 use EquityMintStatus::*;
 
                 match &op.status {
-                    Completed { .. } | Failed { .. } => true,
+                    Completed { .. } | Failed { .. } | Reconciled { .. } => true,
                     Minting | Wrapping | Depositing => false,
                 }
             }
@@ -157,7 +194,7 @@ impl TransferOperation {
                 use EquityRedemptionStatus::*;
 
                 match &op.status {
-                    Completed { .. } | Failed { .. } => true,
+                    Completed { .. } | Failed { .. } | Reconciled { .. } => true,
                     Withdrawing | Unwrapping | Sending | PendingConfirmation => false,
                 }
             }
@@ -165,7 +202,7 @@ impl TransferOperation {
                 use UsdcBridgeStatus::*;
 
                 match &op.status {
-                    Completed { .. } | Failed { .. } => true,
+                    Completed { .. } | Failed { .. } | Reconciled { .. } => true,
                     Converting | Withdrawing | Bridging | Depositing => false,
                 }
             }
@@ -347,6 +384,17 @@ mod tests {
             mint_operation(EquityMintStatus::Completed { completed_at: now }, now).is_terminal()
         );
         assert!(mint_operation(EquityMintStatus::Failed { failed_at: now }, now).is_terminal());
+        assert!(
+            mint_operation(
+                EquityMintStatus::Reconciled {
+                    reconciled_at: now,
+                    failure_reason: "timed out".to_string(),
+                    reconcile_reason: "wrapped manually".to_string(),
+                },
+                now,
+            )
+            .is_terminal()
+        );
 
         assert!(!mint_operation(EquityMintStatus::Minting, now).is_terminal());
         assert!(!mint_operation(EquityMintStatus::Wrapping, now).is_terminal());
@@ -364,6 +412,17 @@ mod tests {
         assert!(
             redemption_operation(EquityRedemptionStatus::Failed { failed_at: now }, now)
                 .is_terminal()
+        );
+        assert!(
+            redemption_operation(
+                EquityRedemptionStatus::Reconciled {
+                    reconciled_at: now,
+                    failure_reason: None,
+                    reconcile_reason: "deposited manually".to_string(),
+                },
+                now,
+            )
+            .is_terminal()
         );
 
         assert!(!redemption_operation(EquityRedemptionStatus::Withdrawing, now).is_terminal());
@@ -405,10 +464,109 @@ mod tests {
             .is_terminal()
         );
 
+        assert!(
+            bridge_operation(
+                UsdcBridgeStatus::Reconciled {
+                    reconciled_at: now,
+                    failure_reason: None,
+                    reconcile_reason: "funds moved manually".to_string(),
+                },
+                now,
+            )
+            .is_terminal()
+        );
+
         assert!(!bridge_operation(UsdcBridgeStatus::Converting, now).is_terminal());
         assert!(!bridge_operation(UsdcBridgeStatus::Withdrawing, now).is_terminal());
         assert!(!bridge_operation(UsdcBridgeStatus::Bridging, now).is_terminal());
         assert!(!bridge_operation(UsdcBridgeStatus::Depositing, now).is_terminal());
+    }
+
+    #[test]
+    fn equity_mint_reconciled_serializes_correctly() {
+        let reconciled_at = "2026-01-02T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let operation = TransferOperation::EquityMint(EquityMintOperation {
+            id: Id::new("mint-001"),
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: FractionalShares::new(float!(10)),
+            status: EquityMintStatus::Reconciled {
+                reconciled_at,
+                failure_reason: "timed out".to_string(),
+                reconcile_reason: "wrapped manually".to_string(),
+            },
+            started_at: reconciled_at,
+            updated_at: reconciled_at,
+        });
+
+        let serialized = serde_json::to_value(&operation).expect("serialization should succeed");
+        assert_eq!(serialized["status"]["status"], json!("reconciled"));
+        assert_eq!(
+            serialized["status"]["reconciledAt"],
+            json!("2026-01-02T00:00:00Z")
+        );
+        assert_eq!(serialized["status"]["failureReason"], json!("timed out"));
+        assert_eq!(
+            serialized["status"]["reconcileReason"],
+            json!("wrapped manually")
+        );
+    }
+
+    #[test]
+    fn equity_redemption_reconciled_serializes_correctly() {
+        let reconciled_at = "2026-01-02T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let operation = TransferOperation::EquityRedemption(EquityRedemptionOperation {
+            id: Id::new("redeem-001"),
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: FractionalShares::new(float!(50)),
+            status: EquityRedemptionStatus::Reconciled {
+                reconciled_at,
+                failure_reason: None,
+                reconcile_reason: "deposited manually".to_string(),
+            },
+            started_at: reconciled_at,
+            updated_at: reconciled_at,
+        });
+
+        let serialized = serde_json::to_value(&operation).expect("serialization should succeed");
+        assert_eq!(serialized["status"]["status"], json!("reconciled"));
+        assert_eq!(
+            serialized["status"]["reconciledAt"],
+            json!("2026-01-02T00:00:00Z")
+        );
+        assert_eq!(serialized["status"]["failureReason"], json!(null));
+        assert_eq!(
+            serialized["status"]["reconcileReason"],
+            json!("deposited manually")
+        );
+    }
+
+    #[test]
+    fn usdc_bridge_reconciled_serializes_correctly() {
+        let reconciled_at = "2026-01-02T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let operation = TransferOperation::UsdcBridge(UsdcBridgeOperation {
+            id: Id::new("bridge-001"),
+            direction: UsdcBridgeDirection::AlpacaToBase,
+            amount: Usdc::new(float!(1000)),
+            status: UsdcBridgeStatus::Reconciled {
+                reconciled_at,
+                failure_reason: None,
+                reconcile_reason: "funds moved manually".to_string(),
+            },
+            started_at: reconciled_at,
+            updated_at: reconciled_at,
+        });
+
+        let serialized = serde_json::to_value(&operation).expect("serialization should succeed");
+        assert_eq!(serialized["status"]["status"], json!("reconciled"));
+        assert_eq!(
+            serialized["status"]["reconciledAt"],
+            json!("2026-01-02T00:00:00Z")
+        );
+        assert_eq!(serialized["status"]["failureReason"], json!(null));
+        assert_eq!(
+            serialized["status"]["reconcileReason"],
+            json!("funds moved manually")
+        );
     }
 
     #[test]

--- a/dashboard/src/lib/transfer.test.ts
+++ b/dashboard/src/lib/transfer.test.ts
@@ -61,6 +61,19 @@ describe('statusStyle', () => {
     expect(statusStyle('pending').text).toBe('text-muted-foreground')
     expect(statusStyle('').text).toBe('text-muted-foreground')
   })
+
+  it('returns amber for reconciled status (case-insensitive)', () => {
+    expect(statusStyle('reconciled').text).toBe('text-amber-500')
+    expect(statusStyle('reconciled').dot).toBe('bg-amber-500')
+    expect(statusStyle('RECONCILED').text).toBe('text-amber-500')
+    expect(statusStyle('Reconciled').text).toBe('text-amber-500')
+  })
+
+  it('returns amber for OperatorReconciled event name (timeline side-effect)', () => {
+    // OperatorReconciled is a raw PascalCase event name that contains 'reconciled';
+    // the substring check intentionally renders it amber in the event timeline.
+    expect(statusStyle('OperatorReconciled').text).toBe('text-amber-500')
+  })
 })
 
 describe('isTxHash', () => {
@@ -454,6 +467,41 @@ describe('transferRecoveryCommands', () => {
         })
       ).toEqual([])
     }
+  })
+
+  it('returns no commands for a reconciled equity mint (any casing)', () => {
+    for (const status of ['reconciled', 'Reconciled', 'RECONCILED']) {
+      expect(
+        transferRecoveryCommands({
+          deployment: PROD,
+          kind: 'equity_mint',
+          id: 'ISS001',
+          status
+        })
+      ).toEqual([])
+    }
+  })
+
+  it('returns no commands for a reconciled equity redemption', () => {
+    expect(
+      transferRecoveryCommands({
+        deployment: PROD,
+        kind: 'equity_redemption',
+        id: 'RED001',
+        status: 'reconciled'
+      })
+    ).toEqual([])
+  })
+
+  it('returns no commands for a reconciled usdc bridge', () => {
+    expect(
+      transferRecoveryCommands({
+        deployment: PROD,
+        kind: 'usdc_bridge',
+        id: 'BRIDGE001',
+        status: 'reconciled'
+      })
+    ).toEqual([])
   })
 
   it('uses the mock cli prefix in a simulation build', () => {

--- a/dashboard/src/lib/transfer.ts
+++ b/dashboard/src/lib/transfer.ts
@@ -54,15 +54,32 @@ export const transferTypeLabel = (transfer: {
 /// Maps a status string to colour classes.  Works for both DTO statuses
 /// (snake_case, used in the table) and raw event names (PascalCase,
 /// used in the detail modal timeline).
+///
+/// Note: `lower.includes('reconciled')` also matches the raw event name
+/// `OperatorReconciled` from the timeline -- this is intentional since that
+/// event IS a reconciliation step and should render amber.
 export const statusStyle = (status: string): StatusStyle => {
   const lower = status.toLowerCase()
 
   if (lower.includes('completed') || lower.includes('deposited') || lower.includes('confirmed')) {
-    return { text: 'text-green-500', dot: 'bg-green-500' }
+    return {
+      text: 'text-green-500',
+      dot: 'bg-green-500',
+    }
+  }
+
+  if (lower.includes('reconciled')) {
+    return {
+      text: 'text-amber-500',
+      dot: 'bg-amber-500',
+    }
   }
 
   if (lower.includes('failed') || lower.includes('rejected')) {
-    return { text: 'text-destructive', dot: 'bg-destructive' }
+    return {
+      text: 'text-destructive',
+      dot: 'bg-destructive',
+    }
   }
 
   return { text: 'text-muted-foreground', dot: 'bg-muted-foreground' }
@@ -238,11 +255,11 @@ const commandPrefix = (deployment: DeploymentContext): string | null => {
 /// recovery verbs.
 const isFailedStatus = (status: string): boolean => status.toLowerCase() === 'failed'
 
-/// Whether a transfer status is a terminal state (failed or completed); no
-/// recovery commands apply to a completed transfer.
-const isTerminalStatus = (status: string): boolean => {
+/// Whether a transfer status is a terminal state (failed, completed, or
+/// reconciled); no recovery commands apply to a reconciled transfer.
+export const isTerminalStatus = (status: string): boolean => {
   const lower = status.toLowerCase()
-  return lower === 'failed' || lower === 'completed'
+  return lower === 'failed' || lower === 'completed' || lower === 'reconciled'
 }
 
 /// Builds the full set of recovery commands an operator could legitimately run
@@ -273,7 +290,11 @@ export const transferRecoveryCommands = (params: {
   const prefix = commandPrefix(params.deployment)
   if (prefix === null) return []
 
-  if (params.status.toLowerCase() === 'completed') return []
+  if (
+    params.status.toLowerCase() === 'completed' ||
+    params.status.toLowerCase() === 'reconciled'
+  )
+    return []
 
   if (params.kind === 'usdc_bridge') {
     return usdcBridgeRecoveryCommands(

--- a/dashboard/src/lib/websocket/transfers.test.ts
+++ b/dashboard/src/lib/websocket/transfers.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+import type { QueryClient } from '@tanstack/svelte-query'
+import type { TransferOperation } from '$lib/api/TransferOperation'
+import { upsertTransfer } from './transfers'
+
+type MockQueryClient = QueryClient & {
+  cache: Map<string, unknown>
+}
+
+const createMockQueryClient = (): MockQueryClient => {
+  const cache = new Map<string, unknown>()
+
+  const setQueryData = (key: unknown[], data: unknown) => {
+    if (typeof data === 'function') {
+      const current = cache.get(JSON.stringify(key))
+      cache.set(JSON.stringify(key), (data as (old: unknown) => unknown)(current))
+    } else {
+      cache.set(JSON.stringify(key), data)
+    }
+
+    return undefined
+  }
+
+  return {
+    setQueryData,
+    cache,
+  } as unknown as MockQueryClient
+}
+
+const makeTransfer = (overrides: Partial<TransferOperation> = {}): TransferOperation =>
+  ({
+    kind: 'equity_mint',
+    id: 'transfer-1',
+    symbol: 'AAPL',
+    quantity: '10',
+    status: { status: 'minting' },
+    startedAt: '2024-01-01T12:00:00Z',
+    updatedAt: '2024-01-01T12:00:00Z',
+    ...overrides,
+  }) as TransferOperation
+
+describe('upsertTransfer', () => {
+  it('moves a completed transfer from active to recent', () => {
+    const queryClient = createMockQueryClient()
+    const active = makeTransfer({ id: 'transfer-1', status: { status: 'minting' } })
+
+    queryClient.setQueryData(['transfers', 'active'], [active])
+    queryClient.setQueryData(['transfers', 'recent'], [])
+
+    const completed = makeTransfer({
+      id: 'transfer-1',
+      status: { status: 'completed', completedAt: '2024-01-01T13:00:00Z' },
+    })
+
+    upsertTransfer(queryClient, completed)
+
+    const activeCache = queryClient.cache.get('["transfers","active"]') as TransferOperation[]
+    const recentCache = queryClient.cache.get('["transfers","recent"]') as TransferOperation[]
+
+    expect(activeCache).toHaveLength(0)
+    expect(recentCache).toHaveLength(1)
+    expect(recentCache[0]).toEqual(completed)
+  })
+
+  it('moves a reconciled transfer from active to recent', () => {
+    const queryClient = createMockQueryClient()
+    const active = makeTransfer({ id: 'transfer-2', status: { status: 'minting' } })
+
+    queryClient.setQueryData(['transfers', 'active'], [active])
+    queryClient.setQueryData(['transfers', 'recent'], [])
+
+    const reconciled = makeTransfer({
+      id: 'transfer-2',
+      status: {
+        status: 'reconciled',
+        reconciledAt: '2024-01-01T14:00:00Z',
+        failureReason: 'deposit timed out',
+        reconcileReason: 'funds moved manually',
+      },
+    })
+
+    upsertTransfer(queryClient, reconciled)
+
+    const activeCache = queryClient.cache.get('["transfers","active"]') as TransferOperation[]
+    const recentCache = queryClient.cache.get('["transfers","recent"]') as TransferOperation[]
+
+    expect(activeCache).toHaveLength(0)
+    expect(recentCache).toHaveLength(1)
+    expect(recentCache[0]).toEqual(reconciled)
+  })
+
+  it('moves a failed transfer from active to recent', () => {
+    const queryClient = createMockQueryClient()
+    const active = makeTransfer({ id: 'transfer-3', status: { status: 'minting' } })
+
+    queryClient.setQueryData(['transfers', 'active'], [active])
+    queryClient.setQueryData(['transfers', 'recent'], [])
+
+    const failed = makeTransfer({
+      id: 'transfer-3',
+      status: { status: 'failed', failedAt: '2024-01-01T13:00:00Z' },
+    })
+
+    upsertTransfer(queryClient, failed)
+
+    const activeCache = queryClient.cache.get('["transfers","active"]') as TransferOperation[]
+    const recentCache = queryClient.cache.get('["transfers","recent"]') as TransferOperation[]
+
+    expect(activeCache).toHaveLength(0)
+    expect(recentCache).toHaveLength(1)
+    expect(recentCache[0]).toEqual(failed)
+  })
+
+  it('inserts a reconciled transfer directly into recent when not in active', () => {
+    const queryClient = createMockQueryClient()
+
+    queryClient.setQueryData(['transfers', 'active'], [])
+    queryClient.setQueryData(['transfers', 'recent'], [])
+
+    const reconciled = makeTransfer({
+      id: 'transfer-4',
+      status: {
+        status: 'reconciled',
+        reconciledAt: '2024-01-01T14:00:00Z',
+        failureReason: 'deposit timed out',
+        reconcileReason: 'funds moved manually',
+      },
+    })
+
+    upsertTransfer(queryClient, reconciled)
+
+    const activeCache = queryClient.cache.get('["transfers","active"]') as TransferOperation[]
+    const recentCache = queryClient.cache.get('["transfers","recent"]') as TransferOperation[]
+
+    expect(activeCache).toHaveLength(0)
+    expect(recentCache).toHaveLength(1)
+    expect(recentCache[0]).toEqual(reconciled)
+  })
+
+  it('inserts an in-flight transfer into active (not recent)', () => {
+    const queryClient = createMockQueryClient()
+
+    queryClient.setQueryData(['transfers', 'active'], [])
+    queryClient.setQueryData(['transfers', 'recent'], [])
+
+    const inflight = makeTransfer({ id: 'transfer-3', status: { status: 'minting' } })
+
+    upsertTransfer(queryClient, inflight)
+
+    const activeCache = queryClient.cache.get('["transfers","active"]') as TransferOperation[]
+    const recentCache = queryClient.cache.get('["transfers","recent"]') as TransferOperation[]
+
+    expect(activeCache).toHaveLength(1)
+    expect(activeCache[0]).toEqual(inflight)
+    expect(recentCache).toHaveLength(0)
+  })
+})

--- a/dashboard/src/lib/websocket/transfers.ts
+++ b/dashboard/src/lib/websocket/transfers.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from '@tanstack/svelte-query'
 import type { CurrentState } from '$lib/api/CurrentState'
 import type { TransferOperation } from '$lib/api/TransferOperation'
 import type { TransferWarning } from '$lib/api/TransferWarning'
+import { isTerminalStatus } from '$lib/transfer'
 
 const MAX_RECENT = 100
 
@@ -21,7 +22,7 @@ export const upsertTransfer = (queryClient: QueryClient, transfer: TransferOpera
     const existing = old ?? []
     const index = existing.findIndex((item) => transferKey(item) === key)
 
-    if (transfer.status.status === 'completed' || transfer.status.status === 'failed') {
+    if (isTerminalStatus(transfer.status.status)) {
       const filtered = index >= 0 ? existing.filter((_, idx) => idx !== index) : existing
 
       queryClient.setQueryData<TransferOperation[]>(

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -1149,12 +1149,11 @@ impl EquityRedemption {
                 updated_at: *failed_at,
             }),
 
-            // Reconciliation is a terminal operator resolution, so it maps to the
-            // existing `Completed` DTO status (no new status needed) -- mirrors the
-            // USDC `Reconciled -> Completed` mapping.
             Self::Reconciled {
                 symbol,
                 quantity,
+                failure_reason,
+                reconcile_reason,
                 started_at,
                 reconciled_at,
                 ..
@@ -1162,8 +1161,10 @@ impl EquityRedemption {
                 id: Id::new(id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
-                status: EquityRedemptionStatus::Completed {
-                    completed_at: *reconciled_at,
+                status: EquityRedemptionStatus::Reconciled {
+                    reconciled_at: *reconciled_at,
+                    failure_reason: failure_reason.clone(),
+                    reconcile_reason: reconcile_reason.clone(),
                 },
                 started_at: *started_at,
                 updated_at: *reconciled_at,
@@ -5101,6 +5102,7 @@ mod tests {
             .expect("event stream should materialize a state");
         let EquityRedemption::Reconciled {
             reconcile_reason,
+            failure_reason,
             quantity,
             ..
         } = state
@@ -5108,6 +5110,13 @@ mod tests {
             panic!("reconciled redemption should be Reconciled, got {state:?}");
         };
         assert_eq!(reconcile_reason, "deposited manually via vault-deposit");
+        // DetectionFailure::Operator carries a reason string; the Failed state
+        // stores it as Some(_) and apply(OperatorReconciled) propagates it.
+        assert_eq!(
+            failure_reason,
+            Some("operator forced terminal".to_string()),
+            "reconciled state must carry the source failure reason from Failed"
+        );
         assert!(
             quantity.eq(float!(50.25)).unwrap(),
             "reconciled state must preserve the requested quantity, got {quantity:?}"
@@ -5178,7 +5187,7 @@ mod tests {
     }
 
     #[test]
-    fn reconciled_to_dto_reports_completed_preserving_quantity() {
+    fn to_dto_reconciled_carries_failure_and_reconcile_reason() {
         let started_at = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
         let reconciled_at = "2026-01-02T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
         let reconciled = EquityRedemption::Reconciled {
@@ -5198,13 +5207,17 @@ mod tests {
         else {
             panic!("expected an EquityRedemption operation");
         };
-        let EquityRedemptionStatus::Completed { completed_at } = operation.status else {
-            panic!(
-                "reconciled redemption must map to the Completed DTO status, got {:?}",
-                operation.status
-            );
-        };
-        assert_eq!(completed_at, reconciled_at);
+        let serialized = serde_json::to_value(&operation.status).expect("serialization failed");
+        assert_eq!(serialized["status"], serde_json::json!("reconciled"));
+        assert_eq!(
+            serialized["reconciledAt"],
+            serde_json::json!("2026-01-02T00:00:00Z")
+        );
+        assert_eq!(serialized["failureReason"], serde_json::json!(null));
+        assert_eq!(
+            serialized["reconcileReason"],
+            serde_json::json!("deposited manually")
+        );
         assert_eq!(operation.updated_at, reconciled_at);
         assert_eq!(operation.started_at, started_at);
         assert_eq!(
@@ -5382,6 +5395,41 @@ mod tests {
                 failed_at: now,
             }
             .is_terminal(),
+        );
+    }
+
+    #[test]
+    fn to_dto_reconciled_with_failure_reason_serializes_non_null() {
+        // When the Failed state carried an operator-supplied reason (e.g. from
+        // DetectionFailure::Operator), apply(OperatorReconciled) propagates it
+        // to the Reconciled state's failure_reason; to_dto must forward it to
+        // the DTO as a non-null string so the dashboard can display the
+        // original failure context alongside the reconciliation note.
+        let started_at = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let reconciled_at = "2026-01-02T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let reconciled = EquityRedemption::Reconciled {
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: float!(50.25),
+            raindex_withdraw_tx: Some(TxHash::random()),
+            redemption_tx: Some(TxHash::random()),
+            tokenization_request_id: None,
+            failure_reason: Some("operator forced terminal".to_string()),
+            reconcile_reason: "deposited manually".to_string(),
+            started_at,
+            reconciled_at,
+        };
+
+        let TransferOperation::EquityRedemption(operation) =
+            reconciled.to_dto(&redemption_aggregate_id("RED-002"))
+        else {
+            panic!("expected an EquityRedemption operation");
+        };
+        let serialized = serde_json::to_value(&operation.status).expect("serialization failed");
+        assert_eq!(serialized["status"], serde_json::json!("reconciled"));
+        assert_eq!(
+            serialized["failureReason"],
+            serde_json::json!("operator forced terminal"),
+            "failure_reason: Some(...) must serialize as a non-null string in the DTO"
         );
     }
 }

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -1331,21 +1331,21 @@ impl TokenizedEquityMint {
                 updated_at: *failed_at,
             }),
 
-            // Reconciliation is a terminal operator resolution, so it maps to the
-            // existing `Completed` DTO status (no new status needed) -- mirrors the
-            // USDC `Reconciled -> Completed` mapping.
             Self::Reconciled {
                 symbol,
                 quantity,
+                failure_reason,
+                reconcile_reason,
                 requested_at,
                 reconciled_at,
-                ..
             } => TransferOperation::EquityMint(EquityMintOperation {
                 id: Id::new(issuer_request_id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
-                status: Completed {
-                    completed_at: *reconciled_at,
+                status: Reconciled {
+                    reconciled_at: *reconciled_at,
+                    failure_reason: failure_reason.clone(),
+                    reconcile_reason: reconcile_reason.clone(),
                 },
                 started_at: *requested_at,
                 updated_at: *reconciled_at,
@@ -3645,7 +3645,7 @@ mod tests {
     }
 
     #[test]
-    fn reconciled_to_dto_reports_completed_preserving_quantity() {
+    fn to_dto_reconciled_carries_failure_and_reconcile_reason() {
         let requested_at = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
         let reconciled_at = "2026-01-02T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
         let reconciled = TokenizedEquityMint::Reconciled {
@@ -3662,13 +3662,17 @@ mod tests {
         else {
             panic!("expected an EquityMint operation");
         };
-        let EquityMintStatus::Completed { completed_at } = operation.status else {
-            panic!(
-                "reconciled mint must map to the Completed DTO status, got {:?}",
-                operation.status
-            );
-        };
-        assert_eq!(completed_at, reconciled_at);
+        let serialized = serde_json::to_value(&operation.status).expect("serialization failed");
+        assert_eq!(serialized["status"], serde_json::json!("reconciled"));
+        assert_eq!(
+            serialized["reconciledAt"],
+            serde_json::json!("2026-01-02T00:00:00Z")
+        );
+        assert_eq!(serialized["failureReason"], serde_json::json!("timed out"));
+        assert_eq!(
+            serialized["reconcileReason"],
+            serde_json::json!("credited offline")
+        );
         assert_eq!(operation.started_at, requested_at);
         assert_eq!(operation.updated_at, reconciled_at);
         assert_eq!(

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -139,6 +139,15 @@ pub(crate) enum ReconcileReason {
     DepositCreditedOffline,
 }
 
+impl Display for ReconcileReason {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FundsMovedManually => formatter.write_str("funds moved manually"),
+            Self::DepositCreditedOffline => formatter.write_str("deposit credited offline"),
+        }
+    }
+}
+
 /// Errors that can occur during USDC rebalance operations.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum UsdcRebalanceError {
@@ -518,6 +527,11 @@ pub(crate) enum UsdcRebalanceEvent {
     /// be absent after a restart), plus `amount` and `initiated_at` so the
     /// projection preserves the real post-burn transfer instead of defaulting
     /// it to a zero-value transfer starting at reconciliation time.
+    ///
+    /// `failure_reason` is intentionally absent from the event (unlike the
+    /// first-pass design): `apply()` derives it from the prior `Failed` state
+    /// so historical events (persisted before the field was introduced) are
+    /// recovered correctly on replay without a serde-default migration.
     OperatorReconciled {
         direction: RebalanceDirection,
         amount: Usdc,
@@ -754,6 +768,10 @@ pub(crate) enum UsdcRebalance {
         direction: RebalanceDirection,
         amount: Usdc,
         reason: ReconcileReason,
+        /// The original failure message from the source terminal state.
+        /// `None` for aggregates reconciled before this field was added.
+        #[serde(default)]
+        failure_reason: Option<String>,
         initiated_at: DateTime<Utc>,
         reconciled_at: DateTime<Utc>,
     },
@@ -1013,14 +1031,17 @@ impl UsdcRebalance {
             Self::Reconciled {
                 direction,
                 amount,
+                reason,
+                failure_reason,
                 initiated_at,
                 reconciled_at,
-                ..
             } => (
                 direction,
                 *amount,
-                UsdcBridgeStatus::Completed {
-                    completed_at: *reconciled_at,
+                UsdcBridgeStatus::Reconciled {
+                    reconciled_at: *reconciled_at,
+                    failure_reason: failure_reason.clone(),
+                    reconcile_reason: reason.to_string(),
                 },
                 *initiated_at,
                 *reconciled_at,
@@ -1487,7 +1508,13 @@ impl EventSourced for UsdcRebalance {
     // v5: added the terminal `Reconciled` state (and `OperatorReconciled` event)
     // for operator reconciliation of a post-burn `DepositFailed`. Bumped to
     // clear stale snapshots so they rebuild from events under the new schema.
-    const SCHEMA_VERSION: u64 = 5;
+    // v6: added `failure_reason: Option<String>` to the `Reconciled` state.
+    // Existing v5 snapshots of a `Reconciled` aggregate would deserialize
+    // `failure_reason` as `None` via serde default and the historical-recovery
+    // in `evolve()` would never run for them. Bumped to invalidate stale
+    // snapshots, forcing a rebuild from events so `failure_reason` is derived
+    // from the prior failed state on replay.
+    const SCHEMA_VERSION: u64 = 6;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use UsdcRebalanceEvent::*;
@@ -1999,6 +2026,15 @@ impl EventSourced for UsdcRebalance {
                 failed_at: *failed_at,
             },
 
+            // OperatorReconciled: derive failure_reason from the prior state and
+            // transition to Reconciled, or return Ok(None) for non-reconcilable
+            // states. The nested match enumerates every UsdcRebalance variant
+            // exhaustively (no wildcard), so adding a new variant forces a
+            // conscious classification here at compile time.
+            //
+            // Deriving failure_reason on replay also covers historical
+            // OperatorReconciled events persisted before failure_reason was
+            // tracked: the correct reason is recovered regardless of event age.
             (
                 OperatorReconciled {
                     direction,
@@ -2007,28 +2043,67 @@ impl EventSourced for UsdcRebalance {
                     initiated_at,
                     reconciled_at,
                 },
-                // Mirrors the states `transition_reconcile_stuck_rebalance`
-                // accepts: a post-burn terminal failure that strands the guard.
-                Self::DepositFailed { .. }
-                | Self::BridgingFailed {
-                    burn_tx_hash: Some(_),
-                    ..
+                state,
+            ) => {
+                match state {
+                    // DepositFailed and ConversionFailed(BaseToAlpaca): post-burn/post-mint,
+                    // manually reconcilable.
+                    Self::DepositFailed {
+                        reason: failure_reason,
+                        ..
+                    }
+                    | Self::ConversionFailed {
+                        reason: failure_reason,
+                        direction: RebalanceDirection::BaseToAlpaca,
+                        ..
+                    } => Self::Reconciled {
+                        direction: *direction,
+                        amount: *amount,
+                        reason: *reason,
+                        failure_reason: Some(failure_reason.clone()),
+                        initiated_at: *initiated_at,
+                        reconciled_at: *reconciled_at,
+                    },
+
+                    // BridgingFailed with a burn tx or cctp nonce: post-burn, manually
+                    // reconcilable.
+                    Self::BridgingFailed {
+                        reason: failure_reason,
+                        burn_tx_hash,
+                        cctp_nonce,
+                        ..
+                    } if burn_tx_hash.is_some() || cctp_nonce.is_some() => Self::Reconciled {
+                        direction: *direction,
+                        amount: *amount,
+                        reason: *reason,
+                        failure_reason: Some(failure_reason.clone()),
+                        initiated_at: *initiated_at,
+                        reconciled_at: *reconciled_at,
+                    },
+
+                    // All remaining states are not reconcilable. Enumerated without a
+                    // wildcard so the compiler rejects unclassified new variants.
+                    Self::Converting { .. }
+                    | Self::ConversionComplete { .. }
+                    | Self::ConversionFailed {
+                        direction: RebalanceDirection::AlpacaToBase,
+                        ..
+                    }
+                    | Self::WithdrawalSubmitting { .. }
+                    | Self::Withdrawing { .. }
+                    | Self::WithdrawalComplete { .. }
+                    | Self::WithdrawalFailed { .. }
+                    | Self::BridgingSubmitting { .. }
+                    | Self::Bridging { .. }
+                    | Self::AwaitingAttestation { .. }
+                    | Self::Attested { .. }
+                    | Self::BridgingFailed { .. }
+                    | Self::Bridged { .. }
+                    | Self::DepositInitiated { .. }
+                    | Self::DepositConfirmed { .. }
+                    | Self::Reconciled { .. } => return Ok(None),
                 }
-                | Self::BridgingFailed {
-                    cctp_nonce: Some(_),
-                    ..
-                }
-                | Self::ConversionFailed {
-                    direction: RebalanceDirection::BaseToAlpaca,
-                    ..
-                },
-            ) => Self::Reconciled {
-                direction: *direction,
-                amount: *amount,
-                reason: *reason,
-                initiated_at: *initiated_at,
-                reconciled_at: *reconciled_at,
-            },
+            }
 
             _ => return Ok(None),
         };
@@ -6498,35 +6573,41 @@ mod tests {
     /// Drives `ReconcileStuckRebalance` against a history that ends in a
     /// guard-stranding post-burn failure and asserts it emits a single
     /// `OperatorReconciled` preserving the source amount and initiation
-    /// timestamp, then materializes the clearing terminal `Reconciled`.
+    /// timestamp, then materializes the clearing terminal `Reconciled` with
+    /// the source failure reason recovered from the prior state.
     async fn assert_reconcile_emits_operator_reconciled(
         history: Vec<UsdcRebalanceEvent>,
         expected_direction: RebalanceDirection,
     ) {
-        // The source failure carries the real post-burn amount and original
-        // initiation timestamp; reconciliation must preserve both so the
-        // projection does not collapse the transfer to a zero-value one.
-        let (source_amount, source_initiated_at) = match replay::<UsdcRebalance>(history.clone())
-            .expect("history should replay")
-            .expect("history should materialize a failure state")
-        {
-            UsdcRebalance::DepositFailed {
-                amount,
-                initiated_at,
-                ..
-            }
-            | UsdcRebalance::BridgingFailed {
-                amount,
-                initiated_at,
-                ..
-            }
-            | UsdcRebalance::ConversionFailed {
-                amount,
-                initiated_at,
-                ..
-            } => (amount, initiated_at),
-            other => panic!("fixture should end in a post-burn failure, got {other:?}"),
-        };
+        // The source failure carries the real post-burn amount, original
+        // initiation timestamp, and failure reason; reconciliation must
+        // preserve all three so the projection does not collapse the transfer
+        // to a zero-value one and does not lose the failure context.
+        let (source_amount, source_initiated_at, source_failure_reason) =
+            match replay::<UsdcRebalance>(history.clone())
+                .expect("history should replay")
+                .expect("history should materialize a failure state")
+            {
+                UsdcRebalance::DepositFailed {
+                    amount,
+                    initiated_at,
+                    reason,
+                    ..
+                }
+                | UsdcRebalance::BridgingFailed {
+                    amount,
+                    initiated_at,
+                    reason,
+                    ..
+                }
+                | UsdcRebalance::ConversionFailed {
+                    amount,
+                    initiated_at,
+                    reason,
+                    ..
+                } => (amount, initiated_at, reason),
+                other => panic!("fixture should end in a post-burn failure, got {other:?}"),
+            };
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(history.clone())
@@ -6553,13 +6634,17 @@ mod tests {
         assert_eq!(*initiated_at, source_initiated_at);
 
         // Applying the event must drive the aggregate to the clearing terminal
-        // Reconciled state -- the evolve arm, not just the command handler.
+        // Reconciled state with failure_reason recovered from the prior state.
         let state = replay::<UsdcRebalance>([history, events].concat())
             .expect("event stream should replay")
             .expect("event stream should materialize aggregate state");
-        assert!(
-            matches!(state, UsdcRebalance::Reconciled { .. }),
-            "reconciled aggregate should be Reconciled, got {state:?}"
+        let UsdcRebalance::Reconciled { failure_reason, .. } = state else {
+            panic!("reconciled aggregate should be Reconciled, got {state:?}");
+        };
+        assert_eq!(
+            failure_reason,
+            Some(source_failure_reason),
+            "reconciled state must carry the source failure reason"
         );
     }
 
@@ -6593,12 +6678,14 @@ mod tests {
             .await
             .events();
 
-        // The DepositFailed source state carries the real post-burn amount and
-        // original initiation timestamp; reconciliation must preserve both so
-        // the projection does not collapse the transfer to a zero-value one.
+        // The DepositFailed source state carries the real post-burn amount,
+        // original initiation timestamp, and failure reason; reconciliation
+        // must preserve all three so the projection does not collapse the
+        // transfer to a zero-value one and does not lose the failure context.
         let UsdcRebalance::DepositFailed {
             amount: failed_amount,
             initiated_at: failed_initiated_at,
+            reason: failed_reason,
             ..
         } = replay::<UsdcRebalance>(history.clone())
             .expect("history should replay")
@@ -6624,20 +6711,25 @@ mod tests {
         assert_eq!(*initiated_at, failed_initiated_at);
 
         // Applying the event must drive the aggregate to the clearing terminal
-        // Reconciled state -- the evolve arm, not just the command handler.
+        // Reconciled state with failure_reason recovered from the prior state.
         let state = replay::<UsdcRebalance>([history, events].concat())
             .expect("event stream should replay")
             .expect("event stream should materialize aggregate state");
-        assert!(
-            matches!(
-                state,
-                UsdcRebalance::Reconciled {
-                    direction: RebalanceDirection::BaseToAlpaca,
-                    reason: ReconcileReason::FundsMovedManually,
-                    ..
-                }
-            ),
-            "reconciled aggregate should be Reconciled, got {state:?}"
+        let UsdcRebalance::Reconciled {
+            direction: reconciled_direction,
+            reason: reconciled_reason,
+            failure_reason,
+            ..
+        } = state
+        else {
+            panic!("reconciled aggregate should be Reconciled, got {state:?}");
+        };
+        assert_eq!(reconciled_direction, RebalanceDirection::BaseToAlpaca);
+        assert_eq!(reconciled_reason, ReconcileReason::FundsMovedManually);
+        assert_eq!(
+            failure_reason,
+            Some(failed_reason),
+            "reconciled state must carry the source failure reason"
         );
     }
 
@@ -6647,6 +6739,7 @@ mod tests {
             direction: RebalanceDirection::BaseToAlpaca,
             amount: Usdc::new(float!(100.00)),
             reason: ReconcileReason::FundsMovedManually,
+            failure_reason: None,
             initiated_at: Utc::now(),
             reconciled_at: Utc::now(),
         };
@@ -6662,10 +6755,85 @@ mod tests {
             direction: RebalanceDirection::AlpacaToBase,
             amount: Usdc::new(float!(100.00)),
             reason: ReconcileReason::DepositCreditedOffline,
+            failure_reason: None,
             initiated_at: Utc::now(),
             reconciled_at: Utc::now(),
         };
         assert_eq!(reconciled.direction(), RebalanceDirection::AlpacaToBase);
+    }
+
+    /// Reconciling from a `DepositFailed` state with `DepositCreditedOffline`
+    /// reason must surface `reconcileReason = "deposit credited offline"` in
+    /// the DTO -- an integration test covering the full
+    /// command -> state -> to_dto pipeline for the `DepositCreditedOffline`
+    /// variant, which is the operator's signal that the deposit settled
+    /// out-of-band without needing a retry.
+    #[tokio::test]
+    async fn reconcile_deposit_credited_offline_surfaces_in_dto() {
+        let history = deposit_failed_history();
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(history.clone())
+            .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
+                reason: ReconcileReason::DepositCreditedOffline,
+            })
+            .await
+            .events();
+
+        let reconciled_state = replay::<UsdcRebalance>([history, events].concat())
+            .expect("event stream should replay")
+            .expect("event stream should materialize aggregate state");
+
+        let id = UsdcRebalanceId(uuid::Uuid::new_v4());
+        let TransferOperation::UsdcBridge(bridge) = reconciled_state.to_dto(&id) else {
+            panic!("expected UsdcBridge variant");
+        };
+        let serialized =
+            serde_json::to_value(&bridge.status).expect("status serialization should succeed");
+        assert_eq!(serialized["status"], serde_json::json!("reconciled"));
+        assert_eq!(
+            serialized["reconcileReason"],
+            serde_json::json!("deposit credited offline"),
+            "DepositCreditedOffline must surface the human-readable string in the DTO"
+        );
+        assert_eq!(
+            serialized["failureReason"],
+            serde_json::json!("deposit rejected"),
+            "failure_reason must be recovered from the prior DepositFailed state"
+        );
+    }
+
+    /// Simulates replaying a HISTORICAL `OperatorReconciled` event that was
+    /// persisted before `failure_reason` was introduced (old events have no
+    /// such field in their JSON). `apply()` must recover the failure reason
+    /// from the prior `DepositFailed` state, so the replayed `Reconciled`
+    /// state carries the correct context even without it in the event.
+    #[tokio::test]
+    async fn historical_operator_reconciled_event_recovers_failure_reason_from_prior_state() {
+        // Build a history: DepositFailed then a legacy-style OperatorReconciled
+        // (no failure_reason field -- matches what old persisted events look like).
+        let mut history = deposit_failed_history();
+        history.push(UsdcRebalanceEvent::OperatorReconciled {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(100.00)),
+            reason: ReconcileReason::FundsMovedManually,
+            initiated_at: Utc::now(),
+            reconciled_at: Utc::now(),
+        });
+
+        let state = replay::<UsdcRebalance>(history)
+            .expect("event stream should replay")
+            .expect("event stream should materialize aggregate state");
+
+        let UsdcRebalance::Reconciled { failure_reason, .. } = state else {
+            panic!("should be Reconciled, got {state:?}");
+        };
+        // "deposit rejected" is the reason set in deposit_failed_history().
+        assert_eq!(
+            failure_reason,
+            Some("deposit rejected".to_string()),
+            "historical replay must recover failure_reason from prior DepositFailed state"
+        );
     }
 
     #[tokio::test]
@@ -8138,14 +8306,15 @@ mod tests {
     }
 
     #[test]
-    fn to_dto_reconciled_preserves_amount_and_original_initiated_at() {
+    fn to_dto_reconciled_carries_reconcile_reason_and_preserves_amount() {
         let id = UsdcRebalanceId(Uuid::new_v4());
-        let initiated_at = Utc::now();
-        let reconciled_at = initiated_at + chrono::Duration::seconds(120);
+        let initiated_at = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let reconciled_at = "2026-01-02T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
         let state = UsdcRebalance::Reconciled {
             direction: RebalanceDirection::BaseToAlpaca,
             amount: Usdc::new(float!(750)),
             reason: ReconcileReason::FundsMovedManually,
+            failure_reason: Some("deposit timed out after max retries".to_string()),
             initiated_at,
             reconciled_at,
         };
@@ -8161,10 +8330,20 @@ mod tests {
         assert_eq!(bridge.amount, Usdc::new(float!(750)));
         assert_eq!(bridge.started_at, initiated_at);
         assert_eq!(bridge.updated_at, reconciled_at);
-        assert!(matches!(
-            bridge.status,
-            UsdcBridgeStatus::Completed { completed_at } if completed_at == reconciled_at
-        ));
+        let serialized = serde_json::to_value(&bridge.status).expect("serialization failed");
+        assert_eq!(serialized["status"], serde_json::json!("reconciled"));
+        assert_eq!(
+            serialized["reconciledAt"],
+            serde_json::json!("2026-01-02T00:00:00Z")
+        );
+        assert_eq!(
+            serialized["failureReason"],
+            serde_json::json!("deposit timed out after max retries")
+        );
+        assert_eq!(
+            serialized["reconcileReason"],
+            serde_json::json!("funds moved manually")
+        );
     }
 
     #[test]
@@ -8885,6 +9064,7 @@ mod tests {
                 direction: BaseToAlpaca,
                 amount,
                 reason: ReconcileReason::FundsMovedManually,
+                failure_reason: None,
                 initiated_at: now,
                 reconciled_at: now,
             }


### PR DESCRIPTION
## What

- Adds a distinct `Reconciled` status to `EquityMintStatus`, `EquityRedemptionStatus`, and `UsdcBridgeStatus` DTOs carrying `reconciled_at`, `failure_reason`, and `reconcile_reason`; previously all three mapped aggregate `Reconciled` → DTO `Completed`, silently dropping failure context
- Mint `failure_reason` is `String` (non-optional — mint `Failed` always has a reason); redemption and USDC use `Option<String>` (timeout/pre-existing-field replay can produce `None`)
- `is_terminal()` updated to include `Reconciled` across all three transfer types
- `UsdcRebalance::Reconciled` aggregate state gains `failure_reason: Option<String>` with `#[serde(default)]`; `apply(OperatorReconciled)` derives it from the prior failed state (not stored in the event) so historical replays recover the reason without a migration
- `ReconcileReason` gains a `Display` impl to emit human-readable `reconcile_reason` strings in the DTO
- SPEC.md updated to document the new distinct `Reconciled` DTO status
- Dashboard: `statusStyle` returns amber for `reconciled` (substring, case-insensitive — also covers `OperatorReconciled` event name in the timeline); `isTerminalStatus` includes `reconciled` so `upsertTransfer` routes active→recent; recovery commands suppressed for reconciled transfers

## Why

[RAI-1156](https://linear.app/makeitrain/issue/RAI-1156/surface-reconciled-equityusdc-transfers-distinctly-in-the-transfer-dto) — Reconciled transfers previously rendered as `Completed` in the DTO, making operator-resolved stuck transfers indistinguishable from genuine successes on the dashboard during incident response.

## How

- `failure_reason` is intentionally absent from the `OperatorReconciled` event; `apply()` derives it from the pre-reconciliation state (e.g. `DepositFailed.reason`). This covers historical events persisted before the field existed — replaying an old `OperatorReconciled` still recovers the correct reason from the state that preceded it.
- `UsdcRebalance::SCHEMA_VERSION` bumped 5 → 6 because a stale `Reconciled` snapshot would silently deserialize `failure_reason` as `None` via `#[serde(default)]`, bypassing the derivation. The bump forces rebuild from events so the field is populated correctly.
- The `OperatorReconciled` evolve arm uses an exhaustive match (no wildcard) over all `UsdcRebalance` variants, forcing any future variant to be explicitly classified at compile time.

## Testing

- Serialization tests for all three `Reconciled` variants (serialize to JSON and assert each field independently with `json!` literals) in `crates/dto/src/transfer.rs`; also covers `is_terminal()` for each
- `to_dto` tests in mint and redemption aggregates updated from the old `Completed`-asserting form to assert `status = "reconciled"` with `failure_reason` and `reconcile_reason` fields
- `historical_operator_reconciled_event_recovers_failure_reason_from_prior_state` in `usdc_rebalance.rs` — simulates a legacy `OperatorReconciled` event (no `failure_reason` field in JSON) and asserts replay derives it from the prior `DepositFailed`
- New `dashboard/src/lib/websocket/transfers.test.ts` — vitest for `upsertTransfer`: active→recent routing for completed/reconciled/failed, cold-arrival of reconciled directly into recent, in-flight stays in active
- Dashboard vitest additions: amber `statusStyle` for `reconciled` and `OperatorReconciled`; `transferRecoveryCommands` returns `[]` for reconciled across all three transfer kinds

## Screenshots

## Anything else

**Deploy note:** `UsdcRebalance::SCHEMA_VERSION` bumped 5 → 6. Any live `Reconciled` snapshots are invalidated on startup and rebuilt from events — no data loss, but aggregates with long event histories will replay on next read.

**Generated TS bindings:** The new `Reconciled` variants in `crates/dto/src/transfer.rs` will cause ts-rs to regenerate `dashboard/src/lib/api/` bindings. CI regenerates and checks freshness; the updated types are consumed by the dashboard tests in this PR.
