### PR TITLE
feat: wire extended-hours counter-trading (hedge, position-check, conductor)

### DIFF
--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -462,6 +462,10 @@ mod tests {
     use crate::position::TradeId;
     use crate::test_utils::{positive_shares, setup_test_db};
 
+    fn repair_order_placer() -> Arc<dyn OrderPlacer> {
+        Arc::new(RepairOrderPlacer)
+    }
+
     /// Seeds a standalone OffchainOrder aggregate for `order_id` into the
     /// non-terminal `Submitted` state (Place -> Placed + Submitted via the noop
     /// placer), so repair can drive it to `Failed`.
@@ -660,7 +664,7 @@ mod tests {
                 price: Usd::new(float!(100)),
                 filled_at: chrono::Utc::now(),
             },
-            crate::offchain::order::noop_order_placer(),
+            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -719,7 +723,7 @@ mod tests {
                 price: Usd::new(float!(100)),
                 filled_at: chrono::Utc::now(),
             },
-            crate::offchain::order::noop_order_placer(),
+            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -769,7 +773,7 @@ mod tests {
                 avg_price: Usd::new(float!(100)),
                 partially_filled_at: chrono::Utc::now(),
             },
-            crate::offchain::order::noop_order_placer(),
+            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -842,7 +846,7 @@ mod tests {
                 avg_price: Usd::new(float!(100)),
                 partially_filled_at: chrono::Utc::now(),
             },
-            crate::offchain::order::noop_order_placer(),
+            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -864,7 +868,7 @@ mod tests {
                 price: Usd::new(float!(100)),
                 filled_at: chrono::Utc::now(),
             },
-            crate::offchain::order::noop_order_placer(),
+            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -886,7 +890,7 @@ mod tests {
                 error: "bot failed it".to_string(),
                 failed_at: chrono::Utc::now(),
             },
-            crate::offchain::order::noop_order_placer(),
+            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -933,7 +937,7 @@ mod tests {
                 price: Usd::new(float!(100)),
                 filled_at: chrono::Utc::now(),
             },
-            crate::offchain::order::noop_order_placer(),
+            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -975,7 +979,7 @@ mod tests {
                 error: "bot failed it concurrently".to_string(),
                 failed_at: chrono::Utc::now(),
             },
-            crate::offchain::order::noop_order_placer(),
+            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -1027,7 +1031,7 @@ mod tests {
                 error: "pre-failed".to_string(),
                 failed_at: chrono::Utc::now(),
             },
-            crate::offchain::order::noop_order_placer(),
+            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -1219,7 +1223,7 @@ mod tests {
                 avg_price: Usd::new(float!(100)),
                 partially_filled_at: chrono::Utc::now(),
             },
-            crate::offchain::order::noop_order_placer(),
+            repair_order_placer(),
         )
         .await
         .unwrap();

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -2167,6 +2167,7 @@ mod tests {
             },
             counter_trade_submission_lock: Arc::new(Mutex::new(())),
             poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
+            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&apalis_pool),
         };
 
         // The trade_event payload is never accessed because process_queued_trade

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -42,7 +42,7 @@ use st0x_evm::{USDC_BASE, Wallet};
 use st0x_execution::{
     AlpacaBrokerApi, AlpacaWalletService, ClientOrderId, CounterTradePreflight,
     CounterTradeReservation, CounterTradeSkipReason, ExecutionError, Executor, FractionalShares,
-    MarketOrder, Symbol, TryIntoExecutor,
+    MarketOrder, MarketSession, Symbol, TryIntoExecutor,
 };
 use st0x_raindex::{RaindexService, RaindexVaultId};
 use st0x_wrapper::WrapperService;
