### PR TITLE
feat: order aggregate for extended-hours counter-trading

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -424,11 +424,11 @@ fn extract_log_file_date(entry: &std::fs::DirEntry) -> Option<chrono::NaiveDate>
     chrono::NaiveDate::parse_from_str(date_suffix, "%Y-%m-%d").ok()
 }
 
-/// Returns non-terminal offchain orders (Pending, Submitted, PartiallyFilled).
+/// Returns non-terminal offchain orders (Pending, Submitted, PartiallyFilled, Cancelling).
 async fn pending_orders(State(state): State<AppState>) -> Json<Vec<PendingOrderResponse>> {
     let rows: Vec<(String, String, String)> = match sqlx::query_as(
         "SELECT view_id, status, payload FROM offchain_order_view \
-         WHERE status IN ('Pending', 'Submitted', 'PartiallyFilled') \
+         WHERE status IN ('Pending', 'Submitted', 'PartiallyFilled', 'Cancelling') \
          ORDER BY rowid DESC LIMIT 100",
     )
     .fetch_all(&state.pool)
@@ -1739,6 +1739,77 @@ mod tests {
         assert_eq!(stuck.amount, "12.5");
         assert_eq!(stuck.location, StuckLocation::Issuer);
         assert_eq!(stuck.reason, StuckReason::MintAcceptanceFailed);
+    }
+
+    #[test]
+    fn parse_pending_order_handles_cancelling_status() {
+        // The cancel-and-replace flow introduced the non-terminal `Cancelling`
+        // state; the /orders/pending endpoint must surface it like any other
+        // live order rather than dropping it on the floor.
+        let payload = r#"{"Live":{"Cancelling":{"symbol":"AAPL","direction":"Sell","shares":"1.5","executor":"DryRun","placed_at":"2026-01-01T00:00:00Z","submitted_at":"2026-01-01T00:00:01Z","shares_filled":"0.5","avg_price":"195.25"}}}"#;
+
+        let parsed = parse_pending_order("order-1".to_string(), "Cancelling".to_string(), payload)
+            .expect("Cancelling order should parse");
+
+        assert_eq!(parsed.view_id, "order-1");
+        assert_eq!(parsed.status, "Cancelling");
+        assert_eq!(parsed.symbol, "AAPL");
+        assert_eq!(parsed.direction, "Sell");
+        assert_eq!(parsed.shares, "1.5");
+        assert_eq!(parsed.executor, "DryRun");
+        assert_eq!(parsed.placed_at, "2026-01-01T00:00:00Z");
+        assert_eq!(parsed.submitted_at.as_deref(), Some("2026-01-01T00:00:01Z"));
+        assert_eq!(parsed.shares_filled.as_deref(), Some("0.5"));
+        assert_eq!(parsed.avg_price.as_deref(), Some("195.25"));
+    }
+
+    #[tokio::test]
+    async fn offchain_order_view_status_column_maps_cancelling_and_cancelled() {
+        // The generated `status` column must map every lifecycle state; a
+        // missing CASE arm yields NULL and hides the order from the
+        // status-filtered pending-orders query.
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        let cancelling_payload = r#"{"Live":{"Cancelling":{"symbol":"AAPL","direction":"Sell","shares":"1.5","executor":"DryRun","placed_at":"2026-01-01T00:00:00Z","submitted_at":"2026-01-01T00:00:01Z"}}}"#;
+        let cancelled_payload = r#"{"Live":{"Cancelled":{"symbol":"AAPL","direction":"Sell","shares":"1.5","executor":"DryRun","placed_at":"2026-01-01T00:00:00Z","cancelled_at":"2026-01-01T00:00:02Z"}}}"#;
+        for (view_id, payload) in [
+            ("order-cancelling", cancelling_payload),
+            ("order-cancelled", cancelled_payload),
+        ] {
+            sqlx::query(
+                "INSERT INTO offchain_order_view (view_id, version, payload) VALUES (?, 1, ?)",
+            )
+            .bind(view_id)
+            .bind(payload)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let statuses: Vec<(String, String)> =
+            sqlx::query_as("SELECT view_id, status FROM offchain_order_view ORDER BY view_id")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            statuses,
+            vec![
+                ("order-cancelled".to_string(), "Cancelled".to_string()),
+                ("order-cancelling".to_string(), "Cancelling".to_string()),
+            ]
+        );
+
+        // The pending-orders filter must surface Cancelling (non-terminal)
+        // and exclude Cancelled (terminal).
+        let pending: Vec<(String,)> = sqlx::query_as(
+            "SELECT view_id FROM offchain_order_view \
+             WHERE status IN ('Pending', 'Submitted', 'PartiallyFilled', 'Cancelling')",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(pending, vec![("order-cancelling".to_string(),)]);
     }
 
     #[test]

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -1,18 +1,53 @@
 //! Repair CLI commands for manually recovering stuck local CQRS state.
 
 use anyhow::{Context, bail};
+use async_trait::async_trait;
 use rain_math_float::Float;
 use sqlx::SqlitePool;
 use std::io::Write;
+use std::sync::Arc;
 
 use st0x_config::ExecutionThreshold;
 use st0x_event_sorcery::{AggregateError, LifecycleError, StoreBuilder};
-use st0x_execution::{FractionalShares, Symbol};
+use st0x_execution::{
+    CancellationOutcome, ExecutorOrderId, FractionalShares, LimitOrder, MarketOrder, Symbol,
+};
 
 use crate::offchain::order::{
-    OffchainOrder, OffchainOrderCommand, OffchainOrderError, OffchainOrderId,
+    OffchainOrder, OffchainOrderCommand, OffchainOrderError, OffchainOrderId, OrderPlacementResult,
+    OrderPlacer,
 };
 use crate::position::{Position, PositionCommand};
+
+/// An [`OrderPlacer`] for repair commands that must never place or cancel an
+/// order: `MarkFailed` is a pure terminal transition that never touches the
+/// placer. Returns an error on the unreachable placement/cancellation paths
+/// rather than panicking.
+struct RepairOrderPlacer;
+
+#[async_trait]
+impl OrderPlacer for RepairOrderPlacer {
+    async fn place_market_order(
+        &self,
+        _order: MarketOrder,
+    ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
+        Err("repair must not place offchain orders; MarkFailed is terminal-only".into())
+    }
+
+    async fn place_limit_order(
+        &self,
+        _order: LimitOrder,
+    ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
+        Err("repair must not place offchain orders; MarkFailed is terminal-only".into())
+    }
+
+    async fn cancel_order(
+        &self,
+        _executor_order_id: &ExecutorOrderId,
+    ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+        Err("repair must not cancel offchain orders; MarkFailed is terminal-only".into())
+    }
+}
 
 /// Fails a position's pending offchain order pointer and drives the orphaned
 /// `OffchainOrder` aggregate to `Failed`.
@@ -66,6 +101,13 @@ pub(super) async fn fail_pending_offchain_order_command<W: Write>(
                     "OffchainOrder {offchain_order_id} is Filled: the hedge executed. This \
                      command cannot repair a filled order -- reconcile the fill into the \
                      position instead of failing it."
+                );
+            }
+            OffchainOrder::Cancelling { .. } | OffchainOrder::Cancelled { .. } => {
+                bail!(
+                    "OffchainOrder {offchain_order_id} is in a cancellation lifecycle state: \
+                     this command fails stuck Pending/Submitted orders, not cancellations -- \
+                     refusing. Confirm the intended recovery path for cancellation states."
                 );
             }
             OffchainOrder::Pending { .. }
@@ -157,10 +199,19 @@ enum ReloadOutcome {
 /// Single source of the executed-shares-escalate rule shared by both re-load
 /// sites in [`fail_offchain_order_aggregate`].
 fn classify_reloaded_state(state: Option<&OffchainOrder>) -> ReloadOutcome {
-    use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
+    use OffchainOrder::{
+        Cancelled, Cancelling, Failed, Filled, PartiallyFilled, Pending, Submitted,
+    };
 
     match state {
-        Some(Filled { .. } | PartiallyFilled { .. }) => ReloadOutcome::Escalate,
+        // Executed shares (Filled/PartiallyFilled) would erase a hedge; and a
+        // concurrent transition into a cancellation lifecycle state during a
+        // fail must route to manual reconciliation rather than being failed
+        // blind (a Cancelled order may carry a partial fill). Confirm the
+        // intended recovery path for cancellation states.
+        Some(Filled { .. } | PartiallyFilled { .. } | Cancelling { .. } | Cancelled { .. }) => {
+            ReloadOutcome::Escalate
+        }
         Some(Failed { .. }) => ReloadOutcome::BenignTerminal,
         Some(Pending { .. } | Submitted { .. }) | None => ReloadOutcome::Proceed,
     }
@@ -180,7 +231,9 @@ async fn fail_offchain_order_aggregate<W: Write>(
     offchain_order_id: OffchainOrderId,
     reason: String,
 ) -> anyhow::Result<()> {
-    use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
+    use OffchainOrder::{
+        Cancelled, Cancelling, Failed, Filled, PartiallyFilled, Pending, Submitted,
+    };
 
     let Some(order) = order else {
         writeln!(
@@ -205,6 +258,13 @@ async fn fail_offchain_order_aggregate<W: Write>(
             bail!(
                 "OffchainOrder {offchain_order_id} has executed shares (state {order:?}) -- \
                  refusing to erase the executed hedge"
+            );
+        }
+        Cancelling { .. } | Cancelled { .. } => {
+            bail!(
+                "OffchainOrder {offchain_order_id} is in a cancellation lifecycle state \
+                 (state {order:?}): this command fails Pending/Submitted orders, not \
+                 cancellations -- refusing. Confirm the intended recovery path."
             );
         }
         Pending { .. } | Submitted { .. } => {}
@@ -253,13 +313,16 @@ async fn fail_offchain_order_aggregate<W: Write>(
     // projection updates immediately -- a stale 'Submitted' row in the view is
     // the very symptom this command exists to repair.
     let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-        .build(())
+        .build(Arc::new(RepairOrderPlacer))
         .await
         .context("failed to build offchain order store")?;
     let send_result = store
         .send(
             &offchain_order_id,
-            OffchainOrderCommand::MarkFailed { error: reason },
+            OffchainOrderCommand::MarkFailed {
+                error: reason,
+                failed_at: chrono::Utc::now(),
+            },
         )
         .await;
 
@@ -390,9 +453,10 @@ mod tests {
     use alloy::primitives::TxHash;
 
     use st0x_config::ExecutionThreshold;
-    use st0x_execution::{Direction, ExecutorOrderId, FractionalShares};
+    use st0x_execution::{ClientOrderId, Direction, ExecutorOrderId, FractionalShares};
     use st0x_finance::Usd;
     use st0x_float_macro::float;
+    use uuid::Uuid;
 
     use super::*;
     use crate::position::TradeId;
@@ -410,8 +474,10 @@ mod tests {
                 shares: positive_shares("0.5"),
                 direction: Direction::Sell,
                 executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                kind: crate::offchain::order::CounterTradeOrderKind::Market,
             },
-            (),
+            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -426,8 +492,10 @@ mod tests {
                 executor_order_id: ExecutorOrderId::new("seed-accept"),
                 placed_shares: positive_shares("0.5"),
                 submitted_at: chrono::Utc::now(),
+                market_session: st0x_execution::MarketSession::Regular,
+                limit_price: None,
             },
-            (),
+            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -590,8 +658,9 @@ mod tests {
             &order_id,
             OffchainOrderCommand::CompleteFill {
                 price: Usd::new(float!(100)),
+                filled_at: chrono::Utc::now(),
             },
-            (),
+            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -648,8 +717,9 @@ mod tests {
             &order_id,
             OffchainOrderCommand::CompleteFill {
                 price: Usd::new(float!(100)),
+                filled_at: chrono::Utc::now(),
             },
-            (),
+            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -697,8 +767,9 @@ mod tests {
             OffchainOrderCommand::UpdatePartialFill {
                 shares_filled: FractionalShares::new(float!(0.25)),
                 avg_price: Usd::new(float!(100)),
+                partially_filled_at: chrono::Utc::now(),
             },
-            (),
+            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -769,8 +840,9 @@ mod tests {
             OffchainOrderCommand::UpdatePartialFill {
                 shares_filled: FractionalShares::new(float!(0.25)),
                 avg_price: Usd::new(float!(100)),
+                partially_filled_at: chrono::Utc::now(),
             },
-            (),
+            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -790,8 +862,9 @@ mod tests {
             &filled_id,
             OffchainOrderCommand::CompleteFill {
                 price: Usd::new(float!(100)),
+                filled_at: chrono::Utc::now(),
             },
-            (),
+            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -811,8 +884,9 @@ mod tests {
             &failed_id,
             OffchainOrderCommand::MarkFailed {
                 error: "bot failed it".to_string(),
+                failed_at: chrono::Utc::now(),
             },
-            (),
+            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -857,8 +931,9 @@ mod tests {
             &order_id,
             OffchainOrderCommand::CompleteFill {
                 price: Usd::new(float!(100)),
+                filled_at: chrono::Utc::now(),
             },
-            (),
+            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -898,8 +973,9 @@ mod tests {
             &order_id,
             OffchainOrderCommand::MarkFailed {
                 error: "bot failed it concurrently".to_string(),
+                failed_at: chrono::Utc::now(),
             },
-            (),
+            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -949,8 +1025,9 @@ mod tests {
             &order_id,
             OffchainOrderCommand::MarkFailed {
                 error: "pre-failed".to_string(),
+                failed_at: chrono::Utc::now(),
             },
-            (),
+            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -1140,8 +1217,9 @@ mod tests {
             OffchainOrderCommand::UpdatePartialFill {
                 shares_filled: FractionalShares::new(float!(0.25)),
                 avg_price: Usd::new(float!(100)),
+                partially_filled_at: chrono::Utc::now(),
             },
-            (),
+            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use tracing::{error, info};
 use uuid::Uuid;
 
+use st0x_config::{BrokerCtx, Ctx};
 use st0x_event_sorcery::{Store, StoreBuilder};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::alpaca_broker_api::{AlpacaLimitOrder, AlpacaLimitPrice};
@@ -17,14 +18,16 @@ use st0x_execution::{
     MockExecutor, MockExecutorCtx, OrderPlacement, OrderState, Positive, Symbol, TimeInForce,
     TryIntoExecutor,
 };
+use st0x_float_serde::format_float_with_fallback;
 
 use crate::conductor::{
     FillAccountingOutcome, account_for_onchain_fill, execute_mark_acknowledged,
     execute_settle_fill, is_expected_place_offchain_order_rejection,
 };
 use crate::offchain::order::{
-    OffchainOrder, OffchainOrderId, OrderPlacementResult, OrderPlacer,
-    client_order_id_for_placement, place_offchain_order_at_broker,
+    OffchainOrder, OffchainOrderId, OffchainOrderPlacement, OrderPlacementResult, OrderPlacer,
+    TerminalPositionFinalization, client_order_id_for_placement, place_offchain_order_at_broker,
+    position_command_for_finalization, terminal_position_finalization,
 };
 use crate::onchain::accumulator::check_execution_readiness;
 use crate::onchain::pyth::PythFeedIds;
@@ -32,8 +35,6 @@ use crate::onchain::{OnChainError, OnchainTrade, TradeValidationError};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeId};
 use crate::position::{Position, PositionCommand};
 use crate::symbol::cache::SymbolCache;
-use st0x_config::{BrokerCtx, Ctx};
-use st0x_float_serde::format_float_with_fallback;
 
 /// OrderPlacer for the CLI that delegates to the broker-specific executor
 /// constructed from config.
@@ -53,7 +54,30 @@ impl OrderPlacer for CliOrderPlacer {
         Ok(OrderPlacementResult {
             executor_order_id: ExecutorOrderId::new(&placement.order_id),
             placed_shares: placement.shares,
+            is_extended_hours: placement.extended_hours,
+            limit_price: placement.limit_price,
         })
+    }
+
+    async fn place_limit_order(
+        &self,
+        _order: st0x_execution::LimitOrder,
+    ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
+        Err("CLI does not support automated limit order placement".into())
+    }
+
+    async fn cancel_order(
+        &self,
+        _executor_order_id: &ExecutorOrderId,
+    ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+        Err("CLI does not support order cancellation".into())
+    }
+
+    async fn get_order_status(
+        &self,
+        _executor_order_id: &ExecutorOrderId,
+    ) -> Result<OrderState, Box<dyn std::error::Error + Send + Sync>> {
+        Err("CLI does not support reading order status via OrderPlacer".into())
     }
 }
 
@@ -162,13 +186,19 @@ fn write_order_status<W: Write>(stdout: &mut W, state: OrderState) -> anyhow::Re
                 "   The order has been submitted and is waiting to be filled."
             )?;
         }
-        OrderState::PartiallyFilled { order_id, .. } => {
-            writeln!(stdout, "⏳ Order Status: PARTIALLY FILLED")?;
+        OrderState::PartiallyFilled {
+            order_id,
+            shares_filled,
+            avg_price,
+            partially_filled_at,
+        } => {
+            writeln!(stdout, "🟡 Order Status: PARTIALLY FILLED")?;
             writeln!(stdout, "   Order ID: {order_id}")?;
-        }
-        OrderState::Cancelled { order_id, .. } => {
-            writeln!(stdout, "🚫 Order Status: CANCELLED")?;
-            writeln!(stdout, "   Order ID: {order_id}")?;
+            writeln!(stdout, "   Partially Filled At: {partially_filled_at}")?;
+            writeln!(stdout, "   Shares Filled: {shares_filled}")?;
+            if let Some(price) = avg_price {
+                writeln!(stdout, "   Avg Fill Price: ${price}")?;
+            }
         }
         OrderState::Filled {
             executed_at,
@@ -178,21 +208,40 @@ fn write_order_status<W: Write>(stdout: &mut W, state: OrderState) -> anyhow::Re
             writeln!(stdout, "✅ Order Status: FILLED")?;
             writeln!(stdout, "   Order ID: {order_id}")?;
             writeln!(stdout, "   Executed At: {executed_at}")?;
-            writeln!(
-                stdout,
-                "   Fill Price: ${}",
-                format_float_with_fallback(&price.into())
-            )?;
+            writeln!(stdout, "   Fill Price: ${price}")?;
+        }
+        OrderState::Cancelled {
+            cancelled_at,
+            order_id,
+            shares_filled,
+            avg_price,
+        } => {
+            writeln!(stdout, "🚫 Order Status: CANCELLED")?;
+            writeln!(stdout, "   Order ID: {order_id}")?;
+            writeln!(stdout, "   Cancelled At: {cancelled_at}")?;
+            if shares_filled != FractionalShares::ZERO {
+                writeln!(stdout, "   Shares Filled: {shares_filled}")?;
+            }
+            if let Some(avg_price) = avg_price {
+                writeln!(stdout, "   Avg Fill Price: ${avg_price}")?;
+            }
         }
         OrderState::Failed {
             failed_at,
             error_reason,
-            ..
+            shares_filled,
+            avg_price,
         } => {
             writeln!(stdout, "❌ Order Status: FAILED")?;
             writeln!(stdout, "   Failed At: {failed_at}")?;
             if let Some(reason) = error_reason {
                 writeln!(stdout, "   Reason: {reason}")?;
+            }
+            if let Some(shares_filled) = shares_filled {
+                writeln!(stdout, "   Shares Filled: {shares_filled}")?;
+            }
+            if let Some(avg_price) = avg_price {
+                writeln!(stdout, "   Avg Fill Price: ${avg_price}")?;
             }
         }
     }
@@ -578,7 +627,7 @@ pub(super) async fn process_found_trade<W: Write>(
         .build(())
         .await?;
     let (offchain_order_store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-        .build(())
+        .build(order_placer.clone())
         .await?;
 
     let Some(block_number) = onchain_trade.block_number else {
@@ -732,11 +781,13 @@ pub(super) async fn process_found_trade<W: Write>(
         &offchain_order_store,
         order_placer.as_ref(),
         &offchain_order_id,
-        params.symbol.clone(),
-        params.shares,
-        params.direction,
-        params.executor,
-        client_order_id,
+        OffchainOrderPlacement::market(
+            params.symbol.clone(),
+            params.shares,
+            params.direction,
+            params.executor,
+            client_order_id,
+        ),
     )
     .await?;
 
@@ -809,18 +860,6 @@ async fn reconcile_existing_pending_order<W: Write>(
             );
         })?;
 
-    let outcome = match &loaded_order {
-        Some(OffchainOrder::Submitted { .. } | OffchainOrder::PartiallyFilled { .. }) => {
-            CliPendingReconciliation::InFlight
-        }
-        None
-        | Some(
-            OffchainOrder::Failed { .. }
-            | OffchainOrder::Pending { .. }
-            | OffchainOrder::Filled { .. },
-        ) => CliPendingReconciliation::Cleared,
-    };
-
     reconcile_loaded_post_place_state(
         loaded_order,
         position_store,
@@ -829,9 +868,7 @@ async fn reconcile_existing_pending_order<W: Write>(
         CliPendingClearNextStep::ContinueThisRun,
         stdout,
     )
-    .await?;
-
-    Ok(outcome)
+    .await
 }
 
 // Mirrors dispatch_post_place_state in the normal pipeline: inspect the
@@ -865,6 +902,7 @@ async fn reconcile_post_place_state<W: Write>(
         stdout,
     )
     .await
+    .map(|_| ())
 }
 
 async fn reconcile_loaded_post_place_state<W: Write>(
@@ -874,7 +912,7 @@ async fn reconcile_loaded_post_place_state<W: Write>(
     offchain_order_id: OffchainOrderId,
     next_step: CliPendingClearNextStep,
     stdout: &mut W,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<CliPendingReconciliation> {
     match loaded_order {
         Some(OffchainOrder::Failed { error, .. }) => {
             // Broker placement failed: clear pending_offchain_order_id so the
@@ -889,12 +927,21 @@ async fn reconcile_loaded_post_place_state<W: Write>(
                 )
                 .await?;
             write_pending_clear_message(stdout, "Hedge placement failed", next_step)?;
+            Ok(CliPendingReconciliation::Cleared)
         }
         Some(OffchainOrder::Submitted { .. } | OffchainOrder::PartiallyFilled { .. }) => {
             // Order submitted to the broker. The CLI does not enqueue a live
             // polling job; the order will be reconciled to a terminal state by
             // the order-status recovery sweep on the next bot startup.
             writeln!(stdout, "Trade processing completed!")?;
+            Ok(CliPendingReconciliation::InFlight)
+        }
+        Some(OffchainOrder::Cancelling { .. }) => {
+            writeln!(
+                stdout,
+                "Pending hedge cancellation is still in progress; not placing another hedge."
+            )?;
+            Ok(CliPendingReconciliation::InFlight)
         }
         None => {
             position_store
@@ -911,16 +958,66 @@ async fn reconcile_loaded_post_place_state<W: Write>(
                 "Hedge placement produced unexpected state",
                 next_step,
             )?;
+            Ok(CliPendingReconciliation::Cleared)
         }
-        Some(OffchainOrder::Pending { .. } | OffchainOrder::Filled { .. }) => {
+        Some(OffchainOrder::Pending { .. }) => {
             anyhow::bail!(
                 "offchain order {offchain_order_id} for {symbol} is in an unexpected \
                  post-placement state; refusing to clear the position claim"
             );
         }
+        Some(order @ (OffchainOrder::Filled { .. } | OffchainOrder::Cancelled { .. })) => {
+            reconcile_terminal_post_place_state(
+                &order,
+                position_store,
+                symbol,
+                offchain_order_id,
+                next_step,
+                stdout,
+            )
+            .await
+        }
     }
+}
 
-    Ok(())
+async fn reconcile_terminal_post_place_state<W: Write>(
+    order: &OffchainOrder,
+    position_store: &Store<Position>,
+    symbol: &Symbol,
+    offchain_order_id: OffchainOrderId,
+    next_step: CliPendingClearNextStep,
+    stdout: &mut W,
+) -> anyhow::Result<CliPendingReconciliation> {
+    let Some(finalization) = terminal_position_finalization(order) else {
+        anyhow::bail!(
+            "offchain order {offchain_order_id} for {symbol} is terminal but did not \
+             produce a position finalization; refusing to clear the position claim"
+        );
+    };
+
+    let command = match finalization {
+        TerminalPositionFinalization::UnpricedFill { shares_filled } => {
+            anyhow::bail!(
+                "offchain order {offchain_order_id} for {symbol} has {shares_filled} filled \
+                 shares without an average price; refusing to clear the position claim"
+            );
+        }
+        finalization => {
+            let Some(command) = position_command_for_finalization(finalization, offchain_order_id)
+            else {
+                anyhow::bail!(
+                    "offchain order {offchain_order_id} for {symbol} could not be mapped to a \
+                     position finalization command; refusing to clear the position claim"
+                );
+            };
+            command
+        }
+    };
+
+    position_store.send(symbol, command).await?;
+    write_pending_clear_message(stdout, "Existing pending hedge finalized", next_step)?;
+
+    Ok(CliPendingReconciliation::Cleared)
 }
 
 fn write_pending_clear_message<W: Write>(
@@ -995,7 +1092,7 @@ mod tests {
         TradeProcessingCqrs, execute_acknowledge_fill, execute_mark_acknowledged,
         process_queued_trade,
     };
-    use crate::offchain::order::PollOrderStatusJobQueue;
+    use crate::offchain::order::{CancellationReason, PollOrderStatusJobQueue, noop_order_placer};
     use crate::onchain::trade::RaindexTradeEvent;
     use crate::onchain_trade::{OnChainTrade as OnChainTradeCqrs, OnChainTradeCommand};
     use crate::test_utils::{
@@ -1016,6 +1113,20 @@ mod tests {
         ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
             Err("broker rejected the order".into())
         }
+
+        async fn place_limit_order(
+            &self,
+            _order: LimitOrder,
+        ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
+            Err("broker rejected the order".into())
+        }
+
+        async fn cancel_order(
+            &self,
+            _executor_order_id: &ExecutorOrderId,
+        ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+            Err("broker rejected the cancellation".into())
+        }
     }
 
     /// `OrderPlacer` that always returns a successful placement, used to drive
@@ -1031,7 +1142,28 @@ mod tests {
             Ok(OrderPlacementResult {
                 executor_order_id: ExecutorOrderId::new("test-broker-order-id"),
                 placed_shares: order.shares,
+                is_extended_hours: false,
+                limit_price: None,
             })
+        }
+
+        async fn place_limit_order(
+            &self,
+            order: LimitOrder,
+        ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(OrderPlacementResult {
+                executor_order_id: ExecutorOrderId::new("test-broker-order-id"),
+                placed_shares: order.shares,
+                is_extended_hours: order.extended_hours,
+                limit_price: Some(order.limit_price),
+            })
+        }
+
+        async fn cancel_order(
+            &self,
+            _executor_order_id: &ExecutorOrderId,
+        ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+            Err("unexpected cancellation from CLI test order placer".into())
         }
     }
 
@@ -1340,19 +1472,14 @@ mod tests {
                 }));
         });
 
-        // The broker-side `client_order_id` is a fresh UUID per CLI invocation,
-        // so its exact value cannot be pinned. Assert the value is a well-formed
-        // CLI idempotency key (`cli-{uuid}`); `json_body_includes` covers the
-        // static fields.
-        let client_order_id_pattern = Regex::new(
-            r#""client_order_id":"cli-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}""#,
-        )
-        .unwrap();
-
         let order_mock = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders")
-                .body_matches(client_order_id_pattern.clone())
+                // CLI limit orders now carry a fresh `cli-{uuid}` client_order_id
+                // (added for broker-side idempotency), so match the static fields
+                // partially and assert the key is a well-formed CLI idempotency
+                // key rather than pinning its random value.
+                .body_matches(client_order_id_cli_pattern())
                 .json_body_includes(
                     json!({
                         "symbol": "AAPL",
@@ -1378,6 +1505,15 @@ mod tests {
         });
 
         (account_mock, asset_mock, order_mock)
+    }
+
+    /// Regex asserting a request body carries a well-formed `cli-{uuid}`
+    /// `client_order_id`, shared by the market- and limit-order mocks.
+    fn client_order_id_cli_pattern() -> Regex {
+        Regex::new(
+            r#""client_order_id":"cli-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}""#,
+        )
+        .unwrap()
     }
 
     #[tokio::test]
@@ -2013,7 +2149,7 @@ mod tests {
             .await
             .unwrap();
         let (offchain_order_store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(())
+            .build(noop_order_placer())
             .await
             .unwrap();
 
@@ -2265,6 +2401,8 @@ mod tests {
             shares: positive_shares("1"),
             direction: Direction::Sell,
             executor: SupportedExecutor::DryRun,
+            retained_fill: None,
+            executor_order_id: None,
             error: "previous placement failed".to_string(),
             placed_at: block_timestamp,
             failed_at: block_timestamp,
@@ -2309,7 +2447,7 @@ mod tests {
             .await
             .unwrap();
         let (offchain_order_store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(())
+            .build(noop_order_placer())
             .await
             .unwrap();
 
@@ -2361,6 +2499,179 @@ mod tests {
         assert!(
             output.contains("pending order cleared"),
             "missing order cleanup must report the cleared pending marker, got: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn existing_cancelling_pending_order_remains_in_flight() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let onchain_trade = OnchainTradeBuilder::default().with_block_number(42).build();
+        let block_timestamp = onchain_trade
+            .block_timestamp
+            .expect("test trade should have a block timestamp");
+
+        let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        execute_acknowledge_fill(
+            &position_store,
+            &onchain_trade,
+            ExecutionThreshold::whole_share(),
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+
+        position_store
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares: positive_shares("1"),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let cancelling_order = OffchainOrder::Cancelling {
+            symbol: symbol.clone(),
+            shares: positive_shares("1"),
+            retained_fill: None,
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            executor_order_id: ExecutorOrderId::new("broker-order-id"),
+            reason: CancellationReason::MarketOpenReplacement,
+            placed_at: block_timestamp,
+            submitted_at: block_timestamp,
+            cancel_requested_at: block_timestamp,
+            market_session: st0x_execution::MarketSession::Regular,
+        };
+
+        let mut stdout = Vec::new();
+        let outcome = reconcile_loaded_post_place_state(
+            Some(cancelling_order),
+            &position_store,
+            &symbol,
+            offchain_order_id,
+            CliPendingClearNextStep::ContinueThisRun,
+            &mut stdout,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            matches!(outcome, CliPendingReconciliation::InFlight),
+            "cancelling orders must remain in flight until broker cancellation confirms"
+        );
+
+        let position = position_store
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist after setup");
+        assert_eq!(
+            position.pending_offchain_order_id,
+            Some(offchain_order_id),
+            "Cancelling must leave the position claim in place"
+        );
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("cancellation is still in progress"),
+            "cancelling order reconciliation must explain why no new hedge is placed, \
+             got: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn existing_cancelled_pending_order_clears_position_claim() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let onchain_trade = OnchainTradeBuilder::default().with_block_number(42).build();
+        let block_timestamp = onchain_trade
+            .block_timestamp
+            .expect("test trade should have a block timestamp");
+
+        let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        execute_acknowledge_fill(
+            &position_store,
+            &onchain_trade,
+            ExecutionThreshold::whole_share(),
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+
+        position_store
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares: positive_shares("1"),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let cancelled_order = OffchainOrder::Cancelled {
+            symbol: symbol.clone(),
+            shares: positive_shares("1"),
+            retained_fill: None,
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            executor_order_id: ExecutorOrderId::new("broker-order-id"),
+            reason: CancellationReason::MarketOpenReplacement,
+            placed_at: block_timestamp,
+            cancelled_at: block_timestamp,
+        };
+
+        let mut stdout = Vec::new();
+        let outcome = reconcile_loaded_post_place_state(
+            Some(cancelled_order),
+            &position_store,
+            &symbol,
+            offchain_order_id,
+            CliPendingClearNextStep::ContinueThisRun,
+            &mut stdout,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            matches!(outcome, CliPendingReconciliation::Cleared),
+            "cancelled orders with no retained fill must clear the pending claim"
+        );
+
+        let position = position_store
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist after setup");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "Cancelled must clear the position claim through CancelOffChainOrder"
+        );
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("Existing pending hedge finalized"),
+            "cancelled order reconciliation must report the finalized pending order, \
+             got: {output}"
         );
     }
 
@@ -2895,7 +3206,7 @@ mod tests {
             .expect("pending_offchain_order_id must be set after successful broker submission");
 
         let (offchain_order_store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(())
+            .build(noop_order_placer())
             .await
             .unwrap();
         let offchain_order = offchain_order_store

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -58,8 +58,10 @@ use crate::inventory::{
     BroadcastingInventory, Inventory, InventoryProjection, InventorySnapshot, Venue,
 };
 use crate::offchain::order::{
-    ExecutorOrderPlacer, OffchainOrder, OffchainOrderId, OrderPlacer, PollOrderStatus,
-    PollOrderStatusJobQueue, client_order_id_for_placement, place_offchain_order_at_broker,
+    ExecutorOrderPlacer, OffchainOrder, OffchainOrderId, OffchainOrderPlacement, OrderPlacer,
+    PollOrderStatus, PollOrderStatusJobQueue, TerminalPositionFinalization,
+    client_order_id_for_placement, place_offchain_order_at_broker,
+    position_command_for_finalization, terminal_position_finalization,
 };
 #[cfg(test)]
 use crate::offchain::order::{OffchainOrderCommand, noop_order_placer};
@@ -151,6 +153,47 @@ pub(crate) async fn setup_apalis_tables(
         .await?;
 
     Ok(())
+}
+
+async fn setup_offchain_order_store<E>(
+    pool: &SqlitePool,
+    executor: &E,
+    position: &Arc<Store<Position>>,
+    position_projection: &Arc<Projection<Position>>,
+) -> anyhow::Result<(Arc<Store<OffchainOrder>>, Arc<Projection<OffchainOrder>>)>
+where
+    E: Executor + Clone + Send + Sync + 'static,
+{
+    // The HedgeLatencyProjection subscribes to BOTH Position and OffchainOrder
+    // (see its deps!). This instance, on the OffchainOrder store, handles the
+    // broker-acceptance event (`Accepted`/legacy `Submitted`) to stamp
+    // submitted_at. The cycle's filled_at/failed_at are stamped by the SAME
+    // projection registered on the Position store (the Position stream carries
+    // the broker's own fill timestamp). Do NOT consolidate the two registrations:
+    // routing OffchainOrder Filled/Failed here would drop the authoritative
+    // broker timestamp.
+    let order_placer: Arc<dyn OrderPlacer> = Arc::new(ExecutorOrderPlacer(executor.clone()));
+    let (offchain_order, offchain_order_projection) =
+        StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
+            .with(Arc::new(LifecycleFailureProjection::new(pool.clone())))
+            .build(order_placer.clone())
+            .await?;
+
+    // Startup recovery runs before any job worker starts, so no concurrent
+    // placement can race its broker re-drive -- it intentionally runs without
+    // `counter_trade_submission_lock` (which the builder constructs later). The
+    // periodic `CheckPositions` sweep, which CAN race live placements, holds the
+    // lock across the same call.
+    recover_orphaned_pending_offchain_orders(
+        position,
+        position_projection,
+        &offchain_order,
+        order_placer.as_ref(),
+    )
+    .await?;
+
+    Ok((offchain_order, offchain_order_projection))
 }
 
 /// Bundles CQRS frameworks used throughout the trade processing pipeline.
@@ -586,33 +629,8 @@ impl Conductor {
         // OffchainOrder reactor (registered below) goes live, in both modes.
         catch_up_lifecycle_failures(&pool).await?;
 
-        // The HedgeLatencyProjection subscribes to BOTH Position and
-        // OffchainOrder (see its deps!). This instance, on the OffchainOrder
-        // store, handles the broker-acceptance event (`Accepted`/legacy
-        // `Submitted`) to stamp submitted_at. The cycle's filled_at/failed_at are
-        // stamped by the SAME projection registered on the Position store (the
-        // Position stream carries the broker's own fill timestamp). Do NOT
-        // consolidate the two registrations: routing OffchainOrder Filled/Failed
-        // here would drop the authoritative broker timestamp.
         let (offchain_order, offchain_order_projection) =
-            StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
-                .with(Arc::new(LifecycleFailureProjection::new(pool.clone())))
-                .build(())
-                .await?;
-
-        // Startup recovery runs before any job worker starts, so no concurrent
-        // placement can race its broker re-drive -- it intentionally runs without
-        // `counter_trade_submission_lock` (which the builder constructs later). The
-        // periodic `CheckPositions` sweep, which CAN race live placements, holds
-        // the lock across the same call.
-        recover_orphaned_pending_offchain_orders(
-            &position,
-            &position_projection,
-            &offchain_order,
-            &ExecutorOrderPlacer(executor.clone()),
-        )
-        .await?;
+            setup_offchain_order_store(&pool, &executor, &position, &position_projection).await?;
 
         let frameworks = CqrsFrameworks {
             onchain_trade,
@@ -1807,7 +1825,11 @@ async fn recover_single_orphaned_order(
 
     // Only live orders remain -- terminal and absent ones were resolved above.
     match order {
-        Some(OffchainOrder::Submitted { .. } | OffchainOrder::PartiallyFilled { .. }) => {
+        Some(
+            OffchainOrder::Submitted { .. }
+            | OffchainOrder::PartiallyFilled { .. }
+            | OffchainOrder::Cancelling { .. },
+        ) => {
             debug!(%symbol, %order_id, "Pending offchain order still in progress");
             Ok(())
         }
@@ -1844,11 +1866,13 @@ async fn recover_single_orphaned_order(
                 offchain_order,
                 order_placer,
                 &order_id,
-                order_symbol,
-                shares,
-                direction,
-                executor,
-                client_order_id,
+                OffchainOrderPlacement::market(
+                    order_symbol,
+                    shares,
+                    direction,
+                    executor,
+                    client_order_id,
+                ),
             )
             .await?;
 
@@ -1871,7 +1895,12 @@ async fn recover_single_orphaned_order(
 
         // Terminal and absent orders are resolved by
         // `resolve_terminal_claimed_order` above.
-        Some(OffchainOrder::Filled { .. } | OffchainOrder::Failed { .. }) | None => Ok(()),
+        Some(
+            OffchainOrder::Filled { .. }
+            | OffchainOrder::Failed { .. }
+            | OffchainOrder::Cancelled { .. },
+        )
+        | None => Ok(()),
     }
 }
 
@@ -1895,49 +1924,62 @@ async fn resolve_terminal_claimed_order(
     order_id: OffchainOrderId,
     order: Option<&OffchainOrder>,
 ) -> Result<bool, SendError<Position>> {
-    use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
+    let Some(order) = order else {
+        warn!(%symbol, %order_id, "Claimed offchain order missing from store -- recovering");
+        position
+            .send(
+                symbol,
+                PositionCommand::FailOffChainOrder {
+                    offchain_order_id: order_id,
+                    error: "pending offchain order has no offchain order aggregate".to_string(),
+                },
+            )
+            .await?;
+        return Ok(true);
+    };
 
-    let command = match order {
-        None => {
-            warn!(%symbol, %order_id, "Claimed offchain order missing from store -- recovering");
-            PositionCommand::FailOffChainOrder {
-                offchain_order_id: order_id,
-                error: "pending offchain order has no offchain order aggregate".to_string(),
-            }
-        }
-
-        Some(Filled {
-            shares,
-            direction,
-            executor_order_id,
-            price,
-            filled_at,
-            ..
-        }) => {
-            info!(%symbol, %order_id, "Claimed offchain order already Filled -- recovering");
-            PositionCommand::CompleteOffChainOrder {
-                offchain_order_id: order_id,
-                shares_filled: *shares,
-                direction: *direction,
-                executor_order_id: executor_order_id.clone(),
-                price: *price,
-                broker_timestamp: *filled_at,
-            }
-        }
-
-        Some(Failed { error, .. }) => {
-            info!(%symbol, %order_id, "Claimed offchain order already Failed -- recovering");
-            PositionCommand::FailOffChainOrder {
-                offchain_order_id: order_id,
-                error: error.clone(),
-            }
-        }
-
-        Some(Pending { .. } | Submitted { .. } | PartiallyFilled { .. }) => return Ok(false),
+    let Some(command) = orphaned_order_position_command(order, symbol, order_id) else {
+        return Ok(false);
     };
 
     position.send(symbol, command).await?;
     Ok(true)
+}
+
+/// Maps an orphaned offchain order to the position command that finalizes
+/// its owning position, or `None` when the position must be left pending.
+/// Routes terminal states through the shared finalization helpers so the
+/// mapping cannot drift from the cancel-and-replace sweep / rejection paths.
+fn orphaned_order_position_command(
+    order: &OffchainOrder,
+    symbol: &Symbol,
+    order_id: OffchainOrderId,
+) -> Option<PositionCommand> {
+    match terminal_position_finalization(order) {
+        Some(TerminalPositionFinalization::UnpricedFill { shares_filled }) => {
+            error!(
+                %symbol, %order_id, %shares_filled,
+                "Orphaned terminal order has a partial fill without avg price; \
+                 leaving position pending"
+            );
+            None
+        }
+
+        None => {
+            if let OffchainOrder::Pending { .. } = order {
+                warn!(%symbol, %order_id, "Orphaned offchain order still Pending at startup -- may never have been submitted to the broker");
+            } else {
+                debug!(%symbol, %order_id, state = ?order, "Orphaned offchain order still in progress");
+            }
+            None
+        }
+
+        Some(finalization) => {
+            let command = position_command_for_finalization(finalization, order_id);
+            info!(%symbol, %order_id, ?command, "Orphaned order terminal -- recovering");
+            command
+        }
+    }
 }
 
 /// Constructs the position CQRS framework with its view query
@@ -2778,7 +2820,9 @@ async fn recover_claimed_offchain_order(
     execution: &ExecutionCtx,
     cqrs: &TradeProcessingCqrs,
 ) -> Result<Option<OffchainOrderId>, TradeAccountingError> {
-    use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
+    use OffchainOrder::{
+        Cancelled, Cancelling, Failed, Filled, PartiallyFilled, Pending, Submitted,
+    };
 
     let Some(pending_id) = cqrs
         .position
@@ -2803,7 +2847,7 @@ async fn recover_claimed_offchain_order(
     }
 
     match order {
-        Some(Submitted { .. } | PartiallyFilled { .. }) => {
+        Some(Submitted { .. } | PartiallyFilled { .. } | Cancelling { .. }) => {
             cqrs.poll_status_queue
                 .clone()
                 .push(PollOrderStatus {
@@ -2838,11 +2882,13 @@ async fn recover_claimed_offchain_order(
                 &cqrs.offchain_order,
                 cqrs.order_placer.as_ref(),
                 &pending_id,
-                symbol,
-                shares,
-                direction,
-                executor,
-                client_order_id,
+                OffchainOrderPlacement::market(
+                    symbol,
+                    shares,
+                    direction,
+                    executor,
+                    client_order_id,
+                ),
             )
             .await?;
 
@@ -2855,7 +2901,7 @@ async fn recover_claimed_offchain_order(
         }
         // Terminal and absent orders were resolved by
         // `resolve_terminal_claimed_order` above.
-        Some(Filled { .. } | Failed { .. }) | None => Ok(None),
+        Some(Filled { .. } | Failed { .. } | Cancelled { .. }) | None => Ok(None),
     }
 }
 
@@ -2867,7 +2913,10 @@ async fn dispatch_post_place_state(
     cqrs: &TradeProcessingCqrs,
     offchain_order_id: OffchainOrderId,
 ) -> Result<PostPlaceOutcome, TradeAccountingError> {
-    use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
+    use OffchainOrder::{
+        Cancelled, Cancelling, Failed, Filled, PartiallyFilled, Pending, Submitted,
+    };
+
     match loaded {
         Some(Failed { error, .. }) => {
             cqrs.position
@@ -2927,7 +2976,7 @@ async fn dispatch_post_place_state(
         // `Filled` at this point is unexpected. Surface it as a retryable error
         // rather than clearing the position claim, which would strand a
         // possibly-live broker order.
-        Some(state @ (Pending { .. } | Filled { .. })) => {
+        Some(state @ (Pending { .. } | Filled { .. } | Cancelling { .. } | Cancelled { .. })) => {
             Err(TradeAccountingError::UnexpectedPostPlaceState {
                 offchain_order_id,
                 state,
@@ -3023,11 +3072,13 @@ async fn execute_create_offchain_order(
         &cqrs.offchain_order,
         cqrs.order_placer.as_ref(),
         &offchain_order_id,
-        execution.symbol.clone(),
-        execution.shares,
-        execution.direction,
-        execution.executor,
-        client_order_id,
+        OffchainOrderPlacement::market(
+            execution.symbol.clone(),
+            execution.shares,
+            execution.direction,
+            execution.executor,
+            client_order_id,
+        ),
     )
     .await
     .inspect(|_| {
@@ -3153,11 +3204,13 @@ where
             offchain_order,
             order_placer,
             &offchain_order_id,
-            execution.symbol.clone(),
-            execution.shares,
-            execution.direction,
-            execution.executor,
-            client_order_id,
+            OffchainOrderPlacement::market(
+                execution.symbol.clone(),
+                execution.shares,
+                execution.direction,
+                execution.executor,
+                client_order_id,
+            ),
         )
         .await;
 
@@ -4665,7 +4718,30 @@ mod tests {
                 Ok(OrderPlacementResult {
                     executor_order_id: ExecutorOrderId::new("TEST_BROKER_ORD"),
                     placed_shares: order.shares,
+                    is_extended_hours: false,
+                    limit_price: None,
                 })
+            }
+
+            async fn place_limit_order(
+                &self,
+                order: st0x_execution::LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(OrderPlacementResult {
+                    executor_order_id: ExecutorOrderId::new("TEST_BROKER_LIMIT_ORD"),
+                    placed_shares: order.shares,
+                    is_extended_hours: order.extended_hours,
+                    limit_price: Some(order.limit_price),
+                })
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &st0x_execution::ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
             }
         }
 
@@ -4687,7 +4763,7 @@ mod tests {
 
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(noop_order_placer())
                 .await
                 .unwrap();
 
@@ -6487,7 +6563,34 @@ mod tests {
                 Ok(OrderPlacementResult {
                     executor_order_id: ExecutorOrderId::new("TEST_BROKER_ORD"),
                     placed_shares: order.shares,
+                    is_extended_hours: false,
+                    limit_price: None,
                 })
+            }
+
+            async fn place_limit_order(
+                &self,
+                order: st0x_execution::LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                if self.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    return Err("Broker rejected first order".into());
+                }
+
+                Ok(OrderPlacementResult {
+                    executor_order_id: ExecutorOrderId::new("TEST_BROKER_LIMIT_ORD"),
+                    placed_shares: order.shares,
+                    is_extended_hours: order.extended_hours,
+                    limit_price: Some(order.limit_price),
+                })
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &st0x_execution::ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
             }
         }
 
@@ -7336,6 +7439,24 @@ mod tests {
                 {
                     Err("API error (403 Forbidden): trade denied due to pattern day trading protection".into())
                 }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: st0x_execution::LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Err("API error (403 Forbidden): trade denied due to pattern day trading protection".into())
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &st0x_execution::ExecutorOrderId,
+                ) -> Result<
+                    st0x_execution::CancellationOutcome,
+                    Box<dyn std::error::Error + Send + Sync>,
+                > {
+                    Ok(st0x_execution::CancellationOutcome::Requested)
+                }
             }
 
             Arc::new(RejectingOrderPlacer)
@@ -7430,6 +7551,24 @@ mod tests {
                 ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
                 {
                     Err("Broker rejected: insufficient buying power".into())
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: st0x_execution::LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Err("Broker rejected: insufficient buying power".into())
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &st0x_execution::ExecutorOrderId,
+                ) -> Result<
+                    st0x_execution::CancellationOutcome,
+                    Box<dyn std::error::Error + Send + Sync>,
+                > {
+                    Ok(st0x_execution::CancellationOutcome::Requested)
                 }
             }
 
@@ -7611,7 +7750,7 @@ mod tests {
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(noop_order_placer())
                 .await
                 .unwrap();
 
@@ -7666,6 +7805,8 @@ mod tests {
                     shares,
                     direction: Direction::Sell,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await
@@ -7678,6 +7819,8 @@ mod tests {
                     executor_order_id: ExecutorOrderId::new("test-order"),
                     placed_shares: shares,
                     submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
                 },
             )
             .await
@@ -7688,6 +7831,7 @@ mod tests {
                 &offchain_order_id,
                 OffchainOrderCommand::CompleteFill {
                     price: Usd::new(float!(78)),
+                    filled_at: Utc::now(),
                 },
             )
             .await
@@ -7696,6 +7840,11 @@ mod tests {
         // Verify position is stuck: pending_offchain_order_id is set
         let pos = position_projection.load(&symbol).await.unwrap().unwrap();
         assert_eq!(pos.pending_offchain_order_id, Some(offchain_order_id));
+        assert_eq!(
+            pos.net,
+            st0x_execution::FractionalShares::new(float!(1)),
+            "Pre-recovery position should still carry the unhedged onchain fill"
+        );
 
         // Step 4: Run recovery
         recover_orphaned_pending_offchain_orders(
@@ -7713,6 +7862,11 @@ mod tests {
             pos.pending_offchain_order_id, None,
             "Recovery should clear pending_offchain_order_id for filled orders"
         );
+        assert_eq!(
+            pos.net,
+            st0x_execution::FractionalShares::new(float!(0.5)),
+            "Recovery must record the filled hedge, not just clear the pending pointer"
+        );
     }
 
     #[tokio::test]
@@ -7725,7 +7879,7 @@ mod tests {
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(noop_order_placer())
                 .await
                 .unwrap();
 
@@ -7807,7 +7961,33 @@ mod tests {
                         0.5
                     )))
                     .unwrap(),
+                    is_extended_hours: false,
+                    limit_price: None,
                 })
+            }
+
+            async fn place_limit_order(
+                &self,
+                order: st0x_execution::LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(OrderPlacementResult {
+                    executor_order_id: ExecutorOrderId::new("test-submitted-limit"),
+                    placed_shares: Positive::new(st0x_execution::FractionalShares::new(float!(
+                        0.5
+                    )))
+                    .unwrap(),
+                    is_extended_hours: order.extended_hours,
+                    limit_price: Some(order.limit_price),
+                })
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &st0x_execution::ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
             }
         }
 
@@ -7820,7 +8000,7 @@ mod tests {
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(noop_order_placer())
                 .await
                 .unwrap();
 
@@ -7872,11 +8052,13 @@ mod tests {
             &offchain_order,
             order_placer.as_ref(),
             &offchain_order_id,
-            symbol.clone(),
-            shares,
-            Direction::Sell,
-            st0x_execution::SupportedExecutor::AlpacaBrokerApi,
-            ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+            OffchainOrderPlacement::market(
+                symbol.clone(),
+                shares,
+                Direction::Sell,
+                st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+            ),
         )
         .await
         .unwrap();
@@ -7922,7 +8104,7 @@ mod tests {
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(noop_order_placer())
                 .await
                 .unwrap();
 
@@ -7976,6 +8158,10 @@ mod tests {
                     shares,
                     direction: Direction::Sell,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(
+                        offchain_order_id.as_uuid(),
+                    ),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await
@@ -8032,6 +8218,24 @@ mod tests {
                 {
                     Err("Broker rejected: insufficient buying power".into())
                 }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: st0x_execution::LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Err("Broker rejected: insufficient buying power".into())
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<
+                    st0x_execution::CancellationOutcome,
+                    Box<dyn std::error::Error + Send + Sync>,
+                > {
+                    Ok(st0x_execution::CancellationOutcome::Requested)
+                }
             }
 
             Arc::new(RejectingPlacer)
@@ -8046,7 +8250,7 @@ mod tests {
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(noop_order_placer())
                 .await
                 .unwrap();
 
@@ -8100,6 +8304,10 @@ mod tests {
                     shares,
                     direction: Direction::Sell,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(
+                        offchain_order_id.as_uuid(),
+                    ),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await
@@ -8141,7 +8349,7 @@ mod tests {
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(noop_order_placer())
                 .await
                 .unwrap();
 
@@ -8196,6 +8404,8 @@ mod tests {
                     shares,
                     direction: Direction::Sell,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await
@@ -8206,6 +8416,7 @@ mod tests {
                 &offchain_order_id,
                 OffchainOrderCommand::MarkFailed {
                     error: "insufficient qty".to_string(),
+                    failed_at: Utc::now(),
                 },
             )
             .await
@@ -8355,6 +8566,7 @@ mod tests {
             direction: Direction::Sell,
             executor: st0x_execution::SupportedExecutor::DryRun,
             placed_at: Utc::now(),
+            market_session: st0x_execution::MarketSession::Regular,
         };
 
         let error =
@@ -8540,6 +8752,8 @@ mod tests {
             shares,
             direction: Direction::Sell,
             executor: st0x_execution::SupportedExecutor::DryRun,
+            retained_fill: None,
+            executor_order_id: None,
             error: "broker rejected".to_string(),
             placed_at: Utc::now(),
             failed_at: Utc::now(),
@@ -8595,6 +8809,10 @@ mod tests {
                     shares,
                     direction: Direction::Sell,
                     executor: st0x_execution::SupportedExecutor::DryRun,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(
+                        offchain_order_id.as_uuid(),
+                    ),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await
@@ -8607,6 +8825,8 @@ mod tests {
                     executor_order_id: ExecutorOrderId::new("ORD_TERMINAL"),
                     placed_shares: shares,
                     submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
                 },
             )
             .await
@@ -8617,6 +8837,7 @@ mod tests {
                 &offchain_order_id,
                 OffchainOrderCommand::CompleteFill {
                     price: Usd::new(float!(150)),
+                    filled_at: Utc::now(),
                 },
             )
             .await

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -249,8 +249,9 @@ where
 
     let poll_status_ctx = Arc::new(PollOrderStatusCtx {
         executor: context.executor.clone(),
-        offchain_order: context.frameworks.offchain_order.clone(),
         offchain_order_projection: context.frameworks.offchain_order_projection.clone(),
+        offchain_order_store: context.frameworks.offchain_order.clone(),
+        position_store: context.frameworks.position.clone(),
         poll_status_queue: poll_status_queue.clone(),
         reconcile_queue: reconcile_queue.clone(),
         rejection_queue: rejection_queue.clone(),

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -140,7 +140,9 @@ impl Reactor for Broadcaster {
                     | Submitted { .. }
                     | Accepted { .. }
                     | PartiallyFilled { .. }
-                    | Failed { .. } => {}
+                    | CancelRequested { .. }
+                    | Failed { .. }
+                    | Cancelled { .. } => {}
                 }
             })
 
@@ -246,7 +248,7 @@ mod tests {
     async fn offchain_order_filled_broadcasts_fill() {
         let pool = setup_test_db().await;
         let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(())
+            .build(crate::offchain::order::noop_order_placer())
             .await
             .unwrap();
         let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
@@ -266,6 +268,8 @@ mod tests {
                     .unwrap(),
                     direction: st0x_execution::Direction::Sell,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await
@@ -280,6 +284,8 @@ mod tests {
                     )
                     .unwrap(),
                     submitted_at: now,
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
                 },
             )
             .await
@@ -289,6 +295,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::CompleteFill {
                     price: st0x_finance::Usd::new(st0x_float_macro::float!(245)),
+                    filled_at: now,
                 },
             )
             .await

--- a/src/dashboard/trade_loader.rs
+++ b/src/dashboard/trade_loader.rs
@@ -80,7 +80,7 @@ async fn load_offchain_trades(pool: &SqlitePool) -> Vec<Trade> {
 mod tests {
     use chrono::Utc;
 
-    use st0x_execution::{Direction, FractionalShares, Positive, Symbol};
+    use st0x_execution::{ClientOrderId, Direction, FractionalShares, Positive, Symbol};
     use st0x_float_macro::float;
 
     use super::*;
@@ -138,7 +138,7 @@ mod tests {
 
         let (store, _projection) =
             st0x_event_sorcery::StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(crate::offchain::order::noop_order_placer())
                 .await
                 .unwrap();
 
@@ -152,6 +152,8 @@ mod tests {
                     shares: Positive::new(FractionalShares::new(float!(50))).unwrap(),
                     direction: Direction::Sell,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await
@@ -164,6 +166,8 @@ mod tests {
                     executor_order_id: st0x_execution::ExecutorOrderId::new("TEST"),
                     placed_shares: Positive::new(FractionalShares::new(float!(50))).unwrap(),
                     submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
                 },
             )
             .await
@@ -174,6 +178,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::CompleteFill {
                     price: st0x_finance::Usd::new(float!(200)),
+                    filled_at: Utc::now(),
                 },
             )
             .await
@@ -288,7 +293,7 @@ mod tests {
 
         let (store, _projection) =
             st0x_event_sorcery::StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(crate::offchain::order::noop_order_placer())
                 .await
                 .unwrap();
 
@@ -302,6 +307,8 @@ mod tests {
                     shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
                     direction: Direction::Buy,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -206,7 +206,13 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
                 executed_at,
             } => {
                 offchain_order
-                    .send(&order_id, OffchainOrderCommand::CompleteFill { price })
+                    .send(
+                        &order_id,
+                        OffchainOrderCommand::CompleteFill {
+                            price,
+                            filled_at: executed_at,
+                        },
+                    )
                     .await?;
 
                 position
@@ -269,6 +275,7 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
                         &order_id,
                         OffchainOrderCommand::MarkFailed {
                             error: error.clone(),
+                            failed_at,
                         },
                     )
                     .await?;
@@ -325,6 +332,7 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
                         &order_id,
                         OffchainOrderCommand::MarkFailed {
                             error: error.clone(),
+                            failed_at: cancelled_at,
                         },
                     )
                     .await?;
@@ -398,6 +406,7 @@ async fn record_poll_partial_fill(
                 OffchainOrderCommand::UpdatePartialFill {
                     shares_filled,
                     avg_price,
+                    partially_filled_at: broker_timestamp,
                 },
             )
             .await?;
@@ -887,7 +896,7 @@ async fn create_test_cqrs_with_assets(
 
     let (offchain_order, offchain_order_projection) =
         StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(())
+            .build(order_placer.clone())
             .await
             .unwrap();
 

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -35,7 +35,6 @@ use chrono::{DateTime, Utc};
 use metrics::{counter, histogram};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-#[cfg(test)]
 use std::sync::Arc;
 use tracing::{debug, warn};
 use uuid::Uuid;
@@ -43,15 +42,15 @@ use uuid::Uuid;
 use st0x_dto::{Direction, Trade, TradingVenue};
 use st0x_event_sorcery::{DomainEvent, EventSourced, SendError, Store, Table};
 use st0x_execution::{
-    AlpacaBrokerApiError, ClientOrderId, ExecutionError, Executor, ExecutorOrderId,
-    FractionalShares, MarketOrder, NotPositive, PersistenceError, Positive, SupportedExecutor,
-    Symbol,
+    AlpacaBrokerApiError, CancellationOutcome, ClientOrderId, ExecutionError, Executor,
+    ExecutorOrderId, FractionalShares, LimitOrder, MarketOrder, MarketSession, OrderState,
+    PersistenceError, Positive, SupportedExecutor, Symbol,
 };
 use st0x_finance::Usd;
 
 use crate::conductor::job::QueuePushError;
 use crate::onchain::OnChainError;
-use crate::position::Position;
+use crate::position::{Position, PositionCommand};
 
 /// Errors surfaced by the per-order job pipeline.
 ///
@@ -79,20 +78,55 @@ pub(crate) enum JobError {
     PositionAggregate(#[from] st0x_event_sorcery::SendError<Position>),
     #[error("Failed to enqueue follow-up job: {0}")]
     Enqueue(#[from] QueuePushError),
-    #[error(
-        "Broker reported partial fill of {shares_filled} for offchain order \
-         {offchain_order_id} without an average price"
-    )]
-    MissingPartialFillPrice {
-        offchain_order_id: OffchainOrderId,
-        shares_filled: FractionalShares,
-    },
-    #[error("Broker reported invalid partial fill for offchain order {offchain_order_id}")]
-    InvalidPartialFill {
-        offchain_order_id: OffchainOrderId,
-        #[source]
-        source: NotPositive<FractionalShares>,
-    },
+    #[error("Offchain order invariant violation: {0}")]
+    OffchainOrder(#[from] OffchainOrderError),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OffchainOrderPlacement {
+    symbol: Symbol,
+    shares: Positive<FractionalShares>,
+    direction: Direction,
+    executor: SupportedExecutor,
+    client_order_id: ClientOrderId,
+    kind: CounterTradeOrderKind,
+}
+
+impl OffchainOrderPlacement {
+    pub(crate) fn market(
+        symbol: Symbol,
+        shares: Positive<FractionalShares>,
+        direction: Direction,
+        executor: SupportedExecutor,
+        client_order_id: ClientOrderId,
+    ) -> Self {
+        Self::with_kind(
+            symbol,
+            shares,
+            direction,
+            executor,
+            client_order_id,
+            CounterTradeOrderKind::Market,
+        )
+    }
+
+    pub(crate) fn with_kind(
+        symbol: Symbol,
+        shares: Positive<FractionalShares>,
+        direction: Direction,
+        executor: SupportedExecutor,
+        client_order_id: ClientOrderId,
+        kind: CounterTradeOrderKind,
+    ) -> Self {
+        Self {
+            symbol,
+            shares,
+            direction,
+            executor,
+            client_order_id,
+            kind,
+        }
+    }
 }
 
 /// Drives one offchain order placement end to end: records intent via `Place`,
@@ -121,12 +155,17 @@ pub(crate) async fn place_offchain_order_at_broker(
     store: &Store<OffchainOrder>,
     order_placer: &dyn OrderPlacer,
     offchain_order_id: &OffchainOrderId,
-    symbol: Symbol,
-    shares: Positive<FractionalShares>,
-    direction: Direction,
-    executor: SupportedExecutor,
-    client_order_id: ClientOrderId,
+    placement: OffchainOrderPlacement,
 ) -> Result<Option<OffchainOrder>, SendError<OffchainOrder>> {
+    let OffchainOrderPlacement {
+        symbol,
+        shares,
+        direction,
+        executor,
+        client_order_id,
+        kind,
+    } = placement;
+
     store
         .send(
             offchain_order_id,
@@ -135,6 +174,8 @@ pub(crate) async fn place_offchain_order_at_broker(
                 shares,
                 direction,
                 executor,
+                client_order_id: client_order_id.clone(),
+                kind: kind.clone(),
             },
         )
         .await?;
@@ -149,8 +190,10 @@ pub(crate) async fn place_offchain_order_at_broker(
         settled @ (Some(
             OffchainOrder::Submitted { .. }
             | OffchainOrder::PartiallyFilled { .. }
+            | OffchainOrder::Cancelling { .. }
             | OffchainOrder::Filled { .. }
-            | OffchainOrder::Failed { .. },
+            | OffchainOrder::Failed { .. }
+            | OffchainOrder::Cancelled { .. },
         )
         | None) => return Ok(settled),
     }
@@ -162,13 +205,29 @@ pub(crate) async fn place_offchain_order_at_broker(
         Direction::Sell => "sell",
     };
 
-    let market_order = MarketOrder {
-        symbol,
-        shares,
-        direction,
-        client_order_id,
+    let placement = match kind {
+        CounterTradeOrderKind::Market => {
+            let market_order = MarketOrder {
+                symbol,
+                shares,
+                direction,
+                client_order_id,
+            };
+            order_placer.place_market_order(market_order).await
+        }
+        CounterTradeOrderKind::ExtendedHoursLimit { limit_price } => {
+            let limit_order = LimitOrder {
+                symbol,
+                shares,
+                direction,
+                limit_price,
+                extended_hours: true,
+                client_order_id,
+            };
+            order_placer.place_limit_order(limit_order).await
+        }
     };
-    let outcome = match order_placer.place_market_order(market_order).await {
+    let outcome = match placement {
         Ok(result) => {
             counter!(
                 "hedge_trades_total",
@@ -196,6 +255,8 @@ pub(crate) async fn place_offchain_order_at_broker(
                 executor_order_id: result.executor_order_id,
                 placed_shares: result.placed_shares,
                 submitted_at: Utc::now(),
+                market_session: market_session_from_extended(result.is_extended_hours),
+                limit_price: result.limit_price,
             }
         }
         Err(error) => {
@@ -233,6 +294,111 @@ pub(crate) fn client_order_id_for_placement(
     ClientOrderId::from_uuid(idempotency_source.as_uuid())
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RetainedFill {
+    Priced {
+        shares_filled: FractionalShares,
+        avg_price: Usd,
+        partially_filled_at: DateTime<Utc>,
+    },
+    Unpriced {
+        shares_filled: FractionalShares,
+    },
+}
+
+impl RetainedFill {
+    fn priced(
+        shares_filled: FractionalShares,
+        avg_price: Usd,
+        partially_filled_at: DateTime<Utc>,
+    ) -> Self {
+        Self::Priced {
+            shares_filled,
+            avg_price,
+            partially_filled_at,
+        }
+    }
+
+    fn shares_filled(self) -> FractionalShares {
+        match self {
+            Self::Priced { shares_filled, .. } | Self::Unpriced { shares_filled } => shares_filled,
+        }
+    }
+}
+
+fn regular_market_session() -> MarketSession {
+    MarketSession::Regular
+}
+
+fn deserialize_market_session<'de, D>(deserializer: D) -> Result<MarketSession, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum EncodedMarketSession {
+        Current(MarketSession),
+        LegacyExtendedHours(bool),
+    }
+
+    match EncodedMarketSession::deserialize(deserializer)? {
+        EncodedMarketSession::Current(session) => Ok(session),
+        EncodedMarketSession::LegacyExtendedHours(is_extended_hours) => {
+            Ok(market_session_from_extended(is_extended_hours))
+        }
+    }
+}
+
+fn market_session_from_extended(is_extended_hours: bool) -> MarketSession {
+    if is_extended_hours {
+        MarketSession::Extended
+    } else {
+        MarketSession::Regular
+    }
+}
+
+fn placed_event(
+    symbol: Symbol,
+    shares: Positive<FractionalShares>,
+    direction: Direction,
+    executor: SupportedExecutor,
+    client_order_id: &ClientOrderId,
+    kind: &CounterTradeOrderKind,
+) -> OffchainOrderEvent {
+    let requested_market_session = kind.market_session();
+    let limit_price = match kind {
+        CounterTradeOrderKind::ExtendedHoursLimit { limit_price } => Some(*limit_price),
+        CounterTradeOrderKind::Market => None,
+    };
+
+    OffchainOrderEvent::Placed {
+        symbol,
+        shares,
+        direction,
+        executor,
+        placed_at: Utc::now(),
+        is_extended_hours: requested_market_session == MarketSession::Extended,
+        limit_price,
+        client_order_id: Some(client_order_id.clone()),
+    }
+}
+
+fn validate_place_replay(
+    existing: &OffchainOrder,
+    symbol: &Symbol,
+    direction: Direction,
+    executor: SupportedExecutor,
+) -> Result<Vec<OffchainOrderEvent>, OffchainOrderError> {
+    if symbol != existing.symbol()
+        || direction != existing.direction()
+        || executor != existing.executor()
+    {
+        return Err(OffchainOrderError::PlacePayloadMismatch);
+    }
+
+    Ok(vec![])
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum OffchainOrder {
     Pending {
@@ -241,6 +407,12 @@ pub enum OffchainOrder {
         direction: Direction,
         executor: SupportedExecutor,
         placed_at: DateTime<Utc>,
+        #[serde(
+            default = "regular_market_session",
+            alias = "is_extended_hours",
+            deserialize_with = "deserialize_market_session"
+        )]
+        market_session: MarketSession,
     },
     /// `shares` carries the broker-accepted quantity for orders placed after the
     /// durable-job extraction (built from [`OffchainOrderEvent::Accepted`]'s
@@ -257,6 +429,12 @@ pub enum OffchainOrder {
         executor_order_id: ExecutorOrderId,
         placed_at: DateTime<Utc>,
         submitted_at: DateTime<Utc>,
+        #[serde(
+            default = "regular_market_session",
+            alias = "is_extended_hours",
+            deserialize_with = "deserialize_market_session"
+        )]
+        market_session: MarketSession,
     },
     PartiallyFilled {
         symbol: Symbol,
@@ -269,6 +447,31 @@ pub enum OffchainOrder {
         placed_at: DateTime<Utc>,
         submitted_at: DateTime<Utc>,
         partially_filled_at: DateTime<Utc>,
+        #[serde(
+            default = "regular_market_session",
+            alias = "is_extended_hours",
+            deserialize_with = "deserialize_market_session"
+        )]
+        market_session: MarketSession,
+    },
+    Cancelling {
+        symbol: Symbol,
+        shares: Positive<FractionalShares>,
+        #[serde(default)]
+        retained_fill: Option<RetainedFill>,
+        direction: Direction,
+        executor: SupportedExecutor,
+        executor_order_id: ExecutorOrderId,
+        reason: CancellationReason,
+        placed_at: DateTime<Utc>,
+        submitted_at: DateTime<Utc>,
+        cancel_requested_at: DateTime<Utc>,
+        #[serde(
+            default = "regular_market_session",
+            alias = "is_extended_hours",
+            deserialize_with = "deserialize_market_session"
+        )]
+        market_session: MarketSession,
     },
     Filled {
         symbol: Symbol,
@@ -286,10 +489,152 @@ pub enum OffchainOrder {
         shares: Positive<FractionalShares>,
         direction: Direction,
         executor: SupportedExecutor,
+        #[serde(default)]
+        retained_fill: Option<RetainedFill>,
+        #[serde(default)]
+        executor_order_id: Option<ExecutorOrderId>,
         error: String,
         placed_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
     },
+    /// Terminal state after a successful broker cancellation. Distinct
+    /// from `Failed` so analytics and the cancel-and-replace recovery
+    /// path can tell intentional cancellation apart from broker rejection.
+    ///
+    /// `retained_fill`/`executor_order_id` carry any partial fills the order
+    /// incurred before cancellation so the position-side cleanup can issue
+    /// `CompleteOffChainOrder` for the filled quantity (otherwise the broker
+    /// keeps those shares but `Position.net` never records them, leading to a
+    /// duplicate hedge on the next scan).
+    Cancelled {
+        symbol: Symbol,
+        shares: Positive<FractionalShares>,
+        #[serde(default)]
+        retained_fill: Option<RetainedFill>,
+        direction: Direction,
+        executor: SupportedExecutor,
+        executor_order_id: ExecutorOrderId,
+        reason: CancellationReason,
+        placed_at: DateTime<Utc>,
+        cancelled_at: DateTime<Utc>,
+    },
+}
+
+fn originate_offchain_order(event: &OffchainOrderEvent) -> Option<OffchainOrder> {
+    use OffchainOrderEvent::Placed;
+    match event {
+        Placed {
+            symbol,
+            shares,
+            direction,
+            executor,
+            placed_at,
+            is_extended_hours,
+            limit_price: _,
+            client_order_id: _,
+        } => Some(OffchainOrder::Pending {
+            symbol: symbol.clone(),
+            shares: *shares,
+            direction: *direction,
+            executor: *executor,
+            placed_at: *placed_at,
+            market_session: market_session_from_extended(*is_extended_hours),
+        }),
+        _ => None,
+    }
+}
+
+async fn cancel_order_events(
+    entity: &OffchainOrder,
+    services: &dyn OrderPlacer,
+    reason: CancellationReason,
+) -> Result<Vec<OffchainOrderEvent>, OffchainOrderError> {
+    match entity {
+        OffchainOrder::Submitted {
+            executor_order_id, ..
+        }
+        | OffchainOrder::PartiallyFilled {
+            executor_order_id, ..
+        } => {
+            let mut events = Vec::new();
+            let local_filled = match entity {
+                OffchainOrder::PartiallyFilled { shares_filled, .. } => Some(*shares_filled),
+                _ => None,
+            };
+            let pre_cancel_events =
+                reconcile_pre_cancel(services, executor_order_id, local_filled, reason).await?;
+            let cancel_short_circuit = pre_cancel_events.iter().any(|event| {
+                matches!(
+                    event,
+                    OffchainOrderEvent::Filled { .. }
+                        | OffchainOrderEvent::Failed { .. }
+                        | OffchainOrderEvent::Cancelled { .. }
+                )
+            });
+            events.extend(pre_cancel_events);
+
+            if cancel_short_circuit {
+                return Ok(events);
+            }
+
+            match services
+                .cancel_order(executor_order_id)
+                .await
+                .map_err(|error| {
+                    tracing::warn!(
+                        %executor_order_id,
+                        %error,
+                        "Failed to cancel order via broker; will retry"
+                    );
+                    OffchainOrderError::CancelFailed {
+                        executor_order_id: executor_order_id.clone(),
+                    }
+                })? {
+                CancellationOutcome::Requested => {
+                    events.push(OffchainOrderEvent::CancelRequested {
+                        reason,
+                        cancel_requested_at: Utc::now(),
+                    });
+                }
+                CancellationOutcome::OrderNotFound => {
+                    tracing::warn!(
+                        %executor_order_id,
+                        ?reason,
+                        "Broker no longer recognises order on cancel; resolving as terminally cancelled"
+                    );
+                    events.push(OffchainOrderEvent::Cancelled {
+                        reason,
+                        cancelled_at: Utc::now(),
+                    });
+                }
+            }
+
+            Ok(events)
+        }
+        OffchainOrder::Pending { .. } => Err(OffchainOrderError::NotSubmitted),
+        OffchainOrder::Cancelling { .. } => Ok(Vec::new()),
+        OffchainOrder::Filled { .. }
+        | OffchainOrder::Failed { .. }
+        | OffchainOrder::Cancelled { .. } => Err(OffchainOrderError::AlreadyCompleted),
+    }
+}
+
+/// Why an [`OffchainOrder`] was cancelled. Carried on
+/// [`OffchainOrderEvent::Cancelled`] so it can be persisted, projected,
+/// and pattern-matched without parsing strings.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CancellationReason {
+    /// Extended-hours limit order cancelled at the Extended -> Regular
+    /// transition so the next monitor scan can place a market order
+    /// instead.
+    MarketOpenReplacement,
+    /// The broker reported the order cancelled without a locally persisted
+    /// cancel request: either an operator/broker-side cancellation (e.g. a
+    /// manual Alpaca-dashboard cancel) or a crash that lost the
+    /// `CancelRequested` event. Recorded by the poll loop's recovery path,
+    /// which cannot distinguish the two -- what it knows is that no local
+    /// request reached the event store.
+    Unrequested,
 }
 
 #[async_trait]
@@ -298,31 +643,15 @@ impl EventSourced for OffchainOrder {
     type Event = OffchainOrderEvent;
     type Command = OffchainOrderCommand;
     type Error = OffchainOrderError;
-    type Services = ();
+    type Services = Arc<dyn OrderPlacer>;
     type Materialized = Table;
 
     const AGGREGATE_TYPE: &'static str = "OffchainOrder";
     const PROJECTION: Table = Table("offchain_order_view");
-    const SCHEMA_VERSION: u64 = 1;
+    const SCHEMA_VERSION: u64 = 2;
 
     fn originate(event: &Self::Event) -> Option<Self> {
-        use OffchainOrderEvent::*;
-        match event {
-            Placed {
-                symbol,
-                shares,
-                direction,
-                executor,
-                placed_at,
-            } => Some(Self::Pending {
-                symbol: symbol.clone(),
-                shares: *shares,
-                direction: *direction,
-                executor: *executor,
-                placed_at: *placed_at,
-            }),
-            _ => None,
-        }
+        originate_offchain_order(event)
     }
 
     fn evolve(entity: &Self, event: &Self::Event) -> Result<Option<Self>, Self::Error> {
@@ -340,6 +669,7 @@ impl EventSourced for OffchainOrder {
                     direction,
                     executor,
                     placed_at,
+                    market_session,
                 } = entity
                 else {
                     return Ok(None);
@@ -353,6 +683,7 @@ impl EventSourced for OffchainOrder {
                     executor_order_id: executor_order_id.clone(),
                     placed_at: *placed_at,
                     submitted_at: *submitted_at,
+                    market_session: *market_session,
                 }))
             }
 
@@ -360,6 +691,8 @@ impl EventSourced for OffchainOrder {
                 executor_order_id,
                 placed_shares,
                 submitted_at,
+                market_session,
+                limit_price: _,
             } => {
                 let Self::Pending {
                     symbol,
@@ -383,6 +716,7 @@ impl EventSourced for OffchainOrder {
                     executor_order_id: executor_order_id.clone(),
                     placed_at: *placed_at,
                     submitted_at: *submitted_at,
+                    market_session: *market_session,
                 }))
             }
 
@@ -390,116 +724,36 @@ impl EventSourced for OffchainOrder {
                 shares_filled,
                 avg_price,
                 partially_filled_at,
-            } => Ok(match entity {
-                Self::Submitted {
-                    symbol,
-                    shares,
-                    direction,
-                    executor,
-                    executor_order_id,
-                    placed_at,
-                    submitted_at,
-                }
-                | Self::PartiallyFilled {
-                    symbol,
-                    shares,
-                    direction,
-                    executor,
-                    executor_order_id,
-                    placed_at,
-                    submitted_at,
-                    ..
-                } => Some(Self::PartiallyFilled {
-                    symbol: symbol.clone(),
-                    shares: *shares,
-                    shares_filled: *shares_filled,
-                    direction: *direction,
-                    executor: *executor,
-                    executor_order_id: executor_order_id.clone(),
-                    avg_price: *avg_price,
-                    placed_at: *placed_at,
-                    submitted_at: *submitted_at,
-                    partially_filled_at: *partially_filled_at,
-                }),
+            } => Ok(evolve_partially_filled(
+                entity,
+                *shares_filled,
+                *avg_price,
+                *partially_filled_at,
+            )),
 
-                Self::Pending { .. } | Self::Filled { .. } | Self::Failed { .. } => None,
-            }),
+            Filled { price, filled_at } => Ok(evolve_filled(entity, *price, *filled_at)),
 
-            Filled { price, filled_at } => Ok(match entity {
-                Self::Submitted {
-                    symbol,
-                    shares,
-                    direction,
-                    executor,
-                    executor_order_id,
-                    placed_at,
-                    submitted_at,
-                }
-                | Self::PartiallyFilled {
-                    symbol,
-                    shares,
-                    direction,
-                    executor,
-                    executor_order_id,
-                    placed_at,
-                    submitted_at,
-                    ..
-                } => Some(Self::Filled {
-                    symbol: symbol.clone(),
-                    shares: *shares,
-                    direction: *direction,
-                    executor: *executor,
-                    executor_order_id: executor_order_id.clone(),
-                    price: *price,
-                    placed_at: *placed_at,
-                    submitted_at: *submitted_at,
-                    filled_at: *filled_at,
-                }),
+            CancelRequested {
+                reason,
+                cancel_requested_at,
+            } => Ok(evolve_cancel_requested(
+                entity,
+                *reason,
+                *cancel_requested_at,
+            )),
 
-                Self::Pending { .. } | Self::Filled { .. } | Self::Failed { .. } => None,
-            }),
+            Failed { error, failed_at } => Ok(evolve_failed(entity, error.clone(), *failed_at)),
 
-            Failed { error, failed_at } => Ok(match entity {
-                Self::Pending {
-                    symbol,
-                    shares,
-                    direction,
-                    executor,
-                    placed_at,
-                }
-                | Self::Submitted {
-                    symbol,
-                    shares,
-                    direction,
-                    executor,
-                    placed_at,
-                    ..
-                }
-                | Self::PartiallyFilled {
-                    symbol,
-                    shares,
-                    direction,
-                    executor,
-                    placed_at,
-                    ..
-                } => Some(Self::Failed {
-                    symbol: symbol.clone(),
-                    shares: *shares,
-                    direction: *direction,
-                    executor: *executor,
-                    error: error.clone(),
-                    placed_at: *placed_at,
-                    failed_at: *failed_at,
-                }),
-
-                Self::Filled { .. } | Self::Failed { .. } => None,
-            }),
+            Cancelled {
+                reason,
+                cancelled_at,
+            } => Ok(evolve_cancelled(entity, *reason, *cancelled_at)),
         }
     }
 
     async fn initialize(
         command: Self::Command,
-        (): &Self::Services,
+        _: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use OffchainOrderCommand::*;
         match command {
@@ -512,13 +766,16 @@ impl EventSourced for OffchainOrder {
                 shares,
                 direction,
                 executor,
-            } => Ok(vec![OffchainOrderEvent::Placed {
+                client_order_id,
+                kind,
+            } => Ok(vec![placed_event(
                 symbol,
                 shares,
                 direction,
                 executor,
-                placed_at: Utc::now(),
-            }]),
+                &client_order_id,
+                &kind,
+            )]),
 
             _ => Err(OffchainOrderError::NotPlaced),
         }
@@ -527,7 +784,7 @@ impl EventSourced for OffchainOrder {
     async fn transition(
         &self,
         command: Self::Command,
-        (): &Self::Services,
+        services: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             // Idempotent against a placement retry: the durable path re-sends
@@ -542,41 +799,94 @@ impl EventSourced for OffchainOrder {
                 direction,
                 executor,
                 shares: _,
-            } => {
-                if symbol != *self.symbol()
-                    || direction != self.direction()
-                    || executor != self.executor()
-                {
-                    return Err(OffchainOrderError::PlacePayloadMismatch);
-                }
-                Ok(vec![])
+                client_order_id: _,
+                kind: _,
+            } => validate_place_replay(self, &symbol, direction, executor),
+
+            OffchainOrderCommand::CancelOrder { reason } => {
+                cancel_order_events(self, services.as_ref(), reason).await
             }
 
-            OffchainOrderCommand::UpdatePartialFill {
-                shares_filled,
-                avg_price,
-            } => match self {
-                Self::Submitted { .. } | Self::PartiallyFilled { .. } => {
-                    Ok(vec![OffchainOrderEvent::PartiallyFilled {
-                        shares_filled,
-                        avg_price,
-                        partially_filled_at: Utc::now(),
-                    }])
+            OffchainOrderCommand::ConfirmCancellation { cancelled_at } => match self {
+                Self::Cancelling { reason, .. } => Ok(vec![OffchainOrderEvent::Cancelled {
+                    reason: *reason,
+                    cancelled_at,
+                }]),
+                Self::Pending { .. } | Self::Submitted { .. } | Self::PartiallyFilled { .. } => {
+                    Err(OffchainOrderError::CancellationNotRequested)
                 }
-                Self::Pending { .. } => Err(OffchainOrderError::NotSubmitted),
-                Self::Filled { .. } | Self::Failed { .. } => {
+                Self::Filled { .. } | Self::Failed { .. } | Self::Cancelled { .. } => {
                     Err(OffchainOrderError::AlreadyCompleted)
                 }
             },
 
-            OffchainOrderCommand::CompleteFill { price } => match self {
+            OffchainOrderCommand::UpdatePartialFill {
+                shares_filled,
+                avg_price,
+                partially_filled_at,
+            } => match self {
+                Self::Submitted { .. } => Ok(vec![OffchainOrderEvent::PartiallyFilled {
+                    shares_filled,
+                    avg_price,
+                    partially_filled_at,
+                }]),
+                Self::PartiallyFilled {
+                    shares_filled: local_filled,
+                    ..
+                } => {
+                    // Cumulative fills must never regress; the guard is
+                    // shared by the live and cancelling states so the
+                    // monotonicity invariant cannot drift between them.
+                    if !broker_fill_exceeds_local(shares_filled, *local_filled)? {
+                        tracing::debug!(
+                            local_shares_filled = %local_filled,
+                            broker_shares_filled = %shares_filled,
+                            "Skipping stale or duplicate partial-fill update"
+                        );
+                        return Ok(Vec::new());
+                    }
+
+                    Ok(vec![OffchainOrderEvent::PartiallyFilled {
+                        shares_filled,
+                        avg_price,
+                        partially_filled_at,
+                    }])
+                }
+                Self::Cancelling { retained_fill, .. } => {
+                    let local_filled = retained_fill
+                        .map(RetainedFill::shares_filled)
+                        .unwrap_or(FractionalShares::ZERO);
+                    if !broker_fill_exceeds_local(shares_filled, local_filled)? {
+                        tracing::debug!(
+                            local_shares_filled = %local_filled,
+                            broker_shares_filled = %shares_filled,
+                            "Skipping stale or duplicate partial-fill update"
+                        );
+                        return Ok(Vec::new());
+                    }
+
+                    Ok(vec![OffchainOrderEvent::PartiallyFilled {
+                        shares_filled,
+                        avg_price,
+                        partially_filled_at,
+                    }])
+                }
+                Self::Pending { .. } => Err(OffchainOrderError::NotSubmitted),
+                Self::Filled { .. } | Self::Failed { .. } | Self::Cancelled { .. } => {
+                    Err(OffchainOrderError::AlreadyCompleted)
+                }
+            },
+
+            OffchainOrderCommand::CompleteFill { price, filled_at } => match self {
                 Self::Submitted {
                     symbol, placed_at, ..
                 }
                 | Self::PartiallyFilled {
                     symbol, placed_at, ..
+                }
+                | Self::Cancelling {
+                    symbol, placed_at, ..
                 } => {
-                    let filled_at = Utc::now();
                     // Wall-clock placement-to-fill latency. A negative delta can
                     // only come from clock skew (never a real latency), so
                     // `to_std()` rejects it and the sample is skipped rather than
@@ -598,7 +908,7 @@ impl EventSourced for OffchainOrder {
                     Ok(vec![OffchainOrderEvent::Filled { price, filled_at }])
                 }
                 Self::Pending { .. } => Err(OffchainOrderError::NotSubmitted),
-                Self::Filled { .. } | Self::Failed { .. } => {
+                Self::Filled { .. } | Self::Failed { .. } | Self::Cancelled { .. } => {
                     Err(OffchainOrderError::AlreadyCompleted)
                 }
             },
@@ -607,18 +917,24 @@ impl EventSourced for OffchainOrder {
                 executor_order_id,
                 placed_shares,
                 submitted_at,
+                market_session,
+                limit_price,
             } => match self {
                 Self::Pending { .. } => Ok(vec![OffchainOrderEvent::Accepted {
                     executor_order_id,
                     placed_shares,
                     submitted_at,
+                    market_session,
+                    limit_price,
                 }]),
                 // Idempotent: a retried placement whose order already left
                 // `Pending` (acceptance recorded, or already terminal) is a no-op.
                 Self::Submitted { .. }
                 | Self::PartiallyFilled { .. }
+                | Self::Cancelling { .. }
                 | Self::Filled { .. }
-                | Self::Failed { .. } => Ok(vec![]),
+                | Self::Failed { .. }
+                | Self::Cancelled { .. } => Ok(vec![]),
             },
 
             // Placement-initiated failure. Unlike `MarkFailed` (the poll-rejection
@@ -635,8 +951,10 @@ impl EventSourced for OffchainOrder {
                 }]),
                 Self::Submitted { symbol, .. }
                 | Self::PartiallyFilled { symbol, .. }
+                | Self::Cancelling { symbol, .. }
                 | Self::Filled { symbol, .. }
-                | Self::Failed { symbol, .. } => {
+                | Self::Failed { symbol, .. }
+                | Self::Cancelled { symbol, .. } => {
                     warn!(
                         %symbol,
                         "Skipping placement-initiated failure: the order is no longer Pending \
@@ -646,18 +964,390 @@ impl EventSourced for OffchainOrder {
                 }
             },
 
-            OffchainOrderCommand::MarkFailed { error } => match self {
-                Self::Pending { .. } | Self::Submitted { .. } | Self::PartiallyFilled { .. } => {
-                    Ok(vec![OffchainOrderEvent::Failed {
-                        error,
-                        failed_at: Utc::now(),
-                    }])
+            OffchainOrderCommand::MarkFailed { error, failed_at } => match self {
+                Self::Pending { .. }
+                | Self::Submitted { .. }
+                | Self::PartiallyFilled { .. }
+                | Self::Cancelling { .. } => {
+                    Ok(vec![OffchainOrderEvent::Failed { error, failed_at }])
                 }
                 // Idempotent: re-failing an already-failed order records nothing.
                 Self::Failed { .. } => Ok(vec![]),
-                Self::Filled { .. } => Err(OffchainOrderError::AlreadyCompleted),
+                Self::Filled { .. } | Self::Cancelled { .. } => {
+                    Err(OffchainOrderError::AlreadyCompleted)
+                }
             },
         }
+    }
+}
+
+fn evolve_filled(
+    entity: &OffchainOrder,
+    price: Usd,
+    filled_at: DateTime<Utc>,
+) -> Option<OffchainOrder> {
+    match entity {
+        OffchainOrder::Submitted {
+            symbol,
+            shares,
+            direction,
+            executor,
+            executor_order_id,
+            placed_at,
+            submitted_at,
+            ..
+        }
+        | OffchainOrder::PartiallyFilled {
+            symbol,
+            shares,
+            direction,
+            executor,
+            executor_order_id,
+            placed_at,
+            submitted_at,
+            ..
+        }
+        | OffchainOrder::Cancelling {
+            symbol,
+            shares,
+            direction,
+            executor,
+            executor_order_id,
+            placed_at,
+            submitted_at,
+            ..
+        } => Some(OffchainOrder::Filled {
+            symbol: symbol.clone(),
+            shares: *shares,
+            direction: *direction,
+            executor: *executor,
+            executor_order_id: executor_order_id.clone(),
+            price,
+            placed_at: *placed_at,
+            submitted_at: *submitted_at,
+            filled_at,
+        }),
+
+        OffchainOrder::Pending { .. }
+        | OffchainOrder::Filled { .. }
+        | OffchainOrder::Failed { .. }
+        | OffchainOrder::Cancelled { .. } => None,
+    }
+}
+
+fn evolve_partially_filled(
+    entity: &OffchainOrder,
+    shares_filled: FractionalShares,
+    avg_price: Usd,
+    partially_filled_at: DateTime<Utc>,
+) -> Option<OffchainOrder> {
+    match entity {
+        OffchainOrder::Submitted {
+            symbol,
+            shares,
+            direction,
+            executor,
+            executor_order_id,
+            placed_at,
+            submitted_at,
+            market_session,
+        }
+        | OffchainOrder::PartiallyFilled {
+            symbol,
+            shares,
+            direction,
+            executor,
+            executor_order_id,
+            placed_at,
+            submitted_at,
+            market_session,
+            ..
+        } => Some(OffchainOrder::PartiallyFilled {
+            symbol: symbol.clone(),
+            shares: *shares,
+            shares_filled,
+            direction: *direction,
+            executor: *executor,
+            executor_order_id: executor_order_id.clone(),
+            avg_price,
+            placed_at: *placed_at,
+            submitted_at: *submitted_at,
+            partially_filled_at,
+            market_session: *market_session,
+        }),
+        OffchainOrder::Cancelling {
+            symbol,
+            shares,
+            direction,
+            executor,
+            executor_order_id,
+            reason,
+            placed_at,
+            submitted_at,
+            cancel_requested_at,
+            market_session,
+            ..
+        } => Some(OffchainOrder::Cancelling {
+            symbol: symbol.clone(),
+            shares: *shares,
+            retained_fill: Some(RetainedFill::priced(
+                shares_filled,
+                avg_price,
+                partially_filled_at,
+            )),
+            direction: *direction,
+            executor: *executor,
+            executor_order_id: executor_order_id.clone(),
+            reason: *reason,
+            placed_at: *placed_at,
+            submitted_at: *submitted_at,
+            cancel_requested_at: *cancel_requested_at,
+            market_session: *market_session,
+        }),
+        OffchainOrder::Pending { .. }
+        | OffchainOrder::Filled { .. }
+        | OffchainOrder::Failed { .. }
+        | OffchainOrder::Cancelled { .. } => None,
+    }
+}
+
+fn evolve_cancel_requested(
+    entity: &OffchainOrder,
+    reason: CancellationReason,
+    cancel_requested_at: DateTime<Utc>,
+) -> Option<OffchainOrder> {
+    match entity {
+        OffchainOrder::Submitted {
+            symbol,
+            shares,
+            direction,
+            executor,
+            executor_order_id,
+            placed_at,
+            submitted_at,
+            market_session,
+        } => Some(OffchainOrder::Cancelling {
+            symbol: symbol.clone(),
+            shares: *shares,
+            retained_fill: None,
+            direction: *direction,
+            executor: *executor,
+            executor_order_id: executor_order_id.clone(),
+            reason,
+            placed_at: *placed_at,
+            submitted_at: *submitted_at,
+            cancel_requested_at,
+            market_session: *market_session,
+        }),
+        OffchainOrder::PartiallyFilled {
+            symbol,
+            shares,
+            shares_filled,
+            direction,
+            executor,
+            executor_order_id,
+            avg_price,
+            placed_at,
+            submitted_at,
+            partially_filled_at,
+            market_session,
+            ..
+        } => Some(OffchainOrder::Cancelling {
+            symbol: symbol.clone(),
+            shares: *shares,
+            retained_fill: Some(RetainedFill::priced(
+                *shares_filled,
+                *avg_price,
+                *partially_filled_at,
+            )),
+            direction: *direction,
+            executor: *executor,
+            executor_order_id: executor_order_id.clone(),
+            reason,
+            placed_at: *placed_at,
+            submitted_at: *submitted_at,
+            cancel_requested_at,
+            market_session: *market_session,
+        }),
+        OffchainOrder::Pending { .. }
+        | OffchainOrder::Cancelling { .. }
+        | OffchainOrder::Filled { .. }
+        | OffchainOrder::Failed { .. }
+        | OffchainOrder::Cancelled { .. } => None,
+    }
+}
+
+fn evolve_failed(
+    entity: &OffchainOrder,
+    error: String,
+    failed_at: DateTime<Utc>,
+) -> Option<OffchainOrder> {
+    match entity {
+        OffchainOrder::Pending {
+            symbol,
+            shares,
+            direction,
+            executor,
+            placed_at,
+            ..
+        } => Some(OffchainOrder::Failed {
+            symbol: symbol.clone(),
+            shares: *shares,
+            direction: *direction,
+            executor: *executor,
+            retained_fill: None,
+            executor_order_id: None,
+            error,
+            placed_at: *placed_at,
+            failed_at,
+        }),
+        OffchainOrder::Submitted {
+            symbol,
+            shares,
+            direction,
+            executor,
+            executor_order_id,
+            placed_at,
+            ..
+        } => Some(OffchainOrder::Failed {
+            symbol: symbol.clone(),
+            shares: *shares,
+            direction: *direction,
+            executor: *executor,
+            retained_fill: None,
+            executor_order_id: Some(executor_order_id.clone()),
+            error,
+            placed_at: *placed_at,
+            failed_at,
+        }),
+        OffchainOrder::PartiallyFilled {
+            symbol,
+            shares,
+            shares_filled,
+            direction,
+            executor,
+            executor_order_id,
+            avg_price,
+            placed_at,
+            partially_filled_at,
+            ..
+        } => Some(OffchainOrder::Failed {
+            symbol: symbol.clone(),
+            shares: *shares,
+            direction: *direction,
+            executor: *executor,
+            retained_fill: Some(RetainedFill::priced(
+                *shares_filled,
+                *avg_price,
+                *partially_filled_at,
+            )),
+            executor_order_id: Some(executor_order_id.clone()),
+            error,
+            placed_at: *placed_at,
+            failed_at,
+        }),
+        OffchainOrder::Cancelling {
+            symbol,
+            shares,
+            retained_fill,
+            direction,
+            executor,
+            executor_order_id,
+            placed_at,
+            ..
+        } => Some(OffchainOrder::Failed {
+            symbol: symbol.clone(),
+            shares: *shares,
+            direction: *direction,
+            executor: *executor,
+            retained_fill: *retained_fill,
+            executor_order_id: Some(executor_order_id.clone()),
+            error,
+            placed_at: *placed_at,
+            failed_at,
+        }),
+        OffchainOrder::Filled { .. }
+        | OffchainOrder::Failed { .. }
+        | OffchainOrder::Cancelled { .. } => None,
+    }
+}
+
+fn evolve_cancelled(
+    entity: &OffchainOrder,
+    reason: CancellationReason,
+    cancelled_at: DateTime<Utc>,
+) -> Option<OffchainOrder> {
+    match entity {
+        OffchainOrder::Submitted {
+            symbol,
+            shares,
+            direction,
+            executor,
+            executor_order_id,
+            placed_at,
+            ..
+        } => Some(OffchainOrder::Cancelled {
+            symbol: symbol.clone(),
+            shares: *shares,
+            retained_fill: None,
+            direction: *direction,
+            executor: *executor,
+            executor_order_id: executor_order_id.clone(),
+            reason,
+            placed_at: *placed_at,
+            cancelled_at,
+        }),
+        OffchainOrder::PartiallyFilled {
+            symbol,
+            shares,
+            shares_filled,
+            direction,
+            executor,
+            executor_order_id,
+            avg_price,
+            placed_at,
+            partially_filled_at,
+            ..
+        } => Some(OffchainOrder::Cancelled {
+            symbol: symbol.clone(),
+            shares: *shares,
+            retained_fill: Some(RetainedFill::priced(
+                *shares_filled,
+                *avg_price,
+                *partially_filled_at,
+            )),
+            direction: *direction,
+            executor: *executor,
+            executor_order_id: executor_order_id.clone(),
+            reason,
+            placed_at: *placed_at,
+            cancelled_at,
+        }),
+        OffchainOrder::Cancelling {
+            symbol,
+            shares,
+            retained_fill,
+            direction,
+            executor,
+            executor_order_id,
+            reason: requested_reason,
+            placed_at,
+            ..
+        } => Some(OffchainOrder::Cancelled {
+            symbol: symbol.clone(),
+            shares: *shares,
+            retained_fill: *retained_fill,
+            direction: *direction,
+            executor: *executor,
+            executor_order_id: executor_order_id.clone(),
+            reason: *requested_reason,
+            placed_at: *placed_at,
+            cancelled_at,
+        }),
+        OffchainOrder::Pending { .. }
+        | OffchainOrder::Filled { .. }
+        | OffchainOrder::Failed { .. }
+        | OffchainOrder::Cancelled { .. } => None,
     }
 }
 
@@ -668,7 +1358,7 @@ impl OffchainOrder {
     /// conversion can fail. Callers that want a silently-discarded `Option`
     /// can write `.ok()`.
     pub(crate) fn try_to_trade(&self, id: &OffchainOrderId) -> Result<Trade, NotFilled> {
-        use OffchainOrder::{Failed, PartiallyFilled, Pending, Submitted};
+        use OffchainOrder::{Cancelled, Cancelling, Failed, PartiallyFilled, Pending, Submitted};
         let Self::Filled {
             symbol,
             shares,
@@ -684,7 +1374,11 @@ impl OffchainOrder {
                 PartiallyFilled { .. } => NotFilled {
                     state: "PartiallyFilled",
                 },
+                Cancelling { .. } => NotFilled {
+                    state: "Cancelling",
+                },
                 Failed { .. } => NotFilled { state: "Failed" },
+                Cancelled { .. } => NotFilled { state: "Cancelled" },
                 Self::Filled { .. } => unreachable!(),
             });
         };
@@ -708,8 +1402,10 @@ impl OffchainOrder {
             Pending { symbol, .. }
             | Submitted { symbol, .. }
             | PartiallyFilled { symbol, .. }
+            | Cancelling { symbol, .. }
             | Filled { symbol, .. }
-            | Failed { symbol, .. } => symbol,
+            | Failed { symbol, .. }
+            | Cancelled { symbol, .. } => symbol,
         }
     }
 
@@ -719,8 +1415,10 @@ impl OffchainOrder {
             Pending { shares, .. }
             | Submitted { shares, .. }
             | PartiallyFilled { shares, .. }
+            | Cancelling { shares, .. }
             | Filled { shares, .. }
-            | Failed { shares, .. } => *shares,
+            | Failed { shares, .. }
+            | Cancelled { shares, .. } => *shares,
         }
     }
 
@@ -730,8 +1428,10 @@ impl OffchainOrder {
             Pending { direction, .. }
             | Submitted { direction, .. }
             | PartiallyFilled { direction, .. }
+            | Cancelling { direction, .. }
             | Filled { direction, .. }
-            | Failed { direction, .. } => *direction,
+            | Failed { direction, .. }
+            | Cancelled { direction, .. } => *direction,
         }
     }
 
@@ -741,8 +1441,10 @@ impl OffchainOrder {
             Pending { executor, .. }
             | Submitted { executor, .. }
             | PartiallyFilled { executor, .. }
+            | Cancelling { executor, .. }
             | Filled { executor, .. }
-            | Failed { executor, .. } => *executor,
+            | Failed { executor, .. }
+            | Cancelled { executor, .. } => *executor,
         }
     }
 
@@ -755,13 +1457,494 @@ impl OffchainOrder {
             | PartiallyFilled {
                 executor_order_id, ..
             }
+            | Cancelling {
+                executor_order_id, ..
+            }
             | Filled {
+                executor_order_id, ..
+            }
+            | Cancelled {
                 executor_order_id, ..
             } => Some(executor_order_id),
 
+            // Pending has no broker id yet; Failed's is Option (a failure can
+            // occur before the broker assigned one).
             Pending { .. } | Failed { .. } => None,
         }
     }
+}
+
+/// How a *terminal* [`OffchainOrder`] should finalize its owning `Position`.
+///
+/// Shared by the two finalization sites -- the startup orphan-recovery sweep in
+/// `conductor` and the cancel-and-replace pass in `position_check` -- so the
+/// terminal-state -> position-command mapping lives in one place and cannot
+/// drift between them. `broker_timestamp` is the order's own broker event time
+/// (`filled_at`/`cancelled_at`/`failed_at`), the moment the broker recorded the
+/// outcome -- not the wall-clock time finalization happens to run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TerminalPositionFinalization {
+    /// Apply the recorded (priced) fill to the position.
+    Complete {
+        shares_filled: Positive<FractionalShares>,
+        direction: Direction,
+        executor_order_id: ExecutorOrderId,
+        price: Usd,
+        broker_timestamp: DateTime<Utc>,
+    },
+    /// No fill to record -- clear the position's pending reference. The
+    /// carried outcome distinguishes intentional cancellation (release the
+    /// slot without failure semantics) from broker failure (set the failure
+    /// anchor), so callers never re-match the order and the
+    /// cancelled-vs-failed mapping cannot drift between them.
+    NoFill(NoFillOutcome),
+    /// A positive fill quantity with no average price: the fill cannot be
+    /// recorded correctly, so the position must NOT be finalized (the caller
+    /// retries) rather than silently dropping the filled shares.
+    UnpricedFill { shares_filled: FractionalShares },
+}
+
+/// How a terminal order with no fill ended, mapping 1:1 onto the position
+/// command the caller must issue.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NoFillOutcome {
+    /// Broker-confirmed intentional cancellation: issue
+    /// `PositionCommand::CancelOffChainOrder`, which clears the pending slot
+    /// and the failure/idempotency anchor. `cancelled_at` is the broker's
+    /// cancellation time.
+    Cancelled {
+        reason: CancellationReason,
+        cancelled_at: DateTime<Utc>,
+    },
+    /// Broker rejection/failure: issue `PositionCommand::FailOffChainOrder`,
+    /// which sets the failure anchor for the next attempt's idempotency key.
+    Failed { error: String },
+}
+
+/// Maps a [`TerminalPositionFinalization`] onto the [`PositionCommand`] that
+/// finalizes the owning position. Returns `None` for an unpriced fill, which
+/// must leave the position pending (callers log and let the every-tick
+/// finalize sweep keep surfacing it) rather than dropping the filled shares.
+pub(crate) fn position_command_for_finalization(
+    finalization: TerminalPositionFinalization,
+    offchain_order_id: OffchainOrderId,
+) -> Option<PositionCommand> {
+    match finalization {
+        TerminalPositionFinalization::Complete {
+            shares_filled,
+            direction,
+            executor_order_id,
+            price,
+            broker_timestamp,
+        } => Some(PositionCommand::CompleteOffChainOrder {
+            offchain_order_id,
+            shares_filled,
+            direction,
+            executor_order_id,
+            price,
+            broker_timestamp,
+        }),
+        TerminalPositionFinalization::NoFill(NoFillOutcome::Cancelled {
+            reason,
+            cancelled_at,
+        }) => Some(PositionCommand::CancelOffChainOrder {
+            offchain_order_id,
+            reason,
+            cancelled_at,
+        }),
+        TerminalPositionFinalization::NoFill(NoFillOutcome::Failed { error }) => {
+            Some(PositionCommand::FailOffChainOrder {
+                offchain_order_id,
+                error,
+            })
+        }
+        TerminalPositionFinalization::UnpricedFill { .. } => None,
+    }
+}
+
+/// Classifies a terminal [`OffchainOrder`] (`Filled`/`Cancelled`/`Failed`) into
+/// the [`TerminalPositionFinalization`] it implies. Returns `None` for
+/// non-terminal states (the caller leaves the position pending and retries).
+pub(crate) fn terminal_position_finalization(
+    order: &OffchainOrder,
+) -> Option<TerminalPositionFinalization> {
+    match order {
+        OffchainOrder::Filled {
+            shares,
+            direction,
+            executor_order_id,
+            price,
+            filled_at,
+            ..
+        } => Some(TerminalPositionFinalization::Complete {
+            shares_filled: *shares,
+            direction: *direction,
+            executor_order_id: executor_order_id.clone(),
+            price: *price,
+            broker_timestamp: *filled_at,
+        }),
+
+        OffchainOrder::Cancelled {
+            retained_fill,
+            direction,
+            executor_order_id,
+            reason,
+            cancelled_at,
+            ..
+        } => Some(classify_terminal_fill(
+            *retained_fill,
+            *direction,
+            executor_order_id.clone(),
+            NoFillOutcome::Cancelled {
+                reason: *reason,
+                cancelled_at: *cancelled_at,
+            },
+        )),
+
+        OffchainOrder::Failed {
+            retained_fill,
+            direction,
+            executor_order_id: Some(executor_order_id),
+            error,
+            ..
+        } => Some(classify_terminal_fill(
+            *retained_fill,
+            *direction,
+            executor_order_id.clone(),
+            NoFillOutcome::Failed {
+                error: error.clone(),
+            },
+        )),
+
+        // Failed with no recorded fill (or no executor id) -- nothing to apply.
+        OffchainOrder::Failed { error, .. } => Some(TerminalPositionFinalization::NoFill(
+            NoFillOutcome::Failed {
+                error: error.clone(),
+            },
+        )),
+
+        OffchainOrder::Pending { .. }
+        | OffchainOrder::Submitted { .. }
+        | OffchainOrder::PartiallyFilled { .. }
+        | OffchainOrder::Cancelling { .. } => None,
+    }
+}
+
+/// A priced positive fill -> `Complete`; a positive fill without a price ->
+/// `UnpricedFill` (must not be dropped); zero -> `NoFill` carrying the
+/// caller-supplied outcome.
+fn classify_terminal_fill(
+    retained_fill: Option<RetainedFill>,
+    direction: Direction,
+    executor_order_id: ExecutorOrderId,
+    no_fill: NoFillOutcome,
+) -> TerminalPositionFinalization {
+    match retained_fill {
+        Some(RetainedFill::Priced {
+            shares_filled,
+            avg_price,
+            partially_filled_at,
+        }) => {
+            let Ok(positive) = Positive::new(shares_filled) else {
+                return TerminalPositionFinalization::NoFill(no_fill);
+            };
+            TerminalPositionFinalization::Complete {
+                shares_filled: positive,
+                direction,
+                executor_order_id,
+                price: avg_price,
+                broker_timestamp: partially_filled_at,
+            }
+        }
+        Some(RetainedFill::Unpriced { shares_filled }) => {
+            if Positive::new(shares_filled).is_ok() {
+                TerminalPositionFinalization::UnpricedFill { shares_filled }
+            } else {
+                TerminalPositionFinalization::NoFill(no_fill)
+            }
+        }
+        None => TerminalPositionFinalization::NoFill(no_fill),
+    }
+}
+
+/// Returns whether the broker-reported cumulative fill strictly exceeds the
+/// locally recorded quantity. Cumulative fills must never regress, so callers
+/// skip the update when this is `false`.
+///
+/// A comparison failure is mapped to the structured
+/// [`OffchainOrderError::FillComparisonFailed`] (after logging the underlying
+/// `FloatError`, which is not serializable) so callers fail closed: the
+/// aggregate stays in its prior state and the command retries rather than
+/// proceeding with potentially lost fill data.
+fn broker_fill_exceeds_local(
+    broker_shares_filled: FractionalShares,
+    local_shares_filled: FractionalShares,
+) -> Result<bool, OffchainOrderError> {
+    broker_shares_filled
+        .inner()
+        .gt(local_shares_filled.inner())
+        .map_err(|error| {
+            tracing::error!(
+                ?error,
+                %broker_shares_filled,
+                %local_shares_filled,
+                "Float comparison of cumulative fills failed"
+            );
+            OffchainOrderError::FillComparisonFailed {
+                broker_shares_filled,
+                local_shares_filled,
+            }
+        })
+}
+
+/// Queries the broker for the current state of an order before cancellation
+/// and emits the appropriate partial-fill / fill events so the local
+/// aggregate is reconciled with the broker before the terminal Cancelled
+/// event. `local_filled` is the cumulative quantity already recorded in
+/// the local PartiallyFilled state (None if the local state is Submitted).
+///
+/// Returns the events that should be emitted *before* the cancel attempt.
+/// If the returned vec contains `Filled`, the caller MUST short-circuit
+/// and not attempt the DELETE (the broker already filled).
+async fn reconcile_pre_cancel(
+    services: &dyn OrderPlacer,
+    executor_order_id: &ExecutorOrderId,
+    local_filled: Option<FractionalShares>,
+    cancellation_reason: CancellationReason,
+) -> Result<Vec<OffchainOrderEvent>, OffchainOrderError> {
+    // Propagate read failures so the aggregate stays in its prior state
+    // and the caller can retry. Silently bypassing reconciliation would
+    // re-introduce the partial-fill loss bug the function exists to fix
+    // -- a transient status-API failure right before cancel must not
+    // become irreversible data loss.
+    let state = services
+        .get_order_status(executor_order_id)
+        .await
+        .map_err(|error| {
+            tracing::warn!(
+                %executor_order_id,
+                %error,
+                "Failed to read broker state for pre-cancel reconciliation; \
+                 will retry without cancelling"
+            );
+            OffchainOrderError::PreCancelStatusFetchFailed {
+                executor_order_id: executor_order_id.clone(),
+            }
+        })?;
+
+    match state {
+        OrderState::PartiallyFilled {
+            shares_filled: broker_filled,
+            avg_price,
+            partially_filled_at,
+            ..
+        } => {
+            if Positive::new(broker_filled).is_err() {
+                if broker_filled == FractionalShares::ZERO {
+                    return Ok(Vec::new());
+                }
+
+                return Err(OffchainOrderError::InvalidTerminalFillQuantity {
+                    executor_order_id: executor_order_id.clone(),
+                    shares_filled: broker_filled,
+                });
+            }
+
+            // Only emit when the broker reports STRICTLY MORE fills than
+            // the local aggregate already records. Equal => no-op (the
+            // local state is already up to date). LESS => stale broker
+            // read (the poll loop recorded fresher data); never regress
+            // the recorded cumulative quantity. A comparison failure
+            // propagates (fail closed, like the status-fetch failure above)
+            // so the cancel retries instead of proceeding blind and
+            // dropping the broker-reported fill.
+            if let Some(local) = local_filled
+                && !broker_fill_exceeds_local(broker_filled, local)?
+            {
+                tracing::debug!(
+                    %executor_order_id,
+                    "Broker partial-fill <= local; skipping pre-cancel reconcile"
+                );
+                return Ok(Vec::new());
+            }
+
+            // We need an avg_price for the event. If the broker did not
+            // return one, drop the reconciliation -- without a price we
+            // can't record the fill correctly. The position would be left
+            // unhedged for the partial quantity, but that's safer than
+            // recording a zero-price fill.
+            let Some(price) = avg_price else {
+                tracing::warn!(
+                    %executor_order_id,
+                    "Broker reports PartiallyFilled but no avg_price; will retry without cancelling"
+                );
+                return Err(OffchainOrderError::PreCancelPartialFillMissingAvgPrice {
+                    executor_order_id: executor_order_id.clone(),
+                    shares_filled: broker_filled,
+                });
+            };
+
+            Ok(vec![OffchainOrderEvent::PartiallyFilled {
+                shares_filled: broker_filled,
+                avg_price: price,
+                partially_filled_at,
+            }])
+        }
+
+        OrderState::Filled {
+            price, executed_at, ..
+        } => {
+            // The order filled completely between our last poll and the
+            // cancel attempt. Record the fill so the position aggregate
+            // gets the full hedge, and skip the DELETE (it would fail or
+            // be no-op).
+            tracing::info!(
+                %executor_order_id,
+                "Broker reports order fully Filled at cancel time; reconciling without DELETE"
+            );
+            Ok(vec![OffchainOrderEvent::Filled {
+                price,
+                filled_at: executed_at,
+            }])
+        }
+
+        OrderState::Failed {
+            error_reason,
+            failed_at,
+            shares_filled,
+            avg_price,
+        } => {
+            // Order terminally failed at the broker between our last poll
+            // and the cancel attempt. Emit Failed (which short-circuits
+            // the DELETE -- attempting it would return 422 "not
+            // cancellable" and trap the aggregate in CancelFailed retry).
+            tracing::info!(
+                %executor_order_id,
+                ?error_reason,
+                "Broker reports order Failed at cancel time; emitting Failed without DELETE"
+            );
+            let error =
+                error_reason.unwrap_or_else(|| "Broker reported Failed at cancel time".to_string());
+
+            reconcile_terminal_fill(
+                executor_order_id,
+                local_filled,
+                shares_filled,
+                avg_price,
+                failed_at,
+                OffchainOrderEvent::Failed { error, failed_at },
+            )
+        }
+
+        OrderState::Cancelled {
+            cancelled_at,
+            shares_filled,
+            avg_price,
+            ..
+        } => {
+            tracing::info!(
+                %executor_order_id,
+                "Broker reports order already Cancelled at cancel time; reconciling without DELETE"
+            );
+
+            reconcile_terminal_fill(
+                executor_order_id,
+                local_filled,
+                Some(shares_filled),
+                avg_price,
+                cancelled_at,
+                OffchainOrderEvent::Cancelled {
+                    reason: cancellation_reason,
+                    cancelled_at,
+                },
+            )
+        }
+
+        OrderState::Pending | OrderState::Submitted { .. } => Ok(Vec::new()),
+    }
+}
+
+/// Shared tail of the `Failed`/`Cancelled` arms of [`reconcile_pre_cancel`]:
+/// applies the broker's terminal fill data ahead of `terminal_event`.
+///
+/// Encodes two invariants that must not drift between the arms:
+/// - cumulative fills never regress -- a broker fill no newer than the local
+///   record emits only the terminal event;
+/// - a positive fill without an average price must NOT be dropped -- it
+///   blocks with [`OffchainOrderError::PreCancelPartialFillMissingAvgPrice`]
+///   so the cancel retries once the broker returns a priced fill, instead of
+///   clearing the position and double-hedging the filled shares.
+///
+/// `broker_timestamp` is the broker event time of the terminal state
+/// (`failed_at`/`cancelled_at`), used as the fill's `partially_filled_at`.
+fn reconcile_terminal_fill(
+    executor_order_id: &ExecutorOrderId,
+    local_filled: Option<FractionalShares>,
+    shares_filled: Option<FractionalShares>,
+    avg_price: Option<Usd>,
+    broker_timestamp: DateTime<Utc>,
+    terminal_event: OffchainOrderEvent,
+) -> Result<Vec<OffchainOrderEvent>, OffchainOrderError> {
+    if let (Some(broker_filled), Some(avg_price)) = (shares_filled, avg_price) {
+        // A zero priced fill carries nothing to record; anything else
+        // non-positive is a corrupt broker value and must not be persisted
+        // (classify_terminal_fill downstream would silently mask it as
+        // NoFill, under-accounting the position).
+        if Positive::new(broker_filled).is_err() {
+            if broker_filled == FractionalShares::ZERO {
+                return Ok(vec![terminal_event]);
+            }
+            return Err(OffchainOrderError::InvalidTerminalFillQuantity {
+                executor_order_id: executor_order_id.clone(),
+                shares_filled: broker_filled,
+            });
+        }
+
+        if let Some(local) = local_filled
+            && !broker_fill_exceeds_local(broker_filled, local)?
+        {
+            return Ok(vec![terminal_event]);
+        }
+
+        return Ok(vec![
+            OffchainOrderEvent::PartiallyFilled {
+                shares_filled: broker_filled,
+                avg_price,
+                partially_filled_at: broker_timestamp,
+            },
+            terminal_event,
+        ]);
+    }
+
+    if let (Some(shares_filled), None) = (shares_filled, avg_price) {
+        if Positive::new(shares_filled).is_err() {
+            if shares_filled == FractionalShares::ZERO {
+                return Ok(vec![terminal_event]);
+            }
+
+            return Err(OffchainOrderError::InvalidTerminalFillQuantity {
+                executor_order_id: executor_order_id.clone(),
+                shares_filled,
+            });
+        }
+
+        // An unpriced broker fill only blocks when it reports MORE than the
+        // local aggregate has already recorded (priced): an equal-or-smaller
+        // unpriced fill carries no new information -- the local priced fill
+        // already covers it, so the terminal event can proceed.
+        if let Some(local) = local_filled
+            && !broker_fill_exceeds_local(shares_filled, local)?
+        {
+            return Ok(vec![terminal_event]);
+        }
+
+        return Err(OffchainOrderError::PreCancelPartialFillMissingAvgPrice {
+            executor_order_id: executor_order_id.clone(),
+            shares_filled,
+        });
+    }
+
+    Ok(vec![terminal_event])
 }
 
 /// Result of a successful order placement, with the executor-assigned ID
@@ -770,6 +1953,17 @@ impl OffchainOrder {
 pub struct OrderPlacementResult {
     pub executor_order_id: ExecutorOrderId,
     pub placed_shares: Positive<FractionalShares>,
+    /// Whether the broker holds the order as extended-hours. Usually echoes
+    /// the requested kind, but a duplicate-`client_order_id` placement adopts
+    /// the order a prior attempt already created -- possibly with different
+    /// session terms (e.g. a regular-hours market retry adopting a still-live
+    /// extended-hours limit order after a lost placement response). The
+    /// aggregate must record THIS value so the regular-open cancel-and-replace
+    /// sweep (which keys off `is_extended_hours`) converges the adopted order.
+    pub is_extended_hours: bool,
+    /// The broker-held limit price, if any. Same adoption semantics as
+    /// `is_extended_hours`.
+    pub limit_price: Option<Positive<Usd>>,
 }
 
 /// Type-erased order placement capability used by the durable placement path
@@ -781,15 +1975,65 @@ pub struct OrderPlacementResult {
 /// This trait exists because the `Executor` trait has associated types
 /// (`Error`, `OrderId`, `Ctx`) which make it non-object-safe - you cannot
 /// write `Arc<dyn Executor>`. This trait provides the minimal surface needed
-/// by the aggregate (just `place_market_order`) with erased error/ID types,
-/// allowing different executor implementations to be used
-/// via `Arc<dyn OrderPlacer>`.
+/// by the aggregate with erased error/ID types, allowing different executor
+/// implementations to be used via `Arc<dyn OrderPlacer>`.
 #[async_trait]
 pub trait OrderPlacer: Send + Sync {
     async fn place_market_order(
         &self,
         order: MarketOrder,
     ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>;
+
+    async fn place_limit_order(
+        &self,
+        order: LimitOrder,
+    ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>;
+
+    async fn cancel_order(
+        &self,
+        executor_order_id: &ExecutorOrderId,
+    ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>;
+
+    /// Fetches the latest trade price for a symbol, used to compute limit
+    /// prices for extended-hours counter-trades. Returns `None` when the
+    /// executor does not support market data lookups.
+    async fn fetch_latest_trade_price(
+        &self,
+        _symbol: &Symbol,
+    ) -> Result<Option<st0x_execution::Positive<Usd>>, Box<dyn std::error::Error + Send + Sync>>
+    {
+        Ok(None)
+    }
+
+    /// Returns the current market session. Used by hedge jobs to re-check
+    /// the session at execution time so a queued job does not submit the
+    /// wrong order type across the 9:30/16:00 ET boundary. The default
+    /// returns `Regular`, which is the safe assumption for executors
+    /// without session awareness (e.g. dry-run).
+    async fn market_session(
+        &self,
+    ) -> Result<st0x_execution::MarketSession, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(st0x_execution::MarketSession::Regular)
+    }
+
+    /// Queries the broker for the current state of an order. Used by the
+    /// `CancelOrder` handler's `reconcile_pre_cancel` to apply any fill that
+    /// landed between the last poll and the cancel.
+    ///
+    /// The default deliberately FAILS rather than fabricating a `Submitted`
+    /// state: a fabricated-`Submitted` default would make an implementer that
+    /// forgot to query the broker silently skip reconciliation and drop a fill
+    /// -- the exact partial-fill loss `reconcile_pre_cancel` exists to prevent.
+    /// `reconcile_pre_cancel` maps this error to `PreCancelStatusFetchFailed`,
+    /// which keeps the order in its prior state and retries instead of
+    /// cancelling blind. Real implementations (`ExecutorOrderPlacer`) override
+    /// this to delegate to the executor.
+    async fn get_order_status(
+        &self,
+        _executor_order_id: &ExecutorOrderId,
+    ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>> {
+        Err("get_order_status not implemented for this OrderPlacer".into())
+    }
 }
 
 /// Bridges `Executor` (which has associated types and is not object-safe)
@@ -806,7 +2050,52 @@ impl<E: Executor> OrderPlacer for ExecutorOrderPlacer<E> {
         Ok(OrderPlacementResult {
             executor_order_id: ExecutorOrderId::new(&placement.order_id),
             placed_shares: placement.shares,
+            is_extended_hours: placement.extended_hours,
+            limit_price: placement.limit_price,
         })
+    }
+
+    async fn place_limit_order(
+        &self,
+        order: LimitOrder,
+    ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
+        let placement = self.0.place_limit_order(order).await?;
+        Ok(OrderPlacementResult {
+            executor_order_id: ExecutorOrderId::new(&placement.order_id),
+            placed_shares: placement.shares,
+            is_extended_hours: placement.extended_hours,
+            limit_price: placement.limit_price,
+        })
+    }
+
+    async fn cancel_order(
+        &self,
+        executor_order_id: &ExecutorOrderId,
+    ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+        let order_id = self.0.parse_order_id(executor_order_id.as_ref())?;
+        Ok(self.0.cancel_order(&order_id).await?)
+    }
+
+    async fn fetch_latest_trade_price(
+        &self,
+        symbol: &Symbol,
+    ) -> Result<Option<st0x_execution::Positive<Usd>>, Box<dyn std::error::Error + Send + Sync>>
+    {
+        Ok(self.0.fetch_latest_trade_price(symbol).await?)
+    }
+
+    async fn market_session(
+        &self,
+    ) -> Result<st0x_execution::MarketSession, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(self.0.market_session().await?)
+    }
+
+    async fn get_order_status(
+        &self,
+        executor_order_id: &ExecutorOrderId,
+    ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>> {
+        let order_id = self.0.parse_order_id(executor_order_id.as_ref())?;
+        Ok(self.0.get_order_status(&order_id).await?)
     }
 }
 
@@ -823,6 +2112,38 @@ pub(crate) fn noop_order_placer() -> Arc<dyn OrderPlacer> {
             Ok(OrderPlacementResult {
                 executor_order_id: ExecutorOrderId::new("noop"),
                 placed_shares: noop_placed_shares(order.shares),
+                is_extended_hours: false,
+                limit_price: None,
+            })
+        }
+
+        async fn place_limit_order(
+            &self,
+            order: LimitOrder,
+        ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(OrderPlacementResult {
+                executor_order_id: ExecutorOrderId::new("noop-limit"),
+                placed_shares: noop_placed_shares(order.shares),
+                is_extended_hours: order.extended_hours,
+                limit_price: Some(order.limit_price),
+            })
+        }
+
+        async fn cancel_order(
+            &self,
+            _executor_order_id: &ExecutorOrderId,
+        ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(CancellationOutcome::Requested)
+        }
+
+        async fn get_order_status(
+            &self,
+            executor_order_id: &ExecutorOrderId,
+        ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>> {
+            // No-op placer reports the order still live, so pre-cancel
+            // reconciliation finds nothing to apply (matches the prior default).
+            Ok(st0x_execution::OrderState::Submitted {
+                order_id: executor_order_id.clone(),
             })
         }
     }
@@ -844,6 +2165,24 @@ pub(crate) fn noop_placed_shares(
     Positive::new(FractionalShares::new(truncated)).expect("truncated shares should be positive")
 }
 
+/// Determines whether a counter-trade is placed as a market order (regular
+/// hours) or a limit order with `extended_hours: true` (pre-market /
+/// after-hours).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CounterTradeOrderKind {
+    Market,
+    ExtendedHoursLimit { limit_price: Positive<Usd> },
+}
+
+impl CounterTradeOrderKind {
+    fn market_session(&self) -> MarketSession {
+        match self {
+            Self::Market => MarketSession::Regular,
+            Self::ExtendedHoursLimit { .. } => MarketSession::Extended,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum OffchainOrderCommand {
     Place {
@@ -851,13 +2190,37 @@ pub enum OffchainOrderCommand {
         shares: Positive<FractionalShares>,
         direction: Direction,
         executor: SupportedExecutor,
+        /// Idempotency key forwarded to the broker so apalis retries of
+        /// the same `PlaceHedge` job do not produce a second order if the
+        /// first placement's response is lost in flight.
+        client_order_id: ClientOrderId,
+        kind: CounterTradeOrderKind,
+    },
+    /// Request broker cancellation for a submitted order and persist the
+    /// in-flight cancellation state. The order becomes terminal only after the
+    /// broker later reports `Cancelled`.
+    CancelOrder {
+        reason: CancellationReason,
+    },
+    ConfirmCancellation {
+        cancelled_at: DateTime<Utc>,
     },
     UpdatePartialFill {
         shares_filled: FractionalShares,
         avg_price: Usd,
+        /// Broker-reported time of the fill (e.g. the order's `updated_at` /
+        /// terminal-state timestamp), persisted on the `PartiallyFilled`
+        /// event. Must NOT be the wall-clock time the caller happens to run:
+        /// it flows into `Position.last_updated` and recency/ordering logic.
+        partially_filled_at: DateTime<Utc>,
     },
     CompleteFill {
         price: Usd,
+        /// Broker-reported execution time, persisted as the `Filled` event's
+        /// `filled_at`. Must NOT be the wall-clock time the caller happens to
+        /// run: it feeds `terminal_position_finalization`'s
+        /// `broker_timestamp` and `Position.last_updated`.
+        filled_at: DateTime<Utc>,
     },
     /// Outcome command: the broker accepted the placement. Fed back by the
     /// durable placement path after `place_market_order`, carrying the
@@ -867,6 +2230,11 @@ pub enum OffchainOrderCommand {
         executor_order_id: ExecutorOrderId,
         placed_shares: Positive<FractionalShares>,
         submitted_at: DateTime<Utc>,
+        /// Broker-adopted session terms. Usually match the requested
+        /// [`CounterTradeOrderKind`], but may differ when a duplicate
+        /// client_order_id adopts an existing broker order.
+        market_session: MarketSession,
+        limit_price: Option<Positive<Usd>>,
     },
     /// Outcome command for a placement-initiated failure: the broker call errored
     /// while the placement path still held a `Pending` order. Honoured only from
@@ -878,6 +2246,11 @@ pub enum OffchainOrderCommand {
     },
     MarkFailed {
         error: String,
+        /// Broker-reported failure time when available; callers without a
+        /// broker timestamp pass their observation time, which is still
+        /// closer to the truth than stamping inside the handler after
+        /// queueing delays.
+        failed_at: DateTime<Utc>,
     },
 }
 
@@ -889,6 +2262,22 @@ pub enum OffchainOrderEvent {
         direction: Direction,
         executor: SupportedExecutor,
         placed_at: DateTime<Utc>,
+        /// Whether this order was placed during extended hours as a limit
+        /// order. Used by the cancel-and-replace logic to avoid cancelling
+        /// regular-hours market orders. Defaults to `false` for events
+        /// persisted before this field existed.
+        #[serde(default)]
+        is_extended_hours: bool,
+        /// The limit price submitted to the broker for an extended-hours order
+        /// (`None` for market orders). Audit-only: not applied to entity state,
+        /// recorded so the actual submitted price is reconstructable from the
+        /// event stream. `#[serde(default)]` for events predating this field.
+        #[serde(default)]
+        limit_price: Option<Positive<Usd>>,
+        /// The broker idempotency key submitted with this placement. Audit-only.
+        /// `#[serde(default)]` (None) for events predating this field.
+        #[serde(default)]
+        client_order_id: Option<ClientOrderId>,
     },
     /// Legacy broker-acceptance event. Predates the durable-job extraction,
     /// where `Place` did the broker call inline and emitted this alongside
@@ -910,11 +2299,19 @@ pub enum OffchainOrderEvent {
         executor_order_id: ExecutorOrderId,
         placed_shares: Positive<FractionalShares>,
         submitted_at: DateTime<Utc>,
+        #[serde(default = "regular_market_session")]
+        market_session: MarketSession,
+        #[serde(default)]
+        limit_price: Option<Positive<Usd>>,
     },
     PartiallyFilled {
         shares_filled: FractionalShares,
         avg_price: Usd,
         partially_filled_at: DateTime<Utc>,
+    },
+    CancelRequested {
+        reason: CancellationReason,
+        cancel_requested_at: DateTime<Utc>,
     },
     Filled {
         price: Usd,
@@ -923,6 +2320,10 @@ pub enum OffchainOrderEvent {
     Failed {
         error: String,
         failed_at: DateTime<Utc>,
+    },
+    Cancelled {
+        reason: CancellationReason,
+        cancelled_at: DateTime<Utc>,
     },
 }
 
@@ -933,8 +2334,10 @@ impl DomainEvent for OffchainOrderEvent {
             Self::Submitted { .. } => "OffchainOrderEvent::Submitted".to_string(),
             Self::Accepted { .. } => "OffchainOrderEvent::Accepted".to_string(),
             Self::PartiallyFilled { .. } => "OffchainOrderEvent::PartiallyFilled".to_string(),
+            Self::CancelRequested { .. } => "OffchainOrderEvent::CancelRequested".to_string(),
             Self::Filled { .. } => "OffchainOrderEvent::Filled".to_string(),
             Self::Failed { .. } => "OffchainOrderEvent::Failed".to_string(),
+            Self::Cancelled { .. } => "OffchainOrderEvent::Cancelled".to_string(),
         }
     }
 
@@ -991,8 +2394,18 @@ pub enum OffchainOrderError {
          submitted to broker yet"
     )]
     NotSubmitted,
-    #[error("Cannot update order: order has already been completed (filled or failed)")]
+    #[error("Cannot update order: order has already been completed (filled, failed, or cancelled)")]
     AlreadyCompleted,
+    #[error("Cannot confirm cancellation: broker cancellation has not been requested")]
+    CancellationNotRequested,
+    #[error(
+        "Broker reported an invalid (non-positive, non-zero) terminal fill quantity \
+         {shares_filled} for order {executor_order_id}; refusing to record it"
+    )]
+    InvalidTerminalFillQuantity {
+        executor_order_id: ExecutorOrderId,
+        shares_filled: FractionalShares,
+    },
     #[error("Order has not been placed yet")]
     NotPlaced,
     #[error(
@@ -1000,10 +2413,47 @@ pub enum OffchainOrderError {
          replay the original symbol, direction, and executor"
     )]
     PlacePayloadMismatch,
+    /// Pre-cancel broker status query failed. Surfaced as an error so the
+    /// aggregate stays in its prior state and the caller retries -- silent
+    /// bypass would lose any partial fills that occurred between the last
+    /// poll and the cancel attempt. The underlying broker error is a
+    /// non-serializable `Box<dyn Error>` (this enum must satisfy the CQRS
+    /// `Clone + Serialize + Deserialize + PartialEq + Eq` derives), so it is
+    /// logged at the call site rather than carried here.
+    #[error("Failed to read pre-cancel broker state for order {executor_order_id}")]
+    PreCancelStatusFetchFailed { executor_order_id: ExecutorOrderId },
+    #[error(
+        "Broker reported partial fill of {shares_filled} shares for order \
+         {executor_order_id} without an average price"
+    )]
+    PreCancelPartialFillMissingAvgPrice {
+        executor_order_id: ExecutorOrderId,
+        shares_filled: FractionalShares,
+    },
+    /// Comparing the broker-reported cumulative fill against the locally
+    /// recorded quantity failed. Carries both operands so the failing
+    /// comparison is reproducible from the error alone; the underlying
+    /// `rain_math_float::FloatError` is not serializable, so it is logged
+    /// at the comparison site ([`broker_fill_exceeds_local`]) instead.
+    #[error(
+        "Failed to compare broker-reported fill {broker_shares_filled} \
+         against locally recorded fill {local_shares_filled}"
+    )]
+    FillComparisonFailed {
+        broker_shares_filled: FractionalShares,
+        local_shares_filled: FractionalShares,
+    },
+    /// The broker rejected or failed the cancellation request. The underlying
+    /// broker error is a non-serializable `Box<dyn Error>`, so it is logged
+    /// at the call site rather than carried here.
+    #[error("Broker rejected the cancellation request for order {executor_order_id}")]
+    CancelFailed { executor_order_id: ExecutorOrderId },
 }
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use st0x_event_sorcery::{AggregateError, LifecycleError, StoreBuilder, TestStore, replay};
 
     use super::*;
@@ -1021,9 +2471,56 @@ mod tests {
             {
                 Err("Broker rejected order".into())
             }
+
+            async fn place_limit_order(
+                &self,
+                _order: LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err("Broker rejected order".into())
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &ExecutorOrderId,
+            ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(CancellationOutcome::Requested)
+            }
         }
 
         Arc::new(Failing)
+    }
+
+    fn limit_failing_order_placer() -> Arc<dyn OrderPlacer> {
+        struct LimitFailing;
+
+        #[async_trait]
+        impl OrderPlacer for LimitFailing {
+            async fn place_market_order(
+                &self,
+                _order: MarketOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                panic!("extended-hours command must use place_limit_order");
+            }
+
+            async fn place_limit_order(
+                &self,
+                _order: LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err("Limit order rejected".into())
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &ExecutorOrderId,
+            ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(CancellationOutcome::Requested)
+            }
+        }
+
+        Arc::new(LimitFailing)
     }
 
     fn place_command() -> OffchainOrderCommand {
@@ -1032,6 +2529,8 @@ mod tests {
             shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
             direction: Direction::Buy,
             executor: SupportedExecutor::DryRun,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            kind: CounterTradeOrderKind::Market,
         }
     }
 
@@ -1049,10 +2548,213 @@ mod tests {
                     executor_order_id: ExecutorOrderId::new("TEST-ACCEPT"),
                     placed_shares: noop_placed_shares(requested),
                     submitted_at: Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
                 },
             )
             .await
             .unwrap();
+    }
+
+    #[test]
+    fn placed_event_records_order_terms_and_defaults_for_legacy_events() {
+        let event = OffchainOrderEvent::Placed {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
+            direction: Direction::Buy,
+            executor: SupportedExecutor::DryRun,
+            placed_at: Utc::now(),
+            is_extended_hours: true,
+            limit_price: Some(Positive::new(Usd::new(float!(195.25))).unwrap()),
+            client_order_id: Some(ClientOrderId::from_uuid(uuid::Uuid::new_v4())),
+        };
+
+        // The submitted terms are recorded on the event for audit.
+        let mut value = serde_json::to_value(&event).unwrap();
+        assert!(
+            !value["Placed"]["limit_price"].is_null(),
+            "limit_price must be recorded on the Placed event"
+        );
+        assert!(
+            !value["Placed"]["client_order_id"].is_null(),
+            "client_order_id must be recorded on the Placed event"
+        );
+
+        // Events persisted before these fields existed (no keys) deserialize
+        // with the fields defaulted to None rather than failing.
+        let placed = value["Placed"].as_object_mut().unwrap();
+        placed.remove("limit_price");
+        placed.remove("client_order_id");
+        let legacy: OffchainOrderEvent = serde_json::from_value(value).unwrap();
+        assert!(
+            matches!(
+                legacy,
+                OffchainOrderEvent::Placed {
+                    limit_price: None,
+                    client_order_id: None,
+                    ..
+                }
+            ),
+            "legacy Placed event must default the audit terms to None, got: {legacy:?}"
+        );
+    }
+
+    #[test]
+    fn cancelled_with_retained_fill_finalizes_with_fill_time_not_cancel_time() {
+        // A partial fill at T1 followed by cancellation at T2 must finalize
+        // the position with the broker's fill time T1 -- the cancellation
+        // time is when the order died, not when the shares were executed.
+        let fill_time = "2026-01-05T14:30:00Z".parse::<DateTime<Utc>>().unwrap();
+        let cancel_time = "2026-01-06T14:32:01Z".parse::<DateTime<Utc>>().unwrap();
+        let order = OffchainOrder::Cancelled {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(2))).unwrap(),
+            retained_fill: Some(RetainedFill::priced(
+                FractionalShares::new(float!(0.5)),
+                Usd::new(float!(195.25)),
+                fill_time,
+            )),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            executor_order_id: ExecutorOrderId::new("cancelled-with-fill"),
+            reason: CancellationReason::MarketOpenReplacement,
+            placed_at: fill_time,
+            cancelled_at: cancel_time,
+        };
+
+        let finalization =
+            terminal_position_finalization(&order).expect("terminal Cancelled order must classify");
+        let TerminalPositionFinalization::Complete {
+            broker_timestamp, ..
+        } = finalization
+        else {
+            panic!("priced retained fill must classify as Complete, got: {finalization:?}");
+        };
+        assert_eq!(
+            broker_timestamp, fill_time,
+            "finalization must stamp the broker fill time, not the cancellation time"
+        );
+    }
+
+    #[test]
+    fn failed_with_retained_fill_finalizes_with_fill_time_not_failure_time() {
+        // Mirror of the Cancelled case: a partial fill at T1 followed by a
+        // rejection at T2 must finalize the position with the broker's fill
+        // time T1, including on a retry that loads the already-Failed order
+        // after MarkFailed persisted.
+        let fill_time = "2026-01-05T14:30:00Z".parse::<DateTime<Utc>>().unwrap();
+        let failure_time = "2026-01-06T14:32:01Z".parse::<DateTime<Utc>>().unwrap();
+        let order = OffchainOrder::Failed {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(2))).unwrap(),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            retained_fill: Some(RetainedFill::priced(
+                FractionalShares::new(float!(0.5)),
+                Usd::new(float!(195.25)),
+                fill_time,
+            )),
+            executor_order_id: Some(ExecutorOrderId::new("failed-with-fill")),
+            error: "broker rejected remainder".to_string(),
+            placed_at: fill_time,
+            failed_at: failure_time,
+        };
+
+        let finalization =
+            terminal_position_finalization(&order).expect("terminal Failed order must classify");
+        let TerminalPositionFinalization::Complete {
+            broker_timestamp, ..
+        } = finalization
+        else {
+            panic!("priced retained fill must classify as Complete, got: {finalization:?}");
+        };
+        assert_eq!(
+            broker_timestamp, fill_time,
+            "finalization must stamp the broker fill time, not the failure time"
+        );
+    }
+
+    #[test]
+    fn legacy_failed_state_without_fill_fields_deserializes() {
+        // Materialized `Failed` payloads persisted before this PR lack the new
+        // retained-fill key; they must deserialize with the fill defaulted to
+        // None, not error.
+        let legacy_payload = json!({
+            "Failed": {
+                "symbol": "AAPL",
+                "shares": "100",
+                "direction": "Buy",
+                "executor": "DryRun",
+                "error": "broker rejected",
+                "placed_at": "2026-01-01T00:00:00Z",
+                "failed_at": "2026-01-01T00:00:01Z",
+            }
+        });
+
+        let state: OffchainOrder = serde_json::from_value(legacy_payload).unwrap();
+        assert!(
+            matches!(
+                state,
+                OffchainOrder::Failed {
+                    retained_fill: None,
+                    executor_order_id: None,
+                    ..
+                }
+            ),
+            "legacy Failed payload must default fill metadata to None, got: {state:?}"
+        );
+    }
+
+    #[test]
+    fn legacy_extended_hours_state_deserializes_to_market_session() {
+        let submitted_at = Utc::now();
+        let submitted = OffchainOrder::Submitted {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
+            direction: Direction::Buy,
+            executor: SupportedExecutor::DryRun,
+            executor_order_id: ExecutorOrderId::new("broker-123"),
+            placed_at: submitted_at,
+            submitted_at,
+            market_session: MarketSession::Extended,
+        };
+
+        let mut legacy_payload = serde_json::to_value(submitted).unwrap();
+        let submitted = legacy_payload
+            .get_mut("Submitted")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("Submitted variant serializes as an object");
+        submitted.remove("market_session");
+        submitted.insert("is_extended_hours".to_string(), json!(true));
+
+        let state: OffchainOrder = serde_json::from_value(legacy_payload).unwrap();
+        assert!(
+            matches!(
+                state,
+                OffchainOrder::Submitted {
+                    market_session: MarketSession::Extended,
+                    ..
+                }
+            ),
+            "legacy is_extended_hours=true must deserialize as Extended, got: {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn place_order_transitions_to_submitted() {
+        let placer = noop_order_placer();
+        let inner = place_at_broker(placer.as_ref())
+            .await
+            .expect("placement helper must produce an order");
+        assert!(matches!(inner, OffchainOrder::Submitted { .. }));
+
+        let expected =
+            noop_placed_shares(Positive::new(FractionalShares::new(float!(100))).unwrap());
+        assert_eq!(
+            inner.shares(),
+            expected,
+            "Persisted shares should reflect the broker-accepted quantity, not the original request"
+        );
     }
 
     /// Builds a real store and runs the durable placement path against
@@ -1060,9 +2762,16 @@ mod tests {
     /// call site, so the placement outcomes are exercised here rather than
     /// through the (now pure) `Place` handler.
     async fn place_at_broker(placer: &dyn OrderPlacer) -> Option<OffchainOrder> {
+        place_at_broker_with_kind(placer, CounterTradeOrderKind::Market).await
+    }
+
+    async fn place_at_broker_with_kind(
+        placer: &dyn OrderPlacer,
+        kind: CounterTradeOrderKind,
+    ) -> Option<OffchainOrder> {
         let pool = crate::test_utils::setup_test_db().await;
         let (store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(())
+            .build(noop_order_placer())
             .await
             .unwrap();
 
@@ -1070,11 +2779,14 @@ mod tests {
             &store,
             placer,
             &OffchainOrderId::new(),
-            Symbol::new("AAPL").unwrap(),
-            Positive::new(FractionalShares::new(float!(100))).unwrap(),
-            Direction::Buy,
-            SupportedExecutor::DryRun,
-            ClientOrderId::from_uuid(Uuid::new_v4()),
+            OffchainOrderPlacement::with_kind(
+                Symbol::new("AAPL").unwrap(),
+                Positive::new(FractionalShares::new(float!(100))).unwrap(),
+                Direction::Buy,
+                SupportedExecutor::DryRun,
+                ClientOrderId::from_uuid(Uuid::new_v4()),
+                kind,
+            ),
         )
         .await
         .unwrap()
@@ -1107,6 +2819,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn place_extended_hours_limit_transitions_to_submitted() {
+        let placer = noop_order_placer();
+        let order = place_at_broker_with_kind(
+            placer.as_ref(),
+            CounterTradeOrderKind::ExtendedHoursLimit {
+                limit_price: Positive::new(Usd::new(float!(195.25))).unwrap(),
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(
+                order,
+                Some(OffchainOrder::Submitted {
+                    ref executor_order_id,
+                    market_session: MarketSession::Extended,
+                    ..
+                }) if executor_order_id == &ExecutorOrderId::new("noop-limit")
+            ),
+            "expected Submitted extended-hours limit order, got: {order:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn placement_increments_broker_errors_counter_on_failure() {
         let handle = crate::metrics::setup().expect("install Prometheus recorder");
         let placer = failing_order_placer();
@@ -1122,6 +2858,23 @@ mod tests {
         assert!(
             !rendered.contains("hedge_trades_total{"),
             "a failed placement must not increment hedge_trades_total, got:\n{rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn place_extended_hours_limit_failure_transitions_to_failed() {
+        let placer = limit_failing_order_placer();
+        let order = place_at_broker_with_kind(
+            placer.as_ref(),
+            CounterTradeOrderKind::ExtendedHoursLimit {
+                limit_price: Positive::new(Usd::new(float!(195.25))).unwrap(),
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(&order, Some(OffchainOrder::Failed { error, .. }) if error.contains("Limit order rejected")),
+            "expected Failed with limit-order error, got: {order:?}"
         );
     }
 
@@ -1142,7 +2895,24 @@ mod tests {
                 Ok(OrderPlacementResult {
                     executor_order_id: ExecutorOrderId::new("OVERFILL"),
                     placed_shares: Positive::new(FractionalShares::new(overfilled)).unwrap(),
+                    is_extended_hours: false,
+                    limit_price: None,
                 })
+            }
+
+            async fn place_limit_order(
+                &self,
+                _order: LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                unimplemented!("test stub")
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &ExecutorOrderId,
+            ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(CancellationOutcome::Requested)
             }
         }
 
@@ -1207,10 +2977,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn place_records_adopted_extended_hours_terms_over_requested_kind() {
+        // Lost-response convergence scenario: the command asks for a MARKET
+        // order (regular-open retry), but the placer adopts the prior
+        // attempt's still-live extended-hours limit order via the broker's
+        // duplicate-client_order_id reconciliation. The aggregate must record
+        // the ADOPTED order's terms -- is_extended_hours=true and its limit
+        // price -- or the regular-open cancel-and-replace sweep (keyed off
+        // is_extended_hours) never converges the stale limit order.
+        fn adopting_order_placer() -> Arc<dyn OrderPlacer> {
+            struct Adopting;
+
+            #[async_trait]
+            impl OrderPlacer for Adopting {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ADOPTED_EXT_LIMIT"),
+                        placed_shares: order.shares,
+                        is_extended_hours: true,
+                        limit_price: Some(Positive::new(Usd::new(float!(195.25))).unwrap()),
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!("test stub")
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(CancellationOutcome::Requested)
+                }
+            }
+
+            Arc::new(Adopting)
+        }
+
+        let placer = adopting_order_placer();
+        let order = place_at_broker(placer.as_ref())
+            .await
+            .expect("placement helper must produce an order");
+
+        assert!(
+            matches!(
+                order,
+                OffchainOrder::Submitted {
+                    market_session: MarketSession::Extended,
+                    ..
+                }
+            ),
+            "adopted extended-hours terms must be recorded on the aggregate, got: {order:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn place_retry_with_divergent_payload_is_rejected() {
         let pool = crate::test_utils::setup_test_db().await;
         let (store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(())
+            .build(noop_order_placer())
             .await
             .unwrap();
         let id = OffchainOrderId::new();
@@ -1229,6 +3063,8 @@ mod tests {
             shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
             direction: Direction::Sell,
             executor: SupportedExecutor::DryRun,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            kind: CounterTradeOrderKind::Market,
         };
         let error = store.send(&id, mismatched).await.unwrap_err();
         assert!(matches!(
@@ -1243,7 +3079,7 @@ mod tests {
     async fn place_at_broker_skips_broker_when_order_left_pending() {
         let pool = crate::test_utils::setup_test_db().await;
         let (store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(())
+            .build(noop_order_placer())
             .await
             .unwrap();
         let id = OffchainOrderId::new();
@@ -1259,6 +3095,8 @@ mod tests {
                     executor_order_id: ExecutorOrderId::new("SETUP"),
                     placed_shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
                     submitted_at: Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
                 },
             )
             .await
@@ -1275,17 +3113,34 @@ mod tests {
             {
                 panic!("broker must not be called for an order that already left Pending");
             }
+
+            async fn place_limit_order(
+                &self,
+                _order: LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                panic!("broker must not be called for an order that already left Pending");
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &ExecutorOrderId,
+            ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(CancellationOutcome::Requested)
+            }
         }
 
         let result = place_offchain_order_at_broker(
             &store,
             &PanicIfCalled,
             &id,
-            Symbol::new("AAPL").unwrap(),
-            Positive::new(FractionalShares::new(float!(100))).unwrap(),
-            Direction::Buy,
-            SupportedExecutor::DryRun,
-            ClientOrderId::from_uuid(Uuid::new_v4()),
+            OffchainOrderPlacement::market(
+                Symbol::new("AAPL").unwrap(),
+                Positive::new(FractionalShares::new(float!(100))).unwrap(),
+                Direction::Buy,
+                SupportedExecutor::DryRun,
+                ClientOrderId::from_uuid(Uuid::new_v4()),
+            ),
         )
         .await
         .unwrap();
@@ -1300,7 +3155,7 @@ mod tests {
     async fn place_at_broker_skips_markfailed_when_order_advanced_concurrently() {
         let pool = crate::test_utils::setup_test_db().await;
         let (store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(())
+            .build(noop_order_placer())
             .await
             .unwrap();
         let id = OffchainOrderId::new();
@@ -1329,12 +3184,29 @@ mod tests {
                             placed_shares: Positive::new(FractionalShares::new(float!(100)))
                                 .unwrap(),
                             submitted_at: Utc::now(),
+                            market_session: MarketSession::Regular,
+                            limit_price: None,
                         },
                     )
                     .await
                     .unwrap();
 
                 Err("broker error after a concurrent attempt already succeeded".into())
+            }
+
+            async fn place_limit_order(
+                &self,
+                _order: LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                unimplemented!("test stub")
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &ExecutorOrderId,
+            ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(CancellationOutcome::Requested)
             }
         }
 
@@ -1347,11 +3219,13 @@ mod tests {
             &store,
             &placer,
             &id,
-            Symbol::new("AAPL").unwrap(),
-            Positive::new(FractionalShares::new(float!(100))).unwrap(),
-            Direction::Buy,
-            SupportedExecutor::DryRun,
-            ClientOrderId::from_uuid(Uuid::new_v4()),
+            OffchainOrderPlacement::market(
+                Symbol::new("AAPL").unwrap(),
+                Positive::new(FractionalShares::new(float!(100))).unwrap(),
+                Direction::Buy,
+                SupportedExecutor::DryRun,
+                ClientOrderId::from_uuid(Uuid::new_v4()),
+            ),
         )
         .await
         .unwrap();
@@ -1365,7 +3239,7 @@ mod tests {
 
     #[tokio::test]
     async fn place_is_idempotent_once_placed() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         // The durable placement path re-sends `Place` on retry; an existing
@@ -1384,6 +3258,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "Market closed".to_string(),
+                    failed_at: Utc::now(),
                 },
             )
             .await
@@ -1401,7 +3276,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_accepted_is_idempotent_on_submitted() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         // The durable placement path re-sends `MarkAccepted` on retry (the broker
@@ -1417,6 +3292,8 @@ mod tests {
                     executor_order_id: ExecutorOrderId::new("SECOND-ACCEPT"),
                     placed_shares: Positive::new(FractionalShares::new(float!(50))).unwrap(),
                     submitted_at: Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
                 },
             )
             .await
@@ -1431,7 +3308,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_failed_is_idempotent_on_failed() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         store.send(&id, place_command()).await.unwrap();
@@ -1440,6 +3317,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "first failure".to_string(),
+                    failed_at: Utc::now(),
                 },
             )
             .await
@@ -1453,6 +3331,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "second failure".to_string(),
+                    failed_at: Utc::now(),
                 },
             )
             .await
@@ -1467,7 +3346,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_accepted_after_failed_is_noop() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         store.send(&id, place_command()).await.unwrap();
@@ -1476,6 +3355,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "broker rejected".to_string(),
+                    failed_at: Utc::now(),
                 },
             )
             .await
@@ -1491,6 +3371,8 @@ mod tests {
                     executor_order_id: ExecutorOrderId::new("LATE-ACCEPT"),
                     placed_shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
                     submitted_at: Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
                 },
             )
             .await
@@ -1504,9 +3386,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn partial_fill_from_submitted() {
-        let store = TestStore::<OffchainOrder>::new(());
+    async fn partial_fill_from_submitted_records_broker_timestamp() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
+        // A timestamp distinct from any wall clock the handler could stamp:
+        // the persisted event must carry the broker's fill time, not
+        // Utc::now() at processing time.
+        let broker_partially_filled_at = Utc::now() - chrono::Duration::hours(3);
 
         place_and_submit(&store, &id).await;
         store
@@ -1515,20 +3401,32 @@ mod tests {
                 OffchainOrderCommand::UpdatePartialFill {
                     shares_filled: FractionalShares::new(float!(50)),
                     avg_price: Usd::new(float!(150.00)),
+                    partially_filled_at: broker_partially_filled_at,
                 },
             )
             .await
             .unwrap();
 
         let inner = store.load(&id).await.unwrap().unwrap();
-        assert!(matches!(inner, OffchainOrder::PartiallyFilled { .. }));
+        let OffchainOrder::PartiallyFilled {
+            partially_filled_at,
+            ..
+        } = inner
+        else {
+            panic!("expected PartiallyFilled, got {inner:?}");
+        };
+        assert_eq!(
+            partially_filled_at, broker_partially_filled_at,
+            "PartiallyFilled must persist the broker-reported fill time"
+        );
     }
 
     #[tokio::test]
     async fn partial_fill_updates_shares() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
+        let latest_partially_filled_at = Utc::now();
         place_and_submit(&store, &id).await;
         store
             .send(
@@ -1536,6 +3434,7 @@ mod tests {
                 OffchainOrderCommand::UpdatePartialFill {
                     shares_filled: FractionalShares::new(float!(50)),
                     avg_price: Usd::new(float!(150.00)),
+                    partially_filled_at: Utc::now(),
                 },
             )
             .await
@@ -1546,22 +3445,40 @@ mod tests {
                 OffchainOrderCommand::UpdatePartialFill {
                     shares_filled: FractionalShares::new(float!(75)),
                     avg_price: Usd::new(float!(150.50)),
+                    partially_filled_at: latest_partially_filled_at,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(50)),
+                    avg_price: Usd::new(float!(151.00)),
+                    partially_filled_at: latest_partially_filled_at + chrono::Duration::minutes(1),
                 },
             )
             .await
             .unwrap();
 
-        let OffchainOrder::PartiallyFilled { shares_filled, .. } =
-            store.load(&id).await.unwrap().unwrap()
+        let OffchainOrder::PartiallyFilled {
+            shares_filled,
+            avg_price,
+            partially_filled_at,
+            ..
+        } = store.load(&id).await.unwrap().unwrap()
         else {
             panic!("Expected PartiallyFilled state");
         };
         assert_eq!(shares_filled, FractionalShares::new(float!(75)));
+        assert_eq!(avg_price, Usd::new(float!(150.50)));
+        assert_eq!(partially_filled_at, latest_partially_filled_at);
     }
 
     #[tokio::test]
     async fn complete_fill_from_submitted() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -1570,6 +3487,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::CompleteFill {
                     price: Usd::new(float!(150.00)),
+                    filled_at: Utc::now(),
                 },
             )
             .await
@@ -1581,7 +3499,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_fill_from_partially_filled() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -1591,6 +3509,7 @@ mod tests {
                 OffchainOrderCommand::UpdatePartialFill {
                     shares_filled: FractionalShares::new(float!(75)),
                     avg_price: Usd::new(float!(150.00)),
+                    partially_filled_at: Utc::now(),
                 },
             )
             .await
@@ -1600,6 +3519,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::CompleteFill {
                     price: Usd::new(float!(150.25)),
+                    filled_at: Utc::now(),
                 },
             )
             .await
@@ -1614,7 +3534,7 @@ mod tests {
         // Process-isolated under nextest; only this fill is sampled. The default
         // Prometheus summary rendering emits a `_count` series we can assert on.
         let handle = crate::metrics::setup().expect("install Prometheus recorder");
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -1623,6 +3543,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::CompleteFill {
                     price: Usd::new(float!(150.00)),
+                    filled_at: Utc::now(),
                 },
             )
             .await
@@ -1637,7 +3558,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_fill_uninitialized_order() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         let err = store
@@ -1645,6 +3566,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::CompleteFill {
                     price: Usd::new(float!(150.00)),
+                    filled_at: Utc::now(),
                 },
             )
             .await
@@ -1657,7 +3579,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_fill_already_filled() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -1666,6 +3588,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::CompleteFill {
                     price: Usd::new(float!(150.00)),
+                    filled_at: Utc::now(),
                 },
             )
             .await
@@ -1676,6 +3599,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::CompleteFill {
                     price: Usd::new(float!(150.00)),
+                    filled_at: Utc::now(),
                 },
             )
             .await
@@ -1688,7 +3612,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_failed_from_submitted() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -1697,6 +3621,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "Insufficient funds".to_string(),
+                    failed_at: Utc::now(),
                 },
             )
             .await
@@ -1708,7 +3633,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_failed_from_partially_filled() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -1718,6 +3643,7 @@ mod tests {
                 OffchainOrderCommand::UpdatePartialFill {
                     shares_filled: FractionalShares::new(float!(50)),
                     avg_price: Usd::new(float!(150.00)),
+                    partially_filled_at: Utc::now(),
                 },
             )
             .await
@@ -1727,18 +3653,33 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "Order cancelled".to_string(),
+                    failed_at: Utc::now(),
                 },
             )
             .await
             .unwrap();
 
         let inner = store.load(&id).await.unwrap().unwrap();
-        assert!(matches!(inner, OffchainOrder::Failed { .. }));
+        assert!(
+            matches!(
+                inner,
+                OffchainOrder::Failed {
+                    retained_fill:
+                        Some(RetainedFill::Priced {
+                            shares_filled,
+                            ..
+                        }),
+                    executor_order_id: Some(_),
+                    ..
+                } if shares_filled == FractionalShares::new(float!(50))
+            ),
+            "Failed order must retain partial-fill metadata for retry recovery, got: {inner:?}"
+        );
     }
 
     #[tokio::test]
     async fn mark_placement_failed_fails_a_pending_order() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         // The placement path's broker call errored while the order was still
@@ -1760,7 +3701,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_placement_failed_leaves_a_live_order_untouched() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         // A stale placement attempt's broker error must never fail a live order a
@@ -1790,7 +3731,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_fail_already_filled() {
-        let store = TestStore::<OffchainOrder>::new(());
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -1799,6 +3740,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::CompleteFill {
                     price: Usd::new(float!(150.00)),
+                    filled_at: Utc::now(),
                 },
             )
             .await
@@ -1809,6 +3751,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "Test error".to_string(),
+                    failed_at: Utc::now(),
                 },
             )
             .await
@@ -1817,6 +3760,1411 @@ mod tests {
             err,
             AggregateError::UserError(LifecycleError::Apply(OffchainOrderError::AlreadyCompleted))
         ));
+    }
+
+    #[tokio::test]
+    async fn cancel_order_from_submitted_transitions_to_cancelling() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                inner,
+                OffchainOrder::Cancelling {
+                    reason: CancellationReason::MarketOpenReplacement,
+                    ..
+                }
+            ),
+            "Expected Cancelling with MarketOpenReplacement reason, got: {inner:?}"
+        );
+    }
+
+    /// Builds a placer whose `get_order_status` reports the given broker
+    /// partial fill, so cancel-path tests can exercise `reconcile_pre_cancel`
+    /// against a locally recorded quantity.
+    fn broker_partial_fill_placer(
+        broker_shares_filled: rain_math_float::Float,
+        broker_partially_filled_at: DateTime<Utc>,
+    ) -> Arc<dyn OrderPlacer> {
+        struct Placer {
+            broker_shares_filled: rain_math_float::Float,
+            broker_partially_filled_at: DateTime<Utc>,
+        }
+
+        #[async_trait]
+        impl OrderPlacer for Placer {
+            async fn place_market_order(
+                &self,
+                order: MarketOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(OrderPlacementResult {
+                    executor_order_id: ExecutorOrderId::new("ORD-OK"),
+                    placed_shares: noop_placed_shares(order.shares),
+                    is_extended_hours: false,
+                    limit_price: None,
+                })
+            }
+
+            async fn place_limit_order(
+                &self,
+                _order: LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                unimplemented!()
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &ExecutorOrderId,
+            ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(CancellationOutcome::Requested)
+            }
+
+            async fn get_order_status(
+                &self,
+                _executor_order_id: &ExecutorOrderId,
+            ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::OrderState::PartiallyFilled {
+                    order_id: ExecutorOrderId::new("ORD-OK"),
+                    shares_filled: FractionalShares::new(self.broker_shares_filled),
+                    avg_price: Some(Usd::new(st0x_float_macro::float!(155.0))),
+                    partially_filled_at: self.broker_partially_filled_at,
+                })
+            }
+        }
+
+        Arc::new(Placer {
+            broker_shares_filled,
+            broker_partially_filled_at,
+        })
+    }
+
+    /// At cancel time the broker reports MORE cumulative fills (60) than the
+    /// local PartiallyFilled state records (50): `reconcile_pre_cancel` must
+    /// apply the newer broker fill (with the broker's fill timestamp) before
+    /// transitioning to Cancelling, otherwise the extra 10 shares are dropped
+    /// and double-hedged by the next scan.
+    #[tokio::test]
+    async fn cancel_order_from_partially_filled_reconciles_newer_broker_fill() {
+        let broker_partially_filled_at = Utc::now() - chrono::Duration::minutes(2);
+        let store = TestStore::<OffchainOrder>::new(broker_partial_fill_placer(
+            float!(60),
+            broker_partially_filled_at,
+        ));
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(50)),
+                    avg_price: Usd::new(float!(150.0)),
+                    partially_filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                inner,
+                OffchainOrder::Cancelling {
+                    reason: CancellationReason::MarketOpenReplacement,
+                    retained_fill:
+                        Some(RetainedFill::Priced {
+                            shares_filled,
+                            partially_filled_at: fill_time,
+                            ..
+                        }),
+                    ..
+                } if shares_filled == FractionalShares::new(float!(60))
+                    && fill_time == broker_partially_filled_at
+            ),
+            "Expected Cancelling with the reconciled 60-share broker fill and \
+             its broker timestamp, got: {inner:?}"
+        );
+    }
+
+    /// At cancel time the broker reports FEWER cumulative fills (30) than the
+    /// local PartiallyFilled state records (50) -- a stale broker read.
+    /// `reconcile_pre_cancel` must not regress the recorded quantity: the
+    /// order proceeds to Cancelling carrying the local 50-share fill.
+    #[tokio::test]
+    async fn cancel_order_from_partially_filled_skips_stale_broker_fill() {
+        let store =
+            TestStore::<OffchainOrder>::new(broker_partial_fill_placer(float!(30), Utc::now()));
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(50)),
+                    avg_price: Usd::new(float!(150.0)),
+                    partially_filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                inner,
+                OffchainOrder::Cancelling {
+                    reason: CancellationReason::MarketOpenReplacement,
+                    retained_fill:
+                        Some(RetainedFill::Priced {
+                            shares_filled,
+                            ..
+                        }),
+                    ..
+                } if shares_filled == FractionalShares::new(float!(50))
+            ),
+            "Expected Cancelling preserving the local 50-share fill against \
+             the stale 30-share broker read, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_cancellation_transitions_cancelling_to_cancelled() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::ConfirmCancellation {
+                    cancelled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                inner,
+                OffchainOrder::Cancelled {
+                    reason: CancellationReason::MarketOpenReplacement,
+                    ..
+                }
+            ),
+            "Expected confirmed cancellation to become terminal Cancelled, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_short_circuits_already_cancelled_zero_fill_without_avg_price() {
+        fn already_cancelled_zero_fill_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-CANCELLED"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    panic!("cancel_order must not be called when broker already reports Cancelled");
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(st0x_execution::OrderState::Cancelled {
+                        order_id: ExecutorOrderId::new("ORD-CANCELLED"),
+                        cancelled_at: Utc::now(),
+                        shares_filled: FractionalShares::ZERO,
+                        avg_price: None,
+                    })
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(already_cancelled_zero_fill_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(inner, OffchainOrder::Cancelled { .. }),
+            "Zero-fill broker cancellation without avg_price must become terminal Cancelled, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_records_priced_fill_from_terminal_cancelled_status() {
+        fn already_cancelled_priced_fill_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-CANCELLED-PRICED"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    panic!("cancel_order must not be called when broker already reports Cancelled");
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<OrderState, Box<dyn std::error::Error + Send + Sync>> {
+                    Ok(OrderState::Cancelled {
+                        order_id: ExecutorOrderId::new("ORD-CANCELLED-PRICED"),
+                        cancelled_at: Utc::now(),
+                        shares_filled: FractionalShares::new(float!(50)),
+                        avg_price: Some(Usd::new(float!(150.0))),
+                    })
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(already_cancelled_priced_fill_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                inner,
+                OffchainOrder::Cancelled {
+                    retained_fill:
+                        Some(RetainedFill::Priced {
+                            shares_filled,
+                            avg_price,
+                            ..
+                        }),
+                    ..
+                } if shares_filled == FractionalShares::new(float!(50))
+                    && avg_price == Usd::new(float!(150.0))
+            ),
+            "Terminal Cancelled status with a priced fill must retain that fill, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_propagates_broker_error_and_leaves_state_unchanged() {
+        // Critical safety invariant: when the broker DELETE fails, the
+        // aggregate MUST stay in Submitted so the caller can retry.
+        // Emitting Cancelled on broker error would let a still-live broker
+        // order coexist with a replacement, causing duplicate hedges.
+        fn cancel_failing_placer() -> Arc<dyn OrderPlacer> {
+            struct CancelFailing;
+
+            #[async_trait]
+            impl OrderPlacer for CancelFailing {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-OK"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Err("simulated broker DELETE failure".into())
+                }
+
+                async fn get_order_status(
+                    &self,
+                    executor_order_id: &ExecutorOrderId,
+                ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    // Order still live -> pre-cancel reconciliation is a no-op,
+                    // so the flow reaches the failing DELETE under test.
+                    Ok(st0x_execution::OrderState::Submitted {
+                        order_id: executor_order_id.clone(),
+                    })
+                }
+            }
+
+            Arc::new(CancelFailing)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(cancel_failing_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    OffchainOrderError::CancelFailed { .. }
+                ))
+            ),
+            "Expected CancelFailed, got: {err:?}"
+        );
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(inner, OffchainOrder::Submitted { .. }),
+            "Aggregate MUST stay Submitted on broker cancel failure, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_resolves_terminal_cancelled_when_broker_does_not_know_order() {
+        // The DELETE can 404 if the broker purged the order between the
+        // pre-cancel status read and the cancel. Entering Cancelling would
+        // strand the order forever: the status poll also 404s (as an error,
+        // never a cancellation confirmation) and CancelOrder on Cancelling is
+        // a no-op. The aggregate must resolve terminally instead.
+        fn order_not_found_placer() -> Arc<dyn OrderPlacer> {
+            struct OrderGone;
+
+            #[async_trait]
+            impl OrderPlacer for OrderGone {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-GONE"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(CancellationOutcome::OrderNotFound)
+                }
+
+                async fn get_order_status(
+                    &self,
+                    executor_order_id: &ExecutorOrderId,
+                ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    // Order still live at the pre-cancel read; it vanishes
+                    // only when the DELETE runs.
+                    Ok(st0x_execution::OrderState::Submitted {
+                        order_id: executor_order_id.clone(),
+                    })
+                }
+            }
+
+            Arc::new(OrderGone)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(order_not_found_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                inner,
+                OffchainOrder::Cancelled {
+                    reason: CancellationReason::MarketOpenReplacement,
+                    ..
+                }
+            ),
+            "Broker-side 404 on cancel must resolve to terminal Cancelled \
+             (not strand the order in Cancelling), got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_on_pending_returns_not_submitted() {
+        // A genuinely `Pending` order: placed locally but not yet acknowledged
+        // by the broker. CancelOrder must reject (`NotSubmitted`) so we never
+        // issue a DELETE for an id the broker never returned. Construct the
+        // state directly because the command path (Place) always drives the
+        // order to Submitted or Failed, never leaving it Pending.
+        let pending = OffchainOrder::Pending {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
+            direction: Direction::Buy,
+            executor: SupportedExecutor::DryRun,
+            placed_at: Utc::now(),
+            market_session: MarketSession::Regular,
+        };
+
+        let err = pending
+            .transition(
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+                &noop_order_placer(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, OffchainOrderError::NotSubmitted),
+            "Expected NotSubmitted from cancel on Pending, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_on_failed_returns_already_completed() {
+        // failing_order_placer drives the aggregate straight to Failed; cancel
+        // on a terminal state must reject with AlreadyCompleted.
+        let store = TestStore::<OffchainOrder>::new(failing_order_placer());
+        let id = OffchainOrderId::new();
+        store.send(&id, place_command()).await.unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkPlacementFailed {
+                    error: "placement failed".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    OffchainOrderError::AlreadyCompleted
+                ))
+            ),
+            "Expected AlreadyCompleted from cancel on Failed, got: {err:?}"
+        );
+    }
+
+    /// Events persisted before this PR lack the new `Placed` fields
+    /// (`is_extended_hours` / `limit_price` / `client_order_id`). Replaying
+    /// such a legacy stream through the real `EventSourced` machinery -- the
+    /// path startup recovery takes for orders that predate the schema change
+    /// -- must still produce the correct terminal `Failed` aggregate with no
+    /// fabricated fill data.
+    #[test]
+    fn legacy_event_stream_replays_to_failed_without_fill_data() {
+        let failed_at = Utc::now();
+        let placed = OffchainOrderEvent::Placed {
+            symbol: Symbol::new("TSLA").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            placed_at: Utc::now(),
+            is_extended_hours: false,
+            limit_price: None,
+            client_order_id: None,
+        };
+
+        // Strip the post-upgrade keys to reconstruct the exact payload shape
+        // a pre-upgrade deployment persisted.
+        let mut placed_value = serde_json::to_value(&placed).unwrap();
+        let placed_object = placed_value
+            .get_mut("Placed")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("Placed variant serializes as an object");
+        placed_object.remove("is_extended_hours");
+        placed_object.remove("limit_price");
+        placed_object.remove("client_order_id");
+
+        let legacy_events: Vec<OffchainOrderEvent> = [
+            placed_value,
+            serde_json::to_value(OffchainOrderEvent::Submitted {
+                executor_order_id: ExecutorOrderId::new("broker-123"),
+                submitted_at: Utc::now(),
+            })
+            .unwrap(),
+            serde_json::to_value(OffchainOrderEvent::Failed {
+                error: "broker rejected".to_string(),
+                failed_at,
+            })
+            .unwrap(),
+        ]
+        .into_iter()
+        .map(|value| serde_json::from_value(value).unwrap())
+        .collect();
+
+        let replayed = replay::<OffchainOrder>(legacy_events)
+            .unwrap()
+            .expect("legacy stream must replay to a live aggregate");
+
+        let OffchainOrder::Failed {
+            symbol,
+            retained_fill,
+            executor_order_id,
+            error,
+            failed_at: replayed_failed_at,
+            ..
+        } = replayed
+        else {
+            panic!("expected Failed, got {replayed:?}");
+        };
+        assert_eq!(symbol, Symbol::new("TSLA").unwrap());
+        // No partial fill was ever recorded, so recovery must see no fill to
+        // apply -- fabricating one here would corrupt the position.
+        assert_eq!(retained_fill, None);
+        assert_eq!(
+            executor_order_id,
+            Some(ExecutorOrderId::new("broker-123")),
+            "Failed must retain the broker order id from the Submitted event"
+        );
+        assert_eq!(error, "broker rejected");
+        assert_eq!(replayed_failed_at, failed_at);
+    }
+
+    #[tokio::test]
+    async fn cancel_order_on_filled_returns_already_completed() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CompleteFill {
+                    price: Usd::new(float!(150.0)),
+                    filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            AggregateError::UserError(LifecycleError::Apply(OffchainOrderError::AlreadyCompleted))
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancel_order_reconciles_partial_fill_before_cancelling() {
+        // Critical correctness: if the broker reports a partial fill that
+        // the local aggregate doesn't know about yet, CancelOrder must
+        // emit PartiallyFilled BEFORE Cancelled, otherwise the partial
+        // fill is silently dropped and the position double-hedges.
+        fn partial_fill_reconciling_placer() -> Arc<dyn OrderPlacer> {
+            struct PartialFillPlacer;
+
+            #[async_trait]
+            impl OrderPlacer for PartialFillPlacer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-OK"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(CancellationOutcome::Requested)
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    // Broker reports 50 shares filled at $150 -- a partial
+                    // fill the local aggregate doesn't know about.
+                    Ok(st0x_execution::OrderState::PartiallyFilled {
+                        order_id: ExecutorOrderId::new("ORD-OK"),
+                        shares_filled: FractionalShares::new(float!(50)),
+                        avg_price: Some(Usd::new(float!(150.0))),
+                        partially_filled_at: Utc::now(),
+                    })
+                }
+            }
+
+            Arc::new(PartialFillPlacer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(partial_fill_reconciling_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        // Must be Cancelling, but the partial-fill event should have been
+        // emitted en route so the eventual terminal cancellation can
+        // finalize the partial fill correctly.
+        assert!(
+            matches!(
+                inner,
+                OffchainOrder::Cancelling {
+                    retained_fill:
+                        Some(RetainedFill::Priced {
+                            shares_filled,
+                            ..
+                        }),
+                    ..
+                } if shares_filled == FractionalShares::new(float!(50))
+            ),
+            "Expected Cancelling with reconciled partial fill, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_blocks_when_broker_failed_with_unpriced_fill() {
+        // If the broker reports the order Failed with filled shares but no
+        // avg_price at cancel time, CancelOrder must NOT emit a bare Failed
+        // (which would clear the position via FailOffChainOrder and silently
+        // drop the filled shares -> the next scan double-hedges them). It must
+        // propagate PreCancelPartialFillMissingAvgPrice so the cancel is
+        // retried once the broker returns a priced fill, leaving the aggregate
+        // in its prior Submitted state. Mirrors the Cancelled-arm guard.
+        fn failed_unpriced_fill_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-OK"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(CancellationOutcome::Requested)
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    // Broker reports a Failed order carrying 50 filled shares
+                    // but no avg_price -- we cannot price the fill.
+                    Ok(st0x_execution::OrderState::Failed {
+                        failed_at: Utc::now(),
+                        error_reason: Some("broker failed".to_string()),
+                        shares_filled: Some(FractionalShares::new(float!(50))),
+                        avg_price: None,
+                    })
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(failed_unpriced_fill_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    OffchainOrderError::PreCancelPartialFillMissingAvgPrice { .. }
+                ))
+            ),
+            "Expected PreCancelPartialFillMissingAvgPrice, got: {err:?}"
+        );
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(inner, OffchainOrder::Submitted { .. }),
+            "Aggregate MUST stay Submitted so the unpriced fill is not dropped, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_blocks_when_broker_cancelled_with_unpriced_fill() {
+        // The Cancelled-arm twin of the Failed-arm guard above: a broker
+        // Cancelled carrying a positive fill without an avg_price must block
+        // (PreCancelPartialFillMissingAvgPrice) rather than emit a bare
+        // Cancelled that clears the position and drops the filled shares.
+        fn cancelled_unpriced_fill_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-OK"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    panic!("cancel_order must not be called when broker already reports Cancelled");
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    // Broker reports an already-Cancelled order carrying 50
+                    // filled shares but no avg_price -- we cannot price the
+                    // fill, so the cancellation must not finalize yet.
+                    Ok(st0x_execution::OrderState::Cancelled {
+                        order_id: ExecutorOrderId::new("ORD-OK"),
+                        cancelled_at: Utc::now(),
+                        shares_filled: FractionalShares::new(float!(50)),
+                        avg_price: None,
+                    })
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(cancelled_unpriced_fill_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    OffchainOrderError::PreCancelPartialFillMissingAvgPrice { .. }
+                ))
+            ),
+            "Expected PreCancelPartialFillMissingAvgPrice, got: {err:?}"
+        );
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(inner, OffchainOrder::Submitted { .. }),
+            "Aggregate MUST stay Submitted so the unpriced fill is not dropped, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_blocks_when_broker_partially_filled_with_unpriced_fill() {
+        // The live-order twin of the terminal guards above: a broker
+        // PartiallyFilled carrying a positive fill without an avg_price at
+        // cancel time cannot be recorded, so the cancel must block with
+        // PreCancelPartialFillMissingAvgPrice BEFORE any DELETE is issued --
+        // proceeding would drop the fill when the order later cancels.
+        fn partially_filled_unpriced_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-OK"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    panic!("cancel_order must not run when the unpriced fill cannot be recorded");
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<OrderState, Box<dyn std::error::Error + Send + Sync>> {
+                    Ok(OrderState::PartiallyFilled {
+                        order_id: ExecutorOrderId::new("ORD-OK"),
+                        shares_filled: FractionalShares::new(float!(50)),
+                        avg_price: None,
+                        partially_filled_at: Utc::now(),
+                    })
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(partially_filled_unpriced_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    OffchainOrderError::PreCancelPartialFillMissingAvgPrice { .. }
+                ))
+            ),
+            "Expected PreCancelPartialFillMissingAvgPrice, got: {err:?}"
+        );
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(inner, OffchainOrder::Submitted { .. }),
+            "Aggregate MUST stay Submitted so the unpriced fill is not dropped, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_proceeds_when_unpriced_terminal_fill_is_covered_locally() {
+        // An unpriced broker terminal fill must NOT block the cancel when the
+        // local aggregate already recorded an equal priced fill: the broker
+        // report carries no new information, so the cancellation finalizes
+        // with the locally retained fill instead of retrying forever.
+        fn cancelled_covered_fill_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-OK"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    panic!("cancel_order must not be called when broker already reports Cancelled");
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<OrderState, Box<dyn std::error::Error + Send + Sync>> {
+                    // Same 50 shares the local aggregate already holds priced,
+                    // but the broker response omits the price.
+                    Ok(OrderState::Cancelled {
+                        order_id: ExecutorOrderId::new("ORD-OK"),
+                        cancelled_at: Utc::now(),
+                        shares_filled: FractionalShares::new(float!(50)),
+                        avg_price: None,
+                    })
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(cancelled_covered_fill_placer());
+        let id = OffchainOrderId::new();
+        let fill_time = Utc::now();
+        place_and_submit(&store, &id).await;
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(50)),
+                    avg_price: Usd::new(float!(195.25)),
+                    partially_filled_at: fill_time,
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        let OffchainOrder::Cancelled { retained_fill, .. } = inner else {
+            panic!("expected the cancellation to finalize, got: {inner:?}");
+        };
+        assert_eq!(
+            retained_fill,
+            Some(RetainedFill::priced(
+                FractionalShares::new(float!(50)),
+                Usd::new(float!(195.25)),
+                fill_time
+            )),
+            "the locally recorded priced fill must be retained"
+        );
+    }
+
+    /// The fail-closed contract of `reconcile_pre_cancel`: when the pre-cancel
+    /// broker read fails, CancelOrder must propagate
+    /// `PreCancelStatusFetchFailed` and leave the aggregate untouched (no
+    /// DELETE issued) so the cancel retries instead of proceeding blind and
+    /// potentially dropping a fill the broker just reported. The float
+    /// comparison inside the same function shares this contract via `?`
+    /// propagation (`FillComparisonFailed`); comparisons over real `Float`
+    /// values are total, so the status fetch is the injectable failure seam.
+    #[tokio::test]
+    async fn cancel_order_blocks_when_pre_cancel_status_fetch_fails() {
+        fn status_fetch_failing_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-OK"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    panic!("cancel_order must not be called when the pre-cancel read failed");
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Err("simulated status API outage".into())
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(status_fetch_failing_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    OffchainOrderError::PreCancelStatusFetchFailed { .. }
+                ))
+            ),
+            "Expected PreCancelStatusFetchFailed, got: {err:?}"
+        );
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(inner, OffchainOrder::Submitted { .. }),
+            "Aggregate MUST stay Submitted when the pre-cancel read fails, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_short_circuits_to_filled_if_broker_already_filled() {
+        // If the order completes at the broker between our last poll and
+        // the cancel attempt, we must emit Filled (not Cancelled) and
+        // NOT call DELETE -- the order is already terminal at the broker.
+        fn already_filled_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-OK"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    panic!("cancel_order must not be called when broker reports Filled");
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(st0x_execution::OrderState::Filled {
+                        order_id: ExecutorOrderId::new("ORD-OK"),
+                        price: Usd::new(float!(150.0)),
+                        executed_at: Utc::now(),
+                    })
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(already_filled_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(inner, OffchainOrder::Filled { .. }),
+            "Cancel-then-broker-Filled must short-circuit to Filled, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_on_already_cancelling_is_idempotent_noop() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(inner, OffchainOrder::Cancelling { .. }),
+            "Duplicate cancel requests should leave order Cancelling, got: {inner:?}"
+        );
     }
 
     #[test]
@@ -1904,5 +5252,344 @@ mod tests {
                 "payload {payload} should produce status {expected_status:?}"
             );
         }
