### PR TITLE
fix: process-tx fails closed on already-recorded fills

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3307,6 +3307,17 @@ effect rather than a generic intent:
   must clear because the funds were handled out-of-band. The USDC
   `ReconcileStuckRebalance` command (see above) is the first realization of the
   `reconcile` verb.
+- **`process-tx` implements the ADR-0005 exactly-once fill accounting
+  protocol.** It fails closed (with a clear operator message) if the fill is
+  already acknowledged, resumes if it was witnessed but not yet acknowledged
+  (crash- recovery window), and creates the full witness/acknowledge record for
+  genuinely missed fills — so every subsequent re-delivery, whether from another
+  CLI run or the normal pipeline, hits the dedup guard and skips cleanly.
+  **Operational precondition**: run with exclusive processing for that fill:
+  stop the live bot, drain any apalis accounting job for the fill, and do not
+  run another `process-tx` for the same `(tx_hash, log_index)` concurrently. The
+  durable dedup guard and the CQRS apply are separate transactions, so any
+  concurrent actor processing the same fill can slip through the TOCTOU window.
 
 ### Event Processing Flow
 

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -2,7 +2,6 @@
 
 use alloy::primitives::TxHash;
 use alloy::providers::Provider;
-use anyhow::Context;
 use async_trait::async_trait;
 use sqlx::SqlitePool;
 use std::io::Write;
@@ -20,8 +19,8 @@ use st0x_execution::{
 };
 
 use crate::conductor::{
-    execute_acknowledge_fill, execute_enrich_trade, execute_mark_acknowledged, execute_settle_fill,
-    execute_witness_trade,
+    FillAccountingOutcome, account_for_onchain_fill, execute_mark_acknowledged,
+    execute_settle_fill, is_expected_place_offchain_order_rejection,
 };
 use crate::offchain::order::{
     OffchainOrder, OffchainOrderId, OrderPlacementResult, OrderPlacer,
@@ -33,7 +32,6 @@ use crate::onchain::{OnChainError, OnchainTrade, TradeValidationError};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeId};
 use crate::position::{Position, PositionCommand};
 use crate::symbol::cache::SymbolCache;
-use st0x_config::ExecutionThreshold;
 use st0x_config::{BrokerCtx, Ctx};
 use st0x_float_serde::format_float_with_fallback;
 
@@ -530,44 +528,69 @@ pub(super) async fn process_found_trade<W: Write>(
 
     writeln!(stdout, "🔄 Processing trade with TradeAccumulator...")?;
 
+    let trade_id = OnChainTradeId {
+        tx_hash: onchain_trade.tx_hash,
+        log_index: onchain_trade.log_index,
+    };
+
+    // Build stores. CLI path: per-invocation instances are fine (single-instance
+    // rule applies to the server path only; see AGENTS.md).
+    let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+        .build(())
+        .await?;
     let (position_store, position_projection) = StoreBuilder::<Position>::new(pool.clone())
         .build(())
         .await?;
     let (offchain_order_store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
         .build(())
         .await?;
-    let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
-        .build(())
-        .await?;
 
-    // Refuse a fill the bot has already recorded (witnessed or acknowledged),
-    // then account this unrecorded fill through the same exactly-once
-    // witness -> acknowledge -> mark -> settle sequence the automated pipeline
-    // uses, so it is recorded in the OnChainTrade log and a re-run is refused
-    // rather than double-counted. process-tx runs in a separate process from the
-    // bot, so an in-process lock cannot serialize them; the persisted
-    // pending-acknowledgement set (ADR 0010) makes the position itself reject an
-    // out-of-order cross-process re-drive, and the recovery-CLI no-concurrent-bot
-    // contract remains the operational backstop.
-    refuse_if_fill_already_recorded(
+    let Some(block_number) = onchain_trade.block_number else {
+        anyhow::bail!("Fill {trade_id}: missing block_number, cannot witness fill");
+    };
+
+    let FillAccountingOutcome::Accounted { trade_id } = account_for_onchain_fill(
+        pool,
         &onchain_trade_store,
         &position_store,
         &onchain_trade,
-        stdout,
-    )
-    .await?;
-    account_fill_exactly_once(
-        &onchain_trade_store,
-        &position_store,
-        &onchain_trade,
+        block_number,
         ctx.execution_threshold,
     )
-    .await?;
+    .await?
+    else {
+        writeln!(
+            stdout,
+            "Fill {trade_id} is already fully accounted. Nothing to do; \
+             the normal pipeline will hedge any unhedged position exposure."
+        )?;
+        return Ok(());
+    };
 
     let executor_type = ctx.broker.to_supported_executor();
     let base_symbol = onchain_trade.symbol.base();
 
-    // CLI test command uses MockExecutor (market always open)
+    match reconcile_existing_pending_order(
+        &offchain_order_store,
+        &position_store,
+        base_symbol,
+        stdout,
+    )
+    .await?
+    {
+        CliPendingReconciliation::NoPending | CliPendingReconciliation::Cleared => {}
+        CliPendingReconciliation::InFlight => {
+            mark_and_settle_fill(
+                &onchain_trade_store,
+                &position_store,
+                &trade_id,
+                &onchain_trade,
+            )
+            .await?;
+            return Ok(());
+        }
+    }
+
     let trading_enabled = ctx.is_trading_enabled(base_symbol);
 
     if !trading_enabled {
@@ -575,6 +598,13 @@ pub(super) async fn process_found_trade<W: Write>(
             stdout,
             "Trading disabled by configuration for {base_symbol}"
         )?;
+        mark_and_settle_fill(
+            &onchain_trade_store,
+            &position_store,
+            &trade_id,
+            &onchain_trade,
+        )
+        .await?;
         return Ok(());
     }
 
@@ -597,6 +627,13 @@ pub(super) async fn process_found_trade<W: Write>(
             stdout,
             "   (Waiting to accumulate enough shares for a whole share execution)"
         )?;
+        mark_and_settle_fill(
+            &onchain_trade_store,
+            &position_store,
+            &trade_id,
+            &onchain_trade,
+        )
+        .await?;
         return Ok(());
     };
 
@@ -607,34 +644,6 @@ pub(super) async fn process_found_trade<W: Write>(
         "Trade triggered execution for {executor_type:?} (ID: {offchain_order_id})"
     )?;
 
-    if let Err(error) = position_store
-        .send(
-            &params.symbol,
-            PositionCommand::PlaceOffChainOrder {
-                offchain_order_id,
-                shares: params.shares,
-                direction: params.direction,
-                executor: params.executor,
-                threshold: ctx.execution_threshold,
-            },
-        )
-        .await
-    {
-        error!(
-            %offchain_order_id,
-            symbol = %params.symbol,
-            "Failed to execute Position::PlaceOffChainOrder: {error}"
-        );
-    }
-
-    // Reuse a prior failed attempt's stashed OffchainOrderId as the broker-side
-    // idempotency anchor (mirroring the automated `execute_create_offchain_order`
-    // path) so a CLI retry after a transient broker failure dedupes instead of
-    // placing a second order. Fail fast on a load error rather than placing under
-    // a fresh key: a transient load failure while an anchor exists would submit a
-    // SECOND live broker order for shares the prior attempt already placed -- a
-    // double-hedge the fail-fast rule exists to prevent. Re-running the CLI
-    // reloads the anchor.
     let anchor = position_store
         .load(&params.symbol)
         .await
@@ -648,9 +657,42 @@ pub(super) async fn process_found_trade<W: Write>(
             );
         })?
         .and_then(|position| position.last_failed_offchain_order_id);
+
+    match position_store
+        .send(
+            &params.symbol,
+            PositionCommand::PlaceOffChainOrder {
+                offchain_order_id,
+                shares: params.shares,
+                direction: params.direction,
+                executor: params.executor,
+                threshold: ctx.execution_threshold,
+            },
+        )
+        .await
+    {
+        Ok(()) => {}
+        Err(error) if is_expected_place_offchain_order_rejection(&error) => {
+            info!(
+                %offchain_order_id,
+                symbol = %params.symbol,
+                "Position::PlaceOffChainOrder rejected by domain state: {error}"
+            );
+            mark_and_settle_fill(
+                &onchain_trade_store,
+                &position_store,
+                &trade_id,
+                &onchain_trade,
+            )
+            .await?;
+            return Ok(());
+        }
+        Err(error) => return Err(error.into()),
+    }
+
     let client_order_id = client_order_id_for_placement(offchain_order_id, anchor);
 
