### PR TITLE
refactor: make UnwrappedEquityRecovery handlers pure (move I/O to recovery job)

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -599,6 +599,7 @@ impl Conductor {
             recovery_transfer,
             wrapped_equity_recovery_store,
             unwrapped_equity_recovery_store,
+            unwrapped_equity_recovery_services,
             mint_store,
             redemption_store,
             transfer_usdc_to_hedging_ctx,
@@ -633,19 +634,8 @@ impl Conductor {
         )
         .await?;
 
-        // Hydrate the in-memory InventoryView from persisted snapshot
-        // state so the runtime projection has the same data as the
-        // database. Without this, the first post-restart poll may emit
-        // no events (unchanged values are deduplicated), leaving the
-        // view empty and potentially causing incorrect rebalancing.
-        hydrate_inventory_from_snapshot(&pool, &inventory).await;
-        if let Some(service) = &rebalancing_service {
-            service.enqueue_recovery_for_current_wallet_balances().await;
-        }
-
-        // Catch the lifecycle-failure read model up to the event log before its
-        // OffchainOrder reactor (registered below) goes live, in both modes.
-        catch_up_lifecycle_failures(&pool).await?;
+        hydrate_startup_inventory_and_read_models(&pool, &inventory, rebalancing_service.as_ref())
+            .await?;
 
         let (offchain_order, offchain_order_projection) =
             setup_offchain_order_store(&pool, &executor, &position, &position_projection).await?;
@@ -676,6 +666,7 @@ impl Conductor {
             EquityRecoveryInputs {
                 wrapped_store: wrapped_equity_recovery_store,
                 unwrapped_store: unwrapped_equity_recovery_store,
+                unwrapped_services: unwrapped_equity_recovery_services,
                 rebalancing_service: rebalancing_service.clone(),
                 mint_store: mint_store.clone(),
                 redemption_store: redemption_store.clone(),
@@ -923,6 +914,7 @@ fn build_wrapped_equity_recovery_ctx(
 /// job needs is present; returns `None` (recovery wiring absent) if any is not.
 fn build_unwrapped_equity_recovery_ctx(
     store: Option<Arc<Store<UnwrappedEquityRecovery>>>,
+    services: Option<UnwrappedEquityRecoveryServices>,
     service: Option<Arc<RebalancingService>>,
     mint_store: Option<Arc<Store<TokenizedEquityMint>>>,
     redemption_store: Option<Arc<Store<EquityRedemption>>>,
@@ -930,8 +922,8 @@ fn build_unwrapped_equity_recovery_ctx(
     queue: UnwrappedEquityRecoveryJobQueue,
     reschedule_interval: Duration,
 ) -> Option<Arc<UnwrappedEquityRecoveryCtx>> {
-    let (Some(store), Some(service), Some(mint_store), Some(redemption_store)) =
-        (store, service, mint_store, redemption_store)
+    let (Some(store), Some(services), Some(service), Some(mint_store), Some(redemption_store)) =
+        (store, services, service, mint_store, redemption_store)
     else {
         return None;
     };
@@ -939,6 +931,7 @@ fn build_unwrapped_equity_recovery_ctx(
     Some(Arc::new(UnwrappedEquityRecoveryCtx {
         inventory,
         store,
+        services,
         mint_store,
         redemption_store,
         equity_in_progress: service.equity_in_progress.clone(),
@@ -1168,6 +1161,26 @@ async fn hydrate_single_snapshot(
     info!(%id, event_count, "Hydrated InventoryView from persisted snapshot");
 }
 
+/// Brings the in-memory startup state into line with the event log before the
+/// job workers and reactors go live: hydrates the `InventoryView` from the
+/// persisted snapshot (without this, the first post-restart poll deduplicates
+/// unchanged values and leaves the view empty, risking incorrect rebalancing),
+/// enqueues recovery for any current wallet balances, and catches the
+/// lifecycle-failure read model up to the log before its `OffchainOrder`
+/// reactor is registered.
+async fn hydrate_startup_inventory_and_read_models(
+    pool: &SqlitePool,
+    inventory: &Arc<BroadcastingInventory>,
+    rebalancing_service: Option<&Arc<RebalancingService>>,
+) -> anyhow::Result<()> {
+    hydrate_inventory_from_snapshot(pool, inventory).await;
+    if let Some(service) = rebalancing_service {
+        service.enqueue_recovery_for_current_wallet_balances().await;
+    }
+    catch_up_lifecycle_failures(pool).await?;
+    Ok(())
+}
+
 struct RebalancingInfrastructure {
     position: Arc<Store<Position>>,
     position_projection: Arc<Projection<Position>>,
@@ -1177,6 +1190,7 @@ struct RebalancingInfrastructure {
     recovery_transfer: Arc<CrossVenueEquityTransfer>,
     wrapped_equity_recovery_store: Arc<Store<WrappedEquityRecovery>>,
     unwrapped_equity_recovery_store: Arc<Store<UnwrappedEquityRecovery>>,
+    unwrapped_equity_recovery_services: UnwrappedEquityRecoveryServices,
     mint_store: Arc<Store<TokenizedEquityMint>>,
     redemption_store: Arc<Store<EquityRedemption>>,
     transfer_usdc_to_hedging_ctx: Arc<TransferUsdcToHedgingCtx>,
@@ -1214,6 +1228,7 @@ struct PositionAndRebalancing {
     recovery_transfer: Option<Arc<CrossVenueEquityTransfer>>,
     wrapped_equity_recovery_store: Option<Arc<Store<WrappedEquityRecovery>>>,
     unwrapped_equity_recovery_store: Option<Arc<Store<UnwrappedEquityRecovery>>>,
+    unwrapped_equity_recovery_services: Option<UnwrappedEquityRecoveryServices>,
     mint_store: Option<Arc<Store<TokenizedEquityMint>>>,
     redemption_store: Option<Arc<Store<EquityRedemption>>>,
     transfer_usdc_to_hedging_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
@@ -1267,6 +1282,7 @@ impl PositionAndRebalancing {
                 recovery_transfer: Some(infra.recovery_transfer),
                 wrapped_equity_recovery_store: Some(infra.wrapped_equity_recovery_store),
                 unwrapped_equity_recovery_store: Some(infra.unwrapped_equity_recovery_store),
+                unwrapped_equity_recovery_services: Some(infra.unwrapped_equity_recovery_services),
                 mint_store: Some(infra.mint_store),
                 redemption_store: Some(infra.redemption_store),
                 transfer_usdc_to_hedging_ctx: Some(infra.transfer_usdc_to_hedging_ctx),
@@ -1306,6 +1322,7 @@ impl PositionAndRebalancing {
                 recovery_transfer: None,
                 wrapped_equity_recovery_store: None,
                 unwrapped_equity_recovery_store: None,
+                unwrapped_equity_recovery_services: None,
                 mint_store: None,
                 redemption_store: None,
                 transfer_usdc_to_hedging_ctx: None,
@@ -1552,18 +1569,22 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         )
         .await?;
 
-        // Built outside `QueryManifest`: services depend on mint/redemption stores
-        // that the manifest produces.
-        let (wrapped_equity_recovery_store, unwrapped_equity_recovery_store) =
-            build_equity_recovery_stores(
-                &deps.pool,
-                raindex_service.clone(),
-                vault_lookup.clone(),
-                wrapper.clone(),
-                recovery_transfer.clone(),
-                base_wallet.address(),
-            )
-            .await?;
+        // Built outside `QueryManifest` because the recovery aggregate's
+        // services include `recovery_transfer`, which depends on the
+        // mint/redemption stores produced by the manifest above.
+        let (
+            wrapped_equity_recovery_store,
+            unwrapped_equity_recovery_store,
+            unwrapped_equity_recovery_services,
+        ) = build_equity_recovery_stores(
+            &deps.pool,
+            raindex_service.clone(),
+            vault_lookup.clone(),
+            wrapper.clone(),
+            recovery_transfer.clone(),
+            base_wallet.address(),
+        )
+        .await?;
 
         let mut resume_tokenization_queue = ResumeTokenizationJobQueue::new(&deps.apalis_pool);
 
@@ -1663,6 +1684,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             recovery_transfer,
             wrapped_equity_recovery_store,
             unwrapped_equity_recovery_store,
+            unwrapped_equity_recovery_services,
             mint_store: built.mint,
             redemption_store: built.redemption,
             transfer_usdc_to_hedging_ctx,
@@ -1756,6 +1778,7 @@ async fn build_equity_recovery_stores<Chain: Wallet + Clone>(
 ) -> anyhow::Result<(
     Arc<Store<WrappedEquityRecovery>>,
     Arc<Store<UnwrappedEquityRecovery>>,
+    UnwrappedEquityRecoveryServices,
 )> {
     let wrapped_store = StoreBuilder::<WrappedEquityRecovery>::new(pool.clone())
         .build(WrappedEquityRecoveryServices {
@@ -1766,17 +1789,22 @@ async fn build_equity_recovery_stores<Chain: Wallet + Clone>(
         })
         .await?;
 
+    // The unwrapped-recovery aggregate is a pure event recorder; its onchain
+    // side effects run in the recovery job, which holds these services on its
+    // ctx rather than on the store.
+    let unwrapped_services = UnwrappedEquityRecoveryServices {
+        raindex,
+        vault_lookup,
+        wrapper,
+        transfer,
+        wallet,
+    };
+
     let unwrapped_store = StoreBuilder::<UnwrappedEquityRecovery>::new(pool.clone())
-        .build(UnwrappedEquityRecoveryServices {
-            raindex,
-            vault_lookup,
-            wrapper,
-            transfer,
-            wallet,
-        })
+        .build(())
         .await?;
 
-    Ok((wrapped_store, unwrapped_store))
+    Ok((wrapped_store, unwrapped_store, unwrapped_services))
 }
 
 /// Recovers inflight state from event history at startup.

--- a/src/conductor/trading_queues.rs
+++ b/src/conductor/trading_queues.rs
@@ -30,6 +30,7 @@ use crate::trading::offchain::hedge::HedgeJobQueue;
 use crate::trading::onchain::trade_accountant::DexTradeAccountingJobQueue;
 use crate::unwrapped_equity_recovery::{
     UnwrappedEquityRecovery, UnwrappedEquityRecoveryCtx, UnwrappedEquityRecoveryJobQueue,
+    UnwrappedEquityRecoveryServices,
 };
 use crate::wrapped_equity_recovery::{
     WrappedEquityRecovery, WrappedEquityRecoveryCtx, WrappedEquityRecoveryJobQueue,
@@ -41,6 +42,7 @@ use crate::wrapped_equity_recovery::{
 pub(super) struct EquityRecoveryInputs {
     pub(super) wrapped_store: Option<Arc<Store<WrappedEquityRecovery>>>,
     pub(super) unwrapped_store: Option<Arc<Store<UnwrappedEquityRecovery>>>,
+    pub(super) unwrapped_services: Option<UnwrappedEquityRecoveryServices>,
     pub(super) rebalancing_service: Option<Arc<RebalancingService>>,
     pub(super) mint_store: Option<Arc<Store<TokenizedEquityMint>>>,
     pub(super) redemption_store: Option<Arc<Store<EquityRedemption>>>,
@@ -77,6 +79,7 @@ pub(super) async fn setup_trading_job_queues(
     let EquityRecoveryInputs {
         wrapped_store: wrapped_equity_recovery_store,
         unwrapped_store: unwrapped_equity_recovery_store,
+        unwrapped_services: unwrapped_equity_recovery_services,
         rebalancing_service,
         mint_store,
         redemption_store,
@@ -115,6 +118,7 @@ pub(super) async fn setup_trading_job_queues(
 
     let unwrapped_equity_recovery_ctx = build_unwrapped_equity_recovery_ctx(
         unwrapped_equity_recovery_store,
+        unwrapped_equity_recovery_services,
         rebalancing_service,
         mint_store,
         redemption_store,

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -2864,16 +2864,14 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_unwrapped_equity_recovery
         Arc::clone(&mint_store),
         Arc::clone(&redemption_store),
     ));
-    let store = Arc::new(test_store(
-        pool.clone(),
-        UnwrappedEquityRecoveryServices {
-            raindex,
-            vault_lookup,
-            wrapper,
-            transfer,
-            wallet: Address::ZERO,
-        },
-    ));
+    let services = UnwrappedEquityRecoveryServices {
+        raindex,
+        vault_lookup,
+        wrapper,
+        transfer,
+        wallet: Address::ZERO,
+    };
+    let store = Arc::new(test_store::<UnwrappedEquityRecovery>(pool.clone(), ()));
 
     // Inventory reports UNWRAPPED balance: wrap failed, tokens are raw tSTOCK
     // in the base wallet.
@@ -2894,6 +2892,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_unwrapped_equity_recovery
     let ctx = UnwrappedEquityRecoveryCtx {
         inventory,
         store: Arc::clone(&store),
+        services,
         mint_store,
         redemption_store,
         equity_in_progress: Arc::clone(&equity_in_progress),
@@ -2981,16 +2980,14 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_dispatches_active_mint() 
         Arc::clone(&mint_store),
         Arc::clone(&redemption_store),
     ));
-    let store = Arc::new(test_store(
-        pool.clone(),
-        UnwrappedEquityRecoveryServices {
-            raindex,
-            vault_lookup,
-            wrapper,
-            transfer,
-            wallet: Address::ZERO,
-        },
-    ));
+    let services = UnwrappedEquityRecoveryServices {
+        raindex,
+        vault_lookup,
+        wrapper,
+        transfer,
+        wallet: Address::ZERO,
+    };
+    let store = Arc::new(test_store::<UnwrappedEquityRecovery>(pool.clone(), ()));
 
     // Seed the mint aggregate in TokensReceived (the persisted pre-wrap state)
     // with quantity matching the unwrapped wallet balance, so resume_mint can
@@ -3041,6 +3038,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_dispatches_active_mint() 
     let ctx = UnwrappedEquityRecoveryCtx {
         inventory,
         store: Arc::clone(&store),
+        services,
         mint_store,
         redemption_store,
         equity_in_progress: Arc::clone(&equity_in_progress),

--- a/src/unwrapped_equity_recovery/aggregate.rs
+++ b/src/unwrapped_equity_recovery/aggregate.rs
@@ -41,18 +41,16 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::sync::Arc;
 use thiserror::Error;
-use tracing::{info, warn};
 use uuid::Uuid;
 
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
 use st0x_execution::{FractionalShares, Symbol};
 use st0x_raindex::Raindex;
 use st0x_tokenization::IssuerRequestId;
-use st0x_wrapper::{WrapConfirmation, Wrapper, WrapperError, node_sync_attempts};
+use st0x_wrapper::Wrapper;
 
 use crate::equity_redemption::RedemptionAggregateId;
 use crate::rebalancing::equity::CrossVenueEquityTransfer;
-use crate::tokenized_equity_mint::TOKENIZED_EQUITY_DECIMALS;
 use crate::vault_lookup::VaultLookup;
 
 /// Aggregate identifier. Each detection creates a fresh UUID; multiple
@@ -74,7 +72,9 @@ impl FromStr for UnwrappedEquityRecoveryId {
     }
 }
 
-/// Services the aggregate calls inside its command handlers.
+/// Onchain/transfer dependencies the recovery job uses to perform the
+/// recovery's side effects before recording the outcome through the aggregate's
+/// pure commands. (The aggregate itself takes `Services = ()`.)
 #[derive(Clone)]
 pub(crate) struct UnwrappedEquityRecoveryServices {
     pub(crate) raindex: Arc<dyn Raindex>,
@@ -86,12 +86,10 @@ pub(crate) struct UnwrappedEquityRecoveryServices {
     pub(crate) wallet: Address,
 }
 
-/// Domain errors returned from the aggregate's `initialize`/`transition`
-/// handlers. Terminal service failures (raindex/wrapper/transfer) are recorded
-/// as `RecoveryFailed` events so failures remain first-class entries in the
-/// audit trail. Retryable service failures that should leave the aggregate
-/// in-place instead surface as errors through this enum (e.g. `NodeSyncFailed`
-/// and the `Retryable*Confirmation` variants).
+/// Domain errors returned from the aggregate's pure `initialize`/`transition`
+/// handlers -- state-machine guards only. The handlers perform no I/O; the
+/// recovery job records terminal service failures as `RecoveryFailed` events
+/// and surfaces retryable service failures as its own job errors.
 #[derive(Debug, Clone, Serialize, Deserialize, Error, PartialEq, Eq)]
 pub(crate) enum UnwrappedEquityRecoveryError {
     #[error("recovery already initialized")]
@@ -105,58 +103,47 @@ pub(crate) enum UnwrappedEquityRecoveryError {
 
     #[error("recovery is already in terminal state")]
     Terminal,
-
-    #[error("wrap confirmation for tx {wrap_tx_hash} is retryable")]
-    RetryableWrapConfirmation { wrap_tx_hash: TxHash },
-
-    #[error("deposit confirmation for tx {vault_deposit_tx_hash} is retryable")]
-    RetryableDepositConfirmation { vault_deposit_tx_hash: TxHash },
-    #[error("RPC node did not catch up to wrap block {required_block} after {attempts} polls")]
-    NodeSyncFailed { required_block: u64, attempts: u32 },
 }
 
+/// Commands are pure event recorders: the recovery job
+/// ([`UnwrappedEquityRecoveryJob`](super::job::UnwrappedEquityRecoveryJob))
+/// performs the onchain/transfer I/O and sends the matching command carrying
+/// the outcome. A terminal service failure is recorded by sending
+/// `FailRecovery`; a retryable failure surfaces as a job error (no command) so
+/// apalis retries from the same persisted state.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) enum UnwrappedEquityRecoveryCommand {
-    /// Initial command. Records the detection trigger; invokes no services.
+    /// Initial command. Records the detection trigger.
     Detect {
         symbol: Symbol,
         shares: FractionalShares,
     },
 
-    /// Recovery has an active mint to resume. The handler calls
-    /// `services.transfer.resume_mint(mint_id)` and emits `DispatchedToMint`
-    /// iff `resume_mint` returns Ok.
+    /// The job resumed an active mint successfully; record the dispatch.
     DispatchToMint { mint_id: IssuerRequestId },
 
-    /// Recovery has an active redemption to resume. The handler calls
-    /// `services.transfer.resume_redemption(redemption_id)` and emits
-    /// `DispatchedToRedemption` iff `resume_redemption` returns Ok.
+    /// The job resumed an active redemption successfully; record the dispatch.
     DispatchToRedemption {
         redemption_id: RedemptionAggregateId,
     },
 
-    /// Orphan path step 1. The handler resolves the wrapped-token
-    /// address via `services.wrapper.lookup_derivative(symbol)`, calls
-    /// `services.wrapper.submit_wrap(...)`, and emits
-    /// `OrphanWrapSubmitted` with the returned tx hash.
-    SubmitOrphanWrap,
+    /// Orphan path step 1. Records the submitted wrap tx hash the job got from
+    /// `wrapper.submit_wrap`.
+    SubmitOrphanWrap { wrap_tx_hash: TxHash },
 
-    /// Orphan path step 2. The handler reads `wrap_tx_hash` from the
-    /// current state and calls `services.wrapper.confirm_wrap(...)`,
-    /// emitting `OrphanWrapped` with the actual minted wrapped amount
-    /// iff confirmation succeeds.
-    ConfirmOrphanWrap,
+    /// Orphan path step 2. Records the confirmed wrap: the actual minted
+    /// wrapped amount and the confirmation block, from `wrapper.confirm_wrap`.
+    ConfirmOrphanWrap {
+        wrapped_amount: U256,
+        wrap_block: u64,
+    },
 
-    /// Orphan path step 3. The handler reads `wrapped_amount` from the
-    /// current state, looks up the Raindex vault, calls
-    /// `services.raindex.submit_deposit(...)`, and emits
-    /// `OrphanDepositSubmitted` with the returned tx hash.
-    SubmitOrphanDeposit,
+    /// Orphan path step 3. Records the submitted Raindex deposit tx hash the
+    /// job got from `raindex.submit_deposit`.
+    SubmitOrphanDeposit { vault_deposit_tx_hash: TxHash },
 
-    /// Orphan path step 4. The handler reads `vault_deposit_tx_hash`
-    /// from the current state and calls
-    /// `services.raindex.confirm_tx(tx_hash)`, emitting
-    /// `OrphanDeposited` iff confirmation succeeds.
+    /// Orphan path step 4. Records the confirmed deposit (the tx hash is read
+    /// from state); the job has already confirmed it via `raindex.confirm_tx`.
     ConfirmOrphanDeposit,
 
     /// Marks the recovery as failed with the supplied reason.
@@ -330,7 +317,7 @@ impl EventSourced for UnwrappedEquityRecovery {
     type Event = UnwrappedEquityRecoveryEvent;
     type Command = UnwrappedEquityRecoveryCommand;
     type Error = UnwrappedEquityRecoveryError;
-    type Services = UnwrappedEquityRecoveryServices;
+    type Services = ();
     type Materialized = Nil;
 
     const AGGREGATE_TYPE: &'static str = "UnwrappedEquityRecovery";
@@ -520,7 +507,7 @@ impl EventSourced for UnwrappedEquityRecovery {
     async fn transition(
         &self,
         command: Self::Command,
-        services: &Self::Services,
+        _services: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use UnwrappedEquityRecoveryCommand::*;
 
@@ -532,51 +519,48 @@ impl EventSourced for UnwrappedEquityRecovery {
             (_, Detect { .. }) => Err(UnwrappedEquityRecoveryError::AlreadyInitialized),
 
             (Self::Detected { .. }, DispatchToMint { mint_id }) => {
-                resume_mint_or_fail(&services.transfer, &mint_id).await
+                Ok(vec![UnwrappedEquityRecoveryEvent::DispatchedToMint {
+                    mint_id,
+                    dispatched_at: Utc::now(),
+                }])
             }
 
             (Self::Detected { .. }, DispatchToRedemption { redemption_id }) => {
-                resume_redemption_or_fail(&services.transfer, &redemption_id).await
+                Ok(vec![UnwrappedEquityRecoveryEvent::DispatchedToRedemption {
+                    redemption_id,
+                    dispatched_at: Utc::now(),
+                }])
             }
 
-            (Self::Detected { symbol, shares, .. }, SubmitOrphanWrap) => {
-                submit_orphan_wrap_or_fail(services, symbol, *shares).await
-            }
-
-            (
-                Self::OrphanWrapSubmitted {
-                    symbol,
+            (Self::Detected { .. }, SubmitOrphanWrap { wrap_tx_hash }) => {
+                Ok(vec![UnwrappedEquityRecoveryEvent::OrphanWrapSubmitted {
                     wrap_tx_hash,
-                    ..
-                },
-                ConfirmOrphanWrap,
-            ) => confirm_orphan_wrap_or_fail(services, symbol, *wrap_tx_hash).await,
+                    submitted_at: Utc::now(),
+                }])
+            }
 
             (
-                Self::OrphanWrapped {
-                    symbol,
+                Self::OrphanWrapSubmitted { wrap_tx_hash, .. },
+                ConfirmOrphanWrap {
                     wrapped_amount,
                     wrap_block,
-                    ..
                 },
-                SubmitOrphanDeposit,
-            ) => {
-                // Skip the wait for legacy aggregates persisted before wrap_block was added.
-                if let Some(block) = wrap_block {
-                    services
-                        .wrapper
-                        .wait_for_block(*block)
-                        .await
-                        .inspect_err(|error| {
-                            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: wait_for_block failed");
-                        })
-                        .map_err(|error| UnwrappedEquityRecoveryError::NodeSyncFailed {
-                            required_block: *block,
-                            attempts: node_sync_attempts(&error),
-                        })?;
-                }
-                submit_orphan_deposit_or_fail(services, symbol, *wrapped_amount).await
-            }
+            ) => Ok(vec![UnwrappedEquityRecoveryEvent::OrphanWrapped {
+                wrap_tx_hash: *wrap_tx_hash,
+                wrapped_amount,
+                confirmed_at: Utc::now(),
+                wrap_block: Some(wrap_block),
+            }]),
+
+            (
+                Self::OrphanWrapped { .. },
+                SubmitOrphanDeposit {
+                    vault_deposit_tx_hash,
+                },
+            ) => Ok(vec![UnwrappedEquityRecoveryEvent::OrphanDepositSubmitted {
+                vault_deposit_tx_hash,
+                submitted_at: Utc::now(),
+            }]),
 
             (
                 Self::OrphanDepositSubmitted {
@@ -584,7 +568,10 @@ impl EventSourced for UnwrappedEquityRecovery {
                     ..
                 },
                 ConfirmOrphanDeposit,
-            ) => confirm_orphan_deposit_or_fail(&services.raindex, *vault_deposit_tx_hash).await,
+            ) => Ok(vec![UnwrappedEquityRecoveryEvent::OrphanDeposited {
+                vault_deposit_tx_hash: *vault_deposit_tx_hash,
+                deposited_at: Utc::now(),
+            }]),
 
             (
                 Self::Detected { .. }
@@ -604,259 +591,15 @@ impl EventSourced for UnwrappedEquityRecovery {
     }
 }
 
-async fn resume_mint_or_fail(
-    transfer: &CrossVenueEquityTransfer,
-    mint_id: &IssuerRequestId,
-) -> Result<Vec<UnwrappedEquityRecoveryEvent>, UnwrappedEquityRecoveryError> {
-    match transfer.resume_mint(mint_id).await {
-        Ok(()) => {
-            info!(target: "rebalance", %mint_id, "Unwrapped equity recovery: resume_mint succeeded");
-            Ok(vec![UnwrappedEquityRecoveryEvent::DispatchedToMint {
-                mint_id: mint_id.clone(),
-                dispatched_at: Utc::now(),
-            }])
-        }
-        Err(error) => {
-            warn!(target: "rebalance", %mint_id, ?error, "Unwrapped equity recovery: resume_mint failed");
-            Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
-                reason: format!("resume_mint failed: {error}"),
-                failed_at: Utc::now(),
-            }])
-        }
-    }
-}
-
-async fn resume_redemption_or_fail(
-    transfer: &CrossVenueEquityTransfer,
-    redemption_id: &RedemptionAggregateId,
-) -> Result<Vec<UnwrappedEquityRecoveryEvent>, UnwrappedEquityRecoveryError> {
-    match transfer.resume_redemption(redemption_id).await {
-        Ok(()) => {
-            info!(target: "rebalance", %redemption_id, "Unwrapped equity recovery: resume_redemption succeeded");
-            Ok(vec![UnwrappedEquityRecoveryEvent::DispatchedToRedemption {
-                redemption_id: redemption_id.clone(),
-                dispatched_at: Utc::now(),
-            }])
-        }
-        Err(error) => {
-            warn!(target: "rebalance", %redemption_id, ?error, "Unwrapped equity recovery: resume_redemption failed");
-            Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
-                reason: format!("resume_redemption failed: {error}"),
-                failed_at: Utc::now(),
-            }])
-        }
-    }
-}
-
-async fn submit_orphan_wrap_or_fail(
-    services: &UnwrappedEquityRecoveryServices,
-    symbol: &Symbol,
-    shares: FractionalShares,
-) -> Result<Vec<UnwrappedEquityRecoveryEvent>, UnwrappedEquityRecoveryError> {
-    let wrapped_token = match services.wrapper.lookup_derivative(symbol) {
-        Ok(token) => token,
-        Err(error) => {
-            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: lookup_derivative failed");
-            return Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
-                reason: format!("wrapper.lookup_derivative failed: {error}"),
-                failed_at: Utc::now(),
-            }]);
-        }
-    };
-
-    let underlying_amount = match shares.to_u256_18_decimals() {
-        Ok(raw) => raw,
-        Err(error) => {
-            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: shares conversion failed");
-            return Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
-                reason: format!("shares conversion failed: {error}"),
-                failed_at: Utc::now(),
-            }]);
-        }
-    };
-
-    match services
-        .wrapper
-        .submit_wrap(wrapped_token, underlying_amount, services.wallet)
-        .await
-    {
-        Ok(wrap_tx_hash) => {
-            info!(target: "rebalance", %symbol, %wrap_tx_hash, "Unwrapped equity recovery: submit_wrap succeeded");
-            Ok(vec![UnwrappedEquityRecoveryEvent::OrphanWrapSubmitted {
-                wrap_tx_hash,
-                submitted_at: Utc::now(),
-            }])
-        }
-        Err(error) => {
-            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: submit_wrap failed");
-            Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
-                reason: format!("wrapper.submit_wrap failed: {error}"),
-                failed_at: Utc::now(),
-            }])
-        }
-    }
-}
-
-async fn confirm_orphan_wrap_or_fail(
-    services: &UnwrappedEquityRecoveryServices,
-    symbol: &Symbol,
-    wrap_tx_hash: TxHash,
-) -> Result<Vec<UnwrappedEquityRecoveryEvent>, UnwrappedEquityRecoveryError> {
-    let wrapped_token = match services.wrapper.lookup_derivative(symbol) {
-        Ok(token) => token,
-        Err(error) => {
-            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: lookup_derivative failed");
-            return Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
-                reason: format!("wrapper.lookup_derivative failed: {error}"),
-                failed_at: Utc::now(),
-            }]);
-        }
-    };
-
-    match services
-        .wrapper
-        .confirm_wrap(wrapped_token, wrap_tx_hash)
-        .await
-    {
-        Ok(WrapConfirmation {
-            shares: wrapped_amount,
-            block: wrap_block,
-        }) => {
-            info!(target: "rebalance", %symbol, %wrap_tx_hash, %wrapped_amount, "Unwrapped equity recovery: confirm_wrap succeeded");
-            Ok(vec![UnwrappedEquityRecoveryEvent::OrphanWrapped {
-                wrap_tx_hash,
-                wrapped_amount,
-                confirmed_at: Utc::now(),
-                wrap_block: Some(wrap_block),
-            }])
-        }
-        Err(error) => {
-            warn!(target: "rebalance", %symbol, %wrap_tx_hash, ?error, "Unwrapped equity recovery: confirm_wrap failed");
-            match error {
-                WrapperError::MissingDepositEvent
-                | WrapperError::Evm(st0x_evm::EvmError::TransactionDropped { .. }) => {
-                    Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
-                        reason: format!("wrapper.confirm_wrap failed: {error}"),
-                        failed_at: Utc::now(),
-                    }])
-                }
-                _ => Err(UnwrappedEquityRecoveryError::RetryableWrapConfirmation { wrap_tx_hash }),
-            }
-        }
-    }
-}
-
-async fn submit_orphan_deposit_or_fail(
-    services: &UnwrappedEquityRecoveryServices,
-    symbol: &Symbol,
-    wrapped_amount: U256,
-) -> Result<Vec<UnwrappedEquityRecoveryEvent>, UnwrappedEquityRecoveryError> {
-    let wrapped_token = match services.wrapper.lookup_derivative(symbol) {
-        Ok(token) => token,
-        Err(error) => {
-            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: lookup_derivative failed");
-            return Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
-                reason: format!("wrapper.lookup_derivative failed: {error}"),
-                failed_at: Utc::now(),
-            }]);
-        }
-    };
-
-    let vault_id = match services
-        .vault_lookup
-        .vault_id_for_token(wrapped_token)
-        .await
-    {
-        Ok(id) => id,
-        Err(error) => {
-            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: vault_id_for_token failed");
-            return Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
-                reason: format!("vault_lookup.vault_id_for_token failed: {error}"),
-                failed_at: Utc::now(),
-            }]);
-        }
-    };
-
-    // `wrapped_amount` is the raw ERC-4626 share amount from the wrap's Deposit
-    // event. Wrapped equity tokens (wtSTOCK) are minted at the system-wide
-    // tokenized-equity precision -- `TOKENIZED_EQUITY_DECIMALS` (18), the same
-    // standard the tSTOCK underlying and `FractionalShares` use -- so the raw
-    // amount is already in 18-decimal units and is interpreted as such. The
-    // wrapped recovery path leans on the identical invariant via
-    // `FractionalShares::to_u256_18_decimals`; a wtSTOCK minted at a different
-    // precision would mis-scale this deposit.
-    match services
-        .raindex
-        .submit_deposit(
-            wrapped_token,
-            vault_id,
-            wrapped_amount,
-            TOKENIZED_EQUITY_DECIMALS,
-        )
-        .await
-    {
-        Ok(vault_deposit_tx_hash) => {
-            info!(target: "rebalance", %symbol, %vault_deposit_tx_hash, "Unwrapped equity recovery: submit_deposit succeeded");
-            Ok(vec![UnwrappedEquityRecoveryEvent::OrphanDepositSubmitted {
-                vault_deposit_tx_hash,
-                submitted_at: Utc::now(),
-            }])
-        }
-        Err(error) => {
-            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: submit_deposit failed");
-            Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
-                reason: format!("raindex.submit_deposit failed: {error}"),
-                failed_at: Utc::now(),
-            }])
-        }
-    }
-}
-
-async fn confirm_orphan_deposit_or_fail(
-    raindex: &Arc<dyn Raindex>,
-    vault_deposit_tx_hash: TxHash,
-) -> Result<Vec<UnwrappedEquityRecoveryEvent>, UnwrappedEquityRecoveryError> {
-    match raindex.confirm_tx(vault_deposit_tx_hash).await {
-        Ok(()) => {
-            info!(target: "rebalance", %vault_deposit_tx_hash, "Unwrapped equity recovery: confirm_tx succeeded");
-            Ok(vec![UnwrappedEquityRecoveryEvent::OrphanDeposited {
-                vault_deposit_tx_hash,
-                deposited_at: Utc::now(),
-            }])
-        }
-        Err(error) => {
-            warn!(target: "rebalance", %vault_deposit_tx_hash, ?error, "Unwrapped equity recovery: confirm_tx failed");
-            if error.is_transaction_dropped() {
-                return Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
-                    reason: format!("raindex.confirm_tx failed: {error}"),
-                    failed_at: Utc::now(),
-                }]);
-            }
-
-            Err(UnwrappedEquityRecoveryError::RetryableDepositConfirmation {
-                vault_deposit_tx_hash,
-            })
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{B256, TxHash, fixed_bytes};
+    use alloy::primitives::{TxHash, fixed_bytes};
     use chrono::Utc;
     use rain_math_float::Float;
 
     use st0x_event_sorcery::EventSourced;