+    }
+
+    // FIX 3: ConfirmCancellation on a non-Cancelling state must return CancellationNotRequested.
+    #[tokio::test]
+    async fn confirm_cancellation_on_submitted_returns_cancellation_not_requested() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let id = OffchainOrderId::new();
+
+        store.send(&id, place_command()).await.unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("TEST-SUBMITTED"),
+                    placed_shares: noop_placed_shares(
+                        Positive::new(FractionalShares::new(float!(100))).unwrap(),
+                    ),
+                    submitted_at: Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::ConfirmCancellation {
+                    cancelled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    OffchainOrderError::CancellationNotRequested
+                ))
+            ),
+            "ConfirmCancellation on Submitted order must return CancellationNotRequested, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_returns_invalid_terminal_fill_quantity_for_negative_broker_fill() {
+        fn negative_fill_cancelled_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-NEG-FILL"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    panic!("cancel_order must not be called when broker already reports Cancelled");
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    // Broker reports Cancelled with a negative fill quantity:
+                    // a corrupt value that reconcile_terminal_fill must reject.
+                    Ok(st0x_execution::OrderState::Cancelled {
+                        order_id: ExecutorOrderId::new("ORD-NEG-FILL"),
+                        cancelled_at: Utc::now(),
+                        shares_filled: FractionalShares::new(float!(-1)),
+                        avg_price: Some(Usd::new(float!(150.0))),
+                    })
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(negative_fill_cancelled_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    OffchainOrderError::InvalidTerminalFillQuantity { .. }
+                ))
+            ),
+            "Negative broker fill quantity must return InvalidTerminalFillQuantity, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_rejects_negative_unpriced_terminal_fill() {
+        fn negative_unpriced_cancelled_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-NEG-UNPRICED"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    panic!("cancel_order must not be called when broker already reports Cancelled");
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<OrderState, Box<dyn std::error::Error + Send + Sync>> {
+                    Ok(OrderState::Cancelled {
+                        order_id: ExecutorOrderId::new("ORD-NEG-UNPRICED"),
+                        cancelled_at: Utc::now(),
+                        shares_filled: FractionalShares::new(float!(-1)),
+                        avg_price: None,
+                    })
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(negative_unpriced_cancelled_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    OffchainOrderError::InvalidTerminalFillQuantity { .. }
+                ))
+            ),
+            "Negative unpriced broker fill must return InvalidTerminalFillQuantity, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_rejects_negative_pre_cancel_partial_fill() {
+        fn negative_partial_fill_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-NEG-PARTIAL"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    panic!("cancel_order must not run after a corrupt pre-cancel fill");
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<OrderState, Box<dyn std::error::Error + Send + Sync>> {
+                    Ok(OrderState::PartiallyFilled {
+                        order_id: ExecutorOrderId::new("ORD-NEG-PARTIAL"),
+                        shares_filled: FractionalShares::new(float!(-1)),
+                        avg_price: Some(Usd::new(float!(150.0))),
+                        partially_filled_at: Utc::now(),
+                    })
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(negative_partial_fill_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    OffchainOrderError::InvalidTerminalFillQuantity { .. }
+                ))
+            ),
+            "Negative pre-cancel partial fill must return InvalidTerminalFillQuantity, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_failed_on_cancelling_retains_partial_fill_metadata() {
+        let partially_filled_at = Utc::now() - chrono::Duration::minutes(5);
+        // Broker reports the same 50-share fill as the local state (stale read);
+        // pre-cancel reconciliation skips the update and the order reaches
+        // Cancelling carrying the locally-recorded fill.
+        let store = TestStore::<OffchainOrder>::new(broker_partial_fill_placer(
+            float!(50),
+            partially_filled_at,
+        ));
+        let id = OffchainOrderId::new();
+
+        place_and_submit(&store, &id).await;
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(50)),
+                    avg_price: Usd::new(float!(150.0)),
+                    partially_filled_at,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkFailed {
+                    error: "Extended hours session expired".to_string(),
+                    failed_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                inner,
+                OffchainOrder::Failed {
+                    retained_fill:
+                        Some(RetainedFill::Priced {
+                            shares_filled,
+                            ..
+                        }),
+                    ..
+                } if shares_filled == FractionalShares::new(float!(50))
+            ),
+            "MarkFailed on Cancelling must retain partial-fill metadata, got: {inner:?}"
+        );
     }
 }