-    match place_offchain_order_at_broker(
+    place_offchain_order_at_broker(
         &offchain_order_store,
         order_placer.as_ref(),
         &offchain_order_id,
@@ -660,172 +702,209 @@ pub(super) async fn process_found_trade<W: Write>(
         params.executor,
         client_order_id,
     )
-    .await
-    {
-        // A broker rejection comes back as `Ok(Some(Failed))`, not `Err`. Mirror
-        // the automated path (`check_and_execute_accumulated_positions`): clear
-        // the position's pending claim so the symbol is not stranded permanently
-        // claimed -- which would block all future hedging for it -- and surface
-        // the rejection to the operator.
-        Ok(Some(OffchainOrder::Failed { error, .. })) => {
+    .await?;
+
+    reconcile_post_place_state(
+        &offchain_order_store,
+        &position_store,
+        &params.symbol,
+        offchain_order_id,
+        stdout,
+    )
+    .await?;
+
+    mark_and_settle_fill(
+        &onchain_trade_store,
+        &position_store,
+        &trade_id,
+        &onchain_trade,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn mark_and_settle_fill(
+    onchain_trade_store: &Store<OnChainTrade>,
+    position_store: &Store<Position>,
+    trade_id: &OnChainTradeId,
+    onchain_trade: &OnchainTrade,
+) -> anyhow::Result<()> {
+    execute_mark_acknowledged(onchain_trade_store, trade_id).await?;
+    execute_settle_fill(position_store, onchain_trade).await?;
+
+    Ok(())
+}
+
+enum CliPendingReconciliation {
+    NoPending,
+    InFlight,
+    Cleared,
+}
+
+#[derive(Clone, Copy)]
+enum CliPendingClearNextStep {
+    ContinueThisRun,
+    NormalPipelineNextCycle,
+}
+
+async fn reconcile_existing_pending_order<W: Write>(
+    offchain_order_store: &Store<OffchainOrder>,
+    position_store: &Store<Position>,
+    symbol: &Symbol,
+    stdout: &mut W,
+) -> anyhow::Result<CliPendingReconciliation> {
+    let Some(position) = position_store.load(symbol).await? else {
+        return Ok(CliPendingReconciliation::NoPending);
+    };
+
+    let Some(offchain_order_id) = position.pending_offchain_order_id else {
+        return Ok(CliPendingReconciliation::NoPending);
+    };
+
+    let loaded_order = offchain_order_store
+        .load(&offchain_order_id)
+        .await
+        .inspect_err(|error| {
             error!(
                 %offchain_order_id,
-                symbol = %params.symbol,
+                %symbol,
                 %error,
-                "Broker rejected the order; clearing the position claim"
+                "Failed to load existing pending offchain order; cannot safely acknowledge fill"
             );
-            if let Err(send_error) = position_store
+        })?;
+
+    let outcome = match &loaded_order {
+        Some(OffchainOrder::Submitted { .. } | OffchainOrder::PartiallyFilled { .. }) => {
+            CliPendingReconciliation::InFlight
+        }
+        None
+        | Some(
+            OffchainOrder::Failed { .. }
+            | OffchainOrder::Pending { .. }
+            | OffchainOrder::Filled { .. },
+        ) => CliPendingReconciliation::Cleared,
+    };
+
+    reconcile_loaded_post_place_state(
+        loaded_order,
+        position_store,
+        symbol,
+        offchain_order_id,
+        CliPendingClearNextStep::ContinueThisRun,
+        stdout,
+    )
+    .await?;
+
+    Ok(outcome)
+}
+
+// Mirrors dispatch_post_place_state in the normal pipeline: inspect the
+// persisted offchain order state and clear the position pending marker on
+// failure so the normal pipeline can re-hedge on its next cycle.
+async fn reconcile_post_place_state<W: Write>(
+    offchain_order_store: &Store<OffchainOrder>,
+    position_store: &Store<Position>,
+    symbol: &Symbol,
+    offchain_order_id: OffchainOrderId,
+    stdout: &mut W,
+) -> anyhow::Result<()> {
+    let loaded_order = offchain_order_store
+        .load(&offchain_order_id)
+        .await
+        .inspect_err(|error| {
+            error!(
+                %offchain_order_id,
+                %symbol,
+                %error,
+                "Failed to load offchain order after Place; cannot determine post-broker state"
+            );
+        })?;
+
+    reconcile_loaded_post_place_state(
+        loaded_order,
+        position_store,
+        symbol,
+        offchain_order_id,
+        CliPendingClearNextStep::NormalPipelineNextCycle,
+        stdout,
+    )
+    .await
+}
+
+async fn reconcile_loaded_post_place_state<W: Write>(
+    loaded_order: Option<OffchainOrder>,
+    position_store: &Store<Position>,
+    symbol: &Symbol,
+    offchain_order_id: OffchainOrderId,
+    next_step: CliPendingClearNextStep,
+    stdout: &mut W,
+) -> anyhow::Result<()> {
+    match loaded_order {
+        Some(OffchainOrder::Failed { error, .. }) => {
+            // Broker placement failed: clear pending_offchain_order_id so the
+            // position is not permanently stuck and the normal pipeline can retry.
+            position_store
                 .send(
-                    &params.symbol,
+                    symbol,
                     PositionCommand::FailOffChainOrder {
                         offchain_order_id,
                         error,
                     },
                 )
-                .await
-            {
-                error!(
-                    %offchain_order_id,
-                    symbol = %params.symbol,
-                    %send_error,
-                    "Failed to clear the position claim after broker rejection"
-                );
-            }
+                .await?;
+            write_pending_clear_message(stdout, "Hedge placement failed", next_step)?;
         }
-        Ok(_) => {}
-        Err(error) => {
-            error!(%offchain_order_id, "Failed to place OffchainOrder: {error}");
+        Some(OffchainOrder::Submitted { .. } | OffchainOrder::PartiallyFilled { .. }) => {
+            // Order submitted to the broker. The CLI does not enqueue a live
+            // polling job; the order will be reconciled to a terminal state by
+            // the order-status recovery sweep on the next bot startup.
+            writeln!(stdout, "Trade processing completed!")?;
+        }
+        None => {
+            position_store
+                .send(
+                    symbol,
+                    PositionCommand::FailOffChainOrder {
+                        offchain_order_id,
+                        error: "Offchain order missing after Place".to_owned(),
+                    },
+                )
+                .await?;
+            write_pending_clear_message(
+                stdout,
+                "Hedge placement produced unexpected state",
+                next_step,
+            )?;
+        }
+        Some(OffchainOrder::Pending { .. } | OffchainOrder::Filled { .. }) => {
+            anyhow::bail!(
+                "offchain order {offchain_order_id} for {symbol} is in an unexpected \
+                 post-placement state; refusing to clear the position claim"
+            );
         }
     }
-
-    writeln!(stdout, "Trade processing completed!")?;
 
     Ok(())
 }
 
-/// Fails closed when the fill at `(tx_hash, log_index)` is already recorded in
-/// the `OnChainTrade` log -- in ANY state. A recorded fill has already been
-/// accounted (acknowledged), or is mid-accounting (witnessed but not yet
-/// acknowledged) by whichever path recorded it -- the automated pipeline OR a
-/// prior `process-tx` run. The `Position` now rejects an out-of-order re-drive
-/// via its persisted pending-acknowledgement set (ADR 0010), but `process-tx`
-/// still refuses a recorded fill outright rather than racing the bot for it:
-/// it only accounts fills with no `OnChainTrade` record.
-async fn refuse_if_fill_already_recorded<W: Write>(
-    onchain_trade_store: &Store<OnChainTrade>,
-    position_store: &Store<Position>,
-    onchain_trade: &OnchainTrade,
+fn write_pending_clear_message<W: Write>(
     stdout: &mut W,
+    reason: &str,
+    next_step: CliPendingClearNextStep,
 ) -> anyhow::Result<()> {
-    let trade_id = OnChainTradeId {
-        tx_hash: onchain_trade.tx_hash,
-        log_index: onchain_trade.log_index,
+    let next_step_message = match next_step {
+        CliPendingClearNextStep::ContinueThisRun => {
+            "process-tx will re-evaluate the position in this run."
+        }
+        CliPendingClearNextStep::NormalPipelineNextCycle => {
+            "The normal pipeline will re-hedge on the next cycle."
+        }
     };
-
-    let Some(recorded) = onchain_trade_store.load(&trade_id).await? else {
-        return Ok(());
-    };
-
-    if recorded.is_acknowledged() {
-        // Self-heal a marker-without-settle leak (ADR 0010): if a prior run
-        // marked this fill but crashed before pruning it from the pending set,
-        // the entry lingers. The fill is fully accounted, so prune before
-        // refusing. A no-op when already pruned.
-        execute_settle_fill(position_store, onchain_trade)
-            .await
-            .context("failed to prune the acknowledged fill from the pending set")?;
-        writeln!(
-            stdout,
-            "❌ Fill {trade_id} is already accounted; refusing to re-apply it"
-        )?;
-        anyhow::bail!(
-            "fill {trade_id} is already recorded and acknowledged in the onchain trade log; \
-             re-applying it would double-count the position. The bot already accounted this \
-             fill -- no manual processing is needed."
-        );
-    }
 
     writeln!(
         stdout,
-        "❌ Fill {trade_id} is already witnessed but not acknowledged; refusing to re-apply it"
+        "{reason}; pending order cleared. {next_step_message}"
     )?;
-    anyhow::bail!(
-        "fill {trade_id} is recorded in the onchain trade log but not yet acknowledged: a prior \
-         process-tx run or an in-flight automated job witnessed it. Re-applying it here could \
-         double-count the position. Verify whether the bot is currently accounting this symbol \
-         (if so, it will finish); otherwise reconcile the position manually -- the record cannot \
-         tell which process wrote it. process-tx only accounts fills with no onchain trade record."
-    );
-}
-
-/// Accounts an unrecorded fill through the automated pipeline's exactly-once
-/// sequence (ADR 0005 + ADR 0010): witness the fill into the `OnChainTrade`
-/// log, enrich it, drive `Position::AcknowledgeOnChainFill` (which records the
-/// fill in the position's pending-acknowledgement set in the same atomic
-/// batch), mark the trade acknowledged, then settle -- pruning the pending
-/// entry now that the marker is durable. The witness comes FIRST so a crash in
-/// the witness->acknowledge window leaves a recorded-but-unacknowledged fill
-/// that `refuse_if_fill_already_recorded` blocks on a CLI re-run. A fill that
-/// cannot be anchored to a block cannot be witnessed, so this fails closed
-/// rather than accounting it unrecorded.
-///
-/// A crash between the acknowledge and the mark leaves the fill durably in the
-/// position's pending-acknowledgement set, so a later re-drive -- even by the
-/// bot, even after a newer fill, even cross-process -- is rejected as a
-/// duplicate rather than double-counted (ADR 0010). A crash between the mark
-/// and the settle leaks one pending entry, pruned by the next re-delivery (the
-/// bot's resume skip branch) or the next CLI re-run (the refuse branch); the
-/// leak is harmless to correctness and self-heals.
-async fn account_fill_exactly_once(
-    onchain_trade_store: &Store<OnChainTrade>,
-    position_store: &Store<Position>,
-    onchain_trade: &OnchainTrade,
-    execution_threshold: ExecutionThreshold,
-) -> anyhow::Result<()> {
-    let trade_id = OnChainTradeId {
-        tx_hash: onchain_trade.tx_hash,
-        log_index: onchain_trade.log_index,
-    };
-
-    let Some(block_number) = onchain_trade.block_number else {
-        anyhow::bail!(
-            "cannot account fill {trade_id}: the transaction carries no block number, so the \
-             fill cannot be witnessed into the onchain trade log"
-        );
-    };
-    let Some(block_timestamp) = onchain_trade.block_timestamp else {
-        anyhow::bail!(
-            "cannot account fill {trade_id}: the transaction carries no block timestamp, so the \
-             fill cannot be witnessed into the onchain trade log"
-        );
-    };
-
-    execute_witness_trade(
-        onchain_trade_store,
-        onchain_trade,
-        block_number,
-        block_timestamp,
-    )
-    .await
-    .context("failed to witness the fill in the onchain trade log")?;
-    // Enrich best-effort with the gas/Pyth data already on the trade, matching
-    // the automated path: the fill is marked acknowledged below so the bot never
-    // re-processes it, making this the only chance to record its enrichment.
-    execute_enrich_trade(onchain_trade_store, onchain_trade).await;
-    execute_acknowledge_fill(
-        position_store,
-        onchain_trade,
-        execution_threshold,
-        block_timestamp,
-    )
-    .await
-    .context("failed to acknowledge the fill in the position aggregate")?;
-    execute_mark_acknowledged(onchain_trade_store, &trade_id)
-        .await
-        .context("failed to mark the fill acknowledged in the onchain trade log")?;
-    execute_settle_fill(position_store, onchain_trade)
-        .await
-        .context("failed to settle the fill acknowledgement in the position aggregate")?;
 
     Ok(())
 }
@@ -852,26 +931,70 @@ fn display_trade_details<W: Write>(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Address, address};
+    use alloy::primitives::{Address, B256, U256, address};
     use chrono::Utc;
     use httpmock::MockServer;
     use rain_math_float::Float;
     use regex::Regex;
     use serde_json::json;
+    use tokio::sync::Mutex;
     use url::Url;
     use uuid::uuid;
 
     use st0x_config::create_test_issuance_ctx;
     use st0x_config::{
-        AssetsConfig, BrokerCtx, EquitiesConfig, EvmCtx, ExecutionThreshold, IngestionCutoff,
-        LogLevel, TradingMode,
+        AssetsConfig, BrokerCtx, EquitiesConfig, EquityAssetConfig, EvmCtx, ExecutionThreshold,
+        IngestionCutoff, LogLevel, OperationMode, TradingMode,
     };
-    use st0x_execution::{AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode};
+    use st0x_execution::{
+        AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, SupportedExecutor,
+    };
 
     use super::*;
-    use crate::onchain_trade::OnChainTradeCommand;
-    use crate::position::TradeId;
-    use crate::test_utils::{OnchainTradeBuilder, positive_shares, setup_test_db};
+    use crate::bindings::IRaindexV6::{ClearConfigV2, ClearV3};
+    use crate::conductor::{
+        TradeProcessingCqrs, execute_acknowledge_fill, execute_mark_acknowledged,
+        process_queued_trade,
+    };
+    use crate::offchain::order::PollOrderStatusJobQueue;
+    use crate::onchain::trade::RaindexTradeEvent;
+    use crate::onchain_trade::{OnChainTrade as OnChainTradeCqrs, OnChainTradeCommand};
+    use crate::test_utils::{
+        OnchainTradeBuilder, get_test_order, positive_shares, setup_test_db, setup_test_pools,
+    };
+    use crate::trading::onchain::inclusion::EmittedOnChain;
+    use crate::trading::onchain::trade_accountant::TradeAccountingError;
+
+    /// `OrderPlacer` that always returns a broker error, used to drive the
+    /// `OffchainOrder::Failed` path in `process_found_trade` tests.
+    struct FailingOrderPlacer;
+
+    #[async_trait]
+    impl OrderPlacer for FailingOrderPlacer {
+        async fn place_market_order(
+            &self,
+            _order: MarketOrder,
+        ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
+            Err("broker rejected the order".into())
+        }
+    }
+
+    /// `OrderPlacer` that always returns a successful placement, used to drive
+    /// the `OffchainOrder::Submitted` happy-path in `process_found_trade` tests.
+    struct SucceedingOrderPlacer;
+
+    #[async_trait]
+    impl OrderPlacer for SucceedingOrderPlacer {
+        async fn place_market_order(
+            &self,
+            order: MarketOrder,
+        ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(OrderPlacementResult {
+                executor_order_id: ExecutorOrderId::new("test-broker-order-id"),
+                placed_shares: order.shares,
+            })
+        }
+    }
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
         AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
@@ -1415,602 +1538,1203 @@ mod tests {
         );
     }
 
-    /// A fill the bot already accounted (witnessed + acknowledged on the
-    /// `OnChainTrade` log) must be refused by `process-tx`: re-applying it
-    /// would double-count the position past the single-slot
-    /// `last_acknowledged_trade_id` guard.
-    #[tokio::test]
-    async fn process_found_trade_refuses_an_already_acknowledged_fill() {
-        let ctx = create_base_test_ctx();
-        let pool = setup_test_db().await;
-        let onchain_trade = OnchainTradeBuilder::default().build();
+    // ------------------------------------------------------------------ //
+    // ADR-0005 exactly-once fill accounting tests for process_found_trade  //
+    // ------------------------------------------------------------------ //
 
-        let base_symbol = onchain_trade.symbol.base().clone();
+    /// `process-tx` on an acknowledged fill must fail closed: output the "already
+    /// fully accounted" message, return immediately, and place NO broker order.
+    /// Position-level exposure is the normal pipeline's responsibility.
+    #[tokio::test]
+    async fn process_tx_skips_accounting_on_acknowledged_fill() {
+        let pool = setup_test_db().await;
+
+        // Enable trading so check_execution_readiness would trigger if we fell
+        // through — confirming that the early return fires before hedge placement.
+        let mut ctx = create_base_test_ctx();
+        ctx.assets.equities.symbols.insert(
+            Symbol::new("AAPL").unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: Address::ZERO,
+                tokenized_equity_derivative: Address::ZERO,
+                pyth_feed_id: None,
+                vault_ids: vec![],
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+
+        let order_placer = create_order_placer(&ctx, &pool);
+
+        let onchain_trade = OnchainTradeBuilder::default().build();
+        let block_timestamp = onchain_trade.block_timestamp.unwrap();
+
         let trade_id = OnChainTradeId {
             tx_hash: onchain_trade.tx_hash,
             log_index: onchain_trade.log_index,
         };
-        let amount = onchain_trade.amount.inner();
-        let price_usdc = onchain_trade.price.value();
-        let direction = onchain_trade.direction;
-        let block_timestamp = onchain_trade.block_timestamp.unwrap();
 
-        // Simulate the automated path having already accounted this fill.
-        let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+        // Pre-seed 1: witness + acknowledge the OnChainTrade aggregate.
+        let onchain_store = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
             .build(())
             .await
             .unwrap();
-        onchain_trade_store
+
+        onchain_store
             .send(
                 &trade_id,
                 OnChainTradeCommand::Witness {
-                    symbol: base_symbol.clone(),
-                    amount,
-                    direction,
-                    price_usdc,
+                    symbol: onchain_trade.symbol.base().clone(),
+                    amount: onchain_trade.amount.inner(),
+                    direction: onchain_trade.direction,
+                    price_usdc: onchain_trade.price.value(),
                     block_number: 1,
                     block_timestamp,
                 },
             )
             .await
             .unwrap();
-        onchain_trade_store
+
+        onchain_store
             .send(&trade_id, OnChainTradeCommand::Acknowledge)
             .await
             .unwrap();
 
-        let order_placer = create_order_placer(&ctx, &pool);
-        let mut stdout = Vec::new();
-        let error = process_found_trade(onchain_trade, &ctx, &pool, &mut stdout, order_placer)
-            .await
-            .unwrap_err();
-
-        assert_eq!(
-            error.to_string(),
-            format!(
-                "fill {trade_id} is already recorded and acknowledged in the onchain trade log; \
-                 re-applying it would double-count the position. The bot already accounted this \
-                 fill -- no manual processing is needed."
-            ),
-        );
-
-        // The position must never have been touched -- the fill is not
-        // re-counted.
-        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-        assert!(
-            projection.load(&base_symbol).await.unwrap().is_none(),
-            "an already-accounted fill must not create or mutate the position",
-        );
-    }
-
-    /// A fill the bot witnessed but has not yet acknowledged (the ADR-0005 crash
-    /// window between the position write and its acknowledgement marker) is owned
-    /// by the automated pipeline. process-tx must refuse it -- the single-slot
-    /// position guard cannot dedupe an out-of-order re-application once a newer
-    /// fill advanced the slot, so re-applying would double-count.
-    #[tokio::test]
-    async fn process_found_trade_refuses_a_witnessed_but_unacknowledged_fill() {
-        let ctx = create_base_test_ctx();
-        let pool = setup_test_db().await;
-        let onchain_trade = OnchainTradeBuilder::default().build();
-
-        let base_symbol = onchain_trade.symbol.base().clone();
-        let trade_id = OnChainTradeId {
-            tx_hash: onchain_trade.tx_hash,
-            log_index: onchain_trade.log_index,
-        };
-        let amount = onchain_trade.amount.inner();
-        let price_usdc = onchain_trade.price.value();
-        let direction = onchain_trade.direction;
-        let block_timestamp = onchain_trade.block_timestamp.unwrap();
-
-        // Witness only -- no Acknowledge: the crash-window state.
-        let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-        onchain_trade_store
-            .send(
-                &trade_id,
-                OnChainTradeCommand::Witness {
-                    symbol: base_symbol.clone(),
-                    amount,
-                    direction,
-                    price_usdc,
-                    block_number: 1,
-                    block_timestamp,
-                },
-            )
-            .await
-            .unwrap();
-
-        let order_placer = create_order_placer(&ctx, &pool);
-        let mut stdout = Vec::new();
-        let error = process_found_trade(onchain_trade, &ctx, &pool, &mut stdout, order_placer)
-            .await
-            .unwrap_err();
-
-        assert_eq!(
-            error.to_string(),
-            format!(
-                "fill {trade_id} is recorded in the onchain trade log but not yet acknowledged: \
-                 a prior process-tx run or an in-flight automated job witnessed it. Re-applying \
-                 it here could double-count the position. Verify whether the bot is currently \
-                 accounting this symbol (if so, it will finish); otherwise reconcile the position \
-                 manually -- the record cannot tell which process wrote it. process-tx only \
-                 accounts fills with no onchain trade record."
-            ),
-        );
-
-        // The position must never have been touched.
-        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-        assert!(
-            projection.load(&base_symbol).await.unwrap().is_none(),
-            "a witnessed-but-unacknowledged fill must not create or mutate the position",
-        );
-    }
-
-    /// A fill with no prior `OnChainTrade` record is the normal `process-tx`
-    /// recovery case and must still be accounted into the position.
-    #[tokio::test]
-    async fn process_found_trade_accounts_a_fill_not_yet_recorded() {
-        let ctx = create_base_test_ctx();
-        let pool = setup_test_db().await;
-        let onchain_trade = OnchainTradeBuilder::default().build();
-
-        let base_symbol = onchain_trade.symbol.base().clone();
-        let expected_net = onchain_trade.amount;
-        let trade_id = OnChainTradeId {
-            tx_hash: onchain_trade.tx_hash,
-            log_index: onchain_trade.log_index,
-        };
-
-        let order_placer = create_order_placer(&ctx, &pool);
-        let mut stdout = Vec::new();
-        process_found_trade(onchain_trade, &ctx, &pool, &mut stdout, order_placer)
-            .await
-            .unwrap();
-
-        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-        let view = projection.load(&base_symbol).await.unwrap().unwrap();
-        assert_eq!(
-            view.net, expected_net,
-            "an unrecorded fill must still be accounted into the position",
-        );
-
-        // process-tx records the fill in the OnChainTrade log via the exactly-once
-        // witness -> acknowledge -> mark pair, so a re-run is refused instead of
-        // double-counted (and the bot's later pickup of the same fill skips it as
-        // already acknowledged).
-        let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-        let recorded = onchain_trade_store
-            .load(&trade_id)
-            .await
-            .unwrap()
-            .expect("process-tx must witness the fill into the OnChainTrade log");
-        assert!(
-            recorded.is_acknowledged(),
-            "the witnessed fill must be marked acknowledged",
-        );
-    }
-
-    /// The exactly-once sequence prunes its own pending-acknowledgement entry:
-    /// after a successful `process-tx` run the set is empty (SETTLE ran),
-    /// keeping the set bounded (ADR 0010).
-    #[tokio::test]
-    async fn account_fill_exactly_once_leaves_pending_set_empty() {
-        let ctx = create_base_test_ctx();
-        let pool = setup_test_db().await;
-        let onchain_trade = OnchainTradeBuilder::default().build();
-        let base_symbol = onchain_trade.symbol.base().clone();
-
-        let mut stdout = Vec::new();
-        process_found_trade(
-            onchain_trade,
-            &ctx,
-            &pool,
-            &mut stdout,
-            create_order_placer(&ctx, &pool),
-        )
-        .await
-        .unwrap();
-
-        let (position_store, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-        let position = position_store
-            .load(&base_symbol)
-            .await
-            .unwrap()
-            .expect("the position exists after accounting the fill");
-        assert!(
-            position.pending_acknowledged_trade_ids.is_empty(),
-            "SETTLE must prune the entry, leaving the pending set empty; got: {:?}",
-            position.pending_acknowledged_trade_ids,
-        );
-    }
-
-    /// A CLI crash between MARK and SETTLE leaks one pending-acknowledgement
-    /// entry. The next `process-tx` re-run on that fill refuses it (already
-    /// accounted) AND prunes the leak, so the set self-heals and stays bounded
-    /// (ADR 0010).
-    #[tokio::test]
-    async fn cli_rerun_on_acknowledged_fill_prunes_leak() {
-        let ctx = create_base_test_ctx();
-        let pool = setup_test_db().await;
-        let onchain_trade = OnchainTradeBuilder::default().build();
-        let base_symbol = onchain_trade.symbol.base().clone();
-        let block_number = onchain_trade
-            .block_number
-            .expect("builder default carries a block number");
-        let block_timestamp = onchain_trade
-            .block_timestamp
-            .expect("builder default carries a block timestamp");
-        let trade_id = OnChainTradeId {
-            tx_hash: onchain_trade.tx_hash,
-            log_index: onchain_trade.log_index,
-        };
-        let position_trade_id = TradeId {
-            tx_hash: onchain_trade.tx_hash,
-            log_index: onchain_trade.log_index,
-        };
-
-        let (position_store, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-        let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+        // Pre-seed 2: apply the fill to the Position aggregate so there is live
+        // unhedged exposure that could trigger hedge placement if we fell through.
+        let (pre_position_store, _) = StoreBuilder::<Position>::new(pool.clone())
             .build(())
             .await
             .unwrap();
 
-        // Simulate a crash between MARK and SETTLE: witness, acknowledge, and
-        // mark the fill, but never settle -- leaving its entry in the set.
-        execute_witness_trade(
-            &onchain_trade_store,
-            &onchain_trade,
-            block_number,
-            block_timestamp,
-        )
-        .await
-        .unwrap();
         execute_acknowledge_fill(
-            &position_store,
+            &pre_position_store,
             &onchain_trade,
             ctx.execution_threshold,
             block_timestamp,
         )
         .await
         .unwrap();
-        execute_mark_acknowledged(&onchain_trade_store, &trade_id)
+
+        let mut stdout = Vec::new();
+        process_found_trade(onchain_trade, &ctx, &pool, &mut stdout, order_placer)
             .await
             .unwrap();
 
-        let leaked = position_store
-            .load(&base_symbol)
-            .await
-            .unwrap()
-            .expect("the position exists");
+        let output = String::from_utf8(stdout).unwrap();
         assert!(
-            leaked
-                .pending_acknowledged_trade_ids
-                .contains(&position_trade_id),
-            "premise: the un-settled fill leaks into the pending set",
+            output.contains("already fully accounted"),
+            "acknowledged fill must output the already-accounted message, got: {output}"
         );
 
-        // Re-run process-tx on the now-acknowledged fill: it must refuse AND
-        // prune the leaked entry.
-        let mut stdout = Vec::new();
-        let error = process_found_trade(
-            onchain_trade,
-            &ctx,
-            &pool,
-            &mut stdout,
-            create_order_placer(&ctx, &pool),
-        )
-        .await
-        .unwrap_err();
+        // No second OnChainOrderFilled event: the pre-seeded fill must not be
+        // re-counted by the re-run.
+        let (fill_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
         assert_eq!(
-            error.to_string(),
-            format!(
-                "fill {trade_id} is already recorded and acknowledged in the onchain trade log; \
-                 re-applying it would double-count the position. The bot already accounted this \
-                 fill -- no manual processing is needed."
-            ),
+            fill_count, 1,
+            "re-running process-tx on an acknowledged fill must not emit a second fill event"
         );
 
-        let healed = position_store
-            .load(&base_symbol)
-            .await
-            .unwrap()
-            .expect("the position exists");
-        assert!(
-            healed.pending_acknowledged_trade_ids.is_empty(),
-            "the refuse path must prune the leaked entry; got: {:?}",
-            healed.pending_acknowledged_trade_ids,
+        // No OffchainOrder placed: fail-closed must not place a spurious hedge
+        // driven by the live position exposure.
+        let (order_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM events WHERE event_type LIKE 'OffchainOrderEvent%'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            order_count, 0,
+            "re-running process-tx on an acknowledged fill must place no broker order"
         );
     }
 
-    /// process-tx is idempotent on a bot-missed fill: the first run witnesses,
-    /// acknowledges, and marks it; a second run on the same fill is refused (it is
-    /// now recorded + acknowledged) and the net is unchanged -- not double-counted.
+    /// `process-tx` must resume the acknowledge step when the fill was witnessed
+    /// but not yet acknowledged (crash-recovery window). After the call, the
+    /// `OnChainTrade` record must be acknowledged and exactly one position fill
+    /// event must exist. Trading is disabled in this test context so hedge
+    /// placement is not reached.
     #[tokio::test]
-    async fn process_found_trade_is_idempotent_on_a_bot_missed_fill() {
-        let ctx = create_base_test_ctx();
+    async fn process_tx_resumes_witnessed_but_unacknowledged_fill() {
         let pool = setup_test_db().await;
-        let onchain_trade = OnchainTradeBuilder::default().build();
-        let base_symbol = onchain_trade.symbol.base().clone();
-        let expected_net = onchain_trade.amount;
+        let ctx = create_base_test_ctx();
+        let order_placer = create_order_placer(&ctx, &pool);
+
+        let onchain_trade = OnchainTradeBuilder::default().with_block_number(1).build();
+        let block_timestamp = onchain_trade.block_timestamp.unwrap();
+
         let trade_id = OnChainTradeId {
             tx_hash: onchain_trade.tx_hash,
             log_index: onchain_trade.log_index,
         };
 
-        // First run accounts the previously-unrecorded fill.
-        let mut first = Vec::new();
-        process_found_trade(
-            onchain_trade.clone(),
-            &ctx,
-            &pool,
-            &mut first,
-            create_order_placer(&ctx, &pool),
-        )
-        .await
-        .unwrap();
-
-        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+        // Pre-seed: witness only (not acknowledged — simulates crash window).
+        let store = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
             .build(())
             .await
             .unwrap();
-        let net_after_first = projection.load(&base_symbol).await.unwrap().unwrap().net;
-        assert_eq!(net_after_first, expected_net);
 
-        // Second run on the same fill is refused -- now recorded + acknowledged.
-        let mut second = Vec::new();
-        let error = process_found_trade(
-            onchain_trade,
-            &ctx,
-            &pool,
-            &mut second,
-            create_order_placer(&ctx, &pool),
-        )
-        .await
-        .unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            format!(
-                "fill {trade_id} is already recorded and acknowledged in the onchain trade log; \
-                 re-applying it would double-count the position. The bot already accounted this \
-                 fill -- no manual processing is needed."
-            ),
-        );
-
-        // The net is unchanged -- the fill was not counted a second time.
-        let net_after_second = projection.load(&base_symbol).await.unwrap().unwrap().net;
-        assert_eq!(
-            net_after_second, net_after_first,
-            "a re-run on an already-accounted fill must not double-count",
-        );
-    }
-
-    /// The motivating financial failure mode: fill A is fully accounted, then a
-    /// newer fill B advances the position's single-slot `last_acknowledged_trade_id`.
-    /// Re-running process-tx on A must still be refused -- the position guard alone
-    /// no longer recognizes A (its slot points at B), so without the OnChainTrade
-    /// witness check A would be counted a second time.
-    #[tokio::test]
-    async fn process_found_trade_refuses_acknowledged_fill_after_a_newer_fill() {
-        let ctx = create_base_test_ctx();
-        let pool = setup_test_db().await;
-        let fill_a = OnchainTradeBuilder::default().with_log_index(1).build();
-        let fill_b = OnchainTradeBuilder::default().with_log_index(2).build();
-
-        let base_symbol = fill_a.symbol.base().clone();
-        let trade_id_a = OnChainTradeId {
-            tx_hash: fill_a.tx_hash,
-            log_index: fill_a.log_index,
-        };
-
-        // Fully account A on the OnChainTrade log (witness + acknowledge).
-        let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-        onchain_trade_store
+        store
             .send(
-                &trade_id_a,
+                &trade_id,
                 OnChainTradeCommand::Witness {
-                    symbol: base_symbol.clone(),
-                    amount: fill_a.amount.inner(),
-                    direction: fill_a.direction,
-                    price_usdc: fill_a.price.value(),
+                    symbol: onchain_trade.symbol.base().clone(),
+                    amount: onchain_trade.amount.inner(),
+                    direction: onchain_trade.direction,
+                    price_usdc: onchain_trade.price.value(),
                     block_number: 1,
-                    block_timestamp: fill_a.block_timestamp.unwrap(),
+                    block_timestamp,
                 },
             )
             .await
             .unwrap();
-        onchain_trade_store
-            .send(&trade_id_a, OnChainTradeCommand::Acknowledge)
-            .await
-            .unwrap();
 
-        // Apply A then the newer B to the position, so its single slot points at B.
-        let (position_store, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-        for fill in [&fill_a, &fill_b] {
-            position_store
-                .send(
-                    &base_symbol,
-                    PositionCommand::AcknowledgeOnChainFill {
-                        symbol: base_symbol.clone(),
-                        threshold: ExecutionThreshold::whole_share(),
-                        trade_id: TradeId {
-                            tx_hash: fill.tx_hash,
-                            log_index: fill.log_index,
-                        },
-                        amount: fill.amount,
-                        direction: fill.direction,
-                        price_usdc: fill.price.value(),
-                        block_timestamp: fill.block_timestamp.unwrap(),
-                    },
-                )
-                .await
-                .unwrap();
-        }
-        let net_before = projection.load(&base_symbol).await.unwrap().unwrap().net;
+        // Call process_found_trade: must resume and complete the acknowledge step.
+        process_found_trade(
+            onchain_trade,
+            &ctx,
+            &pool,
+            &mut std::io::sink(),
+            order_placer,
+        )
+        .await
+        .unwrap();
 
-        // Re-run process-tx on the older fill A: the position slot points at B, but
-        // A is acknowledged on the OnChainTrade log, so it must be refused.
-        let order_placer = create_order_placer(&ctx, &pool);
-        let mut stdout = Vec::new();
-        let error = process_found_trade(fill_a, &ctx, &pool, &mut stdout, order_placer)
-            .await
-            .unwrap_err();
-
-        assert_eq!(
-            error.to_string(),
-            format!(
-                "fill {trade_id_a} is already recorded and acknowledged in the onchain trade log; \
-                 re-applying it would double-count the position. The bot already accounted this \
-                 fill -- no manual processing is needed."
-            ),
-        );
-
-        // The net must be unchanged -- A was not counted a second time.
-        let net_after = projection.load(&base_symbol).await.unwrap().unwrap().net;
-        assert_eq!(
-            net_after, net_before,
-            "re-running process-tx on an older acknowledged fill must not change the net",
-        );
-
-        // The refuse path self-heals a marker-without-settle leak: A is
-        // acknowledged on the OnChainTrade log, so refuse_if_fill_already_recorded
-        // prunes A from the position's pending-acknowledgement set before bailing,
-        // leaving the still-in-flight newer fill B untouched (ADR 0010).
-        let pending = position_store
-            .load(&base_symbol)
+        // Verify the trade is now fully acknowledged.
+        let state = store
+            .load(&trade_id)
             .await
             .unwrap()
-            .expect("position exists after applying A and B")
-            .pending_acknowledged_trade_ids;
+            .expect("OnChainTrade record must exist after resume");
         assert!(
-            !pending.contains(&TradeId {
-                tx_hash: trade_id_a.tx_hash,
-                log_index: trade_id_a.log_index,
-            }),
-            "refusing an acknowledged fill must prune it from the pending set (self-heal)",
+            state.is_acknowledged(),
+            "Fill must be acknowledged after process_found_trade resumes the crash-recovery path"
         );
-        assert!(
-            pending.contains(&TradeId {
-                tx_hash: fill_b.tx_hash,
-                log_index: fill_b.log_index,
-            }),
-            "the untouched newer fill B must remain in the pending set",
+
+        // Exactly one OnChainOrderFilled event must exist — the fill accounting
+        // ran once during resume, not zero times (dropped) or twice (double-counted).
+        let (fill_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            fill_count, 1,
+            "Resume must apply exactly one fill to the position aggregate"
         );
     }
 
-    /// A fill that cannot be anchored to a block must not be silently accounted
-    /// unrecorded: account_fill_exactly_once fails closed on a missing block
-    /// number (the fill cannot be witnessed into the onchain trade log).
+    /// `process-tx` on a genuinely new fill must witness it in the
+    /// `OnChainTrade` aggregate, acknowledge it in the `Position` aggregate,
+    /// and mark it acknowledged — leaving exactly one position fill event.
     #[tokio::test]
-    async fn process_found_trade_fails_closed_when_block_number_absent() {
-        let ctx = create_base_test_ctx();
+    async fn process_tx_witnesses_and_acknowledges_new_fill() {
         let pool = setup_test_db().await;
+        let ctx = create_base_test_ctx();
+        let order_placer = create_order_placer(&ctx, &pool);
+
+        // block_number is required for the Witness step on a new fill.
+        let onchain_trade = OnchainTradeBuilder::default().with_block_number(42).build();
+
+        let trade_id = OnChainTradeId {
+            tx_hash: onchain_trade.tx_hash,
+            log_index: onchain_trade.log_index,
+        };
+
+        process_found_trade(
+            onchain_trade,
+            &ctx,
+            &pool,
+            &mut std::io::sink(),
+            order_placer,
+        )
+        .await
+        .unwrap();
+
+        // The OnChainTrade aggregate must be acknowledged.
+        let store = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let state = store
+            .load(&trade_id)
+            .await
+            .unwrap()
+            .expect("OnChainTrade record must exist after processing a new fill");
+        assert!(
+            state.is_acknowledged(),
+            "Fill must be acknowledged in the OnChainTrade aggregate"
+        );
+
+        // Exactly one OnChainOrderFilled position event must be in the DB.
+        let (fill_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            fill_count, 1,
+            "Exactly one fill must be applied to the position for a new fill"
+        );
+    }
+
+    /// After the CLI applies a fill via `process_found_trade`, the normal
+    /// pipeline re-detecting the same fill (via `process_queued_trade`) must
+    /// return `Ok(None)` — skipping cleanly — and must NOT emit a second
+    /// `OnChainOrderFilled` event. This is the primary double-count guard test.
+    #[tokio::test]
+    async fn process_tx_then_normal_path_does_not_double_count() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let ctx = create_base_test_ctx();
+        let order_placer = create_order_placer(&ctx, &pool);
+
+        let onchain_trade = OnchainTradeBuilder::default().with_block_number(42).build();
+
+        // Step 1: CLI applies the fill.
+        process_found_trade(
+            onchain_trade.clone(),
+            &ctx,
+            &pool,
+            &mut std::io::sink(),
+            order_placer.clone(),
+        )
+        .await
+        .unwrap();
+
+        // Step 2: Construct TradeProcessingCqrs backed by the same pool so the
+        // acknowledged OnChainTrade record written by the CLI is visible.
+        let onchain_trade_store = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position_store, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (offchain_order_store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let cqrs = TradeProcessingCqrs {
+            pool: pool.clone(),
+            onchain_trade: onchain_trade_store,
+            position: position_store,
+            position_projection,
+            offchain_order: offchain_order_store,
+            order_placer,
+            execution_threshold: ExecutionThreshold::whole_share(),
+            assets: AssetsConfig {
+                equities: EquitiesConfig::default(),
+                cash: None,
+            },
+            counter_trade_submission_lock: Arc::new(Mutex::new(())),
+            poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
+        };
+
+        // The trade_event payload is never accessed because process_queued_trade
+        // returns Ok(None) immediately at the is_acknowledged() guard, before
+        // reaching the witness step that would use block_number.
+        let trade_event = EmittedOnChain {
+            event: RaindexTradeEvent::ClearV3(Box::new(ClearV3 {
+                sender: alloy::primitives::Address::ZERO,
+                alice: get_test_order(),
+                bob: get_test_order(),
+                clearConfig: ClearConfigV2 {
+                    aliceInputIOIndex: U256::ZERO,
+                    aliceOutputIOIndex: U256::ZERO,
+                    bobInputIOIndex: U256::ZERO,
+                    bobOutputIOIndex: U256::ZERO,
+                    aliceBountyVaultId: B256::ZERO,
+                    bobBountyVaultId: B256::ZERO,
+                },
+            })),
+            tx_hash: onchain_trade.tx_hash,
+            log_index: onchain_trade.log_index,
+            block_number: 42,
+            block_timestamp: onchain_trade.block_timestamp,
+        };
+
+        // Step 3: Normal pipeline re-detects the same fill.
+        let result = process_queued_trade(
+            &st0x_execution::MockExecutor::new(),
+            &trade_event,
+            onchain_trade,
+            &cqrs,
+            true,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result, None,
+            "Normal pipeline must skip an already-acknowledged fill"
+        );
+
+        // Exactly one OnChainOrderFilled position event: CLI + pipeline together
+        // must not double-count.
+        let (fill_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            fill_count, 1,
+            "CLI then normal pipeline must produce exactly one position fill event, not two"
+        );
+    }
+
+    /// A new fill with no `block_number` must return an error containing
+    /// "missing block_number" so the operator sees a loud failure rather than
+    /// a silent skip.
+    #[tokio::test]
+    async fn process_tx_fails_on_missing_block_number() {
+        let pool = setup_test_db().await;
+        let ctx = create_base_test_ctx();
+        let order_placer = create_order_placer(&ctx, &pool);
+
         let onchain_trade = OnchainTradeBuilder::default()
             .with_block_number(None)
             .build();
-        let base_symbol = onchain_trade.symbol.base().clone();
-        let trade_id = OnChainTradeId {
-            tx_hash: onchain_trade.tx_hash,
-            log_index: onchain_trade.log_index,
-        };
 
-        let mut stdout = Vec::new();
         let error = process_found_trade(
             onchain_trade,
             &ctx,
             &pool,
-            &mut stdout,
-            create_order_placer(&ctx, &pool),
+            &mut std::io::sink(),
+            order_placer,
         )
         .await
         .unwrap_err();
 
-        assert_eq!(
-            error.to_string(),
-            format!(
-                "cannot account fill {trade_id}: the transaction carries no block number, so the \
-                 fill cannot be witnessed into the onchain trade log"
-            ),
-        );
-
-        // Fail-closed before any write: no position, no witness.
-        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
         assert!(
-            projection.load(&base_symbol).await.unwrap().is_none(),
-            "a fill that cannot be witnessed must not touch the position",
+            error.to_string().contains("missing block_number"),
+            "missing block_number must produce an explicit error, got: {error}"
         );
     }
 
-    /// Symmetric fail-closed guard for a missing block timestamp.
+    /// A new fill with no `block_timestamp` must return an error so the operator
+    /// sees a loud failure rather than a silent skip.
     #[tokio::test]
-    async fn process_found_trade_fails_closed_when_block_timestamp_absent() {
-        let ctx = create_base_test_ctx();
+    async fn process_tx_fails_on_missing_block_timestamp() {
         let pool = setup_test_db().await;
+        let ctx = create_base_test_ctx();
+        let order_placer = create_order_placer(&ctx, &pool);
+
+        // block_number is set so the new-fill branch is reached; block_timestamp
+        // is None so the bail fires before the witness step.
         let onchain_trade = OnchainTradeBuilder::default()
+            .with_block_number(42)
             .with_block_timestamp(None)
             .build();
-        let base_symbol = onchain_trade.symbol.base().clone();
+        let expected_trade_id = OnChainTradeId {
+            tx_hash: onchain_trade.tx_hash,
+            log_index: onchain_trade.log_index,
+        };
+
+        let error = process_found_trade(
+            onchain_trade,
+            &ctx,
+            &pool,
+            &mut std::io::sink(),
+            order_placer,
+        )
+        .await
+        .unwrap_err();
+
+        let trade_accounting_error = error
+            .downcast_ref::<TradeAccountingError>()
+            .expect("missing block_timestamp should bubble up as TradeAccountingError");
+        assert!(
+            matches!(
+                trade_accounting_error,
+                TradeAccountingError::MissingBlockTimestamp { trade_id }
+                    if trade_id == &expected_trade_id
+            ),
+            "missing block_timestamp must produce \
+             TradeAccountingError::MissingBlockTimestamp for {expected_trade_id}, \
+             got: {trade_accounting_error}"
+        );
+    }
+
+    /// When broker placement fails (resulting in `OffchainOrder::Failed`),
+    /// `process_found_trade` must send `PositionCommand::FailOffChainOrder` to
+    /// clear `pending_offchain_order_id`, leaving the position unpending so
+    /// the normal pipeline can re-hedge on its next cycle.
+    #[tokio::test]
+    async fn process_tx_clears_pending_order_on_failed_placement() {
+        let pool = setup_test_db().await;
+
+        // Enable trading so check_execution_readiness can trigger hedge placement.
+        let mut ctx = create_base_test_ctx();
+        ctx.assets.equities.symbols.insert(
+            Symbol::new("AAPL").unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: Address::ZERO,
+                tokenized_equity_derivative: Address::ZERO,
+                pyth_feed_id: None,
+                vault_ids: vec![],
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+
+        let order_placer: Arc<dyn OrderPlacer> = Arc::new(FailingOrderPlacer);
+        let onchain_trade = OnchainTradeBuilder::default().with_block_number(42).build();
+
+        let mut stdout = Vec::new();
+        process_found_trade(onchain_trade, &ctx, &pool, &mut stdout, order_placer)
+            .await
+            .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("Hedge placement failed"),
+            "failed placement must report the outcome to the operator, got: {output}"
+        );
+        assert!(
+            output.contains("The normal pipeline will re-hedge on the next cycle."),
+            "post-place cleanup should defer re-hedging to the normal pipeline, got: {output}"
+        );
+
+        // pending_offchain_order_id must be cleared: the position must not be
+        // permanently stuck after a failed broker placement.
+        let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let position = position_store
+            .load(&Symbol::new("AAPL").unwrap())
+            .await
+            .unwrap()
+            .expect("Position must exist after fill accounting");
+
+        assert!(
+            position.pending_offchain_order_id.is_none(),
+            "pending_offchain_order_id must be cleared after a failed broker placement"
+        );
+    }
+
+    #[tokio::test]
+    async fn existing_pending_cleanup_reports_process_tx_continues_this_run() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let block_timestamp = Utc::now();
+
+        let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let onchain_trade = OnchainTradeBuilder::default()
+            .with_block_number(42)
+            .with_block_timestamp(Some(block_timestamp))
+            .build();
+
+        execute_acknowledge_fill(
+            &position_store,
+            &onchain_trade,
+            ExecutionThreshold::whole_share(),
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+
+        position_store
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares: positive_shares("1"),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let failed_order = OffchainOrder::Failed {
+            symbol: symbol.clone(),
+            shares: positive_shares("1"),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            error: "previous placement failed".to_string(),
+            placed_at: block_timestamp,
+            failed_at: block_timestamp,
+        };
+
+        let mut stdout = Vec::new();
+        reconcile_loaded_post_place_state(
+            Some(failed_order),
+            &position_store,
+            &symbol,
+            offchain_order_id,
+            CliPendingClearNextStep::ContinueThisRun,
+            &mut stdout,
+        )
+        .await
+        .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("process-tx will re-evaluate the position in this run."),
+            "existing pending cleanup should report that process-tx continues, got: {output}"
+        );
+        assert!(
+            !output.contains("normal pipeline"),
+            "existing pending cleanup should not imply re-hedging waits for the normal pipeline, \
+             got: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_tx_clears_pending_order_when_post_place_order_missing() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let onchain_trade = OnchainTradeBuilder::default().with_block_number(42).build();
+        let block_timestamp = onchain_trade
+            .block_timestamp
+            .expect("test trade should have a block timestamp");
+
+        let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (offchain_order_store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        execute_acknowledge_fill(
+            &position_store,
+            &onchain_trade,
+            ExecutionThreshold::whole_share(),
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+
+        position_store
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares: positive_shares("1"),
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut stdout = Vec::new();
+        reconcile_post_place_state(
+            &offchain_order_store,
+            &position_store,
+            &symbol,
+            offchain_order_id,
+            &mut stdout,
+        )
+        .await
+        .unwrap();
+
+        let position = position_store
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist after setup");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "missing OffchainOrder state must clear the position's pending id"
+        );
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("pending order cleared"),
+            "missing order cleanup must report the cleared pending marker, got: {output}"
+        );
+    }
+
+    /// When a second client shares the same pool and witnesses the fill first,
+    /// `process_found_trade` must resume the acknowledge step and complete it —
+    /// not silently drop the fill. The fill must be accounted exactly once.
+    ///
+    /// This covers the concurrent-witnessed sub-path: the outer load sees
+    /// `Some(Witnessed)` from the peer writer's record and resumes.
+    #[tokio::test]
+    async fn process_tx_concurrent_witness_resumes_acknowledge() {
+        let pool = setup_test_db().await;
+        let ctx = create_base_test_ctx();
+        let order_placer = create_order_placer(&ctx, &pool);
+
+        let onchain_trade = OnchainTradeBuilder::default().with_block_number(42).build();
+        let block_timestamp = onchain_trade.block_timestamp.unwrap();
+
         let trade_id = OnChainTradeId {
             tx_hash: onchain_trade.tx_hash,
             log_index: onchain_trade.log_index,
         };
 
-        let mut stdout = Vec::new();
-        let error = process_found_trade(
-            onchain_trade,
-            &ctx,
-            &pool,
-            &mut stdout,
-            create_order_placer(&ctx, &pool),
-        )
-        .await
-        .unwrap_err();
-
-        assert_eq!(
-            error.to_string(),
-            format!(
-                "cannot account fill {trade_id}: the transaction carries no block timestamp, so \
-                 the fill cannot be witnessed into the onchain trade log"
-            ),
-        );
-
-        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+        // Simulate a concurrent writer (e.g. the normal pipeline) that witnesses
+        // the fill via its own store instance backed by the same pool. When
+        // process_found_trade's internal store loads the aggregate, it will see
+        // Some(Witnessed) and resume rather than re-witness.
+        let store_a = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
             .build(())
             .await
             .unwrap();
+
+        store_a
+            .send(
+                &trade_id,
+                OnChainTradeCommand::Witness {
+                    symbol: onchain_trade.symbol.base().clone(),
+                    amount: onchain_trade.amount.inner(),
+                    direction: onchain_trade.direction,
+                    price_usdc: onchain_trade.price.value(),
+                    block_number: 42,
+                    block_timestamp,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Call process_found_trade: must resume the acknowledge step and complete
+        // it rather than silently dropping the fill.
+        process_found_trade(
+            onchain_trade,
+            &ctx,
+            &pool,
+            &mut std::io::sink(),
+            order_placer,
+        )
+        .await
+        .unwrap();
+
+        // The trade must be fully acknowledged after the resume.
+        let state = store_a
+            .load(&trade_id)
+            .await
+            .unwrap()
+            .expect("OnChainTrade record must exist after concurrent resume");
         assert!(
-            projection.load(&base_symbol).await.unwrap().is_none(),
-            "a fill that cannot be witnessed must not touch the position",
+            state.is_acknowledged(),
+            "Fill must be acknowledged after process_found_trade resumes from concurrent witness"
+        );
+
+        // Exactly one fill event: the concurrent write-then-resume must not
+        // double-count or drop the fill.
+        let (fill_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            fill_count, 1,
+            "Concurrent witness + resume must apply exactly one fill to the position"
+        );
+    }
+
+    /// When a concurrent writer has already fully acknowledged the fill,
+    /// `process_found_trade` must fail closed: return early without placing a
+    /// hedge or emitting a second fill event.
+    ///
+    /// This covers the concurrent-acknowledged sub-path: the outer load sees
+    /// `Some(Acknowledged)` from the peer writer's record and exits immediately.
+    #[tokio::test]
+    async fn process_tx_concurrent_acknowledged_fails_closed() {
+        let pool = setup_test_db().await;
+
+        // Enable trading so that if we fell through to hedge placement we would
+        // know — confirming the early return fires before any of that.
+        let mut ctx = create_base_test_ctx();
+        ctx.assets.equities.symbols.insert(
+            Symbol::new("AAPL").unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: Address::ZERO,
+                tokenized_equity_derivative: Address::ZERO,
+                pyth_feed_id: None,
+                vault_ids: vec![],
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+
+        let order_placer = create_order_placer(&ctx, &pool);
+
+        let onchain_trade = OnchainTradeBuilder::default().with_block_number(42).build();
+        let block_timestamp = onchain_trade.block_timestamp.unwrap();
+
+        let trade_id = OnChainTradeId {
+            tx_hash: onchain_trade.tx_hash,
+            log_index: onchain_trade.log_index,
+        };
+
+        // Simulate a concurrent writer that has fully processed the fill.
+        let store_a = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        store_a
+            .send(
+                &trade_id,
+                OnChainTradeCommand::Witness {
+                    symbol: onchain_trade.symbol.base().clone(),
+                    amount: onchain_trade.amount.inner(),
+                    direction: onchain_trade.direction,
+                    price_usdc: onchain_trade.price.value(),
+                    block_number: 42,
+                    block_timestamp,
+                },
+            )
+            .await
+            .unwrap();
+
+        store_a
+            .send(&trade_id, OnChainTradeCommand::Acknowledge)
+            .await
+            .unwrap();
+
+        // Apply the fill to the position so there is live unhedged exposure that
+        // could trigger hedge placement if we fell through.
+        let (pre_position_store, _) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        execute_acknowledge_fill(
+            &pre_position_store,
+            &onchain_trade,
+            ctx.execution_threshold,
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+
+        let mut stdout = Vec::new();
+        process_found_trade(onchain_trade, &ctx, &pool, &mut stdout, order_placer)
+            .await
+            .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("already fully accounted"),
+            "concurrent-acknowledged fill must output the already-accounted message, got: {output}"
+        );
+
+        // No second fill event and no spurious hedge order from the concurrent path.
+        let (fill_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            fill_count, 1,
+            "Concurrent acknowledged + second process-tx must not emit a second fill event"
+        );
+
+        let (order_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM events WHERE event_type LIKE 'OffchainOrderEvent%'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            order_count, 0,
+            "Fail-closed on concurrent-acknowledged fill must place no broker order"
+        );
+    }
+
+    /// Regression test for the crash-window double-count bug:
+    ///
+    /// 1. Fill A is witnessed and acknowledged in Position (slot = A), but the
+    ///    process crashes BEFORE `mark_acknowledged` runs — OnChainTrade A stays
+    ///    Witnessed.
+    /// 2. Fill B arrives and is fully processed (slot advances to B).
+    /// 3. `process-tx` is retried for A.
+    ///
+    /// Without the durable `position_fill_already_recorded` guard, the resume
+    /// path would call `execute_acknowledge_fill(A)` again. Because the slot now
+    /// holds B (not A), `PositionError::DuplicateTrade` does NOT fire and A is
+    /// counted a second time — corrupting the net position.
+    ///
+    /// After the fix, the retry must:
+    /// - Apply fill A exactly once (total fill events = 2: one A + one B).
+    /// - Mark OnChainTrade A acknowledged.
+    #[tokio::test]
+    async fn process_tx_does_not_double_count_witnessed_fill_after_newer_fill_acknowledged() {
+        let pool = setup_test_db().await;
+        let ctx = create_base_test_ctx();
+        let order_placer = create_order_placer(&ctx, &pool);
+
+        // Fill A and fill B: same tx_hash, different log_index so they have
+        // distinct (tx_hash, log_index) identities.
+        let fill_a = OnchainTradeBuilder::default().with_block_number(10).build();
+        let fill_b = OnchainTradeBuilder::default()
+            .with_log_index(2)
+            .with_block_number(11)
+            .build();
+
+        let block_timestamp_a = fill_a.block_timestamp.unwrap();
+        let block_timestamp_b = fill_b.block_timestamp.unwrap();
+
+        let trade_id_a = OnChainTradeId {
+            tx_hash: fill_a.tx_hash,
+            log_index: fill_a.log_index,
+        };
+        let trade_id_b = OnChainTradeId {
+            tx_hash: fill_b.tx_hash,
+            log_index: fill_b.log_index,
+        };
+
+        let onchain_store = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        // Step 1: Witness fill A in OnChainTrade.
+        onchain_store
+            .send(
+                &trade_id_a,
+                OnChainTradeCommand::Witness {
+                    symbol: fill_a.symbol.base().clone(),
+                    amount: fill_a.amount.inner(),
+                    direction: fill_a.direction,
+                    price_usdc: fill_a.price.value(),
+                    block_number: 10,
+                    block_timestamp: block_timestamp_a,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Step 2: Acknowledge fill A in Position (slot = A).
+        execute_acknowledge_fill(
+            &position_store,
+            &fill_a,
+            ctx.execution_threshold,
+            block_timestamp_a,
+        )
+        .await
+        .unwrap();
+
+        // Simulate crash: do NOT call execute_mark_acknowledged for fill A.
+        // OnChainTrade A stays Witnessed; Position already has A applied.
+
+        // Step 3: Fully process fill B (witness + acknowledge + mark).
+        onchain_store
+            .send(
+                &trade_id_b,
+                OnChainTradeCommand::Witness {
+                    symbol: fill_b.symbol.base().clone(),
+                    amount: fill_b.amount.inner(),
+                    direction: fill_b.direction,
+                    price_usdc: fill_b.price.value(),
+                    block_number: 11,
+                    block_timestamp: block_timestamp_b,
+                },
+            )
+            .await
+            .unwrap();
+
+        execute_acknowledge_fill(
+            &position_store,
+            &fill_b,
+            ctx.execution_threshold,
+            block_timestamp_b,
+        )
+        .await
+        .unwrap();
+
+        execute_mark_acknowledged(&onchain_store, &trade_id_b)
+            .await
+            .unwrap();
+
+        // At this point:
+        // - Position has fill_a and fill_b applied (last_slot = fill_b's trade_id).
+        // - OnChainTrade fill_a is Witnessed (not Acknowledged).
+        // - OnChainTrade fill_b is Acknowledged.
+        // Without the durable guard, retrying process-tx for fill_a would
+        // re-apply it: last_slot (B) != A, so DuplicateTrade does NOT fire.
+
+        // Step 4: Retry process-tx for fill A (crash-recovery scenario).
+        process_found_trade(fill_a, &ctx, &pool, &mut std::io::sink(), order_placer)
+            .await
+            .unwrap();
+
+        // Assertion 1: OnChainTrade A must now be acknowledged.
+        let state_a = onchain_store
+            .load(&trade_id_a)
+            .await
+            .unwrap()
+            .expect("OnChainTrade fill_a must exist after process_tx retry");
+        assert!(
+            state_a.is_acknowledged(),
+            "fill_a must be acknowledged after process_tx retry"
+        );
+
+        // Assertion 2: Exactly two OnChainOrderFilled events — fill_a once and
+        // fill_b once. Any value other than 2 means double-counting or a dropped
+        // fill.
+        let (fill_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM events WHERE event_type = 'PositionEvent::OnChainOrderFilled'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            fill_count, 2,
+            "process_tx retry on a crash-window fill must not double-count: \
+             expected exactly 2 fill events (fill_a once + fill_b once), got {fill_count}"
+        );
+    }
+
+    /// Regression test for the None-path (fresh-witness) double-count hole:
+    ///
+    /// A legacy fill whose Position record was written (e.g. via a prior direct
+    /// `execute_acknowledge_fill` call) but whose OnChainTrade record was NEVER
+    /// created causes `process_found_trade` to take the `None` branch. Without
+    /// the unified durable guard the fresh-witness arm would call
+    /// `execute_acknowledge_fill` again; because the Position slot already
+    /// advanced to a newer fill (B), `DuplicateTrade` does NOT fire and fill A
+    /// is counted a second time.
+    ///
+    /// After the fix the unified `position_fill_already_recorded` guard runs on
+    /// every path — including the `None` path — and blocks the re-apply.
+    #[tokio::test]
+    async fn process_tx_none_path_does_not_recount_legacy_position_fill() {
+        let pool = setup_test_db().await;
+        let ctx = create_base_test_ctx();
+        let order_placer = create_order_placer(&ctx, &pool);
+
+        // Fill A and fill B have distinct (tx_hash, log_index) identities.
+        let fill_a = OnchainTradeBuilder::default().with_block_number(10).build();
+        let fill_b = OnchainTradeBuilder::default()
+            .with_log_index(2)
+            .with_block_number(11)
+            .build();
+
+        let block_timestamp_a = fill_a.block_timestamp.unwrap();
+        let block_timestamp_b = fill_b.block_timestamp.unwrap();
+
+        let trade_id_a = OnChainTradeId {
+            tx_hash: fill_a.tx_hash,
+            log_index: fill_a.log_index,
+        };
+        let trade_id_b = OnChainTradeId {
+            tx_hash: fill_b.tx_hash,
+            log_index: fill_b.log_index,
+        };
+
+        let onchain_store = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        // Step 1: Apply fill A to Position ONLY — no OnChainTrade witness record.
+        // This simulates a legacy fill whose OnChainTrade record was never created.
+        // process_found_trade will load None for trade_id_a and take the None path.
+        execute_acknowledge_fill(
+            &position_store,
+            &fill_a,
+            ctx.execution_threshold,
+            block_timestamp_a,
+        )
+        .await
+        .unwrap();
+
+        // Step 2: Fully process fill B so the Position slot advances beyond A.
+        // Now last_acknowledged_trade_id = B, so a re-apply of A bypasses the
+        // single-slot DuplicateTrade guard without the durable check.
+        onchain_store
+            .send(
+                &trade_id_b,
+                OnChainTradeCommand::Witness {
+                    symbol: fill_b.symbol.base().clone(),
+                    amount: fill_b.amount.inner(),
+                    direction: fill_b.direction,
+                    price_usdc: fill_b.price.value(),
+                    block_number: 11,
+                    block_timestamp: block_timestamp_b,
+                },
+            )
+            .await
+            .unwrap();
+
+        execute_acknowledge_fill(
+            &position_store,
+            &fill_b,
+            ctx.execution_threshold,
+            block_timestamp_b,
+        )
+        .await
+        .unwrap();
+
+        execute_mark_acknowledged(&onchain_store, &trade_id_b)
+            .await
+            .unwrap();
+
+        // Step 3: Run process_found_trade for fill A. It takes the None branch
+        // (no OnChainTrade record), witnesses A, then the authoritative guard must
+        // detect A already in Position and skip the re-apply.
+        process_found_trade(fill_a, &ctx, &pool, &mut std::io::sink(), order_placer)
+            .await
+            .unwrap();
+
+        // Assertion 1: OnChainTrade A must be acknowledged (witness + mark ran).
+        let state_a = onchain_store
+            .load(&trade_id_a)
+            .await
+            .unwrap()
+            .expect("OnChainTrade fill_a must exist after process_found_trade");
+        assert!(
+            state_a.is_acknowledged(),
+            "fill_a must be acknowledged after process_found_trade takes the None path"
+        );
+
+        // Assertion 2: Exactly two fill events — fill_a once + fill_b once. Any
+        // value other than 2 means fill_a was double-counted on the None path.
+        let (fill_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM events \
+             WHERE event_type = 'PositionEvent::OnChainOrderFilled'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            fill_count, 2,
+            "None-path process_tx must not re-apply a fill already in Position: \
+             expected 2 fill events (fill_a once + fill_b once), got {fill_count}"
+        );
+    }
+
+    /// The happy path: a new fill with trading enabled and a broker that accepts
+    /// the order must print 'Trade processing completed!' and leave the position
+    /// with `pending_offchain_order_id` set (order submitted, not cleared).
+    ///
+    /// This is the only test that exercises the
+    /// `Some(OffchainOrder::Submitted | PartiallyFilled)` arm in
+    /// `process_found_trade`.
+    #[tokio::test]
+    async fn process_tx_submitted_hedge_sets_pending_order_id() {
+        let pool = setup_test_db().await;
+
+        // Enable trading so check_execution_readiness can trigger hedge placement.
+        let mut ctx = create_base_test_ctx();
+        ctx.assets.equities.symbols.insert(
+            Symbol::new("AAPL").unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: Address::ZERO,
+                tokenized_equity_derivative: Address::ZERO,
+                pyth_feed_id: None,
+                vault_ids: vec![],
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+
+        let order_placer: Arc<dyn OrderPlacer> = Arc::new(SucceedingOrderPlacer);
+
+        // 1 share buy -> net +1 -> is_ready_for_execution returns (Sell, 1).
+        let onchain_trade = OnchainTradeBuilder::default().with_block_number(42).build();
+
+        let mut stdout = Vec::new();
+        process_found_trade(onchain_trade, &ctx, &pool, &mut stdout, order_placer)
+            .await
+            .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("Trade processing completed!"),
+            "successful broker submission must print the completion message, got: {output}"
+        );
+
+        // pending_offchain_order_id must be set: the order is submitted to the
+        // broker and in flight; only the order-status sweep will clear it.
+        let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let position = position_store
+            .load(&Symbol::new("AAPL").unwrap())
+            .await
+            .unwrap()
+            .expect("Position must exist after fill accounting");
+
+        let pending_order_id = position
+            .pending_offchain_order_id
+            .expect("pending_offchain_order_id must be set after successful broker submission");
+
+        let (offchain_order_store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let offchain_order = offchain_order_store
+            .load(&pending_order_id)
+            .await
+            .unwrap()
+            .expect("pending_offchain_order_id must refer to a persisted offchain order");
+        assert!(
+            matches!(offchain_order, OffchainOrder::Submitted { .. }),
+            "pending_offchain_order_id must point to the submitted broker order, got: {offchain_order:?}"
+        );
+
+        let (offchain_event_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM events \
+             WHERE aggregate_id = ? AND event_type LIKE 'OffchainOrderEvent%'",
+        )
+        .bind(pending_order_id.to_string())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            offchain_event_count >= 1,
+            "submitted hedge should persist at least one OffchainOrder event for {pending_order_id}"
+        );
+
+        let (fill_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind(crate::position::PositionEvent::ON_CHAIN_ORDER_FILLED_EVENT_TYPE)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            fill_count, 1,
+            "successful broker submission must account the onchain fill exactly once"
         );
     }
 }

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -20,6 +20,7 @@ use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
 use sqlx_apalis::sqlite::{SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode};
 use std::collections::HashMap;
+use std::num::TryFromIntError;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use task_supervisor::SupervisorHandle;
@@ -34,8 +35,8 @@ use st0x_config::{
 };
 use st0x_dto::Statement;
 use st0x_event_sorcery::{
-    AggregateError, LifecycleError, Projection, SendError, Store, StoreBuilder, compact_events,
-    incremental_vacuum, load_all_ids, load_entity,
+    AggregateError, EventSourced, LifecycleError, Projection, SendError, Store, StoreBuilder,
+    compact_events, incremental_vacuum, load_all_ids, load_entity,
 };
 use st0x_evm::{USDC_BASE, Wallet};
 use st0x_execution::{
@@ -73,7 +74,7 @@ use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeError,
 use crate::performance::HedgeLatencyProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
 use crate::performance::reliability::LifecycleFailureProjection;
-use crate::position::{Position, PositionCommand, PositionError, TradeId};
+use crate::position::{Position, PositionCommand, PositionError, PositionEvent, TradeId};
 use crate::rebalancing::equity::{
     CrossVenueEquityTransfer, EquityTransferServices, ResumeTokenizationAggregate,
     ResumeTokenizationCtx, ResumeTokenizationJobQueue, ResumeTokenizationTarget,
@@ -154,6 +155,7 @@ pub(crate) async fn setup_apalis_tables(
 
 /// Bundles CQRS frameworks used throughout the trade processing pipeline.
 pub(crate) struct TradeProcessingCqrs {
+    pub(crate) pool: SqlitePool,
     pub(crate) onchain_trade: Arc<Store<OnChainTrade>>,
     pub(crate) position: Arc<Store<Position>>,
     pub(crate) position_projection: Arc<Projection<Position>>,
@@ -2228,28 +2230,83 @@ pub(crate) async fn execute_settle_fill(
     position.send(base_symbol, command).await
 }
 
-#[tracing::instrument(skip_all, level = tracing::Level::DEBUG)]
-pub(crate) async fn process_queued_trade<E: Executor>(
-    executor: &E,
-    trade_event: &EmittedOnChain<RaindexTradeEvent>,
-    trade: OnchainTrade,
-    cqrs: &TradeProcessingCqrs,
-    asset_enabled: bool,
-) -> Result<Option<OffchainOrderId>, TradeAccountingError>
-where
-    TradeAccountingError: From<E::Error>,
-{
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PositionFillLookupError {
+    #[error("Failed to convert log_index for fill {trade_id}: {source}")]
+    LogIndex {
+        trade_id: OnChainTradeId,
+        #[source]
+        source: TryFromIntError,
+    },
+    #[error("Failed to query durable position fill guard for {trade_id}: {source}")]
+    Query {
+        trade_id: OnChainTradeId,
+        #[source]
+        source: sqlx::Error,
+    },
+}
+
+/// Returns `true` when the `Position` aggregate already has a durable
+/// `OnChainOrderFilled` event for the given `(tx_hash, log_index)`.
+///
+/// Used by the CLI's `process-tx` resume path to guard against
+/// double-counting a witnessed-but-unacknowledged fill. The Position's
+/// single-slot `last_acknowledged_trade_id` guard only deduplicates the
+/// immediately preceding fill; if a newer fill has since advanced the
+/// slot, a CLI retry would re-apply the old fill without this durable check.
+pub(crate) async fn position_fill_already_recorded(
+    pool: &SqlitePool,
+    symbol: &Symbol,
+    trade_id: &OnChainTradeId,
+) -> Result<bool, PositionFillLookupError> {
+    let tx_hash_str = trade_id.tx_hash.to_string();
+    let log_index =
+        i64::try_from(trade_id.log_index).map_err(|source| PositionFillLookupError::LogIndex {
+            trade_id: trade_id.clone(),
+            source,
+        })?;
+
+    let (count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM events \
+         WHERE aggregate_type = ? \
+         AND aggregate_id = ? \
+         AND event_type = ? \
+         AND json_extract(payload, '$.OnChainOrderFilled.trade_id.tx_hash') = ? \
+         AND CAST(json_extract(payload, '$.OnChainOrderFilled.trade_id.log_index') AS INTEGER) = ?",
+    )
+    .bind(Position::AGGREGATE_TYPE)
+    .bind(symbol.to_string())
+    .bind(PositionEvent::ON_CHAIN_ORDER_FILLED_EVENT_TYPE)
+    .bind(tx_hash_str)
+    .bind(log_index)
+    .fetch_one(pool)
+    .await
+    .map_err(|source| PositionFillLookupError::Query {
+        trade_id: trade_id.clone(),
+        source,
+    })?;
+
+    Ok(count > 0)
+}
+
+pub(crate) enum FillAccountingOutcome {
+    AlreadyAcknowledged,
+    Accounted { trade_id: OnChainTradeId },
+}
+
+pub(crate) async fn account_for_onchain_fill(
+    pool: &SqlitePool,
+    onchain_trade: &Store<OnChainTrade>,
+    position: &Store<Position>,
+    trade: &OnchainTrade,
+    block_number: u64,
+    threshold: ExecutionThreshold,
+) -> Result<FillAccountingOutcome, TradeAccountingError> {
     let trade_id = OnChainTradeId {
         tx_hash: trade.tx_hash,
         log_index: trade.log_index,
     };
 
-    // A fill we cannot timestamp can be neither witnessed nor acknowledged.
-    // Fail loudly so the apalis retry surfaces it as an operator-visible
-    // failure instead of completing the job and dropping the fill silently.
-    // The timestamp is baked into the job payload, so retries cannot resolve
-    // it -- they burn the (small) retry budget before the terminal-failure
-    // alert fires, which is an acceptable cost for not silently losing a fill.
     let Some(block_timestamp) = trade.block_timestamp else {
         error!(
             ?trade_id,
@@ -2261,12 +2318,7 @@ where
         });
     };
 
-    // The dedupe is step-grained (ADR 0005): only a trade the position
-    // has acknowledged is fully processed. A trade that exists but is
-    // not acknowledged means a previous delivery died between the
-    // witness and acknowledge writes -- resume the acknowledge pair
-    // instead of skipping the fill into permanent loss.
-    match cqrs.onchain_trade.load(&trade_id).await {
+    match onchain_trade.load(&trade_id).await {
         Ok(Some(state)) if state.is_acknowledged() => {
             debug!(
                 ?trade_id,
@@ -2277,8 +2329,8 @@ where
             // between MARK and SETTLE leaves the trade marked but still in
             // the pending set. The marker is durable, so prune it now. A
             // no-op when already pruned.
-            execute_settle_fill(&cqrs.position, &trade).await?;
-            return Ok(None);
+            execute_settle_fill(position, trade).await?;
+            return Ok(FillAccountingOutcome::AlreadyAcknowledged);
         }
         Ok(Some(state)) => {
             info!(
@@ -2287,43 +2339,74 @@ where
                 "Trade witnessed but not acknowledged; resuming fill accounting"
             );
 
-            // A crash in the witness->enrich window leaves the trade
-            // witnessed but un-enriched. Enrich now so the acknowledged
-            // trade is not permanently stuck with `enrichment: None` --
-            // mirroring the fresh-trade path. Best-effort: enrichment is
-            // observability data, not financial state.
             if !state.is_enriched() {
-                execute_enrich_trade(&cqrs.onchain_trade, &trade).await;
+                execute_enrich_trade(onchain_trade, trade).await;
             }
         }
         Ok(None) => {
-            let witnessed = execute_witness_trade(
-                &cqrs.onchain_trade,
-                &trade,
-                trade_event.block_number,
-                block_timestamp,
-            )
-            .await?;
+            let witnessed =
+                execute_witness_trade(onchain_trade, trade, block_number, block_timestamp).await?;
 
-            if !witnessed {
-                return Ok(None);
+            if witnessed {
+                execute_enrich_trade(onchain_trade, trade).await;
+            } else {
+                match onchain_trade.load(&trade_id).await? {
+                    Some(reloaded) if reloaded.is_acknowledged() => {
+                        execute_settle_fill(position, trade).await?;
+                        return Ok(FillAccountingOutcome::AlreadyAcknowledged);
+                    }
+                    Some(reloaded) => {
+                        info!(
+                            ?trade_id,
+                            symbol = %trade.symbol,
+                            "Concurrent witness detected; resuming fill accounting"
+                        );
+                        if !reloaded.is_enriched() {
+                            execute_enrich_trade(onchain_trade, trade).await;
+                        }
+                    }
+                    None => {
+                        return Err(TradeAccountingError::InconsistentOnChainTradeState {
+                            trade_id,
+                        });
+                    }
+                }
             }
-
-            execute_enrich_trade(&cqrs.onchain_trade, &trade).await;
         }
-        // A failed read must not masquerade as "not a duplicate": the
-        // witness write would also fail on a healthy dedupe path, but
-        // propagating here keeps the retry contract explicit.
         Err(error) => return Err(error.into()),
     }
 
-    execute_acknowledge_fill(
+    if !position_fill_already_recorded(pool, trade.symbol.base(), &trade_id).await? {
+        execute_acknowledge_fill(position, trade, threshold, block_timestamp).await?;
+    }
+
+    Ok(FillAccountingOutcome::Accounted { trade_id })
+}
+
+#[tracing::instrument(skip_all, level = tracing::Level::DEBUG)]
+pub(crate) async fn process_queued_trade<E: Executor>(
+    executor: &E,
+    trade_event: &EmittedOnChain<RaindexTradeEvent>,
+    trade: OnchainTrade,
+    cqrs: &TradeProcessingCqrs,
+    asset_enabled: bool,
+) -> Result<Option<OffchainOrderId>, TradeAccountingError>
+where
+    TradeAccountingError: From<E::Error>,
+{
+    let FillAccountingOutcome::Accounted { trade_id } = account_for_onchain_fill(
+        &cqrs.pool,
+        &cqrs.onchain_trade,
         &cqrs.position,
         &trade,
+        trade_event.block_number,
         cqrs.execution_threshold,
-        block_timestamp,
     )
-    .await?;
+    .await?
+    else {
+        return Ok(None);
+    };
+
     execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id).await?;
     // Prune the pending-acknowledgement entry now that the marker is durable
     // (ADR 0010), before any early return below, so the threshold-not-met and
@@ -2331,6 +2414,11 @@ where
     execute_settle_fill(&cqrs.position, &trade).await?;
 
     let base_symbol = trade.symbol.base();
+
+    match reconcile_existing_pending_order(base_symbol, cqrs).await? {
+        ExistingPendingOrderOutcome::NoPending | ExistingPendingOrderOutcome::Cleared => {}
+        ExistingPendingOrderOutcome::InFlight => return Ok(None),
+    }
 
     let executor_type = executor.to_supported_executor();
 
@@ -2349,7 +2437,13 @@ where
 
     let _counter_trade_submission_guard = cqrs.counter_trade_submission_lock.lock().await;
 
-    match preflight_counter_trade_submission(executor, &execution, None).await? {
+    let counter_trade_submission =
+        match preflight_counter_trade_submission(executor, &execution, None).await {
+            Ok(check) => check,
+            Err(error) => return Err(error),
+        };
+
+    match counter_trade_submission {
         CounterTradeSubmissionCheck::Skipped => return Ok(None),
         CounterTradeSubmissionCheck::Allowed { reservation } => {
             clamp_shares_to_reservation(&mut execution, reservation.as_ref());
@@ -2583,7 +2677,7 @@ async fn place_offchain_order(
     // reused as `client_order_id`, not on aggregate identity.
     let offchain_order_id = OffchainOrderId::new();
 
-    if !execute_place_offchain_order(execution, cqrs, offchain_order_id).await {
+    if !execute_place_offchain_order(execution, cqrs, offchain_order_id).await? {
         // `PendingExecution`: the position is already claimed by a prior
         // placement attempt that may not have completed (e.g. it placed the
         // broker order but crashed/was retried before enqueuing the poll).
@@ -2608,7 +2702,58 @@ async fn place_offchain_order(
             );
         })?;
 
-    dispatch_post_place_state(loaded, execution, cqrs, offchain_order_id).await
+    match dispatch_post_place_state(loaded, &execution.symbol, cqrs, offchain_order_id).await? {
+        PostPlaceOutcome::InFlight(order_id) | PostPlaceOutcome::Failed(order_id) => {
+            Ok(Some(order_id))
+        }
+        PostPlaceOutcome::ClearedNoOrder => Ok(None),
+    }
+}
+
+enum ExistingPendingOrderOutcome {
+    NoPending,
+    InFlight,
+    Cleared,
+}
+
+async fn reconcile_existing_pending_order(
+    symbol: &Symbol,
+    cqrs: &TradeProcessingCqrs,
+) -> Result<ExistingPendingOrderOutcome, TradeAccountingError> {
+    let Some(position) = cqrs.position.load(symbol).await? else {
+        return Ok(ExistingPendingOrderOutcome::NoPending);
+    };
+
+    let Some(offchain_order_id) = position.pending_offchain_order_id else {
+        return Ok(ExistingPendingOrderOutcome::NoPending);
+    };
+
+    let loaded = cqrs
+        .offchain_order
+        .load(&offchain_order_id)
+        .await
+        .inspect_err(|error| {
+            error!(
+                %offchain_order_id,
+                %symbol,
+                %error,
+                "Failed to load existing pending offchain order; cannot safely acknowledge fill"
+            );
+        })?;
+
+    match dispatch_post_place_state(loaded, symbol, cqrs, offchain_order_id).await? {
+        PostPlaceOutcome::InFlight(_) => Ok(ExistingPendingOrderOutcome::InFlight),
+        PostPlaceOutcome::Failed(_) | PostPlaceOutcome::ClearedNoOrder => {
+            Ok(ExistingPendingOrderOutcome::Cleared)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum PostPlaceOutcome {
+    InFlight(OffchainOrderId),
+    Failed(OffchainOrderId),
+    ClearedNoOrder,
 }
 
 /// Recovers the order a position is already claimed by when a fresh placement
@@ -2692,7 +2837,12 @@ async fn recover_claimed_offchain_order(
             )
             .await?;
 
-            dispatch_post_place_state(placed, execution, cqrs, pending_id).await
+            match dispatch_post_place_state(placed, &execution.symbol, cqrs, pending_id).await? {
+                PostPlaceOutcome::InFlight(order_id) | PostPlaceOutcome::Failed(order_id) => {
+                    Ok(Some(order_id))
+                }
+                PostPlaceOutcome::ClearedNoOrder => Ok(None),
+            }
         }
         // Terminal and absent orders were resolved by
         // `resolve_terminal_claimed_order` above.
@@ -2701,23 +2851,19 @@ async fn recover_claimed_offchain_order(
 }
 
 /// Routes the freshly-loaded `OffchainOrder` post-`Place` to either the
-/// rejection-cleanup or poll-enqueue path. Returns the order id wrapped in
-/// `Some` when the order is real and recorded, `None` when no usable order
-/// exists (Place silently failed or persisted state is a lifecycle bug), or
-/// propagates infrastructure errors so DB / queue failures cannot be
-/// silently swallowed.
+/// rejection-cleanup or poll-enqueue path.
 async fn dispatch_post_place_state(
     loaded: Option<OffchainOrder>,
-    execution: &ExecutionCtx,
+    symbol: &Symbol,
     cqrs: &TradeProcessingCqrs,
     offchain_order_id: OffchainOrderId,
-) -> Result<Option<OffchainOrderId>, TradeAccountingError> {
+) -> Result<PostPlaceOutcome, TradeAccountingError> {
     use OffchainOrder::{Failed, Filled, PartiallyFilled, Pending, Submitted};
     match loaded {
         Some(Failed { error, .. }) => {
             cqrs.position
                 .send(
-                    &execution.symbol,
+                    symbol,
                     PositionCommand::FailOffChainOrder {
                         offchain_order_id,
                         error,
@@ -2725,7 +2871,7 @@ async fn dispatch_post_place_state(
                 )
                 .await?;
 
-            Ok(Some(offchain_order_id))
+            Ok(PostPlaceOutcome::Failed(offchain_order_id))
         }
 
         Some(Submitted { .. } | PartiallyFilled { .. }) => {
@@ -2737,13 +2883,13 @@ async fn dispatch_post_place_state(
                 .inspect_err(|error| {
                     error!(
                         %offchain_order_id,
-                        symbol = %execution.symbol,
+                        %symbol,
                         %error,
                         "Failed to enqueue PollOrderStatus job for newly-submitted order"
                     );
                 })?;
 
-            Ok(Some(offchain_order_id))
+            Ok(PostPlaceOutcome::InFlight(offchain_order_id))
         }
 
         // No order exists after a successful Place -- a serious inconsistency,
@@ -2753,7 +2899,7 @@ async fn dispatch_post_place_state(
         None => {
             cqrs.position
                 .send(
-                    &execution.symbol,
+                    symbol,
                     PositionCommand::FailOffChainOrder {
                         offchain_order_id,
                         error: "Offchain order missing after Place".to_string(),
@@ -2761,7 +2907,7 @@ async fn dispatch_post_place_state(
                 )
                 .await?;
 
-            Ok(None)
+            Ok(PostPlaceOutcome::ClearedNoOrder)
         }
 
         // With the pure `Place` handler, `Place` only records intent (entering
@@ -2783,12 +2929,21 @@ async fn dispatch_post_place_state(
 
 /// Returns `true` if the Position aggregate accepted the order, `false` if it
 /// was rejected (e.g. already has a pending execution).
+pub(crate) fn is_expected_place_offchain_order_rejection(error: &SendError<Position>) -> bool {
+    matches!(
+        error,
+        AggregateError::UserError(LifecycleError::Apply(
+            PositionError::PendingExecution { .. } | PositionError::ThresholdNotMet { .. },
+        ))
+    )
+}
+
 #[tracing::instrument(skip_all, level = tracing::Level::DEBUG)]
 async fn execute_place_offchain_order(
     execution: &ExecutionCtx,
     cqrs: &TradeProcessingCqrs,
     offchain_order_id: OffchainOrderId,
-) -> bool {
+) -> Result<bool, SendError<Position>> {
     let command = PositionCommand::PlaceOffChainOrder {
         offchain_order_id,
         shares: execution.shares,
@@ -2804,16 +2959,17 @@ async fn execute_place_offchain_order(
                 symbol = %execution.symbol,
                 "Position::PlaceOffChainOrder succeeded"
             );
-            true
+            Ok(true)
         }
-        Err(error) => {
+        Err(error) if is_expected_place_offchain_order_rejection(&error) => {
             warn!(
                 %offchain_order_id,
                 symbol = %execution.symbol,
-                "Position::PlaceOffChainOrder rejected: {error}"
+                "Position::PlaceOffChainOrder rejected by domain state: {error}"
             );
-            false
+            Ok(false)
         }
+        Err(error) => Err(error),
     }
 }
 
@@ -2949,6 +3105,11 @@ where
             "Executing accumulated position"
         );
 
+        let anchor = position
+            .load(&execution.symbol)
+            .await?
+            .and_then(|loaded| loaded.last_failed_offchain_order_id);
+
         let command = PositionCommand::PlaceOffChainOrder {
             offchain_order_id,
             shares: execution.shares,
@@ -2957,14 +3118,18 @@ where
             threshold: *threshold,
         };
 
-        if let Err(error) = position.send(&execution.symbol, command).await {
-            warn!(
-                %offchain_order_id,
-                symbol = %execution.symbol,
-                "Position::PlaceOffChainOrder rejected (likely pending execution), \
-                 skipping OffchainOrder creation: {error}"
-            );
-            continue;
+        match position.send(&execution.symbol, command).await {
+            Ok(()) => {}
+            Err(error) if is_expected_place_offchain_order_rejection(&error) => {
+                warn!(
+                    %offchain_order_id,
+                    symbol = %execution.symbol,
+                    "Position::PlaceOffChainOrder rejected by domain state; \
+                     skipping OffchainOrder creation: {error}"
+                );
+                continue;
+            }
+            Err(error) => return Err(error.into()),
         }
 
         debug!(
@@ -2973,30 +3138,6 @@ where
             "Position::PlaceOffChainOrder succeeded"
         );
 
-        // Derive the broker-side client_order_id from the live position aggregate,
-        // reusing a prior failed attempt's stashed OffchainOrderId as the
-        // idempotency anchor (mirroring `execute_create_offchain_order`) so this
-        // path exercises the same broker dedupe the production reactor relies on.
-        let anchor = match position.load(&execution.symbol).await {
-            Ok(loaded) => loaded.and_then(|loaded| loaded.last_failed_offchain_order_id),
-            Err(error) => {
-                // Financial-integrity: never place under a fresh idempotency key when the
-                // anchor cannot be read. A stashed `last_failed_offchain_order_id` may
-                // front a live broker order, so a fresh key would double-hedge (this is
-                // why `execute_create_offchain_order` fails fast here). The position is
-                // already claimed above but no OffchainOrder aggregate exists yet, so the
-                // runtime orphaned-pending recovery (ADR 0014) clears the stale claim and
-                // a later CheckPositions scan re-attempts the placement.
-                warn!(
-                    %offchain_order_id,
-                    symbol = %execution.symbol,
-                    %error,
-                    "Failed to load position for the idempotency anchor; deferring \
-                     placement to runtime recovery instead of using a fresh key"
-                );
-                continue;
-            }
-        };
         let client_order_id = client_order_id_for_placement(offchain_order_id, anchor);
 
         let place_result = place_offchain_order_at_broker(
@@ -3067,7 +3208,7 @@ mod tests {
         create_test_ctx_with_order_owner,
     };
     use st0x_dto::Statement;
-    use st0x_event_sorcery::{StoreBuilder, test_store};
+    use st0x_event_sorcery::{DomainEvent, StoreBuilder, test_store};
     use st0x_execution::{
         Direction, EquityPosition, ExecutorOrderId, Inventory as ExecutionInventory, MarketOrder,
         MockExecutor, Positive, Symbol,
@@ -4558,10 +4699,12 @@ mod tests {
 
     fn trade_processing_cqrs_with_threshold(
         frameworks: &CqrsFrameworks,
+        pool: &SqlitePool,
         threshold: ExecutionThreshold,
         apalis_pool: &apalis_sqlite::SqlitePool,
     ) -> TradeProcessingCqrs {
         TradeProcessingCqrs {
+            pool: pool.clone(),
             onchain_trade: frameworks.onchain_trade.clone(),
             position: frameworks.position.clone(),
             position_projection: frameworks.position_projection.clone(),
@@ -4601,12 +4744,55 @@ mod tests {
         EmittedOnChain::from_log(RaindexTradeEvent::ClearV3(Box::new(event)), &log).unwrap()
     }
 
+    #[test]
+    fn position_fill_guard_matches_position_event_json_contract() {
+        let trade_id = TradeId {
+            tx_hash: fixed_bytes!(
+                "0x1111111111111111111111111111111111111111111111111111111111111111"
+            ),
+            log_index: 17,
+        };
+        let event = PositionEvent::OnChainOrderFilled {
+            trade_id: trade_id.clone(),
+            amount: FractionalShares::new(float!(1)),
+            direction: Direction::Buy,
+            price_usdc: float!(100),
+            block_timestamp: Utc::now(),
+            seen_at: Utc::now(),
+        };
+
+        assert_eq!(
+            event.event_type(),
+            PositionEvent::ON_CHAIN_ORDER_FILLED_EVENT_TYPE,
+            "durable duplicate query must use the aggregate event type"
+        );
+
+        let payload = serde_json::to_value(&event).unwrap();
+        let tx_hash = trade_id.tx_hash.to_string();
+
+        assert_eq!(
+            payload
+                .pointer("/OnChainOrderFilled/trade_id/tx_hash")
+                .and_then(|value| value.as_str()),
+            Some(tx_hash.as_str()),
+            "durable duplicate query depends on this tx_hash JSON path"
+        );
+        assert_eq!(
+            payload
+                .pointer("/OnChainOrderFilled/trade_id/log_index")
+                .and_then(serde_json::Value::as_u64),
+            Some(trade_id.log_index),
+            "durable duplicate query depends on this log_index JSON path"
+        );
+    }
+
     #[tokio::test]
     async fn trade_below_threshold_does_not_place_order() {
         let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -4646,6 +4832,7 @@ mod tests {
         let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -4704,6 +4891,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -4800,6 +4988,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -4839,6 +5028,7 @@ mod tests {
         let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5003,6 +5193,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5089,6 +5280,7 @@ mod tests {
         let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5211,6 +5403,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5240,6 +5433,22 @@ mod tests {
         execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id)
             .await
             .expect("re-driving the marker must be idempotent, not propagate an error");
+
+        let (acknowledged_markers,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM events \
+             WHERE aggregate_type = ? AND aggregate_id = ? AND event_type = ?",
+        )
+        .bind(OnChainTrade::AGGREGATE_TYPE)
+        .bind(trade_id.to_string())
+        .bind("OnChainTradeEvent::Acknowledged")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            acknowledged_markers, 1,
+            "re-driving the marker must not emit a second Acknowledged event"
+        );
     }
 
     /// Exactly-once across multiple same-symbol fills: once a fill is
@@ -5255,6 +5464,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5338,6 +5548,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5424,6 +5635,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5473,6 +5685,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5506,6 +5719,7 @@ mod tests {
         let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5603,6 +5817,7 @@ mod tests {
         let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5685,6 +5900,7 @@ mod tests {
         let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5735,6 +5951,7 @@ mod tests {
         let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5798,6 +6015,7 @@ mod tests {
         let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5843,6 +6061,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5887,6 +6106,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -5936,6 +6156,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -6032,6 +6253,7 @@ mod tests {
         let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -6093,6 +6315,7 @@ mod tests {
         let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -6157,6 +6380,7 @@ mod tests {
         let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -6256,6 +6480,7 @@ mod tests {
         let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let mut cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -7102,6 +7327,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let mut cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -7137,6 +7363,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -7197,6 +7424,7 @@ mod tests {
         let (frameworks, _) = create_cqrs_frameworks(&pool).await;
         let mut cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -7270,6 +7498,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -7321,6 +7550,7 @@ mod tests {
         let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -8036,24 +8266,13 @@ mod tests {
         offchain_order_id
     }
 
-    fn execution_ctx_for(
-        symbol: &Symbol,
-        shares: Positive<FractionalShares>,
-    ) -> crate::onchain::accumulator::ExecutionCtx {
-        crate::onchain::accumulator::ExecutionCtx {
-            symbol: symbol.clone(),
-            direction: Direction::Sell,
-            shares,
-            executor: st0x_execution::SupportedExecutor::DryRun,
-        }
-    }
-
     #[tokio::test]
     async fn dispatch_post_place_state_none_clears_position_pending() {
         let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -8071,12 +8290,12 @@ mod tests {
             .unwrap();
         assert_eq!(position.pending_offchain_order_id, Some(offchain_order_id));
 
-        let execution = execution_ctx_for(&symbol, shares);
-        let result = dispatch_post_place_state(None, &execution, &cqrs, offchain_order_id)
+        let result = dispatch_post_place_state(None, &symbol, &cqrs, offchain_order_id)
             .await
             .unwrap();
         assert_eq!(
-            result, None,
+            result,
+            PostPlaceOutcome::ClearedNoOrder,
             "None state must report no order placed so caller does not pretend a phantom \
              id is real"
         );
@@ -8099,6 +8318,7 @@ mod tests {
         let (frameworks, _projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -8119,9 +8339,8 @@ mod tests {
             placed_at: Utc::now(),
         };
 
-        let execution = execution_ctx_for(&symbol, shares);
         let error =
-            dispatch_post_place_state(Some(pending_state), &execution, &cqrs, offchain_order_id)
+            dispatch_post_place_state(Some(pending_state), &symbol, &cqrs, offchain_order_id)
                 .await
                 .unwrap_err();
         assert!(
@@ -8231,6 +8450,7 @@ mod tests {
         let (frameworks, _projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -8254,9 +8474,8 @@ mod tests {
             filled_at: Utc::now(),
         };
 
-        let execution = execution_ctx_for(&symbol, shares);
         let error =
-            dispatch_post_place_state(Some(filled_state), &execution, &cqrs, offchain_order_id)
+            dispatch_post_place_state(Some(filled_state), &symbol, &cqrs, offchain_order_id)
                 .await
                 .unwrap_err();
         assert!(
@@ -8289,6 +8508,7 @@ mod tests {
         let (frameworks, _projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -8307,14 +8527,13 @@ mod tests {
             failed_at: Utc::now(),
         };
 
-        let execution = execution_ctx_for(&symbol, shares);
         let result =
-            dispatch_post_place_state(Some(failed_state), &execution, &cqrs, offchain_order_id)
+            dispatch_post_place_state(Some(failed_state), &symbol, &cqrs, offchain_order_id)
                 .await
                 .unwrap();
         assert_eq!(
             result,
-            Some(offchain_order_id),
+            PostPlaceOutcome::Failed(offchain_order_id),
             "Failed state must report the order id so caller records it"
         );
 
@@ -8336,6 +8555,7 @@ mod tests {
         let (frameworks, _projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
+            &pool,
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
@@ -8402,7 +8622,12 @@ mod tests {
             .unwrap();
         assert_eq!(position.pending_offchain_order_id, Some(offchain_order_id));
 
-        let execution = execution_ctx_for(&symbol, shares);
+        let execution = ExecutionCtx {
+            symbol: symbol.clone(),
+            direction: Direction::Sell,
+            shares,
+            executor: st0x_execution::SupportedExecutor::DryRun,
+        };
         let result = recover_claimed_offchain_order(&execution, &cqrs)
             .await
             .unwrap();

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -299,6 +299,7 @@ where
     });
 
     let trade_cqrs = super::TradeProcessingCqrs {
+        pool: context.pool.clone(),
         onchain_trade: context.frameworks.onchain_trade,
         position: context.frameworks.position,
         position_projection: context.frameworks.position_projection,

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -33,7 +33,7 @@ use st0x_finance::Usd;
 use st0x_float_macro::float;
 use st0x_float_serde::format_float_with_fallback;
 
-use super::{ExpectedEvent, assert_events, fetch_events};
+use super::{ExpectedEvent, StoredEvent, assert_events, fetch_events};
 use crate::bindings::IRaindexV6::{self, TakeOrderV3};
 use crate::bindings::{
     DeployableERC20, Deployer, Interpreter, Parser, RaindexV6, Store as RainStore,
@@ -60,6 +60,29 @@ const TEST_AAPL: &str = "AAPL";
 const TEST_MSFT: &str = "MSFT";
 const AAPL_PRICE: u32 = 100;
 const MSFT_PRICE: u32 = 200;
+
+fn nth_matching_event<'event>(
+    events: &'event [StoredEvent],
+    aggregate_type: &str,
+    aggregate_id: &str,
+    event_type: &str,
+    ordinal: usize,
+) -> &'event StoredEvent {
+    events
+        .iter()
+        .filter(|event| {
+            event.aggregate_type == aggregate_type
+                && event.aggregate_id == aggregate_id
+                && event.event_type == event_type
+        })
+        .nth(ordinal)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected {aggregate_type}/{aggregate_id}/{event_type} event \
+                 at ordinal {ordinal}"
+            )
+        })
+}
 
 // Rainlang interpreter components deploy to deterministic "zoltu" addresses; the
 // expression deployer references the parser/store/interpreter by these hardcoded
@@ -711,6 +734,7 @@ async fn create_test_cqrs_with_assets(
             .unwrap();
 
     let cqrs = TradeProcessingCqrs {
+        pool: pool.clone(),
         onchain_trade,
         position: position.clone(),
         position_projection: position_projection.clone(),
@@ -832,8 +856,14 @@ async fn onchain_trades_accumulate_and_trigger_offchain_fill()
     let events = assert_events(&pool, &expected).await;
 
     // Payload spot-checks: financial values in OnChainOrderFilled events
-    assert_eq!(events[2].event_type, "PositionEvent::OnChainOrderFilled");
-    let trade1_filled = &events[2].payload["OnChainOrderFilled"];
+    let trade1_filled = &nth_matching_event(
+        &events,
+        "Position",
+        TEST_AAPL,
+        "PositionEvent::OnChainOrderFilled",
+        0,
+    )
+    .payload["OnChainOrderFilled"];
     assert_eq!(trade1_filled["amount"].as_str().unwrap(), "0.5");
     assert_eq!(trade1_filled["direction"].as_str().unwrap(), "sell");
     assert_eq!(trade1_filled["price_usdc"].as_str().unwrap(), "100");
@@ -1437,8 +1467,14 @@ async fn buy_direction_accumulates_long() -> Result<(), Box<dyn std::error::Erro
     let events = assert_events(&pool, &expected).await;
 
     // Verify financial values in OnChainOrderFilled events (Buy direction)
-    assert_eq!(events[2].event_type, "PositionEvent::OnChainOrderFilled");
-    let trade1_filled = &events[2].payload["OnChainOrderFilled"];
+    let trade1_filled = &nth_matching_event(
+        &events,
+        "Position",
+        TEST_AAPL,
+        "PositionEvent::OnChainOrderFilled",
+        0,
+    )
+    .payload["OnChainOrderFilled"];
     assert_eq!(trade1_filled["amount"].as_str().unwrap(), "0.5");
     assert_eq!(trade1_filled["direction"].as_str().unwrap(), "buy");
     assert_eq!(trade1_filled["price_usdc"].as_str().unwrap(), "100");
@@ -1546,8 +1582,14 @@ async fn exact_threshold_triggers_execution() -> Result<(), Box<dyn std::error::
     let events = assert_events(&pool, &expected).await;
 
     // Payload spot-checks: financial values in the single-trade threshold crossing
-    assert_eq!(events[2].event_type, "PositionEvent::OnChainOrderFilled");
-    let filled = &events[2].payload["OnChainOrderFilled"];
+    let filled = &nth_matching_event(
+        &events,
+        "Position",
+        TEST_AAPL,
+        "PositionEvent::OnChainOrderFilled",
+        0,
+    )
+    .payload["OnChainOrderFilled"];
     assert_eq!(filled["amount"].as_str().unwrap(), "1");
     assert_eq!(filled["direction"].as_str().unwrap(), "sell");
     assert_eq!(filled["price_usdc"].as_str().unwrap(), "100");

--- a/src/onchain/clear.rs
+++ b/src/onchain/clear.rs
@@ -250,6 +250,8 @@ mod tests {
     use crate::tokenized_symbol;
     use st0x_float_macro::float;
 
+    const TEST_BLOCK_TIMESTAMP: u64 = 1_700_000_000;
+
     fn create_test_ctx() -> EvmCtx {
         EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
@@ -342,7 +344,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(tx_hash),
             transaction_index: None,
             log_index: Some(1),
@@ -357,7 +359,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(tx_hash),
             transaction_index: None,
             log_index: Some(2), // Higher than clear log
@@ -426,7 +428,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(tx_hash),
             transaction_index: None,
             log_index: Some(1),
@@ -441,7 +443,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(tx_hash),
             transaction_index: None,
             log_index: Some(2), // Higher than clear log
@@ -583,7 +585,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(fixed_bytes!(
                 "0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
             )),
@@ -642,7 +644,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(tx_hash),
             transaction_index: None,
             log_index: Some(1),
@@ -657,7 +659,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(fixed_bytes!(
                 "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             )), // Different tx hash
@@ -714,7 +716,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(tx_hash),
             transaction_index: None,
             log_index: Some(5), // Higher log index
@@ -729,7 +731,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(tx_hash),
             transaction_index: None,
             log_index: Some(2), // Lower than clear log index
@@ -779,7 +781,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(tx_hash),
             transaction_index: None,
             log_index: Some(1),
@@ -794,7 +796,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(tx_hash),
             transaction_index: None,
             log_index: Some(2),
@@ -877,7 +879,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(tx_hash),
             transaction_index: None,
             log_index: Some(log_index),
@@ -1017,7 +1019,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(tx_hash),
             transaction_index: None,
             log_index: Some(5),
@@ -1032,7 +1034,7 @@ mod tests {
             },
             block_hash: None,
             block_number: Some(1),
-            block_timestamp: None,
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
             transaction_hash: Some(tx_hash),
             transaction_index: None,
             log_index: Some(5),

--- a/src/onchain/trade.rs
+++ b/src/onchain/trade.rs
@@ -281,11 +281,15 @@ impl OnchainTrade {
         };
         let equity_symbol = TokenizedSymbol::<WrappedTokenizedShares>::parse(&equity_symbol_str)?;
 
+        let block_number = log.block_number.or(receipt_block_number);
+        let block_timestamp =
+            resolve_block_timestamp(evm.provider(), log.block_timestamp, block_number).await?;
+
         let pyth_price = enrich_with_pyth_price(
             evm.provider(),
             pyth_feed_ids,
             equity_symbol.base(),
-            log.block_number.or(receipt_block_number),
+            block_number,
             tx_hash,
         )
         .await;
@@ -300,11 +304,8 @@ impl OnchainTrade {
             amount: trade_details.equity_amount(),
             direction: trade_details.direction(),
             price,
-            block_number: log.block_number.or(receipt_block_number),
-            block_timestamp: log.block_timestamp.and_then(|timestamp_secs| {
-                let secs: i64 = timestamp_secs.try_into().ok()?;
-                DateTime::from_timestamp(secs, 0)
-            }),
+            block_timestamp,
+            block_number,
             gas_used,
             effective_gas_price,
             pyth_price,
@@ -418,6 +419,36 @@ async fn try_convert_log_to_onchain_trade<EvmImpl: Evm>(
     Ok(None)
 }
 
+async fn resolve_block_timestamp<P: Provider>(
+    provider: &P,
+    log_timestamp: Option<u64>,
+    block_number: Option<u64>,
+) -> Result<Option<DateTime<Utc>>, OnChainError> {
+    if let Some(timestamp_secs) = log_timestamp {
+        return timestamp_from_secs(timestamp_secs);
+    }
+
+    let Some(block_number) = block_number else {
+        return Ok(None);
+    };
+
+    let Some(block) = provider.get_block_by_number(block_number.into()).await? else {
+        warn!(
+            block_number,
+            "Block header unavailable while resolving onchain trade timestamp; \
+             provider may be lagging or the block may have reorged"
+        );
+        return Ok(None);
+    };
+
+    timestamp_from_secs(block.header.timestamp)
+}
+
+fn timestamp_from_secs(timestamp_secs: u64) -> Result<Option<DateTime<Utc>>, OnChainError> {
+    let secs = i64::try_from(timestamp_secs)?;
+    Ok(DateTime::from_timestamp(secs, 0))
+}
+
 /// Business logic validation errors for trade processing rules.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum TradeValidationError {
@@ -479,6 +510,7 @@ mod tests {
 
     use alloy::primitives::{Address, Bytes, U256, address, b256, fixed_bytes, uint};
     use alloy::providers::{ProviderBuilder, mock::Asserter};
+    use alloy::rpc::types::{Block, Transaction};
     use alloy::sol_types::SolCall;
     use rain_math_float::Float;
 
@@ -491,6 +523,26 @@ mod tests {
     use crate::symbol::cache::SymbolCache;
     use st0x_config::{EvmCtx, IngestionCutoff};
     use st0x_float_macro::float;
+
+    #[tokio::test]
+    async fn resolve_block_timestamp_fetches_header_when_log_timestamp_missing() {
+        let asserter = Asserter::new();
+        let mut block = Block::<Transaction>::default();
+        block.header.inner.number = 12_345;
+        block.header.inner.timestamp = 1_700_000_123;
+        asserter.push_success(&block);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let timestamp = resolve_block_timestamp(&provider, None, Some(12_345))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            timestamp,
+            DateTime::from_timestamp(1_700_000_123, 0),
+            "receipt logs without block_timestamp should use the block header timestamp"
+        );
+    }
 
     #[tokio::test]
     async fn enrich_with_pyth_price_returns_price_when_feed_configured() {

--- a/src/position.rs
+++ b/src/position.rs
@@ -967,7 +967,7 @@ impl DomainEvent for PositionEvent {
         use PositionEvent::*;
         match self {
             Initialized { .. } => "PositionEvent::Initialized".to_string(),
-            OnChainOrderFilled { .. } => "PositionEvent::OnChainOrderFilled".to_string(),
+            OnChainOrderFilled { .. } => Self::ON_CHAIN_ORDER_FILLED_EVENT_TYPE.to_string(),
             OnChainFillApplied { .. } => "PositionEvent::OnChainFillApplied".to_string(),
             OnChainFillSettled { .. } => "PositionEvent::OnChainFillSettled".to_string(),
             OffChainOrderPlaced { .. } => "PositionEvent::OffChainOrderPlaced".to_string(),
@@ -981,6 +981,11 @@ impl DomainEvent for PositionEvent {
     fn event_version(&self) -> String {
         "1.0".to_string()
     }
+}
+
+impl PositionEvent {
+    pub(crate) const ON_CHAIN_ORDER_FILLED_EVENT_TYPE: &'static str =
+        "PositionEvent::OnChainOrderFilled";
 }
 
 /// Compares two optional `Float` prices, treating both-absent as equal.

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -132,7 +132,7 @@ pub(crate) fn create_log(log_index: u64) -> Log {
         },
         block_hash: None,
         block_number: Some(12345),
-        block_timestamp: None,
+        block_timestamp: Some(1_700_000_000),
         transaction_hash: Some(fixed_bytes!(
             "0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
         )),
@@ -309,8 +309,8 @@ impl OnchainTradeBuilder {
     }
 
     #[must_use]
-    pub(crate) fn with_block_number(mut self, block_number: Option<u64>) -> Self {
-        self.trade.block_number = block_number;
+    pub(crate) fn with_block_number(mut self, block_number: impl IntoOptionalBlockNumber) -> Self {
+        self.trade.block_number = block_number.into_optional_block_number();
         self
     }
 
@@ -335,5 +335,21 @@ impl OnchainTradeBuilder {
 
     pub(crate) fn build(self) -> OnchainTrade {
         self.trade
+    }
+}
+
+pub(crate) trait IntoOptionalBlockNumber {
+    fn into_optional_block_number(self) -> Option<u64>;
+}
+
+impl IntoOptionalBlockNumber for u64 {
+    fn into_optional_block_number(self) -> Option<u64> {
+        Some(self)
+    }
+}
+
+impl IntoOptionalBlockNumber for Option<u64> {
+    fn into_optional_block_number(self) -> Option<u64> {
+        self
     }
 }

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -233,6 +233,8 @@ pub(crate) enum TradeAccountingError {
     AlpacaBrokerApi(#[from] AlpacaBrokerApiError),
     #[error("Failed to enqueue PollOrderStatus job: {0}")]
     EnqueuePollJob(#[from] crate::conductor::job::QueuePushError),
+    #[error("Position fill lookup failed: {0}")]
+    PositionFillLookup(#[from] crate::conductor::PositionFillLookupError),
     #[error("Missing block_timestamp for fill {trade_id}; cannot account for it")]
     MissingBlockTimestamp {
         trade_id: crate::onchain_trade::OnChainTradeId,
@@ -244,6 +246,10 @@ pub(crate) enum TradeAccountingError {
     UnexpectedPostPlaceState {
         offchain_order_id: crate::offchain::order::OffchainOrderId,
         state: crate::offchain::order::OffchainOrder,
+    },
+    #[error("Witness command for fill {trade_id} was rejected but the trade is missing on reload")]
+    InconsistentOnChainTradeState {
+        trade_id: crate::onchain_trade::OnChainTradeId,
     },
 }
 
@@ -335,6 +341,7 @@ mod tests {
                 .unwrap();
 
         let cqrs = TradeProcessingCqrs {
+            pool: pool.clone(),
             onchain_trade,
             position,
             position_projection,
@@ -463,6 +470,7 @@ mod tests {
                 .unwrap();
 
         let cqrs = TradeProcessingCqrs {
+            pool: pool.clone(),
             onchain_trade,
             position,
             position_projection,


### PR DESCRIPTION
## What

Closes [RAI-1157](https://linear.app/makeitrain/issue/RAI-1157/process-tx-must-fail-closed-on-an-already-recorded-tx-hash-log-index).

- `process_found_trade` (`src/cli/trading.rs`) rewritten to follow the ADR-0005 witness/acknowledge sequence and fail closed when a fill is already fully accounted.
- New `position_fill_already_recorded` guard (`src/conductor.rs`): queries `PositionEvent::OnChainOrderFilled` events by `(tx_hash, log_index)` and is consulted on every path before `execute_acknowledge_fill`, closing both the crash-window and legacy-fill double-count holes.
- New `reconcile_post_place_state` in the CLI: mirrors `dispatch_post_place_state` from the normal pipeline; sends `PositionCommand::FailOffChainOrder` on broker failure so `pending_offchain_order_id` is cleared and the normal pipeline can re-hedge.
- `block_number` added as a stored field on `OnchainTrade`; `OnchainTradeBuilder` extended with `with_block_number` / `with_block_timestamp` helpers (`src/test_utils.rs`).
- `execute_witness_trade`, `execute_enrich_trade`, `execute_acknowledge_fill`, `execute_mark_acknowledged` promoted to `pub(crate)` for direct CLI reuse.
- SPEC.md documents the ADR-0005 exactly-once protocol for `process-tx` and its operational precondition.

## Why

- The old CLI bypassed the `OnChainTrade` aggregate and called `execute_acknowledge_fill` directly.
- The `Position` aggregate's single-slot `last_acknowledged_trade_id` guard only deduplicates the *immediately preceding* fill — once a newer fill advances the slot, a CLI retry for an older fill bypasses the guard and counts it twice.
- Two concrete holes: **crash-window** (fill A witnessed+acknowledged in Position, `mark_acknowledged` crashed, fill B advanced slot, CLI retry re-applied A) and **legacy-fill** (fill A in Position via old path, no `OnChainTrade` record, slot advanced by fill B, `None` branch re-applied A).

## How

- `process_found_trade` loads the `OnChainTrade` aggregate first: `Acknowledged` → fail closed (early return, no hedge); `Witnessed` → crash-recovery (skip re-witness, enrich if needed, proceed to acknowledge); `None` → new fill (hard bail if `block_number` or `block_timestamp` absent, witness, enrich, then acknowledge).
- After the branch, a single authoritative `position_fill_already_recorded` check runs on **all three paths** before `execute_acknowledge_fill` — the durable guard that closes both holes.
- `reconcile_post_place_state` reloads the `OffchainOrder` aggregate after placement and sends `PositionCommand::FailOffChainOrder` when the order landed `Failed` (or unexpected state).

## Testing

12 new unit tests in `src/cli/trading.rs`: fail-closed on acknowledged fill (no second event, no hedge); resume of witnessed-but-unacknowledged fill (exactly 1 fill event); witness+acknowledge of a new fill; CLI-then-normal-pipeline integration guard (`process_queued_trade` skips already-acknowledged fill); missing `block_number` and missing `block_timestamp` both produce explicit errors; failed broker placement clears `pending_offchain_order_id`; concurrent-witnessed resumes cleanly; concurrent-acknowledged fails closed; crash-window regression `process_tx_does_not_double_count_witnessed_fill_after_newer_fill_acknowledged`; legacy-fill `None`-path regression `process_tx_none_path_does_not_recount_legacy_position_fill`; successful broker submission sets `pending_offchain_order_id`.

## Anything else

**Operational precondition**: `process-tx` must be run while the live bot is stopped (or after the apalis accounting job for the fill has drained). The durable guard's `SELECT` and the CQRS `apply` are separate transactions — a concurrent live-bot delivery of the same fill can slip through the TOCTOU window. Documented in SPEC.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved trade fill accounting with exactly-once semantics, including fail-closed handling, crash-window resume, and stricter deduplication for recorded fills.
  * Refined offchain hedge/placement lifecycle handling with clearer reconciliation of in-flight vs failed vs cleared states.

* **Bug Fixes**
  * Prevented duplicate fill/event recording during retries and concurrent witness/ack races.
  * Improved resilience when block timestamp data is missing by using fallback resolution.

* **Documentation**
  * Updated the operational specification with a required “stop live bot / drain accounting safely” workflow.

* **Tests**
  * Expanded unit and integration coverage, including updated event ordering expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->