-    use st0x_evm::NODE_SYNC_MAX_ATTEMPTS;
     use st0x_execution::{FractionalShares, Symbol};
-    use st0x_raindex::RaindexVaultId;
     use st0x_tokenization::issuer_request_id;
-    use st0x_tokenization::mock::MockTokenizer;
-    use st0x_wrapper::MockWrapper;
-
-    use crate::equity_redemption::redemption_aggregate_id;
-    use crate::onchain::mock::{ConfirmTxBehavior, DepositBehavior, DepositCall, MockRaindex};
-    use crate::vault_lookup::{MockVaultLookup, VaultLookup};
 
     use super::*;
 
@@ -874,12 +617,6 @@ mod tests {
 
     fn one_share() -> FractionalShares {
         FractionalShares::new(Float::parse("1".to_string()).unwrap())
-    }
-
-    fn mock_vault_lookup() -> MockVaultLookup {
-        MockVaultLookup::new()
-            .with_vault(Address::ZERO, RaindexVaultId(B256::ZERO))
-            .with_default_vault(RaindexVaultId(B256::ZERO))
     }
 
     fn detected() -> UnwrappedEquityRecovery {
@@ -903,57 +640,14 @@ mod tests {
         }
     }
 
-    async fn test_services() -> UnwrappedEquityRecoveryServices {
-        services_with(Arc::new(MockRaindex::new()), Arc::new(MockWrapper::new())).await
-    }
-
-    /// Builds the aggregate's `Services` around caller-supplied raindex/wrapper
-    /// mocks so failure-path tests can inject reverting/failing variants while
-    /// the transfer service (mint/redemption resume) stays wired to fresh
-    /// in-memory stores.
-    async fn services_with(
-        raindex: Arc<dyn Raindex>,
-        wrapper: Arc<dyn Wrapper>,
-    ) -> UnwrappedEquityRecoveryServices {
-        services_with_vault_lookup(raindex, wrapper, Arc::new(mock_vault_lookup())).await
-    }
-
-    async fn services_with_vault_lookup(
-        raindex: Arc<dyn Raindex>,
-        wrapper: Arc<dyn Wrapper>,
-        vault_lookup: Arc<dyn VaultLookup>,
-    ) -> UnwrappedEquityRecoveryServices {
-        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
-        sqlx::migrate!().run(&pool).await.unwrap();
-        let mint_store = Arc::new(st0x_event_sorcery::test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(st0x_event_sorcery::test_store(pool, ()));
-        let transfer = Arc::new(CrossVenueEquityTransfer::new(
-            raindex.clone(),
-            vault_lookup.clone(),
-            Arc::new(MockTokenizer::new()),
-            wrapper.clone(),
-            Address::random(),
-            mint_store,
-            redemption_store,
-        ));
-        UnwrappedEquityRecoveryServices {
-            raindex,
-            vault_lookup,
-            wrapper,
-            transfer,
-            wallet: Address::random(),
-        }
-    }
-
     #[tokio::test]
     async fn detect_initializes_aggregate_into_detected_state() {
-        let services = test_services().await;
         let events = UnwrappedEquityRecovery::initialize(
             UnwrappedEquityRecoveryCommand::Detect {
                 symbol: aapl(),
                 shares: one_share(),
             },
-            &services,
+            &(),
         )
         .await
         .unwrap();
@@ -966,6 +660,60 @@ mod tests {
             *shares,
             one_share(),
             "Detected must carry the detected share quantity",
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_to_mint_emits_dispatched_to_mint_with_command_id() {
+        let mint_id = issuer_request_id("dispatch-mint");
+        let events = detected()
+            .transition(
+                UnwrappedEquityRecoveryCommand::DispatchToMint {
+                    mint_id: mint_id.clone(),
+                },
+                &(),
+            )
+            .await
+            .expect("DispatchToMint should succeed from Detected");
+        let [
+            UnwrappedEquityRecoveryEvent::DispatchedToMint {
+                mint_id: emitted, ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("expected single DispatchedToMint event, got {events:?}");
+        };
+        assert_eq!(
+            *emitted, mint_id,
+            "DispatchedToMint must carry the command's mint_id",
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_to_redemption_emits_dispatched_to_redemption_with_command_id() {
+        let redemption_id =
+            crate::equity_redemption::redemption_aggregate_id("dispatch-redemption");
+        let events = detected()
+            .transition(
+                UnwrappedEquityRecoveryCommand::DispatchToRedemption {
+                    redemption_id: redemption_id.clone(),
+                },
+                &(),
+            )
+            .await
+            .expect("DispatchToRedemption should succeed from Detected");
+        let [
+            UnwrappedEquityRecoveryEvent::DispatchedToRedemption {
+                redemption_id: emitted,
+                ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("expected single DispatchedToRedemption event, got {events:?}");
+        };
+        assert_eq!(
+            *emitted, redemption_id,
+            "DispatchedToRedemption must carry the command's redemption_id",
         );
     }
 
@@ -1045,7 +793,6 @@ mod tests {
 
     #[tokio::test]
     async fn detect_on_live_aggregate_is_rejected() {
-        let services = test_services().await;
         let state = UnwrappedEquityRecovery::Detected {
             symbol: aapl(),
             shares: one_share(),
@@ -1057,7 +804,7 @@ mod tests {
                     symbol: aapl(),
                     shares: one_share(),
                 },
-                &services,
+                &(),
             )
             .await
             .unwrap_err();
@@ -1069,14 +816,19 @@ mod tests {
 
     #[tokio::test]
     async fn confirm_orphan_wrap_only_valid_after_submit_wrap() {
-        let services = test_services().await;
         let state = UnwrappedEquityRecovery::Detected {
             symbol: aapl(),
             shares: one_share(),
             detected_at: Utc::now(),
         };
         let error = state
-            .transition(UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap, &services)
+            .transition(
+                UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap {
+                    wrapped_amount: U256::from(1u64),
+                    wrap_block: 1,
+                },
+                &(),
+            )
             .await
             .unwrap_err();
         assert!(matches!(
@@ -1087,7 +839,6 @@ mod tests {
 
     #[tokio::test]
     async fn submit_orphan_deposit_only_valid_after_confirm_wrap() {
-        let services = test_services().await;
         let state = UnwrappedEquityRecovery::OrphanWrapSubmitted {
             symbol: aapl(),
             shares: one_share(),
@@ -1097,8 +848,10 @@ mod tests {
         };
         let error = state
             .transition(
-                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit,
-                &services,
+                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit {
+                    vault_deposit_tx_hash: FAKE_WRAP_TX,
+                },
+                &(),
             )
             .await
             .unwrap_err();
@@ -1110,7 +863,6 @@ mod tests {
 
     #[tokio::test]
     async fn terminal_state_rejects_further_commands() {
-        let services = test_services().await;
         let state = UnwrappedEquityRecovery::Failed {
             symbol: aapl(),
             shares: one_share(),
@@ -1118,7 +870,12 @@ mod tests {
             failed_at: Utc::now(),
         };
         let error = state
-            .transition(UnwrappedEquityRecoveryCommand::SubmitOrphanWrap, &services)
+            .transition(
+                UnwrappedEquityRecoveryCommand::SubmitOrphanWrap {
+                    wrap_tx_hash: FAKE_WRAP_TX,
+                },
+                &(),
+            )
             .await
             .unwrap_err();
         assert!(matches!(error, UnwrappedEquityRecoveryError::Terminal));
@@ -1126,9 +883,13 @@ mod tests {
 
     #[tokio::test]
     async fn submit_orphan_wrap_emits_submitted_event() {
-        let services = test_services().await;
         let events = detected()
-            .transition(UnwrappedEquityRecoveryCommand::SubmitOrphanWrap, &services)
+            .transition(
+                UnwrappedEquityRecoveryCommand::SubmitOrphanWrap {
+                    wrap_tx_hash: FAKE_WRAP_TX,
+                },
+                &(),
+            )
             .await
             .expect("SubmitOrphanWrap should succeed from Detected");
         let [UnwrappedEquityRecoveryEvent::OrphanWrapSubmitted { wrap_tx_hash, .. }] =
@@ -1136,64 +897,16 @@ mod tests {
         else {
             panic!("expected single OrphanWrapSubmitted event, got {events:?}");
         };
-        assert_ne!(
-            *wrap_tx_hash,
-            TxHash::ZERO,
-            "OrphanWrapSubmitted must carry the real submitted tx hash -- it is \
+        assert_eq!(
+            *wrap_tx_hash, FAKE_WRAP_TX,
+            "OrphanWrapSubmitted must carry the command-supplied submitted tx hash -- it is \
              the crash-recovery anchor ConfirmOrphanWrap confirms against",
-        );
-    }
-
-    /// `submit_wrap` reverting is recorded as `RecoveryFailed`, not surfaced as
-    /// an aggregate error -- service failures stay first-class in the audit trail.
-    #[tokio::test]
-    async fn submit_orphan_wrap_records_failure_when_wrap_fails() {
-        let services = services_with(
-            Arc::new(MockRaindex::new()),
-            Arc::new(MockWrapper::failing()),
-        )
-        .await;
-        let events = detected()
-            .transition(UnwrappedEquityRecoveryCommand::SubmitOrphanWrap, &services)
-            .await
-            .expect("SubmitOrphanWrap should return Ok with RecoveryFailed on wrap failure");
-        let [UnwrappedEquityRecoveryEvent::RecoveryFailed { reason, .. }] = events.as_slice()
-        else {
-            panic!("expected single RecoveryFailed event, got {events:?}");
-        };
-        assert!(
-            reason.contains("submit_wrap failed"),
-            "reason should mention submit_wrap; got {reason:?}",
-        );
-    }
-
-    #[tokio::test]
-    async fn submit_orphan_wrap_records_failure_when_derivative_lookup_fails() {
-        let services = services_with(
-            Arc::new(MockRaindex::new()),
-            Arc::new(MockWrapper::failing_derivative_lookup()),
-        )
-        .await;
-        let events = detected()
-            .transition(UnwrappedEquityRecoveryCommand::SubmitOrphanWrap, &services)
-            .await
-            .expect("SubmitOrphanWrap should return Ok with RecoveryFailed on lookup failure");
-        let [UnwrappedEquityRecoveryEvent::RecoveryFailed { reason, .. }] = events.as_slice()
-        else {
-            panic!("expected single RecoveryFailed event, got {events:?}");
-        };
-        assert!(
-            reason.contains("lookup_derivative failed"),
-            "reason should mention lookup_derivative; got {reason:?}",
         );
     }
 
     #[tokio::test]
     async fn confirm_orphan_wrap_emits_confirmed_wrapped_amount() {
-        let wrapper_mock = Arc::new(MockWrapper::new());
         let wrapped_amount = U256::from(7u64);
-        wrapper_mock.seed_submitted_amount(FAKE_WRAP_TX, wrapped_amount);
-        let services = services_with(Arc::new(MockRaindex::new()), wrapper_mock).await;
         let state = UnwrappedEquityRecovery::OrphanWrapSubmitted {
             symbol: aapl(),
             shares: one_share(),
@@ -1202,13 +915,20 @@ mod tests {
             submitted_at: Utc::now(),
         };
         let events = state
-            .transition(UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap, &services)
+            .transition(
+                UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap {
+                    wrapped_amount,
+                    wrap_block: 5,
+                },
+                &(),
+            )
             .await
             .expect("ConfirmOrphanWrap should succeed from OrphanWrapSubmitted");
         let [
             UnwrappedEquityRecoveryEvent::OrphanWrapped {
                 wrap_tx_hash,
                 wrapped_amount: confirmed,
+                wrap_block,
                 ..
             },
         ] = events.as_slice()
@@ -1217,112 +937,28 @@ mod tests {
         };
         assert_eq!(
             *confirmed, wrapped_amount,
-            "OrphanWrapped should carry the actual minted wrapped amount",
+            "OrphanWrapped should carry the command-supplied minted wrapped amount",
         );
         assert_eq!(
             *wrap_tx_hash, FAKE_WRAP_TX,
-            "OrphanWrapped should carry the submitted wrap tx hash",
+            "OrphanWrapped should carry the submitted wrap tx hash from state",
         );
-    }
-
-    /// `confirm_wrap` failing on a submitted wrap is recorded as
-    /// `RecoveryFailed`, not surfaced as an aggregate error.
-    #[tokio::test]
-    async fn confirm_orphan_wrap_records_failure_when_confirm_wrap_fails() {
-        let services = services_with(
-            Arc::new(MockRaindex::new()),
-            Arc::new(MockWrapper::failing_confirm_wrap()),
-        )
-        .await;
-        let state = UnwrappedEquityRecovery::OrphanWrapSubmitted {
-            symbol: aapl(),
-            shares: one_share(),
-            detected_at: Utc::now(),
-            wrap_tx_hash: FAKE_WRAP_TX,
-            submitted_at: Utc::now(),
-        };
-        let events = state
-            .transition(UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap, &services)
-            .await
-            .expect("ConfirmOrphanWrap should return Ok with RecoveryFailed on confirm failure");
-        let [UnwrappedEquityRecoveryEvent::RecoveryFailed { reason, .. }] = events.as_slice()
-        else {
-            panic!("expected single RecoveryFailed event, got {events:?}");
-        };
-        assert!(
-            reason.contains("confirm_wrap failed"),
-            "reason should mention confirm_wrap; got {reason:?}",
-        );
-    }
-
-    #[tokio::test]
-    async fn confirm_orphan_wrap_retryable_error_keeps_submitted_state_live() {
-        let services = services_with(
-            Arc::new(MockRaindex::new()),
-            Arc::new(MockWrapper::retryable_confirm_wrap()),
-        )
-        .await;
-        let state = UnwrappedEquityRecovery::OrphanWrapSubmitted {
-            symbol: aapl(),
-            shares: one_share(),
-            detected_at: Utc::now(),
-            wrap_tx_hash: FAKE_WRAP_TX,
-            submitted_at: Utc::now(),
-        };
-        let error = state
-            .transition(UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap, &services)
-            .await
-            .unwrap_err();
-
-        assert!(matches!(
-            error,
-            UnwrappedEquityRecoveryError::RetryableWrapConfirmation {
-                wrap_tx_hash: FAKE_WRAP_TX,
-            }
-        ));
-    }
-
-    #[tokio::test]
-    async fn confirm_orphan_wrap_records_failure_when_derivative_lookup_fails_at_confirm() {
-        let services = services_with(
-            Arc::new(MockRaindex::new()),
-            Arc::new(MockWrapper::failing_derivative_lookup()),
-        )
-        .await;
-        let state = UnwrappedEquityRecovery::OrphanWrapSubmitted {
-            symbol: aapl(),
-            shares: one_share(),
-            detected_at: Utc::now(),
-            wrap_tx_hash: FAKE_WRAP_TX,
-            submitted_at: Utc::now(),
-        };
-        let events = state
-            .transition(UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap, &services)
-            .await
-            .expect("ConfirmOrphanWrap should return Ok with RecoveryFailed on lookup failure");
-        let [UnwrappedEquityRecoveryEvent::RecoveryFailed { reason, .. }] = events.as_slice()
-        else {
-            panic!("expected single RecoveryFailed event, got {events:?}");
-        };
-        assert!(
-            reason.contains("lookup_derivative failed"),
-            "reason should mention lookup_derivative; got {reason:?}",
+        assert_eq!(
+            *wrap_block,
+            Some(5),
+            "OrphanWrapped should carry the command-supplied confirmation block",
         );
     }
 
     #[tokio::test]
     async fn submit_orphan_deposit_emits_submitted_event() {
-        let raindex = Arc::new(MockRaindex::new());
-        let wrapped_token = Address::random();
-        let services = services_with(
-            raindex.clone(),
-            Arc::new(MockWrapper::new().with_wrapped_token(wrapped_token)),
-        )
-        .await;
+        let vault_deposit_tx = OTHER_TX;
         let events = orphan_wrapped()
             .transition(
-                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit,
-                &services,
+                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit {
+                    vault_deposit_tx_hash: vault_deposit_tx,
+                },
+                &(),
             )
             .await
             .expect("SubmitOrphanDeposit should succeed from OrphanWrapped");
@@ -1335,81 +971,15 @@ mod tests {
         else {
             panic!("expected single OrphanDepositSubmitted event, got {events:?}");
         };
-        assert_ne!(
-            *vault_deposit_tx_hash,
-            TxHash::ZERO,
-            "OrphanDepositSubmitted must carry the real deposit tx hash -- it is \
-             the crash-recovery anchor ConfirmOrphanDeposit confirms against",
-        );
         assert_eq!(
-            raindex.last_deposit_call(),
-            Some(DepositCall {
-                token: wrapped_token,
-                vault_id: RaindexVaultId(B256::ZERO),
-                amount: U256::from(123u64),
-                decimals: TOKENIZED_EQUITY_DECIMALS,
-            }),
-            "SubmitOrphanDeposit must deposit the confirmed wrapped amount into the \
-             wrapped token vault at tokenized-equity precision",
-        );
-    }
-
-    #[tokio::test]
-    async fn submit_orphan_deposit_records_failure_when_raindex_reverts() {
-        let services = services_with(
-            Arc::new(
-                MockRaindex::new().with_deposit_behavior(DepositBehavior::FailExecutionReverted),
-            ),
-            Arc::new(MockWrapper::new()),
-        )
-        .await;
-        let events = orphan_wrapped()
-            .transition(
-                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit,
-                &services,
-            )
-            .await
-            .expect("SubmitOrphanDeposit should return Ok with RecoveryFailed on revert");
-        let [UnwrappedEquityRecoveryEvent::RecoveryFailed { reason, .. }] = events.as_slice()
-        else {
-            panic!("expected single RecoveryFailed event, got {events:?}");
-        };
-        assert!(
-            reason.contains("submit_deposit failed"),
-            "reason should mention submit_deposit; got {reason:?}",
-        );
-    }
-
-    #[tokio::test]
-    async fn submit_orphan_deposit_records_failure_when_vault_lookup_fails() {
-        let wrapped_token = Address::random();
-        let services = services_with_vault_lookup(
-            Arc::new(MockRaindex::new()),
-            Arc::new(MockWrapper::new().with_wrapped_token(wrapped_token)),
-            Arc::new(MockVaultLookup::new()),
-        )
-        .await;
-        let events = orphan_wrapped()
-            .transition(
-                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit,
-                &services,
-            )
-            .await
-            .expect("SubmitOrphanDeposit should return Ok with RecoveryFailed on lookup failure");
-        let [UnwrappedEquityRecoveryEvent::RecoveryFailed { reason, .. }] = events.as_slice()
-        else {
-            panic!("expected single RecoveryFailed event, got {events:?}");
-        };
-        assert!(
-            reason.contains("vault_lookup.vault_id_for_token failed"),
-            "reason should mention vault lookup failure; got {reason:?}",
+            *vault_deposit_tx_hash, vault_deposit_tx,
+            "OrphanDepositSubmitted must carry the command-supplied deposit tx hash -- it \
+             is the crash-recovery anchor ConfirmOrphanDeposit confirms against",
         );
     }
 
     #[tokio::test]
     async fn confirm_orphan_deposit_completes_orphan_branch() {
-        let raindex = Arc::new(MockRaindex::new());
-        let services = services_with(raindex.clone(), Arc::new(MockWrapper::new())).await;
         let state = UnwrappedEquityRecovery::OrphanDepositSubmitted {
             symbol: aapl(),
             shares: one_share(),
@@ -1420,10 +990,7 @@ mod tests {
             deposit_submitted_at: Utc::now(),
         };
         let events = state
-            .transition(
-                UnwrappedEquityRecoveryCommand::ConfirmOrphanDeposit,
-                &services,
-            )
+            .transition(UnwrappedEquityRecoveryCommand::ConfirmOrphanDeposit, &())
             .await
             .expect("ConfirmOrphanDeposit should succeed from OrphanDepositSubmitted");
         let [
@@ -1437,138 +1004,19 @@ mod tests {
         };
         assert_eq!(
             *vault_deposit_tx_hash, FAKE_WRAP_TX,
-            "OrphanDeposited must carry the submitted deposit tx hash -- it is \
+            "OrphanDeposited must carry the submitted deposit tx hash from state -- it is \
              the idempotency anchor confirm_tx ran against",
-        );
-        assert_eq!(
-            raindex.last_confirmed_tx(),
-            Some(FAKE_WRAP_TX),
-            "ConfirmOrphanDeposit must confirm the persisted deposit tx hash",
-        );
-    }
-
-    /// `confirm_tx` failing on the final deposit confirmation is recorded as
-    /// `RecoveryFailed`, not surfaced as an aggregate error.
-    #[tokio::test]
-    async fn confirm_orphan_deposit_records_failure_when_confirm_tx_fails() {
-        let services = services_with(
-            Arc::new(MockRaindex::new().with_confirm_behavior(ConfirmTxBehavior::Fail)),
-            Arc::new(MockWrapper::new()),
-        )
-        .await;
-        let state = UnwrappedEquityRecovery::OrphanDepositSubmitted {
-            symbol: aapl(),
-            shares: one_share(),
-            detected_at: Utc::now(),
-            wrap_tx_hash: FAKE_WRAP_TX,
-            wrapped_amount: U256::from(123u64),
-            vault_deposit_tx_hash: FAKE_WRAP_TX,
-            deposit_submitted_at: Utc::now(),
-        };
-        let events = state
-            .transition(
-                UnwrappedEquityRecoveryCommand::ConfirmOrphanDeposit,
-                &services,
-            )
-            .await
-            .expect("ConfirmOrphanDeposit should return Ok with RecoveryFailed on confirm failure");
-        let [UnwrappedEquityRecoveryEvent::RecoveryFailed { reason, .. }] = events.as_slice()
-        else {
-            panic!("expected single RecoveryFailed event, got {events:?}");
-        };
-        assert!(
-            reason.contains("confirm_tx failed"),
-            "reason should mention confirm_tx; got {reason:?}",
-        );
-    }
-
-    #[tokio::test]
-    async fn confirm_orphan_deposit_retryable_error_keeps_submitted_state_live() {
-        let services = services_with(
-            Arc::new(MockRaindex::new().with_confirm_behavior(ConfirmTxBehavior::Retryable)),
-            Arc::new(MockWrapper::new()),
-        )
-        .await;
-        let state = UnwrappedEquityRecovery::OrphanDepositSubmitted {
-            symbol: aapl(),
-            shares: one_share(),
-            detected_at: Utc::now(),
-            wrap_tx_hash: FAKE_WRAP_TX,
-            wrapped_amount: U256::from(123u64),
-            vault_deposit_tx_hash: FAKE_WRAP_TX,
-            deposit_submitted_at: Utc::now(),
-        };
-        let error = state
-            .transition(
-                UnwrappedEquityRecoveryCommand::ConfirmOrphanDeposit,
-                &services,
-            )
-            .await
-            .unwrap_err();
-
-        assert!(matches!(
-            error,
-            UnwrappedEquityRecoveryError::RetryableDepositConfirmation {
-                vault_deposit_tx_hash: FAKE_WRAP_TX,
-            }
-        ));
-    }
-
-    /// `resume_mint` fails because no mint aggregate exists -> the handler
-    /// records the failure as `RecoveryFailed` rather than erroring.
-    #[tokio::test]
-    async fn dispatch_to_mint_records_failure_when_resume_mint_fails() {
-        let services = test_services().await;
-        let events = detected()
-            .transition(
-                UnwrappedEquityRecoveryCommand::DispatchToMint {
-                    mint_id: issuer_request_id("ISS-NONEXISTENT"),
-                },
-                &services,
-            )
-            .await
-            .expect("DispatchToMint should return Ok with RecoveryFailed on service failure");
-        let [UnwrappedEquityRecoveryEvent::RecoveryFailed { reason, .. }] = events.as_slice()
-        else {
-            panic!("expected single RecoveryFailed event, got {events:?}");
-        };
-        assert!(
-            reason.contains("resume_mint failed"),
-            "reason should mention resume_mint; got {reason:?}",
-        );
-    }
-
-    #[tokio::test]
-    async fn dispatch_to_redemption_records_failure_when_resume_redemption_fails() {
-        let services = test_services().await;
-        let events = detected()
-            .transition(
-                UnwrappedEquityRecoveryCommand::DispatchToRedemption {
-                    redemption_id: redemption_aggregate_id("nonexistent"),
-                },
-                &services,
-            )
-            .await
-            .expect("DispatchToRedemption should return Ok with RecoveryFailed on service failure");
-        let [UnwrappedEquityRecoveryEvent::RecoveryFailed { reason, .. }] = events.as_slice()
-        else {
-            panic!("expected single RecoveryFailed event, got {events:?}");
-        };
-        assert!(
-            reason.contains("resume_redemption failed"),
-            "reason should mention resume_redemption; got {reason:?}",
         );
     }
 
     #[tokio::test]
     async fn fail_recovery_from_detected_emits_recovery_failed() {
-        let services = test_services().await;
         let events = detected()
             .transition(
                 UnwrappedEquityRecoveryCommand::FailRecovery {
                     reason: "operator abort".to_string(),
                 },
-                &services,
+                &(),
             )
             .await
             .expect("FailRecovery should succeed from a non-terminal state");
@@ -1631,134 +1079,5 @@ mod tests {
         let id = UnwrappedEquityRecoveryId(Uuid::new_v4());
         let parsed = id.to_string().parse::<UnwrappedEquityRecoveryId>().unwrap();
         assert_eq!(id, parsed);
-    }
-
-    #[tokio::test]
-    async fn submit_orphan_deposit_with_wrap_block_calls_wait_for_block() {
-        let raindex = Arc::new(MockRaindex::new());
-        let mock_wrapper = Arc::new(MockWrapper::new().with_wrapped_token(Address::random()));
-        let services = services_with(
-            raindex.clone(),
-            Arc::clone(&mock_wrapper) as Arc<dyn Wrapper>,
-        )
-        .await;
-
-        let state = UnwrappedEquityRecovery::OrphanWrapped {
-            symbol: aapl(),
-            shares: one_share(),
-            detected_at: Utc::now(),
-            wrap_tx_hash: FAKE_WRAP_TX,
-            wrap_submitted_at: Utc::now(),
-            wrapped_amount: U256::from(123u64),
-            wrap_confirmed_at: Utc::now(),
-            wrap_block: Some(9999),
-        };
-
-        let events = state
-            .transition(
-                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit,
-                &services,
-            )
-            .await
-            .expect("SubmitOrphanDeposit with wrap_block=Some(9999) should succeed");
-
-        let [UnwrappedEquityRecoveryEvent::OrphanDepositSubmitted { .. }] = events.as_slice()
-        else {
-            panic!("expected OrphanDepositSubmitted, got {events:?}");
-        };
-
-        assert_eq!(
-            mock_wrapper.wait_for_block_calls(),
-            vec![9999u64],
-            "wait_for_block must be called exactly once with wrap_block=9999"
-        );
-    }
-
-    #[tokio::test]
-    async fn submit_orphan_deposit_propagates_err_when_wait_for_block_fails() {
-        let services = services_with(
-            Arc::new(MockRaindex::new()),
-            Arc::new(MockWrapper::failing_wait_for_block()),
-        )
-        .await;
-
-        let state = UnwrappedEquityRecovery::OrphanWrapped {
-            symbol: aapl(),
-            shares: one_share(),
-            detected_at: Utc::now(),
-            wrap_tx_hash: FAKE_WRAP_TX,
-            wrap_submitted_at: Utc::now(),
-            wrapped_amount: U256::from(123u64),
-            wrap_confirmed_at: Utc::now(),
-            wrap_block: Some(9999),
-        };
-
-        let error = state
-            .transition(
-                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit,
-                &services,
-            )
-            .await
-            .expect_err("wait_for_block failure must propagate as retryable Err");
-
-        assert!(
-            matches!(
-                error,
-                UnwrappedEquityRecoveryError::NodeSyncFailed {
-                    required_block: 9999,
-                    ..
-                }
-            ),
-            "wait_for_block failure must surface as NodeSyncFailed, got: {error:?}"
-        );
-    }
-
-    /// Verifies that the `_ => NODE_SYNC_MAX_ATTEMPTS` fallback arm in the
-    /// `SubmitOrphanDeposit` error-mapping closure is exercised when
-    /// `wait_for_block` fails with a transport error (as opposed to the
-    /// `NodeBehindRequiredBlock` arm covered by
-    /// `submit_orphan_deposit_propagates_err_when_wait_for_block_fails`).
-    ///
-    /// A transport error means every poll failed before any block number was
-    /// observed, so the budget was fully consumed; the fallback must still
-    /// produce `NodeSyncFailed` with `attempts == NODE_SYNC_MAX_ATTEMPTS`.
-    #[tokio::test]
-    async fn submit_orphan_deposit_propagates_err_when_wait_for_block_fails_with_transport_error() {
-        let services = services_with(
-            Arc::new(MockRaindex::new()),
-            Arc::new(MockWrapper::failing_wait_for_block_transport_error()),
-        )
-        .await;
-
-        let state = UnwrappedEquityRecovery::OrphanWrapped {
-            symbol: aapl(),
-            shares: one_share(),
-            detected_at: Utc::now(),
-            wrap_tx_hash: FAKE_WRAP_TX,
-            wrap_submitted_at: Utc::now(),
-            wrapped_amount: U256::from(123u64),
-            wrap_confirmed_at: Utc::now(),
-            wrap_block: Some(9999),
-        };
-
-        let error = state
-            .transition(
-                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit,
-                &services,
-            )
-            .await
-            .expect_err("transport error from wait_for_block must propagate as retryable Err");
-
-        assert!(
-            matches!(
-                error,
-                UnwrappedEquityRecoveryError::NodeSyncFailed {
-                    required_block: 9999,
-                    attempts: NODE_SYNC_MAX_ATTEMPTS,
-                }
-            ),
-            "transport error must map to NodeSyncFailed with attempts=NODE_SYNC_MAX_ATTEMPTS, \
-             got: {error:?}"
-        );
     }
 }

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -1,11 +1,12 @@
 //! Apalis job that orchestrates unwrapped-equity recovery.
 //!
 //! Enqueued per symbol with a positive `BaseWalletUnwrappedEquity`
-//! balance. The job is a thin orchestrator: it reads `InventoryView`,
-//! picks a dispatch path, and sends the command sequence through the
-//! aggregate's store. All side effects (raindex deposit/confirm,
-//! wrapper wrap/confirm, mint/redemption resume) live in the
-//! aggregate's command handlers via its `Services`.
+//! balance. The job owns the recovery's side effects: it reads
+//! `InventoryView`, picks a dispatch path, and drives the onchain/transfer
+//! work (raindex deposit/confirm, wrapper wrap/confirm, mint/redemption
+//! resume) directly via `ctx.services`, recording each outcome through the
+//! aggregate's pure recording commands. The aggregate's handlers are pure
+//! event recorders (`type Services = ()`).
 //!
 //! Steps:
 //!
@@ -32,6 +33,7 @@
 //! target the same aggregate -- the next command in the sequence picks
 //! up wherever the previous attempt stopped.
 
+use alloy::primitives::{TxHash, U256};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -40,29 +42,33 @@ use thiserror::Error;
 use tracing::{debug, info, warn};
 
 use st0x_event_sorcery::{SendError, Store};
+use st0x_evm::EvmError;
 use st0x_execution::{FractionalShares, Symbol};
 use st0x_tokenization::IssuerRequestId;
+use st0x_wrapper::{WrapConfirmation, WrapperError, node_sync_attempts};
 
 use super::aggregate::{
     UnwrappedEquityRecovery, UnwrappedEquityRecoveryCommand, UnwrappedEquityRecoveryError,
-    UnwrappedEquityRecoveryId,
+    UnwrappedEquityRecoveryId, UnwrappedEquityRecoveryServices,
 };
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::equity_redemption::{EquityRedemption, RedemptionAggregateId};
 use crate::inventory::BroadcastingInventory;
 use crate::inventory::view::{InFlightEquityLocation, InventoryView};
 use crate::rebalancing::trigger::{GuardState, claim_guard_for_recovery_or_orphan};
-use crate::tokenized_equity_mint::TokenizedEquityMint;
+use crate::tokenized_equity_mint::{TOKENIZED_EQUITY_DECIMALS, TokenizedEquityMint};
 
 /// Apalis queue type for [`UnwrappedEquityRecoveryJob`].
 pub(crate) type UnwrappedEquityRecoveryJobQueue = JobQueue<UnwrappedEquityRecoveryJob>;
 
 /// Dependencies the recovery job needs to claim the per-symbol concurrency
-/// guard, read inventory, and send commands through the aggregate's store.
-/// Services (raindex/wrapper/transfer/wallet) live on the store -- not here.
+/// guard, read inventory, perform the recovery's onchain/transfer side effects,
+/// and record outcomes through the aggregate's pure command store.
 pub(crate) struct UnwrappedEquityRecoveryCtx {
     pub(crate) inventory: Arc<BroadcastingInventory>,
     pub(crate) store: Arc<Store<UnwrappedEquityRecovery>>,
+    /// Onchain/transfer dependencies the job drives before recording outcomes.
+    pub(crate) services: UnwrappedEquityRecoveryServices,
     pub(crate) mint_store: Arc<Store<TokenizedEquityMint>>,
     pub(crate) redemption_store: Arc<Store<EquityRedemption>>,
     pub(crate) equity_in_progress: Arc<RwLock<HashMap<Symbol, GuardState>>>,
@@ -75,8 +81,10 @@ pub(crate) struct UnwrappedEquityRecoveryCtx {
 }
 
 /// Why a single recovery job attempt failed. Errors propagate up through
-/// apalis; service-call failures inside the aggregate's command handlers
-/// are recorded as `RecoveryFailed` events and don't surface here.
+/// apalis. Terminal service failures are recorded as `RecoveryFailed` via
+/// `fail_recovery`; retryable service failures surface here as
+/// `RetryableWrapConfirmation`/`RetryableDepositConfirmation`/`NodeSyncFailed`
+/// so apalis retries.
 #[derive(Debug, Error)]
 pub(crate) enum UnwrappedEquityRecoveryJobError {
     #[error("recovery aggregate error: {0}")]
@@ -139,6 +147,12 @@ pub(crate) enum UnwrappedEquityRecoveryJobError {
          guard drop restores HeldForRecovery or removes orphan entry"
     )]
     NoBalanceSkip { symbol: Symbol },
+    #[error("wrap confirmation for tx {wrap_tx_hash} is retryable")]
+    RetryableWrapConfirmation { wrap_tx_hash: TxHash },
+    #[error("deposit confirmation for tx {vault_deposit_tx_hash} is retryable")]
+    RetryableDepositConfirmation { vault_deposit_tx_hash: TxHash },
+    #[error("RPC node did not catch up to wrap block {required_block} after {attempts} polls")]
+    NodeSyncFailed { required_block: u64, attempts: u32 },
 }
 
 /// Apalis job payload. The reactor pushes one of these per symbol with a
@@ -215,15 +229,27 @@ impl Job<UnwrappedEquityRecoveryCtx> for UnwrappedEquityRecoveryJob {
             Some(UnwrappedEquityRecovery::Detected { shares, .. }) => {
                 resume_from_detected(ctx, &self.recovery_id, &symbol, shares).await
             }
-            Some(UnwrappedEquityRecovery::OrphanWrapSubmitted { .. }) => {
-                resume_from_confirm_wrap(ctx, &self.recovery_id).await
+            Some(UnwrappedEquityRecovery::OrphanWrapSubmitted { wrap_tx_hash, .. }) => {
+                resume_from_confirm_wrap(ctx, &self.recovery_id, &symbol, wrap_tx_hash).await
             }
-            Some(UnwrappedEquityRecovery::OrphanWrapped { .. }) => {
-                resume_from_submit_deposit(ctx, &self.recovery_id).await
+            Some(UnwrappedEquityRecovery::OrphanWrapped {
+                wrapped_amount,
+                wrap_block,
+                ..
+            }) => {
+                resume_from_submit_deposit(
+                    ctx,
+                    &self.recovery_id,
+                    &symbol,
+                    wrapped_amount,
+                    wrap_block,
+                )
+                .await
             }
-            Some(UnwrappedEquityRecovery::OrphanDepositSubmitted { .. }) => {
-                resume_from_confirm_deposit(ctx, &self.recovery_id).await
-            }
+            Some(UnwrappedEquityRecovery::OrphanDepositSubmitted {
+                vault_deposit_tx_hash,
+                ..
+            }) => resume_from_confirm_deposit(ctx, &self.recovery_id, vault_deposit_tx_hash).await,
             // Terminal states are already short-circuited by the `is_terminal`
             // early-return above; they are enumerated explicitly here (rather
             // than a `_` arm) so that adding a new non-terminal state fails to
@@ -332,7 +358,7 @@ async fn start_from_detect(
         "Unwrapped equity recovery: dispatched detection",
     );
 
-    dispatch_from_detected(ctx, recovery_id, symbol, snapshot.dispatch).await
+    dispatch_from_detected(ctx, recovery_id, symbol, snapshot.shares, snapshot.dispatch).await
 }
 
 /// Resume from `Detected`: a previous attempt persisted `Detect` but crashed
@@ -435,37 +461,85 @@ async fn resume_from_detected(
         "Resuming unwrapped recovery from Detected",
     );
 
-    dispatch_from_detected(ctx, recovery_id, symbol, snapshot.dispatch).await
+    dispatch_from_detected(ctx, recovery_id, symbol, snapshot.shares, snapshot.dispatch).await
 }
 
-/// Picks the dispatch command from a `Detected` state. For the orphan path,
-/// chains into the four-step sequence; for active mint/redemption, sends the
-/// single dispatch command; for conflict, fails the aggregate and returns
-/// success so apalis does not retry a terminal domain rejection.
+/// Records a terminal recovery failure as a `RecoveryFailed` event. Returns
+/// `Ok(())` so the caller stops the chain without burning an apalis retry on an
+/// already-terminal aggregate.
+async fn fail_recovery(
+    ctx: &UnwrappedEquityRecoveryCtx,
+    recovery_id: &UnwrappedEquityRecoveryId,
+    reason: String,
+) -> Result<(), UnwrappedEquityRecoveryJobError> {
+    ctx.store
+        .send(
+            recovery_id,
+            UnwrappedEquityRecoveryCommand::FailRecovery { reason },
+        )
+        .await?;
+    Ok(())
+}
+
+/// Performs the dispatch step's I/O and records the outcome. For active
+/// mint/redemption, resumes the transfer and records the dispatch (or
+/// `RecoveryFailed`); for the orphan path, chains into the four-step sequence;
+/// for conflict, fails the aggregate.
 async fn dispatch_from_detected(
     ctx: &UnwrappedEquityRecoveryCtx,
     recovery_id: &UnwrappedEquityRecoveryId,
     symbol: &Symbol,
+    shares: FractionalShares,
     dispatch: DispatchDecision,
 ) -> Result<(), UnwrappedEquityRecoveryJobError> {
     match dispatch {
-        DispatchDecision::ActiveMint(mint_id) => ctx
-            .store
-            .send(
-                recovery_id,
-                UnwrappedEquityRecoveryCommand::DispatchToMint { mint_id },
-            )
-            .await
-            .map_err(Into::into),
-        DispatchDecision::ActiveRedemption(redemption_id) => ctx
-            .store
-            .send(
-                recovery_id,
-                UnwrappedEquityRecoveryCommand::DispatchToRedemption { redemption_id },
-            )
-            .await
-            .map_err(Into::into),
-        DispatchDecision::Orphan => resume_from_submit_wrap(ctx, recovery_id).await,
+        DispatchDecision::ActiveMint(mint_id) => {
+            match ctx.services.transfer.resume_mint(&mint_id).await {
+                Ok(()) => {
+                    info!(target: "rebalance", %mint_id, "Unwrapped equity recovery: resume_mint succeeded");
+                    ctx.store
+                        .send(
+                            recovery_id,
+                            UnwrappedEquityRecoveryCommand::DispatchToMint { mint_id },
+                        )
+                        .await?;
+                    Ok(())
+                }
+                Err(error) => {
+                    warn!(target: "rebalance", %mint_id, ?error, "Unwrapped equity recovery: resume_mint failed");
+                    fail_recovery(ctx, recovery_id, format!("resume_mint failed: {error}")).await
+                }
+            }
+        }
+        DispatchDecision::ActiveRedemption(redemption_id) => {
+            match ctx
+                .services
+                .transfer
+                .resume_redemption(&redemption_id)
+                .await
+            {
+                Ok(()) => {
+                    info!(target: "rebalance", %redemption_id, "Unwrapped equity recovery: resume_redemption succeeded");
+                    ctx.store
+                        .send(
+                            recovery_id,
+                            UnwrappedEquityRecoveryCommand::DispatchToRedemption { redemption_id },
+                        )
+                        .await?;
+                    Ok(())
+                }
+                Err(error) => {
+                    warn!(target: "rebalance", %redemption_id, ?error, "Unwrapped equity recovery: resume_redemption failed");
+                    fail_recovery(
+                        ctx,
+                        recovery_id,
+                        format!("resume_redemption failed: {error}"),
+                    )
+                    .await
+                }
+            }
+        }
+        DispatchDecision::Orphan => resume_from_submit_wrap(ctx, recovery_id, symbol, shares).await,
         DispatchDecision::Conflict {
             mint_id,
             redemption_id,
@@ -475,13 +549,7 @@ async fn dispatch_from_detected(
                  {redemption_id} for symbol {symbol}; refusing to dispatch"
             );
             warn!(target: "rebalance", %symbol, %mint_id, %redemption_id, "Unwrapped equity recovery: conflict");
-            ctx.store
-                .send(
-                    recovery_id,
-                    UnwrappedEquityRecoveryCommand::FailRecovery { reason },
-                )
-                .await?;
-            Ok(())
+            fail_recovery(ctx, recovery_id, reason).await
         }
     }
 }
@@ -497,92 +565,286 @@ fn is_business_validation_error(error: &UnwrappedEquityRecoveryJobError) -> bool
         | UnwrappedEquityRecoveryJobError::ActiveMintAggregate(_)
         | UnwrappedEquityRecoveryJobError::ActiveRedemptionAggregate(_)
         | UnwrappedEquityRecoveryJobError::Reschedule(_)
+        | UnwrappedEquityRecoveryJobError::RetryableWrapConfirmation { .. }
+        | UnwrappedEquityRecoveryJobError::RetryableDepositConfirmation { .. }
+        | UnwrappedEquityRecoveryJobError::NodeSyncFailed { .. }
         | UnwrappedEquityRecoveryJobError::NoBalanceSkip { .. } => false,
     }
 }
 
-/// Starts the four-step orphan path. Each step is sent independently and
-/// chains to the next via a `resume_from_*` function, so a retry that enters
-/// at any orphan state can pick up at the right command instead of replaying
-/// from `SubmitOrphanWrap`.
+/// Orphan path step 1: resolves the wrapped token, wraps the bot wallet's
+/// underlying tokens, records the submitted tx hash, then chains to confirm.
+/// A lookup/conversion/submit failure is terminal (`RecoveryFailed`).
 async fn resume_from_submit_wrap(
     ctx: &UnwrappedEquityRecoveryCtx,
     recovery_id: &UnwrappedEquityRecoveryId,
+    symbol: &Symbol,
+    shares: FractionalShares,
 ) -> Result<(), UnwrappedEquityRecoveryJobError> {
-    ctx.store
-        .send(
-            recovery_id,
-            UnwrappedEquityRecoveryCommand::SubmitOrphanWrap,
-        )
-        .await?;
-    if aggregate_terminal(ctx, recovery_id).await? {
-        return Ok(());
+    let underlying_amount = match shares.to_u256_18_decimals() {
+        Ok(raw) => raw,
+        Err(error) => {
+            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: shares conversion failed");
+            return fail_recovery(
+                ctx,
+                recovery_id,
+                format!("shares conversion failed: {error}"),
+            )
+            .await;
+        }
+    };
+
+    let wrapped_token = match ctx.services.wrapper.lookup_derivative(symbol) {
+        Ok(token) => token,
+        Err(error) => {
+            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: lookup_derivative failed");
+            return fail_recovery(
+                ctx,
+                recovery_id,
+                format!("wrapper.lookup_derivative failed: {error}"),
+            )
+            .await;
+        }
+    };
+
+    match ctx
+        .services
+        .wrapper
+        .submit_wrap(wrapped_token, underlying_amount, ctx.services.wallet)
+        .await
+    {
+        Ok(wrap_tx_hash) => {
+            info!(target: "rebalance", %symbol, %wrap_tx_hash, "Unwrapped equity recovery: submit_wrap succeeded");
+            ctx.store
+                .send(
+                    recovery_id,
+                    UnwrappedEquityRecoveryCommand::SubmitOrphanWrap { wrap_tx_hash },
+                )
+                .await?;
+            resume_from_confirm_wrap(ctx, recovery_id, symbol, wrap_tx_hash).await
+        }
+        Err(error) => {
+            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: submit_wrap failed");
+            fail_recovery(
+                ctx,
+                recovery_id,
+                format!("wrapper.submit_wrap failed: {error}"),
+            )
+            .await
+        }
     }
-    resume_from_confirm_wrap(ctx, recovery_id).await
 }
 
-/// Continues the orphan path from `OrphanWrapSubmitted` -- the wrap tx hash
-/// is already persisted in state and the aggregate's command handler will
-/// call `wrapper.confirm_wrap` on that tx.
+/// Orphan path step 2: confirms the wrap, records the minted amount and block,
+/// then chains to deposit. A confirmed-missing/dropped receipt is terminal; any
+/// other confirmation error is retryable (the job error propagates so apalis
+/// retries from the persisted `OrphanWrapSubmitted` state).
 async fn resume_from_confirm_wrap(
     ctx: &UnwrappedEquityRecoveryCtx,
     recovery_id: &UnwrappedEquityRecoveryId,
+    symbol: &Symbol,
+    wrap_tx_hash: TxHash,
 ) -> Result<(), UnwrappedEquityRecoveryJobError> {
-    ctx.store
-        .send(
-            recovery_id,
-            UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap,
-        )
-        .await?;
-    if aggregate_terminal(ctx, recovery_id).await? {
-        return Ok(());
+    let wrapped_token = match ctx.services.wrapper.lookup_derivative(symbol) {
+        Ok(token) => token,
+        Err(error) => {
+            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: lookup_derivative failed");
+            return fail_recovery(
+                ctx,
+                recovery_id,
+                format!("wrapper.lookup_derivative failed: {error}"),
+            )
+            .await;
+        }
+    };
+
+    match ctx
+        .services
+        .wrapper
+        .confirm_wrap(wrapped_token, wrap_tx_hash)
+        .await
+    {
+        Ok(WrapConfirmation {
+            shares: wrapped_amount,
+            block: wrap_block,
+        }) => {
+            info!(target: "rebalance", %symbol, %wrap_tx_hash, %wrapped_amount, "Unwrapped equity recovery: confirm_wrap succeeded");
+            ctx.store
+                .send(
+                    recovery_id,
+                    UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap {
+                        wrapped_amount,
+                        wrap_block,
+                    },
+                )
+                .await?;
+            resume_from_submit_deposit(ctx, recovery_id, symbol, wrapped_amount, Some(wrap_block))
+                .await
+        }
+        Err(error) => {
+            warn!(target: "rebalance", %symbol, %wrap_tx_hash, ?error, "Unwrapped equity recovery: confirm_wrap failed");
+            match error {
+                // Terminal: the tx will not succeed on retry (malformed receipt,
+                // dropped tx, config/drift). Record `RecoveryFailed` for the audit
+                // trail instead of looping on apalis.
+                WrapperError::MissingDepositEvent
+                | WrapperError::MissingWithdrawEvent
+                | WrapperError::SymbolNotConfigured(_)
+                | WrapperError::RedeemExceedsMax { .. }
+                | WrapperError::Evm(EvmError::TransactionDropped { .. }) => {
+                    fail_recovery(
+                        ctx,
+                        recovery_id,
+                        format!("wrapper.confirm_wrap failed: {error}"),
+                    )
+                    .await
+                }
+                // Transient: RPC transport/lag, contract view, ratio read, or a
+                // not-yet-finalized receipt -- apalis re-drives the confirm from
+                // the persisted state. Enumerated (no `_`) so a new WrapperError
+                // variant forces a terminal-vs-retryable decision here.
+                WrapperError::Evm(_)
+                | WrapperError::Contract(_)
+                | WrapperError::Ratio(_)
+                | WrapperError::MissingBlockNumber { .. } => {
+                    Err(UnwrappedEquityRecoveryJobError::RetryableWrapConfirmation { wrap_tx_hash })
+                }
+            }
+        }
     }
-    resume_from_submit_deposit(ctx, recovery_id).await
 }
 
-/// Continues the orphan path from `OrphanWrapped` -- the wrapped amount is
-/// persisted in state and the deposit command will use it.
+/// Orphan path step 3: waits for the wrap block (skipped for legacy aggregates
+/// persisted before `wrap_block` existed), resolves the vault, deposits the
+/// wrapped shares, records the tx hash, then chains to confirm. A wait failure
+/// is retryable; a lookup/deposit failure is terminal.
 async fn resume_from_submit_deposit(
     ctx: &UnwrappedEquityRecoveryCtx,
     recovery_id: &UnwrappedEquityRecoveryId,
+    symbol: &Symbol,
+    wrapped_amount: U256,
+    wrap_block: Option<u64>,
 ) -> Result<(), UnwrappedEquityRecoveryJobError> {
-    ctx.store
-        .send(
-            recovery_id,
-            UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit,
-        )
-        .await?;
-    if aggregate_terminal(ctx, recovery_id).await? {
-        return Ok(());
+    if let Some(block) = wrap_block {
+        ctx.services
+            .wrapper
+            .wait_for_block(block)
+            .await
+            .inspect_err(|error| {
+                warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: wait_for_block failed");
+            })
+            .map_err(|error| UnwrappedEquityRecoveryJobError::NodeSyncFailed {
+                required_block: block,
+                attempts: node_sync_attempts(&error),
+            })?;
     }
-    resume_from_confirm_deposit(ctx, recovery_id).await
+
+    let wrapped_token = match ctx.services.wrapper.lookup_derivative(symbol) {
+        Ok(token) => token,
+        Err(error) => {
+            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: lookup_derivative failed");
+            return fail_recovery(
+                ctx,
+                recovery_id,
+                format!("wrapper.lookup_derivative failed: {error}"),
+            )
+            .await;
+        }
+    };
+
+    let vault_id = match ctx
+        .services
+        .vault_lookup
+        .vault_id_for_token(wrapped_token)
+        .await
+    {
+        Ok(id) => id,
+        Err(error) => {
+            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: vault_id_for_token failed");
+            return fail_recovery(
+                ctx,
+                recovery_id,
+                format!("vault_lookup.vault_id_for_token failed: {error}"),
+            )
+            .await;
+        }
+    };
+
+    // `wrapped_amount` is the raw ERC-4626 share amount from the wrap's Deposit
+    // event. Wrapped equity tokens (wtSTOCK) are minted at the system-wide
+    // tokenized-equity precision -- `TOKENIZED_EQUITY_DECIMALS` (18), the same
+    // standard the tSTOCK underlying and `FractionalShares` use -- so the raw
+    // amount is already in 18-decimal units and is interpreted as such.
+    match ctx
+        .services
+        .raindex
+        .submit_deposit(
+            wrapped_token,
+            vault_id,
+            wrapped_amount,
+            TOKENIZED_EQUITY_DECIMALS,
+        )
+        .await
+    {
+        Ok(vault_deposit_tx_hash) => {
+            info!(target: "rebalance", %symbol, %vault_deposit_tx_hash, "Unwrapped equity recovery: submit_deposit succeeded");
+            ctx.store
+                .send(
+                    recovery_id,
+                    UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit {
+                        vault_deposit_tx_hash,
+                    },
+                )
+                .await?;
+            resume_from_confirm_deposit(ctx, recovery_id, vault_deposit_tx_hash).await
+        }
+        Err(error) => {
+            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: submit_deposit failed");
+            fail_recovery(
+                ctx,
+                recovery_id,
+                format!("raindex.submit_deposit failed: {error}"),
+            )
+            .await
+        }
+    }
 }
 
-/// Continues the orphan path from `OrphanDepositSubmitted` -- the deposit
-/// tx hash is persisted in state and the aggregate confirms it via
-/// `raindex.confirm_tx`.
+/// Orphan path step 4: confirms the Raindex deposit and records it. A dropped
+/// tx is terminal; any other confirmation error is retryable.
 async fn resume_from_confirm_deposit(
     ctx: &UnwrappedEquityRecoveryCtx,
     recovery_id: &UnwrappedEquityRecoveryId,
+    vault_deposit_tx_hash: TxHash,
 ) -> Result<(), UnwrappedEquityRecoveryJobError> {
-    ctx.store
-        .send(
-            recovery_id,
-            UnwrappedEquityRecoveryCommand::ConfirmOrphanDeposit,
-        )
-        .await
-        .map_err(Into::into)
-}
-
-async fn aggregate_terminal(
-    ctx: &UnwrappedEquityRecoveryCtx,
-    recovery_id: &UnwrappedEquityRecoveryId,
-) -> Result<bool, UnwrappedEquityRecoveryJobError> {
-    Ok(ctx
-        .store
-        .load(recovery_id)
-        .await?
-        .is_some_and(|agg| agg.is_terminal()))
+    match ctx.services.raindex.confirm_tx(vault_deposit_tx_hash).await {
+        Ok(()) => {
+            info!(target: "rebalance", %vault_deposit_tx_hash, "Unwrapped equity recovery: confirm_tx succeeded");
+            ctx.store
+                .send(
+                    recovery_id,
+                    UnwrappedEquityRecoveryCommand::ConfirmOrphanDeposit,
+                )
+                .await
+                .map_err(Into::into)
+        }
+        Err(error) => {
+            warn!(target: "rebalance", %vault_deposit_tx_hash, ?error, "Unwrapped equity recovery: confirm_tx failed");
+            if error.is_transaction_dropped() {
+                return fail_recovery(
+                    ctx,
+                    recovery_id,
+                    format!("raindex.confirm_tx failed: {error}"),
+                )
+                .await;
+            }
+            Err(
+                UnwrappedEquityRecoveryJobError::RetryableDepositConfirmation {
+                    vault_deposit_tx_hash,
+                },
+            )
+        }
+    }
 }
 
 struct RecoverySnapshot {
@@ -700,6 +962,7 @@ mod tests {
     use uuid::Uuid;
 
     use st0x_event_sorcery::test_store;
+    use st0x_evm::NODE_SYNC_MAX_ATTEMPTS;
     use st0x_raindex::{Raindex, RaindexVaultId};
     use st0x_tokenization::Tokenizer;
     use st0x_tokenization::mock::{MockCompletionOutcome, MockDetectionOutcome, MockTokenizer};
@@ -709,11 +972,11 @@ mod tests {
     use crate::equity_redemption::{
         EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,
     };
-    use crate::onchain::mock::MockRaindex;
+    use crate::onchain::mock::{ConfirmTxBehavior, DepositBehavior, DepositCall, MockRaindex};
     use crate::rebalancing::equity::CrossVenueEquityTransfer;
     use crate::rebalancing::trigger::InProgressGuard;
     use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintCommand};
-    use crate::vault_lookup::MockVaultLookup;
+    use crate::vault_lookup::{MockVaultLookup, VaultLookup};
 
     use super::super::aggregate::UnwrappedEquityRecoveryServices;
     use super::*;
@@ -741,37 +1004,58 @@ mod tests {
         equity_in_progress: HashMap<Symbol, GuardState>,
         tokenizer: Arc<dyn Tokenizer>,
     ) -> UnwrappedEquityRecoveryCtx {
+        test_ctx_with_services(
+            view,
+            equity_in_progress,
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+            Arc::new(mock_vault_lookup()),
+            tokenizer,
+        )
+        .await
+    }
+
+    /// `test_ctx` with caller-supplied raindex/wrapper/vault-lookup mocks, so a
+    /// failure-path test can inject reverting/failing variants while the rest of
+    /// the recovery stays wired to succeeding mocks. The aggregate store is pure
+    /// (`()` services); the onchain services live on the ctx, mirroring
+    /// production wiring.
+    async fn test_ctx_with_services(
+        view: InventoryView,
+        equity_in_progress: HashMap<Symbol, GuardState>,
+        raindex: Arc<dyn Raindex>,
+        wrapper: Arc<dyn Wrapper>,
+        vault_lookup: Arc<dyn VaultLookup>,
+        tokenizer: Arc<dyn Tokenizer>,
+    ) -> UnwrappedEquityRecoveryCtx {
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
-        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
-        let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
         let mint_store = Arc::new(test_store(pool.clone(), ()));
         let redemption_store = Arc::new(test_store(pool.clone(), ()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
-            Arc::new(mock_vault_lookup()),
+            vault_lookup.clone(),
             tokenizer,
             wrapper.clone(),
             Address::random(),
             mint_store.clone(),
             redemption_store.clone(),
         ));
-        let store = Arc::new(test_store(
-            pool,
-            UnwrappedEquityRecoveryServices {
-                raindex,
-                vault_lookup: Arc::new(mock_vault_lookup()),
-                wrapper,
-                transfer,
-                wallet: Address::random(),
-            },
-        ));
+        let services = UnwrappedEquityRecoveryServices {
+            raindex,
+            vault_lookup,
+            wrapper,
+            transfer,
+            wallet: Address::random(),
+        };
+        let store = Arc::new(test_store(pool, ()));
         let (sender, _receiver) = broadcast::channel(16);
         let inventory = Arc::new(BroadcastingInventory::new(view, sender));
 
         UnwrappedEquityRecoveryCtx {
             inventory,
             store,
+            services,
             mint_store,
             redemption_store,
             equity_in_progress: Arc::new(RwLock::new(equity_in_progress)),
@@ -823,16 +1107,14 @@ mod tests {
             mint_store.clone(),
             redemption_store.clone(),
         ));
-        let store = Arc::new(test_store(
-            pool.clone(),
-            UnwrappedEquityRecoveryServices {
-                raindex,
-                vault_lookup: Arc::new(MockVaultLookup::new()),
-                wrapper,
-                transfer,
-                wallet: Address::random(),
-            },
-        ));
+        let services = UnwrappedEquityRecoveryServices {
+            raindex,
+            vault_lookup: Arc::new(MockVaultLookup::new()),
+            wrapper,
+            transfer,
+            wallet: Address::random(),
+        };
+        let store = Arc::new(test_store(pool.clone(), ()));
 
         let (sender, _receiver) = broadcast::channel(16);
         let inventory = Arc::new(BroadcastingInventory::new(InventoryView::default(), sender));
@@ -840,6 +1122,7 @@ mod tests {
         let ctx = UnwrappedEquityRecoveryCtx {
             inventory,
             store,
+            services,
             mint_store,
             redemption_store,
             equity_in_progress,
@@ -898,16 +1181,14 @@ mod tests {
             mint_store.clone(),
             redemption_store.clone(),
         ));
-        let store = Arc::new(test_store(
-            pool.clone(),
-            UnwrappedEquityRecoveryServices {
-                raindex,
-                vault_lookup: Arc::new(MockVaultLookup::new()),
-                wrapper,
-                transfer,
-                wallet: Address::random(),
-            },
-        ));
+        let services = UnwrappedEquityRecoveryServices {
+            raindex,
+            vault_lookup: Arc::new(MockVaultLookup::new()),
+            wrapper,
+            transfer,
+            wallet: Address::random(),
+        };
+        let store = Arc::new(test_store(pool.clone(), ()));
 
         // Inventory reports an unwrapped balance (so a snapshot exists) and an
         // active mint for the symbol (so dispatch resolves to `ActiveMint`), but
@@ -933,6 +1214,7 @@ mod tests {
         let ctx = UnwrappedEquityRecoveryCtx {
             inventory,
             store,
+            services,
             mint_store,
             redemption_store,
             equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
@@ -1774,9 +2056,19 @@ mod tests {
     #[tokio::test]
     async fn perform_resumes_from_orphan_wrap_submitted_without_rewrapping() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let ctx = test_ctx(
+        // Seed the wrapper with the persisted wrap tx so the resumed run's
+        // `confirm_wrap` succeeds against it (a prior attempt's `submit_wrap`
+        // would have recorded it).
+        let wrap_tx = TxHash::from([0x11; 32]);
+        let wrapper = Arc::new(MockWrapper::new());
+        wrapper.seed_submitted_amount(wrap_tx, U256::from(5u64));
+        let ctx = test_ctx_with_services(
             view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5))),
             HashMap::new(),
+            Arc::new(MockRaindex::new()),
+            wrapper,
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
         )
         .await;
         let recovery_id = UnwrappedEquityRecoveryId(Uuid::new_v4());
@@ -1794,7 +2086,9 @@ mod tests {
         ctx.store
             .send(
                 &recovery_id,
-                UnwrappedEquityRecoveryCommand::SubmitOrphanWrap,
+                UnwrappedEquityRecoveryCommand::SubmitOrphanWrap {
+                    wrap_tx_hash: wrap_tx,
+                },
             )
             .await
             .unwrap();
@@ -1852,14 +2146,19 @@ mod tests {
         ctx.store
             .send(
                 &recovery_id,
-                UnwrappedEquityRecoveryCommand::SubmitOrphanWrap,
+                UnwrappedEquityRecoveryCommand::SubmitOrphanWrap {
+                    wrap_tx_hash: TxHash::from([0x11; 32]),
+                },
             )
             .await
             .unwrap();
         ctx.store
             .send(
                 &recovery_id,
-                UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap,
+                UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap {
+                    wrapped_amount: U256::from(5u64),
+                    wrap_block: 0,
+                },
             )
             .await
             .unwrap();
@@ -1917,21 +2216,28 @@ mod tests {
         ctx.store
             .send(
                 &recovery_id,
-                UnwrappedEquityRecoveryCommand::SubmitOrphanWrap,
+                UnwrappedEquityRecoveryCommand::SubmitOrphanWrap {
+                    wrap_tx_hash: TxHash::from([0x11; 32]),
+                },
             )
             .await
             .unwrap();
         ctx.store
             .send(
                 &recovery_id,
-                UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap,
+                UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap {
+                    wrapped_amount: U256::from(5u64),
+                    wrap_block: 0,
+                },
             )
             .await
             .unwrap();
         ctx.store
             .send(
                 &recovery_id,
-                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit,
+                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit {
+                    vault_deposit_tx_hash: TxHash::from([0x22; 32]),
+                },
             )
             .await
             .unwrap();
@@ -1965,5 +2271,487 @@ mod tests {
             vault_deposit_tx_hash, seeded_deposit_tx,
             "the resumed run must confirm the persisted deposit tx, not submit a second deposit",
         );
+    }
+
+    // --- Orphan-path I/O outcomes (the failure/retryable behaviour the job
+    // records through the aggregate's pure commands; relocated here from the
+    // aggregate when the I/O moved to the job). ---
+
+    fn aapl() -> Symbol {
+        Symbol::new("AAPL").unwrap()
+    }
+
+    fn five_shares() -> FractionalShares {
+        FractionalShares::new(float!(5))
+    }
+
+    /// Seeds `Detect` so the orphan path's first step runs against a real
+    /// `Detected` aggregate, then returns the recovery id.
+    async fn seed_detected(ctx: &UnwrappedEquityRecoveryCtx) -> UnwrappedEquityRecoveryId {
+        let recovery_id = UnwrappedEquityRecoveryId(Uuid::new_v4());
+        ctx.store
+            .send(
+                &recovery_id,
+                UnwrappedEquityRecoveryCommand::Detect {
+                    symbol: aapl(),
+                    shares: five_shares(),
+                },
+            )
+            .await
+            .unwrap();
+        recovery_id
+    }
+
+    async fn assert_failed_with(
+        ctx: &UnwrappedEquityRecoveryCtx,
+        id: &UnwrappedEquityRecoveryId,
+        needle: &str,
+    ) {
+        let state = ctx.store.load(id).await.unwrap();
+        let Some(UnwrappedEquityRecovery::Failed { reason, .. }) = state else {
+            panic!("expected Failed state, got {state:?}");
+        };
+        assert!(
+            reason.contains(needle),
+            "RecoveryFailed reason should mention {needle:?}; got {reason:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_wrap_failure_records_recovery_failed() {
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::failing()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_detected(&ctx).await;
+
+        resume_from_submit_wrap(&ctx, &recovery_id, &aapl(), five_shares())
+            .await
+            .expect("a terminal wrap failure is recorded, not surfaced as a job error");
+
+        assert_failed_with(&ctx, &recovery_id, "submit_wrap failed").await;
+    }
+
+    #[tokio::test]
+    async fn submit_wrap_derivative_lookup_failure_records_recovery_failed() {
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::failing_derivative_lookup()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_detected(&ctx).await;
+
+        resume_from_submit_wrap(&ctx, &recovery_id, &aapl(), five_shares())
+            .await
+            .expect("a terminal lookup failure is recorded, not surfaced as a job error");
+
+        assert_failed_with(&ctx, &recovery_id, "lookup_derivative failed").await;
+    }
+
+    #[tokio::test]
+    async fn confirm_wrap_failure_records_recovery_failed() {
+        let wrap_tx = TxHash::from([0x11; 32]);
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::failing_confirm_wrap()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_detected(&ctx).await;
+        ctx.store
+            .send(
+                &recovery_id,
+                UnwrappedEquityRecoveryCommand::SubmitOrphanWrap {
+                    wrap_tx_hash: wrap_tx,
+                },
+            )
+            .await
+            .unwrap();
+
+        resume_from_confirm_wrap(&ctx, &recovery_id, &aapl(), wrap_tx)
+            .await
+            .expect("a confirmed-missing-receipt is recorded, not surfaced as a job error");
+
+        assert_failed_with(&ctx, &recovery_id, "confirm_wrap failed").await;
+    }
+
+    #[tokio::test]
+    async fn confirm_wrap_retryable_error_propagates_and_keeps_state_live() {
+        let wrap_tx = TxHash::from([0x11; 32]);
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::retryable_confirm_wrap()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_detected(&ctx).await;
+        ctx.store
+            .send(
+                &recovery_id,
+                UnwrappedEquityRecoveryCommand::SubmitOrphanWrap {
+                    wrap_tx_hash: wrap_tx,
+                },
+            )
+            .await
+            .unwrap();
+
+        let error = resume_from_confirm_wrap(&ctx, &recovery_id, &aapl(), wrap_tx)
+            .await
+            .expect_err(
+                "a retryable confirm failure must surface as a job error so apalis retries",
+            );
+
+        assert!(matches!(
+            error,
+            UnwrappedEquityRecoveryJobError::RetryableWrapConfirmation { .. }
+        ));
+        let state = ctx.store.load(&recovery_id).await.unwrap();
+        assert!(
+            matches!(
+                state,
+                Some(UnwrappedEquityRecovery::OrphanWrapSubmitted { .. })
+            ),
+            "a retryable error must leave the aggregate live in OrphanWrapSubmitted, got {state:?}",
+        );
+    }
+
+    /// Seeds `OrphanWrapped` (the deposit step's entry state) with the given
+    /// confirmation block, returning the recovery id.
+    async fn seed_orphan_wrapped(
+        ctx: &UnwrappedEquityRecoveryCtx,
+        wrap_block: u64,
+    ) -> UnwrappedEquityRecoveryId {
+        let recovery_id = seed_detected(ctx).await;
+        ctx.store
+            .send(
+                &recovery_id,
+                UnwrappedEquityRecoveryCommand::SubmitOrphanWrap {
+                    wrap_tx_hash: TxHash::from([0x11; 32]),
+                },
+            )
+            .await
+            .unwrap();
+        ctx.store
+            .send(
+                &recovery_id,
+                UnwrappedEquityRecoveryCommand::ConfirmOrphanWrap {
+                    wrapped_amount: U256::from(123u64),
+                    wrap_block,
+                },
+            )
+            .await
+            .unwrap();
+        recovery_id
+    }
+
+    #[tokio::test]
+    async fn submit_deposit_revert_records_recovery_failed() {
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            Arc::new(
+                MockRaindex::new().with_deposit_behavior(DepositBehavior::FailExecutionReverted),
+            ),
+            Arc::new(MockWrapper::new()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_orphan_wrapped(&ctx, 0).await;
+
+        resume_from_submit_deposit(&ctx, &recovery_id, &aapl(), U256::from(123u64), None)
+            .await
+            .expect("a reverted deposit is recorded, not surfaced as a job error");
+
+        assert_failed_with(&ctx, &recovery_id, "submit_deposit failed").await;
+    }
+
+    #[tokio::test]
+    async fn submit_deposit_vault_lookup_failure_records_recovery_failed() {
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new().with_wrapped_token(Address::random())),
+            // Empty vault lookup -> `vault_id_for_token` fails.
+            Arc::new(MockVaultLookup::new()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_orphan_wrapped(&ctx, 0).await;
+
+        resume_from_submit_deposit(&ctx, &recovery_id, &aapl(), U256::from(123u64), None)
+            .await
+            .expect("a vault lookup failure is recorded, not surfaced as a job error");
+
+        assert_failed_with(&ctx, &recovery_id, "vault_id_for_token failed").await;
+    }
+
+    #[tokio::test]
+    async fn submit_deposit_derivative_lookup_failure_records_recovery_failed() {
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            Arc::new(MockRaindex::new()),
+            // `lookup_derivative` fails before the vault lookup / deposit run.
+            Arc::new(MockWrapper::failing_derivative_lookup()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_orphan_wrapped(&ctx, 0).await;
+
+        resume_from_submit_deposit(&ctx, &recovery_id, &aapl(), U256::from(123u64), None)
+            .await
+            .expect("a derivative lookup failure is recorded, not surfaced as a job error");
+
+        assert_failed_with(&ctx, &recovery_id, "wrapper.lookup_derivative failed").await;
+    }
+
+    #[tokio::test]
+    async fn submit_deposit_waits_for_block_then_deposits_at_tokenized_precision() {
+        let wrapped_token = Address::random();
+        let raindex = Arc::new(MockRaindex::new());
+        let wrapper = Arc::new(MockWrapper::new().with_wrapped_token(wrapped_token));
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            raindex.clone(),
+            wrapper.clone(),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_orphan_wrapped(&ctx, 9999).await;
+
+        resume_from_submit_deposit(&ctx, &recovery_id, &aapl(), U256::from(123u64), Some(9999))
+            .await
+            .expect("deposit should succeed after the node-sync wait");
+
+        assert_eq!(
+            wrapper.wait_for_block_calls(),
+            vec![9999u64],
+            "the deposit step must wait for the wrap block before depositing",
+        );
+        assert_eq!(
+            raindex.last_deposit_call(),
+            Some(DepositCall {
+                token: wrapped_token,
+                vault_id: RaindexVaultId(B256::ZERO),
+                amount: U256::from(123u64),
+                decimals: TOKENIZED_EQUITY_DECIMALS,
+            }),
+            "the deposit must use the resolved wrapped token at tokenized-equity precision",
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_deposit_wait_failure_propagates_node_sync_error() {
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::failing_wait_for_block()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_orphan_wrapped(&ctx, 9999).await;
+
+        let error =
+            resume_from_submit_deposit(&ctx, &recovery_id, &aapl(), U256::from(123u64), Some(9999))
+                .await
+                .expect_err("a node-sync wait failure must surface as a retryable job error");
+
+        assert!(matches!(
+            error,
+            UnwrappedEquityRecoveryJobError::NodeSyncFailed {
+                required_block: 9999,
+                ..
+            }
+        ));
+    }
+
+    /// Seeds `OrphanDepositSubmitted` (the confirm step's entry state).
+    async fn seed_orphan_deposit_submitted(
+        ctx: &UnwrappedEquityRecoveryCtx,
+        deposit_tx: TxHash,
+    ) -> UnwrappedEquityRecoveryId {
+        let recovery_id = seed_orphan_wrapped(ctx, 0).await;
+        ctx.store
+            .send(
+                &recovery_id,
+                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit {
+                    vault_deposit_tx_hash: deposit_tx,
+                },
+            )
+            .await
+            .unwrap();
+        recovery_id
+    }
+
+    #[tokio::test]
+    async fn confirm_deposit_failure_records_recovery_failed() {
+        let deposit_tx = TxHash::from([0x22; 32]);
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            Arc::new(MockRaindex::new().with_confirm_behavior(ConfirmTxBehavior::Fail)),
+            Arc::new(MockWrapper::new()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_orphan_deposit_submitted(&ctx, deposit_tx).await;
+
+        resume_from_confirm_deposit(&ctx, &recovery_id, deposit_tx)
+            .await
+            .expect("a dropped deposit tx is recorded, not surfaced as a job error");
+
+        assert_failed_with(&ctx, &recovery_id, "confirm_tx failed").await;
+    }
+
+    #[tokio::test]
+    async fn confirm_deposit_retryable_error_propagates_against_persisted_tx() {
+        let deposit_tx = TxHash::from([0x22; 32]);
+        let raindex =
+            Arc::new(MockRaindex::new().with_confirm_behavior(ConfirmTxBehavior::Retryable));
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            raindex.clone(),
+            Arc::new(MockWrapper::new()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_orphan_deposit_submitted(&ctx, deposit_tx).await;
+
+        let error = resume_from_confirm_deposit(&ctx, &recovery_id, deposit_tx)
+            .await
+            .expect_err("a retryable confirmation must surface as a job error so apalis retries");
+
+        assert!(matches!(
+            error,
+            UnwrappedEquityRecoveryJobError::RetryableDepositConfirmation { .. }
+        ));
+        assert_eq!(
+            raindex.last_confirmed_tx(),
+            Some(deposit_tx),
+            "the confirm step must confirm the persisted deposit tx hash",
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_resume_mint_failure_records_recovery_failed() {
+        let ctx = test_ctx(InventoryView::default(), HashMap::new()).await;
+        let recovery_id = seed_detected(&ctx).await;
+
+        // No mint aggregate exists, so `resume_mint` fails.
+        dispatch_from_detected(
+            &ctx,
+            &recovery_id,
+            &aapl(),
+            five_shares(),
+            DispatchDecision::ActiveMint(issuer_request_id("ISS-NONEXISTENT")),
+        )
+        .await
+        .expect("a failed mint resume is recorded, not surfaced as a job error");
+
+        assert_failed_with(&ctx, &recovery_id, "resume_mint failed").await;
+    }
+
+    #[tokio::test]
+    async fn dispatch_resume_redemption_failure_records_recovery_failed() {
+        let ctx = test_ctx(InventoryView::default(), HashMap::new()).await;
+        let recovery_id = seed_detected(&ctx).await;
+
+        dispatch_from_detected(
+            &ctx,
+            &recovery_id,
+            &aapl(),
+            five_shares(),
+            DispatchDecision::ActiveRedemption(redemption_aggregate_id("nonexistent")),
+        )
+        .await
+        .expect("a failed redemption resume is recorded, not surfaced as a job error");
+
+        assert_failed_with(&ctx, &recovery_id, "resume_redemption failed").await;
+    }
+
+    /// A `wait_for_block` transport error (every poll failed before a tip was
+    /// observed) must still surface as `NodeSyncFailed` with the full budget of
+    /// `NODE_SYNC_MAX_ATTEMPTS` -- the `node_sync_attempts` fallback arm, distinct
+    /// from the `NodeBehindRequiredBlock` arm covered above.
+    #[tokio::test]
+    async fn submit_deposit_transport_error_wait_failure_pins_max_attempts() {
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::failing_wait_for_block_transport_error()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_orphan_wrapped(&ctx, 9999).await;
+
+        let error =
+            resume_from_submit_deposit(&ctx, &recovery_id, &aapl(), U256::from(123u64), Some(9999))
+                .await
+                .expect_err("a transport-error wait failure must surface as a retryable job error");
+
+        assert!(matches!(
+            error,
+            UnwrappedEquityRecoveryJobError::NodeSyncFailed {
+                required_block: 9999,
+                attempts: NODE_SYNC_MAX_ATTEMPTS,
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn confirm_wrap_derivative_lookup_failure_records_recovery_failed() {
+        let wrap_tx = TxHash::from([0x11; 32]);
+        let ctx = test_ctx_with_services(
+            InventoryView::default(),
+            HashMap::new(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::failing_derivative_lookup()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+        )
+        .await;
+        let recovery_id = seed_detected(&ctx).await;
+        ctx.store
+            .send(
+                &recovery_id,
+                UnwrappedEquityRecoveryCommand::SubmitOrphanWrap {
+                    wrap_tx_hash: wrap_tx,
+                },
+            )
+            .await
+            .unwrap();
+
+        resume_from_confirm_wrap(&ctx, &recovery_id, &aapl(), wrap_tx)
+            .await
+            .expect("a terminal lookup failure at the confirm step is recorded, not a job error");
+
+        assert_failed_with(&ctx, &recovery_id, "lookup_derivative failed").await;
     }
 }


### PR DESCRIPTION
## What

Makes the `UnwrappedEquityRecovery` aggregate's command handlers pure
event-recording and moves all onchain/transfer I/O (mint/redemption resume, the
orphan-path ERC-4626 wrap + Raindex deposit, and their confirmations) into the
durable `UnwrappedEquityRecoveryJob`. Implements RAI-930.

## Why

Per [ADR 0013](adrs/0013-equity-family-side-effect-extraction.md), side effects
belong in the durable job that drives the aggregate, not in the aggregate's
command handlers. Pure handlers stay replay-safe; the job re-drives the I/O from
persisted state on crash recovery. This continues the equity-family chain
(RAI-928 mint, RAI-929 redemption) toward the event-sorcery 0.2.0-rc2 bump
(RAI-924), which drops `type Services`.

## How

- The aggregate's `transition` is now pure: each command carries the value the
  job derived from its I/O — `SubmitOrphanWrap { wrap_tx_hash }`,
  `ConfirmOrphanWrap { wrapped_amount, wrap_block }`, `SubmitOrphanDeposit {
  vault_deposit_tx_hash }`; `DispatchToMint`/`DispatchToRedemption` record a
  successful resume. `type Services = ()`.
- The job's `resume_from_*` functions own the I/O and map outcomes: success →
  the recording command (then chain to the next step); a terminal service
  failure → `FailRecovery` (recorded as a `RecoveryFailed` event); a retryable
  failure (non-dropped confirm, node-sync wait) → a job error so apalis retries
  from the persisted state. The retryable/`NodeSyncFailed` variants moved from
  the aggregate error to `UnwrappedEquityRecoveryJobError`.
- The job's ctx now holds the `UnwrappedEquityRecoveryServices` bundle
  (raindex/vault-lookup/wrapper/transfer/wallet) it drives; the aggregate store
  is built with `()`. The bundle is threaded through conductor startup wiring.
- Events are unchanged, so `evolve` and the persisted schema are untouched
  (replay-safe).
- Extracted `hydrate_startup_inventory_and_read_models` from `Conductor::run`
  (the wiring change tipped it over the function-length lint; the extraction is
  a genuine cohesive startup-hydration unit).

## Testing

- Pure aggregate tests: per-command emission, state guards, terminal rejection,
  and `evolve` tx-hash gating.
- Relocated the I/O outcome tests to the job, where the I/O now lives: terminal
  failures record `RecoveryFailed` (wrap/lookup/deposit/confirm), retryable
  failures propagate as job errors (`RetryableWrapConfirmation`,
  `RetryableDepositConfirmation`, `NodeSyncFailed`), the deposit waits for the
  wrap block and deposits at tokenized-equity precision, and the dispatch path
  records `RecoveryFailed` on a failed resume.
- Full recovery + conductor suites green (70 + 139 tests), e2e recovery tests
  included; `cargo clippy --all-targets --all-features` and `cargo fmt --check`
  clean.

## Anything else

- **At-least-once on `*Pending`-equivalent resume (pre-existing, no regression):**
  the orphan wrap/deposit submit steps broadcast before the tx hash is recorded,
  so a crash in that window re-broadcasts on resume — symmetric with the
  pre-refactor handler-side I/O. The split into submit/confirm commands keeps
  the resume loop re-confirming a persisted tx from the `*Submitted` states and
  only re-submitting from the pre-submit states, matching the mint/redemption
  pattern.
- Stacked on RAI-929 (`feat/equity-redemption-pure-handlers`); RAI-931
  (`WrappedEquityRecovery`) is the next slice before the RAI-924 bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved startup reliability by loading persisted state earlier and catching up recovery data before processing resumes.
  * Expanded recovery handling so equity recovery can continue more smoothly after interruptions.

* **Bug Fixes**
  * Reduced the chance of recovery jobs re-running steps unnecessarily after a restart.
  * Improved retry handling for confirmation and node sync issues during recovery.
  * Made orphan recovery flows more resilient by preserving and reusing previously captured progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->