--- a/src/offchain/order/handle_rejection.rs
+++ b/src/offchain/order/handle_rejection.rs
@@ -13,13 +13,14 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use st0x_dto::Direction;
 use st0x_event_sorcery::Store;
-use st0x_execution::{ExecutorOrderId, FractionalShares, NotPositive, Positive, Symbol};
-use st0x_finance::Usd;
+use st0x_execution::{Direction, ExecutorOrderId, FractionalShares, Positive};
 
 use crate::conductor::job::{Job, JobQueue, Label};
-use crate::offchain::order::{JobError, OffchainOrder, OffchainOrderCommand, OffchainOrderId};
+use crate::offchain::order::{
+    JobError, NoFillOutcome, OffchainOrder, OffchainOrderCommand, OffchainOrderId, RetainedFill,
+    TerminalPositionFinalization, terminal_position_finalization,
+};
 use crate::position::{Position, PositionCommand};
 
 pub(crate) type HandleOrderRejectionJobQueue = JobQueue<HandleOrderRejection>;
@@ -35,14 +36,13 @@ pub(crate) struct HandleOrderRejectionCtx {
 pub(crate) struct HandleOrderRejection {
     pub(crate) offchain_order_id: OffchainOrderId,
     pub(crate) error: String,
-}
-
-struct RetainedPartialFill {
-    shares_filled: Positive<FractionalShares>,
-    direction: Direction,
-    executor_order_id: ExecutorOrderId,
-    price: Usd,
-    broker_timestamp: DateTime<Utc>,
+    /// Broker-reported failure time, when the enqueuing poll observed a
+    /// broker `Failed` state. `None` when the rejection has no broker
+    /// timestamp (the job then stamps its own observation time).
+    /// `#[serde(default)]` so jobs queued before this field existed still
+    /// deserialize.
+    #[serde(default)]
+    pub(crate) broker_failed_at: Option<DateTime<Utc>>,
 }
 
 impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
@@ -69,30 +69,15 @@ impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
         };
 
         let symbol = order.symbol().clone();
