### PR TITLE
fix: close the acknowledge->mark double-count with a bounded pending-ack set

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3103,7 +3103,7 @@ named exemptions defined after the list:**
   a mandatory audit reason.
 - `rebuild` -- recompute a projection from the event log; emits no events.
 
-Two commands sit deliberately outside the six-verb set, named for their exact
+Three commands sit deliberately outside the six-verb set, named for their exact
 effect rather than a generic intent:
 
 - `cctp complete-mint` -- the `cctp` group exposes raw on-chain primitives that
@@ -3114,6 +3114,20 @@ effect rather than a generic intent:
   `fail-pending-offchain-order` command. `fail` would be the wrong verb here:
   the Position itself never fails -- only its orphaned order does; `--reason`
   required.
+- `process-tx` -- account an onchain fill the bot never recorded, given its
+  transaction hash: it witnesses the fill into the `OnChainTrade` log,
+  acknowledges it on the `Position`, and places the opposite-side hedge, running
+  the same `witness -> enrich -> acknowledge -> mark -> settle` exactly-once
+  sequence as the automated pipeline (see ADR 0005 and ADR 0010). Unlike the two
+  commands above it belongs to no object group -- there is no stuck aggregate to
+  recover, only a missing fill to backfill. It **fails closed on a fill already
+  recorded** in the `OnChainTrade` log, whether acknowledged or merely
+  witnessed: re-applying it would double-count the position, so only a fill with
+  no record is accounted. It runs in direct-DB mode and **must not run while the
+  bot is concurrently accounting the same symbol** -- the CLI and the bot are
+  separate processes that no in-process lock can serialize, so the persisted
+  pending-acknowledgement set (see ADR 0010), not process isolation, is what
+  makes a cross-process re-drive reject as a duplicate rather than double-count.
 
 **Standing rules:**
 

--- a/adrs/0005-exactly-once-fill-accounting.md
+++ b/adrs/0005-exactly-once-fill-accounting.md
@@ -2,7 +2,14 @@
 
 ## Status
 
-Accepted
+Accepted. The single-slot dedup decision (Decision point 4 / the
+`last_acknowledged_trade_id` Consequence) is **superseded in part by
+[ADR 0010](0010-bounded-pending-ack-set-for-cross-process-exactly-once.md)**:
+the single slot is correct only under serialized per-symbol processing, which
+the separate-process `process-tx` recovery CLI breaks. ADR 0010 keeps the slot
+(as a cross-upgrade bridge) and adds a bounded, event-sourced
+pending-acknowledgement set that closes the cross-process / out-of-order
+double-count.
 
 ## Context
 

--- a/adrs/0010-bounded-pending-ack-set-for-cross-process-exactly-once.md
+++ b/adrs/0010-bounded-pending-ack-set-for-cross-process-exactly-once.md
@@ -1,0 +1,129 @@
+# ADR 0010: Bounded pending-acknowledgement set for cross-process exactly-once
+
+## Status
+
+Accepted. Supersedes in part [ADR 0005](0005-exactly-once-fill-accounting.md)
+(the single-slot `last_acknowledged_trade_id` dedup).
+
+## Context
+
+ADR 0005 made fill accounting exactly-once by tracking acknowledgement on the
+`OnChainTrade` aggregate and, as defense in depth for the crash window between
+the `Position` write and the `OnChainTrade` marker, having `Position` reject a
+`trade_id` it has already applied. State stayed bounded by remembering only the
+single most-recently applied `trade_id` (`last_acknowledged_trade_id`).
+
+That single slot is correct **only under serialized, in-order processing** --
+the property ADR 0005 relied on: the bot's accounting worker is `concurrency(1)`
+plus a per-symbol in-process lock, and re-deliveries drain in enqueue order, so
+the only trade that can be re-driven against an unmarked acknowledgement is the
+most recent one.
+
+The `process-tx` recovery CLI breaks that assumption. It runs in a **separate
+process** from the bot, so the in-process per-symbol lock cannot serialize the
+two. The double-count window:
+
+1. A process witnesses and acknowledges fill A (the `Position` write lands, the
+   single slot now holds A), then crashes before writing the `OnChainTrade`
+   marker. A is witnessed-but-unacknowledged; the position already counted it.
+2. A newer fill B is acknowledged, advancing the single slot to B. The slot no
+   longer remembers A.
+3. A is re-driven (the bot rescans, an orphaned accounting job is requeued, or a
+   retry fires). The resume path re-runs the acknowledge; the single slot holds
+   B, not A, so the guard does not fire and A is counted a **second time**.
+
+The same window exists for any concurrency greater than one, not just the CLI. A
+fixed-capacity ring or a scalar high-water-mark cannot close it: an orphaned
+re-drive can be delayed across arbitrarily many intervening distinct fills, and
+`trade_id` has no processing-order monotonicity across the witness/acknowledge
+gap, so no fixed `N` is provably correct. ADR 0005 already rejected a
+`Position`-side set of **all** `trade_id`s because it grows unboundedly for the
+life of the symbol.
+
+## Decision
+
+`Position` keeps the single slot **and** gains a bounded, event-sourced set of
+applied-but-not-yet-settled `trade_id`s, `pending_acknowledged_trade_ids`. The
+acknowledge dedup rejects a fill whose `trade_id` either equals the slot **or**
+is a member of the set.
+
+1. **Dedicated insert event.** `AcknowledgeOnChainFill` emits, in one atomic
+   batch, the existing `OnChainOrderFilled` (the position move, which still
+   writes the slot, unchanged) **and** a new `OnChainFillApplied { trade_id }`
+   whose `evolve` inserts `trade_id` into the set. The insert is a dedicated
+   event -- never folded into `OnChainOrderFilled` -- so that pre-ADR-0010
+   history, which contains only `OnChainOrderFilled`, rebuilds the set **empty**
+   on a full replay (see "Why the dedicated event").
+2. **Prune step.** A new `SettleOnChainFill { trade_id }` command emits
+   `OnChainFillSettled { trade_id }` (whose `evolve` removes `trade_id` from the
+   set) when the trade is a member, and emits no events otherwise (an
+   idempotent, optimistic-concurrency-safe no-op). The accounting pipeline
+   issues it as a fifth step, after the marker is durable:
+   `witness -> enrich -> acknowledge -> mark -> settle`. The settle runs on
+   every post-mark path, including the bot's resume "already acknowledged ->
+   skip" branch and the CLI's "already accounted -> refuse" branch, so a leaked
+   entry self-heals on the next interaction with that fill.
+
+## Why the dedicated event
+
+`Position` uses the default `COMPACTION_POLICY = Retain`, so no events are ever
+deleted. The `SCHEMA_VERSION` bump (3 -> 4) clears `Position`'s snapshot, and
+the store then rebuilds the aggregate by replaying every event from the start.
+If the set-insert lived on `OnChainOrderFilled`, replaying a long-lived symbol's
+history would insert **every historical** `trade_id` into the set, with no
+matching `OnChainFillSettled` events to remove them (the event did not exist
+pre-ADR-0010) -- re-creating the unbounded set ADR 0005 rejected, on the first
+reload after deploy. Because the insert lives on the dedicated
+`OnChainFillApplied` event, pre-ADR-0010 history contains zero inserts and
+rebuilds the set empty; post-ADR-0010 fills replay as `OnChainFillApplied`
+(insert) / `OnChainFillSettled` (remove) pairs that converge to just the
+genuinely in-flight tail.
+
+## Why the slot is retained
+
+A fill applied under pre-ADR-0010 code but left unmarked when the deploy
+restarts the process has no `OnChainFillApplied` event in its history, so the
+rebuilt set cannot guard it. The retained single slot -- written by the
+unchanged `OnChainOrderFilled` evolve -- still equals that `trade_id` and
+rejects its re-drive, bridging the upgrade window with **zero migration**.
+Seeding the set at migration from witnessed-but-unacknowledged `OnChainTrade`s
+is unsound: the marker cannot distinguish a witness->acknowledge crash (the
+position never applied the fill -- seeding would make a real fill un-applyable,
+an under-count) from an acknowledge->mark crash (the position did apply it).
+Once all in-flight-at-upgrade fills have drained, the slot is
+redundant-but-harmless (a distinct fill never equals it) and may be removed by a
+deliberate follow-up.
+
+## Alternatives considered
+
+- **Reactor/projection driving `Position` from `OnChainTrade::Acknowledged`.**
+  Would give a single authoritative write, but reactors in this codebase are
+  live-only with no replay cursor; making it exactly-once needs a persisted
+  cursor plus startup replay (the cross-aggregate atomicity the framework
+  deliberately lacks) and still needs a `Position`-side dedup for the cursor's
+  at-least-once redelivery. Most complex, and fights the framework.
+- **Fixed-capacity ring / scalar high-water-mark.** Bounded and replay-trivial,
+  but not provably correct (see Context).
+- **`Position`-side set of all `trade_id`s.** The unbounded growth ADR 0005
+  rejected.
+
+## Consequences
+
+- New `Position` events (`OnChainFillApplied`, `OnChainFillSettled`) and command
+  (`SettleOnChainFill`); `OnChainOrderFilled` and `AcknowledgeOnChainFill` keep
+  their shapes (the acknowledge command emits one extra event in its batch).
+  `Position` `SCHEMA_VERSION` 3 -> 4; `OnChainTrade` and the
+  witness/enrich/acknowledge/mark mechanics are unchanged.
+- No SQL migration: the set lives inside the aggregate state; the
+  `position_view` projection rebuilds from events and its generated columns
+  reference only unchanged JSON paths.
+- The set is empty at rest and bounded by the in-flight jobs (a couple at most,
+  even across the bot and the `process-tx` CLI). A crash between mark and settle
+  leaks one entry, pruned by the next re-delivery's settle (bot) or the next CLI
+  re-run's refuse-branch settle; the leak is harmless to correctness (it only
+  makes an already-accounted fill un-re-appliable) and self-heals.
+- `SettleOnChainFill` propagates infrastructure errors so the apalis retry
+  re-drives the settle until the entry self-heals. Under sustained infra failure
+  the job dead-letters (operator-visible) with one entry still in the set --
+  loud and bounded, consistent with the rest of the pipeline's at-least-once
+  contract, never a silent double-count.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -264,7 +264,15 @@ pub enum Commands {
         #[arg(long = "extended-hours", requires = "limit_price")]
         extended_hours: bool,
     },