@@ -60,8 +60,9 @@ use crate::inventory::{
 use crate::offchain::order::{
     ExecutorOrderPlacer, OffchainOrder, OffchainOrderId, OffchainOrderPlacement, OrderPlacer,
     PollOrderStatus, PollOrderStatusJobQueue, TerminalPositionFinalization,
-    client_order_id_for_placement, place_offchain_order_at_broker,
-    position_command_for_finalization, terminal_position_finalization,
+    client_order_id_for_placement, finalize_cancelled_position_or_log_unpriced,
+    place_offchain_order_at_broker, position_command_for_finalization,
+    terminal_position_finalization,
 };
 #[cfg(test)]
 use crate::offchain::order::{OffchainOrderCommand, noop_order_placer};
@@ -215,6 +216,10 @@ pub(crate) struct TradeProcessingCqrs {
     /// hook the order stays `Submitted` forever -- the system has no other
     /// trigger to ask the broker about an in-flight order.
     pub(crate) poll_status_queue: PollOrderStatusJobQueue,
+    /// Used to enqueue an immediate `PlaceHedge` for extended-hours fills, which
+    /// the inline path cannot place itself (it has no `OrderPlacer` for the
+    /// limit-order price lookup). `CheckPositions` is the backstop.
+    pub(crate) hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue,
 }
 
 /// Orchestrates the bot's runtime by composing long-running supervised tasks
@@ -1808,7 +1813,6 @@ pub(crate) async fn recover_orphaned_pending_offchain_orders(
     Ok(())
 }
 
-#[allow(clippy::cognitive_complexity)]
 async fn recover_single_orphaned_order(
     position: &Arc<Store<Position>>,
     offchain_order: &Arc<Store<OffchainOrder>>,
@@ -1948,14 +1952,23 @@ async fn resolve_terminal_claimed_order(
 
 /// Maps an orphaned offchain order to the position command that finalizes
 /// its owning position, or `None` when the position must be left pending.
-/// Routes terminal states through the shared finalization helpers so the
-/// mapping cannot drift from the cancel-and-replace sweep / rejection paths.
+/// Every `None` path logs its reason, so the caller's early return is never
+/// silent.
+#[allow(clippy::cognitive_complexity)]
 fn orphaned_order_position_command(
     order: &OffchainOrder,
     symbol: &Symbol,
     order_id: OffchainOrderId,
 ) -> Option<PositionCommand> {
     match terminal_position_finalization(order) {
+        // Mirrors `CheckPositionsCtx::finalize_position_for_terminal_order`:
+        // the fill cannot be recorded without a price, so leave the position
+        // pending instead of aborting the whole startup recovery sweep. The
+        // order is terminal, so its data never changes -- NO automated path
+        // resolves this; the every-tick finalize sweep only re-logs it, and
+        // operator intervention is required to record or discard the fill.
+        // Aborting here would instead crash-loop the bot and block hedging of
+        // every other symbol.
         Some(TerminalPositionFinalization::UnpricedFill { shares_filled }) => {
             error!(
                 %symbol, %order_id, %shares_filled,
@@ -1965,15 +1978,35 @@ fn orphaned_order_position_command(
             None
         }
 
+        // Non-terminal: the order is still in progress (Submitted /
+        // PartiallyFilled / Cancelling / Pending) -- nothing to finalize yet.
         None => {
-            if let OffchainOrder::Pending { .. } = order {
-                warn!(%symbol, %order_id, "Orphaned offchain order still Pending at startup -- may never have been submitted to the broker");
-            } else {
-                debug!(%symbol, %order_id, state = ?order, "Orphaned offchain order still in progress");
+            // A `Pending` order at startup was claimed by the position but never
+            // submitted to the broker, and this recovery sweep has no path to
+            // re-drive it -- surface it at warn so the anomaly is visible. The
+            // other in-flight states (Submitted/PartiallyFilled/Cancelling) are
+            // owned by the poll loop and are expected here.
+            match order {
+                OffchainOrder::Pending { .. } => {
+                    warn!(%symbol, %order_id, "Orphaned offchain order still Pending at startup -- may never have been submitted to the broker");
+                }
+                OffchainOrder::Submitted { .. }
+                | OffchainOrder::PartiallyFilled { .. }
+                | OffchainOrder::Cancelling { .. } => {
+                    debug!(%symbol, %order_id, state = ?order, "Orphaned offchain order still in progress");
+                }
+                OffchainOrder::Filled { .. }
+                | OffchainOrder::Failed { .. }
+                | OffchainOrder::Cancelled { .. } => {
+                    debug!(%symbol, %order_id, state = ?order, "Orphaned terminal order had no position finalization");
+                }
             }
             None
         }
 
+        // Complete and both NoFill outcomes map through the shared helper so
+        // the terminal-state -> position-command mapping cannot drift from
+        // the cancel-and-replace sweep and rejection paths.
         Some(finalization) => {
             let command = position_command_for_finalization(finalization, order_id);
             info!(%symbol, %order_id, ?command, "Orphaned order terminal -- recovering");
@@ -2240,10 +2273,9 @@ pub(crate) async fn execute_acknowledge_fill(
 }
 
 /// Marks the trade acknowledged on the `OnChainTrade` aggregate after the
-/// position write succeeded, completing the exactly-once pair (ADR 0005).
-/// A re-driven marker (`AlreadyAcknowledged`) is idempotent;
-/// infrastructure errors propagate so the apalis retry re-drives the
-/// idempotent acknowledge pair.
+/// position write succeeded. A re-driven marker (`AlreadyAcknowledged`) is
+/// idempotent; infrastructure errors propagate so the apalis retry re-drives
+/// the idempotent accounting steps.
 pub(crate) async fn execute_mark_acknowledged(
     onchain_trade: &Store<OnChainTrade>,
     trade_id: &OnChainTradeId,
@@ -2485,6 +2517,57 @@ where
     else {
         return Ok(None);
     };
+
+    // Extended-hours counter-trades cannot be placed inline (this path has no
+    // OrderPlacer for the limit-order price lookup). Instead of waiting for the
+    // next CheckPositions scan (~1 min), enqueue an immediate PlaceHedge job,
+    // which has the OrderPlacer and submits the limit order. CheckPositions
+    // remains the backstop. Preflight + clamp here, mirroring the scan path, so
+    // we never enqueue a hedge that would exceed buying power.
+    if execution.market_session == MarketSession::Extended {
+        let _counter_trade_submission_guard = cqrs.counter_trade_submission_lock.lock().await;
+
+        match preflight_counter_trade_submission(executor, &execution, None).await? {
+            CounterTradeSubmissionCheck::Skipped => return Ok(None),
+            CounterTradeSubmissionCheck::Allowed { reservation } => {
+                clamp_shares_to_reservation(&mut execution, reservation.as_ref());
+            }
+        }
+
+        let offchain_order_id = OffchainOrderId::new();
+        info!(
+            target: "hedge",
+            symbol = %execution.symbol,
+            shares = %execution.shares,
+            direction = ?execution.direction,
+            "Extended hours: enqueueing immediate PlaceHedge (limit order via the job's OrderPlacer)"
+        );
+
+        let job = crate::trading::offchain::hedge::PlaceHedge {
+            symbol: execution.symbol.clone(),
+            direction: execution.direction,
+            shares: execution.shares,
+            executor: execution.executor,
+            threshold: cqrs.execution_threshold,
+            offchain_order_id,
+            market_session: execution.market_session,
+        };
+
+        if let Err(error) = cqrs.hedge_queue.clone().push(job).await {
+            error!(
+                target: "hedge",
+                symbol = %execution.symbol,
+                %error,
+                "Failed to enqueue extended-hours hedge; position remains ready for CheckPositions retry"
+            );
+        }
+
+        // No inline offchain order was placed: the durable PlaceHedge job claims
+        // the position (via PlaceOffChainOrder) when it runs. Returning the job's
+        // not-yet-recorded id would be a synthetic handle the aggregates know
+        // nothing about, so signal "no inline placement" with None.
+        return Ok(None);
+    }
 
     let _counter_trade_submission_guard = cqrs.counter_trade_submission_lock.lock().await;
 
@@ -2932,7 +3015,7 @@ async fn dispatch_post_place_state(
             Ok(PostPlaceOutcome::Failed(offchain_order_id))
         }
 
-        Some(Submitted { .. } | PartiallyFilled { .. }) => {
+        Some(Submitted { .. } | PartiallyFilled { .. } | Cancelling { .. }) => {
             let mut queue = cqrs.poll_status_queue.clone();
 
             queue
@@ -2972,15 +3055,32 @@ async fn dispatch_post_place_state(
         // `Pending`) and the durable placement path commits the broker outcome
         // separately. `place_offchain_order_at_broker` returns only once the
         // order has left `Pending`, and a commit failure propagates out of
-        // `execute_create_offchain_order` before we reach here -- so `Pending` or
-        // `Filled` at this point is unexpected. Surface it as a retryable error
-        // rather than clearing the position claim, which would strand a
+        // `execute_create_offchain_order` before we reach here -- so `Pending`
+        // or `Filled` at this point is unexpected. Surface it as a retryable
+        // error rather than clearing the position claim, which would strand a
         // possibly-live broker order.
-        Some(state @ (Pending { .. } | Filled { .. } | Cancelling { .. } | Cancelled { .. })) => {
+        Some(state @ (Pending { .. } | Filled { .. })) => {
             Err(TradeAccountingError::UnexpectedPostPlaceState {
                 offchain_order_id,
                 state,
             })
+        }
+
+        // Cancelled directly after Place is unexpected but is a genuine
+        // broker-confirmed cancellation: route through the shared terminal
+        // finalization instead of recording a failure, which would anchor the
+        // next attempt's client_order_id to the cancelled key and drop any
+        // retained fill. Shared with the matching arm in `PlaceHedge::perform`.
+        Some(cancelled @ Cancelled { .. }) => {
+            finalize_cancelled_position_or_log_unpriced(
+                cqrs.position.as_ref(),
+                symbol,
+                offchain_order_id,
+                &cancelled,
+            )
+            .await?;
+
+            Ok(PostPlaceOutcome::ClearedNoOrder)
         }
     }
 }
@@ -3288,7 +3388,7 @@ mod tests {
     use crate::equity_redemption::{EquityRedemptionCommand, redemption_aggregate_id};
     use crate::inventory::view::Operator;
     use crate::inventory::{ImbalanceThreshold, Inventory, InventoryView, Venue};
-    use crate::offchain::order::OrderPlacementResult;
+    use crate::offchain::order::{CancellationReason, OrderPlacementResult, RetainedFill};
     use crate::onchain::mock::MockRaindex;
     use crate::onchain::trade::OnchainTrade;
     use crate::rebalancing::equity::{
@@ -4751,6 +4851,13 @@ mod tests {
     async fn create_cqrs_frameworks(
         pool: &SqlitePool,
     ) -> (CqrsFrameworks, Arc<Projection<OffchainOrder>>) {
+        create_cqrs_frameworks_with_order_placer(pool, noop_order_placer()).await
+    }
+
+    async fn create_cqrs_frameworks_with_order_placer(
+        pool: &SqlitePool,
+        order_placer: Arc<dyn OrderPlacer>,
+    ) -> (CqrsFrameworks, Arc<Projection<OffchainOrder>>) {
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
             .build(())
             .await
@@ -4763,7 +4870,7 @@ mod tests {
 
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
+                .build(order_placer)
                 .await
                 .unwrap();
 
@@ -4797,6 +4904,25 @@ mod tests {
         threshold: ExecutionThreshold,
         apalis_pool: &apalis_sqlite::SqlitePool,
     ) -> TradeProcessingCqrs {
+        trade_processing_cqrs_with_assets(
+            frameworks,
+            pool,
+            threshold,
+            apalis_pool,
+            AssetsConfig {
+                equities: EquitiesConfig::default(),
+                cash: None,
+            },
+        )
+    }
+
+    fn trade_processing_cqrs_with_assets(
+        frameworks: &CqrsFrameworks,
+        pool: &SqlitePool,
+        threshold: ExecutionThreshold,
+        apalis_pool: &apalis_sqlite::SqlitePool,
+        assets: AssetsConfig,
+    ) -> TradeProcessingCqrs {
         TradeProcessingCqrs {
             pool: pool.clone(),
             onchain_trade: frameworks.onchain_trade.clone(),
@@ -4805,12 +4931,33 @@ mod tests {
             offchain_order: frameworks.offchain_order.clone(),
             order_placer: succeeding_order_placer(),
             execution_threshold: threshold,
-            assets: AssetsConfig {
-                equities: EquitiesConfig::default(),
-                cash: None,
-            },
+            assets,
             counter_trade_submission_lock: Arc::new(Mutex::new(())),
             poll_status_queue: PollOrderStatusJobQueue::new(apalis_pool),
+            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(apalis_pool),
+        }
+    }
+
+    fn extended_hours_assets(symbol: &Symbol) -> AssetsConfig {
+        AssetsConfig {
+            equities: EquitiesConfig {
+                operational_limit: None,
+                symbols: HashMap::from([(
+                    symbol.clone(),
+                    EquityAssetConfig {
+                        tokenized_equity: Address::ZERO,
+                        tokenized_equity_derivative: Address::ZERO,
+                        pyth_feed_id: None,
+                        vault_ids: Vec::new(),
+                        trading: OperationMode::Enabled,
+                        rebalancing: OperationMode::Disabled,
+                        wrapped_equity_recovery: OperationMode::Disabled,
+                        extended_hours_counter_trading: OperationMode::Enabled,
+                        operational_limit: None,
+                    },
+                )]),
+            },
+            cash: None,
         }
     }
 
@@ -6036,6 +6183,329 @@ mod tests {
                 .unwrap()
                 .is_empty(),
             "Skipped counter trades must not create offchain orders"
+        );
+    }
+
+    #[tokio::test]
+    async fn extended_hours_trade_skips_immediate_hedge_without_offchain_inventory() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let cqrs = trade_processing_cqrs_with_assets(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+            extended_hours_assets(&symbol),
+        );
+
+        let trade_event = make_trade_event(75);
+        let trade = test_trade_with_amount_and_direction(float!(1.5), 75, Direction::Buy);
+        let executor = MockExecutor::new()
+            .with_market_session(MarketSession::Extended)
+            .with_inventory(ExecutionInventory {
+                positions: vec![],
+                usd_balance_cents: 100_000,
+                cash_buying_power_cents: Some(100_000),
+                alpaca_usdc: None,
+                cash_withdrawable_cents: None,
+            });
+
+        let result = process_queued_trade(&executor, &trade_event, trade, &cqrs, true)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result, None,
+            "Extended-hours counter trade should be skipped when preflight rejects"
+        );
+
+        let position = cqrs
+            .position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "Skipped extended-hours counter trades must not claim the position"
+        );
+        assert!(
+            offchain_order_projection
+                .load_all()
+                .await
+                .unwrap()
+                .is_empty(),
+            "Skipped extended-hours counter trades must not create offchain orders"
+        );
+
+        let hedge_jobs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<
+                crate::trading::offchain::hedge::PlaceHedge,
+            >())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            hedge_jobs, 0,
+            "Skipped extended-hours counter trades must not enqueue PlaceHedge jobs"
+        );
+    }
+
+    #[tokio::test]
+    async fn extended_hours_trade_enqueues_immediate_hedge_job() {
+        // With extended-hours counter-trading enabled and the broker in an
+        // Extended session, an onchain fill must enqueue an immediate PlaceHedge
+        // job (which has the OrderPlacer for the limit order) rather than place
+        // inline or wait for the next CheckPositions scan.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = TradeProcessingCqrs {
+            pool: pool.clone(),
+            onchain_trade: frameworks.onchain_trade.clone(),
+            position: frameworks.position.clone(),
+            position_projection: frameworks.position_projection.clone(),
+            offchain_order: frameworks.offchain_order.clone(),
+            order_placer: succeeding_order_placer(),
+            execution_threshold: ExecutionThreshold::whole_share(),
+            assets: AssetsConfig {
+                equities: EquitiesConfig {
+                    operational_limit: None,
+                    symbols: HashMap::from([(
+                        Symbol::new("AAPL").unwrap(),
+                        EquityAssetConfig {
+                            tokenized_equity: Address::ZERO,
+                            tokenized_equity_derivative: Address::ZERO,
+                            pyth_feed_id: None,
+                            vault_ids: Vec::new(),
+                            trading: OperationMode::Enabled,
+                            rebalancing: OperationMode::Disabled,
+                            wrapped_equity_recovery: OperationMode::Disabled,
+                            extended_hours_counter_trading: OperationMode::Enabled,
+                            operational_limit: None,
+                        },
+                    )]),
+                },
+                cash: None,
+            },
+            counter_trade_submission_lock: Arc::new(Mutex::new(())),
+            poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
+            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&apalis_pool),
+        };
+
+        let trade_event = make_trade_event(77);
+        let trade = test_trade_with_amount_and_direction(float!(5.0), 77, Direction::Buy);
+
+        let executor = MockExecutor::new()
+            .with_market_session(MarketSession::Extended)
+            .with_inventory(ExecutionInventory {
+                positions: vec![EquityPosition {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: FractionalShares::new(float!(10.0)),
+                    market_value: None,
+                }],
+                usd_balance_cents: 1_000_000,
+                cash_buying_power_cents: Some(1_000_000),
+                alpaca_usdc: None,
+                cash_withdrawable_cents: None,
+            });
+
+        let result = process_queued_trade(&executor, &trade_event, trade, &cqrs, true)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result, None,
+            "no inline offchain order is placed for extended hours; the PlaceHedge \
+             job claims the position when it runs"
+        );
+
+        assert!(
+            offchain_order_projection
+                .load_all()
+                .await
+                .unwrap()
+                .is_empty(),
+            "extended-hours hedge must be deferred to a PlaceHedge job, not placed inline"
+        );
+
+        let hedge_jobs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<
+                crate::trading::offchain::hedge::PlaceHedge,
+            >())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            hedge_jobs, 1,
+            "exactly one immediate PlaceHedge job should be enqueued for the extended-hours fill"
+        );
+
+        let job_bytes: Vec<u8> = sqlx::query_scalar("SELECT job FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<
+                crate::trading::offchain::hedge::PlaceHedge,
+            >())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let job: crate::trading::offchain::hedge::PlaceHedge =
+            serde_json::from_slice(&job_bytes).unwrap();
+
+        assert_eq!(job.symbol, Symbol::new("AAPL").unwrap());
+        assert_eq!(
+            job.direction,
+            Direction::Sell,
+            "an onchain buy must be hedged by an offchain sell"
+        );
+        assert_eq!(
+            job.shares,
+            Positive::new(FractionalShares::new(float!(5.0))).unwrap()
+        );
+        assert_eq!(job.executor, st0x_execution::SupportedExecutor::DryRun);
+        assert_eq!(job.threshold, ExecutionThreshold::whole_share());
+        assert_eq!(
+            job.market_session,
+            MarketSession::Extended,
+            "the enqueue path must carry the observed Extended session into the job \
+             payload so the job can detect a stale session at execution time"
+        );
+    }
+
+    #[tokio::test]
+    async fn extended_hours_trade_enqueues_clamped_immediate_hedge_job() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let cqrs = trade_processing_cqrs_with_assets(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+            extended_hours_assets(&symbol),
+        );
+
+        let trade_event = make_trade_event(76);
+        let trade = test_trade_with_amount_and_direction(float!(5.0), 76, Direction::Buy);
+
+        let executor = MockExecutor::new()
+            .with_market_session(MarketSession::Extended)
+            .with_inventory(ExecutionInventory {
+                positions: vec![EquityPosition {
+                    symbol: symbol.clone(),
+                    quantity: FractionalShares::new(float!(3.0)),
+                    market_value: None,
+                }],
+                usd_balance_cents: 1_000_000,
+                cash_buying_power_cents: Some(1_000_000),
+                alpaca_usdc: None,
+                cash_withdrawable_cents: None,
+            });
+
+        let result = process_queued_trade(&executor, &trade_event, trade, &cqrs, true)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result, None,
+            "extended-hours path defers placement to a queued PlaceHedge job"
+        );
+        assert!(
+            offchain_order_projection
+                .load_all()
+                .await
+                .unwrap()
+                .is_empty(),
+            "clamped extended-hours hedge must still be deferred, not placed inline"
+        );
+
+        let job_bytes: Vec<u8> = sqlx::query_scalar("SELECT job FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<
+                crate::trading::offchain::hedge::PlaceHedge,
+            >())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let job: crate::trading::offchain::hedge::PlaceHedge =
+            serde_json::from_slice(&job_bytes).unwrap();
+
+        assert_eq!(
+            job.shares,
+            Positive::new(FractionalShares::new(float!(3.0))).unwrap(),
+            "queued extended-hours hedge must be clamped to available inventory"
+        );
+    }
+
+    #[tokio::test]
+    async fn extended_hours_enqueue_failure_leaves_position_ready_for_check_positions() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let cqrs = trade_processing_cqrs_with_assets(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+            extended_hours_assets(&symbol),
+        );
+
+        apalis_pool.close().await;
+
+        let trade_event = make_trade_event(77);
+        let trade = test_trade_with_amount_and_direction(float!(2.0), 77, Direction::Buy);
+        let trade_id = OnChainTradeId {
+            tx_hash: trade.tx_hash,
+            log_index: trade.log_index,
+        };
+        let executor = MockExecutor::new()
+            .with_market_session(MarketSession::Extended)
+            .with_inventory(ExecutionInventory {
+                positions: vec![EquityPosition {
+                    symbol: symbol.clone(),
+                    quantity: FractionalShares::new(float!(10.0)),
+                    market_value: None,
+                }],
+                usd_balance_cents: 1_000_000,
+                cash_buying_power_cents: Some(1_000_000),
+                alpaca_usdc: None,
+                cash_withdrawable_cents: None,
+            });
+
+        let result = process_queued_trade(&executor, &trade_event, trade, &cqrs, true)
+            .await
+            .expect("closed apalis pool should defer to the CheckPositions backstop");
+        assert_eq!(
+            result, None,
+            "failed immediate hedge enqueue must not create an inline order"
+        );
+
+        let onchain_trade = cqrs
+            .onchain_trade
+            .load(&trade_id)
+            .await
+            .unwrap()
+            .expect("trade should be witnessed before enqueue");
+        assert!(
+            onchain_trade.is_acknowledged(),
+            "the fill and position write completed; retry comes from the position backstop"
+        );
+
+        let position = cqrs
+            .position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "failed immediate hedge enqueue must not claim the position"
+        );
+        assert!(
+            position.net.inner().eq(float!(2.0)).unwrap(),
+            "failed immediate hedge enqueue must leave the exposure visible for CheckPositions"
         );
     }
 
@@ -8444,6 +8914,493 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn recover_orphaned_pending_clears_cancelled_order() {
+        let pool = setup_test_db().await;
+        let order_placer = crate::offchain::order::noop_order_placer();
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (offchain_order, _offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(order_placer)
+                .await
+                .unwrap();
+
+        let symbol = Symbol::new("NVDA").unwrap();
+        let threshold = ExecutionThreshold::whole_share();
+        let offchain_order_id = OffchainOrderId::new();
+        let shares = Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap();
+
+        position
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: TradeId {
+                        tx_hash: fixed_bytes!(
+                            "0000000000000000000000000000000000000000000000000000000000000005"
+                        ),
+                        log_index: 0,
+                    },
+                    amount: st0x_execution::FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(120),
+                    block_timestamp: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    threshold,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Drive the offchain order to terminal Cancelled with no fill:
+        // Place -> Submitted -> Cancelling -> Cancelled.
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("cancel-test-order"),
+                    placed_shares: shares,
+                    submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::ConfirmCancellation {
+                    cancelled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let order = offchain_order
+            .load(&offchain_order_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(order, OffchainOrder::Cancelled { .. }));
+
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(pos.pending_offchain_order_id, Some(offchain_order_id));
+
+        recover_orphaned_pending_offchain_orders(
+            &position,
+            &position_projection,
+            &offchain_order,
+            noop_order_placer().as_ref(),
+        )
+        .await
+        .unwrap();
+
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            pos.pending_offchain_order_id, None,
+            "Recovery should clear pending_offchain_order_id for cancelled orders"
+        );
+        // CancelOffChainOrder (unlike FailOffChainOrder) must NOT stash the
+        // cancelled order's id as the failure/idempotency anchor: the
+        // replacement is a fresh order, not a retry under the cancelled key.
+        assert_eq!(
+            pos.last_failed_offchain_order_id, None,
+            "An orphaned cancellation must not set the failure anchor; a \
+             replacement order reusing the cancelled client_order_id would be \
+             deduped by the broker against a dead order"
+        );
+    }
+
+    /// A `Cancelling` order is mid-cancellation and NOT yet terminal: orphan
+    /// recovery must leave the position pending (like a still-`Submitted`
+    /// order) rather than clearing it before the broker confirms the
+    /// cancellation.
+    #[tokio::test]
+    async fn recover_orphaned_pending_skips_cancelling_order() {
+        let pool = setup_test_db().await;
+        let order_placer = crate::offchain::order::noop_order_placer();
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (offchain_order, _offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(order_placer)
+                .await
+                .unwrap();
+
+        let symbol = Symbol::new("NVDA").unwrap();
+        let threshold = ExecutionThreshold::whole_share();
+        let offchain_order_id = OffchainOrderId::new();
+        let shares = Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap();
+
+        position
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: TradeId {
+                        tx_hash: fixed_bytes!(
+                            "0000000000000000000000000000000000000000000000000000000000000007"
+                        ),
+                        log_index: 0,
+                    },
+                    amount: st0x_execution::FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(120),
+                    block_timestamp: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    threshold,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Drive the offchain order to Cancelling (Place -> Submitted ->
+        // CancelOrder) but STOP before ConfirmCancellation -- the broker has
+        // not confirmed the cancel yet, so the order is non-terminal.
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("cancelling-test-order"),
+                    placed_shares: shares,
+                    submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let order = offchain_order
+            .load(&offchain_order_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            matches!(order, OffchainOrder::Cancelling { .. }),
+            "Order must be Cancelling before recovery, got: {order:?}"
+        );
+
+        recover_orphaned_pending_offchain_orders(
+            &position,
+            &position_projection,
+            &offchain_order,
+            noop_order_placer().as_ref(),
+        )
+        .await
+        .unwrap();
+
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            pos.pending_offchain_order_id,
+            Some(offchain_order_id),
+            "Recovery must NOT clear a position whose order is still Cancelling (non-terminal)"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_orphaned_pending_completes_cancelled_order_with_partial_fill() {
+        let pool = setup_test_db().await;
+        let order_placer = crate::offchain::order::noop_order_placer();
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (offchain_order, _offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(order_placer)
+                .await
+                .unwrap();
+
+        let symbol = Symbol::new("AMD").unwrap();
+        let threshold = ExecutionThreshold::whole_share();
+        let offchain_order_id = OffchainOrderId::new();
+        let shares = Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap();
+
+        position
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: TradeId {
+                        tx_hash: fixed_bytes!(
+                            "0000000000000000000000000000000000000000000000000000000000000006"
+                        ),
+                        log_index: 0,
+                    },
+                    amount: st0x_execution::FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(95),
+                    block_timestamp: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    threshold,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Drive the offchain order to terminal Cancelled carrying a priced
+        // partial fill: Place -> Submitted -> PartiallyFilled -> Cancelling
+        // -> Cancelled.
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("partial-cancel-test-order"),
+                    placed_shares: shares,
+                    submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: st0x_execution::FractionalShares::new(float!(0.3)),
+                    avg_price: Usd::new(float!(95)),
+                    partially_filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::ConfirmCancellation {
+                    cancelled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(pos.pending_offchain_order_id, Some(offchain_order_id));
+
+        recover_orphaned_pending_offchain_orders(
+            &position,
+            &position_projection,
+            &offchain_order,
+            noop_order_placer().as_ref(),
+        )
+        .await
+        .unwrap();
+
+        // The partial fill must be applied to the position (Sell debits net:
+        // 1 - 0.3 = 0.7), otherwise the broker keeps those shares but the
+        // position never records them and the next scan re-hedges them.
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            pos.pending_offchain_order_id, None,
+            "Recovery should clear pending_offchain_order_id for cancelled \
+             orders with a recorded fill"
+        );
+        assert_eq!(
+            pos.net,
+            st0x_execution::FractionalShares::new(float!(0.7)),
+            "The cancelled order's priced partial fill must debit the position"
+        );
+    }
+
+    #[test]
+    fn orphaned_unpriced_fill_leaves_position_pending() {
+        // A terminal Cancelled order carrying a positive fill without an
+        // average price cannot be finalized correctly. The recovery sweep
+        // must leave the position pending (returning no command) rather
+        // than abort startup -- the order is terminal, so its data never
+        // changes and an abort would crash-loop the bot on every restart.
+        let symbol = Symbol::new("AAPL").unwrap();
+        let order_id = OffchainOrderId::new();
+        let order = OffchainOrder::Cancelled {
+            symbol: symbol.clone(),
+            shares: Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap(),
+            retained_fill: Some(RetainedFill::Unpriced {
+                shares_filled: st0x_execution::FractionalShares::new(float!(0.3)),
+            }),
+            direction: Direction::Sell,
+            executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+            executor_order_id: ExecutorOrderId::new("unpriced-fill"),
+            reason: CancellationReason::MarketOpenReplacement,
+            placed_at: Utc::now(),
+            cancelled_at: Utc::now(),
+        };
+
+        let command = orphaned_order_position_command(&order, &symbol, order_id);
+
+        let None = command else {
+            panic!(
+                "an unpriced terminal fill must leave the position pending for \
+                 operator intervention (no automated path can price it), got {command:?}"
+            );
+        };
+    }
+
+    #[test]
+    fn orphaned_cancelled_order_maps_to_cancel_command() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let order_id = OffchainOrderId::new();
+        let broker_cancelled_at = Utc::now();
+        let order = OffchainOrder::Cancelled {
+            symbol: symbol.clone(),
+            shares: Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap(),
+            retained_fill: None,
+            direction: Direction::Sell,
+            executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+            executor_order_id: ExecutorOrderId::new("cancelled-no-fill"),
+            reason: CancellationReason::MarketOpenReplacement,
+            placed_at: Utc::now(),
+            cancelled_at: broker_cancelled_at,
+        };
+
+        let command = orphaned_order_position_command(&order, &symbol, order_id);
+
+        let Some(PositionCommand::CancelOffChainOrder {
+            offchain_order_id,
+            reason,
+            cancelled_at,
+        }) = command
+        else {
+            panic!("expected CancelOffChainOrder for an orphaned cancelled order with no fill");
+        };
+        assert_eq!(offchain_order_id, order_id);
+        assert_eq!(reason, CancellationReason::MarketOpenReplacement);
+        assert_eq!(
+            cancelled_at, broker_cancelled_at,
+            "the position command must carry the broker's cancellation time"
+        );
+    }
+
     /// Drives a Position into the `pending_offchain_order_id = Some(_)` state
     /// for testing post-Place dispatch logic. Returns the offchain order id
     /// that the position is expecting.
@@ -8538,6 +9495,63 @@ mod tests {
         assert_eq!(
             position.pending_offchain_order_id, None,
             "None state must clear the position's pending offchain order id"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_post_place_state_cancelled_routes_to_cancel_not_failure() {
+        // A Cancelled order directly after Place must release the position
+        // via cancel semantics: the pending slot clears AND the
+        // failure/idempotency anchor stays unset, so the replacement is a
+        // fresh order instead of a broker-deduped retry against a dead key.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let offchain_order_id = drive_position_to_pending(&frameworks, &symbol, shares).await;
+
+        let cancelled = OffchainOrder::Cancelled {
+            symbol: symbol.clone(),
+            shares,
+            retained_fill: None,
+            direction: Direction::Sell,
+            executor: st0x_execution::SupportedExecutor::DryRun,
+            executor_order_id: ExecutorOrderId::new("cancelled-after-place"),
+            reason: CancellationReason::MarketOpenReplacement,
+            placed_at: Utc::now(),
+            cancelled_at: Utc::now(),
+        };
+
+        let result = dispatch_post_place_state(Some(cancelled), &symbol, &cqrs, offchain_order_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            PostPlaceOutcome::ClearedNoOrder,
+            "a cancelled order is not a live placement"
+        );
+
+        let position = frameworks
+            .position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "cancellation must release the position's pending slot"
+        );
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "cancellation must NOT set the failure/idempotency anchor"
         );
     }
 
@@ -8794,10 +9808,6 @@ mod tests {
 
         let symbol = Symbol::new("AAPL").unwrap();
         let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
-
-        // A prior placement attempt claimed the position and the broker filled the
-        // order, but the position update never landed -- the claim is stuck while
-        // the order is already terminal.
         let offchain_order_id = drive_position_to_pending(&frameworks, &symbol, shares).await;
 
         frameworks
@@ -8843,7 +9853,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Sanity: the order is Filled yet the position still holds the claim.
         assert!(matches!(
             frameworks
                 .offchain_order
@@ -8853,6 +9862,7 @@ mod tests {
                 .unwrap(),
             OffchainOrder::Filled { .. }
         ));
+
         let position = frameworks
             .position_projection
             .load(&symbol)
@@ -8866,6 +9876,7 @@ mod tests {
             direction: Direction::Sell,
             shares,
             executor: st0x_execution::SupportedExecutor::DryRun,
+            market_session: st0x_execution::MarketSession::Regular,
         };
         let result = recover_claimed_offchain_order(&execution, &cqrs)
             .await
@@ -8885,6 +9896,125 @@ mod tests {
         assert_eq!(
             position.pending_offchain_order_id, None,
             "recovery must complete the position and clear the stale claim in-process"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_post_place_state_cancelling_enqueues_poll() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let offchain_order_id = drive_position_to_pending(&frameworks, &symbol, shares).await;
+        let cancelling = OffchainOrder::Cancelling {
+            symbol: symbol.clone(),
+            shares,
+            retained_fill: None,
+            direction: Direction::Sell,
+            executor: st0x_execution::SupportedExecutor::DryRun,
+            executor_order_id: ExecutorOrderId::new("cancelling-after-place"),
+            reason: CancellationReason::MarketOpenReplacement,
+            placed_at: Utc::now(),
+            submitted_at: Utc::now(),
+            cancel_requested_at: Utc::now(),
+            market_session: st0x_execution::MarketSession::Regular,
+        };
+
+        let result = dispatch_post_place_state(Some(cancelling), &symbol, &cqrs, offchain_order_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            PostPlaceOutcome::InFlight(offchain_order_id),
+            "Cancelling state must report the order id so the poller can track it"
+        );
+
+        let poll_jobs = pending_job_count::<PollOrderStatus>(&apalis_pool).await;
+        assert_eq!(
+            poll_jobs, 1,
+            "Cancelling state must enqueue a PollOrderStatus job so the broker-side \
+             cancellation is confirmed"
+        );
+
+        let position = frameworks
+            .position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "Cancelling state must NOT set the failure/idempotency anchor"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_post_place_state_cancelled_partial_fill_completes_position() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let offchain_order_id = drive_position_to_pending(&frameworks, &symbol, shares).await;
+        let cancelled_partial = OffchainOrder::Cancelled {
+            symbol: symbol.clone(),
+            shares,
+            retained_fill: Some(RetainedFill::Priced {
+                shares_filled: st0x_execution::FractionalShares::new(float!(0.3)),
+                avg_price: Usd::new(float!(95.0)),
+                partially_filled_at: Utc::now(),
+            }),
+            direction: Direction::Sell,
+            executor: st0x_execution::SupportedExecutor::DryRun,
+            executor_order_id: ExecutorOrderId::new("cancelled-partial-after-place"),
+            reason: CancellationReason::MarketOpenReplacement,
+            placed_at: Utc::now(),
+            cancelled_at: Utc::now(),
+        };
+
+        let result =
+            dispatch_post_place_state(Some(cancelled_partial), &symbol, &cqrs, offchain_order_id)
+                .await
+                .unwrap();
+        assert_eq!(
+            result,
+            PostPlaceOutcome::ClearedNoOrder,
+            "a cancelled order is not a live placement"
+        );
+
+        let position = frameworks
+            .position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "partial-fill Cancelled must release the position's pending slot"
+        );
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "partial-fill Cancelled must NOT set the failure/idempotency anchor"
+        );
+        assert!(
+            position.net.inner().eq(float!(1.7)).unwrap(),
+            "Sell of 0.3 shares must debit position net: 2.0 - 0.3 = 1.7, got {:?}",
+            position.net
         );
     }
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -12,7 +12,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-use st0x_config::{Ctx, ExecutionThreshold};
+use st0x_config::{BrokerCtx, Ctx, ExecutionThreshold};
 use st0x_event_sorcery::{Projection, Store};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::{Executor, Symbol};
@@ -144,6 +144,9 @@ fn configured_inventory_vaults(ctx: &Ctx) -> ConfiguredInventoryVaults {
 }
 
 /// Wires all runtime components and returns a running [`Conductor`].
+// Straight-line builder that wires every runtime context; splitting it would
+// scatter the wiring across helpers without reducing complexity.
+#[allow(clippy::too_many_lines)]
 #[bon::builder]
 pub(crate) fn spawn<Prov, Exec>(
     context: ConductorCtx<Prov, Exec>,
@@ -281,7 +284,12 @@ where
         offchain_order: context.frameworks.offchain_order.clone(),
         order_placer: order_placer.clone(),
         poll_status_queue: poll_status_queue.clone(),
+        assets: context.ctx.assets.clone(),
         counter_trade_submission_lock: counter_trade_submission_lock.clone(),
+        counter_trade_slippage_bps: match &context.ctx.broker {
+            BrokerCtx::AlpacaBrokerApi(alpaca_ctx) => alpaca_ctx.counter_trade_slippage_bps,
+            BrokerCtx::DryRun => st0x_execution::DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,
+        },
     });
 
     let check_positions_ctx = Arc::new(CheckPositionsCtx {
@@ -311,6 +319,7 @@ where
         assets: context.ctx.assets.clone(),
         counter_trade_submission_lock,
         poll_status_queue: poll_status_queue.clone(),
+        hedge_queue: hedge_queue.clone(),
     };
 
     let maintenance_interval = context.executor.maintenance_interval();

--- a/src/conductor/monitor/executor_maintenance.rs
+++ b/src/conductor/monitor/executor_maintenance.rs
@@ -60,8 +60,8 @@ mod tests {
     use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 
     use st0x_execution::{
-        CounterTradePreflight, ExecutionError, InventoryResult, MarketOrder, OrderPlacement,
-        OrderState, SupportedExecutor, TryIntoExecutor,
+        CounterTradePreflight, ExecutionError, InventoryResult, LimitOrder, MarketOrder,
+        OrderPlacement, OrderState, SupportedExecutor, TryIntoExecutor,
     };
 
     use super::*;
@@ -111,7 +111,7 @@ mod tests {
 
         async fn place_limit_order(
             &self,
-            _order: st0x_execution::LimitOrder,
+            _order: LimitOrder,
         ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
             unreachable!("not used in maintenance tests")
         }

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -222,7 +222,7 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
                             offchain_order_id: order_id,
                             shares_filled: order.shares(),
                             direction: order.direction(),
-                            executor_order_id: ExecutorOrderId::new(&broker_order_id),
+                            executor_order_id: broker_order_id.clone(),
                             price,
                             broker_timestamp: executed_at,
                         },
@@ -293,61 +293,20 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
                 }
             }
 
-            Cancelled {
-                shares_filled,
-                avg_price,
-                cancelled_at,
-                ..
-            } => {
-                let error = "Order cancelled by broker".to_string();
-                let partial_fill = record_poll_partial_fill(
-                    &order_id,
-                    executor_order_id,
-                    &order,
-                    offchain_order,
-                    shares_filled,
-                    avg_price,
-                    cancelled_at,
+            // This helper cannot faithfully replay a broker cancellation:
+            // the production path (recover_unrequested_cancellation) drives
+            // CancelOrder + ConfirmCancellation through the aggregate's
+            // OrderPlacer services, but this store is wired with its own
+            // MockExecutor whose status reads would reconcile against the
+            // wrong broker state. Fail loudly so a future test that needs
+            // cancellations drives the real PollOrderStatus job instead of
+            // silently leaving the position stuck.
+            Cancelled { .. } => {
+                return Err(format!(
+                    "poll_submitted_orders does not support broker cancellations \
+                     (order {order_id}); drive the real PollOrderStatus job instead"
                 )
-                .await?;
-
-                if let Some(fill) = &partial_fill {
-                    position
-                        .send(
-                            order.symbol(),
-                            PositionCommand::CompleteOffChainOrder {
-                                offchain_order_id: order_id,
-                                shares_filled: fill.shares_filled,
-                                direction: order.direction(),
-                                executor_order_id: fill.executor_order_id.clone(),
-                                price: fill.price,
-                                broker_timestamp: fill.broker_timestamp,
-                            },
-                        )
-                        .await?;
-                }
-
-                offchain_order
-                    .send(
-                        &order_id,
-                        OffchainOrderCommand::MarkFailed {
-                            error: error.clone(),
-                            failed_at: cancelled_at,
-                        },
-                    )
-                    .await?;
-
-                if partial_fill.is_none() {
-                    position
-                        .send(
-                            order.symbol(),
-                            PositionCommand::FailOffChainOrder {
-                                offchain_order_id: order_id,
-                                error,
-                            },
-                        )
-                        .await?;
-                }
+                .into());
             }
 
             PartiallyFilled {
@@ -911,6 +870,7 @@ async fn create_test_cqrs_with_assets(
         counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
         poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(apalis_pool),
         order_placer,
+        hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(apalis_pool),
     };
 
     (
@@ -1251,7 +1211,7 @@ async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std:
 }
 
 #[tokio::test]
-async fn retains_terminal_partial_fill() -> Result<(), Box<dyn std::error::Error>> {
+async fn retains_failed_terminal_partial_fill() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
     let (pool, apalis_pool) = setup_test_pools().await;
     let (cqrs, position, position_query, offchain_order, offchain_order_projection) =
@@ -1302,14 +1262,14 @@ async fn retains_terminal_partial_fill() -> Result<(), Box<dyn std::error::Error
         .call()
         .await;
 
-    let cancelled_executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
-        cancelled_at: Utc::now(),
-        order_id: ExecutorOrderId::new("broker-order-id"),
-        shares_filled: FractionalShares::new(float!(0.4)),
+    let failed_executor = MockExecutor::new().with_order_status(OrderState::Failed {
+        failed_at: Utc::now(),
+        error_reason: Some("broker rejected after partial fill".to_string()),
+        shares_filled: Some(FractionalShares::new(float!(0.4))),
         avg_price: Some(st0x_finance::Usd::new(float!(100.25))),
     });
     poll_submitted_orders(
-        &cancelled_executor,
+        &failed_executor,
         offchain_order_projection.as_ref(),
         &offchain_order,
         &position,

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -609,6 +609,15 @@ async fn cancel_order_events(
                 }
             }
 
+            if reason == CancellationReason::MarketOpenReplacement {
+                tracing::info!(
+                    target: "hedge",
+                    symbol = %entity.symbol(),
+                    %executor_order_id,
+                    "Regular hours: cancelling extended-hours limit order for market-order replacement"
+                );
+            }
+
             Ok(events)
         }
         OffchainOrder::Pending { .. } => Err(OffchainOrderError::NotSubmitted),
@@ -1562,6 +1571,31 @@ pub(crate) fn position_command_for_finalization(
     }
 }
 
+pub(crate) async fn finalize_cancelled_position_or_log_unpriced(
+    position: &Store<Position>,
+    symbol: &Symbol,
+    offchain_order_id: OffchainOrderId,
+    cancelled: &OffchainOrder,
+) -> Result<(), st0x_event_sorcery::SendError<Position>> {
+    let command = terminal_position_finalization(cancelled).and_then(|finalization| {
+        position_command_for_finalization(finalization, offchain_order_id)
+    });
+
+    if let Some(command) = command {
+        position.send(symbol, command).await?;
+    } else {
+        tracing::error!(
+            symbol = %symbol,
+            %offchain_order_id,
+            "Cancelled order after Place retains an unpriced fill; \
+             position left pending -- no automated path can finalize \
+             this, operator intervention required"
+        );
+    }
+
+    Ok(())
+}
+
 /// Classifies a terminal [`OffchainOrder`] (`Filled`/`Cancelled`/`Failed`) into
 /// the [`TerminalPositionFinalization`] it implies. Returns `None` for
 /// non-terminal states (the caller leaves the position pending and retries).
@@ -1968,9 +2002,9 @@ pub struct OrderPlacementResult {
 
 /// Type-erased order placement capability used by the durable placement path
 /// ([`place_offchain_order_at_broker`]) -- the trade-processing context, the
-/// hedge job, and the CLI each hold one. It is no longer a cqrs-es `Service` of
-/// the `OffchainOrder` aggregate: the broker call was lifted out of the now-pure
-/// `Place` handler, whose `Services` is `()`.
+/// hedge job, and the CLI each hold one. The `OffchainOrder` aggregate keeps
+/// this as its service type for cancel pre-reconciliation and placement-adjacent
+/// recovery paths, while `Place` itself remains a pure intent-recording command.
 ///
 /// This trait exists because the `Executor` trait has associated types
 /// (`Error`, `OrderId`, `Ctx`) which make it non-object-safe - you cannot
@@ -4364,16 +4398,16 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_order_on_failed_returns_already_completed() {
-        // failing_order_placer drives the aggregate straight to Failed; cancel
-        // on a terminal state must reject with AlreadyCompleted.
-        let store = TestStore::<OffchainOrder>::new(failing_order_placer());
+        // Placement feedback drives the aggregate to Failed; cancel on a
+        // terminal state must reject with AlreadyCompleted.
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
         store.send(&id, place_command()).await.unwrap();
         store
             .send(
                 &id,
                 OffchainOrderCommand::MarkPlacementFailed {
-                    error: "placement failed".to_string(),
+                    error: "broker rejected".to_string(),
                 },
             )
             .await
@@ -5260,22 +5294,7 @@ mod tests {
         let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
 
-        store.send(&id, place_command()).await.unwrap();
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::MarkAccepted {
-                    executor_order_id: ExecutorOrderId::new("TEST-SUBMITTED"),
-                    placed_shares: noop_placed_shares(
-                        Positive::new(FractionalShares::new(float!(100))).unwrap(),
-                    ),
-                    submitted_at: Utc::now(),
-                    market_session: MarketSession::Regular,
-                    limit_price: None,
-                },
-            )
-            .await
-            .unwrap();
+        place_and_submit(&store, &id).await;
 
         let err = store
             .send(

--- a/src/offchain/order/handle_rejection.rs
+++ b/src/offchain/order/handle_rejection.rs
@@ -401,6 +401,28 @@ mod tests {
         offchain_order_id
     }
 
+    async fn mark_order_accepted(
+        infra: &TestInfra,
+        order_id: OffchainOrderId,
+        shares: Positive<FractionalShares>,
+    ) {
+        infra
+            .ctx
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("TEST-ACCEPT"),
+                    placed_shares: shares,
+                    submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn handle_order_rejection_emits_offchain_and_position_commands() {
         let infra = build_test_infra().await;
@@ -457,6 +479,7 @@ mod tests {
         let order_id =
             submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
         let broker_timestamp = Utc::now();
+        mark_order_accepted(&infra, order_id, shares).await;
 
         infra
             .ctx
@@ -593,6 +616,7 @@ mod tests {
         let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
         let order_id =
             submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+        mark_order_accepted(&infra, order_id, shares).await;
 
         infra
             .ctx
@@ -739,6 +763,7 @@ mod tests {
             submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
 
         let broker_fill_time = Utc::now() - chrono::Duration::minutes(30);
+        mark_order_accepted(&infra, order_id, shares).await;
         infra
             .ctx
             .offchain_order

--- a/src/onchain/accumulator.rs
+++ b/src/onchain/accumulator.rs
@@ -4,7 +4,9 @@ use tracing::info;
 
 use st0x_config::AssetsConfig;
 use st0x_event_sorcery::Projection;
-use st0x_execution::{Direction, Executor, FractionalShares, Positive, SupportedExecutor, Symbol};
+use st0x_execution::{
+    Direction, Executor, FractionalShares, MarketSession, Positive, SupportedExecutor, Symbol,
+};
 
 use crate::onchain::OnChainError;
 use crate::position::Position;
@@ -15,6 +17,7 @@ pub(crate) struct ExecutionCtx {
     pub(crate) direction: Direction,
     pub(crate) shares: Positive<FractionalShares>,
     pub(crate) executor: SupportedExecutor,
+    pub(crate) market_session: MarketSession,
 }
 
 /// Checks whether a position is ready for offchain execution.
@@ -53,18 +56,21 @@ pub(crate) async fn check_execution_readiness<E: Executor>(
         return Ok(None);
     };
 
-    if !check_market_open(executor, symbol).await? {
+    let Some(market_session) =
+        check_market_session(executor, symbol, assets.is_extended_hours_enabled(symbol)).await?
+    else {
         return Ok(None);
-    }
+    };
 
     let shares = Positive::new(shares)?;
-    debug!(target: "hedge", %symbol, %shares, ?direction, "Position ready for execution");
+    debug!(target: "hedge", %symbol, %shares, ?direction, ?market_session, "Position ready for execution");
 
     Ok(Some(ExecutionCtx {
         symbol: symbol.clone(),
         direction,
         shares,
         executor: executor_type,
+        market_session,
     }))
 }
 
@@ -76,20 +82,37 @@ fn check_asset_enabled(asset_enabled: bool, symbol: &Symbol) -> bool {
     asset_enabled
 }
 
-async fn check_market_open<E: Executor>(
+/// Returns `Some(session)` when execution is allowed (regular hours, or
+/// extended hours when enabled), or `None` when the position should wait.
+async fn check_market_session<E: Executor>(
     executor: &E,
     symbol: &Symbol,
-) -> Result<bool, OnChainError> {
-    let is_open = executor
-        .is_market_open()
+    extended_hours_enabled: bool,
+) -> Result<Option<MarketSession>, OnChainError> {
+    let session = executor
+        .market_session()
         .await
-        .map_err(|e| OnChainError::MarketHoursCheck(Box::new(e)))?;
+        .map_err(|error| OnChainError::MarketHoursCheck(Box::new(error)))?;
 
-    if !is_open {
-        debug!(target: "hedge", symbol = %symbol, "Market closed, deferring execution");
+    match session {
+        MarketSession::Regular => Ok(Some(session)),
+
+        MarketSession::Extended if extended_hours_enabled => {
+            debug!(target: "hedge", %symbol, "Extended hours session, will use limit order");
+            Ok(Some(session))
+        }
+
+        MarketSession::Extended | MarketSession::Closed => {
+            debug!(
+                target: "hedge",
+                %symbol,
+                ?session,
+                extended_hours_enabled,
+                "Market not available for trading, deferring execution"
+            );
+            Ok(None)
+        }
     }
-
-    Ok(is_open)
 }
 
 /// Checks all positions for execution readiness.
@@ -124,9 +147,14 @@ pub(crate) async fn check_all_positions<E: Executor>(
             .or(assets.equities.operational_limit);
 
         if let Some((direction, shares)) = position.is_ready_for_execution(shares_limit)? {
-            if !check_market_open(executor, symbol).await? {
+            // Extended-hours is hardcoded false here: this helper only backs
+            // the test-only check_and_execute_accumulated_positions path in
+            // conductor.rs. The production CheckPositions sweep goes through
+            // check_execution_readiness (src/position_check.rs) with the
+            // per-asset extended_hours_counter_trading config.
+            let Some(market_session) = check_market_session(executor, symbol, false).await? else {
                 continue;
-            }
+            };
 
             let shares = Positive::new(shares)?;
 
@@ -143,6 +171,7 @@ pub(crate) async fn check_all_positions<E: Executor>(
                 direction,
                 shares,
                 executor: executor_type,
+                market_session,
             });
         }
     }
@@ -208,6 +237,35 @@ mod tests {
             )
             .await
             .unwrap();
+    }
+
+    fn assets_with_extended_hours(symbol: &Symbol, enabled: bool) -> AssetsConfig {
+        let extended_hours_counter_trading = if enabled {
+            OperationMode::Enabled
+        } else {
+            OperationMode::Disabled
+        };
+
+        AssetsConfig {
+            equities: EquitiesConfig {
+                operational_limit: None,
+                symbols: HashMap::from([(
+                    symbol.clone(),
+                    EquityAssetConfig {
+                        tokenized_equity: Address::ZERO,
+                        tokenized_equity_derivative: Address::ZERO,
+                        pyth_feed_id: None,
+                        vault_ids: Vec::new(),
+                        trading: OperationMode::Enabled,
+                        rebalancing: OperationMode::Disabled,
+                        wrapped_equity_recovery: OperationMode::Disabled,
+                        extended_hours_counter_trading,
+                        operational_limit: None,
+                    },
+                )]),
+            },
+            cash: None,
+        }
     }
 
     #[tokio::test]
@@ -396,6 +454,71 @@ mod tests {
             result.is_none(),
             "Should return None when market is closed, even with position above threshold"
         );
+    }
+
+    #[tokio::test]
+    async fn check_execution_readiness_returns_none_in_extended_session_when_symbol_disabled() {
+        let pool = setup_test_db().await;
+        let (store, query) = create_test_position_infra(&pool).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        initialize_position_with_fill(
+            &store,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let executor = MockExecutor::new().with_market_session(MarketSession::Extended);
+
+        let result = check_execution_readiness(
+            &executor,
+            &query,
+            &symbol,
+            SupportedExecutor::DryRun,
+            &assets_with_extended_hours(&symbol, false),
+            true,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.is_none(),
+            "Extended session must defer when the symbol is not enabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_execution_readiness_returns_extended_session_when_symbol_enabled() {
+        let pool = setup_test_db().await;
+        let (store, query) = create_test_position_infra(&pool).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        initialize_position_with_fill(
+            &store,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let executor = MockExecutor::new().with_market_session(MarketSession::Extended);
+
+        let params = check_execution_readiness(
+            &executor,
+            &query,
+            &symbol,
+            SupportedExecutor::DryRun,
+            &assets_with_extended_hours(&symbol, true),
+            true,
+        )
+        .await
+        .unwrap()
+        .expect("extended-hours enabled symbol should be ready");
+
+        assert_eq!(params.symbol, symbol);
+        assert_eq!(params.market_session, MarketSession::Extended);
     }
 
     #[tokio::test]

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -15,18 +15,21 @@ use tokio::sync::Mutex;
 use tracing::{debug, error, warn};
 
 use st0x_config::Ctx;
-use st0x_event_sorcery::{Projection, Store};
-use st0x_execution::{ClientOrderId, CounterTradePreflight, Executor, MarketOrder, Symbol};
+use st0x_event_sorcery::{AggregateError, LifecycleError, Projection, Store};
+use st0x_execution::{
+    ClientOrderId, CounterTradePreflight, Executor, MarketOrder, MarketSession, Symbol,
+};
 
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::conductor::{clamp_shares_to_reservation, recover_orphaned_pending_offchain_orders};
 use crate::equity_redemption::symbols_with_active_transfers;
 use crate::offchain::order::{
-    OffchainOrder, OffchainOrderId, OrderPlacer, PollOrderStatusJobQueue,
-    recover_submitted_offchain_orders,
+    CancellationReason, OffchainOrder, OffchainOrderCommand, OffchainOrderId, OrderPlacer,
+    PollOrderStatusJobQueue, TerminalPositionFinalization, position_command_for_finalization,
+    recover_submitted_offchain_orders, terminal_position_finalization,
 };
 use crate::onchain::accumulator::{ExecutionCtx, check_execution_readiness};
-use crate::position::Position;
+use crate::position::{Position, PositionError};
 use crate::trading::offchain::hedge::{HedgeJobQueue, PlaceHedge};
 
 pub(crate) type CheckPositionsJobQueue = JobQueue<CheckPositions>;
@@ -81,12 +84,18 @@ pub(crate) enum CheckPositionsError {
 /// [`PlaceHedge`] for any symbol whose net exposure has crossed the execution
 /// threshold.
 ///
-/// The job carries no state -- the scan reads everything from the position
-/// projection on each run. A single instance is enqueued at startup; each
-/// run re-enqueues itself with a delay equal to the configured check
-/// interval.
+/// The scan reads positions from the projection on each run. A single instance
+/// is enqueued at startup; each run re-enqueues itself with a delay equal to
+/// the configured check interval.
+///
+/// The job is stateless. In particular, the extended-hours cancel-and-replace
+/// pass is level-triggered -- every scan that observes a Regular session sweeps
+/// for still-live extended-hours orders -- so no previously-observed session
+/// needs to be carried between runs. (An earlier edge-triggered design carried
+/// a `last_seen_session` payload field; the empty braces keep old payloads
+/// deserializing cleanly by ignoring it.)
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub(crate) struct CheckPositions;
+pub(crate) struct CheckPositions {}
 
 impl<E> Job<CheckPositionsCtx<E>> for CheckPositions
 where
@@ -105,6 +114,25 @@ where
     }
 
     async fn perform(&self, ctx: &CheckPositionsCtx<E>) -> Result<Self::Output, Self::Error> {
+        // Every tick, independent of the feature flag: clear any position
+        // whose pending order has gone terminal (e.g. a cancellation the
+        // poller has since confirmed). Terminal `Cancelled` orders are
+        // produced by ungated paths too -- a manual broker-dashboard cancel,
+        // or an order left `Cancelling` across a flag-off restart -- and this
+        // sweep is the only runtime path that releases the position's pending
+        // slot for them; gating it would strand such symbols unhedged until
+        // the next restart.
+        ctx.finalize_terminal_pending_positions().await;
+
+        if ctx.ctx.assets.any_extended_hours_enabled() {
+            // Every regular-hours tick: request cancellation of still-live
+            // extended-hours limit orders so they're replaced with market
+            // orders. Level-triggered so an order that slipped past the
+            // session boundary, survived a restart, or whose cancellation
+            // request failed on a previous tick is caught on this one.
+            ctx.request_extended_hours_cancellations().await;
+        }
+
         ctx.scan_and_enqueue().await?;
         ctx.reschedule().await
     }
@@ -221,6 +249,7 @@ where
             executor: ready.executor,
             threshold: self.ctx.execution_threshold,
             offchain_order_id: OffchainOrderId::new(),
+            market_session: ready.market_session,
         };
 
         let mut queue = self.hedge_queue.clone();
@@ -269,9 +298,260 @@ where
     async fn reschedule(&self) -> Result<(), CheckPositionsError> {
         let mut queue = self.check_positions_queue.clone();
         queue
-            .push_with_delay(CheckPositions, self.check_interval)
+            .push_with_delay(CheckPositions {}, self.check_interval)
             .await?;
         Ok(())
+    }
+
+    /// Clears every position whose pending offchain order has reached a
+    /// terminal state, applying any recorded fill and releasing the pending
+    /// reference so the symbol can resume hedging.
+    ///
+    /// Runs every scan, independent of the market session: this is the recovery
+    /// half of cancel-and-replace. The cancellation pass only *requests*
+    /// cancellation (moving the order to `Cancelling`); the poller later drives
+    /// it terminal, and this method clears the owning position on a subsequent
+    /// tick. It also recovers any position left referencing an already-terminal
+    /// order by a prior transient failure.
+    async fn finalize_terminal_pending_positions(&self) {
+        let all_positions = match self.position_projection.load_all().await {
+            Ok(positions) => positions,
+            Err(error) => {
+                warn!("Failed to load positions for terminal-order finalization: {error}");
+                return;
+            }
+        };
+
+        for (symbol, position) in &all_positions {
+            let Some(offchain_order_id) = position.pending_offchain_order_id else {
+                continue;
+            };
+
+            let order = match self.offchain_order.load(&offchain_order_id).await {
+                Ok(Some(order)) => order,
+                // Same claimed-but-not-recorded window as the cancel sweep:
+                // PlaceHedge claims the position before creating the order
+                // aggregate. The stuck-pending recovery later in this tick
+                // clears the claim if the aggregate is still missing.
+                Ok(None) => {
+                    warn!(%symbol, %offchain_order_id, "Pending order aggregate not found during finalization; orphan recovery will handle it");
+                    continue;
+                }
+                Err(error) => {
+                    warn!(%symbol, %offchain_order_id, %error, "Failed to load offchain order for finalization");
+                    continue;
+                }
+            };
+
+            // Only terminal orders need position finalization here. Live and
+            // in-flight orders (Pending/Submitted/PartiallyFilled/Cancelling)
+            // are owned by the poll loop and reconcile jobs.
+            match &order {
+                OffchainOrder::Cancelled { .. }
+                | OffchainOrder::Failed { .. }
+                | OffchainOrder::Filled { .. } => {
+                    self.finalize_position_for_terminal_order(symbol, offchain_order_id, &order)
+                        .await;
+                }
+                OffchainOrder::Pending { .. }
+                | OffchainOrder::Submitted { .. }
+                | OffchainOrder::PartiallyFilled { .. }
+                | OffchainOrder::Cancelling { .. } => {}
+            }
+        }
+    }
+
+    /// While the market is in regular hours, requests broker cancellation of
+    /// any still-live extended-hours limit orders so they can be replaced
+    /// with market orders on a subsequent scan. Only symbols with
+    /// extended-hours counter-trading enabled in the per-asset config are
+    /// swept; orders for disabled symbols are left untouched.
+    ///
+    /// Level-triggered: the sweep runs on every regular-hours tick rather than
+    /// only on an observed session transition. Idempotency comes from the
+    /// per-order filter -- orders already `Cancelling` or terminal are skipped
+    /// -- so re-running is safe and no cheaper edge trigger is needed
+    /// ([`Self::finalize_terminal_pending_positions`] already performs an
+    /// equivalent every-tick sweep). This catches orders an edge-triggered
+    /// pass would strand for the whole session: a limit order submitted by a
+    /// hedge job that read `Extended` just before 9:30 but placed after the
+    /// transition tick scanned, a live order surviving a restart into regular
+    /// hours (startup orphan-recovery only finalizes *terminal* orders), and
+    /// any order whose lookup or cancellation request failed on a previous
+    /// tick. The pass only *requests* cancellation (the order moves to
+    /// `Cancelling`); the poller drives it terminal and
+    /// [`Self::finalize_terminal_pending_positions`] clears the position on a
+    /// later tick.
+    async fn request_extended_hours_cancellations(&self) {
+        let session = match self.executor.market_session().await {
+            Ok(session) => session,
+            Err(error) => {
+                warn!("Failed to check market session for cancel-and-replace: {error}");
+                return;
+            }
+        };
+
+        if session != MarketSession::Regular {
+            return;
+        }
+
+        let all_positions = match self.position_projection.load_all().await {
+            Ok(positions) => positions,
+            Err(error) => {
+                warn!("Failed to load positions for cancel-and-replace: {error}");
+                return;
+            }
+        };
+
+        for (symbol, position) in &all_positions {
+            if !self.ctx.assets.is_extended_hours_enabled(symbol) {
+                continue;
+            }
+
+            let Some(offchain_order_id) = position.pending_offchain_order_id else {
+                continue;
+            };
+
+            let order = match self.offchain_order.load(&offchain_order_id).await {
+                Ok(Some(order)) => order,
+                // The position references a pending order whose aggregate does
+                // not exist yet: `PlaceHedge` claims the position before it
+                // creates the offchain-order aggregate, so there is a brief
+                // window where the order is "claimed but not recorded". The
+                // stuck-pending recovery later in this tick clears the claim if
+                // the aggregate is still missing.
+                Ok(None) => {
+                    warn!(%symbol, %offchain_order_id, "Pending order aggregate not found during cancel-and-replace; orphan recovery will handle it");
+                    continue;
+                }
+                Err(error) => {
+                    warn!(%symbol, %offchain_order_id, %error, "Failed to load offchain order for cancel-and-replace; will retry next tick");
+                    continue;
+                }
+            };
+
+            // Skip orders placed via a different executor than the one
+            // currently configured: cancellation dispatches through our
+            // executor's broker, so cancelling a foreign order would
+            // mis-target. Mirrors the guard in PollOrderStatus and
+            // recover_submitted_offchain_orders.
+            if order.executor() != self.executor.to_supported_executor() {
+                continue;
+            }
+
+            // Only live extended-hours orders need cancelling. Terminal orders
+            // are handled by finalize_terminal_pending_positions, and orders
+            // already Cancelling are awaiting the poller's confirmation -- both
+            // are skipped here, which is what makes the every-tick sweep
+            // idempotent.
+            match &order {
+                OffchainOrder::Submitted {
+                    market_session: MarketSession::Extended,
+                    ..
+                }
+                | OffchainOrder::PartiallyFilled {
+                    market_session: MarketSession::Extended,
+                    ..
+                } => {}
+                OffchainOrder::Submitted { .. }
+                | OffchainOrder::PartiallyFilled { .. }
+                | OffchainOrder::Pending { .. }
+                | OffchainOrder::Cancelling { .. }
+                | OffchainOrder::Filled { .. }
+                | OffchainOrder::Failed { .. }
+                | OffchainOrder::Cancelled { .. } => {
+                    continue;
+                }
+            }
+
+            if let Err(error) = self
+                .offchain_order
+                .send(
+                    &offchain_order_id,
+                    OffchainOrderCommand::CancelOrder {
+                        reason: CancellationReason::MarketOpenReplacement,
+                    },
+                )
+                .await
+            {
+                warn!(%symbol, %offchain_order_id, %error, "Failed to request cancellation of extended-hours order; will retry next tick");
+            }
+        }
+    }
+
+    /// After a successful cancel (or a recovery scan finding an already-
+    /// terminal order), propagate the broker's actual fill quantity to the
+    /// position aggregate so net is correctly debited. Otherwise a partial
+    /// fill recorded on the offchain side is invisible to the position
+    /// scanner and the next cycle re-hedges the same shares.
+    async fn finalize_position_for_terminal_order(
+        &self,
+        symbol: &Symbol,
+        offchain_order_id: OffchainOrderId,
+        order: &OffchainOrder,
+    ) {
+        let command = match terminal_position_finalization(order) {
+            Some(TerminalPositionFinalization::UnpricedFill { shares_filled }) => {
+                error!(
+                    %symbol, %offchain_order_id, ?shares_filled,
+                    "Terminal order has a partial fill without avg price; position left \
+                     pending -- no automated path can finalize this, operator intervention \
+                     required"
+                );
+                return;
+            }
+            None => {
+                warn!(
+                    %symbol, %offchain_order_id, state = ?order,
+                    "Order in non-terminal state during finalization; skipping"
+                );
+                return;
+            }
+            // Complete and both NoFill outcomes map through the shared
+            // helper so the terminal-state -> position-command mapping
+            // cannot drift from the recovery paths.
+            Some(finalization) => {
+                let Some(command) =
+                    position_command_for_finalization(finalization, offchain_order_id)
+                else {
+                    // Unreachable: UnpricedFill (the only None mapping) is
+                    // handled above. Leave the position pending rather than
+                    // guessing a command.
+                    warn!(
+                        %symbol, %offchain_order_id,
+                        "Terminal finalization produced no position command; leaving pending"
+                    );
+                    return;
+                };
+                command
+            }
+        };
+
+        if let Err(error) = self.position.send(symbol, command).await {
+            // A benign race: the poll loop (or a prior finalize tick) already
+            // finalized this position, but our projection read was stale. The
+            // aggregate rejects the duplicate finalize via
+            // `validate_pending_execution`. Log it at debug -- warn here trains
+            // operators to ignore a self-healing condition and would mask a
+            // genuine finalize failure.
+            match &error {
+                AggregateError::UserError(LifecycleError::Apply(
+                    PositionError::NoPendingExecution
+                    | PositionError::OffchainOrderIdMismatch { .. },
+                )) => {
+                    debug!(
+                        %symbol, %offchain_order_id, %error,
+                        "Position already finalized by another writer; skipping"
+                    );
+                }
+                _ => {
+                    warn!(
+                        %symbol, %offchain_order_id, %error,
+                        "Failed to finalize position for terminal order"
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -287,7 +567,7 @@ pub(crate) async fn bootstrap_check_positions(
     queue: &CheckPositionsJobQueue,
 ) -> Result<(), CheckPositionsError> {
     purge_pending_check_positions_jobs(apalis_pool).await?;
-    queue.clone().push(CheckPositions).await?;
+    queue.clone().push(CheckPositions::default()).await?;
     Ok(())
 }
 
@@ -318,20 +598,20 @@ mod tests {
     use alloy::primitives::{Address, TxHash, address};
     use sqlx::SqlitePool;
 
-    use st0x_event_sorcery::StoreBuilder;
-    use st0x_execution::{
-        Direction, FractionalShares, MockExecutor, MockExecutorCtx, Positive, SupportedExecutor,
-        Symbol, TryIntoExecutor,
-    };
-    use st0x_float_macro::float;
-
     use st0x_config::{
         AssetsConfig, EquitiesConfig, EquityAssetConfig, ExecutionThreshold, OperationMode,
         create_test_ctx_with_order_owner,
     };
+    use st0x_event_sorcery::StoreBuilder;
+    use st0x_execution::{
+        ClientOrderId, Direction, ExecutorOrderId, FractionalShares, MockExecutor, MockExecutorCtx,
+        OrderState, Positive, SupportedExecutor, Symbol, TryIntoExecutor,
+    };
+    use st0x_finance::Usd;
+    use st0x_float_macro::float;
 
     use super::*;
-    use crate::offchain::order::{OffchainOrder, OffchainOrderCommand, noop_order_placer};
+    use crate::offchain::order::{CounterTradeOrderKind, OffchainOrder, OffchainOrderCommand};
     use crate::position::{PositionCommand, TradeId};
     use crate::test_utils::setup_test_pools;
 
@@ -344,18 +624,33 @@ mod tests {
         CheckPositionsCtx<MockExecutor>,
         Arc<st0x_event_sorcery::Store<Position>>,
     ) {
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        build_ctx_with_executor(pool, apalis_pool, ctx_cfg, check_interval, executor).await
+    }
+
+    async fn build_ctx_with_executor(
+        pool: SqlitePool,
+        apalis_pool: apalis_sqlite::SqlitePool,
+        ctx_cfg: Ctx,
+        check_interval: Duration,
+        executor: MockExecutor,
+    ) -> (
+        CheckPositionsCtx<MockExecutor>,
+        Arc<st0x_event_sorcery::Store<Position>>,
+    ) {
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
             .build(())
             .await
             .unwrap();
 
+        let order_placer: Arc<dyn crate::offchain::order::OrderPlacer> = Arc::new(
+            crate::offchain::order::ExecutorOrderPlacer(executor.clone()),
+        );
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
+                .build(order_placer.clone())
                 .await
                 .unwrap();
-
-        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
 
         let ctx = CheckPositionsCtx {
             executor,
@@ -363,7 +658,7 @@ mod tests {
             position_projection,
             offchain_order,
             offchain_order_projection,
-            order_placer: crate::offchain::order::noop_order_placer(),
+            order_placer,
             counter_trade_submission_lock: Arc::new(Mutex::new(())),
             hedge_queue: HedgeJobQueue::new(&apalis_pool),
             check_positions_queue: CheckPositionsJobQueue::new(&apalis_pool),
@@ -384,7 +679,7 @@ mod tests {
         // (is_ready_for_execution short-circuits), so without this sweep the
         // order would sit Pending until the next bot restart.
         let (pool, apalis_pool) = setup_test_pools().await;
-        let cfg = dry_run_ctx(&["AAPL"]);
+        let cfg = dry_run_ctx(&["AAPL"], OperationMode::Disabled);
         let (ctx, position) = build_ctx(
             pool.clone(),
             apalis_pool.clone(),
@@ -515,7 +810,7 @@ mod tests {
         std::any::type_name::<CheckPositions>().to_string()
     }
 
-    fn dry_run_ctx(symbols: &[&str]) -> Ctx {
+    fn dry_run_ctx(symbols: &[&str], extended_hours: OperationMode) -> Ctx {
         let mut equity_symbols = HashMap::new();
         for symbol in symbols {
             equity_symbols.insert(
@@ -528,7 +823,7 @@ mod tests {
                     trading: OperationMode::Enabled,
                     rebalancing: OperationMode::Disabled,
                     wrapped_equity_recovery: OperationMode::Disabled,
-                    extended_hours_counter_trading: OperationMode::Disabled,
+                    extended_hours_counter_trading: extended_hours,
                     operational_limit: None,
                 },
             );
@@ -559,7 +854,7 @@ mod tests {
     #[tokio::test]
     async fn broker_outage_does_not_kill_scan_and_reschedules() {
         let (pool, apalis_pool) = setup_test_pools().await;
-        let cfg = dry_run_ctx(&["AAPL"]);
+        let cfg = dry_run_ctx(&["AAPL"], OperationMode::Disabled);
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
             .build(())
@@ -575,19 +870,23 @@ mod tests {
         )
         .await;
 
+        let executor = MockExecutor::with_failure("connection refused");
+        let order_placer: Arc<dyn crate::offchain::order::OrderPlacer> = Arc::new(
+            crate::offchain::order::ExecutorOrderPlacer(executor.clone()),
+        );
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
+                .build(order_placer.clone())
                 .await
                 .unwrap();
 
         let ctx = CheckPositionsCtx {
-            executor: MockExecutor::with_failure("connection refused"),
+            executor,
             position: position.clone(),
             position_projection,
             offchain_order,
             offchain_order_projection,
-            order_placer: crate::offchain::order::noop_order_placer(),
+            order_placer,
             counter_trade_submission_lock: Arc::new(Mutex::new(())),
             hedge_queue: HedgeJobQueue::new(&apalis_pool),
             check_positions_queue: CheckPositionsJobQueue::new(&apalis_pool),
@@ -597,7 +896,7 @@ mod tests {
             check_interval: Duration::from_secs(60),
         };
 
-        CheckPositions.perform(&ctx).await.unwrap();
+        CheckPositions {}.perform(&ctx).await.unwrap();
 
         assert_eq!(
             count_jobs(&apalis_pool, &hedge_job_type()).await,
@@ -614,7 +913,7 @@ mod tests {
     #[tokio::test]
     async fn enqueues_one_hedge_per_ready_symbol() {
         let (pool, apalis_pool) = setup_test_pools().await;
-        let cfg = dry_run_ctx(&["AAPL", "TSLA"]);
+        let cfg = dry_run_ctx(&["AAPL", "TSLA"], OperationMode::Disabled);
         let (ctx, position) = build_ctx(
             pool.clone(),
             apalis_pool.clone(),
@@ -641,7 +940,7 @@ mod tests {
         )
         .await;
 
-        CheckPositions.perform(&ctx).await.unwrap();
+        CheckPositions::default().perform(&ctx).await.unwrap();
 
         assert_eq!(count_jobs(&apalis_pool, &hedge_job_type()).await, 2);
     }
@@ -649,7 +948,7 @@ mod tests {
     #[tokio::test]
     async fn no_positions_above_threshold_enqueues_no_hedge_jobs() {
         let (pool, apalis_pool) = setup_test_pools().await;
-        let cfg = dry_run_ctx(&["AAPL"]);
+        let cfg = dry_run_ctx(&["AAPL"], OperationMode::Disabled);
         let (ctx, position) = build_ctx(
             pool.clone(),
             apalis_pool.clone(),
@@ -668,7 +967,7 @@ mod tests {
         )
         .await;
 
-        CheckPositions.perform(&ctx).await.unwrap();
+        CheckPositions::default().perform(&ctx).await.unwrap();
 
         assert_eq!(count_jobs(&apalis_pool, &hedge_job_type()).await, 0);
     }
@@ -676,11 +975,11 @@ mod tests {
     #[tokio::test]
     async fn reschedules_itself_with_configured_interval() {
         let (pool, apalis_pool) = setup_test_pools().await;
-        let cfg = dry_run_ctx(&["AAPL"]);
+        let cfg = dry_run_ctx(&["AAPL"], OperationMode::Disabled);
         let interval = Duration::from_secs(42);
         let (ctx, _position) = build_ctx(pool.clone(), apalis_pool.clone(), cfg, interval).await;
 
-        CheckPositions.perform(&ctx).await.unwrap();
+        CheckPositions::default().perform(&ctx).await.unwrap();
 
         assert_eq!(
             count_jobs(&apalis_pool, &check_positions_job_type()).await,
@@ -702,12 +1001,637 @@ mod tests {
         );
     }
 
+    /// Claims `symbol`'s position with the given pending offchain order id.
+    /// Mirrors the first half of `PlaceHedge::perform`; deliberately does NOT
+    /// create the offchain-order aggregate, so callers can model the
+    /// "claimed but not yet recorded" window.
+    async fn claim_position(
+        ctx: &CheckPositionsCtx<MockExecutor>,
+        symbol: &Symbol,
+        offchain_order_id: OffchainOrderId,
+    ) {
+        ctx.position
+            .send(
+                symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    /// Records a live extended-hours limit order aggregate for a previously
+    /// claimed position, completing the second half of `PlaceHedge::perform`.
+    async fn record_extended_hours_order(
+        ctx: &CheckPositionsCtx<MockExecutor>,
+        symbol: &Symbol,
+        offchain_order_id: OffchainOrderId,
+    ) {
+        let shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        let limit_price = Positive::new(Usd::new(float!(195.25))).unwrap();
+
+        ctx.offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+                    kind: CounterTradeOrderKind::ExtendedHoursLimit { limit_price },
+                },
+            )
+            .await
+            .unwrap();
+        ctx.offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("broker-eh-1"),
+                    placed_shares: shares,
+                    submitted_at: chrono::Utc::now(),
+                    market_session: MarketSession::Extended,
+                    limit_price: Some(limit_price),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    /// MockExecutor reporting a Regular session whose `get_order_status`
+    /// returns `Submitted`, so the pre-cancel reconcile does not short-circuit
+    /// and a DELETE drives the order to `Cancelling`.
+    fn regular_session_executor() -> MockExecutor {
+        MockExecutor::new()
+            .with_market_session(MarketSession::Regular)
+            .with_order_status(OrderState::Submitted {
+                order_id: ExecutorOrderId::new("broker-eh-1"),
+            })
+    }
+
+    #[tokio::test]
+    async fn restart_into_regular_hours_cancels_live_extended_hours_order() {
+        // A live extended-hours limit order that survives a restart into
+        // regular hours: the very first scan after the restart observes
+        // Regular and the level-triggered cancel-and-replace pass must fire.
+        // Startup orphan-recovery finalizes only *terminal* orders, so without
+        // this the live limit order would rest unconverted for the whole
+        // session, leaving the position under-hedged.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let cfg = dry_run_ctx(&["AAPL"], OperationMode::Enabled);
+        let (ctx, position) = build_ctx_with_executor(
+            pool.clone(),
+            apalis_pool,
+            cfg,
+            Duration::from_secs(60),
+            regular_session_executor(),
+        )
+        .await;
+
+        let aapl = Symbol::new("AAPL").unwrap();
+        accumulate_position(
+            &position,
+            &aapl,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let offchain_order_id = OffchainOrderId::new();
+        claim_position(&ctx, &aapl, offchain_order_id).await;
+        record_extended_hours_order(&ctx, &aapl, offchain_order_id).await;
+
+        // First scan after the restart: market already Regular.
+        CheckPositions::default().perform(&ctx).await.unwrap();
+
+        let order = ctx
+            .offchain_order
+            .load(&offchain_order_id)
+            .await
+            .unwrap()
+            .expect("order should exist");
+        assert!(
+            matches!(order, OffchainOrder::Cancelling { .. }),
+            "restart catch-up must request cancellation of the live extended-hours order, got: {order:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalize_sweep_releases_broker_cancelled_position_with_feature_disabled() {
+        // The finalize sweep must run on EVERY tick, independent of the
+        // extended-hours flag: the paths that produce terminal Cancelled
+        // orders (poller confirming a manual broker-dashboard cancel, an
+        // order left Cancelling across a flag-off restart) are not gated, and
+        // this sweep -- driven here through the real CheckPositions::perform
+        // -- is the only runtime path that releases the position's pending
+        // slot for them.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let cfg = dry_run_ctx(&["AAPL"], OperationMode::Disabled);
+        let (ctx, position) = build_ctx_with_executor(
+            pool.clone(),
+            apalis_pool,
+            cfg,
+            Duration::from_secs(60),
+            regular_session_executor(),
+        )
+        .await;
+
+        let aapl = Symbol::new("AAPL").unwrap();
+        accumulate_position(
+            &position,
+            &aapl,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let offchain_order_id = OffchainOrderId::new();
+        claim_position(&ctx, &aapl, offchain_order_id).await;
+        record_extended_hours_order(&ctx, &aapl, offchain_order_id).await;
+
+        // Drive the order terminal: request cancellation (broker DELETE) and
+        // confirm it, as the poller would after a broker-side cancel.
+        ctx.offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::Unrequested,
+                },
+            )
+            .await
+            .unwrap();
+        ctx.offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::ConfirmCancellation {
+                    cancelled_at: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        CheckPositions::default().perform(&ctx).await.unwrap();
+
+        let recovered = ctx
+            .position_projection
+            .load(&aapl)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            recovered.pending_offchain_order_id, None,
+            "flag-off finalize sweep must release the broker-cancelled position"
+        );
+        assert_eq!(
+            recovered.last_failed_offchain_order_id, None,
+            "an intentional cancellation must not set the failure anchor"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalize_sweep_applies_retained_partial_fill_to_position_net() {
+        // The Complete branch of the sweep: a cancelled order that retained a
+        // priced partial fill must debit the position's net through the real
+        // CheckPositions::perform, not just release the pending slot --
+        // otherwise the next scan re-hedges shares the broker already filled.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let cfg = dry_run_ctx(&["AAPL"], OperationMode::Disabled);
+        let (ctx, position) = build_ctx_with_executor(
+            pool.clone(),
+            apalis_pool,
+            cfg,
+            Duration::from_secs(60),
+            regular_session_executor(),
+        )
+        .await;
+
+        let aapl = Symbol::new("AAPL").unwrap();
+        accumulate_position(
+            &position,
+            &aapl,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let offchain_order_id = OffchainOrderId::new();
+        claim_position(&ctx, &aapl, offchain_order_id).await;
+        record_extended_hours_order(&ctx, &aapl, offchain_order_id).await;
+
+        // Half the 1-share sell order fills before the cancellation lands.
+        ctx.offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(0.5)),
+                    avg_price: Usd::new(float!(195.25)),
+                    partially_filled_at: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        ctx.offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::Unrequested,
+                },
+            )
+            .await
+            .unwrap();
+        ctx.offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::ConfirmCancellation {
+                    cancelled_at: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        CheckPositions::default().perform(&ctx).await.unwrap();
+
+        let recovered = ctx
+            .position_projection
+            .load(&aapl)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            recovered.pending_offchain_order_id, None,
+            "finalize sweep must release the position"
+        );
+        assert_eq!(
+            recovered.net,
+            FractionalShares::new(float!(1.5)),
+            "the retained 0.5-share sell fill must debit net (2.0 -> 1.5)"
+        );
+
+        // Idempotency: a second tick over the already-finalized position must
+        // succeed without re-applying the fill.
+        CheckPositions::default().perform(&ctx).await.unwrap();
+        let after_second_tick = ctx
+            .position_projection
+            .load(&aapl)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(after_second_tick.net, FractionalShares::new(float!(1.5)));
+    }
+
+    #[tokio::test]
+    async fn regular_tick_cancels_extended_hours_order_placed_after_previous_tick() {
+        // Boundary straddle: a hedge job that read Extended just before 9:30
+        // can submit its extended-hours limit order AFTER the first
+        // regular-hours scan already ran (and found nothing to cancel). The
+        // cancel-and-replace pass is level-triggered -- it sweeps every
+        // regular-hours tick -- so the next tick must still converge the
+        // straddling order. An edge-triggered pass would have consumed the
+        // transition on the first tick and stranded the order for the whole
+        // session.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let cfg = dry_run_ctx(&["AAPL"], OperationMode::Enabled);
+        let (ctx, position) = build_ctx_with_executor(
+            pool.clone(),
+            apalis_pool,
+            cfg,
+            Duration::from_secs(60),
+            regular_session_executor(),
+        )
+        .await;
+
+        let aapl = Symbol::new("AAPL").unwrap();
+        accumulate_position(
+            &position,
+            &aapl,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        // First regular-hours tick: no pending order exists yet, the sweep
+        // finds nothing.
+        CheckPositions::default().perform(&ctx).await.unwrap();
+
+        // The boundary-straddling extended-hours order lands after that tick.
+        let offchain_order_id = OffchainOrderId::new();
+        claim_position(&ctx, &aapl, offchain_order_id).await;
+        record_extended_hours_order(&ctx, &aapl, offchain_order_id).await;
+
+        // The next regular-hours tick must still request cancellation.
+        CheckPositions::default().perform(&ctx).await.unwrap();
+
+        let order = ctx
+            .offchain_order
+            .load(&offchain_order_id)
+            .await
+            .unwrap()
+            .expect("order should exist");
+        assert!(
+            matches!(order, OffchainOrder::Cancelling { .. }),
+            "a regular-hours tick after the transition must still cancel a \
+             boundary-straddling extended-hours order, got: {order:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_order_aggregate_is_cleared_without_blocking_others() {
+        // AAPL's position is claimed but its offchain-order aggregate does not
+        // exist. The cancel sweep must still cancel TSLA's live extended-hours
+        // order on this tick, then the shared orphan recovery clears AAPL's
+        // missing claim so the position can be retried by the normal hedge
+        // path instead of remaining stuck.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let cfg = dry_run_ctx(&["AAPL", "TSLA"], OperationMode::Enabled);
+        let (ctx, position) = build_ctx_with_executor(
+            pool.clone(),
+            apalis_pool,
+            cfg,
+            Duration::from_secs(60),
+            regular_session_executor(),
+        )
+        .await;
+
+        let aapl = Symbol::new("AAPL").unwrap();
+        let tsla = Symbol::new("TSLA").unwrap();
+        for symbol in [&aapl, &tsla] {
+            accumulate_position(
+                &position,
+                symbol,
+                FractionalShares::new(float!(2.0)),
+                Direction::Buy,
+            )
+            .await;
+        }
+
+        let aapl_order_id = OffchainOrderId::new();
+        claim_position(&ctx, &aapl, aapl_order_id).await;
+
+        let tsla_order_id = OffchainOrderId::new();
+        claim_position(&ctx, &tsla, tsla_order_id).await;
+        record_extended_hours_order(&ctx, &tsla, tsla_order_id).await;
+
+        CheckPositions::default().perform(&ctx).await.unwrap();
+
+        let tsla_order = ctx
+            .offchain_order
+            .load(&tsla_order_id)
+            .await
+            .unwrap()
+            .expect("TSLA order should exist");
+        assert!(
+            matches!(tsla_order, OffchainOrder::Cancelling { .. }),
+            "an unresolvable order for one symbol must not block another \
+             symbol's cancellation, got: {tsla_order:?}"
+        );
+
+        let aapl_position = ctx
+            .position_projection
+            .load(&aapl)
+            .await
+            .unwrap()
+            .expect("AAPL position should exist");
+        assert_eq!(
+            aapl_position.pending_offchain_order_id, None,
+            "missing offchain-order aggregate must clear the pending claim"
+        );
+        assert_eq!(
+            aapl_position.last_failed_offchain_order_id,
+            Some(aapl_order_id),
+            "missing offchain-order aggregate must leave a failure anchor for retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn extended_hours_disabled_does_not_cancel_live_extended_hours_order() {
+        // With extended-hours counter-trading disabled for the asset, the
+        // cancel-and-replace pass must not touch it: a live extended-hours
+        // order is left untouched even when the scan observes regular hours.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let cfg = dry_run_ctx(&["AAPL"], OperationMode::Disabled);
+        let (ctx, position) = build_ctx_with_executor(
+            pool.clone(),
+            apalis_pool,
+            cfg,
+            Duration::from_secs(60),
+            regular_session_executor(),
+        )
+        .await;
+
+        let aapl = Symbol::new("AAPL").unwrap();
+        accumulate_position(
+            &position,
+            &aapl,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let offchain_order_id = OffchainOrderId::new();
+        claim_position(&ctx, &aapl, offchain_order_id).await;
+        record_extended_hours_order(&ctx, &aapl, offchain_order_id).await;
+
+        CheckPositions::default().perform(&ctx).await.unwrap();
+
+        let order = ctx
+            .offchain_order
+            .load(&offchain_order_id)
+            .await
+            .unwrap()
+            .expect("order should exist");
+        assert!(
+            matches!(
+                order,
+                OffchainOrder::Submitted {
+                    market_session: MarketSession::Extended,
+                    ..
+                }
+            ),
+            "with extended hours disabled the cancel pass must not touch the order, got: {order:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_sweep_skips_orders_placed_by_different_executor() {
+        // The cancel sweep must only dispatch cancellations through the
+        // currently-configured executor. An extended-hours order placed by a
+        // different executor (AlpacaBrokerApi) while the context runs DryRun
+        // must be left untouched: routing the cancellation through the wrong
+        // broker would mis-target. Mirrors the guard in PollOrderStatus and
+        // recover_submitted_offchain_orders.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let cfg = dry_run_ctx(&["AAPL"], OperationMode::Enabled);
+        let (ctx, position) = build_ctx_with_executor(
+            pool.clone(),
+            apalis_pool,
+            cfg,
+            Duration::from_secs(60),
+            regular_session_executor(),
+        )
+        .await;
+
+        let aapl = Symbol::new("AAPL").unwrap();
+        accumulate_position(
+            &position,
+            &aapl,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let offchain_order_id = OffchainOrderId::new();
+
+        // Claim the position with AlpacaBrokerApi executor (different from ctx's DryRun).
+        ctx.position
+            .send(
+                &aapl,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::AlpacaBrokerApi,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Record a live extended-hours limit order with AlpacaBrokerApi executor.
+        let shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        let limit_price = Positive::new(Usd::new(float!(195.25))).unwrap();
+        ctx.offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: aapl.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+                    kind: CounterTradeOrderKind::ExtendedHoursLimit { limit_price },
+                },
+            )
+            .await
+            .unwrap();
+        ctx.offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("alpaca-eh-1"),
+                    placed_shares: shares,
+                    submitted_at: chrono::Utc::now(),
+                    market_session: MarketSession::Extended,
+                    limit_price: Some(limit_price),
+                },
+            )
+            .await
+            .unwrap();
+
+        CheckPositions::default().perform(&ctx).await.unwrap();
+
+        let order = ctx
+            .offchain_order
+            .load(&offchain_order_id)
+            .await
+            .unwrap()
+            .expect("order should exist");
+        assert!(
+            matches!(
+                order,
+                OffchainOrder::Submitted {
+                    market_session: MarketSession::Extended,
+                    ..
+                }
+            ),
+            "cancel sweep must skip an order placed by a different executor, got: {order:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_sweep_only_touches_symbols_with_extended_hours_enabled() {
+        // Per-asset granularity: with AAPL extended-hours enabled and TSLA
+        // disabled, a regular-hours sweep must cancel AAPL's live
+        // extended-hours order while leaving TSLA's untouched.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let mut cfg = dry_run_ctx(&["AAPL", "TSLA"], OperationMode::Enabled);
+        let tsla = Symbol::new("TSLA").unwrap();
+        cfg.assets
+            .equities
+            .symbols
+            .get_mut(&tsla)
+            .unwrap()
+            .extended_hours_counter_trading = OperationMode::Disabled;
+        let (ctx, position) = build_ctx_with_executor(
+            pool.clone(),
+            apalis_pool,
+            cfg,
+            Duration::from_secs(60),
+            regular_session_executor(),
+        )
+        .await;
+
+        let aapl = Symbol::new("AAPL").unwrap();
+        for symbol in [&aapl, &tsla] {
+            accumulate_position(
+                &position,
+                symbol,
+                FractionalShares::new(float!(2.0)),
+                Direction::Buy,
+            )
+            .await;
+        }
+
+        let aapl_order_id = OffchainOrderId::new();
+        claim_position(&ctx, &aapl, aapl_order_id).await;
+        record_extended_hours_order(&ctx, &aapl, aapl_order_id).await;
+
+        let tsla_order_id = OffchainOrderId::new();
+        claim_position(&ctx, &tsla, tsla_order_id).await;
+        record_extended_hours_order(&ctx, &tsla, tsla_order_id).await;
+
+        CheckPositions::default().perform(&ctx).await.unwrap();
+
+        let aapl_order = ctx
+            .offchain_order
+            .load(&aapl_order_id)
+            .await
+            .unwrap()
+            .expect("AAPL order should exist");
+        assert!(
+            matches!(aapl_order, OffchainOrder::Cancelling { .. }),
+            "the enabled symbol's extended-hours order must be cancelled, got: {aapl_order:?}"
+        );
+
+        let tsla_order = ctx
+            .offchain_order
+            .load(&tsla_order_id)
+            .await
+            .unwrap()
+            .expect("TSLA order should exist");
+        assert!(
+            matches!(
+                tsla_order,
+                OffchainOrder::Submitted {
+                    market_session: MarketSession::Extended,
+                    ..
+                }
+            ),
+            "the disabled symbol's extended-hours order must be left untouched, got: {tsla_order:?}"
+        );
+    }
+
     #[tokio::test]
     async fn skips_trading_disabled_symbols_without_blocking_others() {
         let (pool, apalis_pool) = setup_test_pools().await;
         // RKLB is intentionally absent from the trading config -- the scan
         // must skip it without aborting the rest of the loop.
-        let cfg = dry_run_ctx(&["AAPL", "TSLA"]);
+        let cfg = dry_run_ctx(&["AAPL", "TSLA"], OperationMode::Disabled);
         let (ctx, position) = build_ctx(
             pool.clone(),
             apalis_pool.clone(),
@@ -730,7 +1654,7 @@ mod tests {
             .await;
         }
 
-        CheckPositions.perform(&ctx).await.unwrap();
+        CheckPositions::default().perform(&ctx).await.unwrap();
 
         assert_eq!(
             count_jobs(&apalis_pool, &hedge_job_type()).await,

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -6,21 +6,87 @@
 
 use std::sync::Arc;
 
+use alloy::primitives::U256;
+use rain_math_float::Float;
 use serde::{Deserialize, Serialize};
+use st0x_float_macro::float;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
-use st0x_config::ExecutionThreshold;
+use st0x_config::{AssetsConfig, ExecutionThreshold};
 use st0x_event_sorcery::{AggregateError, LifecycleError, Store};
-use st0x_execution::{Direction, FractionalShares, Positive, SupportedExecutor, Symbol};
+use st0x_execution::{
+    Direction, FractionalShares, MarketSession, Positive, SupportedExecutor, Symbol, Usd,
+};
 
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::offchain::order::{
-    OffchainOrder, OffchainOrderId, OffchainOrderPlacement, OrderPlacer, PollOrderStatus,
-    PollOrderStatusJobQueue, client_order_id_for_placement, place_offchain_order_at_broker,
+    CounterTradeOrderKind, OffchainOrder, OffchainOrderId, OffchainOrderPlacement, OrderPlacer,
+    PollOrderStatus, PollOrderStatusJobQueue, client_order_id_for_placement,
+    finalize_cancelled_position_or_log_unpriced, place_offchain_order_at_broker,
 };
 use crate::position::{Position, PositionCommand, PositionError};
 use crate::trading::onchain::trade_accountant::TradeAccountingError;
+
+/// Error returned by [`apply_slippage`].
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SlippageError {
+    #[error("float arithmetic failed: {0}")]
+    FloatArith(#[from] rain_math_float::FloatError),
+    #[error("slippage-adjusted price is non-positive (slippage_bps too large for sell)")]
+    NonPositive(#[from] st0x_finance::NotPositive<Usd>),
+}
+
+/// Applies slippage buffer to a reference price: adds for buys, subtracts
+/// for sells. Rounds the result to Alpaca's required precision (2 decimal
+/// places for prices >= $1, 4 for prices < $1). Rounding direction
+/// maximizes fill probability (ceiling for buys, floor for sells), which
+/// can push the realized limit slightly beyond the configured slippage
+/// budget by up to one tick.
+fn apply_slippage(
+    price: Usd,
+    direction: Direction,
+    slippage_bps: u16,
+) -> Result<Positive<Usd>, SlippageError> {
+    let price = Float::from(price);
+    let basis_points = float!(10000);
+    let slippage = Float::from_fixed_decimal(U256::from(slippage_bps), 0)?;
+
+    let adjusted = match direction {
+        Direction::Buy => {
+            let multiplier = ((basis_points + slippage)? / basis_points)?;
+            (price * multiplier)?
+        }
+        Direction::Sell => {
+            let multiplier = ((basis_points - slippage)? / basis_points)?;
+            (price * multiplier)?
+        }
+    };
+
+    // Precision is keyed off the *adjusted* (limit) price, not the reference
+    // price, on purpose: SEC Rule 612 / Alpaca's minimum price variance is a
+    // rule about the ORDER's price -- orders priced >= $1.00 must be in $0.01
+    // increments, orders < $1.00 may use $0.0001. A sub-$1 reference price that
+    // slips to >= $1.00 must therefore round to pennies, or the broker rejects
+    // the sub-penny limit. Keying off the reference price would emit invalid
+    // orders at the $1 boundary.
+    let max_decimals: u8 = if adjusted.lt(float!(1))? { 4 } else { 2 };
+    let (fixed, lossless) = adjusted.to_fixed_decimal_lossy(max_decimals)?;
+
+    let rounded = if lossless {
+        adjusted
+    } else {
+        // Buys: round up (ceiling) to ensure fill
+        // Sells: round down (floor/truncate) to ensure fill
+        let rounded_fixed = match direction {
+            Direction::Buy => fixed + U256::from(1),
+            Direction::Sell => fixed,
+        };
+        Float::from_fixed_decimal(rounded_fixed, max_decimals)?
+    };
+
+    Ok(Positive::new(Usd::new(rounded))?)
+}
 
 /// Persistent job queue for hedge placement.
 pub(crate) type HedgeJobQueue = JobQueue<PlaceHedge>;
@@ -33,10 +99,22 @@ pub(crate) struct HedgeCtx {
     /// `OffchainOrder::Place` handler.
     pub(crate) order_placer: Arc<dyn OrderPlacer>,
     pub(crate) poll_status_queue: PollOrderStatusJobQueue,
-    /// Shared with the trade-processing path so every broker-placement attempt
-    /// for a symbol serializes (ADR 0014): the original placement and any
-    /// recovery re-drive of the same order cannot interleave and race
-    /// `MarkFailed` against `MarkAccepted`.
+    /// Per-symbol asset config. Gates the extended-hours limit path: only a
+    /// symbol with `extended_hours_counter_trading = enabled` may place a limit
+    /// order during an Extended session. A disabled symbol skips (the
+    /// regular-open cancel-and-replace sweep is keyed off the same per-symbol
+    /// flag, so an extended order for a disabled symbol would be orphaned).
+    pub(crate) assets: AssetsConfig,
+    pub(crate) counter_trade_slippage_bps: u16,
+    /// Serialises broker submissions across hedge jobs and the inline
+    /// counter-trade path in `conductor.rs`, so a preflight running under
+    /// this same lock (the inline path's) observes any prior submission
+    /// rather than racing it. It does NOT re-check buying power for hedge
+    /// jobs themselves: their preflight ran at enqueue time, so two jobs
+    /// enqueued in the same scan window can still collectively exceed the
+    /// budget snapshot they were preflighted against. Broker-side rejection
+    /// is the backstop for that gap -- the rejected order lands as `Failed`
+    /// and releases the position for a later re-hedge.
     pub(crate) counter_trade_submission_lock: Arc<Mutex<()>>,
 }
 
@@ -55,6 +133,92 @@ pub(crate) struct PlaceHedge {
     pub(crate) executor: SupportedExecutor,
     pub(crate) threshold: ExecutionThreshold,
     pub(crate) offchain_order_id: OffchainOrderId,
+    /// Enqueue-time session for staleness diagnostics; perform re-fetches the
+    /// live session before selecting the broker order kind.
+    #[serde(default = "default_market_session")]
+    pub(crate) market_session: MarketSession,
+}
+
+fn default_market_session() -> MarketSession {
+    MarketSession::Regular
+}
+
+async fn select_order_kind_for_current_session(
+    ctx: &HedgeCtx,
+    symbol: &Symbol,
+    direction: Direction,
+    enqueued_session: MarketSession,
+) -> Result<Option<CounterTradeOrderKind>, TradeAccountingError> {
+    let current_session = ctx.order_placer.market_session().await.map_err(|source| {
+        TradeAccountingError::MarketSessionCheck {
+            symbol: symbol.clone(),
+            source,
+        }
+    })?;
+
+    if current_session != enqueued_session {
+        info!(
+            target: "hedge",
+            %symbol,
+            ?enqueued_session,
+            ?current_session,
+            "Market session changed between enqueue and perform; using current"
+        );
+    }
+
+    match current_session {
+        MarketSession::Regular => Ok(Some(CounterTradeOrderKind::Market)),
+        MarketSession::Closed => {
+            info!(
+                target: "hedge",
+                %symbol,
+                "Market closed at perform time; skipping hedge, CheckPositions will re-enqueue when the venue reopens"
+            );
+            Ok(None)
+        }
+        MarketSession::Extended => {
+            if !ctx.assets.is_extended_hours_enabled(symbol) {
+                info!(
+                    target: "hedge",
+                    %symbol,
+                    "Extended session but symbol is not enabled for extended-hours \
+                     counter-trading; skipping, CheckPositions will re-enqueue during \
+                     regular hours"
+                );
+                return Ok(None);
+            }
+
+            let latest_price = ctx
+                .order_placer
+                .fetch_latest_trade_price(symbol)
+                .await
+                .map_err(|source| TradeAccountingError::LimitPriceFetch {
+                    symbol: symbol.clone(),
+                    source,
+                })?
+                .ok_or_else(|| TradeAccountingError::LimitPriceUnavailable {
+                    symbol: symbol.clone(),
+                })?;
+
+            let limit_price = apply_slippage(
+                latest_price.inner(),
+                direction,
+                ctx.counter_trade_slippage_bps,
+            )?;
+
+            info!(
+                target: "hedge",
+                %symbol,
+                %limit_price,
+                direction = ?direction,
+                "Extended hours: placing limit order"
+            );
+
+            Ok(Some(CounterTradeOrderKind::ExtendedHoursLimit {
+                limit_price,
+            }))
+        }
+    }
 }
 
 /// Recovery path for the `PendingExecution` rejection. A previous attempt for
@@ -95,8 +259,16 @@ async fn recover_pending_poll_status(
             shares,
             direction,
             executor,
+            market_session,
             ..
         }) => {
+            let Some(order_kind) =
+                select_order_kind_for_current_session(ctx, &symbol, direction, market_session)
+                    .await?
+            else {
+                return Ok(());
+            };
+
             let anchor = ctx
                 .position
                 .load(&symbol)
@@ -108,19 +280,38 @@ async fn recover_pending_poll_status(
                 &ctx.offchain_order,
                 ctx.order_placer.as_ref(),
                 &pending_id,
-                OffchainOrderPlacement::market(
+                OffchainOrderPlacement::with_kind(
                     symbol.clone(),
                     shares,
                     direction,
                     executor,
                     client_order_id,
+                    order_kind,
                 ),
             )
             .await?;
 
             route_placement_outcome(ctx, &symbol, pending_id, placed).await
         }
-        Some(Filled { .. } | Failed { .. } | Cancelled { .. }) | None => Ok(()),
+        // The position still references a pending order that is already
+        // terminal (Cancelled/Failed) -- a stale apalis retry re-claimed the
+        // position before the finalize sweep released it. Do NOT stay silent:
+        // surface the stuck reference so it is visible to operators. The
+        // CheckPositions `finalize_terminal_pending_positions` sweep releases
+        // the position on its next tick, so no inline finalization is needed
+        // here (and inline finalization would race that sweep).
+        Some(terminal @ (Failed { .. } | Cancelled { .. })) => {
+            warn!(
+                target: "hedge",
+                %pending_id,
+                state = ?terminal,
+                "Position references a pending offchain order that is already \
+                 terminal; the CheckPositions finalize sweep will release the \
+                 position on its next tick"
+            );
+            Ok(())
+        }
+        Some(Filled { .. }) | None => Ok(()),
     }
 }
 
@@ -201,7 +392,15 @@ async fn route_placement_outcome(
             });
         }
 
-        Some(Cancelled { .. }) => {}
+        Some(cancelled @ Cancelled { .. }) => {
+            finalize_cancelled_position_or_log_unpriced(
+                ctx.position.as_ref(),
+                symbol,
+                offchain_order_id,
+                &cancelled,
+            )
+            .await?;
+        }
     }
 
     Ok(())
@@ -224,22 +423,57 @@ impl Job<HedgeCtx> for PlaceHedge {
     }
 
     async fn perform(&self, ctx: &HedgeCtx) -> Result<Self::Output, Self::Error> {
+        // Residual TOCTOU: the session read, the limit-price fetch, and the
+        // broker submission are three separate awaits, so the venue clock can
+        // cross a 9:30/16:00 boundary between them. This is inherent (the clock
+        // is external -- acquiring the submission lock earlier wouldn't close
+        // it, only serialise the price fetch). It is bounded and self-healing:
+        // a boundary-straddling order is either rejected by the broker (and
+        // retried, re-reading the session) or, if it lands as an extended-hours
+        // limit during regular hours, converged by the CheckPositions
+        // cancel-and-replace pass -- that pass is level-triggered (it sweeps
+        // every regular-hours tick, not just the transition tick), so an order
+        // submitted after the first regular-hours scan is still cancelled on
+        // the next one. The order kind is computed before the position is
+        // claimed, so a rejection never strands the position.
+        //
+        // Re-check the market session at execution time, ALWAYS -- independent
+        // of whether any asset enables extended-hours trading. The placer wraps
+        // the executor and is always present, so this recheck is no longer
+        // gated by the extended-hours feature flag. The enqueue-time value
+        // (self.market_session) can be stale by minutes if the job sat in
+        // apalis across a 9:30 or 16:00 ET boundary: a regular job that crossed
+        // the close must not blindly submit a market order into a closed or
+        // extended venue using its stale serialized session.
+        let Some(order_kind) = select_order_kind_for_current_session(
+            ctx,
+            &self.symbol,
+            self.direction,
+            self.market_session,
+        )
+        .await?
+        else {
+            // Not a plain Ok(()): a retry whose first attempt submitted the
+            // order but lost the poll enqueue must re-enqueue it here, or
+            // the live order sits un-polled (and its fill unrecorded) until
+            // the next restart.
+            return recover_pending_poll_status(ctx, self.offchain_order_id).await;
+        };
+
         // Serialize every broker placement (ADR 0014): the trade-processing path
-        // holds this same lock across its placement, so the original placement and
-        // any recovery re-drive of the same order cannot interleave -- closing the
-        // window where a stale `MarkFailed` could strand a live order accepted by
-        // a concurrent attempt. Held for the whole job, including
-        // `recover_pending_poll_status`.
+        // holds this same lock across its placement, so the position claim and
+        // broker side effect cannot interleave with a recovery re-drive or inline
+        // counter-trade placement.
         let _submission_guard = ctx.counter_trade_submission_lock.lock().await;
 
         // Only specific business rejections are safe to swallow:
         // - PendingExecution: another attempt already claimed this position
-        //   — usually idempotent, but if that attempt got the broker submitted
+        //   -- usually idempotent, but if that attempt got the broker submitted
         //   *without* enqueueing PollOrderStatus (e.g. the queue push failed
         //   and apalis is now retrying us), we must re-enqueue the poll here
         //   or the order sits in Submitted until the next bot restart.
         // - ThresholdNotMet: position moved below threshold since the monitor
-        //   scanned — stale job, no action needed.
+        //   scanned -- stale job, no action needed.
         //
         // Everything else (lifecycle bugs, aggregate conflicts, DB errors)
         // propagates so backon retries the job.
@@ -307,12 +541,13 @@ impl Job<HedgeCtx> for PlaceHedge {
             &ctx.offchain_order,
             ctx.order_placer.as_ref(),
             &self.offchain_order_id,
-            OffchainOrderPlacement::market(
+            OffchainOrderPlacement::with_kind(
                 self.symbol.clone(),
                 self.shares,
                 self.direction,
                 self.executor,
                 client_order_id,
+                order_kind,
             ),
         )
         .await?;
@@ -323,7 +558,7 @@ impl Job<HedgeCtx> for PlaceHedge {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::TxHash;
+    use alloy::primitives::{Address, TxHash};
     use proptest::prelude::*;
     use std::any::type_name;
     use std::sync::Arc;
@@ -343,7 +578,40 @@ mod tests {
         OffchainOrder, OffchainOrderCommand, OrderPlacementResult, OrderPlacer,
     };
     use crate::position::{Position, PositionCommand, TradeId};
-    use st0x_config::ExecutionThreshold;
+    use st0x_config::{EquitiesConfig, EquityAssetConfig, ExecutionThreshold, OperationMode};
+
+    /// Builds an [`AssetsConfig`] with a single equity whose extended-hours
+    /// counter-trading flag is set as given. Used to drive the per-symbol
+    /// extended-hours gate in `PlaceHedge::perform`.
+    fn extended_hours_assets(symbol: &str, enabled: bool) -> AssetsConfig {
+        let extended_hours_counter_trading = if enabled {
+            OperationMode::Enabled
+        } else {
+            OperationMode::Disabled
+        };
+
+        AssetsConfig {
+            equities: EquitiesConfig {
+                operational_limit: None,
+                symbols: std::iter::once((
+                    Symbol::new(symbol).unwrap(),
+                    EquityAssetConfig {
+                        tokenized_equity: Address::ZERO,
+                        tokenized_equity_derivative: Address::ZERO,
+                        pyth_feed_id: None,
+                        vault_ids: Vec::new(),
+                        trading: OperationMode::Disabled,
+                        rebalancing: OperationMode::Disabled,
+                        wrapped_equity_recovery: OperationMode::Disabled,
+                        extended_hours_counter_trading,
+                        operational_limit: None,
+                    },
+                ))
+                .collect(),
+            },
+            cash: None,
+        }
+    }
 
     fn succeeding_order_placer() -> Arc<dyn OrderPlacer> {
         struct SucceedingPlacer;
@@ -450,7 +718,13 @@ mod tests {
             position: position.clone(),
             offchain_order,
             poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
+            // The placer doubles as the session source; the default stubs
+            // report a Regular session, so these ctxs exercise the regular
+            // market-order path. AAPL is enabled for extended hours so the
+            // Regular path's session gate is not what skips them.
             order_placer,
+            assets: extended_hours_assets("AAPL", true),
+            counter_trade_slippage_bps: st0x_execution::DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,
             counter_trade_submission_lock: Arc::new(Mutex::new(())),
         };
 
@@ -496,7 +770,30 @@ mod tests {
             executor: SupportedExecutor::DryRun,
             threshold: ExecutionThreshold::whole_share(),
             offchain_order_id: OffchainOrderId::new(),
+            market_session: MarketSession::Regular,
         }
+    }
+
+    #[test]
+    fn legacy_place_hedge_payload_defaults_market_session_to_regular() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let payload = serde_json::json!({
+            "symbol": symbol,
+            "direction": Direction::Sell,
+            "shares": Positive::new(FractionalShares::new(float!(2.0))).unwrap(),
+            "executor": SupportedExecutor::DryRun,
+            "threshold": ExecutionThreshold::whole_share(),
+            "offchain_order_id": offchain_order_id,
+        });
+
+        let job: PlaceHedge = serde_json::from_value(payload).unwrap();
+
+        assert_eq!(
+            job.market_session,
+            MarketSession::Regular,
+            "legacy PlaceHedge jobs without market_session must deserialize as Regular"
+        );
     }
 
     #[tokio::test]
@@ -515,7 +812,7 @@ mod tests {
             direction: Direction::Sell,
             executor: SupportedExecutor::DryRun,
             placed_at: chrono::Utc::now(),
-            market_session: st0x_execution::MarketSession::Regular,
+            market_session: MarketSession::Regular,
         };
 
         let error =
@@ -805,6 +1102,841 @@ mod tests {
     /// `Submitted` but failed to enqueue the `PollOrderStatus` job, and apalis
     /// is re-running the hedge. The retry must re-enqueue the poll so the
     /// order doesn't sit `Submitted` until the next bot restart.
+    fn extended_hours_order_placer(price: rain_math_float::Float) -> Arc<dyn OrderPlacer> {
+        struct ExtHoursPlacer(rain_math_float::Float);
+
+        #[async_trait::async_trait]
+        impl OrderPlacer for ExtHoursPlacer {
+            async fn place_market_order(
+                &self,
+                order: st0x_execution::MarketOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(OrderPlacementResult {
+                    executor_order_id: ExecutorOrderId::new("market-order-1"),
+                    placed_shares: order.shares,
+                    is_extended_hours: false,
+                    limit_price: None,
+                })
+            }
+
+            async fn place_limit_order(
+                &self,
+                order: st0x_execution::LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(OrderPlacementResult {
+                    executor_order_id: ExecutorOrderId::new("limit-order-1"),
+                    placed_shares: order.shares,
+                    is_extended_hours: order.extended_hours,
+                    limit_price: Some(order.limit_price),
+                })
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &st0x_execution::ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
+            }
+
+            async fn fetch_latest_trade_price(
+                &self,
+                _symbol: &Symbol,
+            ) -> Result<
+                Option<st0x_execution::Positive<Usd>>,
+                Box<dyn std::error::Error + Send + Sync>,
+            > {
+                Ok(Some(st0x_execution::Positive::new(Usd::new(self.0))?))
+            }
+
+            async fn market_session(
+                &self,
+            ) -> Result<MarketSession, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(MarketSession::Extended)
+            }
+        }
+
+        Arc::new(ExtHoursPlacer(price))
+    }
+
+    async fn create_extended_hours_ctx(price: rain_math_float::Float) -> TestInfra {
+        let placer = extended_hours_order_placer(price);
+
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (offchain_order, offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(placer.clone())
+                .await
+                .unwrap();
+
+        let ctx = HedgeCtx {
+            position: position.clone(),
+            offchain_order,
+            poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
+            order_placer: placer,
+            assets: extended_hours_assets("AAPL", true),
+            counter_trade_slippage_bps: 100,
+            counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
+        };
+
+        TestInfra {
+            ctx,
+            apalis_pool,
+            position_projection,
+            offchain_order_projection,
+        }
+    }
+
+    #[test]
+    fn apply_slippage_buy_adds_to_price() {
+        let price = Usd::new(float!(150.0));
+        let result = apply_slippage(price, Direction::Buy, 100).unwrap();
+        // 150 * 1.01 = 151.50, already 2 decimal places, no rounding needed
+        assert!(
+            result.inner().inner().eq(float!(151.50)).unwrap(),
+            "Buy slippage should increase the price, got: {result}"
+        );
+    }
+
+    #[test]
+    fn apply_slippage_sell_subtracts_from_price() {
+        let price = Usd::new(float!(150.0));
+        let result = apply_slippage(price, Direction::Sell, 100).unwrap();
+        // 150 * 0.99 = 148.50
+        assert!(
+            result.inner().inner().eq(float!(148.50)).unwrap(),
+            "Sell slippage should decrease the price, got: {result}"
+        );
+    }
+
+    #[test]
+    fn apply_slippage_rounds_buy_up_to_two_decimals() {
+        // 151.23 * 1.01 = 152.7423 -> rounds UP to 152.75 for a buy
+        let price = Usd::new(float!(151.23));
+        let result = apply_slippage(price, Direction::Buy, 100).unwrap();
+        assert!(
+            result.inner().inner().eq(float!(152.75)).unwrap(),
+            "Buy should round up to the nearest cent, got: {result}"
+        );
+    }
+
+    #[test]
+    fn apply_slippage_rounds_sell_down_to_two_decimals() {
+        // 151.23 * 0.99 = 149.7177 -> truncates to 149.71 for a sell
+        let price = Usd::new(float!(151.23));
+        let result = apply_slippage(price, Direction::Sell, 100).unwrap();
+        assert!(
+            result.inner().inner().eq(float!(149.71)).unwrap(),
+            "Sell should round down to the nearest cent, got: {result}"
+        );
+    }
+
+    #[test]
+    fn apply_slippage_zero_bps_is_identity() {
+        let price = Usd::new(float!(100.0));
+        let buy_result = apply_slippage(price, Direction::Buy, 0).unwrap();
+        let sell_result = apply_slippage(price, Direction::Sell, 0).unwrap();
+        assert_eq!(buy_result.inner(), price);
+        assert_eq!(sell_result.inner(), price);
+    }
+
+    #[test]
+    fn apply_slippage_zero_bps_still_rounds_unclean_price() {
+        // At 0 bps the price is unchanged, but the result is still rounded to the
+        // min price variance: buy ceils, sell floors. The clean-$100 identity
+        // test never exercises this branch (100.00 is already 2-decimal).
+        let price = Usd::new(float!(100.001));
+        let buy = apply_slippage(price, Direction::Buy, 0).unwrap();
+        assert!(
+            buy.inner().inner().eq(float!(100.01)).unwrap(),
+            "0-bps buy must still ceil an unclean price to cents, got: {buy}"
+        );
+        let sell = apply_slippage(price, Direction::Sell, 0).unwrap();
+        assert!(
+            sell.inner().inner().eq(float!(100.0)).unwrap(),
+            "0-bps sell must still floor an unclean price to cents, got: {sell}"
+        );
+    }
+
+    #[test]
+    fn apply_slippage_sub_dollar_uses_four_decimals() {
+        // 0.5000 * 1.01 = 0.5050 - 4-decimal precision branch
+        let result = apply_slippage(Usd::new(float!(0.5)), Direction::Buy, 100).unwrap();
+        assert!(
+            result.inner().inner().eq(float!(0.5050)).unwrap(),
+            "Sub-$1 buy should round to 4 decimals (0.5050), got: {result}"
+        );
+
+        let sell = apply_slippage(Usd::new(float!(0.5)), Direction::Sell, 100).unwrap();
+        assert!(
+            sell.inner().inner().eq(float!(0.4950)).unwrap(),
+            "Sub-$1 sell should round to 4 decimals (0.4950), got: {sell}"
+        );
+    }
+
+    #[test]
+    fn apply_slippage_sub_dollar_reference_crossing_one_dollar_rounds_to_pennies() {
+        // 0.99 * 1.02 = 1.0098: the reference is sub-$1 but the ADJUSTED
+        // (limit) price crosses $1.00, so Rule 612 requires penny precision.
+        // The buy must ceil to $1.01 -- a regression that keys precision off
+        // the reference price would emit a sub-penny $1.0098 limit and the
+        // broker would reject the order.
+        let result = apply_slippage(Usd::new(float!(0.99)), Direction::Buy, 200).unwrap();
+        assert!(
+            result.inner().inner().eq(float!(1.01)).unwrap(),
+            "adjusted price crossing $1.00 must round to pennies, got: {result}"
+        );
+    }
+
+    #[test]
+    fn apply_slippage_just_below_one_dollar_keeps_four_decimals() {
+        // 0.99 * 1.0033 = 0.993267 stays below $1.00, so sub-penny (4-decimal)
+        // precision applies: ceil to 0.9933. A regression that always rounded
+        // to pennies would ceil this to $1.00 instead.
+        let result = apply_slippage(Usd::new(float!(0.99)), Direction::Buy, 33).unwrap();
+        assert!(
+            result.inner().inner().eq(float!(0.9933)).unwrap(),
+            "adjusted price below $1.00 must keep 4-decimal precision, got: {result}"
+        );
+    }
+
+    #[test]
+    fn apply_slippage_at_exactly_one_dollar_uses_two_decimals() {
+        // Reference exactly $1.00 with 13 bps buy slippage: 1.00 * 1.0013 =
+        // 1.0013, which is >= $1.00 and must round to pennies ($1.01), not to
+        // four decimals ($1.0013).
+        let result = apply_slippage(Usd::new(float!(1.0)), Direction::Buy, 13).unwrap();
+        assert!(
+            result.inner().inner().eq(float!(1.01)).unwrap(),
+            "price at the $1.00 boundary must use penny precision, got: {result}"
+        );
+    }
+
+    #[test]
+    fn apply_slippage_max_bps_sell_succeeds_at_one_cent() {
+        // 9999 bps slippage on a sell: 100 * 0.0001 = 0.01, still positive.
+        // Config validation caps counter_trade_slippage_bps at 9_999
+        // (loader's MAX_COUNTER_TRADE_SLIPPAGE_BPS); apply_slippage itself
+        // accepts any u16. This guards against future bound regressions:
+        // 9999 must succeed for prices >= $1.
+        let result = apply_slippage(Usd::new(float!(100.0)), Direction::Sell, 9999).unwrap();
+        assert!(
+            result.inner().inner().eq(float!(0.01)).unwrap(),
+            "Max-bps sell should produce 1 cent, got: {result}"
+        );
+    }
+
+    #[test]
+    fn apply_slippage_max_bps_sub_dollar_sell_errors_non_positive() {
+        // A sub-dollar reference at max slippage floors below the minimum
+        // tick: 0.50 * 0.0001 = 0.00005, floored to 0.0000 at sub-dollar
+        // precision. Producing a zero limit must surface as an explicit
+        // error -- never a zero-priced order at the broker.
+        let error = apply_slippage(Usd::new(float!(0.50)), Direction::Sell, 9999).unwrap_err();
+        assert!(
+            matches!(error, SlippageError::NonPositive(_)),
+            "expected NonPositive for a zeroed sub-dollar sell limit, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn extended_hours_places_limit_order() {
+        let TestInfra {
+            ctx,
+            position_projection,
+            offchain_order_projection,
+            ..
+        } = create_extended_hours_ctx(float!(150.0)).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let job = PlaceHedge {
+            symbol: symbol.clone(),
+            direction: Direction::Sell,
+            shares: Positive::new(FractionalShares::new(float!(2.0))).unwrap(),
+            executor: SupportedExecutor::DryRun,
+            threshold: ExecutionThreshold::whole_share(),
+            offchain_order_id: OffchainOrderId::new(),
+            market_session: MarketSession::Extended,
+        };
+
+        job.perform(&ctx).await.unwrap();
+
+        let position = position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id,
+            Some(job.offchain_order_id),
+            "Position should store the hedge job's offchain order ID"
+        );
+
+        let order = offchain_order_projection
+            .load(&job.offchain_order_id)
+            .await
+            .unwrap()
+            .expect("offchain order should exist");
+        assert!(
+            matches!(
+                order,
+                OffchainOrder::Submitted {
+                    market_session: MarketSession::Extended,
+                    ..
+                }
+            ),
+            "Order should be submitted as extended-hours, got: {order:?}"
+        );
+        // The exact limit price computation is covered by the dedicated
+        // `apply_slippage_*` unit tests; this integration test only checks
+        // the lifecycle path.
+    }
+
+    /// Failure mode (some asset enabled): a stale Regular hedge job for a symbol
+    /// whose extended-hours flag is DISABLED arrives during an Extended session.
+    /// The decoupled per-symbol gate must skip it -- placing an extended-hours
+    /// limit would be orphaned, since the regular-open cancel-and-replace sweep
+    /// is keyed off the same per-symbol flag and skips disabled symbols. The
+    /// position must be left unclaimed and no order recorded.
+    #[tokio::test]
+    async fn extended_session_for_disabled_symbol_skips_without_placing_order() {
+        let TestInfra {
+            ctx,
+            position_projection,
+            offchain_order_projection,
+            ..
+        } = create_hedge_ctx_with(
+            extended_hours_order_placer(float!(150.0)),
+            extended_hours_assets("AAPL", false),
+        )
+        .await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let job = PlaceHedge {
+            symbol: symbol.clone(),
+            direction: Direction::Sell,
+            shares: Positive::new(FractionalShares::new(float!(2.0))).unwrap(),
+            executor: SupportedExecutor::DryRun,
+            threshold: ExecutionThreshold::whole_share(),
+            offchain_order_id: OffchainOrderId::new(),
+            // Stale: enqueued during regular hours, retried during Extended.
+            market_session: MarketSession::Regular,
+        };
+
+        job.perform(&ctx)
+            .await
+            .expect("a disabled-symbol extended job must skip cleanly, not error");
+
+        let position = position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "A symbol not enabled for extended hours must not be claimed during an Extended session"
+        );
+
+        let order = offchain_order_projection
+            .load(&job.offchain_order_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            order, None,
+            "No order may be placed for a disabled symbol during extended hours, got: {order:?}"
+        );
+    }
+
+    /// Failure mode (all assets disabled): the perform-time session recheck must
+    /// run UNCONDITIONALLY, not only when extended-hours is enabled. A stale
+    /// Regular job that crossed the close boundary must re-read the live session
+    /// (Closed here) and skip -- never submit a market order into a closed venue
+    /// off its stale serialized Regular session. Before the decoupling this job
+    /// would keep its stale `Regular` and submit a market order.
+    #[tokio::test]
+    async fn regular_job_rechecks_live_session_and_skips_when_venue_closed() {
+        let TestInfra {
+            ctx,
+            position_projection,
+            offchain_order_projection,
+            ..
+        } = create_hedge_ctx_with(
+            market_session_overriding_placer(MarketSession::Closed),
+            extended_hours_assets("AAPL", false),
+        )
+        .await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let job = PlaceHedge {
+            symbol: symbol.clone(),
+            direction: Direction::Sell,
+            shares: Positive::new(FractionalShares::new(float!(2.0))).unwrap(),
+            executor: SupportedExecutor::DryRun,
+            threshold: ExecutionThreshold::whole_share(),
+            offchain_order_id: OffchainOrderId::new(),
+            // Stale serialized session: enqueued during regular hours.
+            market_session: MarketSession::Regular,
+        };
+
+        job.perform(&ctx)
+            .await
+            .expect("a stale Regular job must skip when the live venue is closed");
+
+        let position = position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "A closed-venue recheck must not claim the position off a stale Regular session"
+        );
+
+        let order = offchain_order_projection
+            .load(&job.offchain_order_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            order, None,
+            "No market order may be submitted into a closed venue, got: {order:?}"
+        );
+    }
+
+    /// `OrderPlacer` that reports an Extended session but fails the
+    /// latest-trade-price lookup -- simulates the market-data endpoint being
+    /// down during pre-market. Placement methods error because the job must
+    /// never reach them on this path.
+    fn price_fetch_failing_placer() -> Arc<dyn OrderPlacer> {
+        struct FailingPricePlacer;
+
+        #[async_trait::async_trait]
+        impl OrderPlacer for FailingPricePlacer {
+            async fn place_market_order(
+                &self,
+                _order: st0x_execution::MarketOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err("place_market_order must not be called when the price fetch fails".into())
+            }
+
+            async fn place_limit_order(
+                &self,
+                _order: st0x_execution::LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err("place_limit_order must not be called when the price fetch fails".into())
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &st0x_execution::ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
+            }
+
+            async fn fetch_latest_trade_price(
+                &self,
+                _symbol: &Symbol,
+            ) -> Result<
+                Option<st0x_execution::Positive<Usd>>,
+                Box<dyn std::error::Error + Send + Sync>,
+            > {
+                Err("market data endpoint down".into())
+            }
+
+            async fn market_session(
+                &self,
+            ) -> Result<MarketSession, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(MarketSession::Extended)
+            }
+        }
+
+        Arc::new(FailingPricePlacer)
+    }
+
+    #[tokio::test]
+    async fn price_fetch_failure_during_extended_session_does_not_claim_position() {
+        // order_placer is Some but the latest-trade-price lookup fails (e.g.
+        // market data endpoint down during pre-market). The error must surface
+        // BEFORE the position is claimed: a regression that claims the
+        // position first would leave a dangling pending_offchain_order_id with
+        // no actual order, silently blocking all future hedging of the symbol.
+        let TestInfra {
+            ctx,
+            position_projection,
+            offchain_order_projection,
+            ..
+        } = create_hedge_ctx_with(
+            price_fetch_failing_placer(),
+            extended_hours_assets("AAPL", true),
+        )
+        .await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let job = PlaceHedge {
+            symbol: symbol.clone(),
+            direction: Direction::Sell,
+            shares: Positive::new(FractionalShares::new(float!(2.0))).unwrap(),
+            executor: SupportedExecutor::DryRun,
+            threshold: ExecutionThreshold::whole_share(),
+            offchain_order_id: OffchainOrderId::new(),
+            market_session: MarketSession::Extended,
+        };
+
+        // The job fails with a retryable error (it propagates, so apalis
+        // re-runs it) rather than being swallowed.
+        let result = job.perform(&ctx).await;
+        assert!(
+            matches!(result, Err(TradeAccountingError::LimitPriceFetch { .. })),
+            "expected LimitPriceFetch, got: {result:?}"
+        );
+
+        let position = position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "price fetch failure must not claim the position"
+        );
+
+        let order = offchain_order_projection
+            .load(&job.offchain_order_id)
+            .await
+            .unwrap();
+        assert!(
+            order.is_none(),
+            "no offchain order may be recorded when the price fetch fails, got: {order:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_session_failure_surfaces_dedicated_error_without_claiming_position() {
+        // The session re-check at the top of perform fails (broker calendar /
+        // clock endpoint down). The error must be MarketSessionCheck -- not
+        // LimitPriceFetch, which would point operators at the market-data
+        // endpoint -- and the position must remain unclaimed so the retry can
+        // start clean.
+        struct SessionFailingPlacer;
+
+        #[async_trait::async_trait]
+        impl OrderPlacer for SessionFailingPlacer {
+            async fn place_market_order(
+                &self,
+                _order: st0x_execution::MarketOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err("place_market_order must not be called when the session check fails".into())
+            }
+
+            async fn place_limit_order(
+                &self,
+                _order: st0x_execution::LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err("place_limit_order must not be called when the session check fails".into())
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &st0x_execution::ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
+            }
+
+            async fn market_session(
+                &self,
+            ) -> Result<MarketSession, Box<dyn std::error::Error + Send + Sync>> {
+                Err("broker calendar endpoint down".into())
+            }
+        }
+
+        let TestInfra {
+            ctx,
+            position_projection,
+            ..
+        } = create_hedge_ctx_with(
+            Arc::new(SessionFailingPlacer),
+            extended_hours_assets("AAPL", true),
+        )
+        .await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let job = hedge_job(&symbol, 2.0, Direction::Sell);
+        let result = job.perform(&ctx).await;
+        assert!(
+            matches!(result, Err(TradeAccountingError::MarketSessionCheck { .. })),
+            "expected MarketSessionCheck, got: {result:?}"
+        );
+
+        let position = position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "session-check failure must not claim the position"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_skips_without_claiming_when_session_changes_to_closed() {
+        // Job was enqueued in Extended hours, but by the time perform runs
+        // the market has closed. perform must NOT submit and must NOT model
+        // this as a job error (apalis backoff can't span a multi-hour
+        // closure). It returns Ok and leaves the position unclaimed so the
+        // next CheckPositions scan re-enqueues when the venue reopens.
+        let placer = market_session_overriding_placer(MarketSession::Closed);
+        let TestInfra {
+            ctx,
+            position_projection,
+            ..
+        } = create_hedge_ctx_with(placer, extended_hours_assets("AAPL", true)).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let job = PlaceHedge {
+            symbol: symbol.clone(),
+            direction: Direction::Sell,
+            shares: Positive::new(FractionalShares::new(float!(2.0))).unwrap(),
+            executor: SupportedExecutor::DryRun,
+            threshold: ExecutionThreshold::whole_share(),
+            offchain_order_id: OffchainOrderId::new(),
+            market_session: MarketSession::Extended,
+        };
+
+        job.perform(&ctx)
+            .await
+            .expect("perform must succeed (skip), not error, when the market is closed");
+
+        let position = position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "Position must not be claimed when perform skips a closed-market hedge"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_uses_current_session_when_enqueued_session_is_stale() {
+        // Job was enqueued during Extended hours but Regular has begun by
+        // the time perform runs -- it must submit a market order, not a
+        // limit order with extended_hours=true.
+        let placer = market_session_overriding_placer(MarketSession::Regular);
+        let TestInfra {
+            ctx,
+            offchain_order_projection,
+            ..
+        } = create_hedge_ctx_with(placer, extended_hours_assets("AAPL", true)).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let job = PlaceHedge {
+            symbol: symbol.clone(),
+            direction: Direction::Sell,
+            shares: Positive::new(FractionalShares::new(float!(2.0))).unwrap(),
+            executor: SupportedExecutor::DryRun,
+            threshold: ExecutionThreshold::whole_share(),
+            offchain_order_id: OffchainOrderId::new(),
+            market_session: MarketSession::Extended,
+        };
+
+        job.perform(&ctx).await.unwrap();
+
+        let order = offchain_order_projection
+            .load(&job.offchain_order_id)
+            .await
+            .unwrap()
+            .expect("offchain order should exist");
+
+        // Critical: the order was placed as a *market* order even though the
+        // job was enqueued during extended hours, because perform re-checked
+        // the session and found Regular.
+        assert!(
+            matches!(
+                order,
+                OffchainOrder::Submitted {
+                    market_session: MarketSession::Regular,
+                    ..
+                }
+            ),
+            "Stale Extended job should submit a Regular market order, got: {order:?}"
+        );
+    }
+
+    /// Returns an `OrderPlacer` that reports a configured market_session
+    /// while delegating placement to a succeeding stub. Used to test the
+    /// session re-check inside `PlaceHedge::perform`.
+    fn market_session_overriding_placer(session: MarketSession) -> Arc<dyn OrderPlacer> {
+        struct Stub {
+            session: MarketSession,
+        }
+
+        #[async_trait::async_trait]
+        impl OrderPlacer for Stub {
+            async fn place_market_order(
+                &self,
+                order: st0x_execution::MarketOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(OrderPlacementResult {
+                    executor_order_id: ExecutorOrderId::new("market-1"),
+                    placed_shares: order.shares,
+                    is_extended_hours: false,
+                    limit_price: None,
+                })
+            }
+
+            async fn place_limit_order(
+                &self,
+                order: st0x_execution::LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(OrderPlacementResult {
+                    executor_order_id: ExecutorOrderId::new("limit-1"),
+                    placed_shares: order.shares,
+                    is_extended_hours: order.extended_hours,
+                    limit_price: Some(order.limit_price),
+                })
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &st0x_execution::ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
+            }
+
+            async fn fetch_latest_trade_price(
+                &self,
+                _symbol: &Symbol,
+            ) -> Result<
+                Option<st0x_execution::Positive<Usd>>,
+                Box<dyn std::error::Error + Send + Sync>,
+            > {
+                Ok(Some(
+                    st0x_execution::Positive::new(Usd::new(float!(100.0))).unwrap(),
+                ))
+            }
+
+            async fn market_session(
+                &self,
+            ) -> Result<MarketSession, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(self.session)
+            }
+        }
+
+        Arc::new(Stub { session })
+    }
+
+    /// Variant of `create_hedge_ctx` that wires a specific placer (the session
+    /// source) and asset config through to `HedgeCtx`, so `perform` exercises a
+    /// chosen session and per-symbol extended-hours eligibility.
+    async fn create_hedge_ctx_with(
+        placer: Arc<dyn OrderPlacer>,
+        assets: AssetsConfig,
+    ) -> TestInfra {
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (offchain_order, offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(placer.clone())
+                .await
+                .unwrap();
+
+        let ctx = HedgeCtx {
+            position: position.clone(),
+            offchain_order,
+            poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
+            order_placer: placer,
+            assets,
+            counter_trade_slippage_bps: 100,
+            counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
+        };
+
+        TestInfra {
+            ctx,
+            apalis_pool,
+            position_projection,
+            offchain_order_projection,
+        }
+    }
+
     #[tokio::test]
     async fn retry_after_failed_poll_enqueue_re_enqueues_poll() {
         let TestInfra {
@@ -904,10 +2036,8 @@ mod tests {
                     shares: job.shares,
                     direction: job.direction,
                     executor: job.executor,
-                    client_order_id: st0x_execution::ClientOrderId::from_uuid(
-                        job.offchain_order_id.as_uuid(),
-                    ),
-                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                    client_order_id: ClientOrderId::from_uuid(job.offchain_order_id.as_uuid()),
+                    kind: CounterTradeOrderKind::Market,
                 },
             )
             .await
@@ -939,6 +2069,62 @@ mod tests {
         );
     }
 
+    /// The recovery path must NOT re-enqueue a poll for an order that is
+    /// already terminal (a stale retry landing after the order was cancelled or
+    /// failed). It returns Ok (so apalis marks the job Done) after warning that
+    /// the position is still pending against the terminal order; the
+    /// CheckPositions finalize sweep releases the position.
+    #[tokio::test]
+    async fn recover_pending_poll_status_skips_terminal_order_without_enqueuing_poll() {
+        let TestInfra {
+            ctx, apalis_pool, ..
+        } = create_hedge_ctx(succeeding_order_placer()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        // Drive an offchain order to terminal Failed (Place -> Submitted ->
+        // MarkFailed) without ever enqueueing a poll for it.
+        let order_id = OffchainOrderId::new();
+        ctx.offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares: Positive::new(FractionalShares::new(float!(1.0))).unwrap(),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    client_order_id: ClientOrderId::from_uuid(order_id.as_uuid()),
+                    kind: CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        ctx.offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::MarkFailed {
+                    error: "broker rejected".to_string(),
+                    failed_at: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        recover_pending_poll_status(&ctx, order_id)
+            .await
+            .expect("recovery must not error for a terminal pending order");
+
+        let poll_jobs: i64 =
+            sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                .bind(type_name::<PollOrderStatus>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            poll_jobs, 0,
+            "A terminal pending order must not be re-polled by the recovery path"
+        );
+    }
+
     #[tokio::test]
     async fn perform_blocks_while_submission_lock_held() {
         // ADR 0014: PlaceHedge::perform serializes on the shared submission lock,
@@ -960,11 +2146,8 @@ mod tests {
 
         let job = hedge_job(&symbol, 2.0, Direction::Sell);
 
-        // Hold the lock; perform must block on it and never reach placement.
-        // `perform`'s first statement is `lock().await`, so it parks immediately
-        // and `timeout` always elapses (perform can never resolve while the lock
-        // is held). The window only needs to outlast `perform` reaching the lock,
-        // so keep it small to avoid burning wall-clock on every run.
+        // Hold the lock; after the perform-time session check the job must
+        // block before it claims the position or places at the broker.
         let guard = ctx.counter_trade_submission_lock.clone().lock_owned().await;
         let blocked =
             tokio::time::timeout(std::time::Duration::from_millis(20), job.perform(&ctx)).await;

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -231,8 +231,8 @@ pub(crate) enum TradeAccountingError {
     // TODO: TradeAccountingError should not be coupled to a concrete executor error type.
     #[error("Alpaca broker API error: {0}")]
     AlpacaBrokerApi(#[from] AlpacaBrokerApiError),
-    #[error("Failed to enqueue PollOrderStatus job: {0}")]
-    EnqueuePollJob(#[from] crate::conductor::job::QueuePushError),
+    #[error("Failed to enqueue follow-up job: {0}")]
+    EnqueueJob(#[from] crate::conductor::job::QueuePushError),
     #[error("Position fill lookup failed: {0}")]
     PositionFillLookup(#[from] crate::conductor::PositionFillLookupError),
     #[error("Missing block_timestamp for fill {trade_id}; cannot account for it")]
@@ -251,6 +251,22 @@ pub(crate) enum TradeAccountingError {
     InconsistentOnChainTradeState {
         trade_id: crate::onchain_trade::OnChainTradeId,
     },
+    #[error("Failed to determine market session before placing hedge for {symbol}")]
+    MarketSessionCheck {
+        symbol: st0x_execution::Symbol,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[error("Failed to fetch latest trade price for {symbol}")]
+    LimitPriceFetch {
+        symbol: st0x_execution::Symbol,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[error("Executor does not support fetching trade prices for {symbol}")]
+    LimitPriceUnavailable { symbol: st0x_execution::Symbol },
+    #[error("Slippage calculation failed")]
+    SlippageCalculation(#[from] crate::trading::offchain::hedge::SlippageError),
 }
 
 #[cfg(test)]
@@ -351,6 +367,7 @@ mod tests {
             assets: ctx.assets.clone(),
             counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
             poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(&apalis_pool),
+            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&apalis_pool),
         };
 
         let job_queue = DexTradeAccountingJobQueue::new(&apalis_pool);
@@ -480,6 +497,7 @@ mod tests {
             assets: ctx.assets.clone(),
             counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
             poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(&apalis_pool),
+            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&apalis_pool),
         };
 
         let job_queue = DexTradeAccountingJobQueue::new(&apalis_pool);


### PR DESCRIPTION
## What

- Wire the extended-hours policy on top of the aggregate: session-aware hedge placement (`apply_slippage` limit pricing with Alpaca penny/sub-penny rounding, Market-vs-`ExtendedHoursLimit` selection by `MarketSession` re-checked at perform time), the level-triggered cancel-and-replace sweep that converges still-live extended-hours limit orders to market orders at the regular open, and the inline extended-hours enqueue path.
- Replace the conservative placeholders from #916/#931 with the real logic: `hedge` (in `PlaceHedge::perform`) derives `CounterTradeOrderKind` from the session re-checked at perform time, while `conductor` keeps inline regular-hours placement as `Market` and, for an extended-hours fill, enqueues an immediate `PlaceHedge` job instead of placing inline. Cancellations route through the shared finalization helpers.

## Why

- Final implementation PR of the stack (#915 -> #916 -> #931 -> **#932**). Turns the state machine + execution primitives into the actual extended-hours behaviour. Ships inert (config `"disabled"` everywhere) until enabled per asset in a later config flip.

## How

- `src/trading/offchain/hedge.rs`: session recheck at perform time (run unconditionally — see the post-review fix below), `apply_slippage`, order-kind selection with a per-symbol extended-hours gate, submission lock.
- `src/position_check.rs`: `request_extended_hours_cancellations` sweep gated by `is_extended_hours_enabled`, plus `finalize_terminal_pending_positions`.
- `src/conductor.rs` + `src/conductor/builder.rs`: inline extended-hours enqueue, the hedge `OrderPlacer` wired as a session source, `hedge_queue` wiring, and orphan recovery routed through the shared `position_command_for_finalization` helper.
- `src/onchain/accumulator.rs`, `src/trading/onchain/trade_accountant.rs`, `src/conductor/monitor/executor_maintenance.rs`, `src/integration_tests/arbitrage.rs`.

## Testing

- Unit tests for session-aware order-kind selection / `apply_slippage`, the cancel-and-replace sweep, and the conductor extended-hours enqueue path (`extended_hours_trade_enqueues_immediate_hedge_job`); hedge tests cover both decoupling failure modes (a stale Regular job skips when the live venue is closed; a disabled-symbol job skips during an Extended session) and the terminal-pending recovery no-re-poll path; `integration_tests/arbitrage.rs` updated. Verified locally on the stack tip: `cargo check --all-targets`, `cargo clippy --all-features`, `cargo fmt --check` clean. CI runs the full suite per PR.

## Anything else

- Post-review blocker fix ([RAI-1173](https://linear.app/makeitrain/issue/RAI-1173)): the perform-time market-session recheck was gated by the global `order_placer` flag, which was `Some` only when some asset enabled extended hours. That let a stale Regular job submit a market order after the venue closed (when all assets were disabled) or place an orphan-able extended-hours limit for a per-symbol-disabled symbol. Fix: the `OrderPlacer` is now **always** constructed (a pure session source, decoupled from the feature flag), so the recheck always runs; per-symbol eligibility is carried in `HedgeCtx.assets` and the `Extended` arm skips symbols that are not enabled. `recover_pending_poll_status` now warns instead of silently returning `Ok` for a terminal pending order, and the unreachable `OrderPlacerNotConfigured` error was removed.
- Inert until enabled per asset: with every asset `"disabled"`, the always-present `OrderPlacer` never reaches a limit-order placement because the per-symbol `is_extended_hours_enabled` gate skips every Extended placement, and the cancel-and-replace sweep (`request_extended_hours_cancellations`) skips every symbol — so behaviour is unchanged (market orders during regular hours only).
- One unconditional behaviour change: the `CheckPositions` tick now always runs `finalize_terminal_pending_positions` (finalizes terminal pending offchain orders into position commands, with `Cancelled` orders finalized via cancel/complete rather than failure semantics) regardless of the flag — active even with the feature disabled.
- This stack applies the extended-hours feature on top of current master and deliberately preserves master's operator-recovery / equity-redemption (schema 4) work -- the original single-PR branch predated those and this stack does not revert them.
- Stack: #915 -> #916 -> #931 -> **#932**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extended-hours session-aware trade handling, including slippage-aware counter-trading with limit orders and automatic hedge job routing.
  * Enhanced periodic position monitoring to finalize terminal pending states and sweep/cancel still-live extended-hours orders when enabled.

* **Bug Fixes**
  * Improved startup/orphan order recovery to avoid silent undecided states and to ensure cancelled orders and unpriced terminal partial fills are handled consistently.
  * Adjusted cancelled-state dispatch so it no longer surfaces as a generic failure during post-placement processing.

* **Tests**
  * Updated and expanded coverage for extended-hours hedging, recovery, cancellation routing, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