-        let retained_partial_fill =
-            retained_partial_fill(&order)
-                .transpose()
-                .map_err(|source| JobError::InvalidPartialFill {
-                    offchain_order_id: self.offchain_order_id,
-                    source,
-                })?;
-
-        if let Some(fill) = &retained_partial_fill {
-            self.complete_position_for_partial_fill(ctx, &symbol, fill)
-                .await?;
-        }
-
-        // Retry-safe for no-fill rejections: the two writes (OffchainOrder
-        // MarkFailed + Position FailOffChainOrder) are not atomic. If a prior
-        // attempt completed step 1 but failed step 2, apalis re-runs us with
-        // the order already in `Failed`. Re-sending `MarkFailed` would surface
-        // `AlreadyCompleted` and stall the job forever, so we only run step 1
-        // when the order has not yet been marked failed.
-        //
-        // For retained partial fills, the position update runs first so a retry
-        // cannot lose the partial-fill quantity by loading an already-Failed
-        // OffchainOrder that no longer carries the partial-fill fields.
-        use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
+        // Retry-safe: the two writes (OffchainOrder MarkFailed +
+        // Position FailOffChainOrder) are not atomic. If a prior attempt
+        // completed step 1 but failed step 2, apalis re-runs us with the
+        // order already in `Failed`. Re-sending `MarkFailed` would surface
+        // `AlreadyCompleted` and stall the job forever, so we only run
+        // step 1 when the order has not yet been marked failed.
+        use OffchainOrder::{
+            Cancelled, Cancelling, Failed, Filled, PartiallyFilled, Pending, Submitted,
+        };
         match &order {
             Failed { .. } => {
                 info!(
@@ -101,12 +86,16 @@ impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
                 );
             }
 
-            Pending { .. } | Submitted { .. } | PartiallyFilled { .. } => {
+            Pending { .. } | Submitted { .. } | PartiallyFilled { .. } | Cancelling { .. } => {
                 ctx.offchain_order
                     .send(
                         &self.offchain_order_id,
                         OffchainOrderCommand::MarkFailed {
                             error: self.error.clone(),
+                            // Prefer the broker's failure time; rejections
+                            // without one (e.g. cleanup paths) fall back to
+                            // this job's observation time.
+                            failed_at: self.broker_failed_at.unwrap_or_else(Utc::now),
                         },
                     )
                     .await?;
@@ -119,10 +108,13 @@ impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
                 );
                 return Ok(());
             }
-        }
 
