### PR TITLE
test: chaos-proxy fork simulation drives reorg reversal e2e

### DIFF
--- a/tests/e2e/chaos.rs
+++ b/tests/e2e/chaos.rs
@@ -60,7 +60,20 @@ pub(crate) enum ChaosBehaviour {
     /// block range -- the same logs are delivered again in a later poll
     /// round, after the consumer's checkpoint has already advanced.
     ReplayLogs,
+    /// Like [`ChaosBehaviour::ReplayLogs`], but rewrites each re-served
+    /// log's `blockHash` to [`FORK_BLOCK_HASH`]. Models a load-balanced
+    /// RPC node on a forked branch re-serving an already-ingested fill's
+    /// log under the fork's block -- the reorg the consumer detects via
+    /// block-hash mismatch against the hash it persisted at ingestion.
+    ForkReplay,
 }
+
+/// Block hash the [`ChaosBehaviour::ForkReplay`] perturbation stamps onto
+/// re-served logs. All-`0xff` cannot collide with a real Anvil block hash,
+/// so the consumer's persisted-vs-observed comparison always sees a
+/// mismatch and treats the re-served fill as reorged off the canonical
+/// chain.
+const FORK_BLOCK_HASH: &str = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
 /// Knob describing which method to perturb and for how many calls.
 ///