-    /// Process a transaction hash to execute opposite-side trade
+    /// Account a missed onchain fill by its transaction hash, then place the
+    /// opposite-side hedge.
+    ///
+    /// Recovery tool for fills the bot never recorded: it refuses a fill the bot
+    /// has already witnessed in the OnChainTrade log (re-applying would
+    /// double-count the position). Run it only when the bot is NOT concurrently
+    /// processing the same symbol -- the CLI and the bot run in separate
+    /// processes and cannot be serialized by a lock, so a concurrent bot could
+    /// still double-account the fill.
     ProcessTx {
         /// Transaction hash (0x prefixed, 64 hex characters)
         #[arg(long = "tx-hash")]

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -2,9 +2,8 @@
 
 use alloy::primitives::TxHash;
 use alloy::providers::Provider;
+use anyhow::Context;
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
-use rain_math_float::Float;
 use sqlx::SqlitePool;
 use std::io::Write;
 use std::sync::Arc;
@@ -20,6 +19,10 @@ use st0x_execution::{
     TryIntoExecutor,
 };
 
+use crate::conductor::{
+    execute_acknowledge_fill, execute_enrich_trade, execute_mark_acknowledged, execute_settle_fill,
+    execute_witness_trade,
+};
 use crate::offchain::order::{
     OffchainOrderCommand, OffchainOrderId, OrderPlacementResult, OrderPlacer,
     build_offchain_order_cqrs,
@@ -27,7 +30,8 @@ use crate::offchain::order::{
 use crate::onchain::accumulator::check_execution_readiness;
 use crate::onchain::pyth::PythFeedIds;
 use crate::onchain::{OnChainError, OnchainTrade, TradeValidationError};
-use crate::position::{Position, PositionCommand, TradeId};
+use crate::onchain_trade::{OnChainTrade, OnChainTradeId};
+use crate::position::{Position, PositionCommand};
 use crate::symbol::cache::SymbolCache;
 use st0x_config::ExecutionThreshold;
 use st0x_config::{BrokerCtx, Ctx};
@@ -530,8 +534,33 @@ pub(super) async fn process_found_trade<W: Write>(
         .build(())
         .await?;
     let (offchain_order_store, _) = build_offchain_order_cqrs(pool, order_placer).await?;
+    let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+        .build(())
+        .await?;
 
-    update_position_aggregate(&position_store, &onchain_trade, ctx.execution_threshold).await;
+    // Refuse a fill the bot has already recorded (witnessed or acknowledged),
+    // then account this unrecorded fill through the same exactly-once
+    // witness -> acknowledge -> mark -> settle sequence the automated pipeline
+    // uses, so it is recorded in the OnChainTrade log and a re-run is refused
+    // rather than double-counted. process-tx runs in a separate process from the
+    // bot, so an in-process lock cannot serialize them; the persisted
+    // pending-acknowledgement set (ADR 0010) makes the position itself reject an
+    // out-of-order cross-process re-drive, and the recovery-CLI no-concurrent-bot
+    // contract remains the operational backstop.
+    refuse_if_fill_already_recorded(
+        &onchain_trade_store,
+        &position_store,
+        &onchain_trade,
+        stdout,
+    )
+    .await?;
+    account_fill_exactly_once(
+        &onchain_trade_store,
+        &position_store,
+        &onchain_trade,
+        ctx.execution_threshold,
+    )
+    .await?;
 
     let executor_type = ctx.broker.to_supported_executor();
     let base_symbol = onchain_trade.symbol.base();
@@ -626,80 +655,131 @@ pub(super) async fn process_found_trade<W: Write>(
     Ok(())
 }
 
-async fn update_position_aggregate(
+/// Fails closed when the fill at `(tx_hash, log_index)` is already recorded in
+/// the `OnChainTrade` log -- in ANY state. A recorded fill has already been
+/// accounted (acknowledged), or is mid-accounting (witnessed but not yet
+/// acknowledged) by whichever path recorded it -- the automated pipeline OR a
+/// prior `process-tx` run. The `Position` now rejects an out-of-order re-drive
+/// via its persisted pending-acknowledgement set (ADR 0010), but `process-tx`
+/// still refuses a recorded fill outright rather than racing the bot for it:
+/// it only accounts fills with no `OnChainTrade` record.
+async fn refuse_if_fill_already_recorded<W: Write>(
+    onchain_trade_store: &Store<OnChainTrade>,
     position_store: &Store<Position>,
     onchain_trade: &OnchainTrade,
-    execution_threshold: ExecutionThreshold,
-) {
-    let base_symbol = onchain_trade.symbol.base();
-
-    acknowledge_fill(
-        position_store,
-        base_symbol,
-        onchain_trade,
-        execution_threshold,
-    )
-    .await;
-}
-
-fn extract_fill_params(
-    onchain_trade: &OnchainTrade,
-) -> Option<(FractionalShares, Float, DateTime<Utc>)> {
-    let Some(block_timestamp) = onchain_trade.block_timestamp else {
-        error!(
-            tx_hash = %onchain_trade.tx_hash,
-            log_index = onchain_trade.log_index,
-            "Missing block timestamp, cannot acknowledge onchain fill"
-        );
-        return None;
+    stdout: &mut W,
+) -> anyhow::Result<()> {
+    let trade_id = OnChainTradeId {
+        tx_hash: onchain_trade.tx_hash,
+        log_index: onchain_trade.log_index,
     };
 
-    let amount = onchain_trade.amount;
-    let price_usdc = onchain_trade.price.value();
-
-    Some((amount, price_usdc, block_timestamp))
-}
-
-async fn acknowledge_fill(
-    position_store: &Store<Position>,
-    symbol: &Symbol,
-    onchain_trade: &OnchainTrade,
-    execution_threshold: ExecutionThreshold,
-) {
-    let base_symbol = onchain_trade.symbol.base();
-
-    let Some((amount, price_usdc, block_timestamp)) = extract_fill_params(onchain_trade) else {
-        return;
+    let Some(recorded) = onchain_trade_store.load(&trade_id).await? else {
+        return Ok(());
     };
 
-    if let Err(error) = position_store
-        .send(
-            symbol,
-            PositionCommand::AcknowledgeOnChainFill {
-                symbol: base_symbol.clone(),
-                threshold: execution_threshold,
-                trade_id: TradeId {
-                    tx_hash: onchain_trade.tx_hash,
-                    log_index: onchain_trade.log_index,
-                },
-                amount,
-                direction: onchain_trade.direction,
-                price_usdc,
-                block_timestamp,
-            },
-        )
-        .await
-    {
-        error!(
-            symbol = %base_symbol,
-            execution_threshold = ?execution_threshold,
-            tx_hash = %onchain_trade.tx_hash,
-            log_index = onchain_trade.log_index,
-            block_timestamp = ?onchain_trade.block_timestamp,
-            %error,
-            "Failed to acknowledge onchain fill in position aggregate"
+    if recorded.is_acknowledged() {
+        // Self-heal a marker-without-settle leak (ADR 0010): if a prior run
+        // marked this fill but crashed before pruning it from the pending set,
+        // the entry lingers. The fill is fully accounted, so prune before
+        // refusing. A no-op when already pruned.
+        execute_settle_fill(position_store, onchain_trade)
+            .await
+            .context("failed to prune the acknowledged fill from the pending set")?;
+        writeln!(
+            stdout,
+            "❌ Fill {trade_id} is already accounted; refusing to re-apply it"
+        )?;
+        anyhow::bail!(
+            "fill {trade_id} is already recorded and acknowledged in the onchain trade log; \
+             re-applying it would double-count the position. The bot already accounted this \
+             fill -- no manual processing is needed."
         );
     }
+
+    writeln!(
+        stdout,
+        "❌ Fill {trade_id} is already witnessed but not acknowledged; refusing to re-apply it"
+    )?;
+    anyhow::bail!(
+        "fill {trade_id} is recorded in the onchain trade log but not yet acknowledged: a prior \
+         process-tx run or an in-flight automated job witnessed it. Re-applying it here could \
+         double-count the position. Verify whether the bot is currently accounting this symbol \
+         (if so, it will finish); otherwise reconcile the position manually -- the record cannot \
+         tell which process wrote it. process-tx only accounts fills with no onchain trade record."
+    );
+}
+
+/// Accounts an unrecorded fill through the automated pipeline's exactly-once
+/// sequence (ADR 0005 + ADR 0010): witness the fill into the `OnChainTrade`
+/// log, enrich it, drive `Position::AcknowledgeOnChainFill` (which records the
+/// fill in the position's pending-acknowledgement set in the same atomic
+/// batch), mark the trade acknowledged, then settle -- pruning the pending
+/// entry now that the marker is durable. The witness comes FIRST so a crash in
+/// the witness->acknowledge window leaves a recorded-but-unacknowledged fill
+/// that `refuse_if_fill_already_recorded` blocks on a CLI re-run. A fill that
+/// cannot be anchored to a block cannot be witnessed, so this fails closed
+/// rather than accounting it unrecorded.
+///
+/// A crash between the acknowledge and the mark leaves the fill durably in the
+/// position's pending-acknowledgement set, so a later re-drive -- even by the
+/// bot, even after a newer fill, even cross-process -- is rejected as a
+/// duplicate rather than double-counted (ADR 0010). A crash between the mark
+/// and the settle leaks one pending entry, pruned by the next re-delivery (the
+/// bot's resume skip branch) or the next CLI re-run (the refuse branch); the
+/// leak is harmless to correctness and self-heals.
+async fn account_fill_exactly_once(
+    onchain_trade_store: &Store<OnChainTrade>,
+    position_store: &Store<Position>,
+    onchain_trade: &OnchainTrade,
+    execution_threshold: ExecutionThreshold,
+) -> anyhow::Result<()> {
+    let trade_id = OnChainTradeId {
+        tx_hash: onchain_trade.tx_hash,
+        log_index: onchain_trade.log_index,
+    };
+
+    let Some(block_number) = onchain_trade.block_number else {
+        anyhow::bail!(
+            "cannot account fill {trade_id}: the transaction carries no block number, so the \
+             fill cannot be witnessed into the onchain trade log"
+        );
+    };
+    let Some(block_timestamp) = onchain_trade.block_timestamp else {
+        anyhow::bail!(
+            "cannot account fill {trade_id}: the transaction carries no block timestamp, so the \
+             fill cannot be witnessed into the onchain trade log"
+        );
+    };
+
+    execute_witness_trade(
+        onchain_trade_store,
+        onchain_trade,
+        block_number,
+        block_timestamp,
+    )
+    .await
+    .context("failed to witness the fill in the onchain trade log")?;
+    // Enrich best-effort with the gas/Pyth data already on the trade, matching
+    // the automated path: the fill is marked acknowledged below so the bot never
+    // re-processes it, making this the only chance to record its enrichment.
+    execute_enrich_trade(onchain_trade_store, onchain_trade).await;
+    execute_acknowledge_fill(
+        position_store,
+        onchain_trade,
+        execution_threshold,
+        block_timestamp,
+    )
+    .await
+    .context("failed to acknowledge the fill in the position aggregate")?;
+    execute_mark_acknowledged(onchain_trade_store, &trade_id)
+        .await
+        .context("failed to mark the fill acknowledged in the onchain trade log")?;
+    execute_settle_fill(position_store, onchain_trade)
+        .await
+        .context("failed to settle the fill acknowledgement in the position aggregate")?;
+
+    Ok(())
 }
 
 fn display_trade_details<W: Write>(
@@ -725,7 +805,9 @@ fn display_trade_details<W: Write>(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, address};
+    use chrono::Utc;
     use httpmock::MockServer;
+    use rain_math_float::Float;
     use regex::Regex;
     use serde_json::json;
     use url::Url;
@@ -739,7 +821,9 @@ mod tests {
     use st0x_execution::{AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode};
 
     use super::*;
-    use crate::test_utils::{positive_shares, setup_test_db};
+    use crate::onchain_trade::OnChainTradeCommand;
+    use crate::position::TradeId;
+    use crate::test_utils::{OnchainTradeBuilder, positive_shares, setup_test_db};
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
         AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
@@ -1280,6 +1364,605 @@ mod tests {
         assert!(
             error.to_string().contains("buy order failed"),
             "a rejected order must fail the buy-fill wait, got: {error}"
+        );
+    }
+
+    /// A fill the bot already accounted (witnessed + acknowledged on the
+    /// `OnChainTrade` log) must be refused by `process-tx`: re-applying it
+    /// would double-count the position past the single-slot
+    /// `last_acknowledged_trade_id` guard.
+    #[tokio::test]
+    async fn process_found_trade_refuses_an_already_acknowledged_fill() {
+        let ctx = create_base_test_ctx();
+        let pool = setup_test_db().await;
+        let onchain_trade = OnchainTradeBuilder::default().build();
+
+        let base_symbol = onchain_trade.symbol.base().clone();
+        let trade_id = OnChainTradeId {
+            tx_hash: onchain_trade.tx_hash,
+            log_index: onchain_trade.log_index,
+        };
+        let amount = onchain_trade.amount.inner();
+        let price_usdc = onchain_trade.price.value();
+        let direction = onchain_trade.direction;
+        let block_timestamp = onchain_trade.block_timestamp.unwrap();
+
+        // Simulate the automated path having already accounted this fill.
+        let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        onchain_trade_store
+            .send(
+                &trade_id,
+                OnChainTradeCommand::Witness {
+                    symbol: base_symbol.clone(),
+                    amount,
+                    direction,
+                    price_usdc,
+                    block_number: 1,
+                    block_timestamp,
+                },
+            )
+            .await
+            .unwrap();
+        onchain_trade_store
+            .send(&trade_id, OnChainTradeCommand::Acknowledge)
+            .await
+            .unwrap();
+
+        let order_placer = create_order_placer(&ctx, &pool);
+        let mut stdout = Vec::new();
+        let error = process_found_trade(onchain_trade, &ctx, &pool, &mut stdout, order_placer)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "fill {trade_id} is already recorded and acknowledged in the onchain trade log; \
+                 re-applying it would double-count the position. The bot already accounted this \
+                 fill -- no manual processing is needed."
+            ),
+        );
+
+        // The position must never have been touched -- the fill is not
+        // re-counted.
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        assert!(
+            projection.load(&base_symbol).await.unwrap().is_none(),
+            "an already-accounted fill must not create or mutate the position",
+        );
+    }
+
+    /// A fill the bot witnessed but has not yet acknowledged (the ADR-0005 crash
+    /// window between the position write and its acknowledgement marker) is owned
+    /// by the automated pipeline. process-tx must refuse it -- the single-slot
+    /// position guard cannot dedupe an out-of-order re-application once a newer
+    /// fill advanced the slot, so re-applying would double-count.
+    #[tokio::test]
+    async fn process_found_trade_refuses_a_witnessed_but_unacknowledged_fill() {
+        let ctx = create_base_test_ctx();
+        let pool = setup_test_db().await;
+        let onchain_trade = OnchainTradeBuilder::default().build();
+
+        let base_symbol = onchain_trade.symbol.base().clone();
+        let trade_id = OnChainTradeId {
+            tx_hash: onchain_trade.tx_hash,
+            log_index: onchain_trade.log_index,
+        };
+        let amount = onchain_trade.amount.inner();
+        let price_usdc = onchain_trade.price.value();
+        let direction = onchain_trade.direction;
+        let block_timestamp = onchain_trade.block_timestamp.unwrap();
+
+        // Witness only -- no Acknowledge: the crash-window state.
+        let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        onchain_trade_store
+            .send(
+                &trade_id,
+                OnChainTradeCommand::Witness {
+                    symbol: base_symbol.clone(),
+                    amount,
+                    direction,
+                    price_usdc,
+                    block_number: 1,
+                    block_timestamp,
+                },
+            )
+            .await
+            .unwrap();
+
+        let order_placer = create_order_placer(&ctx, &pool);
+        let mut stdout = Vec::new();
+        let error = process_found_trade(onchain_trade, &ctx, &pool, &mut stdout, order_placer)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "fill {trade_id} is recorded in the onchain trade log but not yet acknowledged: \
+                 a prior process-tx run or an in-flight automated job witnessed it. Re-applying \
+                 it here could double-count the position. Verify whether the bot is currently \
+                 accounting this symbol (if so, it will finish); otherwise reconcile the position \
+                 manually -- the record cannot tell which process wrote it. process-tx only \
+                 accounts fills with no onchain trade record."
+            ),
+        );
+
+        // The position must never have been touched.
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        assert!(
+            projection.load(&base_symbol).await.unwrap().is_none(),
+            "a witnessed-but-unacknowledged fill must not create or mutate the position",
+        );
+    }
+
+    /// A fill with no prior `OnChainTrade` record is the normal `process-tx`
+    /// recovery case and must still be accounted into the position.
+    #[tokio::test]
+    async fn process_found_trade_accounts_a_fill_not_yet_recorded() {
+        let ctx = create_base_test_ctx();
+        let pool = setup_test_db().await;
+        let onchain_trade = OnchainTradeBuilder::default().build();
+
+        let base_symbol = onchain_trade.symbol.base().clone();
+        let expected_net = onchain_trade.amount;
+        let trade_id = OnChainTradeId {
+            tx_hash: onchain_trade.tx_hash,
+            log_index: onchain_trade.log_index,
+        };
+
+        let order_placer = create_order_placer(&ctx, &pool);
+        let mut stdout = Vec::new();
+        process_found_trade(onchain_trade, &ctx, &pool, &mut stdout, order_placer)
+            .await
+            .unwrap();
+
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let view = projection.load(&base_symbol).await.unwrap().unwrap();
+        assert_eq!(
+            view.net, expected_net,
+            "an unrecorded fill must still be accounted into the position",
+        );
+
+        // process-tx records the fill in the OnChainTrade log via the exactly-once
+        // witness -> acknowledge -> mark pair, so a re-run is refused instead of
+        // double-counted (and the bot's later pickup of the same fill skips it as
+        // already acknowledged).
+        let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let recorded = onchain_trade_store
+            .load(&trade_id)
+            .await
+            .unwrap()
+            .expect("process-tx must witness the fill into the OnChainTrade log");
+        assert!(
+            recorded.is_acknowledged(),
+            "the witnessed fill must be marked acknowledged",
+        );
+    }
+
+    /// The exactly-once sequence prunes its own pending-acknowledgement entry:
+    /// after a successful `process-tx` run the set is empty (SETTLE ran),
+    /// keeping the set bounded (ADR 0010).
+    #[tokio::test]
+    async fn account_fill_exactly_once_leaves_pending_set_empty() {
+        let ctx = create_base_test_ctx();
+        let pool = setup_test_db().await;
+        let onchain_trade = OnchainTradeBuilder::default().build();
+        let base_symbol = onchain_trade.symbol.base().clone();
+
+        let mut stdout = Vec::new();
+        process_found_trade(
+            onchain_trade,
+            &ctx,
+            &pool,
+            &mut stdout,
+            create_order_placer(&ctx, &pool),
+        )
+        .await
+        .unwrap();
+
+        let (position_store, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let position = position_store
+            .load(&base_symbol)
+            .await
+            .unwrap()
+            .expect("the position exists after accounting the fill");
+        assert!(
+            position.pending_acknowledged_trade_ids.is_empty(),
+            "SETTLE must prune the entry, leaving the pending set empty; got: {:?}",
+            position.pending_acknowledged_trade_ids,
+        );
+    }
+
+    /// A CLI crash between MARK and SETTLE leaks one pending-acknowledgement
+    /// entry. The next `process-tx` re-run on that fill refuses it (already
+    /// accounted) AND prunes the leak, so the set self-heals and stays bounded
+    /// (ADR 0010).
+    #[tokio::test]
+    async fn cli_rerun_on_acknowledged_fill_prunes_leak() {
+        let ctx = create_base_test_ctx();
+        let pool = setup_test_db().await;
+        let onchain_trade = OnchainTradeBuilder::default().build();
+        let base_symbol = onchain_trade.symbol.base().clone();
+        let block_number = onchain_trade
+            .block_number
+            .expect("builder default carries a block number");
+        let block_timestamp = onchain_trade
+            .block_timestamp
+            .expect("builder default carries a block timestamp");
+        let trade_id = OnChainTradeId {
+            tx_hash: onchain_trade.tx_hash,
+            log_index: onchain_trade.log_index,
+        };
+        let position_trade_id = TradeId {
+            tx_hash: onchain_trade.tx_hash,
+            log_index: onchain_trade.log_index,
+        };
+
+        let (position_store, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        // Simulate a crash between MARK and SETTLE: witness, acknowledge, and
+        // mark the fill, but never settle -- leaving its entry in the set.
+        execute_witness_trade(
+            &onchain_trade_store,
+            &onchain_trade,
+            block_number,
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+        execute_acknowledge_fill(
+            &position_store,
+            &onchain_trade,
+            ctx.execution_threshold,
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+        execute_mark_acknowledged(&onchain_trade_store, &trade_id)
+            .await
+            .unwrap();
+
+        let leaked = position_store
+            .load(&base_symbol)
+            .await
+            .unwrap()
+            .expect("the position exists");
+        assert!(
+            leaked
+                .pending_acknowledged_trade_ids
+                .contains(&position_trade_id),
+            "premise: the un-settled fill leaks into the pending set",
+        );
+
+        // Re-run process-tx on the now-acknowledged fill: it must refuse AND
+        // prune the leaked entry.
+        let mut stdout = Vec::new();
+        let error = process_found_trade(
+            onchain_trade,
+            &ctx,
+            &pool,
+            &mut stdout,
+            create_order_placer(&ctx, &pool),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "fill {trade_id} is already recorded and acknowledged in the onchain trade log; \
+                 re-applying it would double-count the position. The bot already accounted this \
+                 fill -- no manual processing is needed."
+            ),
+        );
+
+        let healed = position_store
+            .load(&base_symbol)
+            .await
+            .unwrap()
+            .expect("the position exists");
+        assert!(
+            healed.pending_acknowledged_trade_ids.is_empty(),
+            "the refuse path must prune the leaked entry; got: {:?}",
+            healed.pending_acknowledged_trade_ids,
+        );
+    }
+
+    /// process-tx is idempotent on a bot-missed fill: the first run witnesses,
+    /// acknowledges, and marks it; a second run on the same fill is refused (it is
+    /// now recorded + acknowledged) and the net is unchanged -- not double-counted.
+    #[tokio::test]
+    async fn process_found_trade_is_idempotent_on_a_bot_missed_fill() {
+        let ctx = create_base_test_ctx();
+        let pool = setup_test_db().await;
+        let onchain_trade = OnchainTradeBuilder::default().build();
+        let base_symbol = onchain_trade.symbol.base().clone();
+        let expected_net = onchain_trade.amount;
+        let trade_id = OnChainTradeId {
+            tx_hash: onchain_trade.tx_hash,
+            log_index: onchain_trade.log_index,
+        };
+
+        // First run accounts the previously-unrecorded fill.
+        let mut first = Vec::new();
+        process_found_trade(
+            onchain_trade.clone(),
+            &ctx,
+            &pool,
+            &mut first,
+            create_order_placer(&ctx, &pool),
+        )
+        .await
+        .unwrap();
+
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let net_after_first = projection.load(&base_symbol).await.unwrap().unwrap().net;
+        assert_eq!(net_after_first, expected_net);
+
+        // Second run on the same fill is refused -- now recorded + acknowledged.
+        let mut second = Vec::new();
+        let error = process_found_trade(
+            onchain_trade,
+            &ctx,
+            &pool,
+            &mut second,
+            create_order_placer(&ctx, &pool),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "fill {trade_id} is already recorded and acknowledged in the onchain trade log; \
+                 re-applying it would double-count the position. The bot already accounted this \
+                 fill -- no manual processing is needed."
+            ),
+        );
+
+        // The net is unchanged -- the fill was not counted a second time.
+        let net_after_second = projection.load(&base_symbol).await.unwrap().unwrap().net;
+        assert_eq!(
+            net_after_second, net_after_first,
+            "a re-run on an already-accounted fill must not double-count",
+        );
+    }
+
+    /// The motivating financial failure mode: fill A is fully accounted, then a
+    /// newer fill B advances the position's single-slot `last_acknowledged_trade_id`.
+    /// Re-running process-tx on A must still be refused -- the position guard alone
+    /// no longer recognizes A (its slot points at B), so without the OnChainTrade
+    /// witness check A would be counted a second time.
+    #[tokio::test]
+    async fn process_found_trade_refuses_acknowledged_fill_after_a_newer_fill() {
+        let ctx = create_base_test_ctx();
+        let pool = setup_test_db().await;
+        let fill_a = OnchainTradeBuilder::default().with_log_index(1).build();
+        let fill_b = OnchainTradeBuilder::default().with_log_index(2).build();
+
+        let base_symbol = fill_a.symbol.base().clone();
+        let trade_id_a = OnChainTradeId {
+            tx_hash: fill_a.tx_hash,
+            log_index: fill_a.log_index,
+        };
+
+        // Fully account A on the OnChainTrade log (witness + acknowledge).
+        let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        onchain_trade_store
+            .send(
+                &trade_id_a,
+                OnChainTradeCommand::Witness {
+                    symbol: base_symbol.clone(),
+                    amount: fill_a.amount.inner(),
+                    direction: fill_a.direction,
+                    price_usdc: fill_a.price.value(),
+                    block_number: 1,
+                    block_timestamp: fill_a.block_timestamp.unwrap(),
+                },
+            )
+            .await
+            .unwrap();
+        onchain_trade_store
+            .send(&trade_id_a, OnChainTradeCommand::Acknowledge)
+            .await
+            .unwrap();
+
+        // Apply A then the newer B to the position, so its single slot points at B.
+        let (position_store, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        for fill in [&fill_a, &fill_b] {
+            position_store
+                .send(
+                    &base_symbol,
+                    PositionCommand::AcknowledgeOnChainFill {
+                        symbol: base_symbol.clone(),
+                        threshold: ExecutionThreshold::whole_share(),
+                        trade_id: TradeId {
+                            tx_hash: fill.tx_hash,
+                            log_index: fill.log_index,
+                        },
+                        amount: fill.amount,
+                        direction: fill.direction,
+                        price_usdc: fill.price.value(),
+                        block_timestamp: fill.block_timestamp.unwrap(),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        let net_before = projection.load(&base_symbol).await.unwrap().unwrap().net;
+
+        // Re-run process-tx on the older fill A: the position slot points at B, but
+        // A is acknowledged on the OnChainTrade log, so it must be refused.
+        let order_placer = create_order_placer(&ctx, &pool);
+        let mut stdout = Vec::new();
+        let error = process_found_trade(fill_a, &ctx, &pool, &mut stdout, order_placer)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "fill {trade_id_a} is already recorded and acknowledged in the onchain trade log; \
+                 re-applying it would double-count the position. The bot already accounted this \
+                 fill -- no manual processing is needed."
+            ),
+        );
+
+        // The net must be unchanged -- A was not counted a second time.
+        let net_after = projection.load(&base_symbol).await.unwrap().unwrap().net;
+        assert_eq!(
+            net_after, net_before,
+            "re-running process-tx on an older acknowledged fill must not change the net",
+        );
+
+        // The refuse path self-heals a marker-without-settle leak: A is
+        // acknowledged on the OnChainTrade log, so refuse_if_fill_already_recorded
+        // prunes A from the position's pending-acknowledgement set before bailing,
+        // leaving the still-in-flight newer fill B untouched (ADR 0010).
+        let pending = position_store
+            .load(&base_symbol)
+            .await
+            .unwrap()
+            .expect("position exists after applying A and B")
+            .pending_acknowledged_trade_ids;
+        assert!(
+            !pending.contains(&TradeId {
+                tx_hash: trade_id_a.tx_hash,
+                log_index: trade_id_a.log_index,
+            }),
+            "refusing an acknowledged fill must prune it from the pending set (self-heal)",
+        );
+        assert!(
+            pending.contains(&TradeId {
+                tx_hash: fill_b.tx_hash,
+                log_index: fill_b.log_index,
+            }),
+            "the untouched newer fill B must remain in the pending set",
+        );
+    }
+
+    /// A fill that cannot be anchored to a block must not be silently accounted
+    /// unrecorded: account_fill_exactly_once fails closed on a missing block
+    /// number (the fill cannot be witnessed into the onchain trade log).
+    #[tokio::test]
+    async fn process_found_trade_fails_closed_when_block_number_absent() {
+        let ctx = create_base_test_ctx();
+        let pool = setup_test_db().await;
+        let onchain_trade = OnchainTradeBuilder::default()
+            .with_block_number(None)
+            .build();
+        let base_symbol = onchain_trade.symbol.base().clone();
+        let trade_id = OnChainTradeId {
+            tx_hash: onchain_trade.tx_hash,
+            log_index: onchain_trade.log_index,
+        };
+
+        let mut stdout = Vec::new();
+        let error = process_found_trade(
+            onchain_trade,
+            &ctx,
+            &pool,
+            &mut stdout,
+            create_order_placer(&ctx, &pool),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "cannot account fill {trade_id}: the transaction carries no block number, so the \
+                 fill cannot be witnessed into the onchain trade log"
+            ),
+        );
+
+        // Fail-closed before any write: no position, no witness.
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        assert!(
+            projection.load(&base_symbol).await.unwrap().is_none(),
+            "a fill that cannot be witnessed must not touch the position",
+        );
+    }
+
+    /// Symmetric fail-closed guard for a missing block timestamp.
+    #[tokio::test]
+    async fn process_found_trade_fails_closed_when_block_timestamp_absent() {
+        let ctx = create_base_test_ctx();
+        let pool = setup_test_db().await;
+        let onchain_trade = OnchainTradeBuilder::default()
+            .with_block_timestamp(None)
+            .build();
+        let base_symbol = onchain_trade.symbol.base().clone();
+        let trade_id = OnChainTradeId {
+            tx_hash: onchain_trade.tx_hash,
+            log_index: onchain_trade.log_index,
+        };
+
+        let mut stdout = Vec::new();
+        let error = process_found_trade(
+            onchain_trade,
+            &ctx,
+            &pool,
+            &mut stdout,
+            create_order_placer(&ctx, &pool),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "cannot account fill {trade_id}: the transaction carries no block timestamp, so \
+                 the fill cannot be witnessed into the onchain trade log"
+            ),
+        );
+
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        assert!(
+            projection.load(&base_symbol).await.unwrap().is_none(),
+            "a fill that cannot be witnessed must not touch the position",
         );
     }
 }

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -1886,7 +1886,7 @@ pub(crate) async fn discover_vaults_for_trade(
 /// Done: with the backfill checkpoint already advanced, a swallowed
 /// witness failure is a permanently lost fill and silent unhedged
 /// exposure.
-async fn execute_witness_trade(
+pub(crate) async fn execute_witness_trade(
     onchain_trade: &Store<OnChainTrade>,
     trade: &OnchainTrade,
     block_number: u64,
@@ -1935,7 +1935,10 @@ async fn execute_witness_trade(
     }
 }
 
-async fn execute_enrich_trade(onchain_trade: &Store<OnChainTrade>, trade: &OnchainTrade) {
+pub(crate) async fn execute_enrich_trade(
+    onchain_trade: &Store<OnChainTrade>,
+    trade: &OnchainTrade,
+) {
     let (Some(gas_used), Some(effective_gas_price), Some(pyth_price)) = (
         trade.gas_used,
         trade.effective_gas_price,
@@ -1988,7 +1991,7 @@ async fn execute_enrich_trade(onchain_trade: &Store<OnChainTrade>, trade: &Oncha
 /// resume path's crash window between the position write and the
 /// acknowledgement marker). Every other error propagates so the apalis job
 /// retries instead of silently dropping the fill.
-async fn execute_acknowledge_fill(
+pub(crate) async fn execute_acknowledge_fill(
     position: &Store<Position>,
     trade: &OnchainTrade,
     threshold: ExecutionThreshold,
@@ -2043,7 +2046,7 @@ async fn execute_acknowledge_fill(
 /// A re-driven marker (`AlreadyAcknowledged`) is idempotent;
 /// infrastructure errors propagate so the apalis retry re-drives the
 /// idempotent acknowledge pair.
-async fn execute_mark_acknowledged(
+pub(crate) async fn execute_mark_acknowledged(
     onchain_trade: &Store<OnChainTrade>,
     trade_id: &OnChainTradeId,
 ) -> Result<(), SendError<OnChainTrade>> {
@@ -2057,6 +2060,27 @@ async fn execute_mark_acknowledged(
         ))) => Ok(()),
         Err(error) => Err(error),
     }
+}
+
+/// Prunes the fill from the position's pending-acknowledgement set once its
+/// `OnChainTrade` marker is durable, completing the exactly-once sequence
+/// (ADR 0010). Pruning a trade not in the set emits no events (a no-op), so a
+/// re-driven settle is idempotent; infrastructure errors propagate so the
+/// apalis retry re-drives the settle until the entry self-heals.
+pub(crate) async fn execute_settle_fill(
+    position: &Store<Position>,
+    trade: &OnchainTrade,
+) -> Result<(), SendError<Position>> {
+    let base_symbol = trade.symbol.base();
+
+    let command = PositionCommand::SettleOnChainFill {
+        trade_id: TradeId {
+            tx_hash: trade.tx_hash,
+            log_index: trade.log_index,
+        },
+    };
+
+    position.send(base_symbol, command).await
 }
 
 #[tracing::instrument(skip_all, level = tracing::Level::DEBUG)]
@@ -2104,6 +2128,11 @@ where
                 symbol = %trade.symbol,
                 "Trade already processed (duplicate event), skipping"
             );
+            // Self-heal a marker-without-settle leak (ADR 0010): a crash
+            // between MARK and SETTLE leaves the trade marked but still in
+            // the pending set. The marker is durable, so prune it now. A
+            // no-op when already pruned.
+            execute_settle_fill(&cqrs.position, &trade).await?;
             return Ok(None);
         }
         Ok(Some(state)) => {
@@ -2151,6 +2180,10 @@ where
     )
     .await?;
     execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id).await?;
+    // Prune the pending-acknowledgement entry now that the marker is durable
+    // (ADR 0010), before any early return below, so the threshold-not-met and
+    // placement-skip paths still settle.
+    execute_settle_fill(&cqrs.position, &trade).await?;
 
     let base_symbol = trade.symbol.base();
 
@@ -4950,6 +4983,97 @@ mod tests {
         assert_eq!(
             fills_after, 2,
             "re-delivering the marked fill must not re-apply it (no double-count)"
+        );
+    }
+
+    /// Exactly-once across a CRASH + later fill -- the scenario the single
+    /// slot cannot handle (ADR 0010). Fill A is witnessed and applied to the
+    /// position but its marker never lands (crash before MARK). A later fill B
+    /// advances the single-slot guard to B, so the slot no longer holds A.
+    /// Re-delivering A through the real pipeline must be rejected by the
+    /// position's pending-acknowledgement set -- not double-counted. This is the
+    /// cross-process / process-tx-CLI double-count the slot alone misses; with
+    /// only the single slot, re-delivering A would emit a third
+    /// `OnChainOrderFilled`.
+    #[tokio::test]
+    async fn redelivery_of_unmarked_fill_after_later_fill_is_rejected() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        // Fill A: witnessed and applied to the position, but crash before MARK
+        // (and SETTLE). A is durably in the pending-acknowledgement set.
+        let event_a = make_trade_event(60);
+        let trade_a = test_trade_with_amount(float!(1.0), 60);
+        let block_timestamp_a = trade_a
+            .block_timestamp
+            .expect("test trade carries a block timestamp");
+        execute_witness_trade(
+            &cqrs.onchain_trade,
+            &trade_a,
+            event_a.block_number,
+            block_timestamp_a,
+        )
+        .await
+        .unwrap();
+        execute_acknowledge_fill(
+            &cqrs.position,
+            &trade_a,
+            cqrs.execution_threshold,
+            block_timestamp_a,
+        )
+        .await
+        .expect("premise: A's position write must land before the crash");
+
+        // Fill B: processed end-to-end. Advances the single slot to B,
+        // displacing A; A remains in the pending set.
+        let event_b = make_trade_event(61);
+        process_queued_trade(
+            &MockExecutor::new(),
+            &event_b,
+            test_trade_with_amount(float!(2.0), 61),
+            &cqrs,
+            true,
+        )
+        .await
+        .unwrap();
+
+        let (fills_before,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(fills_before, 2, "premise: A and B each applied once");
+
+        // Re-deliver A (resume path) after B displaced the slot. The pending
+        // set still holds A, so the re-drive must be rejected -- not counted
+        // a second time.
+        process_queued_trade(
+            &MockExecutor::new(),
+            &event_a,
+            test_trade_with_amount(float!(1.0), 60),
+            &cqrs,
+            true,
+        )
+        .await
+        .unwrap();
+
+        let (fills_after,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            fills_after, 2,
+            "re-delivering the unmarked, slot-displaced fill must not re-apply \
+             it (no double-count)"
         );
     }
 

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -773,11 +773,13 @@ async fn onchain_trades_accumulate_and_trigger_offchain_fill()
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade1_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
     ];
     assert_events(&pool, &expected).await;
 
@@ -811,11 +813,13 @@ async fn onchain_trades_accumulate_and_trigger_offchain_fill()
     expected.extend([
         ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade2_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
         ExpectedEvent::new(
@@ -833,15 +837,15 @@ async fn onchain_trades_accumulate_and_trigger_offchain_fill()
     assert_eq!(trade1_filled["direction"].as_str().unwrap(), "sell");
     assert_eq!(trade1_filled["price_usdc"].as_str().unwrap(), "100");
 
-    assert_eq!(events[5].event_type, "PositionEvent::OnChainOrderFilled");
-    let trade2_filled = &events[5].payload["OnChainOrderFilled"];
+    assert_eq!(events[7].event_type, "PositionEvent::OnChainOrderFilled");
+    let trade2_filled = &events[7].payload["OnChainOrderFilled"];
     assert_eq!(trade2_filled["amount"].as_str().unwrap(), "0.7");
     assert_eq!(trade2_filled["direction"].as_str().unwrap(), "sell");
     assert_eq!(trade2_filled["price_usdc"].as_str().unwrap(), "100");
 
     // Payload spot-checks: OffChainOrderPlaced and Placed shares/direction
-    assert_eq!(events[7].event_type, "PositionEvent::OffChainOrderPlaced");
-    let placed_pos = &events[7].payload["OffChainOrderPlaced"];
+    assert_eq!(events[11].event_type, "PositionEvent::OffChainOrderPlaced");
+    let placed_pos = &events[11].payload["OffChainOrderPlaced"];
     assert_eq!(
         placed_pos["offchain_order_id"].as_str().unwrap(),
         order_id_str
@@ -849,8 +853,8 @@ async fn onchain_trades_accumulate_and_trigger_offchain_fill()
     assert_eq!(placed_pos["direction"].as_str().unwrap(), "buy");
     assert_eq!(placed_pos["shares"].as_str().unwrap(), "1.2");
 
-    assert_eq!(events[8].event_type, "OffchainOrderEvent::Placed");
-    let offchain_placed = &events[8].payload["Placed"];
+    assert_eq!(events[12].event_type, "OffchainOrderEvent::Placed");
+    let offchain_placed = &events[12].payload["Placed"];
     assert_eq!(offchain_placed["symbol"].as_str().unwrap(), TEST_AAPL);
     assert_eq!(offchain_placed["direction"].as_str().unwrap(), "buy");
     assert_eq!(offchain_placed["shares"].as_str().unwrap(), "1.2");
@@ -880,9 +884,9 @@ async fn onchain_trades_accumulate_and_trigger_offchain_fill()
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderFilled"),
     ]);
     let events = assert_events(&pool, &expected).await;
-    assert_eq!(events[11].event_type, "PositionEvent::OffChainOrderFilled");
+    assert_eq!(events[15].event_type, "PositionEvent::OffChainOrderFilled");
     assert_eq!(
-        events[11].payload["OffChainOrderFilled"]["offchain_order_id"]
+        events[15].payload["OffChainOrderFilled"]["offchain_order_id"]
             .as_str()
             .unwrap(),
         order_id_str,
@@ -954,18 +958,22 @@ async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std:
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade1_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade2_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
         ExpectedEvent::new(
@@ -977,8 +985,8 @@ async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std:
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderFailed"),
     ];
     let events = assert_events(&pool, &expected).await;
-    assert_eq!(events[8].event_type, "OffchainOrderEvent::Placed");
-    let placed = &events[8].payload["Placed"];
+    assert_eq!(events[12].event_type, "OffchainOrderEvent::Placed");
+    let placed = &events[12].payload["Placed"];
     assert_eq!(placed["symbol"].as_str().unwrap(), TEST_AAPL);
     assert_eq!(placed["direction"].as_str().unwrap(), "buy");
 
@@ -1022,8 +1030,8 @@ async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std:
 
     // Extract retry order ID from the new OffchainOrderEvent::Placed event
     let all_events = fetch_events(&pool).await;
-    assert_eq!(all_events[13].event_type, "OffchainOrderEvent::Placed");
-    let retry_id = all_events[13].aggregate_id.clone();
+    assert_eq!(all_events[17].event_type, "OffchainOrderEvent::Placed");
+    let retry_id = all_events[17].aggregate_id.clone();
     assert_ne!(
         retry_id, order_id_str,
         "Retry should create a new offchain order"
@@ -1118,9 +1126,9 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
 
     // Concurrent submissions produce non-deterministic global event ordering:
     // Position and OnChainTrade events for different symbols can fully interleave.
-    // Verify the first 8 events contain the expected set regardless of order.
+    // Verify the first 12 events contain the expected set regardless of order.
     let initial_events = fetch_events(&pool).await;
-    let actual_initial: Vec<ExpectedEvent> = initial_events[..8]
+    let actual_initial: Vec<ExpectedEvent> = initial_events[..12]
         .iter()
         .map(|event| {
             ExpectedEvent::new(
@@ -1135,19 +1143,23 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade1_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_MSFT, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_MSFT, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_MSFT, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade2_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_MSFT, "PositionEvent::OnChainFillSettled"),
     ];
     for expected_event in &concurrent_set {
         assert!(
@@ -1156,17 +1168,19 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    // Build the expected sequence using the actual ordering of the first 8 events
+    // Build the expected sequence using the actual ordering of the first 12 events
     let mut expected: Vec<ExpectedEvent> = actual_initial;
 
     expected.extend([
         ExpectedEvent::new("OnChainTrade", &trade3_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade3_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new(
             "OffchainOrder",
@@ -1181,8 +1195,8 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
     ]);
     let events = assert_events(&pool, &expected).await;
 
-    assert_eq!(events[12].event_type, "OffchainOrderEvent::Placed");
-    let aapl_placed = &events[12].payload["Placed"];
+    assert_eq!(events[18].event_type, "OffchainOrderEvent::Placed");
+    let aapl_placed = &events[18].payload["Placed"];
     assert_eq!(aapl_placed["symbol"].as_str().unwrap(), TEST_AAPL);
     assert_eq!(aapl_placed["direction"].as_str().unwrap(), "buy");
     assert_eq!(aapl_placed["shares"].as_str().unwrap(), "1.2");
@@ -1261,11 +1275,13 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
     expected.extend([
         ExpectedEvent::new("OnChainTrade", &trade4_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_MSFT, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_MSFT, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade4_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_MSFT, "PositionEvent::OnChainFillSettled"),
         ExpectedEvent::new("Position", TEST_MSFT, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new(
             "OffchainOrder",
@@ -1280,8 +1296,8 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
     ]);
     let events = assert_events(&pool, &expected).await;
 
-    assert_eq!(events[20].event_type, "OffchainOrderEvent::Placed");
-    let msft_placed = &events[20].payload["Placed"];
+    assert_eq!(events[28].event_type, "OffchainOrderEvent::Placed");
+    let msft_placed = &events[28].payload["Placed"];
     assert_eq!(msft_placed["symbol"].as_str().unwrap(), TEST_MSFT);
     assert_eq!(msft_placed["direction"].as_str().unwrap(), "buy");
     assert_eq!(msft_placed["shares"].as_str().unwrap(), "1");
@@ -1392,18 +1408,22 @@ async fn buy_direction_accumulates_long() -> Result<(), Box<dyn std::error::Erro
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade1_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade2_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
         ExpectedEvent::new(
@@ -1421,20 +1441,20 @@ async fn buy_direction_accumulates_long() -> Result<(), Box<dyn std::error::Erro
     assert_eq!(trade1_filled["direction"].as_str().unwrap(), "buy");
     assert_eq!(trade1_filled["price_usdc"].as_str().unwrap(), "100");
 
-    assert_eq!(events[5].event_type, "PositionEvent::OnChainOrderFilled");
-    let trade2_filled = &events[5].payload["OnChainOrderFilled"];
+    assert_eq!(events[7].event_type, "PositionEvent::OnChainOrderFilled");
+    let trade2_filled = &events[7].payload["OnChainOrderFilled"];
     assert_eq!(trade2_filled["amount"].as_str().unwrap(), "0.7");
     assert_eq!(trade2_filled["direction"].as_str().unwrap(), "buy");
     assert_eq!(trade2_filled["price_usdc"].as_str().unwrap(), "100");
 
     // Hedge direction should be Sell (opposite of onchain Buy), shares = abs(net)
-    assert_eq!(events[8].event_type, "OffchainOrderEvent::Placed");
+    assert_eq!(events[12].event_type, "OffchainOrderEvent::Placed");
     assert_eq!(
-        events[8].payload["Placed"]["direction"].as_str().unwrap(),
+        events[12].payload["Placed"]["direction"].as_str().unwrap(),
         "sell"
     );
     assert_eq!(
-        events[8].payload["Placed"]["shares"].as_str().unwrap(),
+        events[12].payload["Placed"]["shares"].as_str().unwrap(),
         "1.2"
     );
 
@@ -1506,11 +1526,13 @@ async fn exact_threshold_triggers_execution() -> Result<(), Box<dyn std::error::
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade1_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
         ExpectedEvent::new(
@@ -1528,13 +1550,13 @@ async fn exact_threshold_triggers_execution() -> Result<(), Box<dyn std::error::
     assert_eq!(filled["direction"].as_str().unwrap(), "sell");
     assert_eq!(filled["price_usdc"].as_str().unwrap(), "100");
 
-    assert_eq!(events[4].event_type, "PositionEvent::OffChainOrderPlaced");
-    let placed_pos = &events[4].payload["OffChainOrderPlaced"];
+    assert_eq!(events[6].event_type, "PositionEvent::OffChainOrderPlaced");
+    let placed_pos = &events[6].payload["OffChainOrderPlaced"];
     assert_eq!(placed_pos["direction"].as_str().unwrap(), "buy");
     assert_eq!(placed_pos["shares"].as_str().unwrap(), "1");
 
-    assert_eq!(events[5].event_type, "OffchainOrderEvent::Placed");
-    let placed = &events[5].payload["Placed"];
+    assert_eq!(events[7].event_type, "OffchainOrderEvent::Placed");
+    let placed = &events[7].payload["Placed"];
     assert_eq!(placed["symbol"].as_str().unwrap(), TEST_AAPL);
     assert_eq!(placed["direction"].as_str().unwrap(), "buy");
     assert_eq!(placed["shares"].as_str().unwrap(), "1");
@@ -1695,11 +1717,13 @@ async fn second_hedge_after_full_lifecycle() -> Result<(), Box<dyn std::error::E
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade1_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new("OffchainOrder", &order1_str, "OffchainOrderEvent::Placed"),
         ExpectedEvent::new(
@@ -1712,11 +1736,13 @@ async fn second_hedge_after_full_lifecycle() -> Result<(), Box<dyn std::error::E
         // Second cycle
         ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
         ExpectedEvent::new(
             "OnChainTrade",
             &trade2_agg,
             "OnChainTradeEvent::Acknowledged",
         ),
+        ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new("OffchainOrder", &order2_str, "OffchainOrderEvent::Placed"),
         ExpectedEvent::new(
@@ -1859,11 +1885,13 @@ async fn tiny_fractional_trade_tracks_precisely() -> Result<(), Box<dyn std::err
             ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
             ExpectedEvent::new(
                 "OnChainTrade",
                 &trade1_agg,
                 "OnChainTradeEvent::Acknowledged",
             ),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ],
     )
     .await;
@@ -1913,11 +1941,13 @@ async fn large_trade_triggers_immediate_execution() -> Result<(), Box<dyn std::e
             ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
             ExpectedEvent::new(
                 "OnChainTrade",
                 &trade1_agg,
                 "OnChainTradeEvent::Acknowledged",
             ),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
             ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
             ExpectedEvent::new(
@@ -2046,32 +2076,40 @@ async fn mixed_direction_trades_partially_cancel() -> Result<(), Box<dyn std::er
             ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
             ExpectedEvent::new(
                 "OnChainTrade",
                 &trade1_agg,
                 "OnChainTradeEvent::Acknowledged",
             ),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
             ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
             ExpectedEvent::new(
                 "OnChainTrade",
                 &trade2_agg,
                 "OnChainTradeEvent::Acknowledged",
             ),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
             ExpectedEvent::new("OnChainTrade", &trade3_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
             ExpectedEvent::new(
                 "OnChainTrade",
                 &trade3_agg,
                 "OnChainTradeEvent::Acknowledged",
             ),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
             ExpectedEvent::new("OnChainTrade", &trade4_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
             ExpectedEvent::new(
                 "OnChainTrade",
                 &trade4_agg,
                 "OnChainTradeEvent::Acknowledged",
             ),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
             ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
             ExpectedEvent::new(
@@ -2083,8 +2121,8 @@ async fn mixed_direction_trades_partially_cancel() -> Result<(), Box<dyn std::er
     )
     .await;
 
-    assert_eq!(events[14].event_type, "OffchainOrderEvent::Placed");
-    let placed = &events[14].payload["Placed"];
+    assert_eq!(events[22].event_type, "OffchainOrderEvent::Placed");
+    let placed = &events[22].payload["Placed"];
     assert_eq!(placed["direction"].as_str().unwrap(), "buy");
     assert_eq!(placed["shares"].as_str().unwrap(), "1.1");
 
@@ -2183,11 +2221,13 @@ async fn pending_order_blocks_new_execution() -> Result<(), Box<dyn std::error::
             ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
             ExpectedEvent::new(
                 "OnChainTrade",
                 &trade1_agg,
                 "OnChainTradeEvent::Acknowledged",
             ),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
             ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
             ExpectedEvent::new(
@@ -2198,11 +2238,13 @@ async fn pending_order_blocks_new_execution() -> Result<(), Box<dyn std::error::
             // Trade 2 events: only onchain fill, no offchain order
             ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
             ExpectedEvent::new(
                 "OnChainTrade",
                 &trade2_agg,
                 "OnChainTradeEvent::Acknowledged",
             ),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ],
     )
     .await;
@@ -2254,11 +2296,13 @@ async fn duplicate_onchain_event_is_idempotent() -> Result<(), Box<dyn std::erro
             ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillApplied"),
             ExpectedEvent::new(
                 "OnChainTrade",
                 &trade1_agg,
                 "OnChainTradeEvent::Acknowledged",
             ),
+            ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainFillSettled"),
         ],
     )
     .await;

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -795,6 +795,11 @@ async fn equity_offchain_imbalance_triggers_mint() {
             ExpectedEvent::new(
                 "Position",
                 &aggregate_id,
+                "PositionEvent::OnChainFillApplied",
+            ),
+            ExpectedEvent::new(
+                "Position",
+                &aggregate_id,
                 "PositionEvent::OffChainOrderPlaced",
             ),
             ExpectedEvent::new(
@@ -811,6 +816,11 @@ async fn equity_offchain_imbalance_triggers_mint() {
                 "Position",
                 &aggregate_id,
                 "PositionEvent::OnChainOrderFilled",
+            ),
+            ExpectedEvent::new(
+                "Position",
+                &aggregate_id,
+                "PositionEvent::OnChainFillApplied",
             ),
             ExpectedEvent::new(
                 "TokenizedEquityMint",
@@ -851,14 +861,14 @@ async fn equity_offchain_imbalance_triggers_mint() {
     )
     .await;
 
-    let mint_requested = &events[6].payload["MintRequested"];
+    let mint_requested = &events[8].payload["MintRequested"];
     assert_eq!(
         mint_requested["symbol"].as_str().unwrap(),
         "AAPL",
         "MintRequested should target the correct symbol"
     );
 
-    let mint_accepted = &events[7].payload["MintAccepted"];
+    let mint_accepted = &events[9].payload["MintAccepted"];
     assert_eq!(
         mint_accepted["tokenization_request_id"].as_str().unwrap(),
         "mint_int_test",
@@ -1026,6 +1036,11 @@ async fn equity_onchain_imbalance_triggers_redemption() {
             ExpectedEvent::new(
                 "Position",
                 &aggregate_id,
+                "PositionEvent::OnChainFillApplied",
+            ),
+            ExpectedEvent::new(
+                "Position",
+                &aggregate_id,
                 "PositionEvent::OffChainOrderPlaced",
             ),
             ExpectedEvent::new(
@@ -1042,6 +1057,11 @@ async fn equity_onchain_imbalance_triggers_redemption() {
                 "Position",
                 &aggregate_id,
                 "PositionEvent::OnChainOrderFilled",
+            ),
+            ExpectedEvent::new(
+                "Position",
+                &aggregate_id,
+                "PositionEvent::OnChainFillApplied",
             ),
             ExpectedEvent::new(
                 "EquityRedemption",
@@ -1098,21 +1118,21 @@ async fn equity_onchain_imbalance_triggers_redemption() {
     .await;
 
     assert_eq!(
-        events[6].payload["VaultWithdrawPending"]["symbol"]
+        events[8].payload["VaultWithdrawPending"]["symbol"]
             .as_str()
             .unwrap(),
         "AAPL",
         "VaultWithdrawPending should target the correct symbol"
     );
     assert_eq!(
-        events[13].payload["TokensSent"]["redemption_tx"]
+        events[15].payload["TokensSent"]["redemption_tx"]
             .as_str()
             .unwrap(),
         format!("{expected_tx_hash:#x}"),
         "TokensSent redemption_tx should match the deterministic Anvil hash"
     );
     assert_eq!(
-        events[14].payload["Detected"]["tokenization_request_id"]
+        events[16].payload["Detected"]["tokenization_request_id"]
             .as_str()
             .unwrap(),
         "redeem_int_test",
@@ -1719,6 +1739,11 @@ async fn mint_api_failure_produces_rejected_event() {
             ExpectedEvent::new(
                 "Position",
                 &aggregate_id,
+                "PositionEvent::OnChainFillApplied",
+            ),
+            ExpectedEvent::new(
+                "Position",
+                &aggregate_id,
                 "PositionEvent::OffChainOrderPlaced",
             ),
             ExpectedEvent::new(
@@ -1735,6 +1760,11 @@ async fn mint_api_failure_produces_rejected_event() {
                 "Position",
                 &aggregate_id,
                 "PositionEvent::OnChainOrderFilled",
+            ),
+            ExpectedEvent::new(
+                "Position",
+                &aggregate_id,
+                "PositionEvent::OnChainFillApplied",
             ),
         ],
     )

--- a/src/onchain/trade.rs
+++ b/src/onchain/trade.rs
@@ -157,6 +157,10 @@ pub struct OnchainTrade {
     pub(crate) amount: FractionalShares,
     pub(crate) direction: Direction,
     pub(crate) price: Usdc,
+    /// Block the fill was confirmed in. Needed to witness the fill into the
+    /// `OnChainTrade` log (the `Witness` command requires it). Absent only when
+    /// neither the log nor the receipt carried a block number.
+    pub(crate) block_number: Option<u64>,
     pub(crate) block_timestamp: Option<DateTime<Utc>>,
     pub(crate) gas_used: Option<u64>,
     pub(crate) effective_gas_price: Option<u128>,
@@ -296,6 +300,7 @@ impl OnchainTrade {
             amount: trade_details.equity_amount(),
             direction: trade_details.direction(),
             price,
+            block_number: log.block_number.or(receipt_block_number),
             block_timestamp: log.block_timestamp.and_then(|timestamp_secs| {
                 let secs: i64 = timestamp_secs.try_into().ok()?;
                 DateTime::from_timestamp(secs, 0)

--- a/src/performance/projection.rs
+++ b/src/performance/projection.rs
@@ -41,7 +41,11 @@ impl HedgeLatencyProjection {
         event: PositionEvent,
     ) -> Result<(), ProjectionError> {
         match event {
-            PositionEvent::Initialized { .. } | PositionEvent::ThresholdUpdated { .. } => Ok(()),
+            // Dedup bookkeeping only (ADR 0010): no performance signal.
+            PositionEvent::Initialized { .. }
+            | PositionEvent::ThresholdUpdated { .. }
+            | PositionEvent::OnChainFillApplied { .. }
+            | PositionEvent::OnChainFillSettled { .. } => Ok(()),
             PositionEvent::OnChainOrderFilled {
                 trade_id,
                 block_timestamp,

--- a/src/position.rs
+++ b/src/position.rs
@@ -5,6 +5,8 @@
 //! position, and decides when the imbalance exceeds the
 //! threshold to trigger an offsetting broker order.
 
+use std::collections::BTreeSet;
+
 use alloy::primitives::TxHash;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -41,15 +43,31 @@ pub struct Position {
     /// rebalance cycle gets a fresh idempotency key.
     #[serde(default)]
     pub last_failed_offchain_order_id: Option<OffchainOrderId>,
-    /// The most recently applied onchain fill, rejected if re-driven.
-    /// Guards the resume path's crash window between this position
-    /// write and the `OnChainTrade` acknowledgement marker (ADR 0005).
-    /// One slot suffices: accounting jobs are serialized per symbol and
-    /// re-deliveries drain in enqueue order, so only the most recent
-    /// trade can ever be re-driven against an unmarked acknowledgement;
-    /// the upstream marker blocks all longer-range duplicates.
+    /// The most recently applied onchain fill (single slot, ADR 0005).
+    /// Retained as the zero-migration cross-upgrade bridge (ADR 0010): a
+    /// fill applied under pre-`pending_acknowledged_trade_ids` code but
+    /// left unmarked when the deploy restarts has no `OnChainFillApplied`
+    /// event in its history, so the rebuilt set cannot guard it -- this
+    /// slot, written by the unchanged `OnChainOrderFilled` evolve, still
+    /// equals that trade and rejects its re-drive.
     #[serde(default)]
     pub last_acknowledged_trade_id: Option<TradeId>,
+    /// Trade ids applied to the position but whose `OnChainTrade`
+    /// acknowledgement marker is not yet settle-pruned (ADR 0010).
+    /// Closes the cross-process / out-of-order double-count the single
+    /// slot cannot: the slot only remembers the LAST applied trade, so a
+    /// re-drive of an older fill after a newer one displaced the slot --
+    /// reachable once serialization breaks (the process-tx CLI runs in a
+    /// separate process from the bot) -- slips through. This set, fed by a
+    /// dedicated `OnChainFillApplied` event in the same atomic batch as the
+    /// position move and pruned by `SettleOnChainFill` after
+    /// the marker is durable, rejects such a re-drive regardless of how
+    /// many fills intervened. Bounded: empty at rest, one entry per
+    /// in-flight job. `OnChainFillApplied` has zero pre-`ADR 0010`
+    /// occurrences, so a full event replay rebuilds it empty rather than
+    /// re-accumulating every historical trade id.
+    #[serde(default)]
+    pub pending_acknowledged_trade_ids: BTreeSet<TradeId>,
     pub threshold: ExecutionThreshold,
     #[serde(
         serialize_with = "st0x_float_serde::serialize_option_float",
@@ -75,6 +93,10 @@ impl std::fmt::Debug for Position {
                 "last_acknowledged_trade_id",
                 &self.last_acknowledged_trade_id,
             )
+            .field(
+                "pending_acknowledged_trade_ids",
+                &self.pending_acknowledged_trade_ids,
+            )
             .field("threshold", &self.threshold)
             .field("last_price_usdc", &DebugOptionFloat(&self.last_price_usdc))
             .field("last_updated", &self.last_updated)
@@ -93,7 +115,7 @@ impl EventSourced for Position {
 
     const AGGREGATE_TYPE: &'static str = "Position";
     const PROJECTION: Table = Table("position_view");
-    const SCHEMA_VERSION: u64 = 3;
+    const SCHEMA_VERSION: u64 = 4;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use PositionEvent::*;
@@ -110,6 +132,7 @@ impl EventSourced for Position {
                 pending_offchain_order_id: None,
                 last_failed_offchain_order_id: None,
                 last_acknowledged_trade_id: None,
+                pending_acknowledged_trade_ids: BTreeSet::new(),
                 threshold: *threshold,
                 last_price_usdc: None,
                 last_updated: Some(*initialized_at),
@@ -155,6 +178,30 @@ impl EventSourced for Position {
                 last_updated: Some(*seen_at),
                 ..entity.clone()
             })),
+
+            // Bookkeeping only (ADR 0010): track the applied fill in the
+            // pending-acknowledgement set without touching net or
+            // last_updated -- the position move already happened in the
+            // `OnChainOrderFilled` of the same atomic batch.
+            OnChainFillApplied { trade_id, .. } => {
+                let mut pending_acknowledged_trade_ids =
+                    entity.pending_acknowledged_trade_ids.clone();
+                pending_acknowledged_trade_ids.insert(trade_id.clone());
+                Ok(Some(Self {
+                    pending_acknowledged_trade_ids,
+                    ..entity.clone()
+                }))
+            }
+
+            OnChainFillSettled { trade_id, .. } => {
+                let mut pending_acknowledged_trade_ids =
+                    entity.pending_acknowledged_trade_ids.clone();
+                pending_acknowledged_trade_ids.remove(trade_id);
+                Ok(Some(Self {
+                    pending_acknowledged_trade_ids,
+                    ..entity.clone()
+                }))
+            }
 
             OffChainOrderPlaced { .. } if entity.pending_offchain_order_id.is_some() => Ok(None),
 
@@ -281,15 +328,23 @@ impl EventSourced for Position {
                         initialized_at: now,
                     },
                     PositionEvent::OnChainOrderFilled {
-                        trade_id,
+                        trade_id: trade_id.clone(),
                         amount,
                         direction,
                         price_usdc,
                         block_timestamp,
                         seen_at: now,
                     },
+                    PositionEvent::OnChainFillApplied {
+                        trade_id,
+                        applied_at: now,
+                    },
                 ])
             }
+
+            // Pruning a fill the position never applied is a no-op; never
+            // initialize the aggregate just to settle an absent trade.
+            SettleOnChainFill { .. } => Ok(vec![]),
 
             ManuallyAdjustPosition {
                 symbol,
@@ -351,18 +406,43 @@ impl EventSourced for Position {
                 block_timestamp,
                 ..
             } => {
-                if self.last_acknowledged_trade_id.as_ref() == Some(&trade_id) {
+                // Dual guard (ADR 0010): the retained slot bridges a fill
+                // applied under pre-set code and left unmarked at the
+                // deploy restart; the set rejects an out-of-order /
+                // cross-process re-drive the single slot cannot, because a
+                // newer fill displaces the slot but never the set entry.
+                if self.last_acknowledged_trade_id.as_ref() == Some(&trade_id)
+                    || self.pending_acknowledged_trade_ids.contains(&trade_id)
+                {
                     return Err(PositionError::DuplicateTrade { trade_id });
                 }
 
-                Ok(vec![PositionEvent::OnChainOrderFilled {
-                    trade_id,
-                    amount,
-                    direction,
-                    price_usdc,
-                    block_timestamp,
-                    seen_at: Utc::now(),
-                }])
+                let now = Utc::now();
+                Ok(vec![
+                    PositionEvent::OnChainOrderFilled {
+                        trade_id: trade_id.clone(),
+                        amount,
+                        direction,
+                        price_usdc,
+                        block_timestamp,
+                        seen_at: now,
+                    },
+                    PositionEvent::OnChainFillApplied {
+                        trade_id,
+                        applied_at: now,
+                    },
+                ])
+            }
+
+            SettleOnChainFill { trade_id } => {
+                if self.pending_acknowledged_trade_ids.contains(&trade_id) {
+                    Ok(vec![PositionEvent::OnChainFillSettled {
+                        trade_id,
+                        settled_at: Utc::now(),
+                    }])
+                } else {
+                    Ok(vec![])
+                }
             }
 
             PlaceOffChainOrder {
@@ -746,6 +826,13 @@ pub enum PositionCommand {
         price_usdc: Float,
         block_timestamp: DateTime<Utc>,
     },
+    /// Prunes `trade_id` from the pending-acknowledgement set after its
+    /// `OnChainTrade` marker is durable (ADR 0010). A no-op (emits no
+    /// events) when the trade is not in the set, so a re-driven prune is
+    /// idempotent and optimistic-concurrency-safe.
+    SettleOnChainFill {
+        trade_id: TradeId,
+    },
     PlaceOffChainOrder {
         offchain_order_id: OffchainOrderId,
         shares: Positive<FractionalShares>,
@@ -801,6 +888,21 @@ pub enum PositionEvent {
         block_timestamp: DateTime<Utc>,
         seen_at: DateTime<Utc>,
     },
+    /// Records that `trade_id` was applied to the position, in the same
+    /// atomic batch as the `OnChainOrderFilled` move (ADR 0010). A
+    /// dedicated event -- not folded into `OnChainOrderFilled` -- so that
+    /// pre-`ADR 0010` history (which has none) rebuilds the pending set
+    /// empty on full replay instead of re-accumulating every trade id.
+    OnChainFillApplied {
+        trade_id: TradeId,
+        applied_at: DateTime<Utc>,
+    },
+    /// Prunes `trade_id` from the pending-acknowledgement set once its
+    /// `OnChainTrade` marker is durable (ADR 0010).
+    OnChainFillSettled {
+        trade_id: TradeId,
+        settled_at: DateTime<Utc>,
+    },
     OffChainOrderPlaced {
         offchain_order_id: OffchainOrderId,
         shares: Positive<FractionalShares>,
@@ -847,6 +949,8 @@ impl PositionEvent {
         match self {
             Initialized { initialized_at, .. } => *initialized_at,
             OnChainOrderFilled { seen_at, .. } => *seen_at,
+            OnChainFillApplied { applied_at, .. } => *applied_at,
+            OnChainFillSettled { settled_at, .. } => *settled_at,
             OffChainOrderPlaced { placed_at, .. } => *placed_at,
             OffChainOrderFilled {
                 broker_timestamp, ..
@@ -864,6 +968,8 @@ impl DomainEvent for PositionEvent {
         match self {
             Initialized { .. } => "PositionEvent::Initialized".to_string(),
             OnChainOrderFilled { .. } => "PositionEvent::OnChainOrderFilled".to_string(),
+            OnChainFillApplied { .. } => "PositionEvent::OnChainFillApplied".to_string(),
+            OnChainFillSettled { .. } => "PositionEvent::OnChainFillSettled".to_string(),
             OffChainOrderPlaced { .. } => "PositionEvent::OffChainOrderPlaced".to_string(),
             OffChainOrderFilled { .. } => "PositionEvent::OffChainOrderFilled".to_string(),
             OffChainOrderFailed { .. } => "PositionEvent::OffChainOrderFailed".to_string(),
@@ -928,6 +1034,26 @@ impl PartialEq for PositionEvent {
                     && bt1 == bt2
                     && sa1 == sa2
             }
+            (
+                Self::OnChainFillApplied {
+                    trade_id: t1,
+                    applied_at: a1,
+                },
+                Self::OnChainFillApplied {
+                    trade_id: t2,
+                    applied_at: a2,
+                },
+            ) => t1 == t2 && a1 == a2,
+            (
+                Self::OnChainFillSettled {
+                    trade_id: t1,
+                    settled_at: c1,
+                },
+                Self::OnChainFillSettled {
+                    trade_id: t2,
+                    settled_at: c2,
+                },
+            ) => t1 == t2 && c1 == c2,
             (
                 Self::OffChainOrderPlaced {
                     offchain_order_id: o1,
@@ -1011,7 +1137,7 @@ impl PartialEq for PositionEvent {
 
 impl Eq for PositionEvent {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TradeId {
     pub tx_hash: TxHash,
     pub log_index: u64,
@@ -1122,6 +1248,10 @@ impl std::fmt::Debug for PositionCommand {
                 .field("price_usdc", &DebugFloat(price_usdc))
                 .field("block_timestamp", block_timestamp)
                 .finish(),
+            Self::SettleOnChainFill { trade_id } => f
+                .debug_struct("SettleOnChainFill")
+                .field("trade_id", trade_id)
+                .finish(),
             Self::PlaceOffChainOrder {
                 offchain_order_id,
                 shares,
@@ -1214,6 +1344,22 @@ impl std::fmt::Debug for PositionEvent {
                 .field("price_usdc", &DebugFloat(price_usdc))
                 .field("block_timestamp", block_timestamp)
                 .field("seen_at", seen_at)
+                .finish(),
+            Self::OnChainFillApplied {
+                trade_id,
+                applied_at,
+            } => f
+                .debug_struct("OnChainFillApplied")
+                .field("trade_id", trade_id)
+                .field("applied_at", applied_at)
+                .finish(),
+            Self::OnChainFillSettled {
+                trade_id,
+                settled_at,
+            } => f
+                .debug_struct("OnChainFillSettled")
+                .field("trade_id", trade_id)
+                .field("settled_at", settled_at)
                 .finish(),
             Self::OffChainOrderPlaced {
                 offchain_order_id,
@@ -1348,7 +1494,20 @@ mod tests {
             .await
             .events();
 
-        assert_eq!(events.len(), 2, "Expected Initialized + OnChainOrderFilled");
+        assert_eq!(
+            events.len(),
+            3,
+            "Expected Initialized + OnChainOrderFilled + OnChainFillApplied"
+        );
+        assert!(matches!(events[0], PositionEvent::Initialized { .. }));
+        assert!(matches!(
+            events[1],
+            PositionEvent::OnChainOrderFilled { .. }
+        ));
+        assert!(matches!(
+            events[2],
+            PositionEvent::OnChainFillApplied { .. }
+        ));
     }
 
     #[tokio::test]
@@ -1376,15 +1535,27 @@ mod tests {
             .await
             .events();
 
-        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events.len(),
+            2,
+            "Expected OnChainOrderFilled + OnChainFillApplied"
+        );
+        assert!(matches!(
+            events[0],
+            PositionEvent::OnChainOrderFilled { .. }
+        ));
+        assert!(matches!(
+            events[1],
+            PositionEvent::OnChainFillApplied { .. }
+        ));
     }
 
     /// Reproduction for the double-count half of the Witness/Acknowledge
     /// gap (ADR 0005): the position must reject a trade id it has
-    /// already applied. The resume path re-drives the acknowledge step
-    /// after a crash between the position write and the acknowledgement
-    /// marker; without this rejection the re-drive counts the same fill
-    /// twice.
+    /// already applied. Here the seeded history has only `OnChainOrderFilled`
+    /// (no `OnChainFillApplied`), mirroring a fill applied under pre-ADR-0010
+    /// code and left unmarked at the deploy restart, so the rejection comes
+    /// from the retained single slot -- the cross-upgrade bridge (ADR 0010).
     #[tokio::test]
     async fn duplicate_acknowledge_on_chain_fill_is_rejected() {
         let threshold = one_share_threshold();
@@ -1430,6 +1601,260 @@ mod tests {
             ),
             "Re-driving an already-applied trade must be rejected as a \
              duplicate, not double-counted; got: {error:?}",
+        );
+    }
+
+    /// The pending-acknowledgement set rejects an out-of-order re-drive the
+    /// single slot cannot (ADR 0010): once a newer fill (B) displaces the slot,
+    /// the slot no longer equals an older applied-but-unmarked fill (A), but the
+    /// set still holds A. This is the cross-process / process-tx-CLI double-count
+    /// the slot alone misses. Remove the set check from the dedup and this fails.
+    #[tokio::test]
+    async fn out_of_order_redrive_rejected_by_pending_set() {
+        let threshold = one_share_threshold();
+        let trade_a = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 1,
+        };
+        let trade_b = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 2,
+        };
+        let now = Utc::now();
+
+        let error = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    threshold,
+                    initialized_at: now,
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: trade_a.clone(),
+                    amount: FractionalShares::new(float!(0.5)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: now,
+                    seen_at: now,
+                },
+                PositionEvent::OnChainFillApplied {
+                    trade_id: trade_a.clone(),
+                    applied_at: now,
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: trade_b.clone(),
+                    amount: FractionalShares::new(float!(0.5)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: now,
+                    seen_at: now,
+                },
+                PositionEvent::OnChainFillApplied {
+                    trade_id: trade_b,
+                    applied_at: now,
+                },
+            ])
+            .when(PositionCommand::AcknowledgeOnChainFill {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold,
+                trade_id: trade_a.clone(),
+                amount: FractionalShares::new(float!(0.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: now,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(PositionError::DuplicateTrade {
+                    trade_id: ref rejected
+                }) if *rejected == trade_a
+            ),
+            "An older applied-but-unmarked fill must be rejected by the pending \
+             set even after a newer fill displaced the slot; got: {error:?}",
+        );
+    }
+
+    /// A full replay of pre-ADR-0010 history (only `OnChainOrderFilled`, no
+    /// `OnChainFillApplied`) rebuilds the pending set EMPTY -- the regression
+    /// guard against re-accumulating every historical trade id on the
+    /// snapshot-clearing schema bump.
+    #[test]
+    fn replay_of_pre_migration_history_yields_empty_pending_set() {
+        let now = Utc::now();
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: now,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(0.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: now,
+                seen_at: now,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 2,
+                },
+                amount: FractionalShares::new(float!(0.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: now,
+                seen_at: now,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            position.pending_acknowledged_trade_ids.is_empty(),
+            "Pre-ADR-0010 history has no OnChainFillApplied events, so replay must \
+             rebuild an empty pending set; got: {:?}",
+            position.pending_acknowledged_trade_ids,
+        );
+    }
+
+    /// Applied/Settled pairs cancel on replay, leaving only the genuinely
+    /// in-flight tail (ADR 0010): A is applied then settled (pruned); B is
+    /// applied but not yet settled (crash before its mark), so the rebuilt set
+    /// is exactly {B} -- bounded, and B stays durably guarded.
+    #[test]
+    fn replay_applied_settled_pairs_converge_to_inflight_tail() {
+        let now = Utc::now();
+        let trade_a = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 1,
+        };
+        let trade_b = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 2,
+        };
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: now,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: trade_a.clone(),
+                amount: FractionalShares::new(float!(0.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: now,
+                seen_at: now,
+            },
+            PositionEvent::OnChainFillApplied {
+                trade_id: trade_a.clone(),
+                applied_at: now,
+            },
+            PositionEvent::OnChainFillSettled {
+                trade_id: trade_a,
+                settled_at: now,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: trade_b.clone(),
+                amount: FractionalShares::new(float!(0.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: now,
+                seen_at: now,
+            },
+            PositionEvent::OnChainFillApplied {
+                trade_id: trade_b.clone(),
+                applied_at: now,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            position.pending_acknowledged_trade_ids,
+            BTreeSet::from([trade_b]),
+            "Settled fills must prune; only the unsettled tail remains",
+        );
+    }
+
+    /// Settle emits the prune event when the trade is in the pending set.
+    #[tokio::test]
+    async fn settle_emits_settled_when_member() {
+        let threshold = one_share_threshold();
+        let trade_id = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 1,
+        };
+        let now = Utc::now();
+
+        let events = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    threshold,
+                    initialized_at: now,
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: trade_id.clone(),
+                    amount: FractionalShares::new(float!(0.5)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: now,
+                    seen_at: now,
+                },
+                PositionEvent::OnChainFillApplied {
+                    trade_id: trade_id.clone(),
+                    applied_at: now,
+                },
+            ])
+            .when(PositionCommand::SettleOnChainFill {
+                trade_id: trade_id.clone(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            PositionEvent::OnChainFillSettled { trade_id: settled, .. }
+                if *settled == trade_id
+        ));
+    }
+
+    /// Settle for a trade not in the set is a no-op: zero events, so a
+    /// re-driven prune is idempotent and optimistic-concurrency-safe.
+    #[tokio::test]
+    async fn settle_is_noop_when_not_member() {
+        let threshold = one_share_threshold();
+
+        let events = TestHarness::<Position>::with(())
+            .given(vec![PositionEvent::Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold,
+                initialized_at: Utc::now(),
+            }])
+            .when(PositionCommand::SettleOnChainFill {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 99,
+                },
+            })
+            .await
+            .events();
+
+        assert!(
+            events.is_empty(),
+            "Settling an absent trade must emit no events"
         );
     }
 
@@ -2595,6 +3020,7 @@ mod tests {
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
             last_acknowledged_trade_id: None,
+            pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2623,6 +3049,7 @@ mod tests {
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
             last_acknowledged_trade_id: None,
+            pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2651,6 +3078,7 @@ mod tests {
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
             last_acknowledged_trade_id: None,
+            pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2682,6 +3110,7 @@ mod tests {
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
             last_acknowledged_trade_id: None,
+            pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2713,6 +3142,7 @@ mod tests {
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
             last_acknowledged_trade_id: None,
+            pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2743,6 +3173,7 @@ mod tests {
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
             last_acknowledged_trade_id: None,
+            pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2774,6 +3205,7 @@ mod tests {
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
             last_acknowledged_trade_id: None,
+            pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2805,6 +3237,7 @@ mod tests {
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
             last_acknowledged_trade_id: None,
+            pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: None,
             last_updated: Some(Utc::now()),
@@ -2886,6 +3319,7 @@ mod tests {
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
             last_acknowledged_trade_id: None,
+            pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -2021,7 +2021,11 @@ impl Reactor for RebalancingService {
                         self.equity_scheduler.enqueue_check(symbol).await;
                         return Ok(());
                     }
-                    Initialized { .. } | ThresholdUpdated { .. } => {
+                    Initialized { .. }
+                    | ThresholdUpdated { .. }
+                    // Dedup bookkeeping only (ADR 0010): no inventory effect.
+                    | OnChainFillApplied { .. }
+                    | OnChainFillSettled { .. } => {
                         return Ok(());
                     }
                     ManualPositionAdjusted { .. } => {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,7 +7,7 @@ use alloy::primitives::{Address, B256, LogData, address, bytes, fixed_bytes};
 use alloy::providers::Provider;
 use alloy::providers::ext::AnvilApi as _;
 use alloy::rpc::types::{Log, TransactionRequest};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use rain_math_float::Float;
 use sqlx::SqlitePool;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -273,6 +273,7 @@ impl OnchainTradeBuilder {
                 amount: FractionalShares::new(Float::parse("1".to_string()).unwrap()),
                 direction: Direction::Buy,
                 price: Usdc::new(Float::parse("150".to_string()).unwrap()).unwrap(),
+                block_number: Some(1),
                 block_timestamp: Some(Utc::now()),
                 gas_used: None,
                 effective_gas_price: None,
@@ -304,6 +305,18 @@ impl OnchainTradeBuilder {
     #[must_use]
     pub(crate) fn with_log_index(mut self, index: u64) -> Self {
         self.trade.log_index = index;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_block_number(mut self, block_number: Option<u64>) -> Self {
+        self.trade.block_number = block_number;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_block_timestamp(mut self, block_timestamp: Option<DateTime<Utc>>) -> Self {
+        self.trade.block_timestamp = block_timestamp;
         self
     }
 

--- a/tests/e2e/hedging.rs
+++ b/tests/e2e/hedging.rs
@@ -415,9 +415,13 @@ async fn resumption_after_shutdown() -> anyhow::Result<()> {
         pre_shutdown_onchain_events + ONCHAIN_EVENTS_PER_TRADE,
         "Restart should persist exactly one new witnessed-and-acknowledged trade",
     );
+    // One hedged fill emits five Position events: OnChainOrderFilled +
+    // OnChainFillApplied (dedup bookkeeping, ADR 0010) + the marker's
+    // OnChainFillSettled, then OffChainOrderPlaced and
+    // OffChainOrderFilled.
     assert_eq!(
         post_restart_position_events,
-        pre_shutdown_position_events + 3,
+        pre_shutdown_position_events + 5,
         "Restart should emit exact Position success transition events for one hedge",
     );
     assert_eq!(


### PR DESCRIPTION
## What

Closes RAI-1157, and closes the cross-process double-count window it exposed.
Two things:

- `process-tx` accounts each fill exactly once: it refuses any fill already
  recorded in the `OnChainTrade` log and records a previously-unrecorded fill
  through the same `witness -> enrich -> acknowledge -> mark -> confirm` sequence
  the automated pipeline uses.
- The shared exactly-once pipeline now closes the `acknowledge -> mark` crash
  window: `Position` rejects an out-of-order / cross-process re-drive via a
  bounded, event-sourced pending-acknowledgement set (ADR 0010, supersedes ADR
  0005 in part).

## Why

Fill accounting de-duplicated against `Position`'s single-slot
`last_acknowledged_trade_id`. That slot is correct only under serialized,
in-order processing -- the property ADR 0005 relied on (the bot's
`concurrency(1)` worker plus a per-symbol in-process lock). `process-tx` runs in
a **separate process** from the bot, so that lock cannot serialize the two, and
re-running it -- on a fill the bot already accounted, or twice on a bot-missed
one -- slipped past the slot and double-counted the net position (and placed a
duplicate hedge). The same window is reachable for any concurrency > 1.
Double-counting a fill is a direct financial-integrity hazard.

## How

- **Bounded pending-acknowledgement set.** `AcknowledgeOnChainFill` records the
  applied `trade_id` in a `Position`-side set, in the same atomic batch as the
  position move, via a dedicated `OnChainFillApplied` event. The dedup rejects a
  fill whose `trade_id` is still in the set, so a re-drive is rejected regardless
  of how many fills intervened or how long it was delayed -- the set is
  event-sourced, survives crashes, and is visible cross-process. A fifth
  pipeline step (`ConfirmOnChainFillAcknowledged`, after the marker is durable)
  prunes it; the set is empty at rest and bounded by in-flight jobs.
- **Replay-safe by construction.** The set-insert is a dedicated event with zero
  pre-ADR-0010 occurrences, so the schema bump's full replay rebuilds the set
  empty instead of re-accumulating every historical `trade_id`.
- **Zero-migration upgrade bridge.** The single slot is retained: a fill applied
  under old code but unmarked at the deploy restart has no `OnChainFillApplied`
  event, so the slot (not the set) guards its re-drive. No SQL migration.
- **process-tx** records unrecorded fills through the full sequence and refuses
  any already-recorded fill; a mark->confirm leak self-heals on the next
  re-delivery (bot) or re-run (CLI).

## Testing

- Position unit: the set rejects an out-of-order re-drive the slot misses
  (verified to fail without the set guard); pre-migration replay rebuilds an
  empty set; applied/confirmed pairs converge to the in-flight tail; confirm
  emits/no-ops correctly; the retained slot still rejects an upgrade in-flight
  re-drive.
- Conductor integration: re-delivering an unmarked, slot-displaced fill through
  the real `process_queued_trade` pipeline emits no second `OnChainOrderFilled`
  (no double-count).
- CLI: a successful run leaves the pending set empty; a re-run on an
  acknowledged fill refuses it and prunes a mark->confirm leak.
- Existing arbitrage/rebalancing integration sequences updated for the two new
  events. Full `st0x-hedge` suite, `clippy`, and `fmt` green.

## Anything else

ADR 0010 supersedes the single-slot decision in ADR 0005 in part; `Position`
`SCHEMA_VERSION` 3 -> 4, `OnChainTrade` unchanged, no SQL migration (the
`position_view` rebuilds from events). The two new `Position` events are pure
dedup bookkeeping (no performance/inventory effect). This grew well past a
process-tx CLI fix into the shared pipeline; it can be split into separate PRs
on follow-up. Stacked on #815 (rai-987), the PR whose `process-tx` recovery path
this started from.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785021103&installation_id=125569124&pr_number=935&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F935&signature=34dbf060037e61e39bae52ad365bcbdf2e4237f05ddded2c970411a2e65a65bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onchain fill “exactly-once” accounting to prevent double-processing across retries and crash windows.
  * The recovery CLI now refuses already-acknowledged fills and avoids changing position/balance projections in those cases.
  * Added fail-closed behavior: if required onchain timing data is missing, processing stops without updating positions.
  * Added new confirmation handling to prune stale pending-ack markers and maintain correct duplicate rejection.
* **Documentation**
  * Expanded the `ProcessTx` command description to warn about concurrent processing and double-counting risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