-        if retained_partial_fill.is_some() {
-            return Ok(());
+            Cancelled { .. } => {
+                info!(
+                    offchain_order_id = %self.offchain_order_id,
+                    "HandleOrderRejection: order already Cancelled -- skipping MarkFailed, resuming position update"
+                );
+            }
         }
 
         // Retry-safe step 2: if a prior attempt or the startup recovery
@@ -143,86 +135,139 @@ impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
             return Ok(());
         }
 
-        ctx.position
-            .send(
-                &symbol,
-                PositionCommand::FailOffChainOrder {
-                    offchain_order_id: self.offchain_order_id,
-                    error: self.error.clone(),
-                },
-            )
-            .await?;
+        // `broker_timestamp` must be the broker event time the matched state
+        // recorded, not the wall-clock time this recovery job happens to run --
+        // it flows into `Position.last_updated` and any recency/ordering logic
+        // keyed off it. Each state carries its own broker timestamp.
+        let position_command = match &order {
+            PartiallyFilled {
+                shares_filled,
+                direction,
+                executor_order_id,
+                avg_price,
+                partially_filled_at,
+                ..
+            }
+            | Cancelling {
+                retained_fill:
+                    Some(RetainedFill::Priced {
+                        shares_filled,
+                        avg_price,
+                        partially_filled_at,
+                    }),
+                direction,
+                executor_order_id,
+                ..
+            }
+            | Failed {
+                retained_fill:
+                    Some(RetainedFill::Priced {
+                        shares_filled,
+                        avg_price,
+                        partially_filled_at,
+                    }),
+                executor_order_id: Some(executor_order_id),
+                direction,
+                ..
+            } => position_command_for_retained_fill(
+                self.offchain_order_id,
+                *shares_filled,
+                *direction,
+                executor_order_id.clone(),
+                *avg_price,
+                *partially_filled_at,
+                self.error.clone(),
+            ),
+
+            // A locally-`Cancelled` order is already terminal and must NOT be
+            // recorded as a broker failure: that would set the failure /
+            // idempotency anchor for an intentional cancellation and drop any
+            // partial fill it retained. Route through the shared terminal
+            // finalization so this mapping cannot drift from the recovery and
+            // cancel-and-replace paths.
+            cancelled @ Cancelled { .. } => {
+                match terminal_position_finalization(cancelled) {
+                    Some(TerminalPositionFinalization::Complete {
+                        shares_filled,
+                        direction,
+                        executor_order_id,
+                        price,
+                        broker_timestamp,
+                    }) => PositionCommand::CompleteOffChainOrder {
+                        offchain_order_id: self.offchain_order_id,
+                        shares_filled,
+                        direction,
+                        executor_order_id,
+                        price,
+                        broker_timestamp,
+                    },
+                    // Zero-fill cancellation: release the slot without the
+                    // failure anchor.
+                    Some(TerminalPositionFinalization::NoFill(NoFillOutcome::Cancelled {
+                        reason,
+                        cancelled_at,
+                    })) => PositionCommand::CancelOffChainOrder {
+                        offchain_order_id: self.offchain_order_id,
+                        reason,
+                        cancelled_at,
+                    },
+                    // A Cancelled order always classifies as the Cancelled
+                    // outcome, so a Failed outcome cannot occur here; a
+                    // positive fill with no price cannot be applied. Both fail
+                    // so the slot is released rather than left pending forever.
+                    Some(
+                        TerminalPositionFinalization::NoFill(NoFillOutcome::Failed { .. })
+                        | TerminalPositionFinalization::UnpricedFill { .. },
+                    )
+                    | None => PositionCommand::FailOffChainOrder {
+                        offchain_order_id: self.offchain_order_id,
+                        error: self.error.clone(),
+                    },
+                }
+            }
+
+            Pending { .. }
+            | Submitted { .. }
+            | Cancelling { .. }
+            | Failed {
+                executor_order_id: None,
+                ..
+            }
+            | Failed { .. } => PositionCommand::FailOffChainOrder {
+                offchain_order_id: self.offchain_order_id,
+                error: self.error.clone(),
+            },
+            Filled { .. } => unreachable!("filled orders return before position update"),
+        };
+
+        ctx.position.send(&symbol, position_command).await?;
 
         Ok(())
     }
 }
 