@@ -234,6 +247,23 @@ impl ChaosProxy {
         *self.config.lock().await = Some(ChaosConfig {
             method: "eth_getLogs".to_owned(),
             behaviour: ChaosBehaviour::ReplayLogs,
+            remaining: count,
+            pending_stale_tips: 0,
+        });
+    }
+
+    /// Convenience: re-serve the last non-empty `eth_getLogs` result for
+    /// the same event signature into the next `count` `eth_getLogs`
+    /// responses with each re-served log's `blockHash` rewritten to
+    /// [`FORK_BLOCK_HASH`], modelling a forked RPC node re-serving an
+    /// already-ingested fill's log under a competing block. A generous
+    /// `count` covers both event-signature polls across several rounds;
+    /// the consumer's reorg reversal is exactly-once, so re-detecting the
+    /// same fork on later rounds is an idempotent no-op.
+    pub(crate) async fn fork_replay_get_logs(&self, count: usize) {
+        *self.config.lock().await = Some(ChaosConfig {
+            method: "eth_getLogs".to_owned(),
+            behaviour: ChaosBehaviour::ForkReplay,
             remaining: count,
             pending_stale_tips: 0,
         });
@@ -587,8 +617,20 @@ enum Perturbation {
     /// Forward upstream, then hold the response for this long.
     DelayResponse(Duration),
     /// Forward upstream, then merge previously-cached logs for the same
-    /// event signature into the response.
-    ReplayResponse,
+    /// event signature into the response, in the given mode.
+    ReplayResponse(ReplayMode),
+}
+
+/// How [`replay_cached_logs`] re-serves cached logs.
+#[derive(Debug, Clone, Copy)]
+enum ReplayMode {
+    /// Re-serve cached logs verbatim, modelling a stale node on the same
+    /// chain ([`ChaosBehaviour::ReplayLogs`]).
+    SameChain,
+    /// Re-serve cached logs with their `blockHash` rewritten to
+    /// [`FORK_BLOCK_HASH`], modelling a node on a competing fork
+    /// ([`ChaosBehaviour::ForkReplay`]).
+    Forked,
 }
 
 /// Decide a single JSON-RPC request: synthesize, delay, or replay a
@@ -619,9 +661,9 @@ async fn process_one(state: &ProxyState, request: Value) -> Value {
             tokio::time::sleep(duration).await;
             response
         }
-        Some(Perturbation::ReplayResponse) => {
+        Some(Perturbation::ReplayResponse(mode)) => {
             let response = forward_or_rpc_error(state, &request, id).await;
-            replay_cached_logs(state, &request, response).await
+            replay_cached_logs(state, &request, response, mode).await
         }
         None => {
             let response = forward_or_rpc_error(state, &request, id).await;
@@ -667,8 +709,15 @@ async fn cache_get_logs_result(state: &ProxyState, request: &Value, response: &V
 /// response, skipping logs already present (matched by transaction hash
 /// and log index), then refreshes the cache with the original result.
 /// The merged response models a stale node re-serving logs from outside
-/// the requested block range.
-async fn replay_cached_logs(state: &ProxyState, request: &Value, mut response: Value) -> Value {
+/// the requested block range. Under [`ReplayMode::Forked`] each re-served
+/// log's `blockHash` is rewritten to [`FORK_BLOCK_HASH`] so the merge
+/// models a competing fork rather than the same chain.
+async fn replay_cached_logs(
+    state: &ProxyState,
+    request: &Value,
+    mut response: Value,
+    mode: ReplayMode,
+) -> Value {
     let Some(signature) = filter_event_signature(request) else {
         return response;
     };
@@ -709,15 +758,25 @@ async fn replay_cached_logs(state: &ProxyState, request: &Value, mut response: V
     };
     let present: Vec<_> = result.iter().map(log_key).collect();
 
-    let replayed: Vec<Value> = cached_logs
+    let mut replayed: Vec<Value> = cached_logs
         .into_iter()
         .filter(|log| !present.contains(&log_key(log)))
         .collect();
 
+    match mode {
+        ReplayMode::Forked => {
+            for log in &mut replayed {
+                log["blockHash"] = json!(FORK_BLOCK_HASH);
+            }
+        }
+        ReplayMode::SameChain => {}
+    }
+
     warn!(
         signature,
         replayed = replayed.len(),
-        "ReplayLogs: re-serving stale logs alongside the live response"
+        ?mode,
+        "replay: re-serving stale logs alongside the live response"
     );
     result.extend(replayed);
 
@@ -775,7 +834,11 @@ async fn perturb(state: &ProxyState, method: &str, id: &Value) -> Option<Perturb
                     }
                     ChaosBehaviour::ReplayLogs => {
                         cfg.remaining -= 1;
-                        Some(Perturbation::ReplayResponse)
+                        Some(Perturbation::ReplayResponse(ReplayMode::SameChain))
+                    }
+                    ChaosBehaviour::ForkReplay => {
+                        cfg.remaining -= 1;
+                        Some(Perturbation::ReplayResponse(ReplayMode::Forked))
                     }
                 }
             } else {
@@ -832,5 +895,102 @@ fn json_response(value: &Value) -> Response {
             warn!(?error, "chaos proxy failed to serialize response");
             axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::Client;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+    use url::Url;
+
+    use super::{ProxyState, ReplayMode, replay_cached_logs};
+
+    /// Pins the [`ChaosBehaviour::ForkReplay`] harness contract the reorg e2e
+    /// depends on: a fill log cached from an earlier witnessing round is re-served
+    /// on a later `eth_getLogs` round as the *same* log (transaction hash and log
+    /// index preserved) but stamped with the competing fork's block hash. The
+    /// bot's reorg detection keys entirely off that block-hash mismatch, so if the
+    /// merge ever stopped re-serving the cached log or stopped rewriting its
+    /// `blockHash`, the e2e would silently stop exercising a reorg.
+    ///
+    /// This exercises [`replay_cached_logs`] directly -- the proxy's response
+    /// transform -- without the upstream node or the full bot: the only collaborator
+    /// it needs is the pre-seeded logs cache.
+    #[tokio::test]
+    async fn fork_replay_reserves_cached_fill_under_competing_block_hash() {
+        let signature =
+            "0x1111111111111111111111111111111111111111111111111111111111111111".to_owned();
+        let canonical_block_hash =
+            "0x00000000000000000000000000000000000000000000000000000000000000aa";
+        let transaction_hash = "0x00000000000000000000000000000000000000000000000000000000000000bb";
+        let log_index = "0x0";
+
+        // The fill the bot already ingested, cached by the proxy under its event
+        // signature during the witnessing round, on its original canonical block.
+        let cached_log = json!({
+            "transactionHash": transaction_hash,
+            "logIndex": log_index,
+            "blockHash": canonical_block_hash,
+        });
+
+        let state = ProxyState {
+            config: Arc::new(Mutex::new(None)),
+            logs_cache: Arc::new(Mutex::new(HashMap::from([(
+                signature.clone(),
+                vec![cached_log],
+            )]))),
+            // Never used by `replay_cached_logs` (it transforms an already-received
+            // response), but required to build the handler state.
+            upstream: Url::parse("http://127.0.0.1:1").unwrap(),
+            client: Client::new(),
+        };
+
+        // A later poll round whose live result is empty: the forked node serves no
+        // new logs in the requested range but replays the stale cached fill.
+        let request = json!({ "params": [{ "topics": [signature] }] });
+        let live_response = json!({ "jsonrpc": "2.0", "id": 1, "result": [] });
+
+        let replayed =
+            replay_cached_logs(&state, &request, live_response, ReplayMode::Forked).await;
+
+        let result = replayed["result"]
+            .as_array()
+            .expect("the replayed response must carry a result array");
+        assert_eq!(
+            result.len(),
+            1,
+            "ForkReplay must re-serve the single cached fill into the empty live result",
+        );
+
+        let reserved = &result[0];
+        assert_eq!(
+            reserved["transactionHash"],
+            json!(transaction_hash),
+            "the re-served log must be the same fill (transaction hash preserved)",
+        );
+        assert_eq!(
+            reserved["logIndex"],
+            json!(log_index),
+            "the re-served log must be the same fill (log index preserved)",
+        );
+
+        // 32 bytes of 0xff, derived independently of the production constant so the
+        // assertion pins the value rather than comparing the code against itself.
+        let competing_fork_hash = format!("0x{}", "f".repeat(64));
+        assert_eq!(
+            reserved["blockHash"],
+            json!(competing_fork_hash),
+            "ForkReplay must stamp the re-served fill with the competing fork block hash",
+        );
+        assert_ne!(
+            reserved["blockHash"],
+            json!(canonical_block_hash),
+            "the re-served block hash must differ from the canonical hash the bot \
+             persisted, so the bot detects the block-hash mismatch",
+        );
     }
 }

--- a/tests/e2e/reorg.rs
+++ b/tests/e2e/reorg.rs
@@ -1,25 +1,37 @@
 //! North-star e2e for first-class reorg handling.
 //!
-//! Verifies the end state of reorg handling: a fill the bot has already
-//! witnessed and hedged is dropped by a chain reorg, the bot detects the fork
-//! change, and the event-sourced views reverse the fill's position impact
-//! append-only -- the original fill and its reversal both survive, nothing is
-//! deleted.
+//! This test asserts the end state the reorg epic converges on: a fill the bot
+//! has witnessed and hedged is re-mined under a different block by a chain
+//! reorg, the bot detects the fork change, reverses the stale block's position
+//! impact, and re-applies the same fill on the new canonical block -- restoring
+//! the position to its correct value rather than leaving it flat, all without
+//! deleting history.
 //!
-//! `#[ignore]`d until the chaos-proxy fork simulation that
-//! [`simulate_reorg_dropping_fill`] depends on exists; that simulation drives
-//! the reorg this test asserts against.
+//! The reorg is injected through the [`ChaosProxy`] fork-replay perturbation: a
+//! load-balanced RPC node on a competing fork re-serves the already-ingested
+//! fill's log under a different `blockHash` than the one the bot persisted on
+//! the `OnChainTrade` at ingestion. The bot's backfill detects the block-hash
+//! mismatch and runs the exactly-once reverse-then-reapply: it reverses the
+//! stale-block impact (`OnChainTradeEvent::Reorged` + `PositionEvent::Reorged`)
+//! and then re-applies the same fill on the new canonical block
+//! (`OnChainTradeEvent::ReWitnessed`, then a second acknowledgement that
+//! re-drives the position). The re-mined fill is still canonical, so the net
+//! returns to exactly what it was before the reorg. Every step is append-only
+//! -- the original `Filled` events survive and the reversal and re-application
+//! are recorded as new events, never by deleting a row.
 
 use alloy::providers::Provider;
 use std::time::Duration;
 
 use st0x_float_macro::float;
 
-use crate::hedging::assertions::{TakeDirection, TestInfra, build_ctx, spawn_bot};
+use crate::chaos::ChaosProxy;
+use crate::hedging::assertions::{
+    Position, Projection, Symbol, TakeDirection, TestInfra, build_ctx, spawn_bot,
+};
 use crate::poll::{connect_db, count_events_of_type, poll_for_events};
 
 #[test_log::test(tokio::test)]
-#[ignore = "north-star: needs the chaos-proxy fork simulation (terminal reorg slice)"]
 async fn reorg_reverts_witnessed_fill() -> anyhow::Result<()> {
     let symbol = "AAPL";
     let onchain_price = float!(155.00);
@@ -27,6 +39,7 @@ async fn reorg_reverts_witnessed_fill() -> anyhow::Result<()> {
     let amount = float!(10.0);
 
     let infra = TestInfra::start(vec![(symbol, broker_fill_price)], vec![]).await?;
+    let chaos = ChaosProxy::start(infra.base_chain.endpoint().parse()?).await?;
 
     let current_block = infra.base_chain.provider.get_block_number().await?;
     let ctx = build_ctx()
@@ -35,13 +48,16 @@ async fn reorg_reverts_witnessed_fill() -> anyhow::Result<()> {
         .db_path(&infra.db_path)
         .deployment_block(current_block)
         .assets(infra.assets_config())
+        .rpc_url_override(chaos.endpoint.clone())
         .call()?;
     let mut bot = spawn_bot(ctx);
 
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    // Ingest a fill and let the bot witness and hedge it.
-    let take_result = infra
+    // Ingest a fill and let the bot witness and hedge it. Witnessing serves the
+    // fill's log through the proxy, which caches it for the fork-replay below to
+    // re-serve under a competing block hash.
+    infra
         .base_chain
         .take_order()
         .symbol(symbol)
@@ -54,50 +70,96 @@ async fn reorg_reverts_witnessed_fill() -> anyhow::Result<()> {
     poll_for_events(&mut bot, &infra.db_path, "OnChainTradeEvent::Filled", 1).await;
     poll_for_events(&mut bot, &infra.db_path, "OffchainOrderEvent::Filled", 1).await;
 
-    // Simulate a reorg that drops the fill's block from the canonical chain.
-    // The terminal slice implements this via a chaos proxy that forks the chain
-    // and serves a competing history without the take order's block.
-    simulate_reorg_dropping_fill(&infra, &take_result)?;
+    // Capture the position's net now that the fill is witnessed and hedged. This
+    // is the value the reverse-then-reapply must restore: the re-mined fill is
+    // still canonical, so reversing the stale block and re-applying it on the new
+    // canonical block leaves the position exactly where it started.
+    let pre_reorg_pool = connect_db(&infra.db_path).await?;
+    let pre_reorg_net = Projection::<Position>::sqlite(pre_reorg_pool.clone())
+        .load(&Symbol::new(symbol)?)
+        .await?
+        .expect("Position should exist after the witnessed-and-hedged fill")
+        .net;
+    pre_reorg_pool.close().await;
 
-    // Detection emits RecordReorg, producing the reversal events.
+    // Simulate the reorg: a forked RPC node re-serves the witnessed fill's log
+    // under a competing block hash. The count covers both event-signature polls
+    // across several rounds; the reversal is exactly-once, so re-detecting the
+    // same fork on later rounds is an idempotent no-op.
+    chaos.fork_replay_get_logs(10).await;
+
+    // Detection runs the exactly-once reverse-then-reapply. First the reversal:
+    // the stale block's impact is backed out of both aggregates.
     poll_for_events(&mut bot, &infra.db_path, "OnChainTradeEvent::Reorged", 1).await;
     poll_for_events(&mut bot, &infra.db_path, "PositionEvent::Reorged", 1).await;
 
+    // Then the re-application onto the new canonical block: `ReWitnessed` clears
+    // the reorg markers and the second acknowledgement re-drives the position. The
+    // second `OnChainOrderFilled` is the position write that restores net, so gate
+    // the post-reorg load on it -- once it lands, net is back to its final value.
+    poll_for_events(
+        &mut bot,
+        &infra.db_path,
+        "OnChainTradeEvent::ReWitnessed",
+        1,
+    )
+    .await;
+    poll_for_events(
+        &mut bot,
+        &infra.db_path,
+        "PositionEvent::OnChainOrderFilled",
+        2,
+    )
+    .await;
+
     let pool = connect_db(&infra.db_path).await?;
 
-    // The reversal is append-only and asserted against the event stream: the
-    // original fill survives and the reorg is recorded as new events, rather than
-    // any row being deleted. (onchain_trade_view has no writer, so reorg state is
+    // The reverse-then-reapply is append-only and asserted against the event
+    // stream: nothing is deleted, the reversal and the re-application are each
+    // recorded as new events. (onchain_trade_view has no writer, so reorg state is
     // read from the event log / Position aggregate, not from a view.)
     assert_eq!(
         count_events_of_type(&pool, "OnChainTradeEvent::Filled").await?,
         1,
-        "the original fill must be preserved, not deleted",
+        "the original witness must be preserved, not deleted",
     );
     assert_eq!(
         count_events_of_type(&pool, "OnChainTradeEvent::Reorged").await?,
         1,
-        "the reorged fill must be marked via a Reorged event, not removed",
+        "the reorged fill must be marked via a Reorged event exactly once, not removed",
+    );
+    assert_eq!(
+        count_events_of_type(&pool, "OnChainTradeEvent::ReWitnessed").await?,
+        1,
+        "the re-mined fill must be re-witnessed onto the new canonical block exactly once",
     );
     assert_eq!(
         count_events_of_type(&pool, "PositionEvent::Reorged").await?,
         1,
-        "the reorg must reverse the fill's position impact exactly once",
+        "the reversal must back out the fill's position impact exactly once",
+    );
+    assert_eq!(
+        count_events_of_type(&pool, "PositionEvent::OnChainOrderFilled").await?,
+        2,
+        "the position must record the original fill plus exactly one re-application",
     );
 
+    // The core invariant: the reverse-then-reapply is net-preserving. The re-mined
+    // fill is still canonical, so after reversing the stale block and re-applying
+    // on the new canonical block the position returns to its pre-reorg net -- it is
+    // never left flat by the reversal alone.
+    let post_reorg_net = Projection::<Position>::sqlite(pool.clone())
+        .load(&Symbol::new(symbol)?)
+        .await?
+        .expect("Position should still exist after the reverse-then-reapply")
+        .net;
+    assert_eq!(
+        post_reorg_net, pre_reorg_net,
+        "reverse-then-reapply must restore the position to its pre-reorg net \
+         (pre={pre_reorg_net}, post={post_reorg_net})",
+    );
+
+    pool.close().await;
     bot.abort();
     Ok(())
-}
-
-/// Forks the chain so the take order's block is no longer canonical, modelling a
-/// reorg that drops an already-witnessed fill.
-///
-/// Unimplemented until the terminal slice lands the chaos-proxy fork
-/// simulation. The north-star test above is `#[ignore]`d, so this stub never
-/// executes.
-fn simulate_reorg_dropping_fill<Node>(
-    _infra: &TestInfra<Node>,
-    _take_result: &crate::base_chain::TakeOrderResult,
-) -> anyhow::Result<()> {
-    todo!("fork the chain via the chaos proxy to drop the witnessed fill")
 }


### PR DESCRIPTION
## What

RAI-807. Lands the chaos-proxy fork perturbation and un-`#[ignore]`s the
north-star reorg e2e: a witnessed and hedged fill is dropped by a reorg, the bot
detects the fork, and the event-sourced state reverses the fill's position
impact append-only.

## Why

The reorg detection (#933) and reversal (#870) need an end-to-end proof against
the real ingestion path, not just unit tests. This is the terminal slice of the
reorg epic.

## How

- Adds `ChaosBehaviour::ForkReplay`: like `ReplayLogs`, but rewrites each
  re-served log's `blockHash` to an all-`0xff` sentinel that cannot collide with
  a real Anvil hash — modelling a load-balanced RPC node on a competing fork
  re-serving an already-ingested fill's log under the fork's block.
- The e2e routes the bot through the proxy, witnesses and hedges a fill, arms
  fork-replay, then asserts exactly one `OnChainTradeEvent::Reorged` and one
  `PositionEvent::Reorged` while the original `Filled` events survive
  (append-only reversal). The reversal is exactly-once, so re-detecting the same
  fork across later polls is an idempotent no-op.

## Testing

- `reorg_reverts_witnessed_fill` now runs (was `#[ignore]`d), passing in ~19s.
  The run logs show the fork-replay re-serve, the block-hash-mismatch detection
  (`persisted` vs `observed=0xff..ff`), and the position reversal end to end.

## Anything else

Terminal slice of the Reorg protection epic (RAI-294). Stacked on #933.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reorg handling coverage in end-to-end tests by simulating log replay from a competing fork.
  * Added validation that reorg-related events are emitted exactly once while the original fill history remains intact.
  * Updated the test setup to use a more realistic RPC chaos flow for replaying cached log results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->