### PR TITLE
refactor: make EquityRedemption handlers pure (move I/O to orchestrator)

### DIFF
--- a/crates/tokenization/src/mock.rs
+++ b/crates/tokenization/src/mock.rs
@@ -108,6 +108,8 @@ pub struct MockTokenizer {
     call_count: AtomicUsize,
     /// Number of `request_mint` calls made (the provider-side mint requests).
     request_mint_count: AtomicUsize,
+    /// Number of `send_for_redemption` calls made.
+    redemption_send_count: AtomicUsize,
     pending_requests: Vec<TokenizationRequest>,
     /// Override the token_symbol in completed mint responses.
     token_symbol_behavior: MockTokenSymbolBehavior,
@@ -132,6 +134,7 @@ impl MockTokenizer {
             last_issuer_request_id: Mutex::new(None),
             call_count: AtomicUsize::new(0),
             request_mint_count: AtomicUsize::new(0),
+            redemption_send_count: AtomicUsize::new(0),
             token_symbol_behavior: MockTokenSymbolBehavior::Default,
             fees_override: None,
             pending_requests: Vec::new(),
@@ -146,6 +149,13 @@ impl MockTokenizer {
     /// Returns how many times `request_mint` was called since construction.
     pub fn request_mint_count(&self) -> usize {
         self.request_mint_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of `send_for_redemption` calls made. Lets a test
+    /// assert that a step short-circuited (e.g. on a failed `wait_for_block`)
+    /// before sending tokens to Alpaca.
+    pub fn redemption_send_count(&self) -> usize {
+        self.redemption_send_count.load(Ordering::Relaxed)
     }
 
     #[must_use]
@@ -360,6 +370,7 @@ impl Tokenizer for MockTokenizer {
         _amount: U256,
     ) -> Result<TxHash, TokenizerError> {
         self.call_count.fetch_add(1, Ordering::Relaxed);
+        self.redemption_send_count.fetch_add(1, Ordering::Relaxed);
         match self.send_outcome {
             MockSendOutcome::ApiError => {
                 Err(TokenizerError::Alpaca(AlpacaTokenizationError::ApiError {

--- a/crates/wrapper/src/mock.rs
+++ b/crates/wrapper/src/mock.rs
@@ -179,6 +179,17 @@ impl MockWrapper {
             .unwrap_or_else(PoisonError::into_inner)
             .clone()
     }
+
+    /// The amount passed to `submit_unwrap`, or `None` if no unwrap was
+    /// submitted. Lets a test assert that a step short-circuited (e.g. on a
+    /// failed `wait_for_block`) before submitting the unwrap.
+    pub fn submitted_unwrap_amount(&self) -> Option<U256> {
+        self.submitted_amounts
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&self.unwrap_tx)
+            .copied()
+    }
 }
 
 impl Default for MockWrapper {

--- a/src/api.rs
+++ b/src/api.rs
@@ -1091,7 +1091,7 @@ fn stuck_redemption_info(rows: &[(String, String, i64)]) -> Option<StuckTransfer
                     .or_else(|| shares_from_u256_18_decimal(unwrapped_amount));
             }
 
-            TokensSent { .. } => sent = true,
+            TokensSent { .. } | SendSubmitted { .. } => sent = true,
 
             DetectionFailed { .. } if sent => {
                 terminal = Some((

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -32,7 +32,7 @@ use crate::api::ResumeResponse;
 use crate::equity_redemption::{
     DetectionFailure, EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId,
 };
-use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
+use crate::rebalancing::equity::CrossVenueEquityTransfer;
 use crate::rebalancing::to_wrapped_equities;
 use crate::rebalancing::trigger::freeze::FreezeStatusReader;
 use crate::rebalancing::usdc::{CrossVenueCashTransfer, UsdcSettlementParams, UsdcTransferError};
@@ -105,19 +105,12 @@ async fn build_equity_transfer_services(
         wallet,
     ));
 
-    let services = EquityTransferServices {
-        raindex: raindex.clone(),
-        vault_lookup: vault_lookup.clone(),
-        tokenizer: tokenization_service.clone(),
-        wrapper: wrapper.clone(),
-    };
-
     let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
         .build(())
         .await?;
 
     let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
-        .build(services.clone())
+        .build(())
         .await?;
 
     let transfer = CrossVenueEquityTransfer::new(
@@ -1447,10 +1440,6 @@ pub(crate) async fn fail_transfer_command<W: Write>(
         }
 
         TransferType::Redemption => {
-            // Only the redemption aggregate still takes `EquityTransferServices`;
-            // its failure commands never invoke them, so the panicking stub is safe.
-            let services = EquityTransferServices::panicking();
-
             let redemption_id: RedemptionAggregateId = id
                 .parse()
                 .map_err(|error| anyhow::anyhow!("Invalid redemption ID: {error}"))?;
@@ -1471,6 +1460,16 @@ pub(crate) async fn fail_transfer_command<W: Write>(
                 | SendPending { .. } => FailTransfer {
                     reason: reason.to_string(),
                 },
+                // The redemption transfer was broadcast and is finalizing to
+                // `TokensSent` (a pure, resume-driven step). Failing it here would
+                // mis-record a broadcast transfer as never-sent; let it finalize,
+                // then fail from `TokensSent` if detection never fires.
+                SendSubmitted { .. } => {
+                    anyhow::bail!(
+                        "Redemption {id} is mid-send (transfer broadcast, finalizing); \
+                         re-run once it reaches TokensSent"
+                    );
+                }
                 // Tokens reached Alpaca's redemption wallet but detection never
                 // fired: force the detection-failure terminal (DetectionFailed
                 // -> Failed), persisting the operator's reason on the event.
@@ -1495,14 +1494,9 @@ pub(crate) async fn fail_transfer_command<W: Write>(
                 }
             };
 
-            st0x_event_sorcery::send_command::<EquityRedemption>(
-                pool,
-                &redemption_id,
-                command,
-                services,
-            )
-            .await
-            .map_err(|error| stale_state_context("Redemption", id, error))?;
+            st0x_event_sorcery::send_command::<EquityRedemption>(pool, &redemption_id, command, ())
+                .await
+                .map_err(|error| stale_state_context("Redemption", id, error))?;
 
             writeln!(
                 stdout,
@@ -1570,10 +1564,6 @@ pub(crate) async fn reconcile_equity_transfer_command<W: Write>(
         }
 
         TransferType::Redemption => {
-            // Only the redemption aggregate still takes `EquityTransferServices`;
-            // Reconcile never invokes them, so the panicking stub is safe.
-            let services = EquityTransferServices::panicking();
-
             let redemption_id: RedemptionAggregateId = id.parse().map_err(|error| {
                 anyhow::anyhow!("transfer reconcile: invalid redemption id {id:?}: {error}")
             })?;
@@ -1594,7 +1584,7 @@ pub(crate) async fn reconcile_equity_transfer_command<W: Write>(
                 pool,
                 &redemption_id,
                 EquityRedemptionCommand::Reconcile { reason },
-                services,
+                (),
             )
             .await?;
 
@@ -1729,7 +1719,7 @@ pub(crate) async fn resume_interrupted_transfers_command<W: Write>(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Address, B256, address, b256};
+    use alloy::primitives::{Address, TxHash, address, b256};
     use alloy::providers::ProviderBuilder;
     use rain_math_float::Float;
     use url::Url;
@@ -1750,17 +1740,13 @@ mod tests {
     };
     use st0x_finance::Usdc;
     use st0x_float_macro::float;
-    use st0x_tokenization::mock::MockTokenizer;
     use st0x_tokenization::{issuer_request_id, tokenization_request_id};
-    use st0x_wrapper::MockWrapper;
 
     use super::*;
     use crate::equity_redemption::{EquityRedemptionError, redemption_aggregate_id};
     use crate::inventory::ImbalanceThreshold;
-    use crate::onchain::mock::MockRaindex;
     use crate::test_utils::setup_test_db;
     use crate::usdc_rebalance::{ReconcileReason, TransferRef, UsdcRebalanceCommand};
-    use crate::vault_lookup::MockVaultLookup;
 
     /// RAI-835: the manual redrive loop must re-invoke `resume` on the same id
     /// after an attestation timeout and drive through to success -- so a single
@@ -3865,17 +3851,6 @@ mod tests {
         );
     }
 
-    fn redemption_services() -> EquityTransferServices {
-        EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(
-                MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO)),
-            ),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        }
-    }
-
     /// Drives a redemption through the real CQRS command flow until the vault
     /// withdrawal is confirmed (`WithdrawnFromRaindex`) -- stuck before the
     /// tokens leave the bot's custody.
@@ -3883,7 +3858,7 @@ mod tests {
         use EquityRedemptionCommand::*;
 
         let store = StoreBuilder::<EquityRedemption>::new(pool.clone())
-            .build(redemption_services())
+            .build(())
             .await
             .unwrap();
 
@@ -3899,8 +3874,25 @@ mod tests {
             )
             .await
             .unwrap();
-        store.send(id, SubmitWithdraw).await.unwrap();
-        store.send(id, ConfirmWithdraw).await.unwrap();
+        store
+            .send(
+                id,
+                SubmitWithdraw {
+                    tx_hash: TxHash::random(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                ConfirmWithdraw {
+                    actual_wrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
+                    raindex_withdraw_block: 1,
+                },
+            )
+            .await
+            .unwrap();
     }
 
     /// Continues the real CQRS command flow until the redemption is stuck in
@@ -3912,18 +3904,43 @@ mod tests {
         seed_redemption_to_withdrawn(pool, id).await;
 
         let store = StoreBuilder::<EquityRedemption>::new(pool.clone())
-            .build(redemption_services())
+            .build(())
             .await
             .unwrap();
-        for command in [
-            UnwrapTokens,
-            SubmitUnwrap,
-            ConfirmUnwrap,
-            PrepareSend,
-            SendTokens,
-        ] {
-            store.send(id, command).await.unwrap();
-        }
+        store.send(id, UnwrapTokens).await.unwrap();
+        store
+            .send(
+                id,
+                SubmitUnwrap {
+                    unwrap_tx_hash: TxHash::random(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                ConfirmUnwrap {
+                    underlying_token: Address::random(),
+                    unwrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
+                    unwrap_block: 2,
+                },
+            )
+            .await
+            .unwrap();
+        store.send(id, PrepareSend).await.unwrap();
+        store
+            .send(
+                id,
+                RecordSendOutcome {
+                    outcome: crate::equity_redemption::SendOutcome::Sent {
+                        redemption_wallet: Address::random(),
+                        redemption_tx: TxHash::random(),
+                    },
+                },
+            )
+            .await
+            .unwrap();
     }
 
     async fn send_redemption_command(
@@ -3932,7 +3949,7 @@ mod tests {
         command: EquityRedemptionCommand,
     ) {
         let store = StoreBuilder::<EquityRedemption>::new(pool.clone())
-            .build(redemption_services())
+            .build(())
             .await
             .unwrap();
         store.send(id, command).await.unwrap();

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -89,10 +89,9 @@ use crate::performance::rebalance::RebalanceTimingProjection;
 use crate::performance::reliability::LifecycleFailureProjection;
 use crate::position::{Position, PositionCommand, PositionError, PositionEvent, TradeId};
 use crate::rebalancing::equity::{
-    CrossVenueEquityTransfer, EquityTransferServices, ResumeTokenizationAggregate,
-    ResumeTokenizationCtx, ResumeTokenizationJobQueue, ResumeTokenizationTarget,
-    TransferEquityToHedging, TransferEquityToHedgingCtx, TransferEquityToMarketMaking,
-    TransferEquityToMarketMakingCtx,
+    CrossVenueEquityTransfer, ResumeTokenizationAggregate, ResumeTokenizationCtx,
+    ResumeTokenizationJobQueue, ResumeTokenizationTarget, TransferEquityToHedging,
+    TransferEquityToHedgingCtx, TransferEquityToMarketMaking, TransferEquityToMarketMakingCtx,
 };
 use crate::rebalancing::trigger::GuardState;
 use crate::rebalancing::usdc::{
@@ -1494,13 +1493,6 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             to_wrapped_equities(&deps.ctx.assets.equities.symbols),
         ));
 
-        let equity_transfer_services = EquityTransferServices {
-            raindex: raindex_service.clone(),
-            vault_lookup: vault_lookup.clone(),
-            tokenizer: tokenizer.clone(),
-            wrapper: wrapper.clone(),
-        };
-
         let transfer_usdc_to_hedging_queue = deps.schedulers.transfer_usdc_to_hedging.clone();
         let transfer_usdc_to_market_making_queue =
             deps.schedulers.transfer_usdc_to_market_making.clone();
@@ -1527,7 +1519,6 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             &deps.pool,
             deps.event_sender,
             rebalancing_service.clone(),
-            equity_transfer_services,
         )
         .await?;
 
@@ -1690,7 +1681,6 @@ async fn build_rebalancing_frameworks(
     pool: &SqlitePool,
     event_sender: broadcast::Sender<Statement>,
     rebalancing_service: Arc<RebalancingService>,
-    equity_transfer_services: EquityTransferServices,
 ) -> anyhow::Result<BuiltFrameworks> {
     let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
     let hedge_latency = HedgeLatencyProjection::new(pool.clone());
@@ -1708,7 +1698,7 @@ async fn build_rebalancing_frameworks(
         lifecycle_failure,
     );
 
-    manifest.build(pool.clone(), equity_transfer_services).await
+    manifest.build(pool.clone()).await
 }
 
 /// Catches the lifecycle-failure read model up to the event log before its
@@ -3624,10 +3614,10 @@ mod tests {
     };
     use st0x_finance::{Usd, Usdc};
     use st0x_float_macro::float;
-    use st0x_raindex::{Raindex, RaindexContracts};
+    use st0x_raindex::RaindexContracts;
     use st0x_tokenization::mock::MockTokenizer;
     use st0x_tokenization::{issuer_request_id, tokenization_request_id};
-    use st0x_wrapper::{MockWrapper, RATIO_ONE, UnderlyingPerWrapped, Wrapper};
+    use st0x_wrapper::{MockWrapper, RATIO_ONE, UnderlyingPerWrapped};
 
     use super::*;
     use crate::bindings::IRaindexInventory::{OperatorDeposit, OperatorWithdraw};
@@ -3639,11 +3629,10 @@ mod tests {
     use crate::inventory::view::Operator;
     use crate::inventory::{ImbalanceThreshold, Inventory, InventoryView, Venue};
     use crate::offchain::order::{CancellationReason, OrderPlacementResult, RetainedFill};
-    use crate::onchain::mock::MockRaindex;
     use crate::onchain::trade::{InventoryTrade, OnchainTrade};
     use crate::rebalancing::equity::{
-        EquityTransferServices, ResumeTokenizationAggregate, ResumeTokenizationJobQueue,
-        ResumeTokenizationTarget, TransferEquityToHedging, TransferEquityToMarketMaking,
+        ResumeTokenizationAggregate, ResumeTokenizationJobQueue, ResumeTokenizationTarget,
+        TransferEquityToHedging, TransferEquityToMarketMaking,
     };
     use crate::rebalancing::{RebalancingSchedulers, RebalancingService};
     use crate::test_utils::{
@@ -3655,7 +3644,6 @@ mod tests {
     use crate::trading::onchain::trade_accountant::AccountForDexTrade;
     use crate::unwrapped_equity_recovery::UnwrappedEquityRecoveryJob;
     use crate::unwrapped_equity_recovery::aggregate::UnwrappedEquityRecoveryId;
-    use crate::vault_lookup::MockVaultLookup;
 
     fn one_to_one_ratio() -> UnderlyingPerWrapped {
         UnderlyingPerWrapped::new(RATIO_ONE).unwrap()
@@ -3757,20 +3745,15 @@ mod tests {
 
     async fn freeze_guard_test_transfer() -> CrossVenueEquityTransfer {
         let (pool, _apalis_pool) = setup_test_pools().await;
-        let raindex: Arc<dyn Raindex> = Arc::new(crate::onchain::mock::MockRaindex::new());
+        let raindex: Arc<dyn st0x_raindex::Raindex> =
+            Arc::new(crate::onchain::mock::MockRaindex::new());
         let wrapper: Arc<dyn st0x_wrapper::Wrapper> = Arc::new(MockWrapper::new());
         let tokenizer: Arc<dyn st0x_tokenization::Tokenizer> =
             Arc::new(st0x_tokenization::mock::MockTokenizer::new());
         let vault_lookup = Arc::new(crate::vault_lookup::MockVaultLookup::new());
 
-        let services = crate::rebalancing::equity::EquityTransferServices {
-            raindex: raindex.clone(),
-            vault_lookup: vault_lookup.clone(),
-            tokenizer: tokenizer.clone(),
-            wrapper: wrapper.clone(),
-        };
         let mint_store = Arc::new(test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool, services));
+        let redemption_store = Arc::new(test_store(pool, ()));
 
         CrossVenueEquityTransfer::new(
             raindex,
@@ -3918,7 +3901,6 @@ mod tests {
     struct InterruptedAggregateFixture {
         pool: sqlx::SqlitePool,
         apalis_pool: apalis_sqlite::SqlitePool,
-        services: crate::rebalancing::equity::EquityTransferServices,
         mint_id: st0x_tokenization::IssuerRequestId,
         redemption_id: crate::equity_redemption::RedemptionAggregateId,
         tokenizer: Arc<st0x_tokenization::mock::MockTokenizer>,
@@ -3942,22 +3924,10 @@ mod tests {
         let mint_id = issuer_request_id(mint_label);
         let redemption_id = redemption_aggregate_id(redemption_label);
 
-        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
-        let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
         let tokenizer = Arc::new(MockTokenizer::new());
 
-        let services = EquityTransferServices {
-            raindex: raindex.clone(),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: tokenizer.clone(),
-            wrapper: wrapper.clone(),
-        };
-
         let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-        let seeding_redemption_store = Arc::new(test_store::<EquityRedemption>(
-            pool.clone(),
-            services.clone(),
-        ));
+        let seeding_redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
 
         seeding_mint_store
             .send(
@@ -4022,7 +3992,6 @@ mod tests {
         InterruptedAggregateFixture {
             pool,
             apalis_pool,
-            services,
             mint_id,
             redemption_id,
             tokenizer,
@@ -4044,7 +4013,6 @@ mod tests {
         let InterruptedAggregateFixture {
             pool,
             apalis_pool,
-            services,
             mint_id,
             redemption_id,
             tokenizer,
@@ -4062,10 +4030,7 @@ mod tests {
         // not invoke tokenizer methods. Use the same services for the function
         // call -- MockTokenizer methods are never called during load().
         let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store::<EquityRedemption>(
-            pool.clone(),
-            services.clone(),
-        ));
+        let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
         let calls_before = tokenizer.call_count();
 
         // Must complete in under 1 second: no issuer poll blocking.
@@ -4136,7 +4101,6 @@ mod tests {
         let InterruptedAggregateFixture {
             pool,
             apalis_pool,
-            services,
             mint_id: _,
             redemption_id: _,
             tokenizer: _,
@@ -4156,10 +4120,7 @@ mod tests {
             &rebalancing_service,
             inventory.as_ref(),
             Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-            Arc::new(test_store::<EquityRedemption>(
-                pool.clone(),
-                services.clone(),
-            )),
+            Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
             &mut resume_queue,
         )
         .await
@@ -4177,10 +4138,7 @@ mod tests {
             &rebalancing_service,
             inventory.as_ref(),
             Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-            Arc::new(test_store::<EquityRedemption>(
-                pool.clone(),
-                services.clone(),
-            )),
+            Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
             &mut resume_queue,
         )
         .await
@@ -4198,7 +4156,6 @@ mod tests {
         let InterruptedAggregateFixture {
             pool,
             apalis_pool,
-            services,
             mint_id,
             redemption_id,
             tokenizer: _,
@@ -4239,7 +4196,7 @@ mod tests {
             &rebalancing_service,
             inventory.as_ref(),
             Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-            Arc::new(test_store::<EquityRedemption>(pool.clone(), services)),
+            Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
             &mut resume_queue,
         )
         .await
@@ -4272,7 +4229,6 @@ mod tests {
         let InterruptedAggregateFixture {
             pool,
             apalis_pool,
-            services,
             mint_id,
             redemption_id,
             tokenizer: _,
@@ -4323,7 +4279,7 @@ mod tests {
             &rebalancing_service,
             inventory.as_ref(),
             Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-            Arc::new(test_store::<EquityRedemption>(pool.clone(), services)),
+            Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
             &mut resume_queue,
         )
         .await
@@ -4353,7 +4309,6 @@ mod tests {
         let InterruptedAggregateFixture {
             pool,
             apalis_pool,
-            services,
             mint_id: _,
             redemption_id: _,
             tokenizer: _,
@@ -4373,10 +4328,7 @@ mod tests {
             &rebalancing_service,
             inventory.as_ref(),
             Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-            Arc::new(test_store::<EquityRedemption>(
-                pool.clone(),
-                services.clone(),
-            )),
+            Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
             &mut resume_queue,
         )
         .await
@@ -4398,10 +4350,7 @@ mod tests {
             &rebalancing_service,
             inventory.as_ref(),
             Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-            Arc::new(test_store::<EquityRedemption>(
-                pool.clone(),
-                services.clone(),
-            )),
+            Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
             &mut resume_queue,
         )
         .await
@@ -4453,16 +4402,6 @@ mod tests {
         // is_pre_wrap_held_for_recovery blocks the resume push.
         let (pool, apalis_pool) = setup_test_pools().await;
         let mint_id = issuer_request_id("pre-wrap-held-mint");
-        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
-        let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
-        let tokenizer = Arc::new(MockTokenizer::new());
-
-        let services = EquityTransferServices {
-            raindex: raindex.clone(),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: tokenizer.clone(),
-            wrapper: wrapper.clone(),
-        };
 
         let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
 
@@ -4530,10 +4469,7 @@ mod tests {
         );
 
         let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store::<EquityRedemption>(
-            pool.clone(),
-            services.clone(),
-        ));
+        let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
         let mut resume_queue = ResumeTokenizationJobQueue::new(&apalis_pool);
 
         recover_interrupted_tokenization_aggregates(
@@ -4557,13 +4493,6 @@ mod tests {
         // --- Control case: recovery DISABLED keeps ActiveTransfer, job IS enqueued ---
         let (pool2, apalis_pool2) = setup_test_pools().await;
         let mint_id2 = issuer_request_id("pre-wrap-active-mint");
-
-        let services2 = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
 
         let seeding_mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(pool2.clone(), ()));
 
@@ -4629,10 +4558,7 @@ mod tests {
         );
 
         let mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(pool2.clone(), ()));
-        let redemption_store2 = Arc::new(test_store::<EquityRedemption>(
-            pool2.clone(),
-            services2.clone(),
-        ));
+        let redemption_store2 = Arc::new(test_store::<EquityRedemption>(pool2.clone(), ()));
         let mut resume_queue2 = ResumeTokenizationJobQueue::new(&apalis_pool2);
 
         recover_interrupted_tokenization_aggregates(

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -26,7 +26,7 @@ use crate::performance::equity_timing::EquityTimingProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
 use crate::performance::reliability::LifecycleFailureProjection;
 use crate::position::Position;
-use crate::rebalancing::{RebalancingService, equity::EquityTransferServices};
+use crate::rebalancing::RebalancingService;
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::usdc_rebalance::UsdcRebalance;
 
@@ -90,11 +90,7 @@ impl QueryManifest {
     /// Destructures `self` to ensure every field is handled. If you
     /// add a new query to the manifest, this method won't compile
     /// until you wire it.
-    pub(super) async fn build(
-        self,
-        pool: SqlitePool,
-        services: EquityTransferServices,
-    ) -> anyhow::Result<BuiltFrameworks> {
+    pub(super) async fn build(self, pool: SqlitePool) -> anyhow::Result<BuiltFrameworks> {
         let Self {
             rebalancing_service,
             broadcaster,
@@ -124,7 +120,7 @@ impl QueryManifest {
             .with(broadcaster.clone())
             .with(equity_timing)
             .with(lifecycle_failure.clone())
-            .build(services)
+            .build(())
             .await?;
 
         let usdc = StoreBuilder::<UsdcRebalance>::new(pool.clone())
@@ -165,7 +161,6 @@ mod tests {
     use st0x_execution::{Direction, FractionalShares, Symbol};
     use st0x_finance::Usdc;
     use st0x_float_macro::float;
-    use st0x_tokenization::mock::MockTokenizer;
     use st0x_wrapper::MockWrapper;
 
     use super::*;
@@ -173,14 +168,12 @@ mod tests {
     use crate::inventory::{
         BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, Operator, Venue,
     };
-    use crate::onchain::mock::MockRaindex;
     use crate::position::{PositionCommand, TradeId};
     use crate::rebalancing::equity::TransferEquityToMarketMaking;
     use crate::rebalancing::{
         RebalancingSchedulers, RebalancingService, RebalancingServiceConfig, drain_pending_jobs,
     };
     use crate::test_utils::{rebalancing_enabled_equities, setup_test_pools};
-    use crate::vault_lookup::MockVaultLookup;
     use crate::vault_registry::{VaultRegistryCommand, VaultRegistryId};
     use st0x_config::{AssetsConfig, ExecutionThreshold};
 
@@ -242,14 +235,7 @@ mod tests {
             lifecycle_failure,
         );
 
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
-
-        let frameworks = manifest.build(pool, services).await.unwrap();
+        let frameworks = manifest.build(pool).await.unwrap();
 
         // Verify stores are usable by checking that loading a
         // nonexistent position returns None
@@ -303,13 +289,7 @@ mod tests {
             equity_timing,
             lifecycle_failure,
         );
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
-        let built = manifest.build(pool, services).await.unwrap();
+        let built = manifest.build(pool).await.unwrap();
 
         // Dispatch a live snapshot command through the built store and
         // verify it lands in the shared BroadcastingInventory via the
@@ -422,13 +402,7 @@ mod tests {
             equity_timing,
             lifecycle_failure,
         );
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
-        let built = manifest.build(pool.clone(), services).await.unwrap();
+        let built = manifest.build(pool.clone()).await.unwrap();
 
         built
             .position

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -4,47 +4,42 @@
 //! Tracks the workflow from withdrawing tokens from the Raindex vault
 //! through sending to Alpaca's redemption wallet to share delivery.
 //!
+//! # Pure handlers, orchestrated side effects
+//!
+//! This aggregate is a pure event recorder (`type Services = ()`): its command
+//! handlers emit events from the values the command carries and never perform
+//! I/O. The onchain/broker steps -- the Raindex withdrawal, the ERC-4626
+//! unwrap, and the send to Alpaca's redemption wallet -- are driven by the
+//! [`CrossVenueEquityTransfer`](crate::rebalancing::equity::CrossVenueEquityTransfer)
+//! orchestrator running inside a durable apalis job. Each step splits into a
+//! submit command (records the broadcast tx hash) and a confirm command
+//! (records the receipt-derived outcome), so a crash leaves the aggregate in a
+//! `*Submitted` state the resume loop can re-confirm without re-broadcasting.
+//!
 //! # State Flow
 //!
-//! The aggregate progresses through the following states:
+//! The aggregate progresses through the following states (each non-terminal
+//! state can also transition to `Failed`):
 //!
 //! ```text
-//!     Redeem ------------> Failed
-//!       |
-//!       v
-//!     WithdrawnFromRaindex --> Failed
-//!       |
-//!       v
-//!     TokensUnwrapped ------> Failed
-//!       |
-//!       v
-//!     TokensSent ------------> Failed
-//!       |
-//!       v
-//!     Pending ---------------> Failed
-//!       |
-//!       v
-//!     Completed
+//!     VaultWithdrawPending --> VaultWithdrawSubmitted --> WithdrawnFromRaindex
+//!                                                              |
+//!                                                              v
+//!     UnwrapPending --> UnwrapSubmitted --> TokensUnwrapped --> SendPending
+//!                                                                   |
+//!                                                                   v
+//!     TokensSent --> Pending --> Completed
 //! ```
 //!
-//! - `Redeem` withdraws wrapped tokens from the Raindex vault
-//! - `WithdrawnFromRaindex` tracks tokens withdrawn, awaiting unwrap
-//! - `UnwrapTokens` unwraps ERC-4626 shares into underlying tokens
-//! - `TokensUnwrapped` tracks unwrapped tokens, ready to send
-//! - `TokensSent` tracks tokens sent to Alpaca's redemption wallet
+//! - `Redeem` opens the redemption at `VaultWithdrawPending`
+//! - `SubmitWithdraw` / `ConfirmWithdraw` record the vault withdrawal tx and
+//!   the receipt-derived actual amount (`WithdrawnFromRaindex`)
+//! - `SubmitUnwrap` / `ConfirmUnwrap` record the ERC-4626 unwrap tx and the
+//!   resolved underlying token + amount (`TokensUnwrapped`)
+//! - `PrepareSend` / `RecordSendOutcome` record the send-to-Alpaca outcome
+//!   (`TokensSent`, or `Failed` for a missing wallet / failed send)
 //! - `Pending` indicates Alpaca detected the transfer
 //! - `Completed` and `Failed` are terminal states
-//!
-//! # Services
-//!
-//! The aggregate uses cqrs-es Services (`RedemptionServices`) with `Tokenizer` and `Vault`
-//! traits to execute side effects atomically:
-//!
-//! - `vault.withdraw()` - Withdraws tokens from Rain OrderBook vault
-//! - `tokenizer.send_for_redemption()` - Sends tokens to Alpaca's redemption wallet
-//!
-//! This pattern ensures that if Raindex withdraw succeeds but send fails, the aggregate stays
-//! in `WithdrawnFromRaindex` state (tokens in wallet, not stranded).
 //!
 //! # Error Handling
 //!
@@ -56,8 +51,6 @@
 //! - All state transitions are captured as events for complete audit trail
 
 use alloy::primitives::{Address, TxHash, U256};
-use alloy::rpc::types::TransactionReceipt;
-use alloy::sol_types::SolEvent;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rain_math_float::Float;
@@ -71,14 +64,9 @@ use uuid::Uuid;
 
 use st0x_dto::{EquityRedemptionOperation, EquityRedemptionStatus, TransferOperation};
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
-use st0x_evm::{EvmError, IERC20, NODE_SYNC_MAX_ATTEMPTS};
 use st0x_execution::Symbol;
 use st0x_finance::{FractionalShares, Id};
 use st0x_tokenization::TokenizationRequestId;
-use st0x_tokenization::Tokenizer;
-use st0x_wrapper::WrapperError;
-
-use crate::rebalancing::equity::EquityTransferServices;
 
 /// Our tokenized equity tokens use 18 decimals.
 const TOKENIZED_EQUITY_DECIMALS: u8 = 18;
@@ -124,41 +112,11 @@ pub(crate) fn redemption_aggregate_id(label: &str) -> RedemptionAggregateId {
 /// These errors enforce state machine constraints and prevent invalid transitions.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum EquityRedemptionError {
-    /// Raindex vault lookup failed for the given token
-    #[error("Token {0} not found in Raindex vault registry")]
-    RaindexVaultNotFound(Address),
-    /// Raindex vault withdrawal transaction failed.
-    /// RaindexError can't be wrapped with #[from] because it contains
-    /// alloy types that don't implement Serialize/Deserialize (required
-    /// by DomainError).
-    #[error(
-        "Raindex vault withdraw failed for token {token}, \
-         amount {amount}: {error_message}"
-    )]
-    RaindexWithdrawFailed {
-        token: Address,
-        amount: U256,
-        error_message: String,
-    },
-    /// Confirmed Raindex withdrawal receipt did not contain the expected token transfer.
-    #[error(
-        "Raindex withdrawal receipt {tx_hash} did not contain a transfer \
-         for token {token} to recipient {recipient}"
-    )]
-    RaindexWithdrawTransferNotFound {
-        tx_hash: TxHash,
-        token: Address,
-        recipient: Address,
-    },
-    /// Confirmed Raindex withdrawal receipt contained transfer values that overflowed.
-    #[error("Raindex withdrawal transfer amount overflowed for tx {tx_hash}")]
-    RaindexWithdrawTransferOverflow { tx_hash: TxHash },
-    /// Confirmed Raindex withdrawal receipt contained a malformed transfer log.
-    #[error(
-        "Raindex withdrawal receipt {tx_hash} contained malformed transfer log for token {token}"
-    )]
-    RaindexWithdrawTransferDecodeFailed { tx_hash: TxHash, token: Address },
     /// Actual withdrawal amount could not be converted to fractional shares.
+    ///
+    /// Raised by the `ConfirmUnwrap` handler when the orchestrator-supplied
+    /// unwrapped amount cannot be represented as a [`Float`] -- the one piece
+    /// of financial validation the aggregate still performs.
     #[error(
         "Raindex withdrawal amount {amount} for tx {tx_hash} could not be converted to shares: {error_message}"
     )]
@@ -167,30 +125,16 @@ pub(crate) enum EquityRedemptionError {
         amount: U256,
         error_message: String,
     },
-    /// ERC-4626 unwrap operation failed.
-    /// WrapperError can't be wrapped with #[from] because it contains
-    /// alloy types that don't implement Serialize/Deserialize (required
-    /// by DomainError).
-    #[error(
-        "Token unwrap failed for {token}, \
-         wrapped_amount {wrapped_amount}: {error_message}"
-    )]
-    UnwrapFailed {
-        token: Address,
-        wrapped_amount: U256,
-        error_message: String,
-    },
-    /// Underlying token address lookup failed after unwrapping.
-    /// WrapperError can't be wrapped with #[from] for the same reason
-    /// as UnwrapFailed above.
-    #[error(
-        "Underlying token lookup failed for {symbol}: \
-         {error_message}"
-    )]
-    UnderlyingLookupFailed {
-        symbol: Symbol,
-        error_message: String,
-    },
+    /// A confirmed withdrawal reported a zero actual amount. The orchestrator's
+    /// receipt decode already rejects an empty transfer; this guard also fails
+    /// fast on a directly-issued (e.g. CLI) `ConfirmWithdraw` now that the
+    /// command path no longer goes through `step::confirm_vault_withdraw`.
+    #[error("Cannot confirm withdrawal: actual withdrawn amount is zero for tx {tx_hash}")]
+    ZeroWithdrawAmount { tx_hash: TxHash },
+    /// A confirmed unwrap reported a zero amount. Fails fast at the CQRS
+    /// boundary so a zero never drives the downstream Alpaca redemption send.
+    #[error("Cannot confirm unwrap: unwrapped amount is zero for tx {tx_hash}")]
+    ZeroUnwrapAmount { tx_hash: TxHash },
     /// Transaction failed with a known tx hash
     #[error("Transaction failed: {tx_hash}")]
     TransactionFailed { tx_hash: TxHash },
@@ -224,21 +168,6 @@ pub(crate) enum EquityRedemptionError {
     /// Attempted to modify a failed redemption operation
     #[error("Already failed")]
     AlreadyFailed,
-    /// RPC node did not catch up to the required block before the wait budget
-    /// was exhausted. This is a retryable failure; the job should be retried
-    /// once the node has indexed the required block.
-    #[error(
-        "RPC node did not catch up to required block {required_block} \
-         after {attempts} polls"
-    )]
-    NodeSyncFailed { required_block: u64, attempts: u32 },
-    /// The Raindex withdrawal receipt did not include a block number.
-    /// Fresh receipts must carry a block number so the node-sync guard in
-    /// SubmitUnwrap can wait for the correct block before submitting the
-    /// unwrap. A None block number on a freshly confirmed receipt indicates
-    /// an RPC edge case (e.g. pending or uncle-block receipt).
-    #[error("Raindex withdrawal receipt for {tx_hash} is missing block number")]
-    MissingWithdrawBlock { tx_hash: TxHash },
     /// Attempted to reconcile a redemption that is not in the `Failed` state
     #[error("Cannot reconcile: redemption is not in the Failed state")]
     NotFailed,
@@ -270,14 +199,21 @@ pub(crate) enum EquityRedemptionCommand {
         amount: U256,
         pending_at: DateTime<Utc>,
     },
-    /// Waits for a previously submitted withdrawal to confirm.
+    /// Records the orchestrator-confirmed withdrawal receipt (pure).
     /// Emits WithdrawnFromRaindex.
-    ConfirmWithdraw,
+    ConfirmWithdraw {
+        actual_wrapped_amount: U256,
+        raindex_withdraw_block: u64,
+    },
     /// Test/fixture-only: identical to `ConfirmWithdraw` but takes
     /// `withdrawn_at` explicitly instead of stamping `Utc::now()`, so
     /// fixture seeding can backdate synthetic history.
     #[cfg(any(test, feature = "test-support"))]
-    ConfirmWithdrawAt { withdrawn_at: DateTime<Utc> },
+    ConfirmWithdrawAt {
+        actual_wrapped_amount: U256,
+        raindex_withdraw_block: u64,
+        withdrawn_at: DateTime<Utc>,
+    },
     /// Submits ERC-4626 unwrap tx and emits UnwrapSubmitted.
     UnwrapTokens,
     /// Test/fixture-only: identical to `UnwrapTokens` but takes `pending_at`
@@ -285,23 +221,28 @@ pub(crate) enum EquityRedemptionCommand {
     /// backdate synthetic history.
     #[cfg(any(test, feature = "test-support"))]
     UnwrapTokensAt { pending_at: DateTime<Utc> },
-    /// Waits for a previously submitted unwrap to confirm.
+    /// Records the orchestrator-confirmed unwrap result (pure).
     /// Emits TokensUnwrapped.
-    ConfirmUnwrap,
+    ConfirmUnwrap {
+        underlying_token: Address,
+        unwrapped_amount: U256,
+        unwrap_block: u64,
+    },
     /// Test/fixture-only: identical to `ConfirmUnwrap` but takes
     /// `unwrapped_at` explicitly instead of stamping `Utc::now()`, so
     /// fixture seeding can backdate synthetic history.
     #[cfg(any(test, feature = "test-support"))]
-    ConfirmUnwrapAt { unwrapped_at: DateTime<Utc> },
-    /// Send unwrapped tokens to Alpaca's redemption wallet.
-    SendTokens,
-    /// Test/fixture-only: identical to `SendTokens` but takes `sent_at`
-    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
-    /// backdate synthetic history. Only the success (`TokensSent`) path
-    /// honours the timestamp; the failure (`TransferFailed`) path keeps
-    /// `Utc::now()` since the fixture never drives it.
-    #[cfg(any(test, feature = "test-support"))]
-    SendTokensAt { sent_at: DateTime<Utc> },
+    ConfirmUnwrapAt {
+        underlying_token: Address,
+        unwrapped_amount: U256,
+        unwrap_block: u64,
+        unwrapped_at: DateTime<Utc>,
+    },
+    /// Records the outcome of the orchestrator's send-to-Alpaca step (pure).
+    /// Emits TokensSent (success) or TransferFailed (missing wallet / send
+    /// failure). Carries the raw outcome so the wallet/send invariants stay
+    /// enforced at the aggregate boundary.
+    RecordSendOutcome { outcome: SendOutcome },
     /// Alpaca detected the token transfer.
     Detect {
         tokenization_request_id: TokenizationRequestId,
@@ -332,22 +273,52 @@ pub(crate) enum EquityRedemptionCommand {
     /// Operator or timeout-driven failure from `WithdrawnFromRaindex` or
     /// `TokensUnwrapped` states.
     FailTransfer { reason: String },
-    /// Performs the actual vault withdrawal (side-effectful).
+    /// Records the orchestrator-submitted vault withdrawal tx (pure).
     /// Valid from `VaultWithdrawPending`.
-    SubmitWithdraw,
+    SubmitWithdraw { tx_hash: TxHash },
     /// Test/fixture-only: identical to `SubmitWithdraw` but takes
     /// `submitted_at` explicitly instead of stamping `Utc::now()`, so
     /// fixture seeding can backdate synthetic history.
     #[cfg(any(test, feature = "test-support"))]
-    SubmitWithdrawAt { submitted_at: DateTime<Utc> },
-    /// Performs the actual ERC-4626 unwrap (side-effectful).
+    SubmitWithdrawAt {
+        tx_hash: TxHash,
+        submitted_at: DateTime<Utc>,
+    },
+    /// Records the orchestrator-submitted ERC-4626 unwrap tx (pure).
     /// Valid from `UnwrapPending`.
-    SubmitUnwrap,
+    SubmitUnwrap { unwrap_tx_hash: TxHash },
     /// Test/fixture-only: identical to `SubmitUnwrap` but takes
     /// `submitted_at` explicitly instead of stamping `Utc::now()`, so
     /// fixture seeding can backdate synthetic history.
     #[cfg(any(test, feature = "test-support"))]
-    SubmitUnwrapAt { submitted_at: DateTime<Utc> },
+    SubmitUnwrapAt {
+        unwrap_tx_hash: TxHash,
+        submitted_at: DateTime<Utc>,
+    },
+    /// Records the orchestrator-broadcast redemption transfer tx (pure).
+    /// Valid from `SendPending`. Persists the tx immediately after broadcast so
+    /// resume finalizes it rather than re-broadcasting an irreversible transfer.
+    SubmitSend {
+        redemption_wallet: Address,
+        redemption_tx: TxHash,
+    },
+    /// Test/fixture-only: identical to `SubmitSend` but takes `submitted_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    SubmitSendAt {
+        redemption_wallet: Address,
+        redemption_tx: TxHash,
+        submitted_at: DateTime<Utc>,
+    },
+    /// Finalizes a broadcast redemption send to `TokensSent` (pure).
+    /// Valid from `SendSubmitted`.
+    ConfirmSend,
+    /// Test/fixture-only: identical to `ConfirmSend` but takes `sent_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    ConfirmSendAt { sent_at: DateTime<Utc> },
     /// Prepares sending tokens (pure, no side effects).
     /// Valid from `TokensUnwrapped`.
     PrepareSend,
@@ -361,6 +332,22 @@ pub(crate) enum EquityRedemptionCommand {
     /// (e.g. via wrap-equity/vault-deposit), so this is a bookkeeping resolution
     /// rather than a re-drive. Valid ONLY from `Failed`.
     Reconcile { reason: String },
+}
+
+/// Outcome of the orchestrator's send-to-Alpaca step, carried by
+/// [`EquityRedemptionCommand::RecordSendOutcome`]. Commands are never
+/// persisted, so this does not derive Serialize/Deserialize.
+#[derive(Debug, Clone)]
+pub(crate) enum SendOutcome {
+    /// The provider transfer was submitted.
+    Sent {
+        redemption_wallet: Address,
+        redemption_tx: TxHash,
+    },
+    /// No redemption wallet is configured for the provider.
+    WalletNotConfigured,
+    /// The provider rejected/failed the transfer.
+    SendFailed,
 }
 
 /// Why redemption detection failed.
@@ -443,8 +430,8 @@ pub(crate) enum EquityRedemptionEvent {
         /// Block number in which the unwrap tx confirmed.
         ///
         /// `None` for events emitted before this field was added (schema
-        /// backward-compatibility). When `None`, the RPC node-sync wait is
-        /// skipped in `SendTokens`.
+        /// backward-compatibility). When `None`, the orchestrator skips the
+        /// RPC node-sync wait before sending.
         #[serde(default)]
         unwrap_block: Option<u64>,
         unwrapped_at: DateTime<Utc>,
@@ -461,6 +448,15 @@ pub(crate) enum EquityRedemptionEvent {
     /// Send requested, awaiting submission.
     SendPending {
         pending_at: DateTime<Utc>,
+    },
+    /// Token transfer to Alpaca's redemption wallet broadcast, pending the
+    /// bookkeeping finalization. Recorded immediately after broadcast so a crash
+    /// before finalization resumes by finalizing the persisted tx rather than
+    /// re-broadcasting an irreversible transfer.
+    SendSubmitted {
+        redemption_wallet: Address,
+        redemption_tx: TxHash,
+        submitted_at: DateTime<Utc>,
     },
     /// Raindex withdraw succeeded but transfer to redemption wallet failed.
     TransferFailed {
@@ -518,46 +514,47 @@ fn resolve_withdrawn_wrapped_amount(
     actual_wrapped_amount.unwrap_or(wrapped_amount)
 }
 
-fn actual_withdrawn_amount_from_receipt(
-    receipt: &TransactionReceipt,
-    token: Address,
-    recipient: Address,
-) -> Result<U256, EquityRedemptionError> {
-    receipt
-        .inner
-        .logs()
-        .iter()
-        .filter(|log| log.address() == token)
-        .filter(|log| log.topics().first() == Some(&IERC20::Transfer::SIGNATURE_HASH))
-        .try_fold(U256::ZERO, |total: U256, log| {
-            let decoded = log.log_decode_validate::<IERC20::Transfer>().map_err(|_| {
-                EquityRedemptionError::RaindexWithdrawTransferDecodeFailed {
-                    tx_hash: receipt.transaction_hash,
-                    token,
-                }
-            })?;
+/// Field-wise equality of two `WithdrawnFromRaindex` events (the widest event,
+/// extracted from the `PartialEq` match for readability). Returns `false` for
+/// any non-`WithdrawnFromRaindex` pair.
+fn withdrawn_from_raindex_events_eq(
+    left: &EquityRedemptionEvent,
+    right: &EquityRedemptionEvent,
+) -> bool {
+    let (
+        EquityRedemptionEvent::WithdrawnFromRaindex {
+            symbol: s1,
+            quantity: q1,
+            token: t1,
+            wrapped_amount: w1,
+            actual_wrapped_amount: aw1,
+            raindex_withdraw_tx: r1,
+            raindex_withdraw_block: rb1,
+            withdrawn_at: wa1,
+        },
+        EquityRedemptionEvent::WithdrawnFromRaindex {
+            symbol: s2,
+            quantity: q2,
+            token: t2,
+            wrapped_amount: w2,
+            actual_wrapped_amount: aw2,
+            raindex_withdraw_tx: r2,
+            raindex_withdraw_block: rb2,
+            withdrawn_at: wa2,
+        },
+    ) = (left, right)
+    else {
+        return false;
+    };
 
-            if decoded.data().to != recipient {
-                return Ok(total);
-            }
-
-            total.checked_add(decoded.data().value).ok_or(
-                EquityRedemptionError::RaindexWithdrawTransferOverflow {
-                    tx_hash: receipt.transaction_hash,
-                },
-            )
-        })
-        .and_then(|amount: U256| {
-            if amount.is_zero() {
-                Err(EquityRedemptionError::RaindexWithdrawTransferNotFound {
-                    tx_hash: receipt.transaction_hash,
-                    token,
-                    recipient,
-                })
-            } else {
-                Ok(amount)
-            }
-        })
+    s1 == s2
+        && q1.eq(*q2).unwrap_or(false)
+        && t1 == t2
+        && w1 == w2
+        && aw1 == aw2
+        && r1 == r2
+        && rb1 == rb2
+        && wa1 == wa2
 }
 
 /// Required by `cqrs_es::DomainEvent`.
@@ -620,36 +617,9 @@ impl PartialEq for EquityRedemptionEvent {
                 pa1 == pa2
             }
             (
-                Self::WithdrawnFromRaindex {
-                    symbol: s1,
-                    quantity: q1,
-                    token: t1,
-                    wrapped_amount: w1,
-                    actual_wrapped_amount: aw1,
-                    raindex_withdraw_tx: r1,
-                    raindex_withdraw_block: rb1,
-                    withdrawn_at: wa1,
-                },
-                Self::WithdrawnFromRaindex {
-                    symbol: s2,
-                    quantity: q2,
-                    token: t2,
-                    wrapped_amount: w2,
-                    actual_wrapped_amount: aw2,
-                    raindex_withdraw_tx: r2,
-                    raindex_withdraw_block: rb2,
-                    withdrawn_at: wa2,
-                },
-            ) => {
-                s1 == s2
-                    && q1.eq(*q2).unwrap_or(false)
-                    && t1 == t2
-                    && w1 == w2
-                    && aw1 == aw2
-                    && r1 == r2
-                    && rb1 == rb2
-                    && wa1 == wa2
-            }
+                left @ Self::WithdrawnFromRaindex { .. },
+                right @ Self::WithdrawnFromRaindex { .. },
+            ) => withdrawn_from_raindex_events_eq(left, right),
             (
                 Self::TokensUnwrapped {
                     quantity: q1,
@@ -700,6 +670,18 @@ impl PartialEq for EquityRedemptionEvent {
                     redemption_wallet: w2,
                     redemption_tx: t2,
                     sent_at: s2,
+                },
+            )
+            | (
+                Self::SendSubmitted {
+                    redemption_wallet: w1,
+                    redemption_tx: t1,
+                    submitted_at: s1,
+                },
+                Self::SendSubmitted {
+                    redemption_wallet: w2,
+                    redemption_tx: t2,
+                    submitted_at: s2,
                 },
             ) => w1 == w2 && t1 == t2 && s1 == s2,
             (
@@ -778,6 +760,7 @@ impl DomainEvent for EquityRedemptionEvent {
             UnwrapPending { .. } => "EquityRedemptionEvent::UnwrapPending".to_string(),
             UnwrapSubmitted { .. } => "EquityRedemptionEvent::UnwrapSubmitted".to_string(),
             SendPending { .. } => "EquityRedemptionEvent::SendPending".to_string(),
+            SendSubmitted { .. } => "EquityRedemptionEvent::SendSubmitted".to_string(),
             TokensUnwrapped { .. } => "EquityRedemptionEvent::TokensUnwrapped".to_string(),
             TransferFailed { .. } => "EquityRedemptionEvent::TransferFailed".to_string(),
             TokensSent { .. } => "EquityRedemptionEvent::TokensSent".to_string(),
@@ -917,13 +900,31 @@ pub(crate) enum EquityRedemption {
         unwrapped_amount: U256,
         /// Block in which the unwrap tx confirmed; `None` for pre-fix aggregates.
         ///
-        /// `None` disables the RPC node-sync wait in `SendTokens` for
-        /// backward-compatibility with in-flight aggregates that were
-        /// persisted before this field was added.
+        /// `None` disables the orchestrator's RPC node-sync wait before
+        /// sending, for backward-compatibility with in-flight aggregates that
+        /// were persisted before this field was added.
         #[serde(default)]
         unwrap_block: Option<u64>,
         withdrawn_at: DateTime<Utc>,
         unwrapped_at: DateTime<Utc>,
+    },
+
+    /// Token transfer to Alpaca's redemption wallet broadcast, awaiting the
+    /// bookkeeping finalization to `TokensSent`. Resume confirms the persisted
+    /// `redemption_tx` here without re-broadcasting the transfer.
+    SendSubmitted {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        quantity: Float,
+        token: Address,
+        raindex_withdraw_tx: TxHash,
+        unwrap_tx_hash: TxHash,
+        redemption_wallet: Address,
+        redemption_tx: TxHash,
+        submitted_at: DateTime<Utc>,
     },
 
     /// Tokens sent to Alpaca's redemption wallet
@@ -1032,6 +1033,7 @@ impl EquityRedemption {
             | Self::UnwrapSubmitted { quantity, .. }
             | Self::TokensUnwrapped { quantity, .. }
             | Self::SendPending { quantity, .. }
+            | Self::SendSubmitted { quantity, .. }
             | Self::TokensSent { quantity, .. }
             | Self::Pending { quantity, .. }
             | Self::Completed { quantity, .. }
@@ -1056,6 +1058,7 @@ impl EquityRedemption {
             | Self::UnwrapSubmitted { .. }
             | Self::TokensUnwrapped { .. }
             | Self::SendPending { .. }
+            | Self::SendSubmitted { .. }
             | Self::TokensSent { .. }
             | Self::Pending { .. } => false,
         }
@@ -1077,7 +1080,8 @@ impl EquityRedemption {
             | Self::UnwrapSubmitted { .. }
             | Self::TokensUnwrapped { .. }
             | Self::SendPending { .. } => true,
-            Self::TokensSent { .. }
+            Self::SendSubmitted { .. }
+            | Self::TokensSent { .. }
             | Self::Pending { .. }
             | Self::Completed { .. }
             | Self::Failed { .. }
@@ -1096,6 +1100,7 @@ impl EquityRedemption {
             | Self::UnwrapSubmitted { symbol, .. }
             | Self::TokensUnwrapped { symbol, .. }
             | Self::SendPending { symbol, .. }
+            | Self::SendSubmitted { symbol, .. }
             | Self::TokensSent { symbol, .. }
             | Self::Pending { symbol, .. }
             | Self::Completed { symbol, .. }
@@ -1188,6 +1193,20 @@ impl EquityRedemption {
                 status: EquityRedemptionStatus::Unwrapping,
                 started_at: *withdrawn_at,
                 updated_at: *unwrapped_at,
+            }),
+
+            Self::SendSubmitted {
+                symbol,
+                quantity,
+                submitted_at,
+                ..
+            } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
+                id: Id::new(id.to_string()),
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(*quantity),
+                status: EquityRedemptionStatus::Sending,
+                started_at: *submitted_at,
+                updated_at: *submitted_at,
             }),
 
             Self::TokensSent {
@@ -1283,7 +1302,7 @@ impl EventSourced for EquityRedemption {
     type Event = EquityRedemptionEvent;
     type Command = EquityRedemptionCommand;
     type Error = EquityRedemptionError;
-    type Services = EquityTransferServices;
+    type Services = ();
     type Materialized = Nil;
 
     const AGGREGATE_TYPE: &'static str = "EquityRedemption";
@@ -1622,6 +1641,31 @@ impl EventSourced for EquityRedemption {
                 _ => None,
             },
 
+            SendSubmitted {
+                redemption_wallet,
+                redemption_tx,
+                submitted_at,
+            } => match entity {
+                Self::SendPending {
+                    symbol,
+                    quantity,
+                    underlying_token,
+                    raindex_withdraw_tx,
+                    unwrap_tx_hash,
+                    ..
+                } => Some(Self::SendSubmitted {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    token: *underlying_token,
+                    raindex_withdraw_tx: *raindex_withdraw_tx,
+                    unwrap_tx_hash: *unwrap_tx_hash,
+                    redemption_wallet: *redemption_wallet,
+                    redemption_tx: *redemption_tx,
+                    submitted_at: *submitted_at,
+                }),
+                _ => None,
+            },
+
             TokensSent {
                 redemption_wallet,
                 redemption_tx,
@@ -1662,6 +1706,23 @@ impl EventSourced for EquityRedemption {
                     symbol: symbol.clone(),
                     quantity: *quantity,
                     token: *underlying_token,
+                    raindex_withdraw_tx: *raindex_withdraw_tx,
+                    unwrap_tx_hash: Some(*unwrap_tx_hash),
+                    redemption_wallet: *redemption_wallet,
+                    redemption_tx: *redemption_tx,
+                    sent_at: *sent_at,
+                }),
+                Self::SendSubmitted {
+                    symbol,
+                    quantity,
+                    token,
+                    raindex_withdraw_tx,
+                    unwrap_tx_hash,
+                    ..
+                } => Some(Self::TokensSent {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    token: *token,
                     raindex_withdraw_tx: *raindex_withdraw_tx,
                     unwrap_tx_hash: Some(*unwrap_tx_hash),
                     redemption_wallet: *redemption_wallet,
@@ -1868,13 +1929,15 @@ impl EventSourced for EquityRedemption {
                 wrapped_amount: amount,
                 pending_at,
             }]),
-            SubmitWithdraw
-            | SubmitUnwrap
+            SubmitWithdraw { .. }
+            | SubmitUnwrap { .. }
+            | SubmitSend { .. }
+            | ConfirmSend
             | PrepareSend
-            | ConfirmWithdraw
-            | ConfirmUnwrap
+            | ConfirmWithdraw { .. }
+            | ConfirmUnwrap { .. }
             | UnwrapTokens
-            | SendTokens
+            | RecordSendOutcome { .. }
             | Detect { .. }
             | FailDetection { .. }
             | Complete
@@ -1895,7 +1958,9 @@ impl EventSourced for EquityRedemption {
             #[cfg(any(test, feature = "test-support"))]
             UnwrapTokensAt { .. } => Err(EquityRedemptionError::NotStarted),
             #[cfg(any(test, feature = "test-support"))]
-            SendTokensAt { .. } => Err(EquityRedemptionError::NotStarted),
+            SubmitSendAt { .. } => Err(EquityRedemptionError::NotStarted),
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmSendAt { .. } => Err(EquityRedemptionError::NotStarted),
             #[cfg(any(test, feature = "test-support"))]
             DetectAt { .. } => Err(EquityRedemptionError::NotStarted),
             #[cfg(any(test, feature = "test-support"))]
@@ -1907,7 +1972,7 @@ impl EventSourced for EquityRedemption {
     async fn transition(
         &self,
         command: Self::Command,
-        services: &Self::Services,
+        _services: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use EquityRedemptionCommand::*;
         use EquityRedemptionEvent::*;
@@ -1926,45 +1991,119 @@ impl EventSourced for EquityRedemption {
                 _ => Err(EquityRedemptionError::AlreadyStarted),
             },
 
-            SubmitWithdraw => self.transition_submit_withdraw(services, None).await,
+            SubmitWithdraw { tx_hash } => self.transition_submit_withdraw(tx_hash, Utc::now()),
             #[cfg(any(test, feature = "test-support"))]
-            SubmitWithdrawAt { submitted_at } => {
-                self.transition_submit_withdraw(services, Some(submitted_at))
-                    .await
-            }
+            SubmitWithdrawAt {
+                tx_hash,
+                submitted_at,
+            } => self.transition_submit_withdraw(tx_hash, submitted_at),
 
-            ConfirmWithdraw => self.transition_confirm_withdraw(services, None).await,
+            ConfirmWithdraw {
+                actual_wrapped_amount,
+                raindex_withdraw_block,
+            } => self.transition_confirm_withdraw(
+                actual_wrapped_amount,
+                raindex_withdraw_block,
+                Utc::now(),
+            ),
             #[cfg(any(test, feature = "test-support"))]
-            ConfirmWithdrawAt { withdrawn_at } => {
-                self.transition_confirm_withdraw(services, Some(withdrawn_at))
-                    .await
-            }
+            ConfirmWithdrawAt {
+                actual_wrapped_amount,
+                raindex_withdraw_block,
+                withdrawn_at,
+            } => self.transition_confirm_withdraw(
+                actual_wrapped_amount,
+                raindex_withdraw_block,
+                withdrawn_at,
+            ),
 
             UnwrapTokens => self.transition_unwrap_tokens(Utc::now()),
             #[cfg(any(test, feature = "test-support"))]
             UnwrapTokensAt { pending_at } => self.transition_unwrap_tokens(pending_at),
 
-            SubmitUnwrap => self.transition_submit_unwrap(services, None).await,
-            #[cfg(any(test, feature = "test-support"))]
-            SubmitUnwrapAt { submitted_at } => {
-                self.transition_submit_unwrap(services, Some(submitted_at))
-                    .await
+            SubmitUnwrap { unwrap_tx_hash } => {
+                self.transition_submit_unwrap(unwrap_tx_hash, Utc::now())
             }
+            #[cfg(any(test, feature = "test-support"))]
+            SubmitUnwrapAt {
+                unwrap_tx_hash,
+                submitted_at,
+            } => self.transition_submit_unwrap(unwrap_tx_hash, submitted_at),
 
-            ConfirmUnwrap => self.transition_confirm_unwrap(services, None).await,
+            ConfirmUnwrap {
+                underlying_token,
+                unwrapped_amount,
+                unwrap_block,
+            } => self.transition_confirm_unwrap(
+                underlying_token,
+                unwrapped_amount,
+                unwrap_block,
+                Utc::now(),
+            ),
             #[cfg(any(test, feature = "test-support"))]
-            ConfirmUnwrapAt { unwrapped_at } => {
-                self.transition_confirm_unwrap(services, Some(unwrapped_at))
-                    .await
-            }
+            ConfirmUnwrapAt {
+                underlying_token,
+                unwrapped_amount,
+                unwrap_block,
+                unwrapped_at,
+            } => self.transition_confirm_unwrap(
+                underlying_token,
+                unwrapped_amount,
+                unwrap_block,
+                unwrapped_at,
+            ),
 
             PrepareSend => self.transition_prepare_send(Utc::now()),
             #[cfg(any(test, feature = "test-support"))]
             PrepareSendAt { pending_at } => self.transition_prepare_send(pending_at),
 
-            SendTokens => self.transition_send_tokens(services, None).await,
+            SubmitSend {
+                redemption_wallet,
+                redemption_tx,
+            } => self.transition_submit_send(redemption_wallet, redemption_tx, Utc::now()),
             #[cfg(any(test, feature = "test-support"))]
-            SendTokensAt { sent_at } => self.transition_send_tokens(services, Some(sent_at)).await,
+            SubmitSendAt {
+                redemption_wallet,
+                redemption_tx,
+                submitted_at,
+            } => self.transition_submit_send(redemption_wallet, redemption_tx, submitted_at),
+
+            ConfirmSend => self.transition_confirm_send(Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmSendAt { sent_at } => self.transition_confirm_send(sent_at),
+
+            RecordSendOutcome { outcome } => match self {
+                Self::SendPending { symbol, .. } => match outcome {
+                    SendOutcome::Sent {
+                        redemption_wallet,
+                        redemption_tx,
+                    } => Ok(vec![TokensSent {
+                        redemption_wallet,
+                        redemption_tx,
+                        sent_at: Utc::now(),
+                    }]),
+                    SendOutcome::WalletNotConfigured => {
+                        warn!(target: "rebalance", %symbol, "Redemption wallet not configured");
+                        Ok(vec![TransferFailed {
+                            tx_hash: None,
+                            reason: Some("redemption wallet not configured".to_string()),
+                            failed_at: Utc::now(),
+                        }])
+                    }
+                    SendOutcome::SendFailed => {
+                        warn!(target: "rebalance", %symbol, "Send for redemption failed");
+                        Ok(vec![TransferFailed {
+                            tx_hash: None,
+                            reason: Some("send for redemption failed".to_string()),
+                            failed_at: Utc::now(),
+                        }])
+                    }
+                },
+                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
+                _ => Err(EquityRedemptionError::TokensNotUnwrapped),
+            },
 
             Detect {
                 tokenization_request_id,
@@ -1993,7 +2132,8 @@ impl EventSourced for EquityRedemption {
                 | Self::UnwrapPending { .. }
                 | Self::UnwrapSubmitted { .. }
                 | Self::TokensUnwrapped { .. }
-                | Self::SendPending { .. } => Err(EquityRedemptionError::TokensNotSent),
+                | Self::SendPending { .. }
+                | Self::SendSubmitted { .. } => Err(EquityRedemptionError::TokensNotSent),
                 Self::Pending { .. } => Err(EquityRedemptionError::AlreadyDetected),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
                 Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
@@ -2012,6 +2152,7 @@ impl EventSourced for EquityRedemption {
                 | Self::UnwrapSubmitted { .. }
                 | Self::TokensUnwrapped { .. }
                 | Self::SendPending { .. }
+                | Self::SendSubmitted { .. }
                 | Self::TokensSent { .. } => Err(EquityRedemptionError::NotPendingForRejection),
                 Self::Pending { symbol, .. } => {
                     warn!(
@@ -2094,10 +2235,10 @@ impl EventSourced for EquityRedemption {
 
 impl EquityRedemption {
     /// Shared body for `SubmitWithdraw`/`SubmitWithdrawAt`.
-    async fn transition_submit_withdraw(
+    fn transition_submit_withdraw(
         &self,
-        services: &EquityTransferServices,
-        override_at: Option<DateTime<Utc>>,
+        tx_hash: TxHash,
+        submitted_at: DateTime<Utc>,
     ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
         use EquityRedemptionEvent::*;
 
@@ -2109,39 +2250,14 @@ impl EquityRedemption {
                 wrapped_amount,
                 ..
             } => {
-                let vault_id = match services.vault_lookup.vault_id_for_token(*token).await {
-                    Ok(id) => id,
-                    Err(error) => {
-                        warn!(target: "rebalance", %error, %token, "Vault lookup failed");
-                        return Err(EquityRedemptionError::RaindexVaultNotFound(*token));
-                    }
-                };
-
-                info!(target: "rebalance", ?vault_id, %token, %wrapped_amount, "Submitting Raindex vault withdrawal");
-
-                let tx_hash = match services
-                    .raindex
-                    .submit_withdraw(*token, vault_id, *wrapped_amount, TOKENIZED_EQUITY_DECIMALS)
-                    .await
-                {
-                    Ok(tx) => tx,
-                    Err(error) => {
-                        warn!(target: "rebalance", %error, %token, %wrapped_amount, "Raindex vault withdrawal submission failed");
-                        return Err(EquityRedemptionError::RaindexWithdrawFailed {
-                            token: *token,
-                            amount: *wrapped_amount,
-                            error_message: error.to_string(),
-                        });
-                    }
-                };
-
+                info!(target: "rebalance", %token, %wrapped_amount, %tx_hash, "Recording Raindex vault withdrawal submission");
                 Ok(vec![VaultWithdrawSubmitted {
                     symbol: symbol.clone(),
                     quantity: *quantity,
                     token: *token,
                     wrapped_amount: *wrapped_amount,
                     tx_hash,
-                    submitted_at: override_at.unwrap_or_else(Utc::now),
+                    submitted_at,
                 }])
             }
             Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
@@ -2152,14 +2268,18 @@ impl EquityRedemption {
     }
 
     /// Shared body for `ConfirmWithdraw`/`ConfirmWithdrawAt`.
-    async fn transition_confirm_withdraw(
+    fn transition_confirm_withdraw(
         &self,
-        services: &EquityTransferServices,
-        override_at: Option<DateTime<Utc>>,
+        actual_wrapped_amount: U256,
+        raindex_withdraw_block: u64,
+        withdrawn_at: DateTime<Utc>,
     ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
         use EquityRedemptionEvent::*;
 
         match self {
+            Self::VaultWithdrawSubmitted { tx_hash, .. } if actual_wrapped_amount.is_zero() => {
+                Err(EquityRedemptionError::ZeroWithdrawAmount { tx_hash: *tx_hash })
+            }
             Self::VaultWithdrawSubmitted {
                 symbol,
                 quantity,
@@ -2167,33 +2287,16 @@ impl EquityRedemption {
                 wrapped_amount,
                 tx_hash,
                 ..
-            } => {
-                let receipt = services
-                    .raindex
-                    .confirm_tx_receipt(*tx_hash)
-                    .await
-                    .map_err(|error| EquityRedemptionError::RaindexWithdrawFailed {
-                        token: *token,
-                        amount: *wrapped_amount,
-                        error_message: error.to_string(),
-                    })?;
-                let raindex_withdraw_block = receipt
-                    .block_number
-                    .ok_or(EquityRedemptionError::MissingWithdrawBlock { tx_hash: *tx_hash })?;
-                let recipient = services.wrapper.owner();
-                let actual_wrapped_amount =
-                    actual_withdrawn_amount_from_receipt(&receipt, *token, recipient)?;
-                Ok(vec![WithdrawnFromRaindex {
-                    symbol: symbol.clone(),
-                    quantity: *quantity,
-                    token: *token,
-                    wrapped_amount: *wrapped_amount,
-                    actual_wrapped_amount: Some(actual_wrapped_amount),
-                    raindex_withdraw_tx: *tx_hash,
-                    raindex_withdraw_block: Some(raindex_withdraw_block),
-                    withdrawn_at: override_at.unwrap_or_else(Utc::now),
-                }])
-            }
+            } => Ok(vec![WithdrawnFromRaindex {
+                symbol: symbol.clone(),
+                quantity: *quantity,
+                token: *token,
+                wrapped_amount: *wrapped_amount,
+                actual_wrapped_amount: Some(actual_wrapped_amount),
+                raindex_withdraw_tx: *tx_hash,
+                raindex_withdraw_block: Some(raindex_withdraw_block),
+                withdrawn_at,
+            }]),
             Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
             Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
             Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
@@ -2218,52 +2321,18 @@ impl EquityRedemption {
     }
 
     /// Shared body for `SubmitUnwrap`/`SubmitUnwrapAt`.
-    async fn transition_submit_unwrap(
+    fn transition_submit_unwrap(
         &self,
-        services: &EquityTransferServices,
-        override_at: Option<DateTime<Utc>>,
+        unwrap_tx_hash: TxHash,
+        submitted_at: DateTime<Utc>,
     ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
         use EquityRedemptionEvent::*;
 
         match self {
-            Self::UnwrapPending {
-                token,
-                wrapped_amount,
-                raindex_withdraw_block,
-                ..
-            } => {
-                // Wait for the RPC node to catch up to the block where the
-                // Raindex withdrawal tx confirmed before submitting the unwrap.
-                // Without this, a load-balanced backend that hasn't indexed
-                // the withdrawal may simulate the unwrap against a stale
-                // wrapped-token balance. `raindex_withdraw_block` is None for
-                // pre-fix aggregates; skip the wait for backward-compatibility.
-                if let Some(block) = raindex_withdraw_block {
-                    services
-                        .wrapper
-                        .wait_for_block(*block)
-                        .await
-                        .map_err(|error| node_sync_failed(*block, &error))?;
-                }
-                let owner = services.wrapper.owner();
-                let unwrap_tx_hash = services
-                    .wrapper
-                    .submit_unwrap(*token, *wrapped_amount, owner, owner)
-                    .await
-                    .inspect_err(|error| {
-                        warn!(target: "rebalance", %error, %token, "Token unwrap submission failed");
-                    })
-                    .map_err(|error| EquityRedemptionError::UnwrapFailed {
-                        token: *token,
-                        wrapped_amount: *wrapped_amount,
-                        error_message: error.to_string(),
-                    })?;
-
-                Ok(vec![UnwrapSubmitted {
-                    unwrap_tx_hash,
-                    submitted_at: override_at.unwrap_or_else(Utc::now),
-                }])
-            }
+            Self::UnwrapPending { .. } => Ok(vec![UnwrapSubmitted {
+                unwrap_tx_hash,
+                submitted_at,
+            }]),
             Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
             Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
             Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
@@ -2272,46 +2341,24 @@ impl EquityRedemption {
     }
 
     /// Shared body for `ConfirmUnwrap`/`ConfirmUnwrapAt`.
-    async fn transition_confirm_unwrap(
+    fn transition_confirm_unwrap(
         &self,
-        services: &EquityTransferServices,
-        override_at: Option<DateTime<Utc>>,
+        underlying_token: Address,
+        unwrapped_amount: U256,
+        unwrap_block: u64,
+        unwrapped_at: DateTime<Utc>,
     ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
         use EquityRedemptionEvent::*;
 
         match self {
-            Self::UnwrapSubmitted {
-                symbol,
-                token,
-                wrapped_amount,
-                unwrap_tx_hash,
-                ..
-            } => {
-                let underlying_token = services
-                    .wrapper
-                    .lookup_underlying(symbol)
-                    .inspect_err(|error| {
-                        warn!(target: "rebalance", %error, %symbol, "Underlying token lookup failed");
-                    })
-                    .map_err(|error| EquityRedemptionError::UnderlyingLookupFailed {
-                        symbol: symbol.clone(),
-                        error_message: error.to_string(),
-                    })?;
-
-                let unwrap_confirmation = services
-                    .wrapper
-                    .confirm_unwrap(*token, *unwrap_tx_hash)
-                    .await
-                    .inspect_err(|error| {
-                        warn!(target: "rebalance", %error, %token, "Token unwrap confirmation failed");
-                    })
-                    .map_err(|error| EquityRedemptionError::UnwrapFailed {
-                        token: *token,
-                        wrapped_amount: *wrapped_amount,
-                        error_message: error.to_string(),
-                    })?;
-                let unwrapped_amount = unwrap_confirmation.assets;
-                let unwrap_block = unwrap_confirmation.block;
+            Self::UnwrapSubmitted { unwrap_tx_hash, .. } if unwrapped_amount.is_zero() => {
+                Err(EquityRedemptionError::ZeroUnwrapAmount {
+                    tx_hash: *unwrap_tx_hash,
+                })
+            }
+            Self::UnwrapSubmitted { unwrap_tx_hash, .. } => {
+                // Financial precision validation stays at the aggregate
+                // boundary (fail-fast, no defaults).
                 let quantity =
                     Float::from_fixed_decimal(unwrapped_amount, TOKENIZED_EQUITY_DECIMALS)
                         .map_err(|error| {
@@ -2328,7 +2375,7 @@ impl EquityRedemption {
                     unwrap_tx_hash: *unwrap_tx_hash,
                     unwrapped_amount,
                     unwrap_block: Some(unwrap_block),
-                    unwrapped_at: override_at.unwrap_or_else(Utc::now),
+                    unwrapped_at,
                 }])
             }
             Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
@@ -2354,82 +2401,49 @@ impl EquityRedemption {
         }
     }
 
-    /// Shared body for `SendTokens`/`SendTokensAt`: only `sent_at` (the
-    /// success path's timestamp) is parameterized -- the `TransferFailed`
-    /// failure path keeps `Utc::now()` since fixture seeding only ever
-    /// drives the happy path.
-    async fn transition_send_tokens(
+    /// Shared body for `SubmitSend`/`SubmitSendAt`.
+    fn transition_submit_send(
         &self,
-        services: &EquityTransferServices,
-        override_at: Option<DateTime<Utc>>,
+        redemption_wallet: Address,
+        redemption_tx: TxHash,
+        submitted_at: DateTime<Utc>,
     ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
         use EquityRedemptionEvent::*;
 
         match self {
-            Self::SendPending {
-                symbol,
-                underlying_token,
-                unwrapped_amount,
-                unwrap_block,
-                ..
-            } => {
-                let token = *underlying_token;
-                let amount = *unwrapped_amount;
-
-                let Some(redemption_wallet) =
-                    Tokenizer::redemption_wallet(services.tokenizer.as_ref())
-                else {
-                    warn!(target: "rebalance", %symbol, "Redemption wallet not configured");
-                    return Ok(vec![TransferFailed {
-                        tx_hash: None,
-                        reason: None,
-                        failed_at: Utc::now(),
-                    }]);
-                };
-
-                // Wait for the RPC node to catch up to the block where the
-                // unwrap tx confirmed before sending the transfer. Without
-                // this, a load-balanced backend that hasn't indexed the
-                // unwrap block yet sees the wallet balance as zero and the
-                // send_for_redemption call reverts with
-                // ERC20InsufficientBalance. The wait runs on the tokenizer's
-                // provider -- the same one that performs the transfer -- so
-                // a caught-up wrapper provider can't mask a lagging
-                // tokenizer provider. `unwrap_block` is None for aggregates
-                // persisted before this field was added; in that case the
-                // wait is skipped for backward-compatibility.
-                if let Some(block) = unwrap_block {
-                    services
-                        .tokenizer
-                        .wait_for_block(*block)
-                        .await
-                        .map_err(|error| node_sync_failed_from_evm(*block, &error))?;
-                }
-
-                info!(target: "rebalance", %token, %amount, "Sending unwrapped tokens for redemption");
-
-                match Tokenizer::send_for_redemption(services.tokenizer.as_ref(), token, amount)
-                    .await
-                {
-                    Ok(redemption_tx) => Ok(vec![TokensSent {
-                        redemption_wallet,
-                        redemption_tx,
-                        sent_at: override_at.unwrap_or_else(Utc::now),
-                    }]),
-                    Err(error) => {
-                        warn!(target: "rebalance", %error, %token, %amount, "Send for redemption failed");
-                        Ok(vec![TransferFailed {
-                            tx_hash: None,
-                            reason: None,
-                            failed_at: Utc::now(),
-                        }])
-                    }
-                }
-            }
+            Self::SendPending { .. } => Ok(vec![SendSubmitted {
+                redemption_wallet,
+                redemption_tx,
+                submitted_at,
+            }]),
             Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
             Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
             Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
             _ => Err(EquityRedemptionError::TokensNotUnwrapped),
+        }
+    }
+
+    /// Shared body for `ConfirmSend`/`ConfirmSendAt`.
+    fn transition_confirm_send(
+        &self,
+        sent_at: DateTime<Utc>,
+    ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
+        use EquityRedemptionEvent::*;
+
+        match self {
+            Self::SendSubmitted {
+                redemption_wallet,
+                redemption_tx,
+                ..
+            } => Ok(vec![TokensSent {
+                redemption_wallet: *redemption_wallet,
+                redemption_tx: *redemption_tx,
+                sent_at,
+            }]),
+            Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+            Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
+            _ => Err(EquityRedemptionError::TokensNotSent),
         }
     }
 
@@ -2452,7 +2466,8 @@ impl EquityRedemption {
             | Self::UnwrapPending { .. }
             | Self::UnwrapSubmitted { .. }
             | Self::TokensUnwrapped { .. }
-            | Self::SendPending { .. } => Err(EquityRedemptionError::TokensNotSent),
+            | Self::SendPending { .. }
+            | Self::SendSubmitted { .. } => Err(EquityRedemptionError::TokensNotSent),
             Self::Pending { .. } => Err(EquityRedemptionError::AlreadyDetected),
             Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
             Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
@@ -2475,6 +2490,7 @@ impl EquityRedemption {
             | Self::UnwrapSubmitted { .. }
             | Self::TokensUnwrapped { .. }
             | Self::SendPending { .. }
+            | Self::SendSubmitted { .. }
             | Self::TokensSent { .. } => Err(EquityRedemptionError::NotPending),
             Self::Pending { .. } => Ok(vec![Completed { completed_at }]),
             Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
@@ -2806,135 +2822,14 @@ fn parse_requested_stuck_quantity(
     Ok(Some(FractionalShares::new(quantity)))
 }
 
-/// Constructs a [`EquityRedemptionError::NodeSyncFailed`] from a `required_block` and a
-/// [`WrapperError`] returned by `wait_for_block`.
-///
-/// Delegates attempt extraction to [`st0x_wrapper::node_sync_attempts`] so
-/// both the equity-redemption and orphan-recovery paths share the same
-/// extraction logic and stay in sync when new error variants are added.
-fn node_sync_failed(required_block: u64, error: &WrapperError) -> EquityRedemptionError {
-    EquityRedemptionError::NodeSyncFailed {
-        required_block,
-        attempts: st0x_wrapper::node_sync_attempts(error),
-    }
-}
-
-/// Constructs a [`EquityRedemptionError::NodeSyncFailed`] from a node-sync
-/// [`EvmError`] raised by [`Tokenizer::wait_for_block`].
-///
-/// Returns the recorded attempt count for `NodeBehindRequiredBlock`; every
-/// other variant signals the full polling budget was consumed without a
-/// recorded count, so it falls back to [`NODE_SYNC_MAX_ATTEMPTS`]. The match is
-/// non-exhaustive because `EvmError` has feature-gated variants that cannot be
-/// enumerated here.
-fn node_sync_failed_from_evm(required_block: u64, error: &EvmError) -> EquityRedemptionError {
-    let attempts = match error {
-        EvmError::NodeBehindRequiredBlock { attempts, .. } => *attempts,
-        _ => NODE_SYNC_MAX_ATTEMPTS,
-    };
-
-    EquityRedemptionError::NodeSyncFailed {
-        required_block,
-        attempts,
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use alloy::consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy::primitives::{B256, Bloom, Bytes, Log as PrimitiveLog, LogData};
-    use alloy::rpc::types::Log;
     use st0x_dto::EquityRedemptionStatus;
     use st0x_event_sorcery::{AggregateError, LifecycleError, TestHarness, TestStore, replay};
-    use st0x_evm::NODE_SYNC_MAX_ATTEMPTS;
     use st0x_float_macro::float;
-    use st0x_raindex::RaindexVaultId;
-    use st0x_tokenization::mock::MockTokenizer;
     use st0x_tokenization::tokenization_request_id;
-    use st0x_wrapper::MockWrapper;
 
     use super::*;
-    use crate::onchain::mock::{ConfirmTxBehavior, MockRaindex};
-    use crate::vault_lookup::MockVaultLookup;
-
-    fn mock_vault_lookup() -> MockVaultLookup {
-        MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO))
-    }
-
-    fn mock_services() -> EquityTransferServices {
-        EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        }
-    }
-
-    fn receipt_with_logs(logs: Vec<Log>) -> TransactionReceipt {
-        TransactionReceipt {
-            inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom {
-                receipt: Receipt {
-                    status: true.into(),
-                    cumulative_gas_used: 0,
-                    logs,
-                },
-                logs_bloom: Bloom::default(),
-            }),
-            transaction_hash: TxHash::random(),
-            transaction_index: Some(0),
-            block_hash: None,
-            block_number: Some(0),
-            gas_used: 21000,
-            effective_gas_price: 1,
-            blob_gas_used: None,
-            blob_gas_price: None,
-            from: Address::ZERO,
-            to: Some(Address::ZERO),
-            contract_address: None,
-        }
-    }
-
-    fn transfer_receipt_log(token: Address, recipient: Address, amount: U256) -> Log {
-        let event = IERC20::Transfer {
-            from: Address::ZERO,
-            to: recipient,
-            value: amount,
-        };
-        Log {
-            inner: PrimitiveLog {
-                address: token,
-                data: event.encode_log_data(),
-            },
-            transaction_hash: None,
-            transaction_index: None,
-            block_hash: None,
-            block_number: None,
-            block_timestamp: None,
-            log_index: None,
-            removed: false,
-        }
-    }
-
-    fn malformed_transfer_receipt_log(token: Address) -> Log {
-        Log {
-            inner: PrimitiveLog {
-                address: token,
-                data: LogData::new_unchecked(
-                    vec![IERC20::Transfer::SIGNATURE_HASH],
-                    Bytes::from_static(&[0x01]),
-                ),
-            },
-            transaction_hash: None,
-            transaction_index: None,
-            block_hash: None,
-            block_number: None,
-            block_timestamp: None,
-            log_index: None,
-            removed: false,
-        }
-    }
 
     fn vault_withdraw_pending_event() -> EquityRedemptionEvent {
         EquityRedemptionEvent::VaultWithdrawPending {
@@ -2959,6 +2854,12 @@ mod tests {
         }
     }
 
+    fn unwrap_pending_event() -> EquityRedemptionEvent {
+        EquityRedemptionEvent::UnwrapPending {
+            pending_at: Utc::now(),
+        }
+    }
+
     fn tokens_sent_event() -> EquityRedemptionEvent {
         EquityRedemptionEvent::TokensSent {
             redemption_wallet: Address::random(),
@@ -2978,19 +2879,6 @@ mod tests {
         }
     }
 
-    fn unwrap_pending_event() -> EquityRedemptionEvent {
-        EquityRedemptionEvent::UnwrapPending {
-            pending_at: Utc::now(),
-        }
-    }
-
-    fn unwrap_submitted_event() -> EquityRedemptionEvent {
-        EquityRedemptionEvent::UnwrapSubmitted {
-            unwrap_tx_hash: TxHash::random(),
-            submitted_at: Utc::now(),
-        }
-    }
-
     fn detected_event() -> EquityRedemptionEvent {
         EquityRedemptionEvent::Detected {
             tokenization_request_id: tokenization_request_id("REQ789"),
@@ -2998,9 +2886,24 @@ mod tests {
         }
     }
 
+    /// Event history for a redemption stranded in the terminal `Failed` state
+    /// (withdrawn, tokens sent to Alpaca, then detection timed out).
+    fn failed_redemption_history() -> Vec<EquityRedemptionEvent> {
+        vec![
+            withdrawn_from_raindex_event(),
+            tokens_sent_event(),
+            EquityRedemptionEvent::DetectionFailed {
+                failure: DetectionFailure::Operator {
+                    reason: "operator forced terminal".to_string(),
+                },
+                failed_at: Utc::now(),
+            },
+        ]
+    }
+
     #[tokio::test]
     async fn redeem_from_uninitialized_produces_vault_withdraw_pending() {
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given_no_previous_events()
             .when(EquityRedemptionCommand::Redeem {
                 symbol: Symbol::new("AAPL").unwrap(),
@@ -3020,7 +2923,7 @@ mod tests {
 
     #[tokio::test]
     async fn detect_after_tokens_sent_produces_detected() {
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
             .when(EquityRedemptionCommand::Detect {
                 tokenization_request_id: tokenization_request_id("REQ789"),
@@ -3034,7 +2937,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_from_pending_produces_completed() {
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_sent_event(),
@@ -3050,7 +2953,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_redemption_flow_end_to_end() {
-        let store = TestStore::<EquityRedemption>::new(mock_services());
+        let store = TestStore::<EquityRedemption>::new(());
         let id = redemption_aggregate_id("end-to-end");
 
         store
@@ -3067,12 +2970,23 @@ mod tests {
             .unwrap();
 
         store
-            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitWithdraw {
+                    tx_hash: TxHash::random(),
+                },
+            )
             .await
             .unwrap();
 
         store
-            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmWithdraw {
+                    actual_wrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
+                    raindex_withdraw_block: 100,
+                },
+            )
             .await
             .unwrap();
 
@@ -3082,12 +2996,24 @@ mod tests {
             .unwrap();
 
         store
-            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitUnwrap {
+                    unwrap_tx_hash: TxHash::random(),
+                },
+            )
             .await
             .unwrap();
 
         store
-            .send(&id, EquityRedemptionCommand::ConfirmUnwrap)
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmUnwrap {
+                    underlying_token: Address::random(),
+                    unwrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
+                    unwrap_block: 101,
+                },
+            )
             .await
             .unwrap();
 
@@ -3097,7 +3023,15 @@ mod tests {
             .unwrap();
 
         store
-            .send(&id, EquityRedemptionCommand::SendTokens)
+            .send(
+                &id,
+                EquityRedemptionCommand::RecordSendOutcome {
+                    outcome: SendOutcome::Sent {
+                        redemption_wallet: Address::random(),
+                        redemption_tx: TxHash::random(),
+                    },
+                },
+            )
             .await
             .unwrap();
 
@@ -3120,17 +3054,20 @@ mod tests {
         assert!(matches!(entity, EquityRedemption::Completed { .. }));
     }
 
-    /// Covers the fixture-only `*At` siblings of the async transitions that
-    /// take an explicit timestamp instead of `Utc::now()`: each must thread
-    /// the caller-supplied timestamp through to the emitted event's field
-    /// rather than silently falling back to the current time.
+    /// Covers the fixture-only `*At` siblings of the transitions that take an
+    /// explicit timestamp instead of `Utc::now()`: each must thread the
+    /// caller-supplied timestamp through to the emitted event's field rather
+    /// than silently falling back to the current time.
     #[tokio::test]
     async fn submit_withdraw_at_uses_supplied_timestamp() {
         let submitted_at = Utc::now() - chrono::Duration::hours(3);
 
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(vec![vault_withdraw_pending_event()])
-            .when(EquityRedemptionCommand::SubmitWithdrawAt { submitted_at })
+            .when(EquityRedemptionCommand::SubmitWithdrawAt {
+                tx_hash: TxHash::random(),
+                submitted_at,
+            })
             .await
             .events();
 
@@ -3148,8 +3085,9 @@ mod tests {
     #[tokio::test]
     async fn confirm_withdraw_at_uses_supplied_timestamp() {
         let withdrawn_at = Utc::now() - chrono::Duration::hours(2);
+        let amount = U256::from(50_250_000_000_000_000_000_u128);
 
-        let store = TestStore::<EquityRedemption>::new(mock_services());
+        let store = TestStore::<EquityRedemption>::new(());
         let id = redemption_aggregate_id("confirm-withdraw-at");
 
         store
@@ -3159,20 +3097,29 @@ mod tests {
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(50.25),
                     token: Address::random(),
-                    amount: U256::from(50_250_000_000_000_000_000_u128),
+                    amount,
                 },
             )
             .await
             .unwrap();
         store
-            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitWithdraw {
+                    tx_hash: TxHash::random(),
+                },
+            )
             .await
             .unwrap();
 
         store
             .send(
                 &id,
-                EquityRedemptionCommand::ConfirmWithdrawAt { withdrawn_at },
+                EquityRedemptionCommand::ConfirmWithdrawAt {
+                    actual_wrapped_amount: amount,
+                    raindex_withdraw_block: 100,
+                    withdrawn_at,
+                },
             )
             .await
             .unwrap();
@@ -3192,9 +3139,12 @@ mod tests {
     async fn submit_unwrap_at_uses_supplied_timestamp() {
         let submitted_at = Utc::now() - chrono::Duration::hours(1);
 
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(vec![withdrawn_from_raindex_event(), unwrap_pending_event()])
-            .when(EquityRedemptionCommand::SubmitUnwrapAt { submitted_at })
+            .when(EquityRedemptionCommand::SubmitUnwrapAt {
+                unwrap_tx_hash: TxHash::random(),
+                submitted_at,
+            })
             .await
             .events();
 
@@ -3212,8 +3162,9 @@ mod tests {
     #[tokio::test]
     async fn confirm_unwrap_at_uses_supplied_timestamp() {
         let unwrapped_at = Utc::now() - chrono::Duration::minutes(30);
+        let amount = U256::from(50_250_000_000_000_000_000_u128);
 
-        let store = TestStore::<EquityRedemption>::new(mock_services());
+        let store = TestStore::<EquityRedemption>::new(());
         let id = redemption_aggregate_id("confirm-unwrap-at");
 
         store
@@ -3223,17 +3174,28 @@ mod tests {
                     symbol: Symbol::new("AAPL").unwrap(),
                     quantity: float!(50.25),
                     token: Address::random(),
-                    amount: U256::from(50_250_000_000_000_000_000_u128),
+                    amount,
                 },
             )
             .await
             .unwrap();
         store
-            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitWithdraw {
+                    tx_hash: TxHash::random(),
+                },
+            )
             .await
             .unwrap();
         store
-            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmWithdraw {
+                    actual_wrapped_amount: amount,
+                    raindex_withdraw_block: 100,
+                },
+            )
             .await
             .unwrap();
         store
@@ -3241,14 +3203,24 @@ mod tests {
             .await
             .unwrap();
         store
-            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitUnwrap {
+                    unwrap_tx_hash: TxHash::random(),
+                },
+            )
             .await
             .unwrap();
 
         store
             .send(
                 &id,
-                EquityRedemptionCommand::ConfirmUnwrapAt { unwrapped_at },
+                EquityRedemptionCommand::ConfirmUnwrapAt {
+                    underlying_token: Address::random(),
+                    unwrapped_amount: amount,
+                    unwrap_block: 101,
+                    unwrapped_at,
+                },
             )
             .await
             .unwrap();
@@ -3265,10 +3237,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_tokens_at_uses_supplied_timestamp() {
-        let sent_at = Utc::now() - chrono::Duration::minutes(15);
+    async fn submit_send_at_uses_supplied_timestamp() {
+        let submitted_at = Utc::now() - chrono::Duration::minutes(20);
 
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_unwrapped_event(),
@@ -3276,7 +3248,43 @@ mod tests {
                     pending_at: Utc::now(),
                 },
             ])
-            .when(EquityRedemptionCommand::SendTokensAt { sent_at })
+            .when(EquityRedemptionCommand::SubmitSendAt {
+                redemption_wallet: Address::random(),
+                redemption_tx: TxHash::random(),
+                submitted_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let EquityRedemptionEvent::SendSubmitted {
+            submitted_at: event_submitted_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected SendSubmitted, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_submitted_at, submitted_at);
+    }
+
+    #[tokio::test]
+    async fn confirm_send_at_uses_supplied_timestamp() {
+        let sent_at = Utc::now() - chrono::Duration::minutes(15);
+
+        let events = TestHarness::<EquityRedemption>::with(())
+            .given(vec![
+                withdrawn_from_raindex_event(),
+                tokens_unwrapped_event(),
+                EquityRedemptionEvent::SendPending {
+                    pending_at: Utc::now(),
+                },
+                EquityRedemptionEvent::SendSubmitted {
+                    redemption_wallet: Address::random(),
+                    redemption_tx: TxHash::random(),
+                    submitted_at: Utc::now(),
+                },
+            ])
+            .when(EquityRedemptionCommand::ConfirmSendAt { sent_at })
             .await
             .events();
 
@@ -3295,7 +3303,7 @@ mod tests {
     async fn redeem_at_uses_supplied_timestamp() {
         let pending_at = Utc::now() - chrono::Duration::hours(4);
 
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given_no_previous_events()
             .when(EquityRedemptionCommand::RedeemAt {
                 symbol: Symbol::new("AAPL").unwrap(),
@@ -3322,7 +3330,7 @@ mod tests {
     async fn unwrap_tokens_at_uses_supplied_timestamp() {
         let pending_at = Utc::now() - chrono::Duration::hours(3);
 
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(vec![withdrawn_from_raindex_event()])
             .when(EquityRedemptionCommand::UnwrapTokensAt { pending_at })
             .await
@@ -3342,7 +3350,7 @@ mod tests {
     async fn prepare_send_at_uses_supplied_timestamp() {
         let pending_at = Utc::now() - chrono::Duration::hours(2);
 
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_unwrapped_event(),
@@ -3365,7 +3373,7 @@ mod tests {
     async fn detect_at_uses_supplied_timestamp() {
         let detected_at = Utc::now() - chrono::Duration::hours(1);
 
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
             .when(EquityRedemptionCommand::DetectAt {
                 tokenization_request_id: tokenization_request_id("REQ789"),
@@ -3389,7 +3397,7 @@ mod tests {
     async fn complete_at_uses_supplied_timestamp() {
         let completed_at = Utc::now() - chrono::Duration::minutes(45);
 
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_sent_event(),
@@ -3409,19 +3417,13 @@ mod tests {
         assert_eq!(*event_completed_at, completed_at);
     }
 
+    /// The recorded `TokensSent` state must carry the underlying token (carried
+    /// by `ConfirmUnwrap`), not the wrapped token the redemption started with.
     #[tokio::test]
-    async fn send_tokens_uses_underlying_token_not_wrapped_token() {
+    async fn send_records_underlying_token_not_wrapped_token() {
         let wrapped_token = Address::random();
         let underlying_token = Address::random();
-
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new().with_tokenized_shares(underlying_token)),
-        };
-
-        let store = TestStore::<EquityRedemption>::new(services);
+        let store = TestStore::<EquityRedemption>::new(());
         let id = redemption_aggregate_id("underlying-token-fix");
 
         store
@@ -3438,12 +3440,23 @@ mod tests {
             .unwrap();
 
         store
-            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitWithdraw {
+                    tx_hash: TxHash::random(),
+                },
+            )
             .await
             .unwrap();
 
         store
-            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmWithdraw {
+                    actual_wrapped_amount: U256::from(10_000_000_000_000_000_000_u128),
+                    raindex_withdraw_block: 100,
+                },
+            )
             .await
             .unwrap();
 
@@ -3453,12 +3466,24 @@ mod tests {
             .unwrap();
 
         store
-            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitUnwrap {
+                    unwrap_tx_hash: TxHash::random(),
+                },
+            )
             .await
             .unwrap();
 
         store
-            .send(&id, EquityRedemptionCommand::ConfirmUnwrap)
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmUnwrap {
+                    underlying_token,
+                    unwrapped_amount: U256::from(10_000_000_000_000_000_000_u128),
+                    unwrap_block: 101,
+                },
+            )
             .await
             .unwrap();
 
@@ -3468,7 +3493,15 @@ mod tests {
             .unwrap();
 
         store
-            .send(&id, EquityRedemptionCommand::SendTokens)
+            .send(
+                &id,
+                EquityRedemptionCommand::RecordSendOutcome {
+                    outcome: SendOutcome::Sent {
+                        redemption_wallet: Address::random(),
+                        redemption_tx: TxHash::random(),
+                    },
+                },
+            )
             .await
             .unwrap();
 
@@ -3479,22 +3512,20 @@ mod tests {
 
         assert_eq!(
             token, underlying_token,
-            "SendTokens should use the underlying token, not the wrapped token"
+            "Recorded send should use the underlying token, not the wrapped token"
         );
     }
 
+    /// The `WithdrawnFromRaindex` event preserves both the requested
+    /// `wrapped_amount` and the receipt's `actual_wrapped_amount` for replay
+    /// fidelity, but the resulting state collapses to the actual amount so the
+    /// downstream unwrap operates on what was really withdrawn (receipt
+    /// decoding itself is covered by `step.rs`).
     #[tokio::test]
-    async fn confirm_withdraw_records_actual_transfer_amount_from_receipt() {
-        let requested_amount = U256::from(37_143_292_455_000_000_000_u128);
-        let actual_amount = U256::from(33_681_456_848_531_939_569_u128);
-
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new().with_withdraw_actual_amount(actual_amount)),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
-        let store = TestStore::<EquityRedemption>::new(services);
+    async fn confirm_withdraw_collapses_state_amount_to_actual_receipt_amount() {
+        let requested = U256::from(37_143_292_455_000_000_000_u128);
+        let actual = U256::from(33_681_456_848_531_939_569_u128);
+        let store = TestStore::<EquityRedemption>::new(());
         let id = redemption_aggregate_id("partial-withdraw");
 
         store
@@ -3504,19 +3535,30 @@ mod tests {
                     symbol: Symbol::new("COIN").unwrap(),
                     quantity: float!(37.143292455),
                     token: Address::random(),
-                    amount: requested_amount,
+                    amount: requested,
                 },
             )
             .await
             .unwrap();
 
         store
-            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitWithdraw {
+                    tx_hash: TxHash::random(),
+                },
+            )
             .await
             .unwrap();
 
         store
-            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmWithdraw {
+                    actual_wrapped_amount: actual,
+                    raindex_withdraw_block: 100,
+                },
+            )
             .await
             .unwrap();
 
@@ -3526,44 +3568,94 @@ mod tests {
         };
 
         assert_eq!(
-            wrapped_amount, actual_amount,
-            "Confirmed withdrawal should carry actual receipt transfer amount"
+            wrapped_amount, actual,
+            "Confirmed-withdrawal state should carry the actual receipt transfer amount"
         );
     }
 
     #[tokio::test]
-    async fn unwrap_uses_actual_withdrawn_amount_after_partial_withdraw() {
-        let requested_amount = U256::from(37_143_292_455_000_000_000_u128);
-        let actual_amount = U256::from(33_681_456_848_531_939_569_u128);
-
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new().with_withdraw_actual_amount(actual_amount)),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
-        let store = TestStore::<EquityRedemption>::new(services);
-        let id = redemption_aggregate_id("unwrap-partial-withdraw");
+    async fn confirm_withdraw_rejects_zero_actual_amount() {
+        let store = TestStore::<EquityRedemption>::new(());
+        let id = redemption_aggregate_id("zero-withdraw");
 
         store
             .send(
                 &id,
                 EquityRedemptionCommand::Redeem {
                     symbol: Symbol::new("COIN").unwrap(),
-                    quantity: float!(37.143292455),
+                    quantity: float!(10),
                     token: Address::random(),
-                    amount: requested_amount,
+                    amount: U256::from(10_000_000_000_000_000_000_u128),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitWithdraw {
+                    tx_hash: TxHash::random(),
                 },
             )
             .await
             .unwrap();
 
+        let err = store
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmWithdraw {
+                    actual_wrapped_amount: U256::ZERO,
+                    raindex_withdraw_block: 100,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    EquityRedemptionError::ZeroWithdrawAmount { .. }
+                ))
+            ),
+            "a zero actual withdrawn amount must be rejected, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_unwrap_rejects_zero_amount() {
+        let store = TestStore::<EquityRedemption>::new(());
+        let id = redemption_aggregate_id("zero-unwrap");
+
         store
-            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .send(
+                &id,
+                EquityRedemptionCommand::Redeem {
+                    symbol: Symbol::new("COIN").unwrap(),
+                    quantity: float!(10),
+                    token: Address::random(),
+                    amount: U256::from(10_000_000_000_000_000_000_u128),
+                },
+            )
             .await
             .unwrap();
         store
-            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitWithdraw {
+                    tx_hash: TxHash::random(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmWithdraw {
+                    actual_wrapped_amount: U256::from(10_000_000_000_000_000_000_u128),
+                    raindex_withdraw_block: 100,
+                },
+            )
             .await
             .unwrap();
         store
@@ -3571,170 +3663,41 @@ mod tests {
             .await
             .unwrap();
         store
-            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
-            .await
-            .unwrap();
-        store
-            .send(&id, EquityRedemptionCommand::ConfirmUnwrap)
-            .await
-            .unwrap();
-
-        let entity = store.load(&id).await.unwrap().unwrap();
-        let EquityRedemption::TokensUnwrapped {
-            unwrapped_amount, ..
-        } = entity
-        else {
-            panic!("Expected TokensUnwrapped state, got: {entity:?}");
-        };
-
-        assert_eq!(
-            unwrapped_amount, actual_amount,
-            "Unwrap confirmation should reflect the actual withdrawn amount"
-        );
-    }
-
-    #[tokio::test]
-    async fn confirm_withdraw_fails_without_matching_receipt_transfer() {
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new().with_withdraw_actual_amount(U256::ZERO)),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
-        let store = TestStore::<EquityRedemption>::new(services);
-        let id = redemption_aggregate_id("missing-withdraw-transfer");
-
-        store
             .send(
                 &id,
-                EquityRedemptionCommand::Redeem {
-                    symbol: Symbol::new("COIN").unwrap(),
-                    quantity: float!(10),
-                    token: Address::random(),
-                    amount: U256::from(10_000_000_000_000_000_000_u128),
+                EquityRedemptionCommand::SubmitUnwrap {
+                    unwrap_tx_hash: TxHash::random(),
                 },
             )
             .await
             .unwrap();
 
-        store
-            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
-            .await
-            .unwrap();
-
-        let error = store
-            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
-            .await
-            .unwrap_err();
-
-        assert!(
-            matches!(
-                error,
-                AggregateError::UserError(LifecycleError::Apply(
-                    EquityRedemptionError::RaindexWithdrawTransferNotFound { .. }
-                ))
-            ),
-            "Expected missing transfer error, got: {error:?}"
-        );
-    }
-
-    /// Verifies that `ConfirmWithdraw` returns `MissingWithdrawBlock` when the
-    /// Raindex receipt does not carry a block number.
-    ///
-    /// A fresh receipt with `block_number: None` (e.g. from a load-balanced RPC
-    /// returning a pending receipt) must fail hard; silently storing `None`
-    /// would bypass the `SubmitUnwrap` node-sync guard, re-introducing the
-    /// stale-RPC regression this PR was created to prevent.
-    #[tokio::test]
-    async fn confirm_withdraw_fails_when_receipt_has_no_block_number() {
-        let services = EquityTransferServices {
-            raindex: Arc::new(
-                MockRaindex::new()
-                    .with_confirm_behavior(ConfirmTxBehavior::SucceedWithoutBlockNumber),
-            ),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
-        let store = TestStore::<EquityRedemption>::new(services);
-        let id = redemption_aggregate_id("no-block-number");
-
-        store
+        let err = store
             .send(
                 &id,
-                EquityRedemptionCommand::Redeem {
-                    symbol: Symbol::new("COIN").unwrap(),
-                    quantity: float!(10),
-                    token: Address::random(),
-                    amount: U256::from(10_000_000_000_000_000_000_u128),
+                EquityRedemptionCommand::ConfirmUnwrap {
+                    underlying_token: Address::random(),
+                    unwrapped_amount: U256::ZERO,
+                    unwrap_block: 101,
                 },
             )
             .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
-            .await
-            .unwrap();
-
-        let error = store
-            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
-            .await
             .unwrap_err();
 
         assert!(
             matches!(
-                error,
+                err,
                 AggregateError::UserError(LifecycleError::Apply(
-                    EquityRedemptionError::MissingWithdrawBlock { .. }
+                    EquityRedemptionError::ZeroUnwrapAmount { .. }
                 ))
             ),
-            "Expected MissingWithdrawBlock when receipt has no block number, got: {error:?}"
-        );
-    }
-
-    #[test]
-    fn actual_withdrawn_amount_sums_only_matching_receipt_transfers() {
-        let token = Address::repeat_byte(0x11);
-        let other_token = Address::repeat_byte(0x22);
-        let recipient = Address::repeat_byte(0x33);
-        let other_recipient = Address::repeat_byte(0x44);
-        let receipt = receipt_with_logs(vec![
-            transfer_receipt_log(other_token, recipient, U256::from(100)),
-            transfer_receipt_log(token, other_recipient, U256::from(200)),
-            transfer_receipt_log(token, recipient, U256::from(30)),
-            transfer_receipt_log(token, recipient, U256::from(12)),
-        ]);
-
-        let amount = actual_withdrawn_amount_from_receipt(&receipt, token, recipient).unwrap();
-
-        assert_eq!(
-            amount,
-            U256::from(42),
-            "Only matching token and recipient transfer values should be summed"
-        );
-    }
-
-    #[test]
-    fn actual_withdrawn_amount_errors_on_malformed_matching_transfer_log() {
-        let token = Address::repeat_byte(0x11);
-        let recipient = Address::repeat_byte(0x33);
-        let receipt = receipt_with_logs(vec![malformed_transfer_receipt_log(token)]);
-
-        let error = actual_withdrawn_amount_from_receipt(&receipt, token, recipient).unwrap_err();
-
-        assert!(
-            matches!(
-                error,
-                EquityRedemptionError::RaindexWithdrawTransferDecodeFailed { .. }
-            ),
-            "Expected decode failure, got: {error:?}"
+            "a zero unwrapped amount must be rejected, got: {err:?}"
         );
     }
 
     #[tokio::test]
     async fn cannot_detect_before_sending_tokens() {
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given_no_previous_events()
             .when(EquityRedemptionCommand::Detect {
                 tokenization_request_id: tokenization_request_id("REQ789"),
@@ -3750,7 +3713,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_complete_before_pending() {
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given_no_previous_events()
             .when(EquityRedemptionCommand::Complete)
             .await
@@ -3766,7 +3729,7 @@ mod tests {
     async fn fail_detection_from_tokens_sent_state() {
         let history = vec![withdrawn_from_raindex_event(), tokens_sent_event()];
 
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(history.clone())
             .when(EquityRedemptionCommand::FailDetection {
                 failure: DetectionFailure::Timeout,
@@ -3832,7 +3795,7 @@ mod tests {
         // the replayed `Failed` state.
         let history = vec![withdrawn_from_raindex_event(), tokens_sent_event()];
 
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(history.clone())
             .when(EquityRedemptionCommand::FailDetection {
                 failure: DetectionFailure::Operator {
@@ -3874,7 +3837,7 @@ mod tests {
             detected_event(),
         ];
 
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(history.clone())
             .when(EquityRedemptionCommand::RejectRedemption {
                 reason: "test rejection".to_string(),
@@ -3903,7 +3866,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_reject_redemption_before_pending() {
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
             .when(EquityRedemptionCommand::RejectRedemption {
                 reason: "test rejection".to_string(),
@@ -3972,7 +3935,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_fail_detection_before_sending() {
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given_no_previous_events()
             .when(EquityRedemptionCommand::FailDetection {
                 failure: DetectionFailure::Timeout,
@@ -3988,7 +3951,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_reject_redemption_before_sending() {
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given_no_previous_events()
             .when(EquityRedemptionCommand::RejectRedemption {
                 reason: "test rejection".to_string(),
@@ -4120,198 +4083,58 @@ mod tests {
         assert!(result.is_none());
     }
 
+    /// A `SendFailed` outcome (the orchestrator's mapping of a send revert)
+    /// records `TransferFailed`. The orchestrator's error-to-outcome mapping is
+    /// covered separately in `rebalancing::equity`'s `send_to_alpaca` tests.
     #[tokio::test]
-    async fn send_tokens_with_failure_emits_transfer_failed() {
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new().with_send_failure()),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
-
-        let store = TestStore::<EquityRedemption>::new(services);
-        let id = redemption_aggregate_id("send-fail");
-
-        store
-            .send(
-                &id,
-                EquityRedemptionCommand::Redeem {
-                    symbol: Symbol::new("AAPL").unwrap(),
-                    quantity: float!(50.25),
-                    token: Address::random(),
-                    amount: U256::from(50_250_000_000_000_000_000_u128),
-                },
-            )
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::UnwrapTokens)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::ConfirmUnwrap)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::PrepareSend)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::SendTokens)
-            .await
-            .unwrap();
-
-        let entity = store.load(&id).await.unwrap().unwrap();
-        assert!(
-            matches!(entity, EquityRedemption::Failed { .. }),
-            "Expected Failed state after send failure, got: {entity:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn send_tokens_without_redemption_wallet_emits_transfer_failed() {
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new().with_no_redemption_wallet()),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
-
-        let store = TestStore::<EquityRedemption>::new(services);
-        let id = redemption_aggregate_id("no-wallet");
-
-        store
-            .send(
-                &id,
-                EquityRedemptionCommand::Redeem {
-                    symbol: Symbol::new("AAPL").unwrap(),
-                    quantity: float!(50.25),
-                    token: Address::random(),
-                    amount: U256::from(50_250_000_000_000_000_000_u128),
-                },
-            )
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::UnwrapTokens)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::ConfirmUnwrap)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::PrepareSend)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::SendTokens)
-            .await
-            .unwrap();
-
-        let entity = store.load(&id).await.unwrap().unwrap();
-        assert!(
-            matches!(entity, EquityRedemption::Failed { .. }),
-            "Expected Failed state when redemption wallet is None, got: {entity:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn unwrap_failure_returns_unwrap_failed_error() {
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::failing_unwrap()),
-        };
-
-        // UnwrapTokens is now pure (emits UnwrapPending).
-        // SubmitUnwrap performs the actual service call and should fail.
-        let error = TestHarness::<EquityRedemption>::with(services)
-            .given(vec![withdrawn_from_raindex_event(), unwrap_pending_event()])
-            .when(EquityRedemptionCommand::SubmitUnwrap)
-            .await
-            .then_expect_error();
-
-        assert!(
-            matches!(
-                error,
-                LifecycleError::Apply(EquityRedemptionError::UnwrapFailed { .. })
-            ),
-            "Expected UnwrapFailed error, got: {error:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn underlying_lookup_failure_returns_underlying_lookup_failed_error() {
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::failing_lookup()),
-        };
-
-        // UnwrapTokens now emits UnwrapSubmitted (no lookup yet).
-        // The lookup happens during ConfirmUnwrap.
-        let error = TestHarness::<EquityRedemption>::with(services)
+    async fn record_send_failed_outcome_records_provider_failure_reason() {
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(vec![
                 withdrawn_from_raindex_event(),
-                unwrap_submitted_event(),
+                tokens_unwrapped_event(),
+                EquityRedemptionEvent::SendPending {
+                    pending_at: Utc::now(),
+                },
             ])
-            .when(EquityRedemptionCommand::ConfirmUnwrap)
+            .when(EquityRedemptionCommand::RecordSendOutcome {
+                outcome: SendOutcome::SendFailed,
+            })
             .await
-            .then_expect_error();
+            .events();
 
-        assert!(
-            matches!(
-                error,
-                LifecycleError::Apply(EquityRedemptionError::UnderlyingLookupFailed { .. })
-            ),
-            "Expected UnderlyingLookupFailed error, got: {error:?}"
-        );
+        let [EquityRedemptionEvent::TransferFailed { reason, .. }] = events.as_slice() else {
+            panic!("expected TransferFailed, got {events:?}");
+        };
+        assert_eq!(reason.as_deref(), Some("send for redemption failed"));
+    }
+
+    /// A `WalletNotConfigured` outcome (no redemption wallet) records
+    /// `TransferFailed`.
+    #[tokio::test]
+    async fn record_wallet_not_configured_outcome_records_configuration_reason() {
+        let events = TestHarness::<EquityRedemption>::with(())
+            .given(vec![
+                withdrawn_from_raindex_event(),
+                tokens_unwrapped_event(),
+                EquityRedemptionEvent::SendPending {
+                    pending_at: Utc::now(),
+                },
+            ])
+            .when(EquityRedemptionCommand::RecordSendOutcome {
+                outcome: SendOutcome::WalletNotConfigured,
+            })
+            .await
+            .events();
+
+        let [EquityRedemptionEvent::TransferFailed { reason, .. }] = events.as_slice() else {
+            panic!("expected TransferFailed, got {events:?}");
+        };
+        assert_eq!(reason.as_deref(), Some("redemption wallet not configured"));
     }
 
     #[tokio::test]
     async fn redeem_when_already_started_returns_already_started() {
-        let store = TestStore::<EquityRedemption>::new(mock_services());
+        let store = TestStore::<EquityRedemption>::new(());
         let id = redemption_aggregate_id("redemption-1");
 
         store
@@ -4348,83 +4171,24 @@ mod tests {
 
     #[tokio::test]
     async fn redeem_when_pending_returns_already_started() {
-        let store = TestStore::<EquityRedemption>::new(mock_services());
-        let id = redemption_aggregate_id("redemption-1");
-
-        store
-            .send(
-                &id,
-                EquityRedemptionCommand::Redeem {
-                    symbol: Symbol::new("AAPL").unwrap(),
-                    quantity: float!(10),
-                    token: Address::random(),
-                    amount: U256::from(10_000_000_000_000_000_000_u128),
-                },
-            )
+        let error = TestHarness::<EquityRedemption>::with(())
+            .given(vec![
+                withdrawn_from_raindex_event(),
+                tokens_sent_event(),
+                detected_event(),
+            ])
+            .when(EquityRedemptionCommand::Redeem {
+                symbol: Symbol::new("AAPL").unwrap(),
+                quantity: float!(10),
+                token: Address::random(),
+                amount: U256::from(10_000_000_000_000_000_000_u128),
+            })
             .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::UnwrapTokens)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::ConfirmUnwrap)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::PrepareSend)
-            .await
-            .unwrap();
-
-        store
-            .send(&id, EquityRedemptionCommand::SendTokens)
-            .await
-            .unwrap();
-
-        store
-            .send(
-                &id,
-                EquityRedemptionCommand::Detect {
-                    tokenization_request_id: tokenization_request_id("REQ123"),
-                },
-            )
-            .await
-            .unwrap();
-
-        let err = store
-            .send(
-                &id,
-                EquityRedemptionCommand::Redeem {
-                    symbol: Symbol::new("AAPL").unwrap(),
-                    quantity: float!(10),
-                    token: Address::random(),
-                    amount: U256::from(10_000_000_000_000_000_000_u128),
-                },
-            )
-            .await
-            .unwrap_err();
+            .then_expect_error();
 
         assert!(matches!(
-            err,
-            AggregateError::UserError(LifecycleError::Apply(EquityRedemptionError::AlreadyStarted))
+            error,
+            LifecycleError::Apply(EquityRedemptionError::AlreadyStarted)
         ));
     }
 
@@ -5199,7 +4963,7 @@ mod tests {
 
     #[tokio::test]
     async fn recover_provider_completion_rejected_for_active_redemption() {
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given(vec![withdrawn_from_raindex_event()])
             .when(EquityRedemptionCommand::RecoverProviderCompletion {
                 tokenization_request_id: tokenization_request_id("TOK001"),
@@ -5218,7 +4982,7 @@ mod tests {
 
     #[tokio::test]
     async fn recover_provider_completion_rejected_for_completed_redemption() {
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_sent_event(),
@@ -5250,7 +5014,7 @@ mod tests {
             reconciled_at: Utc::now(),
         });
 
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given(history)
             .when(EquityRedemptionCommand::RecoverProviderCompletion {
                 tokenization_request_id: tokenization_request_id("TOK001"),
@@ -5269,7 +5033,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_transfer_from_withdrawn_transitions_to_failed() {
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(vec![withdrawn_from_raindex_event()])
             .when(EquityRedemptionCommand::FailTransfer {
                 reason: "Transfer timed out".to_string(),
@@ -5286,7 +5050,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_transfer_from_unwrapped_transitions_to_failed() {
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_unwrapped_event(),
@@ -5306,7 +5070,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_transfer_rejected_from_tokens_sent() {
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
             .when(EquityRedemptionCommand::FailTransfer {
                 reason: "should not work".to_string(),
@@ -5322,7 +5086,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_transfer_rejected_before_start() {
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given_no_previous_events()
             .when(EquityRedemptionCommand::FailTransfer {
                 reason: "should not work".to_string(),
@@ -5336,320 +5100,11 @@ mod tests {
         ));
     }
 
-    /// Verifies that `SendTokens` calls `wait_for_block` with the unwrap
-    /// block number before submitting the transfer, ensuring the RPC node
-    /// has indexed the unwrap tx's effects before the send is attempted.
-    #[tokio::test]
-    async fn send_tokens_waits_for_block_before_sending() {
-        let unwrap_block = 1234u64;
-        let mock_tokenizer = Arc::new(MockTokenizer::new());
-
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: mock_tokenizer.clone(),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
-
-        let events = TestHarness::<EquityRedemption>::with(services)
-            .given(vec![
-                withdrawn_from_raindex_event(),
-                EquityRedemptionEvent::TokensUnwrapped {
-                    quantity: Some(float!(1.0)),
-                    underlying_token: Address::ZERO,
-                    unwrap_tx_hash: TxHash::random(),
-                    unwrapped_amount: U256::from(1_000_000_000_000_000_000_u64),
-                    unwrap_block: Some(unwrap_block),
-                    unwrapped_at: Utc::now(),
-                },
-                EquityRedemptionEvent::SendPending {
-                    pending_at: Utc::now(),
-                },
-            ])
-            .when(EquityRedemptionCommand::SendTokens)
-            .await
-            .events();
-
-        assert_eq!(
-            events.len(),
-            1,
-            "expected exactly one event from SendTokens"
-        );
-        assert!(
-            matches!(events[0], EquityRedemptionEvent::TokensSent { .. }),
-            "expected TokensSent, got {:?}",
-            events[0]
-        );
-
-        let calls = mock_tokenizer.wait_for_block_calls();
-
-        assert_eq!(
-            calls,
-            vec![unwrap_block],
-            "wait_for_block must be called once with the unwrap block number"
-        );
-    }
-
-    /// Verifies the backward-compat path: when `unwrap_block` is `None`
-    /// (aggregates persisted before this field was added), `SendTokens`
-    /// skips `wait_for_block` entirely and proceeds to `send_for_redemption`.
-    #[tokio::test]
-    async fn send_tokens_skips_wait_for_block_when_unwrap_block_is_none() {
-        let mock_tokenizer = Arc::new(MockTokenizer::new());
-
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: mock_tokenizer.clone(),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
-
-        let events = TestHarness::<EquityRedemption>::with(services)
-            .given(vec![
-                withdrawn_from_raindex_event(),
-                EquityRedemptionEvent::TokensUnwrapped {
-                    quantity: Some(float!(1.0)),
-                    underlying_token: Address::ZERO,
-                    unwrap_tx_hash: TxHash::random(),
-                    unwrapped_amount: U256::from(1_000_000_000_000_000_000_u64),
-                    unwrap_block: None,
-                    unwrapped_at: Utc::now(),
-                },
-                EquityRedemptionEvent::SendPending {
-                    pending_at: Utc::now(),
-                },
-            ])
-            .when(EquityRedemptionCommand::SendTokens)
-            .await
-            .events();
-
-        assert_eq!(
-            events.len(),
-            1,
-            "expected exactly one event from SendTokens"
-        );
-        assert!(
-            matches!(events[0], EquityRedemptionEvent::TokensSent { .. }),
-            "expected TokensSent to succeed without wait_for_block, got {:?}",
-            events[0]
-        );
-
-        let calls = mock_tokenizer.wait_for_block_calls();
-
-        assert_eq!(
-            calls,
-            Vec::<u64>::new(),
-            "wait_for_block must NOT be called when unwrap_block is None, got calls: {calls:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn send_tokens_fails_with_node_sync_failed_when_wait_for_block_fails() {
-        let required_block = 42u64;
-
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new().failing_wait_for_block()),
-            wrapper: Arc::new(MockWrapper::new()),
-        };
-
-        let error = TestHarness::<EquityRedemption>::with(services)
-            .given(vec![
-                withdrawn_from_raindex_event(),
-                EquityRedemptionEvent::TokensUnwrapped {
-                    quantity: Some(float!(1.0)),
-                    underlying_token: Address::ZERO,
-                    unwrap_tx_hash: TxHash::random(),
-                    unwrapped_amount: U256::from(1_000_000_000_000_000_000_u64),
-                    unwrap_block: Some(required_block),
-                    unwrapped_at: Utc::now(),
-                },
-                EquityRedemptionEvent::SendPending {
-                    pending_at: Utc::now(),
-                },
-            ])
-            .when(EquityRedemptionCommand::SendTokens)
-            .await
-            .then_expect_error();
-
-        assert!(
-            matches!(
-                error,
-                LifecycleError::Apply(EquityRedemptionError::NodeSyncFailed {
-                    required_block: 42,
-                    attempts: NODE_SYNC_MAX_ATTEMPTS,
-                })
-            ),
-            "expected NodeSyncFailed {{ required_block: 42, attempts: {NODE_SYNC_MAX_ATTEMPTS} }}, got: {error:?}",
-        );
-    }
-
-    /// Verifies SubmitUnwrap waits for the Raindex withdrawal block before submitting.
-    #[tokio::test]
-    async fn submit_unwrap_waits_for_block_before_submitting() {
-        let withdraw_block = 5555u64;
-        let mock_wrapper = Arc::new(MockWrapper::new());
-
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: mock_wrapper.clone(),
-        };
-
-        let token = Address::ZERO;
-        let events = TestHarness::<EquityRedemption>::with(services)
-            .given(vec![
-                EquityRedemptionEvent::WithdrawnFromRaindex {
-                    symbol: Symbol::new("AAPL").unwrap(),
-                    quantity: float!(1.0),
-                    token,
-                    wrapped_amount: U256::from(1_000_000_000_000_000_000_u64),
-                    actual_wrapped_amount: Some(U256::from(1_000_000_000_000_000_000_u64)),
-                    raindex_withdraw_tx: TxHash::random(),
-                    raindex_withdraw_block: Some(withdraw_block),
-                    withdrawn_at: Utc::now(),
-                },
-                EquityRedemptionEvent::UnwrapPending {
-                    pending_at: Utc::now(),
-                },
-            ])
-            .when(EquityRedemptionCommand::SubmitUnwrap)
-            .await
-            .events();
-
-        assert_eq!(events.len(), 1, "expected exactly one event");
-        assert!(
-            matches!(events[0], EquityRedemptionEvent::UnwrapSubmitted { .. }),
-            "expected UnwrapSubmitted, got {:?}",
-            events[0]
-        );
-
-        let calls = mock_wrapper.wait_for_block_calls();
-        assert_eq!(
-            calls,
-            vec![withdraw_block],
-            "wait_for_block must be called once with the withdraw block before submitting unwrap"
-        );
-    }
-
-    /// Verifies that when raindex_withdraw_block is None (legacy aggregate),
-    /// SubmitUnwrap skips wait_for_block and proceeds directly.
-    #[tokio::test]
-    async fn submit_unwrap_skips_wait_for_block_when_withdraw_block_is_none() {
-        let mock_wrapper = Arc::new(MockWrapper::new());
-
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: mock_wrapper.clone(),
-        };
-
-        let token = Address::ZERO;
-        let events = TestHarness::<EquityRedemption>::with(services)
-            .given(vec![
-                EquityRedemptionEvent::WithdrawnFromRaindex {
-                    symbol: Symbol::new("AAPL").unwrap(),
-                    quantity: float!(1.0),
-                    token,
-                    wrapped_amount: U256::from(1_000_000_000_000_000_000_u64),
-                    actual_wrapped_amount: Some(U256::from(1_000_000_000_000_000_000_u64)),
-                    raindex_withdraw_tx: TxHash::random(),
-                    raindex_withdraw_block: None,
-                    withdrawn_at: Utc::now(),
-                },
-                EquityRedemptionEvent::UnwrapPending {
-                    pending_at: Utc::now(),
-                },
-            ])
-            .when(EquityRedemptionCommand::SubmitUnwrap)
-            .await
-            .events();
-
-        assert_eq!(events.len(), 1, "expected exactly one event");
-        assert!(
-            matches!(events[0], EquityRedemptionEvent::UnwrapSubmitted { .. }),
-            "expected UnwrapSubmitted, got {:?}",
-            events[0]
-        );
-
-        assert_eq!(
-            mock_wrapper.wait_for_block_calls(),
-            Vec::<u64>::new(),
-            "wait_for_block must NOT be called when raindex_withdraw_block is None"
-        );
-    }
-
-    /// Verifies that `SubmitUnwrap` propagates a `wait_for_block` failure as
-    /// `NodeSyncFailed` when `raindex_withdraw_block` is `Some`.
-    ///
-    /// Symmetric to `send_tokens_fails_with_node_sync_failed_when_wait_for_block_fails`.
-    /// A copy-paste or refactor error in the `SubmitUnwrap` error-mapping arm
-    /// would mis-classify the error, breaking the retry-logic that depends on
-    /// receiving `NodeSyncFailed`.
-    #[tokio::test]
-    async fn submit_unwrap_fails_with_node_sync_failed_when_wait_for_block_fails() {
-        let required_block = 42u64;
-
-        let services = EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::failing_wait_for_block()),
-        };
-
-        let error = TestHarness::<EquityRedemption>::with(services)
-            .given(vec![
-                EquityRedemptionEvent::WithdrawnFromRaindex {
-                    symbol: Symbol::new("AAPL").unwrap(),
-                    quantity: float!(1.0),
-                    token: Address::ZERO,
-                    wrapped_amount: U256::from(1_000_000_000_000_000_000_u64),
-                    actual_wrapped_amount: Some(U256::from(1_000_000_000_000_000_000_u64)),
-                    raindex_withdraw_tx: TxHash::random(),
-                    raindex_withdraw_block: Some(required_block),
-                    withdrawn_at: Utc::now(),
-                },
-                EquityRedemptionEvent::UnwrapPending {
-                    pending_at: Utc::now(),
-                },
-            ])
-            .when(EquityRedemptionCommand::SubmitUnwrap)
-            .await
-            .then_expect_error();
-
-        assert!(
-            matches!(
-                error,
-                LifecycleError::Apply(EquityRedemptionError::NodeSyncFailed {
-                    required_block: 42,
-                    attempts: NODE_SYNC_MAX_ATTEMPTS,
-                })
-            ),
-            "expected NodeSyncFailed {{ required_block: 42, attempts: {NODE_SYNC_MAX_ATTEMPTS} }}, got: {error:?}",
-        );
-    }
-
-    fn failed_redemption_history() -> Vec<EquityRedemptionEvent> {
-        vec![
-            withdrawn_from_raindex_event(),
-            tokens_sent_event(),
-            EquityRedemptionEvent::DetectionFailed {
-                failure: DetectionFailure::Operator {
-                    reason: "operator forced terminal".to_string(),
-                },
-                failed_at: Utc::now(),
-            },
-        ]
-    }
-
     #[tokio::test]
     async fn reconcile_from_failed_emits_operator_reconciled_and_replays_to_reconciled() {
         let history = failed_redemption_history();
 
-        let events = TestHarness::<EquityRedemption>::with(mock_services())
+        let events = TestHarness::<EquityRedemption>::with(())
             .given(history.clone())
             .when(EquityRedemptionCommand::Reconcile {
                 reason: "deposited manually via vault-deposit".to_string(),
@@ -5691,7 +5146,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_from_non_failed_is_rejected() {
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
             .when(EquityRedemptionCommand::Reconcile {
                 reason: "should be rejected".to_string(),
@@ -5710,7 +5165,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_with_blank_reason_is_rejected() {
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given(failed_redemption_history())
             .when(EquityRedemptionCommand::Reconcile {
                 reason: "   ".to_string(),
@@ -5735,7 +5190,7 @@ mod tests {
             reconciled_at: Utc::now(),
         });
 
-        let error = TestHarness::<EquityRedemption>::with(mock_services())
+        let error = TestHarness::<EquityRedemption>::with(())
             .given(history)
             .when(EquityRedemptionCommand::Reconcile {
                 reason: "second attempt".to_string(),

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -47,7 +47,7 @@ use super::{
 use crate::bindings::TestERC20;
 use crate::conductor::job::Job;
 use crate::equity_redemption::{
-    EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,
+    EquityRedemption, EquityRedemptionCommand, SendOutcome, redemption_aggregate_id,
 };
 use crate::inventory::view::InFlightEquityLocation;
 use crate::inventory::{BroadcastingInventory, ImbalanceThreshold, InventoryView, Venue};
@@ -55,7 +55,7 @@ use crate::offchain::order::OffchainOrderId;
 use crate::onchain::mock::MockRaindex;
 use crate::position::{Position, PositionCommand, TradeId};
 use crate::rebalancing::equity::{
-    CrossVenueEquityTransfer, EquityTransferServices, MintTransferError, TransferEquityToHedging,
+    CrossVenueEquityTransfer, MintTransferError, TransferEquityToHedging,
     TransferEquityToHedgingCtx, TransferEquityToMarketMaking, TransferEquityToMarketMakingCtx,
     TransferEquityToMarketMakingJobError,
 };
@@ -463,17 +463,8 @@ fn build_equity_transfer_with_wrapper(
 ) -> Arc<CrossVenueEquityTransfer> {
     let wrapper: Arc<dyn st0x_wrapper::Wrapper> = Arc::new(mock_wrapper);
 
-    let equity_services = EquityTransferServices {
-        raindex: Arc::clone(&raindex),
-        vault_lookup: Arc::clone(&vault_lookup),
-        tokenizer: Arc::clone(&tokenizer),
-        wrapper: Arc::clone(&wrapper),
-    };
     let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-    let redemption_store = Arc::new(test_store::<EquityRedemption>(
-        pool.clone(),
-        equity_services,
-    ));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
     Arc::new(CrossVenueEquityTransfer::new(
         raindex,
         vault_lookup,
@@ -500,13 +491,6 @@ async fn build_equity_transfer_with_service(
 ) -> Arc<CrossVenueEquityTransfer> {
     let wrapper: Arc<dyn st0x_wrapper::Wrapper> = Arc::new(mock_wrapper);
 
-    let equity_services = EquityTransferServices {
-        raindex: Arc::clone(&raindex),
-        vault_lookup: Arc::clone(&vault_lookup),
-        tokenizer: Arc::clone(&tokenizer),
-        wrapper: Arc::clone(&wrapper),
-    };
-
     let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
         .with(Arc::clone(service))
         .build(())
@@ -515,7 +499,7 @@ async fn build_equity_transfer_with_service(
 
     let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
         .with(Arc::clone(service))
-        .build(equity_services)
+        .build(())
         .await
         .unwrap();
 
@@ -1015,6 +999,11 @@ async fn equity_onchain_imbalance_triggers_redemption() {
             ExpectedEvent::new(
                 "EquityRedemption",
                 &redemption_agg_id,
+                "EquityRedemptionEvent::SendSubmitted",
+            ),
+            ExpectedEvent::new(
+                "EquityRedemption",
+                &redemption_agg_id,
                 "EquityRedemptionEvent::TokensSent",
             ),
             ExpectedEvent::new(
@@ -1039,14 +1028,21 @@ async fn equity_onchain_imbalance_triggers_redemption() {
         "VaultWithdrawPending should target the correct symbol"
     );
     assert_eq!(
-        events[15].payload["TokensSent"]["redemption_tx"]
+        events[15].payload["SendSubmitted"]["redemption_tx"]
+            .as_str()
+            .unwrap(),
+        format!("{expected_tx_hash:#x}"),
+        "SendSubmitted should record the broadcast redemption_tx before finalizing"
+    );
+    assert_eq!(
+        events[16].payload["TokensSent"]["redemption_tx"]
             .as_str()
             .unwrap(),
         format!("{expected_tx_hash:#x}"),
         "TokensSent redemption_tx should match the deterministic Anvil hash"
     );
     assert_eq!(
-        events[16].payload["Detected"]["tokenization_request_id"]
+        events[17].payload["Detected"]["tokenization_request_id"]
             .as_str()
             .unwrap(),
         "redeem_int_test",
@@ -2481,18 +2477,9 @@ async fn transfer_failed_cancels_redemption_inflight() {
     seed_vault_registry(&pool, &symbol, token_address).await;
 
     // Build a redemption store wired to the trigger so events flow through
-    let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new().with_send_failure());
-
-    let equity_services = EquityTransferServices {
-        raindex: Arc::new(MockRaindex::new()),
-        vault_lookup: mock_vault_lookup_for_symbol(&symbol, token_address),
-        tokenizer,
-        wrapper: Arc::new(MockWrapper::new()),
-    };
-
     let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
         .with(Arc::clone(&service))
-        .build(equity_services)
+        .build(())
         .await
         .unwrap();
 
@@ -2524,12 +2511,23 @@ async fn transfer_failed_cancels_redemption_inflight() {
     );
 
     redemption_store
-        .send(&redemption_id, EquityRedemptionCommand::SubmitWithdraw)
+        .send(
+            &redemption_id,
+            EquityRedemptionCommand::SubmitWithdraw {
+                tx_hash: TxHash::random(),
+            },
+        )
         .await
         .unwrap();
 
     redemption_store
-        .send(&redemption_id, EquityRedemptionCommand::ConfirmWithdraw)
+        .send(
+            &redemption_id,
+            EquityRedemptionCommand::ConfirmWithdraw {
+                actual_wrapped_amount: U256::from(10_000_000_000_000_000_000_u128),
+                raindex_withdraw_block: 100,
+            },
+        )
         .await
         .unwrap();
 
@@ -2541,12 +2539,24 @@ async fn transfer_failed_cancels_redemption_inflight() {
         .unwrap();
 
     redemption_store
-        .send(&redemption_id, EquityRedemptionCommand::SubmitUnwrap)
+        .send(
+            &redemption_id,
+            EquityRedemptionCommand::SubmitUnwrap {
+                unwrap_tx_hash: TxHash::random(),
+            },
+        )
         .await
         .unwrap();
 
     redemption_store
-        .send(&redemption_id, EquityRedemptionCommand::ConfirmUnwrap)
+        .send(
+            &redemption_id,
+            EquityRedemptionCommand::ConfirmUnwrap {
+                underlying_token: token_address,
+                unwrapped_amount: U256::from(10_000_000_000_000_000_000_u128),
+                unwrap_block: 101,
+            },
+        )
         .await
         .unwrap();
 
@@ -2556,10 +2566,15 @@ async fn transfer_failed_cancels_redemption_inflight() {
         .await
         .unwrap();
 
-    // SendTokens: mock tokenizer fails -> TransferFailed event
-    // The aggregate emits TransferFailed, trigger cancels inflight
+    // A failed send (what the orchestrator records when send_for_redemption
+    // reverts) emits TransferFailed; the trigger must cancel inflight.
     redemption_store
-        .send(&redemption_id, EquityRedemptionCommand::SendTokens)
+        .send(
+            &redemption_id,
+            EquityRedemptionCommand::RecordSendOutcome {
+                outcome: SendOutcome::SendFailed,
+            },
+        )
         .await
         .unwrap();
 
@@ -2607,17 +2622,8 @@ async fn wrapped_recovery_reschedules_when_held_for_recovery_but_no_balance() {
     let vault_lookup: Arc<dyn VaultLookup> = Arc::new(MockVaultLookup::new());
     let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
 
-    let equity_services = EquityTransferServices {
-        raindex: Arc::clone(&raindex),
-        vault_lookup: Arc::clone(&vault_lookup),
-        tokenizer: Arc::clone(&tokenizer),
-        wrapper: Arc::clone(&wrapper),
-    };
     let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-    let redemption_store = Arc::new(test_store::<EquityRedemption>(
-        pool.clone(),
-        equity_services,
-    ));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
     let transfer = Arc::new(CrossVenueEquityTransfer::new(
         Arc::clone(&raindex),
         Arc::clone(&vault_lookup),
@@ -2722,17 +2728,8 @@ async fn recovery_job_breaks_deadlock_when_wrap_landed_wrapped_equity_recovery()
     );
     let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
 
-    let equity_services = EquityTransferServices {
-        raindex: Arc::clone(&raindex),
-        vault_lookup: Arc::clone(&vault_lookup),
-        tokenizer: Arc::clone(&tokenizer),
-        wrapper: Arc::clone(&wrapper),
-    };
     let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-    let redemption_store = Arc::new(test_store::<EquityRedemption>(
-        pool.clone(),
-        equity_services,
-    ));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
     let transfer = Arc::new(CrossVenueEquityTransfer::new(
         Arc::clone(&raindex),
         Arc::clone(&vault_lookup),
@@ -2856,17 +2853,8 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_unwrapped_equity_recovery
     );
     let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
 
-    let equity_services = EquityTransferServices {
-        raindex: Arc::clone(&raindex),
-        vault_lookup: Arc::clone(&vault_lookup),
-        tokenizer: Arc::clone(&tokenizer),
-        wrapper: Arc::clone(&wrapper),
-    };
     let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-    let redemption_store = Arc::new(test_store::<EquityRedemption>(
-        pool.clone(),
-        equity_services,
-    ));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
     let transfer = Arc::new(CrossVenueEquityTransfer::new(
         Arc::clone(&raindex),
         Arc::clone(&vault_lookup),
@@ -2982,17 +2970,8 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_dispatches_active_mint() 
     );
     let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
 
-    let equity_services = EquityTransferServices {
-        raindex: Arc::clone(&raindex),
-        vault_lookup: Arc::clone(&vault_lookup),
-        tokenizer: Arc::clone(&tokenizer),
-        wrapper: Arc::clone(&wrapper),
-    };
     let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-    let redemption_store = Arc::new(test_store::<EquityRedemption>(
-        pool.clone(),
-        equity_services,
-    ));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
     let transfer = Arc::new(CrossVenueEquityTransfer::new(
         Arc::clone(&raindex),
         Arc::clone(&vault_lookup),

--- a/src/onchain/mock.rs
+++ b/src/onchain/mock.rs
@@ -23,6 +23,15 @@ pub(crate) enum DepositBehavior {
     FailExecutionReverted,
 }
 
+/// Whether `submit_withdraw` should succeed or fail with a generic error
+/// (simulating a submission revert or RPC failure on the withdrawal path).
+#[derive(Default)]
+pub(crate) enum WithdrawBehavior {
+    #[default]
+    Succeed,
+    FailGeneric,
+}
+
 /// Whether `confirm_tx_receipt` should succeed, fail terminally
 /// (simulating a submitted transaction whose receipt never
 /// materializes), or fail with a retryable inconclusive scan
@@ -51,9 +60,11 @@ pub(crate) struct DepositCall {
 
 /// Arguments captured from the last `submit_withdraw` call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct WithdrawCall {
-    token: Address,
-    amount: U256,
+pub(crate) struct WithdrawCall {
+    pub(crate) token: Address,
+    pub(crate) vault_id: RaindexVaultId,
+    pub(crate) amount: U256,
+    pub(crate) decimals: u8,
 }
 
 pub(crate) struct MockRaindex {
@@ -61,6 +72,7 @@ pub(crate) struct MockRaindex {
     deposit_tx: TxHash,
     deposit_behavior: DepositBehavior,
     confirm_behavior: ConfirmTxBehavior,
+    withdraw_behavior: WithdrawBehavior,
     deposited_token: Mutex<Option<Address>>,
     deposit_call: Mutex<Option<DepositCall>>,
     confirmed_tx: Mutex<Option<TxHash>>,
@@ -122,6 +134,7 @@ impl MockRaindex {
             deposit_tx: TxHash::random(),
             deposit_behavior: DepositBehavior::Succeed,
             confirm_behavior: ConfirmTxBehavior::Succeed,
+            withdraw_behavior: WithdrawBehavior::Succeed,
             deposited_token: Mutex::new(None),
             deposit_call: Mutex::new(None),
             confirmed_tx: Mutex::new(None),
@@ -143,6 +156,17 @@ impl MockRaindex {
     pub(crate) fn with_confirm_behavior(mut self, behavior: ConfirmTxBehavior) -> Self {
         self.confirm_behavior = behavior;
         self
+    }
+
+    /// Configures how `submit_withdraw` behaves; combinable with the other
+    /// behaviour knobs.
+    pub(crate) fn with_withdraw_behavior(mut self, behavior: WithdrawBehavior) -> Self {
+        self.withdraw_behavior = behavior;
+        self
+    }
+
+    pub(crate) fn last_withdraw_call(&self) -> Option<WithdrawCall> {
+        *self.withdraw_transfer.lock().unwrap()
     }
 
     /// Returns the token address that was passed to the last `deposit()` call.
@@ -222,15 +246,22 @@ impl Raindex for MockRaindex {
     async fn submit_withdraw(
         &self,
         token: Address,
-        _vault_id: RaindexVaultId,
+        vault_id: RaindexVaultId,
         target_amount: U256,
-        _decimals: u8,
+        decimals: u8,
     ) -> Result<TxHash, RaindexError> {
-        *self.withdraw_transfer.lock().unwrap() = Some(WithdrawCall {
-            token,
-            amount: target_amount,
-        });
-        Ok(self.withdraw_tx)
+        match self.withdraw_behavior {
+            WithdrawBehavior::Succeed => {
+                *self.withdraw_transfer.lock().unwrap() = Some(WithdrawCall {
+                    token,
+                    vault_id,
+                    amount: target_amount,
+                    decimals,
+                });
+                Ok(self.withdraw_tx)
+            }
+            WithdrawBehavior::FailGeneric => Err(RaindexError::ZeroAmount),
+        }
     }
 
     async fn confirm_tx_receipt(
@@ -254,7 +285,7 @@ impl Raindex for MockRaindex {
                     .withdraw_transfer
                     .lock()
                     .unwrap()
-                    .map(|WithdrawCall { token, amount }| {
+                    .map(|WithdrawCall { token, amount, .. }| {
                         let amount = self.withdraw_actual_amount.unwrap_or(amount);
                         vec![transfer_log(token, Address::ZERO, amount)]
                     })
@@ -271,7 +302,7 @@ impl Raindex for MockRaindex {
             .withdraw_transfer
             .lock()
             .unwrap()
-            .map(|WithdrawCall { token, amount }| {
+            .map(|WithdrawCall { token, amount, .. }| {
                 let amount = self.withdraw_actual_amount.unwrap_or(amount);
                 vec![transfer_log(token, Address::ZERO, amount)]
             })

--- a/src/performance/equity_timing/redemption.rs
+++ b/src/performance/equity_timing/redemption.rs
@@ -124,6 +124,13 @@ impl StoredOperation {
             SendPending { pending_at } => {
                 self.open_once(RedemptionSend, *pending_at);
             }
+            // Mid-stream-first case as above: `open_once` no-ops when
+            // `SendPending` already opened the stage, so this only seeds the
+            // send stage for an operation first observed at the submitted
+            // event (deploy/restart backfill).
+            SendSubmitted { submitted_at, .. } => {
+                self.open_once(RedemptionSend, *submitted_at);
+            }
             // Terminal failures: whichever stage is currently open (varies by
             // which of these fired) is closed as failed and the operation
             // ends. `TransferFailed` is emitted either by `SendTokens` (from
@@ -306,6 +313,9 @@ pub(super) fn redemption_observed_at(event: &EquityRedemptionEvent) -> DateTime<
             unwrapped_at: at, ..
         }
         | SendPending { pending_at: at }
+        | SendSubmitted {
+            submitted_at: at, ..
+        }
         | TransferFailed { failed_at: at, .. }
         | TokensSent { sent_at: at, .. }
         | DetectionFailed { failed_at: at, .. }

--- a/src/performance/reliability.rs
+++ b/src/performance/reliability.rs
@@ -504,6 +504,7 @@ fn equity_redemption_failure(
         | EquityRedemptionEvent::UnwrapPending { .. }
         | EquityRedemptionEvent::UnwrapSubmitted { .. }
         | EquityRedemptionEvent::SendPending { .. }
+        | EquityRedemptionEvent::SendSubmitted { .. }
         | EquityRedemptionEvent::TokensSent { .. }
         | EquityRedemptionEvent::Detected { .. }
         | EquityRedemptionEvent::Completed { .. }

--- a/src/performance/simulated_transfers.rs
+++ b/src/performance/simulated_transfers.rs
@@ -18,36 +18,20 @@
 //! `EquityRedemptionError::AlreadyStarted`). The only caller (`simulate()` in
 //! `tests/e2e/full_system.rs`) always seeds a freshly created database file.
 
-use alloy::consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
-use alloy::primitives::{Address, B256, Bloom, Log as PrimitiveLog, TxHash, U256};
-use alloy::rpc::types::{Log, TransactionReceipt};
-use alloy::sol_types::SolEvent;
-use async_trait::async_trait;
+use alloy::primitives::{Address, B256, TxHash};
 use chrono::{DateTime, Duration, Utc};
 use rain_math_float::Float;
 use sqlx::SqlitePool;
-use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 
 use st0x_event_sorcery::{RetryOnBusy, Store, StoreBuilder};
-use st0x_evm::IERC20;
-use st0x_execution::{AlpacaTransferId, ClientOrderId, FractionalShares, Symbol};
+use st0x_execution::{AlpacaTransferId, ClientOrderId, Symbol};
 use st0x_finance::Usdc;
-use st0x_raindex::{Raindex, RaindexError, RaindexVaultId};
-use st0x_tokenization::{
-    AlpacaTokenizationError, IssuerRequestId, TokenizationRequest, TokenizationRequestId,
-    TokenizationRequestStatus, TokenizationRequestType, Tokenizer, TokenizerError,
-    tokenization_request_id,
-};
-use st0x_wrapper::{
-    UnderlyingPerWrapped, UnwrapConfirmation, WrapConfirmation, Wrapper, WrapperError,
-};
+use st0x_tokenization::{IssuerRequestId, tokenization_request_id};
 
 use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
 use crate::performance::equity_timing::EquityTimingProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
-use crate::rebalancing::equity::EquityTransferServices;
 use crate::tokenized_equity_mint::{
     TOKENIZED_EQUITY_DECIMALS, TokenizedEquityMint, TokenizedEquityMintCommand,
 };
@@ -55,159 +39,6 @@ use crate::usdc_rebalance::{
     ConversionAmounts, RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand,
     UsdcRebalanceId,
 };
-use crate::vault_lookup::{VaultLookup, VaultLookupError};
-
-/// Minimal [`Tokenizer`] shared by [`seed_simulated_mint_history`]'s and
-/// [`seed_simulated_equity_redemption_history`]'s temporary stores.
-///
-/// The mint fixture drives only the mint happy path (`RecordMintRequestedAt` ->
-/// `RecordTokensReceivedAt` -> `WrapTokensAt` -> `DepositToVaultAt`), which calls exactly
-/// `request_mint`/`poll_mint_until_complete`. The redemption fixture drives
-/// only `wait_for_block`/`redemption_wallet`/`send_for_redemption` (its
-/// `Detect`/`Complete` steps are pure state transitions with no service
-/// call). Every other `Tokenizer` method is unreachable from either path.
-///
-/// Stateful rather than static (unlike `st0x_tokenization::mock::MockTokenizer`)
-/// because `poll_mint_until_complete` must echo back the SAME symbol
-/// `request_mint` was called with -- the mint aggregate validates
-/// `token_symbol == format!("t{symbol}")`, and this fixture cycles through
-/// multiple symbols in one run.
-struct FixtureTokenizer {
-    pending: Mutex<HashMap<TokenizationRequestId, (Symbol, TxHash)>>,
-    redemption_wallet: Address,
-    /// Feeds `send_for_redemption`'s synthetic tx hash through
-    /// `simulated_transfer_uuid`, keeping it deterministic across runs like
-    /// every other id in this module.
-    day: u32,
-}
-
-impl FixtureTokenizer {
-    fn new(redemption_wallet: Address, day: u32) -> Self {
-        Self {
-            pending: Mutex::new(HashMap::new()),
-            redemption_wallet,
-            day,
-        }
-    }
-}
-
-#[async_trait]
-impl Tokenizer for FixtureTokenizer {
-    async fn request_mint(
-        &self,
-        symbol: Symbol,
-        quantity: FractionalShares,
-        wallet: Address,
-        issuer_request_id: IssuerRequestId,
-    ) -> Result<TokenizationRequest, TokenizerError> {
-        let id = tokenization_request_id(&format!("sim-mint-{issuer_request_id}"));
-        // Derived from the 16-byte `IssuerRequestId` uuid, not the (longer)
-        // `TokenizationRequestId` string: `TxHash::left_padding_from` panics
-        // above 32 input bytes, and the request-id string exceeds that.
-        let tx_hash = TxHash::left_padding_from(issuer_request_id.0.as_bytes());
-        self.pending
-            .lock()
-            .await
-            .insert(id.clone(), (symbol.clone(), tx_hash));
-
-        Ok(TokenizationRequest {
-            id,
-            r#type: Some(TokenizationRequestType::Mint),
-            status: TokenizationRequestStatus::Pending,
-            underlying_symbol: symbol,
-            token_symbol: None,
-            quantity,
-            wallet: Some(wallet),
-            issuer_request_id: Some(issuer_request_id),
-            tx_hash: None,
-            fees: None,
-            created_at: Utc::now(),
-        })
-    }
-
-    async fn poll_mint_until_complete(
-        &self,
-        id: &TokenizationRequestId,
-    ) -> Result<TokenizationRequest, TokenizerError> {
-        let (symbol, tx_hash) = self.pending.lock().await.get(id).cloned().ok_or_else(|| {
-            TokenizerError::Alpaca(AlpacaTokenizationError::RequestNotFound { id: id.clone() })
-        })?;
-
-        Ok(TokenizationRequest {
-            id: id.clone(),
-            r#type: Some(TokenizationRequestType::Mint),
-            status: TokenizationRequestStatus::Completed,
-            token_symbol: Some(format!("t{symbol}")),
-            underlying_symbol: symbol,
-            quantity: FractionalShares::ZERO,
-            wallet: None,
-            issuer_request_id: None,
-            tx_hash: Some(tx_hash),
-            fees: None,
-            created_at: Utc::now(),
-        })
-    }
-
-    async fn get_request(
-        &self,
-        _id: &TokenizationRequestId,
-    ) -> Result<TokenizationRequest, TokenizerError> {
-        unimplemented!("FixtureTokenizer: mint fixture never calls get_request")
-    }
-
-    fn redemption_wallet(&self) -> Option<Address> {
-        Some(self.redemption_wallet)
-    }
-
-    async fn wait_for_block(&self, _block: u64) -> Result<(), st0x_evm::EvmError> {
-        Ok(())
-    }
-
-    async fn send_for_redemption(
-        &self,
-        _token: Address,
-        _amount: U256,
-    ) -> Result<TxHash, TokenizerError> {
-        Ok(TxHash::left_padding_from(
-            simulated_transfer_uuid("redeem-send-tx", self.day).as_bytes(),
-        ))
-    }
-
-    async fn poll_for_redemption(
-        &self,
-        _tx_hash: &TxHash,
-    ) -> Result<TokenizationRequest, TokenizerError> {
-        unimplemented!("FixtureTokenizer: mint fixture never calls poll_for_redemption")
-    }
-
-    async fn find_redemption_by_tx(
-        &self,
-        _tx_hash: &TxHash,
-    ) -> Result<Option<TokenizationRequest>, TokenizerError> {
-        unimplemented!("FixtureTokenizer: mint fixture never calls find_redemption_by_tx")
-    }
-
-    async fn poll_redemption_until_complete(
-        &self,
-        _id: &TokenizationRequestId,
-    ) -> Result<TokenizationRequest, TokenizerError> {
-        unimplemented!("FixtureTokenizer: mint fixture never calls poll_redemption_until_complete")
-    }
-
-    async fn verify_mint_tx(
-        &self,
-        _tx_hash: TxHash,
-        _token_address: Address,
-        _wallet: Address,
-        _expected_amount: U256,
-    ) -> Result<(), st0x_tokenization::MintVerificationError> {
-        unimplemented!("FixtureTokenizer: mint fixture never calls verify_mint_tx")
-    }
-
-    async fn list_pending_requests(&self) -> Result<Vec<TokenizationRequest>, TokenizerError> {
-        unimplemented!("FixtureTokenizer: mint fixture never calls list_pending_requests")
-    }
-}
 
 /// Deterministic UUID for this module's fixtures, namespaced separately from
 /// `super::simulated_latency_uuid` so the two fixtures' synthetic ids never
@@ -707,318 +538,15 @@ async fn seed_base_to_alpaca(
     Ok(())
 }
 
-/// Builds a synthetic, always-`status: true` transaction receipt whose logs
-/// are exactly `logs`. Mirrors `src/onchain/mock.rs`'s `successful_receipt`
-/// (that copy is `#[cfg(test)]`-only, so unusable from a `test-support` e2e
-/// build; this is its `test-support`-gated counterpart).
-fn successful_receipt(tx_hash: TxHash, block_number: u64, logs: Vec<Log>) -> TransactionReceipt {
-    TransactionReceipt {
-        inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom {
-            receipt: Receipt {
-                status: true.into(),
-                cumulative_gas_used: 0,
-                logs,
-            },
-            logs_bloom: Bloom::default(),
-        }),
-        transaction_hash: tx_hash,
-        transaction_index: Some(0),
-        block_hash: None,
-        block_number: Some(block_number),
-        gas_used: 21_000,
-        effective_gas_price: 1,
-        blob_gas_used: None,
-        blob_gas_price: None,
-        from: Address::ZERO,
-        to: Some(Address::ZERO),
-        contract_address: None,
-    }
-}
-
-/// Builds a decodable ERC20 `Transfer` log, mirroring `src/onchain/mock.rs`'s
-/// `transfer_log` (see `successful_receipt` above for why this can't just
-/// reuse that `#[cfg(test)]`-only copy).
-fn transfer_log(token: Address, to: Address, amount: U256) -> Log {
-    let event = IERC20::Transfer {
-        from: Address::ZERO,
-        to,
-        value: amount,
-    };
-    let inner = PrimitiveLog {
-        address: token,
-        data: event.encode_log_data(),
-    };
-
-    Log {
-        inner,
-        transaction_hash: None,
-        transaction_index: None,
-        block_hash: None,
-        block_number: None,
-        block_timestamp: None,
-        log_index: None,
-        removed: false,
-    }
-}
-
-/// Minimal [`Raindex`] for one [`seed_simulated_equity_redemption_history`]
-/// cycle. Scoped to a single redemption (a fresh instance per day, not
-/// shared across the seeding loop), so `submit_withdraw`'s single-slot
-/// `pending_withdraw` is always populated by the time `confirm_tx_receipt`
-/// reads it -- the redemption fixture always calls them in that order.
-/// `withdraw`/`submit_deposit` are unreachable from `EquityRedemption`'s
-/// happy path (it only ever calls `submit_withdraw`/`confirm_tx_receipt`).
-struct FixtureRaindex {
-    /// Recipient the synthetic withdrawal's `Transfer` log credits -- must
-    /// match `FixtureWrapper::owner()`, since `ConfirmWithdraw`'s handler
-    /// reads `services.wrapper.owner()` as the expected recipient.
-    recipient: Address,
-    block_number: u64,
-    pending_withdraw: Mutex<Option<(Address, U256)>>,
-    /// Feeds `submit_withdraw`'s synthetic tx hash through
-    /// `simulated_transfer_uuid`, keeping it deterministic across runs like
-    /// every other id in this module.
-    day: u32,
-}
-
-impl FixtureRaindex {
-    fn new(recipient: Address, block_number: u64, day: u32) -> Self {
-        Self {
-            recipient,
-            block_number,
-            pending_withdraw: Mutex::new(None),
-            day,
-        }
-    }
-}
-
-#[async_trait]
-impl Raindex for FixtureRaindex {
-    async fn withdraw(
-        &self,
-        _token: Address,
-        _vault_id: RaindexVaultId,
-        _target_amount: U256,
-        _decimals: u8,
-    ) -> Result<TxHash, RaindexError> {
-        unimplemented!("FixtureRaindex: redemption fixture never calls withdraw")
-    }
-
-    async fn submit_deposit(
-        &self,
-        _token: Address,
-        _vault_id: RaindexVaultId,
-        _amount: U256,
-        _decimals: u8,
-    ) -> Result<TxHash, RaindexError> {
-        unimplemented!("FixtureRaindex: redemption fixture never calls submit_deposit")
-    }
-
-    async fn submit_withdraw(
-        &self,
-        token: Address,
-        _vault_id: RaindexVaultId,
-        target_amount: U256,
-        _decimals: u8,
-    ) -> Result<TxHash, RaindexError> {
-        *self.pending_withdraw.lock().await = Some((token, target_amount));
-        Ok(TxHash::left_padding_from(
-            simulated_transfer_uuid("redeem-withdraw-tx", self.day).as_bytes(),
-        ))
-    }
-
-    async fn confirm_tx_receipt(
-        &self,
-        tx_hash: TxHash,
-    ) -> Result<TransactionReceipt, RaindexError> {
-        let (token, amount) = self
-            .pending_withdraw
-            .lock()
-            .await
-            .ok_or(RaindexError::ScanInconclusive { from_block: 0 })?;
-
-        Ok(successful_receipt(
-            tx_hash,
-            self.block_number,
-            vec![transfer_log(token, self.recipient, amount)],
-        ))
-    }
-}
-
-/// Minimal [`VaultLookup`] for one redemption cycle: resolves every token to
-/// the same fixed vault id. `vault_token_for_symbol` is unreachable from
-/// `EquityRedemption`'s happy path.
-struct FixtureVaultLookup {
-    vault_id: RaindexVaultId,
-}
-
-impl FixtureVaultLookup {
-    fn new(vault_id: RaindexVaultId) -> Self {
-        Self { vault_id }
-    }
-}
-
-#[async_trait]
-impl VaultLookup for FixtureVaultLookup {
-    async fn vault_id_for_token(
-        &self,
-        _token: Address,
-    ) -> Result<RaindexVaultId, VaultLookupError> {
-        Ok(self.vault_id)
-    }
-
-    async fn vault_token_for_symbol(&self, _symbol: &Symbol) -> Result<Address, VaultLookupError> {
-        unimplemented!("FixtureVaultLookup: redemption fixture never calls vault_token_for_symbol")
-    }
-}
-
-/// Minimal [`Wrapper`] for one [`seed_simulated_equity_redemption_history`]
-/// cycle. Scoped to a single redemption, same reasoning as [`FixtureRaindex`]:
-/// `submit_unwrap`'s single-slot `pending_unwrap` is always populated by the
-/// time `confirm_unwrap` reads it. 1:1 unwrap ratio, matching
-/// `st0x_wrapper::mock::MockWrapper`'s convention. Every method beyond
-/// `owner`/`lookup_underlying`/`submit_unwrap`/`confirm_unwrap`/
-/// `wait_for_block` is unreachable from `EquityRedemption`'s happy path.
-struct FixtureWrapper {
-    owner: Address,
-    underlying_token: Address,
-    unwrap_block: u64,
-    pending_unwrap: Mutex<Option<U256>>,
-    /// Feeds `submit_unwrap`'s synthetic tx hash through
-    /// `simulated_transfer_uuid`, keeping it deterministic across runs like
-    /// every other id in this module.
-    day: u32,
-}
-
-impl FixtureWrapper {
-    fn new(owner: Address, underlying_token: Address, unwrap_block: u64, day: u32) -> Self {
-        Self {
-            owner,
-            underlying_token,
-            unwrap_block,
-            pending_unwrap: Mutex::new(None),
-            day,
-        }
-    }
-}
-
-#[async_trait]
-impl Wrapper for FixtureWrapper {
-    async fn get_ratio_for_symbol(
-        &self,
-        _symbol: &Symbol,
-    ) -> Result<UnderlyingPerWrapped, WrapperError> {
-        unimplemented!("FixtureWrapper: redemption fixture never calls get_ratio_for_symbol")
-    }
-
-    fn lookup_underlying(&self, _symbol: &Symbol) -> Result<Address, WrapperError> {
-        Ok(self.underlying_token)
-    }
-
-    fn lookup_derivative(&self, _symbol: &Symbol) -> Result<Address, WrapperError> {
-        unimplemented!("FixtureWrapper: redemption fixture never calls lookup_derivative")
-    }
-
-    async fn to_wrapped(
-        &self,
-        _wrapped_token: Address,
-        _underlying_amount: U256,
-        _receiver: Address,
-    ) -> Result<(TxHash, U256), WrapperError> {
-        unimplemented!("FixtureWrapper: redemption fixture never calls to_wrapped")
-    }
-
-    async fn to_underlying(
-        &self,
-        _wrapped_token: Address,
-        _wrapped_amount: U256,
-        _receiver: Address,
-        _owner: Address,
-    ) -> Result<(TxHash, U256), WrapperError> {
-        unimplemented!("FixtureWrapper: redemption fixture never calls to_underlying")
-    }
-
-    async fn donate(
-        &self,
-        _wrapped_token: Address,
-        _underlying_amount: U256,
-    ) -> Result<TxHash, WrapperError> {
-        unimplemented!("FixtureWrapper: redemption fixture never calls donate")
-    }
-
-    async fn submit_wrap(
-        &self,
-        _wrapped_token: Address,
-        _underlying_amount: U256,
-        _receiver: Address,
-    ) -> Result<TxHash, WrapperError> {
-        unimplemented!("FixtureWrapper: redemption fixture never calls submit_wrap")
-    }
-
-    async fn confirm_wrap(
-        &self,
-        _wrapped_token: Address,
-        _tx_hash: TxHash,
-    ) -> Result<WrapConfirmation, WrapperError> {
-        unimplemented!("FixtureWrapper: redemption fixture never calls confirm_wrap")
-    }
-
-    async fn submit_unwrap(
-        &self,
-        _wrapped_token: Address,
-        wrapped_amount: U256,
-        _receiver: Address,
-        _owner: Address,
-    ) -> Result<TxHash, WrapperError> {
-        *self.pending_unwrap.lock().await = Some(wrapped_amount);
-        Ok(TxHash::left_padding_from(
-            simulated_transfer_uuid("redeem-unwrap-tx", self.day).as_bytes(),
-        ))
-    }
-
-    async fn confirm_unwrap(
-        &self,
-        _wrapped_token: Address,
-        _tx_hash: TxHash,
-    ) -> Result<UnwrapConfirmation, WrapperError> {
-        let assets = self
-            .pending_unwrap
-            .lock()
-            .await
-            .ok_or(WrapperError::MissingWithdrawEvent)?;
-
-        Ok(UnwrapConfirmation {
-            assets,
-            block: self.unwrap_block,
-        })
-    }
-
-    async fn wait_for_block(&self, _block: u64) -> Result<(), WrapperError> {
-        Ok(())
-    }
-
-    fn owner(&self) -> Address {
-        self.owner
-    }
-}
-
 /// Seeds deterministic equity-redemption history for local dashboard
 /// simulation.
 ///
 /// Drives the `EquityRedemption` aggregate's happy path (`RedeemAt` ->
 /// `SubmitWithdrawAt` -> `ConfirmWithdrawAt` -> `UnwrapTokensAt` ->
 /// `SubmitUnwrapAt` -> `ConfirmUnwrapAt` -> `PrepareSendAt` ->
-/// `SendTokensAt` -> `DetectAt` -> `CompleteAt`), one redemption per day
-/// alternating between the same dedicated fixture symbols
+/// `SubmitSendAt` -> `ConfirmSendAt` -> `DetectAt` -> `CompleteAt`), one
+/// redemption per day alternating between the same dedicated fixture symbols
 /// (`AAPL.SIM`/`TSLA.SIM`) used by [`super::seed_simulated_hedge_latency_history`].
-///
-/// Unlike the mint/USDC fixtures, `EquityRedemption`'s service-calling
-/// commands (`SubmitWithdraw`/`ConfirmWithdraw`/`SubmitUnwrap`/
-/// `ConfirmUnwrap`/`SendTokens`) drive the side effect FROM WITHIN
-/// `transition()` itself (mint's analogous commands take the service
-/// result as command input instead), so a fresh, single-cycle-scoped
-/// [`FixtureRaindex`]/[`FixtureVaultLookup`]/[`FixtureWrapper`] triple is
-/// built for every redemption.
 pub async fn seed_simulated_equity_redemption_history(
     pool: &SqlitePool,
     now: DateTime<Utc>,
@@ -1029,7 +557,6 @@ pub async fn seed_simulated_equity_redemption_history(
     let range_start = now - Duration::days(i64::from(days)) - Duration::days(1);
     let aapl = Symbol::new("AAPL.SIM")?;
     let tsla = Symbol::new("TSLA.SIM")?;
-    let owner = Address::repeat_byte(0x5A);
     let redemption_wallet = Address::repeat_byte(0xA1);
 
     for day in 0..days {
@@ -1039,29 +566,14 @@ pub async fn seed_simulated_equity_redemption_history(
         let underlying_token = Address::left_padding_from(
             simulated_transfer_uuid("redeem-underlying", day).as_bytes(),
         );
-        let vault_id = RaindexVaultId(B256::left_padding_from(
-            simulated_transfer_uuid("redeem-vault", day).as_bytes(),
-        ));
         let withdraw_block = 4_000_000_u64 + u64::from(day) * 10;
         let unwrap_block = withdraw_block + 5;
-
-        let services = EquityTransferServices {
-            raindex: Arc::new(FixtureRaindex::new(owner, withdraw_block, day)),
-            vault_lookup: Arc::new(FixtureVaultLookup::new(vault_id)),
-            tokenizer: Arc::new(FixtureTokenizer::new(redemption_wallet, day)),
-            wrapper: Arc::new(FixtureWrapper::new(
-                owner,
-                underlying_token,
-                unwrap_block,
-                day,
-            )),
-        };
 
         let redemption = StoreBuilder::<EquityRedemption>::new(pool.clone())
             .with(Arc::new(RetryOnBusy {
                 inner: EquityTimingProjection::new(pool.clone()),
             }))
-            .build(services)
+            .build(())
             .await?;
 
         let id = RedemptionAggregateId(simulated_transfer_uuid("redemption", day));
@@ -1095,14 +607,23 @@ pub async fn seed_simulated_equity_redemption_history(
         redemption
             .send(
                 &id,
-                EquityRedemptionCommand::SubmitWithdrawAt { submitted_at },
+                EquityRedemptionCommand::SubmitWithdrawAt {
+                    tx_hash: TxHash::left_padding_from(
+                        simulated_transfer_uuid("redeem-withdraw-tx", day).as_bytes(),
+                    ),
+                    submitted_at,
+                },
             )
             .await?;
 
         redemption
             .send(
                 &id,
-                EquityRedemptionCommand::ConfirmWithdrawAt { withdrawn_at },
+                EquityRedemptionCommand::ConfirmWithdrawAt {
+                    actual_wrapped_amount: wrapped_amount,
+                    raindex_withdraw_block: withdraw_block,
+                    withdrawn_at,
+                },
             )
             .await?;
 
@@ -1119,6 +640,9 @@ pub async fn seed_simulated_equity_redemption_history(
             .send(
                 &id,
                 EquityRedemptionCommand::SubmitUnwrapAt {
+                    unwrap_tx_hash: TxHash::left_padding_from(
+                        simulated_transfer_uuid("redeem-unwrap-tx", day).as_bytes(),
+                    ),
                     submitted_at: unwrap_submitted_at,
                 },
             )
@@ -1127,7 +651,12 @@ pub async fn seed_simulated_equity_redemption_history(
         redemption
             .send(
                 &id,
-                EquityRedemptionCommand::ConfirmUnwrapAt { unwrapped_at },
+                EquityRedemptionCommand::ConfirmUnwrapAt {
+                    underlying_token,
+                    unwrapped_amount: wrapped_amount,
+                    unwrap_block,
+                    unwrapped_at,
+                },
             )
             .await?;
 
@@ -1141,7 +670,20 @@ pub async fn seed_simulated_equity_redemption_history(
             .await?;
 
         redemption
-            .send(&id, EquityRedemptionCommand::SendTokensAt { sent_at })
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitSendAt {
+                    redemption_wallet,
+                    redemption_tx: TxHash::left_padding_from(
+                        simulated_transfer_uuid("redeem-send-tx", day).as_bytes(),
+                    ),
+                    submitted_at: sent_at,
+                },
+            )
+            .await?;
+
+        redemption
+            .send(&id, EquityRedemptionCommand::ConfirmSendAt { sent_at })
             .await?;
 
         redemption

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -29,8 +29,6 @@ pub(crate) use resume_job::{
 
 use alloy::hex::FromHexError;
 use alloy::primitives::{Address, TxHash, U256};
-use alloy::rpc::types::TransactionReceipt;
-use async_trait::async_trait;
 use sqlx::SqlitePool;
 use std::sync::Arc;
 use thiserror::Error;
@@ -40,21 +38,19 @@ use tracing::{debug, error, info, instrument, warn};
 use st0x_event_sorcery::{AggregateError, LifecycleError, SendError, Store};
 use st0x_evm::EvmError;
 use st0x_execution::{FractionalShares, SharesConversionError, Symbol};
-use st0x_raindex::{Raindex, RaindexError, RaindexVaultId};
+use st0x_raindex::{Raindex, RaindexError};
 use st0x_tokenization::{
     AlpacaTokenizationError, IssuerRequestId, MintVerificationError, TokenizationRequest,
     TokenizationRequestId, TokenizationRequestIdError, TokenizationRequestStatus, Tokenizer,
     TokenizerError,
 };
-use st0x_wrapper::{
-    UnderlyingPerWrapped, UnwrapConfirmation, WrapConfirmation, Wrapper, WrapperError,
-};
+use st0x_wrapper::{WrapConfirmation, Wrapper, WrapperError};
 
 use super::RebalancingService;
 use super::trigger::RecoveryClaim;
 use super::trigger::freeze::FreezeStatusReader;
 use crate::equity_redemption::{
-    DetectionFailure, EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId,
+    DetectionFailure, EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId, SendOutcome,
 };
 use crate::tokenized_equity_mint::{
     TokenizedEquityMint, TokenizedEquityMintCommand, TokenizedEquityMintError,
@@ -188,241 +184,6 @@ async fn load_mint_recheck_context(
     })
 }
 
-/// Services shared by both equity transfer aggregates.
-///
-/// Both `TokenizedEquityMint` (hedging -> market-making) and
-/// `EquityRedemption` (market-making -> hedging) need Raindex for
-/// vault operations and Tokenizer for Alpaca API interactions.
-#[derive(Clone)]
-pub(crate) struct EquityTransferServices {
-    pub(crate) raindex: Arc<dyn Raindex>,
-    pub(crate) vault_lookup: Arc<dyn VaultLookup>,
-    pub(crate) tokenizer: Arc<dyn Tokenizer>,
-    pub(crate) wrapper: Arc<dyn Wrapper>,
-}
-
-impl EquityTransferServices {
-    /// Constructs a services instance whose methods all panic.
-    ///
-    /// Only the redemption aggregate (`EquityRedemption`) still takes
-    /// `EquityTransferServices`; its failure and `Reconcile` commands never
-    /// invoke them, so the panicking stub is safe for the CLI `transfer fail`
-    /// and `transfer reconcile` subcommands where no real broker/RPC connection
-    /// exists. Mint commands use `()` services directly -- `TokenizedEquityMint`
-    /// performs no I/O in its handlers.
-    pub(crate) fn panicking() -> Self {
-        Self {
-            raindex: Arc::new(PanickingRaindex),
-            vault_lookup: Arc::new(PanickingVaultLookup),
-            tokenizer: Arc::new(PanickingTokenizer),
-            wrapper: Arc::new(PanickingWrapper),
-        }
-    }
-}
-
-/// Panicking Raindex stub for CLI-only use. All methods panic.
-struct PanickingRaindex;
-
-#[async_trait]
-impl Raindex for PanickingRaindex {
-    async fn withdraw(
-        &self,
-        _: Address,
-        _: RaindexVaultId,
-        _: U256,
-        _: u8,
-    ) -> Result<TxHash, RaindexError> {
-        unimplemented!("PanickingRaindex: not available in CLI context")
-    }
-
-    async fn submit_deposit(
-        &self,
-        _: Address,
-        _: RaindexVaultId,
-        _: U256,
-        _: u8,
-    ) -> Result<TxHash, RaindexError> {
-        unimplemented!("PanickingRaindex: not available in CLI context")
-    }
-
-    async fn submit_withdraw(
-        &self,
-        _: Address,
-        _: RaindexVaultId,
-        _: U256,
-        _: u8,
-    ) -> Result<TxHash, RaindexError> {
-        unimplemented!("PanickingRaindex: not available in CLI context")
-    }
-
-    async fn confirm_tx_receipt(&self, _: TxHash) -> Result<TransactionReceipt, RaindexError> {
-        unimplemented!("PanickingRaindex: not available in CLI context")
-    }
-}
-
-/// Panicking VaultLookup stub for CLI-only use. All methods panic.
-struct PanickingVaultLookup;
-
-#[async_trait]
-impl VaultLookup for PanickingVaultLookup {
-    async fn vault_id_for_token(&self, _: Address) -> Result<RaindexVaultId, VaultLookupError> {
-        unimplemented!("PanickingVaultLookup: not available in CLI context")
-    }
-
-    async fn vault_token_for_symbol(&self, _: &Symbol) -> Result<Address, VaultLookupError> {
-        unimplemented!("PanickingVaultLookup: not available in CLI context")
-    }
-}
-
-/// Panicking Tokenizer stub for CLI-only use. All methods panic.
-struct PanickingTokenizer;
-
-#[async_trait]
-impl Tokenizer for PanickingTokenizer {
-    async fn request_mint(
-        &self,
-        _: Symbol,
-        _: FractionalShares,
-        _: Address,
-        _: IssuerRequestId,
-    ) -> Result<TokenizationRequest, TokenizerError> {
-        unimplemented!("PanickingTokenizer: not available in CLI context")
-    }
-
-    async fn poll_mint_until_complete(
-        &self,
-        _: &TokenizationRequestId,
-    ) -> Result<TokenizationRequest, TokenizerError> {
-        unimplemented!("PanickingTokenizer: not available in CLI context")
-    }
-
-    async fn get_request(
-        &self,
-        _: &TokenizationRequestId,
-    ) -> Result<TokenizationRequest, TokenizerError> {
-        unimplemented!("PanickingTokenizer: not available in CLI context")
-    }
-
-    fn redemption_wallet(&self) -> Option<Address> {
-        unimplemented!("PanickingTokenizer: not available in CLI context")
-    }
-
-    async fn wait_for_block(&self, _: u64) -> Result<(), EvmError> {
-        unimplemented!("PanickingTokenizer: not available in CLI context")
-    }
-
-    async fn send_for_redemption(&self, _: Address, _: U256) -> Result<TxHash, TokenizerError> {
-        unimplemented!("PanickingTokenizer: not available in CLI context")
-    }
-
-    async fn poll_for_redemption(&self, _: &TxHash) -> Result<TokenizationRequest, TokenizerError> {
-        unimplemented!("PanickingTokenizer: not available in CLI context")
-    }
-
-    async fn find_redemption_by_tx(
-        &self,
-        _: &TxHash,
-    ) -> Result<Option<TokenizationRequest>, TokenizerError> {
-        unimplemented!("PanickingTokenizer: not available in CLI context")
-    }
-
-    async fn poll_redemption_until_complete(
-        &self,
-        _: &TokenizationRequestId,
-    ) -> Result<TokenizationRequest, TokenizerError> {
-        unimplemented!("PanickingTokenizer: not available in CLI context")
-    }
-
-    async fn verify_mint_tx(
-        &self,
-        _: TxHash,
-        _: Address,
-        _: Address,
-        _: U256,
-    ) -> Result<(), MintVerificationError> {
-        unimplemented!("PanickingTokenizer: not available in CLI context")
-    }
-
-    async fn list_pending_requests(&self) -> Result<Vec<TokenizationRequest>, TokenizerError> {
-        unimplemented!("PanickingTokenizer: not available in CLI context")
-    }
-}
-
-/// Panicking Wrapper stub for CLI-only use. All methods panic.
-struct PanickingWrapper;
-
-#[async_trait]
-impl Wrapper for PanickingWrapper {
-    async fn get_ratio_for_symbol(&self, _: &Symbol) -> Result<UnderlyingPerWrapped, WrapperError> {
-        unimplemented!("PanickingWrapper: not available in CLI context")
-    }
-
-    fn lookup_underlying(&self, _: &Symbol) -> Result<Address, WrapperError> {
-        unimplemented!("PanickingWrapper: not available in CLI context")
-    }
-
-    fn lookup_derivative(&self, _: &Symbol) -> Result<Address, WrapperError> {
-        unimplemented!("PanickingWrapper: not available in CLI context")
-    }
-
-    async fn to_wrapped(
-        &self,
-        _: Address,
-        _: U256,
-        _: Address,
-    ) -> Result<(TxHash, U256), WrapperError> {
-        unimplemented!("PanickingWrapper: not available in CLI context")
-    }
-
-    async fn to_underlying(
-        &self,
-        _: Address,
-        _: U256,
-        _: Address,
-        _: Address,
-    ) -> Result<(TxHash, U256), WrapperError> {
-        unimplemented!("PanickingWrapper: not available in CLI context")
-    }
-
-    async fn donate(&self, _: Address, _: U256) -> Result<TxHash, WrapperError> {
-        unimplemented!("PanickingWrapper: not available in CLI context")
-    }
-
-    async fn submit_wrap(&self, _: Address, _: U256, _: Address) -> Result<TxHash, WrapperError> {
-        unimplemented!("PanickingWrapper: not available in CLI context")
-    }
-
-    async fn confirm_wrap(&self, _: Address, _: TxHash) -> Result<WrapConfirmation, WrapperError> {
-        unimplemented!("PanickingWrapper: not available in CLI context")
-    }
-
-    async fn submit_unwrap(
-        &self,
-        _: Address,
-        _: U256,
-        _: Address,
-        _: Address,
-    ) -> Result<TxHash, WrapperError> {
-        unimplemented!("PanickingWrapper: not available in CLI context")
-    }
-
-    async fn confirm_unwrap(
-        &self,
-        _: Address,
-        _: TxHash,
-    ) -> Result<UnwrapConfirmation, WrapperError> {
-        unimplemented!("PanickingWrapper: not available in CLI context")
-    }
-
-    async fn wait_for_block(&self, _: u64) -> Result<(), WrapperError> {
-        unimplemented!("PanickingWrapper: not available in CLI context")
-    }
-
-    fn owner(&self) -> Address {
-        unimplemented!("PanickingWrapper: not available in CLI context")
-    }
-}
-
 #[derive(Debug, Error)]
 pub(crate) enum MintError {
     #[error("Aggregate error: {0}")]
@@ -498,6 +259,7 @@ impl From<step::EquityVaultStepError> for MintError {
             step::EquityVaultStepError::Wrapper(error) => Self::Wrapper(error),
             step::EquityVaultStepError::Raindex(error) => Self::Raindex(error),
             step::EquityVaultStepError::VaultLookup(error) => Self::VaultLookup(error),
+            other => unreachable!("withdrawal-specific step error on mint path: {other:?}"),
         }
     }
 }
@@ -575,6 +337,10 @@ pub(crate) enum RedemptionError {
     Tokenizer(#[from] TokenizerError),
     #[error(transparent)]
     SharesConversion(#[from] SharesConversionError),
+    #[error(transparent)]
+    Step(#[from] step::EquityVaultStepError),
+    #[error(transparent)]
+    NodeSync(#[from] EvmError),
     #[error("Entity not found after command: {aggregate_id}")]
     EntityNotFound { aggregate_id: RedemptionAggregateId },
     #[error("Token send to Alpaca failed: {entity:?}")]
@@ -1116,8 +882,8 @@ impl CrossVenueEquityTransfer {
         Ok(())
     }
 
-    /// Sends the Redeem command to submit vault withdrawal, then
-    /// ConfirmWithdraw to wait for confirmation.
+    /// Sends Redeem, then drives the withdraw I/O in the orchestrator,
+    /// recording the submitted tx and the confirmation via pure commands.
     async fn withdraw_from_raindex(
         &self,
         aggregate_id: &RedemptionAggregateId,
@@ -1138,14 +904,64 @@ impl CrossVenueEquityTransfer {
             )
             .await?;
 
-        self.redemption_store
-            .send(aggregate_id, EquityRedemptionCommand::SubmitWithdraw)
-            .await?;
+        self.submit_and_confirm_withdraw(aggregate_id, token, amount)
+            .await
+    }
+
+    /// Submits the vault withdrawal, records it, then confirms it. Shared by the
+    /// fresh-start path and resume from `VaultWithdrawPending`.
+    async fn submit_and_confirm_withdraw(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        token: Address,
+        wrapped_amount: U256,
+    ) -> Result<(), RedemptionError> {
+        let tx_hash = step::submit_vault_withdraw(
+            self.vault_lookup.as_ref(),
+            self.raindex.as_ref(),
+            token,
+            wrapped_amount,
+        )
+        .await?;
 
         self.redemption_store
-            .send(aggregate_id, EquityRedemptionCommand::ConfirmWithdraw)
+            .send(
+                aggregate_id,
+                EquityRedemptionCommand::SubmitWithdraw { tx_hash },
+            )
             .await?;
 
+        self.confirm_withdraw(aggregate_id, token, tx_hash).await
+    }
+
+    /// Confirms a submitted withdrawal and records the decoded receipt. Shared
+    /// by resume from `VaultWithdrawSubmitted`.
+    async fn confirm_withdraw(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        token: Address,
+        tx_hash: TxHash,
+    ) -> Result<(), RedemptionError> {
+        let step::ConfirmedWithdraw {
+            actual_wrapped_amount,
+            raindex_withdraw_block,
+        } = step::confirm_vault_withdraw(
+            self.raindex.as_ref(),
+            self.wrapper.as_ref(),
+            token,
+            tx_hash,
+        )
+        .await?;
+
+        self.redemption_store
+            .send(
+                aggregate_id,
+                EquityRedemptionCommand::ConfirmWithdraw {
+                    actual_wrapped_amount,
+                    raindex_withdraw_block,
+                },
+            )
+            .await?;
         Ok(())
     }
 
@@ -1159,13 +975,26 @@ impl CrossVenueEquityTransfer {
             .send(aggregate_id, EquityRedemptionCommand::UnwrapTokens)
             .await?;
 
-        self.redemption_store
-            .send(aggregate_id, EquityRedemptionCommand::SubmitUnwrap)
-            .await?;
+        let (symbol, token, wrapped_amount, raindex_withdraw_block) =
+            match self.load_redemption_entity(aggregate_id).await? {
+                EquityRedemption::UnwrapPending {
+                    symbol,
+                    token,
+                    wrapped_amount,
+                    raindex_withdraw_block,
+                    ..
+                } => (symbol, token, wrapped_amount, raindex_withdraw_block),
+                entity => return Err(RedemptionError::UnexpectedEntity { entity }),
+            };
 
-        self.redemption_store
-            .send(aggregate_id, EquityRedemptionCommand::ConfirmUnwrap)
-            .await?;
+        self.submit_and_confirm_unwrap(
+            aggregate_id,
+            &symbol,
+            token,
+            wrapped_amount,
+            raindex_withdraw_block,
+        )
+        .await?;
 
         info!(target: "rebalance", %aggregate_id, "Tokens unwrapped, sending to Alpaca");
 
@@ -1173,20 +1002,174 @@ impl CrossVenueEquityTransfer {
             .send(aggregate_id, EquityRedemptionCommand::PrepareSend)
             .await?;
 
-        self.redemption_store
-            .send(aggregate_id, EquityRedemptionCommand::SendTokens)
-            .await?;
+        self.send_redemption(aggregate_id).await?;
 
-        let entity = self.redemption_store.load(aggregate_id).await?.ok_or(
-            RedemptionError::EntityNotFound {
-                aggregate_id: aggregate_id.clone(),
-            },
-        )?;
-
-        match entity {
+        match self.load_redemption_entity(aggregate_id).await? {
             EquityRedemption::TokensSent { redemption_tx, .. } => Ok(redemption_tx),
             entity @ EquityRedemption::Failed { .. } => Err(RedemptionError::SendFailed { entity }),
             entity => Err(RedemptionError::UnexpectedEntity { entity }),
+        }
+    }
+
+    /// Submits the ERC-4626 unwrap, records it, then confirms it. Shared by the
+    /// fresh-start path and resume from `UnwrapPending`.
+    async fn submit_and_confirm_unwrap(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        symbol: &Symbol,
+        token: Address,
+        wrapped_amount: U256,
+        raindex_withdraw_block: Option<u64>,
+    ) -> Result<(), RedemptionError> {
+        let unwrap_tx_hash = step::submit_token_unwrap(
+            self.wrapper.as_ref(),
+            token,
+            wrapped_amount,
+            raindex_withdraw_block,
+        )
+        .await?;
+
+        self.redemption_store
+            .send(
+                aggregate_id,
+                EquityRedemptionCommand::SubmitUnwrap { unwrap_tx_hash },
+            )
+            .await?;
+
+        self.confirm_unwrap(aggregate_id, symbol, token, unwrap_tx_hash)
+            .await
+    }
+
+    /// Confirms a submitted unwrap and records the result. Shared by resume from
+    /// `UnwrapSubmitted`.
+    async fn confirm_unwrap(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        symbol: &Symbol,
+        token: Address,
+        unwrap_tx_hash: TxHash,
+    ) -> Result<(), RedemptionError> {
+        let step::ConfirmedUnwrap {
+            underlying_token,
+            unwrapped_amount,
+            unwrap_block,
+        } = step::confirm_token_unwrap(self.wrapper.as_ref(), symbol, token, unwrap_tx_hash)
+            .await?;
+
+        self.redemption_store
+            .send(
+                aggregate_id,
+                EquityRedemptionCommand::ConfirmUnwrap {
+                    underlying_token,
+                    unwrapped_amount,
+                    unwrap_block,
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Performs the send-to-Alpaca step (reading the persisted `SendPending`
+    /// state) and records its outcome. Shared by the fresh-start path and resume
+    /// from `SendPending`.
+    async fn send_redemption(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+    ) -> Result<(), RedemptionError> {
+        let (symbol, underlying_token, unwrapped_amount, unwrap_block) =
+            match self.load_redemption_entity(aggregate_id).await? {
+                EquityRedemption::SendPending {
+                    symbol,
+                    underlying_token,
+                    unwrapped_amount,
+                    unwrap_block,
+                    ..
+                } => (symbol, underlying_token, unwrapped_amount, unwrap_block),
+                entity => return Err(RedemptionError::UnexpectedEntity { entity }),
+            };
+
+        let outcome = self
+            .send_to_alpaca(&symbol, underlying_token, unwrapped_amount, unwrap_block)
+            .await?;
+
+        match outcome {
+            SendOutcome::Sent {
+                redemption_wallet,
+                redemption_tx,
+            } => {
+                // Persist the broadcast tx immediately, before finalizing, so a
+                // crash here resumes by confirming the recorded tx rather than
+                // re-broadcasting an irreversible transfer.
+                self.redemption_store
+                    .send(
+                        aggregate_id,
+                        EquityRedemptionCommand::SubmitSend {
+                            redemption_wallet,
+                            redemption_tx,
+                        },
+                    )
+                    .await?;
+                self.confirm_send(aggregate_id).await
+            }
+            failure @ (SendOutcome::WalletNotConfigured | SendOutcome::SendFailed) => {
+                self.redemption_store
+                    .send(
+                        aggregate_id,
+                        EquityRedemptionCommand::RecordSendOutcome { outcome: failure },
+                    )
+                    .await?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Finalizes a broadcast redemption send to `TokensSent` without
+    /// re-broadcasting. Shared by the fresh-send path and resume from
+    /// `SendSubmitted`.
+    async fn confirm_send(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+    ) -> Result<(), RedemptionError> {
+        self.redemption_store
+            .send(aggregate_id, EquityRedemptionCommand::ConfirmSend)
+            .await?;
+        Ok(())
+    }
+
+    /// Sends unwrapped tokens to Alpaca's redemption wallet, mapping the result
+    /// to a [`SendOutcome`]. A missing wallet or a send revert is a terminal
+    /// outcome (the aggregate records `TransferFailed`); a node-sync wait
+    /// failure is a retryable error so apalis retries the job.
+    async fn send_to_alpaca(
+        &self,
+        symbol: &Symbol,
+        token: Address,
+        amount: U256,
+        unwrap_block: Option<u64>,
+    ) -> Result<SendOutcome, RedemptionError> {
+        let Some(redemption_wallet) = Tokenizer::redemption_wallet(self.tokenizer.as_ref()) else {
+            warn!(target: "rebalance", %symbol, "Redemption wallet not configured");
+            return Ok(SendOutcome::WalletNotConfigured);
+        };
+
+        // Wait for the tokenizer's provider to index the unwrap block before
+        // sending, so the transfer is not simulated against a stale zero
+        // balance. A wait failure is retryable (NOT a terminal send failure).
+        if let Some(block) = unwrap_block {
+            self.tokenizer.wait_for_block(block).await?;
+        }
+
+        info!(target: "rebalance", %token, %amount, "Sending unwrapped tokens for redemption");
+
+        match Tokenizer::send_for_redemption(self.tokenizer.as_ref(), token, amount).await {
+            Ok(redemption_tx) => Ok(SendOutcome::Sent {
+                redemption_wallet,
+                redemption_tx,
+            }),
+            Err(error) => {
+                warn!(target: "rebalance", %error, %token, %amount, "Send for redemption failed");
+                Ok(SendOutcome::SendFailed)
+            }
         }
     }
 
@@ -1372,31 +1355,47 @@ impl CrossVenueEquityTransfer {
             }
 
             match entity {
-                EquityRedemption::VaultWithdrawPending { .. } => {
+                EquityRedemption::VaultWithdrawPending {
+                    token,
+                    wrapped_amount,
+                    ..
+                } => {
                     info!(%aggregate_id, "Resuming pending vault withdrawal");
-                    self.redemption_store
-                        .send(aggregate_id, EquityRedemptionCommand::SubmitWithdraw)
+                    self.submit_and_confirm_withdraw(aggregate_id, token, wrapped_amount)
                         .await?;
                 }
-                EquityRedemption::VaultWithdrawSubmitted { .. } => {
+                EquityRedemption::VaultWithdrawSubmitted { token, tx_hash, .. } => {
                     info!(%aggregate_id, "Resuming submitted vault withdrawal");
-                    self.redemption_store
-                        .send(aggregate_id, EquityRedemptionCommand::ConfirmWithdraw)
-                        .await?;
+                    self.confirm_withdraw(aggregate_id, token, tx_hash).await?;
                 }
                 EquityRedemption::WithdrawnFromRaindex { .. } => {
                     self.resume_withdrawn_redemption(aggregate_id).await?;
                 }
-                EquityRedemption::UnwrapPending { .. } => {
+                EquityRedemption::UnwrapPending {
+                    symbol,
+                    token,
+                    wrapped_amount,
+                    raindex_withdraw_block,
+                    ..
+                } => {
                     info!(%aggregate_id, "Resuming pending unwrap");
-                    self.redemption_store
-                        .send(aggregate_id, EquityRedemptionCommand::SubmitUnwrap)
-                        .await?;
+                    self.submit_and_confirm_unwrap(
+                        aggregate_id,
+                        &symbol,
+                        token,
+                        wrapped_amount,
+                        raindex_withdraw_block,
+                    )
+                    .await?;
                 }
-                EquityRedemption::UnwrapSubmitted { .. } => {
+                EquityRedemption::UnwrapSubmitted {
+                    symbol,
+                    token,
+                    unwrap_tx_hash,
+                    ..
+                } => {
                     info!(%aggregate_id, "Resuming submitted unwrap");
-                    self.redemption_store
-                        .send(aggregate_id, EquityRedemptionCommand::ConfirmUnwrap)
+                    self.confirm_unwrap(aggregate_id, &symbol, token, unwrap_tx_hash)
                         .await?;
                 }
                 EquityRedemption::TokensUnwrapped { .. } => {
@@ -1404,9 +1403,11 @@ impl CrossVenueEquityTransfer {
                 }
                 EquityRedemption::SendPending { .. } => {
                     info!(%aggregate_id, "Resuming pending send");
-                    self.redemption_store
-                        .send(aggregate_id, EquityRedemptionCommand::SendTokens)
-                        .await?;
+                    self.send_redemption(aggregate_id).await?;
+                }
+                EquityRedemption::SendSubmitted { .. } => {
+                    info!(%aggregate_id, "Resuming submitted send");
+                    self.confirm_send(aggregate_id).await?;
                 }
                 EquityRedemption::TokensSent { redemption_tx, .. } => {
                     self.resume_sent_redemption(aggregate_id, &redemption_tx)
@@ -1986,6 +1987,7 @@ mod tests {
     use st0x_float_macro::float;
 
     use st0x_config::{AssetsConfig, EquitiesConfig};
+    use st0x_raindex::RaindexVaultId;
     use st0x_tokenization::issuer_request_id;
     use st0x_tokenization::mock::{
         MockCompletionOutcome, MockDetectionOutcome, MockMintPollOutcome, MockMintRequestOutcome,
@@ -2012,15 +2014,6 @@ mod tests {
             .with_symbol_token(Symbol::new("TEST").unwrap(), Address::ZERO)
             .with_vault(Address::ZERO, RaindexVaultId(B256::ZERO))
             .with_default_vault(RaindexVaultId(B256::ZERO))
-    }
-
-    fn mock_services() -> EquityTransferServices {
-        EquityTransferServices {
-            raindex: Arc::new(MockRaindex::new()),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: Arc::new(MockWrapper::new()),
-        }
     }
 
     async fn insert_mint_event(
@@ -2184,7 +2177,7 @@ mod tests {
             .unwrap();
         let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
             .with(service.clone())
-            .build(mock_services())
+            .build(())
             .await
             .unwrap();
         service
@@ -2331,7 +2324,7 @@ mod tests {
             .unwrap();
         let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
             .with(service.clone())
-            .build(mock_services())
+            .build(())
             .await
             .unwrap();
         service
@@ -2660,7 +2653,7 @@ mod tests {
             .unwrap();
         let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
             .with(service.clone())
-            .build(mock_services())
+            .build(())
             .await
             .unwrap();
         service
@@ -2704,7 +2697,7 @@ mod tests {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
         let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool.clone(), mock_services()));
+        let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
         let vault_lookup = mock_vault_lookup();
 
         let transfer = CrossVenueEquityTransfer::new(
@@ -2718,6 +2711,150 @@ mod tests {
         );
 
         (transfer, pool)
+    }
+
+    #[tokio::test]
+    async fn send_to_alpaca_returns_wallet_not_configured_when_no_wallet() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new().with_no_redemption_wallet()),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let outcome = transfer
+            .send_to_alpaca(
+                &Symbol::new("AAPL").unwrap(),
+                Address::ZERO,
+                U256::from(1_000_000_000_000_000_000_u64),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(outcome, SendOutcome::WalletNotConfigured),
+            "expected WalletNotConfigured, got {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_to_alpaca_returns_send_failed_on_send_error() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new().with_send_failure()),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let outcome = transfer
+            .send_to_alpaca(
+                &Symbol::new("AAPL").unwrap(),
+                Address::ZERO,
+                U256::from(1_000_000_000_000_000_000_u64),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(outcome, SendOutcome::SendFailed),
+            "expected SendFailed when send_for_redemption errors, got {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_to_alpaca_waits_for_unwrap_block_then_sends() {
+        let unwrap_block = 4242u64;
+        let tokenizer = Arc::new(MockTokenizer::new());
+        let transfer = create_equity_transfer(
+            tokenizer.clone(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let outcome = transfer
+            .send_to_alpaca(
+                &Symbol::new("AAPL").unwrap(),
+                Address::ZERO,
+                U256::from(1_000_000_000_000_000_000_u64),
+                Some(unwrap_block),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(outcome, SendOutcome::Sent { .. }),
+            "expected Sent, got {outcome:?}"
+        );
+        assert_eq!(
+            tokenizer.wait_for_block_calls(),
+            vec![unwrap_block],
+            "send must wait for the unwrap block before sending"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_to_alpaca_skips_wait_when_unwrap_block_is_none() {
+        let tokenizer = Arc::new(MockTokenizer::new());
+        let transfer = create_equity_transfer(
+            tokenizer.clone(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let outcome = transfer
+            .send_to_alpaca(
+                &Symbol::new("AAPL").unwrap(),
+                Address::ZERO,
+                U256::from(1_000_000_000_000_000_000_u64),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, SendOutcome::Sent { .. }));
+        assert_eq!(
+            tokenizer.wait_for_block_calls(),
+            Vec::<u64>::new(),
+            "send must NOT wait for a block when unwrap_block is None"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_to_alpaca_returns_node_sync_error_when_wait_fails() {
+        let tokenizer = Arc::new(MockTokenizer::new().failing_wait_for_block());
+        let transfer = create_equity_transfer(
+            tokenizer.clone(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let error = transfer
+            .send_to_alpaca(
+                &Symbol::new("AAPL").unwrap(),
+                Address::ZERO,
+                U256::from(1_000_000_000_000_000_000_u64),
+                Some(99),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                RedemptionError::NodeSync(EvmError::NodeBehindRequiredBlock { .. })
+            ),
+            "a wait-for-block failure must surface as a retryable NodeSync error, got {error:?}"
+        );
+        assert_eq!(
+            tokenizer.redemption_send_count(),
+            0,
+            "tokens must NOT be sent when the node-sync wait fails (wait happens first)"
+        );
     }
 
     #[tokio::test]
@@ -3263,36 +3400,474 @@ mod tests {
         );
     }
 
-    /// Drives a redemption to `SendPending` (the last pre-send state) via the
-    /// command chain, without touching the tokenizer.
+    /// Resume from `VaultWithdrawSubmitted` re-confirms the persisted withdraw tx
+    /// without re-broadcasting it -- the crash-recovery property the submit/confirm
+    /// split exists to deliver.
+    #[tokio::test]
+    async fn resume_from_vault_withdraw_submitted_confirms_without_resubmitting() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+            MockTokenizer::new()
+                .with_detection_outcome(MockDetectionOutcome::Detected)
+                .with_completion_outcome(MockCompletionOutcome::Completed),
+        );
+        let transfer = create_equity_transfer(
+            tokenizer,
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = redemption_aggregate_id("resume-withdraw-submitted");
+        let symbol = Symbol::new("TEST").unwrap();
+        let quantity = FractionalShares::new(float!(50));
+        let token = transfer
+            .vault_lookup
+            .vault_token_for_symbol(&symbol)
+            .await
+            .unwrap();
+        let amount = quantity.to_u256_18_decimals().unwrap();
+
+        // Seed `VaultWithdrawSubmitted`: the withdraw tx was broadcast and
+        // recorded, then the process crashed before confirmation.
+        transfer
+            .redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::Redeem {
+                    symbol: symbol.clone(),
+                    quantity: quantity.inner(),
+                    token,
+                    amount,
+                },
+            )
+            .await
+            .unwrap();
+        let tx_hash = step::submit_vault_withdraw(
+            transfer.vault_lookup.as_ref(),
+            transfer.raindex.as_ref(),
+            token,
+            amount,
+        )
+        .await
+        .unwrap();
+        transfer
+            .redemption_store
+            .send(&id, EquityRedemptionCommand::SubmitWithdraw { tx_hash })
+            .await
+            .unwrap();
+
+        let seeded = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(seeded, EquityRedemption::VaultWithdrawSubmitted { .. }),
+            "test setup must seed VaultWithdrawSubmitted, got: {seeded:?}"
+        );
+
+        // Resume takes the confirm-only arm. Re-entering the submit path would
+        // re-send `SubmitWithdraw` from an already-submitted aggregate, which the
+        // state machine rejects -- so reaching `Completed` proves the persisted
+        // withdraw was confirmed, never re-broadcast.
+        transfer.resume_redemption(&id).await.unwrap();
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::Completed { .. }),
+            "Expected Completed after resume from VaultWithdrawSubmitted, got: {entity:?}"
+        );
+    }
+
+    /// Resume from `UnwrapSubmitted` re-confirms the persisted unwrap tx without
+    /// re-broadcasting it.
+    #[tokio::test]
+    async fn resume_from_unwrap_submitted_confirms_without_resubmitting() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+            MockTokenizer::new()
+                .with_detection_outcome(MockDetectionOutcome::Detected)
+                .with_completion_outcome(MockCompletionOutcome::Completed),
+        );
+        let transfer = create_equity_transfer(
+            tokenizer,
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = redemption_aggregate_id("resume-unwrap-submitted");
+        let symbol = Symbol::new("TEST").unwrap();
+        let quantity = FractionalShares::new(float!(50));
+        let token = transfer
+            .vault_lookup
+            .vault_token_for_symbol(&symbol)
+            .await
+            .unwrap();
+        let amount = quantity.to_u256_18_decimals().unwrap();
+
+        // Drive through the confirmed withdrawal to `UnwrapPending`.
+        transfer
+            .withdraw_from_raindex(&id, &symbol, quantity, token, amount)
+            .await
+            .unwrap();
+        transfer
+            .redemption_store
+            .send(&id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+
+        // Seed `UnwrapSubmitted`: the unwrap tx was broadcast and recorded, then
+        // the process crashed before confirmation.
+        let (unwrap_token, wrapped_amount, raindex_withdraw_block) =
+            match transfer.redemption_store.load(&id).await.unwrap().unwrap() {
+                EquityRedemption::UnwrapPending {
+                    token,
+                    wrapped_amount,
+                    raindex_withdraw_block,
+                    ..
+                } => (token, wrapped_amount, raindex_withdraw_block),
+                other => panic!("expected UnwrapPending, got: {other:?}"),
+            };
+        let unwrap_tx_hash = step::submit_token_unwrap(
+            transfer.wrapper.as_ref(),
+            unwrap_token,
+            wrapped_amount,
+            raindex_withdraw_block,
+        )
+        .await
+        .unwrap();
+        transfer
+            .redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitUnwrap { unwrap_tx_hash },
+            )
+            .await
+            .unwrap();
+
+        let seeded = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(seeded, EquityRedemption::UnwrapSubmitted { .. }),
+            "test setup must seed UnwrapSubmitted, got: {seeded:?}"
+        );
+
+        // Resume takes the confirm-only arm; re-entering submit would re-send
+        // `SubmitUnwrap` from an already-submitted aggregate (rejected), so
+        // reaching `Completed` proves the unwrap was confirmed, not re-broadcast.
+        transfer.resume_redemption(&id).await.unwrap();
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::Completed { .. }),
+            "Expected Completed after resume from UnwrapSubmitted, got: {entity:?}"
+        );
+    }
+
+    /// A partial vault fill collapses the withdrawn amount; the orchestrator must
+    /// unwrap that actual amount, not the originally requested one.
+    #[tokio::test]
+    async fn unwrap_uses_actual_partial_withdraw_amount_through_orchestrator() {
+        let quantity = FractionalShares::new(float!(37.143292455));
+        let requested = quantity.to_u256_18_decimals().unwrap();
+        let actual = U256::from(33_681_456_848_531_939_569_u128);
+
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
+        let wrapper = Arc::new(MockWrapper::new());
+        let transfer = create_equity_transfer(
+            tokenizer,
+            Arc::new(MockRaindex::new().with_withdraw_actual_amount(actual)),
+            wrapper.clone(),
+        )
+        .await;
+
+        let id = redemption_aggregate_id("partial-unwrap");
+        let symbol = Symbol::new("TEST").unwrap();
+        let token = transfer
+            .vault_lookup
+            .vault_token_for_symbol(&symbol)
+            .await
+            .unwrap();
+
+        // Orchestrator-driven partial withdrawal: the receipt yields `actual` <
+        // `requested`, which the aggregate collapses into the persisted amount.
+        transfer
+            .withdraw_from_raindex(&id, &symbol, quantity, token, requested)
+            .await
+            .unwrap();
+        transfer
+            .redemption_store
+            .send(&id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+
+        let (unwrap_token, wrapped_amount, raindex_withdraw_block) =
+            match transfer.redemption_store.load(&id).await.unwrap().unwrap() {
+                EquityRedemption::UnwrapPending {
+                    token,
+                    wrapped_amount,
+                    raindex_withdraw_block,
+                    ..
+                } => (token, wrapped_amount, raindex_withdraw_block),
+                other => panic!("expected UnwrapPending, got: {other:?}"),
+            };
+
+        assert_eq!(
+            wrapped_amount, actual,
+            "orchestrator-driven confirm must collapse the persisted amount to the \
+             partial receipt amount"
+        );
+
+        // The unwrap submits the collapsed amount the orchestrator loaded, not the
+        // original request. (Asserted before confirm, which consumes the record.)
+        step::submit_token_unwrap(
+            transfer.wrapper.as_ref(),
+            unwrap_token,
+            wrapped_amount,
+            raindex_withdraw_block,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            wrapper.submitted_unwrap_amount(),
+            Some(actual),
+            "the orchestrator must unwrap the actual partial-withdraw amount, not the request"
+        );
+    }
+
+    /// RPC lag while waiting to unwrap surfaces as a retryable
+    /// `RedemptionError::Step(Wrapper(Evm(NodeBehindRequiredBlock)))`, so apalis
+    /// retries it. Documents the intended retryable shape for unwrap waits (the
+    /// unwrap path mirrors the mint path's treatment of the same wrapper wait,
+    /// unlike the send path which maps its tokenizer wait to `NodeSync`).
+    #[tokio::test]
+    async fn unwrap_wait_for_block_lag_surfaces_as_retryable_step_error() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
+        let transfer = create_equity_transfer(
+            tokenizer,
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::failing_wait_for_block()),
+        )
+        .await;
+
+        let id = redemption_aggregate_id("unwrap-wait-lag");
+        let symbol = Symbol::new("TEST").unwrap();
+        let quantity = FractionalShares::new(float!(50));
+        let token = transfer
+            .vault_lookup
+            .vault_token_for_symbol(&symbol)
+            .await
+            .unwrap();
+        let amount = quantity.to_u256_18_decimals().unwrap();
+
+        transfer
+            .withdraw_from_raindex(&id, &symbol, quantity, token, amount)
+            .await
+            .unwrap();
+
+        let error = transfer.unwrap_and_send(&id).await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                RedemptionError::Step(step::EquityVaultStepError::Wrapper(WrapperError::Evm(
+                    EvmError::NodeBehindRequiredBlock { .. }
+                )))
+            ),
+            "unwrap wait-for-block lag must surface as a retryable Step error, got: {error:?}"
+        );
+    }
+
+    /// The full redemption flow broadcasts the Alpaca transfer exactly once
+    /// (submit/confirm split: SubmitSend records the broadcast, ConfirmSend
+    /// finalizes without re-sending).
+    #[tokio::test]
+    async fn send_redemption_broadcasts_the_transfer_exactly_once() {
+        let tokenizer = Arc::new(
+            MockTokenizer::new()
+                .with_detection_outcome(MockDetectionOutcome::Detected)
+                .with_completion_outcome(MockCompletionOutcome::Completed),
+        );
+        let transfer = create_equity_transfer(
+            tokenizer.clone(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = redemption_aggregate_id("send-once");
+        transfer
+            .resume_equity_to_hedging(
+                &id,
+                &Symbol::new("TEST").unwrap(),
+                FractionalShares::new(float!(50)),
+            )
+            .await
+            .unwrap();
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::Completed { .. }),
+            "expected Completed, got: {entity:?}"
+        );
+        assert_eq!(
+            tokenizer.redemption_send_count(),
+            1,
+            "the redemption transfer must be broadcast exactly once across the full flow"
+        );
+    }
+
+    /// Resume from `SendSubmitted` finalizes the persisted redemption tx without
+    /// re-broadcasting -- the crash-window the submit/confirm split closes.
+    #[tokio::test]
+    async fn resume_from_send_submitted_finalizes_without_resending() {
+        let tokenizer = Arc::new(
+            MockTokenizer::new()
+                .with_detection_outcome(MockDetectionOutcome::Detected)
+                .with_completion_outcome(MockCompletionOutcome::Completed),
+        );
+        let transfer = create_equity_transfer(
+            tokenizer.clone(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = redemption_aggregate_id("resume-send-submitted");
+        let symbol = Symbol::new("TEST").unwrap();
+        let quantity = FractionalShares::new(float!(50));
+        let token = transfer
+            .vault_lookup
+            .vault_token_for_symbol(&symbol)
+            .await
+            .unwrap();
+        let amount = quantity.to_u256_18_decimals().unwrap();
+
+        // Drive to `SendPending` through the orchestrator.
+        transfer
+            .withdraw_from_raindex(&id, &symbol, quantity, token, amount)
+            .await
+            .unwrap();
+        transfer
+            .redemption_store
+            .send(&id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+        let (unwrap_token, wrapped_amount, raindex_withdraw_block) =
+            match transfer.redemption_store.load(&id).await.unwrap().unwrap() {
+                EquityRedemption::UnwrapPending {
+                    token,
+                    wrapped_amount,
+                    raindex_withdraw_block,
+                    ..
+                } => (token, wrapped_amount, raindex_withdraw_block),
+                other => panic!("expected UnwrapPending, got: {other:?}"),
+            };
+        transfer
+            .submit_and_confirm_unwrap(
+                &id,
+                &symbol,
+                unwrap_token,
+                wrapped_amount,
+                raindex_withdraw_block,
+            )
+            .await
+            .unwrap();
+        transfer
+            .redemption_store
+            .send(&id, EquityRedemptionCommand::PrepareSend)
+            .await
+            .unwrap();
+
+        // Seed `SendSubmitted`: the transfer was broadcast and recorded, then a
+        // crash before the bookkeeping finalization. (SubmitSend is pure -- no
+        // real send happens in the test, so the send counter stays at zero.)
+        transfer
+            .redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitSend {
+                    redemption_wallet: Address::random(),
+                    redemption_tx: TxHash::random(),
+                },
+            )
+            .await
+            .unwrap();
+        let seeded = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(seeded, EquityRedemption::SendSubmitted { .. }),
+            "test setup must seed SendSubmitted, got: {seeded:?}"
+        );
+
+        // Resume takes the confirm-only arm. Re-entering the send path would
+        // re-send `SubmitSend` from a non-SendPending state (rejected) and
+        // re-broadcast, so reaching Completed with zero sends proves the transfer
+        // was finalized, never re-broadcast.
+        transfer.resume_redemption(&id).await.unwrap();
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::Completed { .. }),
+            "resume from SendSubmitted must finalize to Completed, got: {entity:?}"
+        );
+        assert_eq!(
+            tokenizer.redemption_send_count(),
+            0,
+            "resume from SendSubmitted must NOT re-broadcast the irreversible transfer"
+        );
+    }
+
+    /// Drives a redemption to `SendPending` (the last pre-send state) through
+    /// the orchestrator steps, without touching the tokenizer.
     async fn seed_send_pending(
         transfer: &CrossVenueEquityTransfer,
         id: &RedemptionAggregateId,
         symbol: &Symbol,
     ) {
+        let quantity = FractionalShares::new(float!(50));
+        let token = transfer
+            .vault_lookup
+            .vault_token_for_symbol(symbol)
+            .await
+            .unwrap();
+        let amount = quantity.to_u256_18_decimals().unwrap();
+
+        transfer
+            .withdraw_from_raindex(id, symbol, quantity, token, amount)
+            .await
+            .unwrap();
         transfer
             .redemption_store
-            .send(
+            .send(id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+        let (unwrap_token, wrapped_amount, raindex_withdraw_block) =
+            match transfer.redemption_store.load(id).await.unwrap().unwrap() {
+                EquityRedemption::UnwrapPending {
+                    token,
+                    wrapped_amount,
+                    raindex_withdraw_block,
+                    ..
+                } => (token, wrapped_amount, raindex_withdraw_block),
+                other => panic!("expected UnwrapPending, got: {other:?}"),
+            };
+        transfer
+            .submit_and_confirm_unwrap(
                 id,
-                EquityRedemptionCommand::Redeem {
-                    symbol: symbol.clone(),
-                    quantity: float!(50),
-                    token: Address::ZERO,
-                    amount: U256::from(50_000_000_000_000_000_000_u128),
-                },
+                symbol,
+                unwrap_token,
+                wrapped_amount,
+                raindex_withdraw_block,
             )
             .await
             .unwrap();
-        for command in [
-            EquityRedemptionCommand::SubmitWithdraw,
-            EquityRedemptionCommand::ConfirmWithdraw,
-            EquityRedemptionCommand::UnwrapTokens,
-            EquityRedemptionCommand::SubmitUnwrap,
-            EquityRedemptionCommand::ConfirmUnwrap,
-            EquityRedemptionCommand::PrepareSend,
-        ] {
-            transfer.redemption_store.send(id, command).await.unwrap();
-        }
+        transfer
+            .redemption_store
+            .send(id, EquityRedemptionCommand::PrepareSend)
+            .await
+            .unwrap();
+
+        let seeded = transfer.redemption_store.load(id).await.unwrap().unwrap();
+        assert!(
+            matches!(seeded, EquityRedemption::SendPending { .. }),
+            "test setup must seed SendPending, got: {seeded:?}"
+        );
     }
 
     /// A pre-send redemption holds during a dividend freeze: the resume
@@ -3378,12 +3953,20 @@ mod tests {
 
         let id = redemption_aggregate_id("redeem-frozen-post-send");
         let symbol = Symbol::new("TEST").unwrap();
-        seed_send_pending(&transfer, &id, &symbol).await;
-        transfer
-            .redemption_store
-            .send(&id, EquityRedemptionCommand::SendTokens)
+        let quantity = FractionalShares::new(float!(50));
+        let token = transfer
+            .vault_lookup
+            .vault_token_for_symbol(&symbol)
             .await
             .unwrap();
+        let amount = quantity.to_u256_18_decimals().unwrap();
+
+        // Drive past the send commitment (`TokensSent`) before freezing.
+        transfer
+            .withdraw_from_raindex(&id, &symbol, quantity, token, amount)
+            .await
+            .unwrap();
+        transfer.unwrap_and_send(&id).await.unwrap();
 
         transfer
             .set_freeze_status_reader(Arc::new(StubFreezeReader::Frozen))

--- a/src/rebalancing/equity/resume_job.rs
+++ b/src/rebalancing/equity/resume_job.rs
@@ -105,10 +105,9 @@ mod tests {
 
     use super::*;
     use crate::equity_redemption::{
-        EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,
+        EquityRedemption, EquityRedemptionCommand, SendOutcome, redemption_aggregate_id,
     };
     use crate::onchain::mock::MockRaindex;
-    use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintCommand};
     use crate::vault_lookup::MockVaultLookup;
 
@@ -140,15 +139,8 @@ mod tests {
         let vault_lookup =
             Arc::new(MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO)));
 
-        let transfer_services = EquityTransferServices {
-            raindex: raindex.clone(),
-            vault_lookup: vault_lookup.clone(),
-            tokenizer: tokenizer.clone(),
-            wrapper: wrapper.clone(),
-        };
-
         let mint_store = Arc::new(test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool, transfer_services));
+        let redemption_store = Arc::new(test_store(pool, ()));
 
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex,
@@ -317,8 +309,7 @@ mod tests {
 
         // Drive redemption to Completed: Redeem -> SubmitWithdraw ->
         // ConfirmWithdraw -> UnwrapTokens -> SubmitUnwrap -> ConfirmUnwrap ->
-        // PrepareSend -> SendTokens -> (TokensSent). Then detect via DetectSend.
-        // MockRaindex and MockWrapper complete synchronously.
+        // PrepareSend -> RecordSendOutcome -> (TokensSent). Then detect.
         redemption_store
             .send(
                 &id,
@@ -332,22 +323,67 @@ mod tests {
             .await
             .unwrap();
 
-        // Drive through intermediate states to SendPending.
-        for cmd in [
-            EquityRedemptionCommand::SubmitWithdraw,
-            EquityRedemptionCommand::ConfirmWithdraw,
-            EquityRedemptionCommand::UnwrapTokens,
-            EquityRedemptionCommand::SubmitUnwrap,
-            EquityRedemptionCommand::ConfirmUnwrap,
-            EquityRedemptionCommand::PrepareSend,
-        ] {
-            redemption_store.send(&id, cmd).await.unwrap();
-        }
-
-        // SendTokens uses MockTokenizer.send_for_redemption which succeeds.
-        // Drives SendPending -> TokensSent.
+        // Drive through intermediate states to SendPending, supplying the
+        // values the orchestrator would normally derive from its onchain steps.
         redemption_store
-            .send(&id, EquityRedemptionCommand::SendTokens)
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitWithdraw {
+                    tx_hash: TxHash::random(),
+                },
+            )
+            .await
+            .unwrap();
+        redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmWithdraw {
+                    actual_wrapped_amount: U256::from(1_000_000_000_000_000_000_u128),
+                    raindex_withdraw_block: 100,
+                },
+            )
+            .await
+            .unwrap();
+        redemption_store
+            .send(&id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+        redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitUnwrap {
+                    unwrap_tx_hash: TxHash::random(),
+                },
+            )
+            .await
+            .unwrap();
+        redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmUnwrap {
+                    underlying_token: Address::ZERO,
+                    unwrapped_amount: U256::from(1_000_000_000_000_000_000_u128),
+                    unwrap_block: 101,
+                },
+            )
+            .await
+            .unwrap();
+        redemption_store
+            .send(&id, EquityRedemptionCommand::PrepareSend)
+            .await
+            .unwrap();
+
+        // Record a successful send: SendPending -> TokensSent.
+        redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::RecordSendOutcome {
+                    outcome: SendOutcome::Sent {
+                        redemption_wallet: Address::ZERO,
+                        redemption_tx: TxHash::random(),
+                    },
+                },
+            )
             .await
             .unwrap();
 
@@ -519,16 +555,53 @@ mod tests {
             )
             .await
             .unwrap();
-        for cmd in [
-            EquityRedemptionCommand::SubmitWithdraw,
-            EquityRedemptionCommand::ConfirmWithdraw,
-            EquityRedemptionCommand::UnwrapTokens,
-            EquityRedemptionCommand::SubmitUnwrap,
-            EquityRedemptionCommand::ConfirmUnwrap,
-            EquityRedemptionCommand::PrepareSend,
-        ] {
-            redemption_store.send(&id, cmd).await.unwrap();
-        }
+        redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitWithdraw {
+                    tx_hash: TxHash::random(),
+                },
+            )
+            .await
+            .unwrap();
+        redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmWithdraw {
+                    actual_wrapped_amount: U256::from(1_000_000_000_000_000_000_u128),
+                    raindex_withdraw_block: 100,
+                },
+            )
+            .await
+            .unwrap();
+        redemption_store
+            .send(&id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+        redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitUnwrap {
+                    unwrap_tx_hash: TxHash::random(),
+                },
+            )
+            .await
+            .unwrap();
+        redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmUnwrap {
+                    underlying_token: Address::ZERO,
+                    unwrapped_amount: U256::from(1_000_000_000_000_000_000_u128),
+                    unwrap_block: 101,
+                },
+            )
+            .await
+            .unwrap();
+        redemption_store
+            .send(&id, EquityRedemptionCommand::PrepareSend)
+            .await
+            .unwrap();
 
         let seeded = redemption_store.load(&id).await.unwrap();
         assert!(

--- a/src/rebalancing/equity/step.rs
+++ b/src/rebalancing/equity/step.rs
@@ -15,16 +15,20 @@
 //! into its own events or outcome commands.
 
 use alloy::primitives::{Address, TxHash, U256};
+use alloy::rpc::types::TransactionReceipt;
+use alloy::sol_types::SolEvent;
 use thiserror::Error;
 
+use st0x_evm::IERC20;
 use st0x_execution::Symbol;
 use st0x_raindex::{Raindex, RaindexError};
-use st0x_wrapper::{Wrapper, WrapperError};
+use st0x_wrapper::{UnwrapConfirmation, Wrapper, WrapperError};
 
 use crate::tokenized_equity_mint::TOKENIZED_EQUITY_DECIMALS;
 use crate::vault_lookup::{VaultLookup, VaultLookupError};
 
-/// Failure of a shared equity vault step (wrap or vault deposit).
+/// Failure of a shared equity vault step (wrap, vault deposit, withdraw, or
+/// unwrap).
 #[derive(Debug, Error)]
 pub(crate) enum EquityVaultStepError {
     #[error(transparent)]
@@ -33,6 +37,23 @@ pub(crate) enum EquityVaultStepError {
     Raindex(#[from] RaindexError),
     #[error(transparent)]
     VaultLookup(#[from] VaultLookupError),
+    #[error("withdrawal receipt {tx_hash} is missing a block number")]
+    MissingWithdrawBlock { tx_hash: TxHash },
+    #[error("withdrawal receipt {tx_hash} has no transfer of token {token} to {recipient}")]
+    WithdrawTransferNotFound {
+        tx_hash: TxHash,
+        token: Address,
+        recipient: Address,
+    },
+    #[error("withdrawal transfer amount overflowed for tx {tx_hash}")]
+    WithdrawTransferOverflow { tx_hash: TxHash },
+    #[error("withdrawal receipt {tx_hash} has a malformed transfer log for token {token}")]
+    WithdrawTransferDecodeFailed {
+        tx_hash: TxHash,
+        token: Address,
+        #[source]
+        source: alloy::sol_types::Error,
+    },
 }
 
 /// Outcome of submitting an equity wrap: the resolved derivative token and the
@@ -90,21 +111,243 @@ pub(crate) async fn submit_vault_deposit(
         .await?)
 }
 
+/// Result of confirming a Raindex vault withdrawal: the amount the recipient
+/// actually received (decoded from the receipt) and the confirmation block.
+#[derive(Debug)]
+pub(crate) struct ConfirmedWithdraw {
+    pub(crate) actual_wrapped_amount: U256,
+    pub(crate) raindex_withdraw_block: u64,
+}
+
+/// Result of confirming an ERC-4626 unwrap: the resolved underlying token, the
+/// confirmed unwrapped amount, and the confirmation block.
+#[derive(Debug)]
+pub(crate) struct ConfirmedUnwrap {
+    pub(crate) underlying_token: Address,
+    pub(crate) unwrapped_amount: U256,
+    pub(crate) unwrap_block: u64,
+}
+
+/// Resolves `wrapped_token`'s vault and submits a withdrawal of `wrapped_amount`
+/// shares, returning the submitted withdraw tx hash. The caller confirms it with
+/// [`confirm_vault_withdraw`].
+pub(crate) async fn submit_vault_withdraw(
+    vault_lookup: &dyn VaultLookup,
+    raindex: &dyn Raindex,
+    wrapped_token: Address,
+    wrapped_amount: U256,
+) -> Result<TxHash, EquityVaultStepError> {
+    let vault_id = vault_lookup.vault_id_for_token(wrapped_token).await?;
+    Ok(raindex
+        .submit_withdraw(
+            wrapped_token,
+            vault_id,
+            wrapped_amount,
+            TOKENIZED_EQUITY_DECIMALS,
+        )
+        .await?)
+}
+
+/// Confirms a submitted withdrawal: waits for the receipt, decodes the amount
+/// the wrapper owner actually received for `token`, and extracts the
+/// confirmation block. Fails fast if the receipt lacks a block number or the
+/// expected transfer.
+pub(crate) async fn confirm_vault_withdraw(
+    raindex: &dyn Raindex,
+    wrapper: &dyn Wrapper,
+    token: Address,
+    tx_hash: TxHash,
+) -> Result<ConfirmedWithdraw, EquityVaultStepError> {
+    let receipt = raindex.confirm_tx_receipt(tx_hash).await?;
+    let raindex_withdraw_block = receipt
+        .block_number
+        .ok_or(EquityVaultStepError::MissingWithdrawBlock { tx_hash })?;
+    let recipient = wrapper.owner();
+    let actual_wrapped_amount = actual_withdrawn_amount_from_receipt(&receipt, token, recipient)?;
+
+    Ok(ConfirmedWithdraw {
+        actual_wrapped_amount,
+        raindex_withdraw_block,
+    })
+}
+
+/// Waits for the RPC node to catch up to `raindex_withdraw_block` (skipped when
+/// `None`, for aggregates persisted before the field existed) then submits the
+/// ERC-4626 unwrap of `wrapped_amount` of `token` to the wrapper owner,
+/// returning the submitted unwrap tx hash. Confirm with [`confirm_token_unwrap`].
+pub(crate) async fn submit_token_unwrap(
+    wrapper: &dyn Wrapper,
+    token: Address,
+    wrapped_amount: U256,
+    raindex_withdraw_block: Option<u64>,
+) -> Result<TxHash, EquityVaultStepError> {
+    if let Some(block) = raindex_withdraw_block {
+        wrapper.wait_for_block(block).await?;
+    }
+    let owner = wrapper.owner();
+    Ok(wrapper
+        .submit_unwrap(token, wrapped_amount, owner, owner)
+        .await?)
+}
+
+/// Resolves `symbol`'s underlying token and confirms a submitted unwrap,
+/// returning the underlying token, the confirmed unwrapped amount, and the
+/// confirmation block.
+pub(crate) async fn confirm_token_unwrap(
+    wrapper: &dyn Wrapper,
+    symbol: &Symbol,
+    token: Address,
+    unwrap_tx_hash: TxHash,
+) -> Result<ConfirmedUnwrap, EquityVaultStepError> {
+    let underlying_token = wrapper.lookup_underlying(symbol)?;
+    let UnwrapConfirmation { assets, block } =
+        wrapper.confirm_unwrap(token, unwrap_tx_hash).await?;
+
+    Ok(ConfirmedUnwrap {
+        underlying_token,
+        unwrapped_amount: assets,
+        unwrap_block: block,
+    })
+}
+
+/// Sums the ERC-20 `Transfer` amounts to `recipient` for `token` in a confirmed
+/// withdrawal receipt. The actual received amount can differ from the requested
+/// amount on a partial vault fill, so the caller uses this rather than trusting
+/// the request.
+fn actual_withdrawn_amount_from_receipt(
+    receipt: &TransactionReceipt,
+    token: Address,
+    recipient: Address,
+) -> Result<U256, EquityVaultStepError> {
+    receipt
+        .inner
+        .logs()
+        .iter()
+        .filter(|log| log.address() == token)
+        .filter(|log| log.topics().first() == Some(&IERC20::Transfer::SIGNATURE_HASH))
+        .try_fold(U256::ZERO, |total: U256, log| {
+            let decoded = log
+                .log_decode_validate::<IERC20::Transfer>()
+                .map_err(
+                    |source| EquityVaultStepError::WithdrawTransferDecodeFailed {
+                        tx_hash: receipt.transaction_hash,
+                        token,
+                        source,
+                    },
+                )?;
+
+            if decoded.data().to != recipient {
+                return Ok(total);
+            }
+
+            total.checked_add(decoded.data().value).ok_or(
+                EquityVaultStepError::WithdrawTransferOverflow {
+                    tx_hash: receipt.transaction_hash,
+                },
+            )
+        })
+        .and_then(|amount: U256| {
+            if amount.is_zero() {
+                Err(EquityVaultStepError::WithdrawTransferNotFound {
+                    tx_hash: receipt.transaction_hash,
+                    token,
+                    recipient,
+                })
+            } else {
+                Ok(amount)
+            }
+        })
+}
+
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Address, B256, TxHash, U256, address};
+    use alloy::consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy::primitives::{
+        Address, B256, Bloom, Bytes, Log as PrimitiveLog, LogData, TxHash, U256, address,
+    };
+    use alloy::rpc::types::{Log, TransactionReceipt};
+    use alloy::sol_types::SolEvent;
 
+    use st0x_evm::{EvmError, IERC20};
     use st0x_execution::Symbol;
     use st0x_raindex::RaindexVaultId;
-    use st0x_wrapper::MockWrapper;
+    use st0x_wrapper::{MockWrapper, WrapperError};
 
-    use super::{EquityVaultStepError, SubmittedWrap, submit_vault_deposit, submit_wrap};
-    use crate::onchain::mock::{DepositBehavior, MockRaindex};
+    use super::{
+        ConfirmedUnwrap, ConfirmedWithdraw, EquityVaultStepError, SubmittedWrap,
+        actual_withdrawn_amount_from_receipt, confirm_token_unwrap, confirm_vault_withdraw,
+        submit_token_unwrap, submit_vault_deposit, submit_vault_withdraw, submit_wrap,
+    };
+    use crate::onchain::mock::{ConfirmTxBehavior, DepositBehavior, MockRaindex, WithdrawBehavior};
     use crate::tokenized_equity_mint::TOKENIZED_EQUITY_DECIMALS;
     use crate::vault_lookup::MockVaultLookup;
 
     fn aapl() -> Symbol {
         Symbol::new("AAPL").unwrap()
+    }
+
+    fn receipt_with_logs(logs: Vec<Log>) -> TransactionReceipt {
+        TransactionReceipt {
+            inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom {
+                receipt: Receipt {
+                    status: true.into(),
+                    cumulative_gas_used: 0,
+                    logs,
+                },
+                logs_bloom: Bloom::default(),
+            }),
+            transaction_hash: TxHash::random(),
+            transaction_index: Some(0),
+            block_hash: None,
+            block_number: Some(0),
+            gas_used: 21000,
+            effective_gas_price: 1,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
+    }
+
+    fn transfer_receipt_log(token: Address, recipient: Address, amount: U256) -> Log {
+        let event = IERC20::Transfer {
+            from: Address::ZERO,
+            to: recipient,
+            value: amount,
+        };
+        Log {
+            inner: PrimitiveLog {
+                address: token,
+                data: event.encode_log_data(),
+            },
+            transaction_hash: None,
+            transaction_index: None,
+            block_hash: None,
+            block_number: None,
+            block_timestamp: None,
+            log_index: None,
+            removed: false,
+        }
+    }
+
+    fn malformed_transfer_receipt_log(token: Address) -> Log {
+        Log {
+            inner: PrimitiveLog {
+                address: token,
+                data: LogData::new_unchecked(
+                    vec![IERC20::Transfer::SIGNATURE_HASH],
+                    Bytes::from_static(&[0x01]),
+                ),
+            },
+            transaction_hash: None,
+            transaction_index: None,
+            block_hash: None,
+            block_number: None,
+            block_timestamp: None,
+            log_index: None,
+            removed: false,
+        }
     }
 
     #[tokio::test]
@@ -196,5 +439,299 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(error, EquityVaultStepError::Raindex(_)));
+    }
+
+    #[tokio::test]
+    async fn submit_vault_withdraw_uses_tokenized_equity_decimals_and_resolved_vault() {
+        let token = address!("0x00000000000000000000000000000000000000ab");
+        let vault_id = RaindexVaultId(B256::repeat_byte(0x22));
+        let vault_lookup = MockVaultLookup::new().with_default_vault(vault_id);
+        let raindex = MockRaindex::new();
+        let amount = U256::from(4_250_000_000_000_000_000u128);
+
+        submit_vault_withdraw(&vault_lookup, &raindex, token, amount)
+            .await
+            .unwrap();
+
+        let call = raindex.last_withdraw_call().unwrap();
+        assert_eq!(call.token, token);
+        assert_eq!(call.vault_id, vault_id);
+        assert_eq!(call.amount, amount);
+        assert_eq!(call.decimals, TOKENIZED_EQUITY_DECIMALS);
+    }
+
+    #[tokio::test]
+    async fn submit_vault_withdraw_propagates_vault_lookup_failure() {
+        let vault_lookup = MockVaultLookup::new();
+        let raindex = MockRaindex::new();
+
+        let error = submit_vault_withdraw(
+            &vault_lookup,
+            &raindex,
+            address!("0x00000000000000000000000000000000000000cc"),
+            U256::from(1u64),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, EquityVaultStepError::VaultLookup(_)));
+    }
+
+    #[tokio::test]
+    async fn submit_vault_withdraw_propagates_withdraw_failure() {
+        let vault_lookup = MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO));
+        let raindex = MockRaindex::new().with_withdraw_behavior(WithdrawBehavior::FailGeneric);
+
+        let error = submit_vault_withdraw(
+            &vault_lookup,
+            &raindex,
+            address!("0x00000000000000000000000000000000000000cc"),
+            U256::from(1u64),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, EquityVaultStepError::Raindex(_)));
+    }
+
+    #[tokio::test]
+    async fn confirm_vault_withdraw_records_actual_receipt_amount() {
+        let token = address!("0x00000000000000000000000000000000000000dd");
+        let requested = U256::from(37_143_292_455_000_000_000_u128);
+        let actual = U256::from(33_681_456_848_531_939_569_u128);
+        let vault_lookup = MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO));
+        let raindex = MockRaindex::new().with_withdraw_actual_amount(actual);
+        let wrapper = MockWrapper::new();
+
+        let tx_hash = submit_vault_withdraw(&vault_lookup, &raindex, token, requested)
+            .await
+            .unwrap();
+
+        let ConfirmedWithdraw {
+            actual_wrapped_amount,
+            ..
+        } = confirm_vault_withdraw(&raindex, &wrapper, token, tx_hash)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            actual_wrapped_amount, actual,
+            "confirmed withdrawal must carry the actual receipt transfer amount, not the request"
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_vault_withdraw_fails_without_matching_transfer() {
+        let token = address!("0x00000000000000000000000000000000000000dd");
+        let vault_lookup = MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO));
+        let raindex = MockRaindex::new().with_withdraw_actual_amount(U256::ZERO);
+        let wrapper = MockWrapper::new();
+
+        let tx_hash = submit_vault_withdraw(&vault_lookup, &raindex, token, U256::from(10u64))
+            .await
+            .unwrap();
+
+        let error = confirm_vault_withdraw(&raindex, &wrapper, token, tx_hash)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, EquityVaultStepError::WithdrawTransferNotFound { .. }),
+            "expected WithdrawTransferNotFound, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_vault_withdraw_fails_when_receipt_has_no_block_number() {
+        let token = address!("0x00000000000000000000000000000000000000dd");
+        let vault_lookup = MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO));
+        let raindex =
+            MockRaindex::new().with_confirm_behavior(ConfirmTxBehavior::SucceedWithoutBlockNumber);
+        let wrapper = MockWrapper::new();
+
+        let tx_hash = submit_vault_withdraw(&vault_lookup, &raindex, token, U256::from(10u64))
+            .await
+            .unwrap();
+
+        let error = confirm_vault_withdraw(&raindex, &wrapper, token, tx_hash)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, EquityVaultStepError::MissingWithdrawBlock { .. }),
+            "expected MissingWithdrawBlock when the receipt has no block number, got: {error:?}"
+        );
+    }
+
+    #[test]
+    fn actual_withdrawn_amount_sums_only_matching_receipt_transfers() {
+        let token = Address::repeat_byte(0x11);
+        let other_token = Address::repeat_byte(0x22);
+        let recipient = Address::repeat_byte(0x33);
+        let other_recipient = Address::repeat_byte(0x44);
+        let receipt = receipt_with_logs(vec![
+            transfer_receipt_log(other_token, recipient, U256::from(100)),
+            transfer_receipt_log(token, other_recipient, U256::from(200)),
+            transfer_receipt_log(token, recipient, U256::from(30)),
+            transfer_receipt_log(token, recipient, U256::from(12)),
+        ]);
+
+        let amount = actual_withdrawn_amount_from_receipt(&receipt, token, recipient).unwrap();
+
+        assert_eq!(
+            amount,
+            U256::from(42),
+            "only matching token and recipient transfer values should be summed"
+        );
+    }
+
+    #[test]
+    fn actual_withdrawn_amount_errors_on_malformed_matching_transfer_log() {
+        let token = Address::repeat_byte(0x11);
+        let recipient = Address::repeat_byte(0x33);
+        let receipt = receipt_with_logs(vec![malformed_transfer_receipt_log(token)]);
+
+        let error = actual_withdrawn_amount_from_receipt(&receipt, token, recipient).unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                EquityVaultStepError::WithdrawTransferDecodeFailed { .. }
+            ),
+            "expected decode failure, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_token_unwrap_waits_for_block_before_submitting() {
+        let withdraw_block = 5555u64;
+        let wrapper = MockWrapper::new();
+
+        submit_token_unwrap(
+            &wrapper,
+            Address::ZERO,
+            U256::from(1_000_000_000_000_000_000_u64),
+            Some(withdraw_block),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            wrapper.wait_for_block_calls(),
+            vec![withdraw_block],
+            "wait_for_block must be called once with the withdraw block before submitting unwrap"
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_token_unwrap_skips_wait_for_block_when_block_is_none() {
+        let wrapper = MockWrapper::new();
+
+        submit_token_unwrap(
+            &wrapper,
+            Address::ZERO,
+            U256::from(1_000_000_000_000_000_000_u64),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            wrapper.wait_for_block_calls(),
+            Vec::<u64>::new(),
+            "wait_for_block must NOT be called when raindex_withdraw_block is None"
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_token_unwrap_propagates_wait_for_block_failure() {
+        let wrapper = MockWrapper::failing_wait_for_block();
+
+        let error = submit_token_unwrap(
+            &wrapper,
+            Address::ZERO,
+            U256::from(1_000_000_000_000_000_000_u64),
+            Some(42),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                EquityVaultStepError::Wrapper(WrapperError::Evm(
+                    EvmError::NodeBehindRequiredBlock { .. }
+                ))
+            ),
+            "expected Wrapper(Evm(NodeBehindRequiredBlock)) from a failed wait, got: {error:?}"
+        );
+        assert_eq!(
+            wrapper.submitted_unwrap_amount(),
+            None,
+            "unwrap must NOT be submitted when the node-sync wait fails (wait happens first)"
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_token_unwrap_propagates_unwrap_failure() {
+        let wrapper = MockWrapper::failing_unwrap();
+
+        let error = submit_token_unwrap(&wrapper, Address::ZERO, U256::from(1u64), None)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, EquityVaultStepError::Wrapper(_)),
+            "expected Wrapper error from a failed unwrap, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_token_unwrap_propagates_underlying_lookup_failure() {
+        let wrapper = MockWrapper::failing_lookup();
+
+        let error = confirm_token_unwrap(&wrapper, &aapl(), Address::ZERO, TxHash::random())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, EquityVaultStepError::Wrapper(_)),
+            "expected Wrapper error from a failed underlying lookup, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_token_unwrap_returns_resolved_underlying_amount_and_block() {
+        let underlying = address!("0x00000000000000000000000000000000000000ee");
+        let token = address!("0x00000000000000000000000000000000000000ff");
+        let amount = U256::from(33_681_456_848_531_939_569_u128);
+        let wrapper = MockWrapper::new().with_tokenized_shares(underlying);
+
+        // Submitting records the unwrap amount the mock returns on confirm,
+        // exercising the full submit -> confirm field mapping.
+        let unwrap_tx = submit_token_unwrap(&wrapper, token, amount, None)
+            .await
+            .unwrap();
+
+        let ConfirmedUnwrap {
+            underlying_token,
+            unwrapped_amount,
+            unwrap_block,
+        } = confirm_token_unwrap(&wrapper, &aapl(), token, unwrap_tx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            underlying_token, underlying,
+            "confirm must return the resolved underlying token"
+        );
+        assert_eq!(
+            unwrapped_amount, amount,
+            "confirm must map UnwrapConfirmation::assets to unwrapped_amount, not block"
+        );
+        assert_eq!(
+            unwrap_block, 0,
+            "confirm must map UnwrapConfirmation::block to unwrap_block"
+        );
     }
 }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -411,6 +411,17 @@ impl RedemptionTracking {
                 self.stage = RedemptionTrackingStage::SendPending;
                 self.last_progress_at = *pending_at;
             }
+            EquityRedemptionEvent::SendSubmitted {
+                redemption_tx,
+                submitted_at,
+                ..
+            } => {
+                // The transfer is broadcast; track it as sent (the bookkeeping
+                // finalization to TokensSent is a pure, resume-driven step).
+                self.redemption_tx = Some(*redemption_tx);
+                self.stage = RedemptionTrackingStage::TokensSent;
+                self.last_progress_at = *submitted_at;
+            }
             EquityRedemptionEvent::TokensSent {
                 redemption_tx,
                 sent_at,
@@ -2714,6 +2725,7 @@ impl RebalancingService {
             | UnwrapSubmitted { .. }
             | TokensUnwrapped { .. }
             | SendPending { .. }
+            | SendSubmitted { .. }
             | TokensSent { .. }
             | DetectionFailed { .. }
             | Detected { .. }
@@ -2751,6 +2763,7 @@ impl RebalancingService {
             | WithdrawnFromRaindex { quantity, .. }
             | UnwrapPending { quantity, .. }
             | UnwrapSubmitted { quantity, .. }
+            | SendSubmitted { quantity, .. }
             | TokensSent { quantity, .. }
             | Pending { quantity, .. } => Ok(FractionalShares::new(*quantity)),
             TokensUnwrapped {
@@ -4823,6 +4836,7 @@ impl RebalancingService {
             | UnwrapSubmitted { symbol, .. }
             | TokensUnwrapped { symbol, .. }
             | SendPending { symbol, .. }
+            | SendSubmitted { symbol, .. }
             | TokensSent { symbol, .. }
             | Pending { symbol, .. } => {
                 let quantity = Self::recovered_redemption_quantity(entity)?;
@@ -4869,6 +4883,16 @@ impl RebalancingService {
                         *unwrapped_at,
                         None,
                         None,
+                    ),
+                    SendSubmitted {
+                        submitted_at,
+                        redemption_tx,
+                        ..
+                    } => (
+                        RedemptionTrackingStage::TokensSent,
+                        *submitted_at,
+                        None,
+                        Some(*redemption_tx),
                     ),
                     TokensSent {
                         sent_at,
@@ -5166,6 +5190,7 @@ impl RebalancingService {
             | UnwrapSubmitted { .. }
             | TokensUnwrapped { .. }
             | SendPending { .. }
+            | SendSubmitted { .. }
             | TokensSent { .. }
             | Detected { .. } => false,
         }
@@ -5255,7 +5280,6 @@ mod tests {
     use crate::inventory::{InventoryError, InventoryView, TransferOp, Venue};
     use crate::offchain::order::OffchainOrderId;
     use crate::position::{Position, PositionCommand, PositionEvent, TradeId, TriggerReason};
-    use crate::rebalancing::equity::EquityTransferServices;
     use crate::test_utils::rebalancing_enabled_equities;
     use crate::tokenized_equity_mint::TokenizedEquityMintCommand;
     use crate::usdc_rebalance::{
@@ -13376,10 +13400,7 @@ mod tests {
         service
             .set_stores(
                 Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-                Arc::new(test_store::<EquityRedemption>(
-                    pool,
-                    EquityTransferServices::panicking(),
-                )),
+                Arc::new(test_store::<EquityRedemption>(pool, ())),
                 Arc::new(usdc_store),
             )
             .await;
@@ -14024,8 +14045,7 @@ mod tests {
         pool: &SqlitePool,
         redemption_id: &RedemptionAggregateId,
     ) {
-        let store =
-            test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking());
+        let store = test_store::<EquityRedemption>(pool.clone(), ());
         store
             .send(
                 redemption_id,
@@ -14055,8 +14075,7 @@ mod tests {
         pool: &SqlitePool,
         redemption_id: &RedemptionAggregateId,
     ) {
-        let store =
-            test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking());
+        let store = test_store::<EquityRedemption>(pool.clone(), ());
         store
             .send(
                 redemption_id,
@@ -14191,7 +14210,7 @@ mod tests {
             &service,
             pool.clone(),
             test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<EquityRedemption>(pool.clone(), ()),
         )
         .await;
 
@@ -14249,7 +14268,7 @@ mod tests {
             &service,
             pool.clone(),
             test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<EquityRedemption>(pool.clone(), ()),
         )
         .await;
 
@@ -14307,7 +14326,7 @@ mod tests {
             &service,
             pool.clone(),
             test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<EquityRedemption>(pool.clone(), ()),
         )
         .await;
 
@@ -14361,7 +14380,7 @@ mod tests {
             &service,
             pool.clone(),
             test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<EquityRedemption>(pool.clone(), ()),
         )
         .await;
 
@@ -14454,7 +14473,7 @@ mod tests {
             &service,
             pool.clone(),
             test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<EquityRedemption>(pool.clone(), ()),
         )
         .await;
 
@@ -14515,7 +14534,7 @@ mod tests {
             &service,
             pool.clone(),
             test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<EquityRedemption>(pool.clone(), ()),
         )
         .await;
 
@@ -14567,7 +14586,7 @@ mod tests {
             &service,
             pool.clone(),
             test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<EquityRedemption>(pool.clone(), ()),
         )
         .await;
 
@@ -14619,7 +14638,7 @@ mod tests {
             &service,
             pool.clone(),
             test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<EquityRedemption>(pool.clone(), ()),
         )
         .await;
 
@@ -14696,7 +14715,7 @@ mod tests {
             &service,
             pool.clone(),
             test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), EquityTransferServices::panicking()),
+            test_store::<EquityRedemption>(pool.clone(), ()),
         )
         .await;
 
@@ -14973,10 +14992,7 @@ mod tests {
         trigger
             .set_stores(
                 Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-                Arc::new(test_store::<EquityRedemption>(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
                 Arc::new(store),
             )
             .await;
@@ -15096,10 +15112,7 @@ mod tests {
         trigger
             .set_stores(
                 Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-                Arc::new(test_store::<EquityRedemption>(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
                 Arc::new(store),
             )
             .await;
@@ -15194,10 +15207,7 @@ mod tests {
         trigger
             .set_stores(
                 Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-                Arc::new(test_store::<EquityRedemption>(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
                 Arc::new(store),
             )
             .await;
@@ -15363,10 +15373,7 @@ mod tests {
         trigger
             .set_stores(
                 Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-                Arc::new(test_store::<EquityRedemption>(
-                    pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
-                )),
+                Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
                 Arc::clone(&store),
             )
             .await;
@@ -15467,7 +15474,7 @@ mod tests {
                 >(unmigrated_pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     unmigrated_pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
+                    (),
                 )),
                 Arc::new(test_store::<UsdcRebalance>(unmigrated_pool.clone(), ())),
             )
@@ -15539,7 +15546,7 @@ mod tests {
                 >(unmigrated_pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     unmigrated_pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
+                    (),
                 )),
                 Arc::new(test_store::<UsdcRebalance>(unmigrated_pool.clone(), ())),
             )
@@ -15653,7 +15660,7 @@ mod tests {
                 >(pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
+                    (),
                 )),
                 Arc::new(store),
             )
@@ -16000,7 +16007,7 @@ mod tests {
                 >(pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
+                    (),
                 )),
                 Arc::clone(&store),
             )
@@ -16197,7 +16204,7 @@ mod tests {
                 >(pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
+                    (),
                 )),
                 Arc::clone(&store),
             )
@@ -16348,7 +16355,7 @@ mod tests {
                 >(pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
+                    (),
                 )),
                 Arc::clone(&store),
             )
@@ -16922,7 +16929,7 @@ mod tests {
                 >(pool.clone(), ())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
-                    crate::rebalancing::equity::EquityTransferServices::panicking(),
+                    (),
                 )),
                 store,
             )

--- a/src/unwrapped_equity_recovery/aggregate.rs
+++ b/src/unwrapped_equity_recovery/aggregate.rs
@@ -856,7 +856,6 @@ mod tests {
 
     use crate::equity_redemption::redemption_aggregate_id;
     use crate::onchain::mock::{ConfirmTxBehavior, DepositBehavior, DepositCall, MockRaindex};
-    use crate::rebalancing::equity::EquityTransferServices;
     use crate::vault_lookup::{MockVaultLookup, VaultLookup};
 
     use super::*;
@@ -926,14 +925,8 @@ mod tests {
     ) -> UnwrappedEquityRecoveryServices {
         let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
-        let services = EquityTransferServices {
-            raindex: raindex.clone(),
-            vault_lookup: vault_lookup.clone(),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: wrapper.clone(),
-        };
         let mint_store = Arc::new(st0x_event_sorcery::test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(st0x_event_sorcery::test_store(pool, services));
+        let redemption_store = Arc::new(st0x_event_sorcery::test_store(pool, ()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
             vault_lookup.clone(),

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -710,7 +710,7 @@ mod tests {
         EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,
     };
     use crate::onchain::mock::MockRaindex;
-    use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
+    use crate::rebalancing::equity::CrossVenueEquityTransfer;
     use crate::rebalancing::trigger::InProgressGuard;
     use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintCommand};
     use crate::vault_lookup::MockVaultLookup;
@@ -745,14 +745,8 @@ mod tests {
 
         let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
-        let transfer_services = EquityTransferServices {
-            raindex: raindex.clone(),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: tokenizer.clone(),
-            wrapper: wrapper.clone(),
-        };
         let mint_store = Arc::new(test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
+        let redemption_store = Arc::new(test_store(pool.clone(), ()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
             Arc::new(mock_vault_lookup()),
@@ -818,14 +812,8 @@ mod tests {
 
         let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
-        let transfer_services = EquityTransferServices {
-            raindex: raindex.clone(),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: wrapper.clone(),
-        };
         let mint_store = Arc::new(test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
+        let redemption_store = Arc::new(test_store(pool.clone(), ()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
             Arc::new(MockVaultLookup::new()),
@@ -899,14 +887,8 @@ mod tests {
 
         let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
-        let transfer_services = EquityTransferServices {
-            raindex: raindex.clone(),
-            vault_lookup: Arc::new(MockVaultLookup::new()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: wrapper.clone(),
-        };
         let mint_store = Arc::new(test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
+        let redemption_store = Arc::new(test_store(pool.clone(), ()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
             Arc::new(MockVaultLookup::new()),

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -588,7 +588,6 @@ mod tests {
 
     use crate::equity_redemption::redemption_aggregate_id;
     use crate::onchain::mock::{DepositBehavior, MockRaindex};
-    use crate::rebalancing::equity::EquityTransferServices;
     use crate::vault_lookup::MockVaultLookup;
 
     use super::*;
@@ -624,14 +623,8 @@ mod tests {
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
         let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
-        let services = EquityTransferServices {
-            raindex: raindex.clone(),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: wrapper.clone(),
-        };
         let mint_store = Arc::new(st0x_event_sorcery::test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(st0x_event_sorcery::test_store(pool, services));
+        let redemption_store = Arc::new(st0x_event_sorcery::test_store(pool, ()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
             Arc::new(mock_vault_lookup()),
@@ -817,14 +810,8 @@ mod tests {
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
         let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
-        let inner_services = EquityTransferServices {
-            raindex: raindex.clone(),
-            vault_lookup: Arc::new(mock_vault_lookup()),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: wrapper.clone(),
-        };
         let mint_store = Arc::new(st0x_event_sorcery::test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(st0x_event_sorcery::test_store(pool, inner_services));
+        let redemption_store = Arc::new(st0x_event_sorcery::test_store(pool, ()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
             Arc::new(mock_vault_lookup()),

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -466,7 +466,7 @@ mod tests {
     use crate::inventory::BroadcastingInventory;
     use crate::inventory::view::InventoryView;
     use crate::onchain::mock::MockRaindex;
-    use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
+    use crate::rebalancing::equity::CrossVenueEquityTransfer;
     use crate::vault_lookup::{MockVaultLookup, VaultLookup};
 
     #[tokio::test]
@@ -482,14 +482,8 @@ mod tests {
         let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
         let vault_lookup: Arc<dyn VaultLookup> = Arc::new(MockVaultLookup::new());
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
-        let transfer_services = EquityTransferServices {
-            raindex: raindex.clone(),
-            vault_lookup: vault_lookup.clone(),
-            tokenizer: Arc::new(MockTokenizer::new()),
-            wrapper: wrapper.clone(),
-        };
         let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
+        let redemption_store = Arc::new(test_store(pool.clone(), ()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
             vault_lookup.clone(),

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -663,8 +663,8 @@ async fn assert_equity_redeem_rebalancing<P: Provider>(
     let redeem_events = fetch_events_by_type(pool, "EquityRedemption").await?;
     assert_eq!(
         redeem_events.len(),
-        10,
-        "Expected exactly 10 EquityRedemption success events",
+        11,
+        "Expected exactly 11 EquityRedemption success events",
     );
     assert_event_subsequence(
         &redeem_events,
@@ -676,6 +676,7 @@ async fn assert_equity_redeem_rebalancing<P: Provider>(
             "EquityRedemptionEvent::UnwrapSubmitted",
             "EquityRedemptionEvent::TokensUnwrapped",
             "EquityRedemptionEvent::SendPending",
+            "EquityRedemptionEvent::SendSubmitted",
             "EquityRedemptionEvent::TokensSent",
             "EquityRedemptionEvent::Detected",
             "EquityRedemptionEvent::Completed",


### PR DESCRIPTION
## What

Makes the `EquityRedemption` aggregate's command handlers pure event-recording
and moves all onchain/broker I/O (Raindex withdraw + confirm, ERC-4626 unwrap +
confirm, send-to-Alpaca) into the durable `CrossVenueEquityTransfer`
orchestrator and the shared `step.rs` wrappers. Implements RAI-929.

## Why

Per [ADR 0013](adrs/0013-equity-family-side-effect-extraction.md), side effects
belong in the orchestrator that runs inside durable apalis jobs, not in
aggregate command handlers. Pure handlers stay replay-safe and crash recovery
re-drives the I/O from persisted state. This also unblocks the event-sorcery
0.2.0-rc2 bump (RAI-924), which drops `type Services` from `EventSourced`.

## How

- Commands now carry the values the orchestrator derives from its onchain
  steps: `SubmitWithdraw { tx_hash }`, `ConfirmWithdraw { actual_wrapped_amount,
  raindex_withdraw_block }`, `SubmitUnwrap { unwrap_tx_hash }`, `ConfirmUnwrap {
  underlying_token, unwrapped_amount, unwrap_block }`.
- `SendTokens` is replaced by `RecordSendOutcome { outcome: SendOutcome }`;
  `SendOutcome` (`Sent` / `WalletNotConfigured` / `SendFailed`) is the
  orchestrator's mapping of the send result, and the handler emits `TokensSent`
  or `TransferFailed` purely from it.
- The shared onchain steps live in `step.rs`: `submit_vault_withdraw`,
  `confirm_vault_withdraw` (receipt decode + block extraction),
  `submit_token_unwrap` (node-sync wait), `confirm_token_unwrap`.
- `WithdrawnFromRaindex` keeps both the requested `wrapped_amount` and the
  receipt's `actual_wrapped_amount` for replay fidelity; the resulting state
  collapses to the actual amount so the unwrap operates on what was withdrawn.
- `EquityRedemption::Services` is now `()`; the obsolete `EquityTransferServices`
  test fixture is deleted (the orchestrator holds the individual service Arcs).

## Testing

- Pure aggregate tests: per-command emission, `Already*` idempotency on advanced
  states, and state-collapse to the actual withdrawn amount.
- `step.rs` unit tests: receipt-amount decoding (sum-matching, malformed,
  missing-transfer, missing-block) and unwrap node-sync wait (waits / skips /
  propagates failure).
- Orchestrator `send_to_alpaca` tests: `WalletNotConfigured`, `SendFailed`,
  wait-for-block + skip, and the retryable `NodeSync` error on wait failure.
- Full suite green (564 tests), `cargo clippy --all-targets --all-features` and
  `cargo fmt --check` clean.

## Anything else

- **Pre-existing double-send window (no regression, follow-up needed):** if the
  process crashes after `send_for_redemption` lands the transfer but before
  `RecordSendOutcome` commits, resume from `SendPending` re-calls
  `send_for_redemption` — an irreversible duplicate send. This window predates
  this PR; the extraction preserves it rather than fixing it. Needs a follow-up
  issue (idempotent send keyed on the redemption, or a pre-send marker event).
- **Resume re-submits withdraw/unwrap:** a crash before `SubmitWithdraw` /
  `SubmitUnwrap` commits re-submits the tx on resume. The resume loop only
  re-confirms a persisted tx from the `*Submitted` states and re-submits from
  `*Pending`, matching the proven mint pattern.
- Stacked on RAI-928 (`feat/tokenized-equity-mint-pure-handlers`); part of the
  chain toward the RAI-924 event-sorcery bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redemption and recovery workflows so submitted actions and outcomes are tracked more reliably.
  * Enhanced handling of withdraw, unwrap, and send steps to better reflect real transaction results and reduce failed or stuck rebalancing flows.
  * Added clearer failure handling when network sync is behind or when transfer details are missing.

* **Refactor**
  * Simplified several rebalancing and recovery paths, reducing dependency on intermediate service plumbing and making the flow more consistent across commands and jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->