-impl HandleOrderRejection {
-    async fn complete_position_for_partial_fill(
-        &self,
-        ctx: &HandleOrderRejectionCtx,
-        symbol: &Symbol,
-        fill: &RetainedPartialFill,
-    ) -> Result<(), JobError> {
-        let position_pending = ctx
-            .position
-            .load(symbol)
-            .await?
-            .and_then(|position| position.pending_offchain_order_id);
-        if position_pending != Some(self.offchain_order_id) {
-            info!(
-                offchain_order_id = %self.offchain_order_id,
-                ?position_pending,
-                "HandleOrderRejection: position no longer expecting this partial fill, skipping"
-            );
-            return Ok(());
-        }
-
-        ctx.position
-            .send(
-                symbol,
-                PositionCommand::CompleteOffChainOrder {
-                    offchain_order_id: self.offchain_order_id,
-                    shares_filled: fill.shares_filled,
-                    direction: fill.direction,
-                    executor_order_id: fill.executor_order_id.clone(),
-                    price: fill.price,
-                    broker_timestamp: fill.broker_timestamp,
-                },
-            )
-            .await?;
-
-        Ok(())
-    }
-}
-
-fn retained_partial_fill(
-    order: &OffchainOrder,
-) -> Option<Result<RetainedPartialFill, NotPositive<FractionalShares>>> {
-    let OffchainOrder::PartiallyFilled {
-        shares_filled,
-        direction,
-        executor_order_id,
-        avg_price,
-        partially_filled_at,
-        ..
-    } = order
-    else {
-        return None;
-    };
-
-    if *shares_filled == FractionalShares::ZERO {
-        return None;
-    }
-
-    Some(
-        Positive::new(*shares_filled).map(|shares_filled| RetainedPartialFill {
-            shares_filled,
-            direction: *direction,
-            executor_order_id: executor_order_id.clone(),
-            price: *avg_price,
-            broker_timestamp: *partially_filled_at,
-        }),
+fn position_command_for_retained_fill(
+    offchain_order_id: OffchainOrderId,
+    shares_filled: FractionalShares,
+    direction: Direction,
+    executor_order_id: ExecutorOrderId,
+    avg_price: st0x_finance::Usd,
+    broker_timestamp: chrono::DateTime<chrono::Utc>,
+    fallback_error: String,
+) -> PositionCommand {
+    Positive::new(shares_filled).map_or_else(
+        |_| PositionCommand::FailOffChainOrder {
+            offchain_order_id,
+            error: fallback_error,
+        },
+        |positive_filled| PositionCommand::CompleteOffChainOrder {
+            offchain_order_id,
+            shares_filled: positive_filled,
+            direction,
+            executor_order_id,
+            price: avg_price,
+            broker_timestamp,
+        },
     )
 }
 
@@ -232,7 +277,11 @@ mod tests {
 
     use st0x_config::ExecutionThreshold;
     use st0x_event_sorcery::StoreBuilder;
-    use st0x_execution::{Direction, FractionalShares, Positive, SupportedExecutor, Symbol};
+    use st0x_execution::{
+        ClientOrderId, Direction, FractionalShares, MarketSession, Positive, SupportedExecutor,
+        Symbol,
+    };
+    use st0x_finance::Usd;
     use st0x_float_macro::float;
 
     use super::*;
@@ -247,7 +296,7 @@ mod tests {
         let pool = setup_test_db().await;
 
         let (offchain_order, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(())
+            .build(crate::offchain::order::noop_order_placer())
             .await
             .unwrap();
 
@@ -326,6 +375,8 @@ mod tests {
                     shares,
                     direction,
                     executor: SupportedExecutor::DryRun,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await
@@ -340,6 +391,8 @@ mod tests {
                     executor_order_id: ExecutorOrderId::new("test-broker-order-id"),
                     placed_shares: shares,
                     submitted_at: Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
                 },
             )
             .await
@@ -361,6 +414,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: error_message.clone(),
+            broker_failed_at: None,
         }
         .perform(&infra.ctx)
         .await
@@ -412,6 +466,7 @@ mod tests {
                 OffchainOrderCommand::UpdatePartialFill {
                     shares_filled: FractionalShares::new(float!(0.75)),
                     avg_price: Usd::new(float!(150.25)),
+                    partially_filled_at: broker_timestamp,
                 },
             )
             .await
@@ -420,6 +475,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: "broker cancelled after partial fill".to_string(),
+            broker_failed_at: None,
         }
         .perform(&infra.ctx)
         .await
@@ -489,6 +545,7 @@ mod tests {
                 &order_id,
                 OffchainOrderCommand::MarkFailed {
                     error: original_error.clone(),
+                    failed_at: Utc::now(),
                 },
             )
             .await
@@ -510,6 +567,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: original_error,
+            broker_failed_at: None,
         }
         .perform(&infra.ctx)
         .await
@@ -525,6 +583,62 @@ mod tests {
         assert_eq!(
             position_after.pending_offchain_order_id, None,
             "Retry must clear the position's pending state by running step 2"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_after_failed_partial_fill_completes_position_fill() {
+        let infra = build_test_infra().await;
+        let symbol = Symbol::new("TSLA").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+
+        infra
+            .ctx
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(1)),
+                    avg_price: st0x_finance::Usd::new(float!(150)),
+                    partially_filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        infra
+            .ctx
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::MarkFailed {
+                    error: "broker failed after partial fill".to_string(),
+                    failed_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        HandleOrderRejection {
+            offchain_order_id: order_id,
+            error: "broker failed after partial fill".to_string(),
+            broker_failed_at: None,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let position_after = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position_after.pending_offchain_order_id, None,
+            "Retry must clear pending by completing the retained partial fill"
         );
     }
 
@@ -545,6 +659,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: error_message.clone(),
+            broker_failed_at: None,
         }
         .perform(&infra.ctx)
         .await
@@ -554,6 +669,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: error_message,
+            broker_failed_at: None,
         }
         .perform(&infra.ctx)
         .await
@@ -569,6 +685,110 @@ mod tests {
         assert_eq!(
             position.pending_offchain_order_id, None,
             "Position must remain cleared after no-op retry"
+        );
+    }
+
+    /// The broker's failure time (carried on the job from the status poll)
+    /// must be the timestamp persisted on the `Failed` event, not the wall
+    /// clock at which this recovery job happens to run.
+    #[tokio::test]
+    async fn rejection_records_broker_failure_time_on_failed_event() {
+        let infra = build_test_infra().await;
+        let symbol = Symbol::new("TSLA").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+
+        let broker_failed_at = Utc::now() - chrono::Duration::hours(2);
+
+        HandleOrderRejection {
+            offchain_order_id: order_id,
+            error: "broker rejected".to_string(),
+            broker_failed_at: Some(broker_failed_at),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let order = infra
+            .ctx
+            .offchain_order
+            .load(&order_id)
+            .await
+            .unwrap()
+            .expect("offchain order should exist");
+        let OffchainOrder::Failed { failed_at, .. } = order else {
+            panic!("expected Failed, got {order:?}");
+        };
+        assert_eq!(
+            failed_at, broker_failed_at,
+            "Failed event must carry the broker-reported failure time"
+        );
+    }
+
+    /// A rejection that lands while the order is `Cancelling` with a retained
+    /// fill must finalize the position with the fill's broker timestamp (the
+    /// `partially_filled_at` carried onto the Cancelling state), not the
+    /// local cancel-request wall clock.
+    #[tokio::test]
+    async fn cancelling_rejection_finalizes_position_with_fill_broker_time() {
+        let infra = build_test_infra().await;
+        let symbol = Symbol::new("TSLA").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+
+        let broker_fill_time = Utc::now() - chrono::Duration::minutes(30);
+        infra
+            .ctx
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(1)),
+                    avg_price: st0x_finance::Usd::new(float!(150)),
+                    partially_filled_at: broker_fill_time,
+                },
+            )
+            .await
+            .unwrap();
+        infra
+            .ctx
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: crate::offchain::order::CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        HandleOrderRejection {
+            offchain_order_id: order_id,
+            error: "broker rejected during cancellation".to_string(),
+            broker_failed_at: None,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let position = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "Retained fill must complete the position and release the slot"
+        );
+        assert_eq!(
+            position.last_updated,
+            Some(broker_fill_time),
+            "Position must be stamped with the fill's broker time, not the \
+             cancel-request wall clock"
         );
     }
 }

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -11,11 +11,11 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use st0x_event_sorcery::{Projection, Store};
 use st0x_execution::{
-    Executor, ExecutorOrderId, FractionalShares, OrderState, SupportedExecutor, Symbol,
+    Executor, ExecutorOrderId, FractionalShares, OrderState, Positive, SupportedExecutor, Symbol,
 };
 use st0x_finance::Usd;
 
@@ -24,18 +24,33 @@ use crate::offchain::order::handle_rejection::{
     HandleOrderRejection, HandleOrderRejectionJobQueue,
 };
 use crate::offchain::order::reconcile_fill::{ReconcileOrderFill, ReconcileOrderFillJobQueue};
-use crate::offchain::order::{JobError, OffchainOrder, OffchainOrderCommand, OffchainOrderId};
+use crate::offchain::order::{
+    CancellationReason, JobError, OffchainOrder, OffchainOrderCommand, OffchainOrderId,
+    RetainedFill, TerminalPositionFinalization, position_command_for_finalization,
+    terminal_position_finalization,
+};
+use crate::position::Position;
 
 pub(crate) type PollOrderStatusJobQueue = JobQueue<PollOrderStatus>;
 
 /// Dependencies [`PollOrderStatus`] needs to query the broker and route the
-/// result. Carries no aggregate stores -- the actual state mutation happens
-/// in [`ReconcileOrderFill`] / [`HandleOrderRejection`], which this job
-/// enqueues via their respective queues.
+/// result. The `Filled` and `Failed` terminal transitions are deferred to
+/// [`ReconcileOrderFill`] / [`HandleOrderRejection`] via their queues, but the
+/// cancellation-confirmation path finalizes the owning `Position` inline (the
+/// broker only reports a cancelled order once, so there is no separate
+/// terminal-Cancelled queue to defer to) -- hence the direct `position_store`.
 pub(crate) struct PollOrderStatusCtx<E: Executor + Clone + Send + Sync + 'static> {
     pub(crate) executor: E,
-    pub(crate) offchain_order: Arc<Store<OffchainOrder>>,
     pub(crate) offchain_order_projection: Arc<Projection<OffchainOrder>>,
+    /// Store for sending `UpdatePartialFill` directly when the broker
+    /// reports a partial fill. Cannot use the reconcile queue because
+    /// that's gated to terminal-Filled transitions.
+    pub(crate) offchain_order_store: Arc<Store<OffchainOrder>>,
+    /// Store for finalizing the owning `Position` when a cancellation is
+    /// confirmed terminal. Without this the position keeps
+    /// `pending_offchain_order_id = Some(..)` forever after a cancellation,
+    /// permanently blocking the symbol from new hedges.
+    pub(crate) position_store: Arc<Store<Position>>,
     pub(crate) poll_status_queue: PollOrderStatusJobQueue,
     pub(crate) reconcile_queue: ReconcileOrderFillJobQueue,
     pub(crate) rejection_queue: HandleOrderRejectionJobQueue,
@@ -97,6 +112,10 @@ where
 
         match dispatch_for_order_state(self.offchain_order_id, &order) {
             PollAction::Drop => Ok(()),
+            PollAction::FinalizeCancelled => {
+                self.finalize_position_for_terminal_order(ctx, order.symbol())
+                    .await
+            }
             PollAction::Reschedule => reschedule_self(ctx, self.offchain_order_id).await,
             PollAction::Query { executor_order_id } => {
                 self.query_broker_and_dispatch(ctx, &order, executor_order_id)
@@ -142,46 +161,107 @@ impl PollOrderStatus {
                 order_id,
                 executed_at,
             } => {
-                self.enqueue_reconcile(ctx, symbol, price.into(), order_id, executed_at)
+                self.enqueue_reconcile(ctx, symbol, price, order_id, executed_at)
                     .await
             }
 
             Failed {
                 error_reason,
-                shares_filled,
-                avg_price,
-                ..
+                shares_filled: Some(shares_filled),
+                avg_price: Some(avg_price),
+                failed_at,
             } => {
-                if let Some(shares_filled) = shares_filled {
-                    self.record_partial_fill(ctx, order, shares_filled, avg_price)
-                        .await?;
-                }
-
-                self.enqueue_rejection(ctx, symbol, error_reason).await
+                self.record_partial_fill(ctx, symbol, shares_filled, Some(avg_price), failed_at)
+                    .await?;
+                self.enqueue_rejection(ctx, symbol, error_reason, Some(failed_at))
+                    .await
             }
 
-            // The execution layer now surfaces broker-side cancellations as a
-            // distinct state; treat as a rejection until the aggregate learns
-            // to reconcile cancellations against the pending position.
-            Cancelled {
-                shares_filled,
-                avg_price,
+            // Broker-*terminal* Failed with a positive fill it never priced.
+            // A terminal order's fill data is immutable, so re-polling can
+            // never surface the missing price -- the old `reschedule_self`
+            // looped forever. Fail closed instead: leave the position pending
+            // (NEVER clear it -- clearing under-accounts the executed shares and
+            // double-hedges on the next scan) and stop re-polling. The order
+            // stays non-terminal, so startup orphan-recovery re-polls it on the
+            // next restart without an in-process tight loop; the error log
+            // surfaces it for manual reconciliation.
+            Failed {
+                error_reason: _,
+                shares_filled: Some(shares_filled),
+                avg_price: None,
+                ..
+            } if Positive::new(shares_filled).is_ok() => {
+                error!(
+                    target: "broker",
+                    %symbol,
+                    offchain_order_id = %self.offchain_order_id,
+                    %shares_filled,
+                    "Broker reports Failed with filled shares but no avg_price; \
+                     leaving the position pending (fail closed) and not re-polling"
+                );
+                Ok(())
+            }
+
+            Failed {
+                error_reason,
+                failed_at,
                 ..
             } => {
-                self.record_partial_fill(ctx, order, shares_filled, avg_price)
-                    .await?;
-
-                self.enqueue_rejection(ctx, symbol, Some("Order cancelled by broker".to_string()))
+                self.enqueue_rejection(ctx, symbol, error_reason, Some(failed_at))
                     .await
+            }
+
+            Cancelled {
+                shares_filled,
+                avg_price: Some(avg_price),
+                cancelled_at,
+                ..
+            } if Positive::new(shares_filled).is_ok() => {
+                self.record_partial_fill(ctx, symbol, shares_filled, Some(avg_price), cancelled_at)
+                    .await?;
+                self.confirm_cancellation(ctx, symbol, cancelled_at).await
+            }
+
+            // Broker-terminal Cancelled with a positive unpriced fill -- same
+            // fail-closed handling as the Failed arm above: leave the position
+            // pending and stop re-polling rather than looping forever or
+            // clearing the executed shares.
+            Cancelled {
+                cancelled_at: _,
+                shares_filled,
+                avg_price: None,
+                ..
+            } if Positive::new(shares_filled).is_ok() => {
+                error!(
+                    target: "broker",
+                    %symbol,
+                    offchain_order_id = %self.offchain_order_id,
+                    %shares_filled,
+                    "Broker reports Cancelled with filled shares but no avg_price; \
+                     leaving the position pending (fail closed) and not re-polling"
+                );
+                Ok(())
+            }
+
+            Cancelled { cancelled_at, .. } => {
+                self.confirm_cancellation(ctx, symbol, cancelled_at).await
             }
 
             PartiallyFilled {
                 shares_filled,
                 avg_price,
+                partially_filled_at,
                 ..
             } => {
-                self.record_partial_fill(ctx, order, shares_filled, avg_price)
-                    .await?;
+                self.record_partial_fill(
+                    ctx,
+                    symbol,
+                    shares_filled,
+                    avg_price,
+                    partially_filled_at,
+                )
+                .await?;
 
                 debug!(
                     target: "broker",
@@ -206,11 +286,120 @@ impl PollOrderStatus {
         }
     }
 
+    async fn record_partial_fill<E>(
+        &self,
+        ctx: &PollOrderStatusCtx<E>,
+        symbol: &Symbol,
+        broker_shares_filled: FractionalShares,
+        avg_price: Option<Usd>,
+        partially_filled_at: DateTime<Utc>,
+    ) -> Result<(), JobError>
+    where
+        E: Executor + Clone + Send + Sync + 'static,
+    {
+        if broker_shares_filled == FractionalShares::ZERO {
+            return Ok(());
+        }
+
+        let Some(price) = avg_price else {
+            warn!(
+                target: "broker",
+                %symbol,
+                offchain_order_id = %self.offchain_order_id,
+                "Broker reports filled shares but no avg_price; skipping UpdatePartialFill"
+            );
+            return Ok(());
+        };
+
+        // Avoid no-op or stale writes when the local aggregate already
+        // reflects this partial-fill quantity or a newer cumulative quantity.
+        // Partial fills are cumulative and must never move backwards.
+        let local_filled = ctx
+            .offchain_order_projection
+            .load(&self.offchain_order_id)
+            .await?
+            .and_then(|local_order| match local_order {
+                OffchainOrder::PartiallyFilled { shares_filled, .. } => Some(shares_filled),
+                OffchainOrder::Cancelling { retained_fill, .. } => {
+                    retained_fill.map(RetainedFill::shares_filled)
+                }
+                OffchainOrder::Pending { .. }
+                | OffchainOrder::Submitted { .. }
+                | OffchainOrder::Filled { .. }
+                | OffchainOrder::Failed { .. }
+                | OffchainOrder::Cancelled { .. } => None,
+            });
+
+        if let Some(local_filled) = local_filled {
+            match super::broker_fill_exceeds_local(broker_shares_filled, local_filled) {
+                Ok(true) => {}
+                Ok(false) => {
+                    debug!(
+                        target: "broker",
+                        %symbol,
+                        offchain_order_id = %self.offchain_order_id,
+                        local_shares_filled = %local_filled,
+                        broker_shares_filled = ?broker_shares_filled,
+                        "Skipping duplicate or stale broker partial fill"
+                    );
+                    return Ok(());
+                }
+                // Fail the whole dispatch (apalis retries it) instead of
+                // swallowing the error: the callers that follow this with
+                // confirm_cancellation / enqueue_rejection would otherwise
+                // finalize the position from a possibly-stale local fill,
+                // under-accounting executed shares (double hedge). Mirrors
+                // the fail-closed contract of the aggregate's own
+                // fill-comparison guard.
+                Err(error) => {
+                    warn!(
+                        target: "broker",
+                        %symbol,
+                        offchain_order_id = %self.offchain_order_id,
+                        %error,
+                        "Failed to compare broker and local partial fills; failing the poll so it retries"
+                    );
+                    return Err(error.into());
+                }
+            }
+        }
+
+        info!(
+            target: "broker",
+            %symbol,
+            offchain_order_id = %self.offchain_order_id,
+            shares_filled = ?broker_shares_filled,
+            "PollOrderStatus: broker reports PartiallyFilled, recording UpdatePartialFill"
+        );
+
+        ctx.offchain_order_store
+            .send(
+                &self.offchain_order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: broker_shares_filled,
+                    avg_price: price,
+                    partially_filled_at,
+                },
+            )
+            .await
+            .inspect_err(|error| {
+                warn!(
+                    target: "broker",
+                    %symbol,
+                    offchain_order_id = %self.offchain_order_id,
+                    %error,
+                    "Failed to send UpdatePartialFill; leaving order non-terminal for retry"
+                );
+            })?;
+
+        Ok(())
+    }
+
     async fn enqueue_reconcile<E>(
         &self,
         ctx: &PollOrderStatusCtx<E>,
         symbol: &Symbol,
-        price: rain_math_float::Float,
+        price: Usd,
         order_id: ExecutorOrderId,
         executed_at: DateTime<Utc>,
     ) -> Result<(), JobError>
@@ -228,7 +417,7 @@ impl PollOrderStatus {
         queue
             .push(ReconcileOrderFill {
                 offchain_order_id: self.offchain_order_id,
-                price: Usd::new(price),
+                price,
                 executor_order_id: order_id,
                 broker_timestamp: executed_at,
             })
@@ -237,61 +426,16 @@ impl PollOrderStatus {
         Ok(())
     }
 
-    async fn record_partial_fill<E>(
-        &self,
-        ctx: &PollOrderStatusCtx<E>,
-        order: &OffchainOrder,
-        shares_filled: FractionalShares,
-        avg_price: Option<Usd>,
-    ) -> Result<(), JobError>
-    where
-        E: Executor + Clone + Send + Sync + 'static,
-    {
-        if shares_filled == FractionalShares::ZERO {
-            return Ok(());
-        }
-
-        let Some(avg_price) = avg_price else {
-            return Err(JobError::MissingPartialFillPrice {
-                offchain_order_id: self.offchain_order_id,
-                shares_filled,
-            });
-        };
-
-        let already_recorded = match order {
-            OffchainOrder::PartiallyFilled {
-                shares_filled: current_shares_filled,
-                avg_price: current_avg_price,
-                ..
-            } => *current_shares_filled == shares_filled && *current_avg_price == avg_price,
-            OffchainOrder::Pending { .. }
-            | OffchainOrder::Submitted { .. }
-            | OffchainOrder::Filled { .. }
-            | OffchainOrder::Failed { .. } => false,
-        };
-
-        if already_recorded {
-            return Ok(());
-        }
-
-        ctx.offchain_order
-            .send(
-                &self.offchain_order_id,
-                OffchainOrderCommand::UpdatePartialFill {
-                    shares_filled,
-                    avg_price,
-                },
-            )
-            .await?;
-
-        Ok(())
-    }
-
+    /// `broker_failed_at` is the broker-reported failure time when this
+    /// rejection stems from a broker `Failed` state; `None` when no broker
+    /// timestamp exists for the rejection (the job then stamps its own
+    /// observation time).
     async fn enqueue_rejection<E>(
         &self,
         ctx: &PollOrderStatusCtx<E>,
         symbol: &Symbol,
         error_reason: Option<String>,
+        broker_failed_at: Option<DateTime<Utc>>,
     ) -> Result<(), JobError>
     where
         E: Executor + Clone + Send + Sync + 'static,
@@ -311,10 +455,268 @@ impl PollOrderStatus {
             .push(HandleOrderRejection {
                 offchain_order_id: self.offchain_order_id,
                 error: error_message,
+                broker_failed_at,
             })
             .await?;
 
         Ok(())
+    }
+
+    async fn confirm_cancellation<E>(
+        &self,
+        ctx: &PollOrderStatusCtx<E>,
+        symbol: &Symbol,
+        cancelled_at: DateTime<Utc>,
+    ) -> Result<(), JobError>
+    where
+        E: Executor + Clone + Send + Sync + 'static,
+    {
+        let Some(order) = ctx
+            .offchain_order_projection
+            .load(&self.offchain_order_id)
+            .await?
+        else {
+            warn!(
+                target: "broker",
+                %symbol,
+                offchain_order_id = %self.offchain_order_id,
+                "PollOrderStatus: order disappeared before confirming cancellation"
+            );
+            return Ok(());
+        };
+
+        match order {
+            OffchainOrder::Cancelling { .. } => {
+                info!(
+                    target: "broker",
+                    %symbol,
+                    offchain_order_id = %self.offchain_order_id,
+                    "PollOrderStatus: broker confirms Cancelled, marking order terminal"
+                );
+
+                ctx.offchain_order_store
+                    .send(
+                        &self.offchain_order_id,
+                        OffchainOrderCommand::ConfirmCancellation { cancelled_at },
+                    )
+                    .await?;
+
+                self.finalize_position_for_terminal_order(ctx, symbol).await
+            }
+
+            // The broker reports Cancelled while the local order is still
+            // live. Two ways here: the `CancelOrder` crash window (DELETE
+            // succeeded, process died before `CancelRequested` persisted) or
+            // a cancellation that never had a local request at all (operator
+            // dashboard cancel, broker-initiated cancel). Either way this is
+            // a cancellation, NOT a broker rejection -- routing it to
+            // HandleOrderRejection would set `last_failed_offchain_order_id`
+            // and let the next replacement adopt the cancelled broker order
+            // via duplicate-client-order-id recovery.
+            OffchainOrder::Submitted { .. } | OffchainOrder::PartiallyFilled { .. } => {
+                self.recover_unrequested_cancellation(ctx, symbol, cancelled_at)
+                    .await
+            }
+
+            OffchainOrder::Pending { .. }
+            | OffchainOrder::Filled { .. }
+            | OffchainOrder::Failed { .. }
+            | OffchainOrder::Cancelled { .. } => {
+                warn!(
+                    target: "broker",
+                    %symbol,
+                    offchain_order_id = %self.offchain_order_id,
+                    state = ?order,
+                    "Broker reports Cancelled for order that is neither live nor \
+                     Cancelling; enqueueing rejection cleanup"
+                );
+                self.enqueue_rejection(
+                    ctx,
+                    symbol,
+                    Some("Broker reported Cancelled before local cancellation request".to_string()),
+                    None,
+                )
+                .await
+            }
+        }
+    }
+
+    /// Recovers a broker-side cancellation observed while the local order is
+    /// still `Submitted`/`PartiallyFilled` (the cancel request did not survive
+    /// a crash). Re-drives `CancelOrder`: its pre-cancel reconcile reads the
+    /// broker's `Cancelled` state and emits terminal `Cancelled` directly,
+    /// preserving any priced fill. If the aggregate's own broker read raced
+    /// and still saw the order live, the order lands in `Cancelling` instead
+    /// and is confirmed with the broker timestamp this poll already holds.
+    async fn recover_unrequested_cancellation<E>(
+        &self,
+        ctx: &PollOrderStatusCtx<E>,
+        symbol: &Symbol,
+        cancelled_at: DateTime<Utc>,
+    ) -> Result<(), JobError>
+    where
+        E: Executor + Clone + Send + Sync + 'static,
+    {
+        warn!(
+            target: "broker",
+            %symbol,
+            offchain_order_id = %self.offchain_order_id,
+            "Broker reports Cancelled for a live local order (cancel request \
+             lost, e.g. crash before persisting CancelRequested); recovering \
+             as cancellation instead of failure"
+        );
+
+        // This path also catches cancellations that never had a local
+        // request at all (operator dashboard cancels, broker-initiated
+        // cancels), so record `Unrequested` rather than guessing a specific
+        // local reason -- mislabelling a 2pm manual cancel as a market-open
+        // replacement would corrupt the cancellation analytics the reason
+        // field exists for.
+        ctx.offchain_order_store
+            .send(
+                &self.offchain_order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::Unrequested,
+                },
+            )
+            .await?;
+
+        let Some(recovered) = ctx
+            .offchain_order_store
+            .load(&self.offchain_order_id)
+            .await?
+        else {
+            warn!(
+                target: "broker",
+                %symbol,
+                offchain_order_id = %self.offchain_order_id,
+                "PollOrderStatus: order disappeared during cancellation recovery"
+            );
+            return Ok(());
+        };
+
+        match recovered {
+            OffchainOrder::Cancelling { .. } => {
+                ctx.offchain_order_store
+                    .send(
+                        &self.offchain_order_id,
+                        OffchainOrderCommand::ConfirmCancellation { cancelled_at },
+                    )
+                    .await?;
+            }
+            // `CancelOrder`'s pre-cancel reconcile may have read the broker's
+            // Cancelled state and driven the order terminal directly, skipping
+            // `Cancelling`. Either way the finalization below classifies the
+            // resulting terminal state and finalizes the position.
+            OffchainOrder::Pending { .. }
+            | OffchainOrder::Submitted { .. }
+            | OffchainOrder::PartiallyFilled { .. }
+            | OffchainOrder::Filled { .. }
+            | OffchainOrder::Failed { .. }
+            | OffchainOrder::Cancelled { .. } => {}
+        }
+
+        self.finalize_position_for_terminal_order(ctx, symbol).await
+    }
+
+    /// Reloads the order and, if it has reached a terminal state, finalizes the
+    /// owning `Position` via the shared
+    /// [`terminal_position_finalization`] mapping -- the same classification
+    /// the startup orphan-recovery sweep and rejection path use, so the
+    /// terminal-state -> position-command mapping cannot drift between them.
+    ///
+    /// Fails closed in two ways, never clearing the position incorrectly:
+    /// - an `UnpricedFill` (a positive fill the broker never priced) leaves the
+    ///   position pending and logs loudly -- dropping or force-clearing it
+    ///   would under-account the executed shares (double hedge on the next
+    ///   scan);
+    /// - a still-non-terminal order leaves the position pending for the next
+    ///   poll/recovery pass.
+    async fn finalize_position_for_terminal_order<E>(
+        &self,
+        ctx: &PollOrderStatusCtx<E>,
+        symbol: &Symbol,
+    ) -> Result<(), JobError>
+    where
+        E: Executor + Clone + Send + Sync + 'static,
+    {
+        let Some(order) = ctx
+            .offchain_order_projection
+            .load(&self.offchain_order_id)
+            .await?
+        else {
+            warn!(
+                target: "broker",
+                %symbol,
+                offchain_order_id = %self.offchain_order_id,
+                "PollOrderStatus: order disappeared before finalizing its position"
+            );
+            return Ok(());
+        };
+
+        match terminal_position_finalization(&order) {
+            Some(TerminalPositionFinalization::UnpricedFill { shares_filled }) => {
+                error!(
+                    target: "broker",
+                    %symbol,
+                    offchain_order_id = %self.offchain_order_id,
+                    %shares_filled,
+                    "Terminal order carries a positive fill the broker never priced; \
+                     leaving the position pending (fail closed) rather than clearing it"
+                );
+
+                Ok(())
+            }
+
+            Some(finalization) => {
+                let Some(command) =
+                    position_command_for_finalization(finalization, self.offchain_order_id)
+                else {
+                    // `UnpricedFill` is the only `None` case and is handled
+                    // above; this arm is unreachable but stays fail-closed.
+                    return Ok(());
+                };
+
+                let position_pending = ctx
+                    .position_store
+                    .load(symbol)
+                    .await?
+                    .and_then(|position| position.pending_offchain_order_id);
+                if position_pending != Some(self.offchain_order_id) {
+                    info!(
+                        target: "broker",
+                        %symbol,
+                        offchain_order_id = %self.offchain_order_id,
+                        ?position_pending,
+                        "PollOrderStatus: position no longer expecting this terminal order, skipping"
+                    );
+                    return Ok(());
+                }
+
+                ctx.position_store.send(symbol, command).await?;
+                info!(
+                    target: "broker",
+                    %symbol,
+                    offchain_order_id = %self.offchain_order_id,
+                    "PollOrderStatus: finalized the owning position for a terminal order"
+                );
+
+                Ok(())
+            }
+
+            None => {
+                warn!(
+                    target: "broker",
+                    %symbol,
+                    offchain_order_id = %self.offchain_order_id,
+                    state = ?order,
+                    "PollOrderStatus: order not terminal after cancellation handling; \
+                     leaving the position pending"
+                );
+
+                Ok(())
+            }
+        }
     }
 }
 
@@ -324,6 +726,8 @@ impl PollOrderStatus {
 enum PollAction {
     /// Already terminal or unrecoverable -- discard this poll job.
     Drop,
+    /// Terminal cancellation whose position finalization may need retrying.
+    FinalizeCancelled,
     /// Not yet submitted to the broker. Re-queue and wait.
     Reschedule,
     /// Submitted (or partially filled). Ask the broker for status.
@@ -334,7 +738,9 @@ fn dispatch_for_order_state(
     offchain_order_id: OffchainOrderId,
     order: &OffchainOrder,
 ) -> PollAction {
-    use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
+    use OffchainOrder::{
+        Cancelled, Cancelling, Failed, Filled, PartiallyFilled, Pending, Submitted,
+    };
     let symbol = order.symbol();
     match order {
         Filled { .. } | Failed { .. } => {
@@ -346,6 +752,17 @@ fn dispatch_for_order_state(
             );
 
             PollAction::Drop
+        }
+
+        Cancelled { .. } => {
+            debug!(
+                target: "broker",
+                %symbol,
+                %offchain_order_id,
+                "PollOrderStatus: order already Cancelled, retrying position finalization"
+            );
+
+            PollAction::FinalizeCancelled
         }
 
         Pending { .. } => {
@@ -360,21 +777,23 @@ fn dispatch_for_order_state(
             PollAction::Reschedule
         }
 
-        Submitted { .. } | PartiallyFilled { .. } => order.executor_order_id().map_or_else(
-            || {
-                warn!(
-                    target: "broker",
-                    %symbol,
-                    %offchain_order_id,
-                    "PollOrderStatus: missing executor_order_id on submitted order"
-                );
+        Submitted { .. } | PartiallyFilled { .. } | Cancelling { .. } => {
+            order.executor_order_id().map_or_else(
+                || {
+                    warn!(
+                        target: "broker",
+                        %symbol,
+                        %offchain_order_id,
+                        "PollOrderStatus: missing executor_order_id on submitted order"
+                    );
 
-                PollAction::Drop
-            },
-            |executor_order_id| PollAction::Query {
-                executor_order_id: executor_order_id.clone(),
-            },
-        ),
+                    PollAction::Drop
+                },
+                |executor_order_id| PollAction::Query {
+                    executor_order_id: executor_order_id.clone(),
+                },
+            )
+        }
     }
 }
 
@@ -408,20 +827,26 @@ pub(crate) async fn recover_submitted_offchain_orders(
     poll_status_queue: &mut PollOrderStatusJobQueue,
     executor_type: SupportedExecutor,
 ) -> Result<(), JobError> {
-    use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
+    use OffchainOrder::{
+        Cancelled, Cancelling, Failed, Filled, PartiallyFilled, Pending, Submitted,
+    };
     let orders = offchain_order_projection.load_all().await?;
 
     let pending_poll: Vec<_> = orders
         .into_iter()
         .filter_map(|(id, order)| match order {
-            Submitted { .. } | PartiallyFilled { .. } if order.executor() == executor_type => {
+            Submitted { .. } | PartiallyFilled { .. } | Cancelling { .. }
+                if order.executor() == executor_type =>
+            {
                 Some(id)
             }
             Submitted { .. }
             | PartiallyFilled { .. }
+            | Cancelling { .. }
             | Pending { .. }
             | Filled { .. }
-            | Failed { .. } => None,
+            | Failed { .. }
+            | Cancelled { .. } => None,
         })
         .collect();
 
@@ -452,12 +877,15 @@ mod tests {
     use st0x_config::ExecutionThreshold;
     use st0x_event_sorcery::StoreBuilder;
     use st0x_execution::{
-        Direction, ExecutionError, FractionalShares, MockExecutor, Positive, Symbol,
+        ClientOrderId, Direction, ExecutionError, FractionalShares, MockExecutor, Positive, Symbol,
     };
     use st0x_float_macro::float;
 
     use super::*;
-    use crate::offchain::order::OffchainOrderCommand;
+    use crate::offchain::order::{
+        NoFillOutcome, OffchainOrderCommand, TerminalPositionFinalization, noop_order_placer,
+        terminal_position_finalization,
+    };
     use crate::position::{Position, PositionCommand, TradeId};
     use crate::test_utils::{OnchainTradeBuilder, setup_test_pools};
 
@@ -477,7 +905,7 @@ mod tests {
 
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(noop_order_placer())
                 .await
                 .unwrap();
 
@@ -488,8 +916,9 @@ mod tests {
 
         let ctx = PollOrderStatusCtx {
             executor,
-            offchain_order: offchain_order.clone(),
             offchain_order_projection,
+            offchain_order_store: offchain_order.clone(),
+            position_store: position.clone(),
             poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
             reconcile_queue: ReconcileOrderFillJobQueue::new(&apalis_pool),
             rejection_queue: HandleOrderRejectionJobQueue::new(&apalis_pool),
@@ -582,6 +1011,8 @@ mod tests {
                     shares,
                     direction,
                     executor: order_executor,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await
@@ -595,6 +1026,8 @@ mod tests {
                     executor_order_id: ExecutorOrderId::new("test-accept"),
                     placed_shares: shares,
                     submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
                 },
             )
             .await
@@ -736,6 +1169,422 @@ mod tests {
         );
     }
 
+    /// Asserts that polling a confirmed broker cancellation finalized the owning
+    /// position INLINE -- releasing the pending slot with no fill and no failure
+    /// anchor -- rather than leaving it stuck. The terminal order's
+    /// classification is checked against the shared
+    /// `terminal_position_finalization` mapping (the same one the conductor
+    /// recovery and rejection paths use), and the position is asserted already
+    /// released by `PollOrderStatus::perform`, NOT finalized by the test.
+    async fn assert_position_released_without_fill<E: Executor + Clone + Send + Sync + 'static>(
+        infra: &TestInfra<E>,
+        symbol: &Symbol,
+        order: &OffchainOrder,
+    ) {
+        let OffchainOrder::Cancelled {
+            reason,
+            cancelled_at,
+            ..
+        } = order
+        else {
+            panic!("expected a terminal Cancelled order, got: {order:?}");
+        };
+
+        let finalization = terminal_position_finalization(order)
+            .expect("terminal Cancelled order must classify for finalization");
+        assert_eq!(
+            finalization,
+            TerminalPositionFinalization::NoFill(NoFillOutcome::Cancelled {
+                reason: *reason,
+                cancelled_at: *cancelled_at,
+            }),
+            "Zero-fill cancellation must classify as NoFill with the broker's cancellation outcome"
+        );
+
+        let position = infra.position.load(symbol).await.unwrap().unwrap();
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "Polling a confirmed cancellation must release the position's pending slot inline"
+        );
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "Intentional cancellation must NOT set the failure anchor"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_with_cancelled_broker_confirms_local_cancellation() {
+        let cancelled_at = Utc::now();
+        let executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
+            cancelled_at,
+            order_id: ExecutorOrderId::new("noop"),
+            shares_filled: FractionalShares::ZERO,
+            avg_price: None,
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        infra
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(
+            matches!(order, OffchainOrder::Cancelled { .. }),
+            "Broker Cancelled must mark local Cancelling order terminal, got: {order:?}"
+        );
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            0,
+            "Terminal cancellation must not re-enqueue PollOrderStatus"
+        );
+
+        assert_position_released_without_fill(&infra, &symbol, &order).await;
+    }
+
+    #[tokio::test]
+    async fn poll_with_cancelled_zero_fill_without_avg_price_confirms_cancellation() {
+        let cancelled_at = Utc::now();
+        let executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
+            cancelled_at,
+            order_id: ExecutorOrderId::new("noop"),
+            shares_filled: FractionalShares::ZERO,
+            avg_price: None,
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        infra
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(
+            matches!(order, OffchainOrder::Cancelled { .. }),
+            "Zero-fill broker cancellation without avg_price must mark local order terminal, got: {order:?}"
+        );
+
+        assert_position_released_without_fill(&infra, &symbol, &order).await;
+    }
+
+    #[tokio::test]
+    async fn retry_after_confirmed_cancellation_finalizes_position() {
+        let executor = MockExecutor::new();
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        infra
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+        infra
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::ConfirmCancellation {
+                    cancelled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let position_before = infra.position.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            position_before.pending_offchain_order_id,
+            Some(order_id),
+            "test setup should leave the position pending after order-only confirmation"
+        );
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let position_after = infra.position.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            position_after.pending_offchain_order_id, None,
+            "Retrying a terminal Cancelled poll must finish the position finalization"
+        );
+        assert_eq!(
+            position_after.last_failed_offchain_order_id, None,
+            "Cancellation finalization must not create a failure idempotency anchor"
+        );
+    }
+
+    /// Broker reports Cancelled with a positive priced partial fill while the
+    /// order is locally `Cancelling`: the poll must record the fill
+    /// (`UpdatePartialFill`) BEFORE confirming the cancellation, so the
+    /// terminal `Cancelled` state carries the executed shares and the
+    /// position finalization completes the hedge for them instead of
+    /// double-hedging on the next scan.
+    #[tokio::test]
+    async fn poll_with_cancelled_partial_fill_records_fill_before_confirming_cancellation() {
+        let cancelled_at = Utc::now();
+        let executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
+            cancelled_at,
+            order_id: ExecutorOrderId::new("noop"),
+            shares_filled: FractionalShares::new(float!(50)),
+            avg_price: Some(Usd::new(float!(150.0))),
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(100))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        infra
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                &order,
+                OffchainOrder::Cancelled {
+                    retained_fill:
+                        Some(RetainedFill::Priced {
+                            shares_filled,
+                            avg_price,
+                            ..
+                        }),
+                    ..
+                } if *shares_filled == FractionalShares::new(float!(50))
+                    && *avg_price == Usd::new(float!(150.0))
+            ),
+            "Cancelled order must retain the broker-reported priced fill, got: {order:?}"
+        );
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
+            0,
+            "Cancellation with a partial fill must not be routed to rejection"
+        );
+
+        // Position-side: the shared terminal classification must complete the
+        // hedge for the filled quantity, stamped with the broker's
+        // cancellation time.
+        let finalization = terminal_position_finalization(&order)
+            .expect("terminal Cancelled order must classify for finalization");
+        assert_eq!(
+            finalization,
+            TerminalPositionFinalization::Complete {
+                shares_filled: Positive::new(FractionalShares::new(float!(50))).unwrap(),
+                direction: Direction::Sell,
+                executor_order_id: ExecutorOrderId::new("test-accept"),
+                price: Usd::new(float!(150.0)),
+                broker_timestamp: cancelled_at,
+            },
+        );
+
+        // `perform` must finalize the owning position inline -- the retained
+        // priced fill is completed and the pending slot released, stamped with
+        // the broker cancellation time (not the local wall clock).
+        let position = infra.position.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "Polling the priced cancellation must complete the retained fill and release the slot inline"
+        );
+        assert_eq!(
+            position.last_updated,
+            Some(cancelled_at),
+            "Position must be stamped with the broker cancellation time, not local wall clock"
+        );
+
+        // The priced cancellation path finalizes the owning position inline,
+        // so no follow-up poll is needed. A duplicate poll against the
+        // terminal aggregate must still no-op rather than loop or re-route.
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            0,
+            "Inline cancellation finalization must not enqueue a redundant follow-up poll"
+        );
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+        let after_followup = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(
+            matches!(after_followup, OffchainOrder::Cancelled { .. }),
+            "Follow-up poll against a terminal order must leave it Cancelled"
+        );
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
+            0,
+            "Follow-up poll must not enqueue rejection for a terminal order"
+        );
+    }
+
+    /// Crash window in `CancelOrder`: the broker accepted the DELETE but the
+    /// process died before `CancelRequested` was persisted, so recovery polls
+    /// a locally-`Submitted` order whose broker state is already Cancelled.
+    /// The poll must record it as an intentional cancellation -- NOT route it
+    /// to `HandleOrderRejection`, which would set the position's
+    /// `last_failed_offchain_order_id` anchor and let the next replacement
+    /// adopt the cancelled broker order via duplicate-client-order-id
+    /// recovery.
+    #[tokio::test]
+    async fn poll_with_cancelled_broker_without_local_cancel_request_records_cancelled_not_failed()
+    {
+        let cancelled_at = Utc::now();
+        let executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
+            cancelled_at,
+            order_id: ExecutorOrderId::new("noop"),
+            shares_filled: FractionalShares::ZERO,
+            avg_price: None,
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+        // No CancelOrder command: the local order is still Submitted.
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(
+            matches!(order, OffchainOrder::Cancelled { .. }),
+            "Broker-confirmed cancellation must become terminal Cancelled even \
+             without a surviving local cancel request, got: {order:?}"
+        );
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
+            0,
+            "Broker-side cancellation must NOT be misclassified as a failure"
+        );
+
+        assert_position_released_without_fill(&infra, &symbol, &order).await;
+    }
+
+    /// Same crash window as above, but the order partially filled before the
+    /// broker cancelled it: recovery must record the priced fill AND resolve
+    /// the order as Cancelled, preserving both properties at once.
+    #[tokio::test]
+    async fn poll_with_cancelled_partial_fill_after_crash_recovers_fill_and_cancellation() {
+        let cancelled_at = Utc::now();
+        let executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
+            cancelled_at,
+            order_id: ExecutorOrderId::new("noop"),
+            shares_filled: FractionalShares::new(float!(50)),
+            avg_price: Some(Usd::new(float!(150.0))),
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(100))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+        // No CancelOrder command: the local order is still Submitted.
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                &order,
+                OffchainOrder::Cancelled {
+                    retained_fill:
+                        Some(RetainedFill::Priced {
+                            shares_filled,
+                            avg_price,
+                            ..
+                        }),
+                    ..
+                } if *shares_filled == FractionalShares::new(float!(50))
+                    && *avg_price == Usd::new(float!(150.0))
+            ),
+            "Crash recovery must preserve the priced fill on the Cancelled order, got: {order:?}"
+        );
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
+            0,
+            "Broker-side cancellation must NOT be misclassified as a failure"
+        );
+
+        let finalization = terminal_position_finalization(&order)
+            .expect("terminal Cancelled order must classify for finalization");
+        assert_eq!(
+            finalization,
+            TerminalPositionFinalization::Complete {
+                shares_filled: Positive::new(FractionalShares::new(float!(50))).unwrap(),
+                direction: Direction::Sell,
+                executor_order_id: ExecutorOrderId::new("test-accept"),
+                price: Usd::new(float!(150.0)),
+                broker_timestamp: cancelled_at,
+            },
+            "Recovered cancellation must complete the position for the filled shares"
+        );
+    }
+
     #[tokio::test]
     async fn poll_with_failed_broker_enqueues_handle_rejection() {
         let executor = MockExecutor::new().with_order_status(OrderState::Failed {
@@ -806,7 +1655,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_with_cancelled_broker_enqueues_handle_rejection() {
+    async fn poll_with_cancelled_broker_confirms_cancellation_without_rejection() {
         let executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
             cancelled_at: Utc::now(),
             order_id: ExecutorOrderId::new("some-broker-order-id"),
@@ -826,10 +1675,19 @@ mod tests {
         .await
         .unwrap();
 
+        // A broker Cancelled (no-fill) for a still-live local order is a
+        // cancellation, not a rejection: 2b routes it through the
+        // cancellation-confirmation path, driving the order terminal Cancelled
+        // rather than enqueueing a HandleOrderRejection cleanup job.
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(
+            matches!(order, OffchainOrder::Cancelled { .. }),
+            "Broker Cancelled must drive a live local order terminal Cancelled, got: {order:?}"
+        );
         assert_eq!(
             count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
-            1,
-            "Cancelled broker state must enqueue exactly one HandleOrderRejection"
+            0,
+            "Cancellation must NOT enqueue a HandleOrderRejection job"
         );
         assert_eq!(
             count_jobs(&infra.apalis_pool, reconcile_order_fill_job_type()).await,
@@ -841,21 +1699,39 @@ mod tests {
             0,
             "Terminal state must not re-enqueue PollOrderStatus"
         );
+
+        // The cancellation must also finalize the owning position inline:
+        // recovering a broker-side cancel on a still-live order releases the
+        // pending slot (without the failure anchor) so the symbol is not
+        // permanently blocked from new hedges.
+        let position = infra.position.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "Confirming a broker-side cancellation must release the position's pending slot inline"
+        );
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "An intentional cancellation must NOT set the failure anchor"
+        );
     }
 
+    /// Broker reports a terminal `Cancelled` with a positive fill it never
+    /// priced (`avg_price: None`). The old behavior re-polled forever; the fix
+    /// fails closed -- it must NOT reschedule (a terminal order's price will not
+    /// appear on a later poll) and must leave the position pending rather than
+    /// clearing it, since the executed shares cannot be recorded without a price
+    /// and clearing would double-hedge on the next scan.
     #[tokio::test]
-    async fn poll_with_cancelled_partial_fill_records_fill_before_rejection() {
-        let shares_filled = FractionalShares::new(float!(1));
-        let avg_price = Usd::new(float!(150.0));
+    async fn poll_with_cancelled_unpriced_fill_fails_closed_without_reschedule() {
         let executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
             cancelled_at: Utc::now(),
-            order_id: ExecutorOrderId::new("some-broker-order-id"),
-            shares_filled,
-            avg_price: Some(avg_price),
+            order_id: ExecutorOrderId::new("noop"),
+            shares_filled: FractionalShares::new(float!(50)),
+            avg_price: None,
         });
         let infra = build_test_infra(executor).await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(100))).unwrap();
         let order_id =
             submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
 
@@ -866,11 +1742,64 @@ mod tests {
         .await
         .unwrap();
 
-        assert_partially_filled_order(&infra, order_id, shares_filled, avg_price).await;
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            0,
+            "Unpriced terminal fill must NOT reschedule a poll (no infinite loop)"
+        );
         assert_eq!(
             count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
-            1,
-            "Cancelled partial fill must still enqueue HandleOrderRejection"
+            0,
+            "Unpriced terminal fill must not be routed to rejection"
+        );
+
+        let position = infra.position.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            position.pending_offchain_order_id,
+            Some(order_id),
+            "Unpriced fill must leave the position pending (fail closed), never cleared"
+        );
+    }
+
+    /// Same fail-closed contract as the cancelled case, but the broker reports a
+    /// terminal `Failed` carrying a positive unpriced fill.
+    #[tokio::test]
+    async fn poll_with_failed_unpriced_fill_fails_closed_without_reschedule() {
+        let executor = MockExecutor::new().with_order_status(OrderState::Failed {
+            failed_at: Utc::now(),
+            error_reason: Some("broker rejected after partial fill".to_string()),
+            shares_filled: Some(FractionalShares::new(float!(50))),
+            avg_price: None,
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(100))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            0,
+            "Unpriced terminal fill must NOT reschedule a poll (no infinite loop)"
+        );
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
+            0,
+            "Unpriced terminal fill must not be routed to rejection"
+        );
+
+        let position = infra.position.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            position.pending_offchain_order_id,
+            Some(order_id),
+            "Unpriced fill must leave the position pending (fail closed), never cleared"
         );
     }
 
@@ -963,20 +1892,6 @@ mod tests {
                 self.inner.place_market_order(order).await
             }
 
-            async fn place_limit_order(
-                &self,
-                order: st0x_execution::LimitOrder,
-            ) -> Result<st0x_execution::OrderPlacement<Self::OrderId>, Self::Error> {
-                self.inner.place_limit_order(order).await
-            }
-
-            async fn cancel_order(
-                &self,
-                order_id: &Self::OrderId,
-            ) -> Result<st0x_execution::CancellationOutcome, Self::Error> {
-                self.inner.cancel_order(order_id).await
-            }
-
             async fn get_order_status(
                 &self,
                 order_id: &Self::OrderId,
@@ -1007,6 +1922,20 @@ mod tests {
                 order: st0x_execution::MarketOrder,
             ) -> Result<st0x_execution::CounterTradePreflight, Self::Error> {
                 self.inner.preflight_counter_trade(order).await
+            }
+
+            async fn place_limit_order(
+                &self,
+                order: st0x_execution::LimitOrder,
+            ) -> Result<st0x_execution::OrderPlacement<Self::OrderId>, Self::Error> {
+                self.inner.place_limit_order(order).await
+            }
+
+            async fn cancel_order(
+                &self,
+                order_id: &Self::OrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Self::Error> {
+                self.inner.cancel_order(order_id).await
             }
         }
 
@@ -1114,6 +2043,7 @@ mod tests {
                 OffchainOrderCommand::UpdatePartialFill {
                     shares_filled: FractionalShares::new(float!(5)),
                     avg_price: Usd::new(float!(150.0)),
+                    partially_filled_at: Utc::now(),
                 },
             )
             .await
@@ -1136,6 +2066,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recover_enqueues_poll_for_cancelling_order() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(10))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+        infra
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: crate::offchain::order::CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut queue = infra.ctx.poll_status_queue.clone();
+        recover_submitted_offchain_orders(
+            &infra.ctx.offchain_order_projection,
+            &mut queue,
+            SupportedExecutor::DryRun,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            1,
+            "Cancelling order must trigger one PollOrderStatus on recovery"
+        );
+    }
+
+    #[tokio::test]
     async fn recover_skips_filled_order() {
         let infra = build_test_infra(MockExecutor::new()).await;
         let symbol = Symbol::new("AAPL").unwrap();
@@ -1148,6 +2112,7 @@ mod tests {
                 &order_id,
                 OffchainOrderCommand::CompleteFill {
                     price: Usd::new(float!(150.0)),
+                    filled_at: Utc::now(),
                 },
             )
             .await
@@ -1182,6 +2147,7 @@ mod tests {
                 &order_id,
                 OffchainOrderCommand::MarkFailed {
                     error: "broker rejected".to_string(),
+                    failed_at: Utc::now(),
                 },
             )
             .await
@@ -1222,6 +2188,7 @@ mod tests {
                 &msft_id,
                 OffchainOrderCommand::CompleteFill {
                     price: Usd::new(float!(150.0)),
+                    filled_at: Utc::now(),
                 },
             )
             .await

--- a/src/offchain/order/reconcile_fill.rs
+++ b/src/offchain/order/reconcile_fill.rs
@@ -71,7 +71,9 @@ impl Job<ReconcileOrderFillCtx> for ReconcileOrderFill {
         // with the order already in `Filled`. Re-sending `CompleteFill`
         // would surface `AlreadyCompleted` and stall the job forever, so
         // we only run step 1 when the order is still pre-terminal.
-        use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
+        use OffchainOrder::{
+            Cancelled, Cancelling, Failed, Filled, PartiallyFilled, Pending, Submitted,
+        };
         match &order {
             Filled { .. } => {
                 info!(
@@ -80,16 +82,19 @@ impl Job<ReconcileOrderFillCtx> for ReconcileOrderFill {
                 );
             }
 
-            Submitted { .. } | PartiallyFilled { .. } => {
+            Submitted { .. } | PartiallyFilled { .. } | Cancelling { .. } => {
                 ctx.offchain_order
                     .send(
                         &self.offchain_order_id,
-                        OffchainOrderCommand::CompleteFill { price: self.price },
+                        OffchainOrderCommand::CompleteFill {
+                            price: self.price,
+                            filled_at: self.broker_timestamp,
+                        },
                     )
                     .await?;
             }
 
-            Pending { .. } | Failed { .. } => {
+            Pending { .. } | Failed { .. } | Cancelled { .. } => {
                 warn!(
                     offchain_order_id = %self.offchain_order_id,
                     state = ?order,
@@ -141,7 +146,9 @@ mod tests {
 
     use st0x_config::ExecutionThreshold;
     use st0x_event_sorcery::StoreBuilder;
-    use st0x_execution::{Direction, FractionalShares, Positive, SupportedExecutor, Symbol};
+    use st0x_execution::{
+        ClientOrderId, Direction, FractionalShares, Positive, SupportedExecutor, Symbol,
+    };
     use st0x_float_macro::float;
 
     use super::*;
@@ -157,7 +164,7 @@ mod tests {
         let pool = setup_test_db().await;
 
         let (offchain_order, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(())
+            .build(crate::offchain::order::noop_order_placer())
             .await
             .unwrap();
 
@@ -236,6 +243,8 @@ mod tests {
                     shares,
                     direction,
                     executor: SupportedExecutor::DryRun,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await
@@ -250,6 +259,8 @@ mod tests {
                     executor_order_id: ExecutorOrderId::new("noop"),
                     placed_shares: noop_placed_shares(shares),
                     submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
                 },
             )
             .await
@@ -335,7 +346,10 @@ mod tests {
             .offchain_order
             .send(
                 &order_id,
-                OffchainOrderCommand::CompleteFill { price: fill_price },
+                OffchainOrderCommand::CompleteFill {
+                    price: fill_price,
+                    filled_at: Utc::now(),
+                },
             )
             .await
             .unwrap();

--- a/src/performance/projection.rs
+++ b/src/performance/projection.rs
@@ -87,6 +87,9 @@ impl HedgeLatencyProjection {
             PositionEvent::ManualPositionAdjusted { adjusted_at, .. } => {
                 self.manual_position_adjusted(&symbol, adjusted_at).await
             }
+            PositionEvent::OffChainOrderCancelled {
+                offchain_order_id, ..
+            } => self.offchain_order_cancelled(offchain_order_id).await,
         }
     }
 
@@ -276,6 +279,27 @@ impl HedgeLatencyProjection {
         Ok(())
     }
 
+    /// An intentionally cancelled hedge is neither a fill nor a failure, so it
+    /// must not linger as a never-resolved pending cycle nor count toward
+    /// failure-rate analytics. Drop the pending cycle row; a cycle that already
+    /// recorded a terminal outcome (fill/failure) is left untouched.
+    async fn offchain_order_cancelled(
+        &self,
+        offchain_order_id: OffchainOrderId,
+    ) -> Result<(), ProjectionError> {
+        let id_str = offchain_order_id.to_string();
+
+        sqlx::query(
+            "DELETE FROM hedge_cycle \
+             WHERE offchain_order_id = ? AND filled_at IS NULL AND failed_at IS NULL",
+        )
+        .bind(&id_str)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
     async fn on_offchain_order(
         &self,
         id: OffchainOrderId,
@@ -316,7 +340,9 @@ impl HedgeLatencyProjection {
             OffchainOrderEvent::Placed { .. }
             | OffchainOrderEvent::PartiallyFilled { .. }
             | OffchainOrderEvent::Filled { .. }
-            | OffchainOrderEvent::Failed { .. } => Ok(()),
+            | OffchainOrderEvent::Failed { .. }
+            | OffchainOrderEvent::CancelRequested { .. }
+            | OffchainOrderEvent::Cancelled { .. } => Ok(()),
         }
     }
 }

--- a/src/performance/reliability.rs
+++ b/src/performance/reliability.rs
@@ -439,7 +439,9 @@ fn offchain_order_failure(event: &OffchainOrderEvent) -> Option<(FailureEventTyp
         | OffchainOrderEvent::Submitted { .. }
         | OffchainOrderEvent::Accepted { .. }
         | OffchainOrderEvent::PartiallyFilled { .. }
-        | OffchainOrderEvent::Filled { .. } => None,
+        | OffchainOrderEvent::Filled { .. }
+        | OffchainOrderEvent::CancelRequested { .. }
+        | OffchainOrderEvent::Cancelled { .. } => None,
     }
 }
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -13,7 +13,7 @@ use chrono::{DateTime, Utc};
 use metrics::gauge;
 use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use st0x_config::ExecutionThreshold;
 use st0x_event_sorcery::{DomainEvent, EventSourced, Projection, ProjectionError, Table};
@@ -24,7 +24,7 @@ use st0x_finance::{Usd, Usdc};
 use st0x_float_macro::float;
 use st0x_float_serde::{DebugFloat, DebugOptionFloat};
 
-use crate::offchain::order::OffchainOrderId;
+use crate::offchain::order::{CancellationReason, OffchainOrderId};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Position {
@@ -323,6 +323,27 @@ impl EventSourced for Position {
                 ..entity.clone()
             })),
 
+            OffChainOrderCancelled {
+                offchain_order_id, ..
+            } if entity.pending_offchain_order_id != Some(*offchain_order_id) => Ok(None),
+
+            OffChainOrderCancelled { cancelled_at, .. } => Ok(Some(Self {
+                // Intentional cancellation: release the pending slot so the
+                // symbol can re-hedge. Deliberately does NOT set the
+                // failure/idempotency anchor -- the replacement is a fresh
+                // order, not a retry of the cancelled one.
+                pending_offchain_order_id: None,
+                // Clear any pre-existing failure anchor too: if a prior attempt
+                // failed and stashed its OID, the cancelled order may have been
+                // placed under that key. The market-order replacement must be a
+                // FRESH order, so it must not reuse the cancelled order's
+                // `client_order_id` and be deduped by the broker against an
+                // order that no longer exists.
+                last_failed_offchain_order_id: None,
+                last_updated: Some(*cancelled_at),
+                ..entity.clone()
+            })),
+
             ThresholdUpdated {
                 new_threshold,
                 updated_at,
@@ -570,6 +591,26 @@ impl EventSourced for Position {
                     offchain_order_id,
                     error,
                     failed_at: Utc::now(),
+                }])
+            }
+
+            CancelOffChainOrder {
+                offchain_order_id,
+                reason,
+                cancelled_at,
+            } => {
+                self.validate_pending_execution(offchain_order_id)?;
+
+                info!(
+                    target: "hedge",
+                    %offchain_order_id, symbol = %self.symbol, ?reason,
+                    "Offchain order cancelled; clearing pending"
+                );
+
+                Ok(vec![PositionEvent::OffChainOrderCancelled {
+                    offchain_order_id,
+                    reason,
+                    cancelled_at,
                 }])
             }
 
@@ -904,6 +945,19 @@ pub enum PositionCommand {
         offchain_order_id: OffchainOrderId,
         error: String,
     },
+    /// Clear a pending offchain order that was intentionally cancelled (e.g.
+    /// the extended-hours -> regular cancel-and-replace), distinct from a broker
+    /// failure. Does not set the failure/idempotency anchor: the replacement is
+    /// a fresh order, not a retry under the cancelled key.
+    CancelOffChainOrder {
+        offchain_order_id: OffchainOrderId,
+        reason: CancellationReason,
+        /// The broker's cancellation time (from the terminal order), not the
+        /// wall-clock time the finalization sweep happens to run -- it flows
+        /// into `Position.last_updated`, mirroring `CompleteOffChainOrder`'s
+        /// `broker_timestamp`.
+        cancelled_at: DateTime<Utc>,
+    },
     UpdateThreshold {
         threshold: ExecutionThreshold,
     },
@@ -976,6 +1030,14 @@ pub enum PositionEvent {
         error: String,
         failed_at: DateTime<Utc>,
     },
+    /// A pending offchain order was intentionally cancelled (not a failure), so
+    /// failure-rate analytics can tell the two apart. Clears the pending
+    /// reference without setting the failure/idempotency anchor.
+    OffChainOrderCancelled {
+        offchain_order_id: OffchainOrderId,
+        reason: CancellationReason,
+        cancelled_at: DateTime<Utc>,
+    },
     ThresholdUpdated {
         old_threshold: ExecutionThreshold,
         new_threshold: ExecutionThreshold,
@@ -1008,6 +1070,7 @@ impl PositionEvent {
                 broker_timestamp, ..
             } => *broker_timestamp,
             OffChainOrderFailed { failed_at, .. } => *failed_at,
+            OffChainOrderCancelled { cancelled_at, .. } => *cancelled_at,
             ThresholdUpdated { updated_at, .. } => *updated_at,
             ManualPositionAdjusted { adjusted_at, .. } => *adjusted_at,
         }
@@ -1025,6 +1088,7 @@ impl DomainEvent for PositionEvent {
             OffChainOrderPlaced { .. } => "PositionEvent::OffChainOrderPlaced".to_string(),
             OffChainOrderFilled { .. } => "PositionEvent::OffChainOrderFilled".to_string(),
             OffChainOrderFailed { .. } => "PositionEvent::OffChainOrderFailed".to_string(),
+            OffChainOrderCancelled { .. } => "PositionEvent::OffChainOrderCancelled".to_string(),
             ThresholdUpdated { .. } => "PositionEvent::ThresholdUpdated".to_string(),
             ManualPositionAdjusted { .. } => "PositionEvent::ManualPositionAdjusted".to_string(),
         }
@@ -1159,6 +1223,18 @@ impl PartialEq for PositionEvent {
                     failed_at: f2,
                 },
             ) => o1 == o2 && e1 == e2 && f1 == f2,
+            (
+                Self::OffChainOrderCancelled {
+                    offchain_order_id: o1,
+                    reason: r1,
+                    cancelled_at: c1,
+                },
+                Self::OffChainOrderCancelled {
+                    offchain_order_id: o2,
+                    reason: r2,
+                    cancelled_at: c2,
+                },
+            ) => o1 == o2 && r1 == r2 && c1 == c2,
             (
                 Self::ThresholdUpdated {
                     old_threshold: ot1,
@@ -1347,6 +1423,16 @@ impl std::fmt::Debug for PositionCommand {
                 .field("offchain_order_id", offchain_order_id)
                 .field("error", error)
                 .finish(),
+            Self::CancelOffChainOrder {
+                offchain_order_id,
+                reason,
+                cancelled_at,
+            } => f
+                .debug_struct("CancelOffChainOrder")
+                .field("offchain_order_id", offchain_order_id)
+                .field("reason", reason)
+                .field("cancelled_at", cancelled_at)
+                .finish(),
             Self::UpdateThreshold { threshold } => f
                 .debug_struct("UpdateThreshold")
                 .field("threshold", threshold)
@@ -1459,6 +1545,16 @@ impl std::fmt::Debug for PositionEvent {
                 .field("offchain_order_id", offchain_order_id)
                 .field("error", error)
                 .field("failed_at", failed_at)
+                .finish(),
+            Self::OffChainOrderCancelled {
+                offchain_order_id,
+                reason,
+                cancelled_at,
+            } => f
+                .debug_struct("OffChainOrderCancelled")
+                .field("offchain_order_id", offchain_order_id)
+                .field("reason", reason)
+                .field("cancelled_at", cancelled_at)
                 .finish(),
             Self::ThresholdUpdated {
                 old_threshold,
@@ -2144,6 +2240,133 @@ mod tests {
             .events();
 
         assert_eq!(events.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cancel_offchain_order_emits_cancelled_not_failed() {
+        let threshold = one_share_threshold();
+        let offchain_order_id = OffchainOrderId::new();
+        let broker_cancelled_at = Utc::now();
+
+        let events = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    threshold,
+                    initialized_at: Utc::now(),
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 1,
+                    },
+                    amount: FractionalShares::new(float!(1.5)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: Utc::now(),
+                    seen_at: Utc::now(),
+                },
+                PositionEvent::OffChainOrderPlaced {
+                    offchain_order_id,
+                    shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    trigger_reason: TriggerReason::SharesThreshold {
+                        net_position_shares: float!(1.5),
+                        threshold_shares: float!(1),
+                    },
+                    placed_at: Utc::now(),
+                },
+            ])
+            .when(PositionCommand::CancelOffChainOrder {
+                offchain_order_id,
+                reason: CancellationReason::MarketOpenReplacement,
+                cancelled_at: broker_cancelled_at,
+            })
+            .await
+            .events();
+
+        // An intentional cancellation must emit OffChainOrderCancelled, NOT
+        // OffChainOrderFailed -- otherwise it pollutes failure-rate analytics.
+        // The event must carry the broker's cancellation time, not the
+        // wall-clock time the command handler ran.
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(
+                events.first(),
+                Some(PositionEvent::OffChainOrderCancelled {
+                    reason: CancellationReason::MarketOpenReplacement,
+                    cancelled_at,
+                    ..
+                }) if *cancelled_at == broker_cancelled_at
+            ),
+            "expected OffChainOrderCancelled carrying the broker timestamp, got: {:?}",
+            events.first()
+        );
+    }
+
+    #[test]
+    fn cancelling_an_order_clears_a_pre_existing_failure_anchor() {
+        // A prior attempt failed and stashed its OID as the idempotency anchor.
+        // The next attempt is placed (and reuses that anchor as its
+        // client_order_id), then cancelled at the Extended->Regular transition.
+        // The cancel must clear the anchor so the market-order REPLACEMENT is a
+        // fresh order, not a retry deduped by the broker against the cancelled
+        // order's key.
+        let failed_order_id = OffchainOrderId::new();
+        let cancelled_order_id = OffchainOrderId::new();
+
+        let placed = |offchain_order_id| PositionEvent::OffChainOrderPlaced {
+            offchain_order_id,
+            shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            trigger_reason: TriggerReason::SharesThreshold {
+                net_position_shares: float!(1.5),
+                threshold_shares: float!(1),
+            },
+            placed_at: Utc::now(),
+        };
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: Utc::now(),
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(1.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: Utc::now(),
+                seen_at: Utc::now(),
+            },
+            placed(failed_order_id),
+            PositionEvent::OffChainOrderFailed {
+                offchain_order_id: failed_order_id,
+                error: "broker rejected".to_string(),
+                failed_at: Utc::now(),
+            },
+            placed(cancelled_order_id),
+            PositionEvent::OffChainOrderCancelled {
+                offchain_order_id: cancelled_order_id,
+                reason: CancellationReason::MarketOpenReplacement,
+                cancelled_at: Utc::now(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "cancellation must clear the failure/idempotency anchor so the \
+             replacement is a fresh order"
+        );
+        assert_eq!(position.pending_offchain_order_id, None);
     }
 
     #[tokio::test]

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -331,7 +331,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::offchain::order::{OffchainOrder, OffchainOrderCommand};
+    use crate::offchain::order::{OffchainOrder, OffchainOrderCommand, noop_order_placer};
     use crate::position::{PositionCommand, TradeId};
     use crate::test_utils::setup_test_pools;
 
@@ -351,7 +351,7 @@ mod tests {
 
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(noop_order_placer())
                 .await
                 .unwrap();
 
@@ -427,6 +427,10 @@ mod tests {
                     shares,
                     direction: Direction::Sell,
                     executor: SupportedExecutor::DryRun,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(
+                        offchain_order_id.as_uuid(),
+                    ),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await
@@ -573,7 +577,7 @@ mod tests {
 
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(noop_order_placer())
                 .await
                 .unwrap();
 

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -2056,7 +2056,10 @@ impl Reactor for RebalancingService {
                             .insert(symbol);
                         return Ok(());
                     }
-                    OffChainOrderFailed { .. } => {
+                    OffChainOrderFailed { .. } | OffChainOrderCancelled { .. } => {
+                        // A failure or an intentional cancellation both release
+                        // the symbol's pending-offchain-order gate; nudge an
+                        // immediate equity check rather than waiting a poll cycle.
                         self.pending_offchain_order_symbols
                             .write()
                             .await

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -16,8 +16,8 @@ use st0x_execution::{Direction, FractionalShares, Positive, SupportedExecutor, S
 
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::offchain::order::{
-    OffchainOrder, OffchainOrderId, OrderPlacer, PollOrderStatus, PollOrderStatusJobQueue,
-    client_order_id_for_placement, place_offchain_order_at_broker,
+    OffchainOrder, OffchainOrderId, OffchainOrderPlacement, OrderPlacer, PollOrderStatus,
+    PollOrderStatusJobQueue, client_order_id_for_placement, place_offchain_order_at_broker,
 };
 use crate::position::{Position, PositionCommand, PositionError};
 use crate::trading::onchain::trade_accountant::TradeAccountingError;
@@ -77,9 +77,11 @@ async fn recover_pending_poll_status(
     ctx: &HedgeCtx,
     pending_id: OffchainOrderId,
 ) -> Result<(), TradeAccountingError> {
-    use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
+    use OffchainOrder::{
+        Cancelled, Cancelling, Failed, Filled, PartiallyFilled, Pending, Submitted,
+    };
     match ctx.offchain_order.load(&pending_id).await? {
-        Some(Submitted { .. } | PartiallyFilled { .. }) => {
+        Some(Submitted { .. } | PartiallyFilled { .. } | Cancelling { .. }) => {
             ctx.poll_status_queue
                 .clone()
                 .push(PollOrderStatus {
@@ -106,17 +108,19 @@ async fn recover_pending_poll_status(
                 &ctx.offchain_order,
                 ctx.order_placer.as_ref(),
                 &pending_id,
-                symbol.clone(),
-                shares,
-                direction,
-                executor,
-                client_order_id,
+                OffchainOrderPlacement::market(
+                    symbol.clone(),
+                    shares,
+                    direction,
+                    executor,
+                    client_order_id,
+                ),
             )
             .await?;
 
             route_placement_outcome(ctx, &symbol, pending_id, placed).await
         }
-        Some(Filled { .. } | Failed { .. }) | None => Ok(()),
+        Some(Filled { .. } | Failed { .. } | Cancelled { .. }) | None => Ok(()),
     }
 }
 
@@ -141,7 +145,9 @@ async fn route_placement_outcome(
     offchain_order_id: OffchainOrderId,
     placed: Option<OffchainOrder>,
 ) -> Result<(), TradeAccountingError> {
-    use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
+    use OffchainOrder::{
+        Cancelled, Cancelling, Failed, Filled, PartiallyFilled, Pending, Submitted,
+    };
     match placed {
         Some(Failed { error, .. }) => {
             ctx.position
@@ -155,7 +161,7 @@ async fn route_placement_outcome(
                 .await?;
         }
 
-        Some(Submitted { .. } | PartiallyFilled { .. }) => {
+        Some(Submitted { .. } | PartiallyFilled { .. } | Cancelling { .. }) => {
             ctx.poll_status_queue
                 .clone()
                 .push(PollOrderStatus { offchain_order_id })
@@ -194,6 +200,8 @@ async fn route_placement_outcome(
                 state,
             });
         }
+
+        Some(Cancelled { .. }) => {}
     }
 
     Ok(())
@@ -299,11 +307,13 @@ impl Job<HedgeCtx> for PlaceHedge {
             &ctx.offchain_order,
             ctx.order_placer.as_ref(),
             &self.offchain_order_id,
-            self.symbol.clone(),
-            self.shares,
-            self.direction,
-            self.executor,
-            client_order_id,
+            OffchainOrderPlacement::market(
+                self.symbol.clone(),
+                self.shares,
+                self.direction,
+                self.executor,
+                client_order_id,
+            ),
         )
         .await?;
 
@@ -348,7 +358,30 @@ mod tests {
                 Ok(OrderPlacementResult {
                     executor_order_id: ExecutorOrderId::new("test-order-123"),
                     placed_shares: order.shares,
+                    is_extended_hours: false,
+                    limit_price: None,
                 })
+            }
+
+            async fn place_limit_order(
+                &self,
+                order: st0x_execution::LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(OrderPlacementResult {
+                    executor_order_id: ExecutorOrderId::new("test-limit-order-123"),
+                    placed_shares: order.shares,
+                    is_extended_hours: order.extended_hours,
+                    limit_price: Some(order.limit_price),
+                })
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &st0x_execution::ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
             }
         }
 
@@ -368,6 +401,24 @@ mod tests {
                 Box<dyn std::error::Error + Send + Sync>,
             > {
                 Err("Broker rejected: insufficient buying power".into())
+            }
+
+            async fn place_limit_order(
+                &self,
+                _order: st0x_execution::LimitOrder,
+            ) -> Result<
+                crate::offchain::order::OrderPlacementResult,
+                Box<dyn std::error::Error + Send + Sync>,
+            > {
+                Err("Broker rejected: insufficient buying power".into())
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &st0x_execution::ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
             }
         }
 
@@ -391,7 +442,7 @@ mod tests {
 
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(order_placer.clone())
                 .await
                 .unwrap();
 
@@ -464,6 +515,7 @@ mod tests {
             direction: Direction::Sell,
             executor: SupportedExecutor::DryRun,
             placed_at: chrono::Utc::now(),
+            market_session: st0x_execution::MarketSession::Regular,
         };
 
         let error =
@@ -852,6 +904,10 @@ mod tests {
                     shares: job.shares,
                     direction: job.direction,
                     executor: job.executor,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(
+                        job.offchain_order_id.as_uuid(),
+                    ),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
                 },
             )
             .await

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -330,7 +330,7 @@ mod tests {
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(noop_order_placer())
                 .await
                 .unwrap();
 
@@ -459,7 +459,7 @@ mod tests {
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(())
+                .build(noop_order_placer())
                 .await
                 .unwrap();
 


### PR DESCRIPTION
## What

- Bring the `OffchainOrder` event-sourced aggregate to its full extended-hours shape: `Cancelling` / `Cancelled` states, `CancelOrder` / `ConfirmCancellation` / `UpdatePartialFill` commands+events, `CounterTradeOrderKind`, and the shared `terminal_position_finalization` / `position_command_for_finalization` finalization helpers.
- Two-phase cancellation is fail-closed: a pre-cancel reconcile fetches broker state first and, if that fetch fails or the order has positive unpriced fills, blocks and retries rather than cancelling blind.
- Reconcile broker outcomes in the poll loop (`poll_status`): record partial fills, recover broker-side (unrequested) cancellations, confirm requested cancellations; `handle_rejection` / `reconcile_fill` thread broker timestamps through terminal transitions.
- Confirmed cancellations finalize the owning `Position` inline in the poll path: `PollOrderStatusCtx` carries a `position_store`, and `confirm_cancellation` + the broker-side-cancel recovery dispatch the position command through the shared finalization helpers — fail-closed on an unpriced fill (leave the position pending, never clear it).
- `Position` gains the `OffChainOrderCancelled` event/command (distinct from `Failed`); `api` adds `Cancelling` to the pending-orders query.

## Why

- Second PR of the stack (#916 -> **#931** -> #932). Lands the state machine and outcome reconciliation on top of the execution layer, before the hedge / cancel-and-replace policy wiring in #932.

## How

- `src/offchain/order.rs` + `poll_status.rs` / `handle_rejection.rs` / `reconcile_fill.rs`, `src/position.rs`, `src/api.rs` at the feature version. `cli/trading` and the event projections (`performance/projection`, `performance/reliability`, `dashboard/*`, `rebalancing/trigger`) are also brought up (additive arms for the new events).
- Consumer glue, conservative and finalized in #932: `conductor` and `hedge` handle the new `Cancelling` / `Cancelled` states and pass `kind: CounterTradeOrderKind::Market` on `Place`; conductor's orphan recovery is refactored to route terminal states through the shared `position_command_for_finalization` helper so #932's cancel-and-replace sweep cannot drift from it.

## Testing

- New aggregate unit tests cover the `Cancelling` / `Cancelled` transitions, partial-fill recording, broker-vs-requested cancellation reconciliation, and the finalization helpers; poll-path tests assert the position is released/completed inline on cancellation and that a terminal broker state with an unpriced fill fails closed (leaves the position pending, no re-poll loop). Projection/`api`/`cli` tests are updated for the new events. Verified locally on the stack tip: `cargo check --all-targets`, `cargo clippy --all-features`, `cargo fmt --check` clean. CI runs the full suite per PR.

## Anything else

- Post-review blocker fix ([RAI-1172](https://linear.app/makeitrain/issue/RAI-1172)): the normal poll path previously confirmed an order terminal `Cancelled` but never finalized the owning `Position`, leaving `pending_offchain_order_id` set forever and permanently blocking the symbol from new hedges. The poll path now finalizes it (fail-closed on unpriced fills), and the unbounded re-poll for terminal broker `Failed`/`Cancelled` states carrying an unpriced fill is replaced with a fail-closed leave-pending.
- Event-sourcing: bumps `OffchainOrder::SCHEMA_VERSION` 1 -> 2; new states/events are added and new payload fields default when absent, so pre-feature events still deserialize on replay.
- Stack: #915 -> #916 -> **#931** -> #932. The placeholder `kind: Market` and the conservative cancel-state arms here are replaced by the session-aware logic in #932.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end handling for orders in the **Cancelling** lifecycle across pending views, polling, reconciliation, and recovery.
  * Enhanced order/position reporting with richer timestamps for fills, partial fills, failures, and cancellations (including improved CLI status output).
* **Bug Fixes**
  * Fixed cancellation handling so **Cancelled** and **Failed** are processed separately, with terminal states excluded from retries/repairs.
  * Improved dashboard/performance behavior so cancellation events no longer trigger fill-related broadcasts or hedge-cycle updates.
* **Tests**
  * Expanded coverage to verify correct state mapping, terminal behavior, and timestamp propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
