### PR TITLE
feat: adopt the jobs-model event-sorcery 0.2.0-rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,9 +2615,13 @@ dependencies = [
 
 [[package]]
 name = "event-sorcery"
-version = "0.1.2"
-source = "git+https://github.com/ST0x-Technology/event-sorcery.git?rev=2cf958dd0899becd6f5b3ac34b7b1841bac55219#2cf958dd0899becd6f5b3ac34b7b1841bac55219"
+version = "0.1.0"
+source = "git+https://github.com/ST0x-Technology/event-sorcery.git?tag=0.2.0-rc2#70267675e3e7ad5dda57e52addbc23822a929d84"
 dependencies = [
+ "apalis",
+ "apalis-codec",
+ "apalis-core",
+ "apalis-sqlite",
  "async-trait",
  "cqrs-es 0.5.0",
  "serde",
@@ -2627,6 +2631,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "ulid",
 ]
 
 [[package]]
@@ -3391,7 +3396,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -4786,7 +4791,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4823,7 +4828,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -6102,8 +6107,8 @@ dependencies = [
 
 [[package]]
 name = "sqlite-es"
-version = "0.1.2"
-source = "git+https://github.com/ST0x-Technology/event-sorcery.git?rev=2cf958dd0899becd6f5b3ac34b7b1841bac55219#2cf958dd0899becd6f5b3ac34b7b1841bac55219"
+version = "0.1.0"
+source = "git+https://github.com/ST0x-Technology/event-sorcery.git?tag=0.2.0-rc2#70267675e3e7ad5dda57e52addbc23822a929d84"
 dependencies = [
  "chrono",
  "cqrs-es 0.5.0",
@@ -7084,7 +7089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8227,7 +8232,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,9 +139,14 @@ uuid = { version = "1.11", features = ["serde", "v4", "v5"] }
 # newer crates require >=0.2.122).
 wasm-bindgen = "=0.2.122"
 
+[workspace.dependencies.sqlite-es]
+git = "https://github.com/ST0x-Technology/event-sorcery.git"
+tag = "0.2.0-rc2"
+package = "sqlite-es"
+
 [workspace.dependencies.st0x-event-sorcery]
 git = "https://github.com/ST0x-Technology/event-sorcery.git"
-rev = "2cf958dd0899becd6f5b3ac34b7b1841bac55219"
+tag = "0.2.0-rc2"
 package = "event-sorcery"
 
 [package]

--- a/rust.nix
+++ b/rust.nix
@@ -41,14 +41,14 @@ let
   fullSrc = withRainMathFloat "st0x-src" cleanedSrc;
 
   # Vendor cargo deps with git dependency hashes
-  baseVendorDir = craneLib.vendorCargoDeps {
+  cargoVendorDir = craneLib.vendorCargoDeps {
     src = fullSrc;
     cargoLock = ./Cargo.lock;
     outputHashes = {
       "git+https://github.com/rainlanguage/rain.error#3d2ed70fb2f7c6156706846e10f163d1e493a8d3" =
         "sha256-dDsvRkrGXhfoFunvk6fwP+12fSsjiWYoxz/CzVVGpHA=";
-      "git+https://github.com/ST0x-Technology/event-sorcery.git?rev=2cf958dd0899becd6f5b3ac34b7b1841bac55219#2cf958dd0899becd6f5b3ac34b7b1841bac55219" =
-        "sha256-6gfvjw1aPmI8u3ViJkY2mqweuGGb4VvX/T1Bc5MTvE0=";
+      "git+https://github.com/ST0x-Technology/event-sorcery.git?tag=0.2.0-rc2#70267675e3e7ad5dda57e52addbc23822a929d84" =
+        "sha256-CBPWEhc5HGtTiwHBon2s8dbpfaCTwMbInb3k/pPzX0w=";
       "git+https://github.com/rainlanguage/rain.wasm?rev=06990d85a0b7c55378a1c8cca4dd9e2bc34a596a#06990d85a0b7c55378a1c8cca4dd9e2bc34a596a" =
         "sha256-MkuPc9mWAmry5Yzjph4/IbaIvjevFUerji1lipLUK4g=";
     };
@@ -83,14 +83,11 @@ let
         drv;
   };
 
-  # sqlite-es uses sqlx::migrate!("../../migrations") which resolves inside
-  # the vendor dir. Fetch migrations from event-sorcery at the same commit
-  # as Cargo.lock specifies for event-sorcery.
+  # event-sorcery 0.2.0-rc2 makes sqlite-es self-contained: its migrations live
+  # in-crate (`migrate!("./migrations")`) and survive `cargo package`, so the
+  # vendored crate already carries them. No migration-copy workaround is needed
+  # (the pre-0.2.0 `migrate!("../../migrations")` hack is gone).
   cargoLock = builtins.fromTOML (builtins.readFile ./Cargo.lock);
-  eventSorceryPackage = builtins.head (
-    builtins.filter (p: p.name or "" == "event-sorcery") cargoLock.package
-  );
-  eventSorceryRev = builtins.head (builtins.match ".*#([a-f0-9]+)" eventSorceryPackage.source);
 
   # Issuance vendor override (above) reuses the rev Cargo.lock locks for the
   # st0x-issuance-* crates, so the rev can never drift from the Cargo.toml pins.
@@ -99,29 +96,6 @@ let
     builtins.filter (p: p.name or "" == "st0x-issuance-dto") cargoLock.package
   );
   issuanceRev = builtins.head (builtins.match ".*#([a-f0-9]+)" issuancePackage.source);
-
-  sqliteEsMigrations =
-    builtins.fetchGit {
-      url = "https://github.com/ST0x-Technology/event-sorcery";
-      rev = eventSorceryRev;
-    }
-    + "/migrations";
-
-  cargoVendorDir = pkgs.runCommand "vendor-with-migrations" { } ''
-    cp -rL --no-preserve=mode ${baseVendorDir} $out
-
-    # sqlite-es's ../../migrations resolves from crate root (sqlite-es-0.1.0/),
-    # going up two levels to vendor root
-    cp -r ${sqliteEsMigrations} "$out/migrations"
-
-    # config.toml tells cargo where to find vendored crates. It contains
-    # absolute nix store paths like:
-    #   [source.nix-sources-c798c58f...]
-    #   directory = "/nix/store/xxx-vendor-cargo-deps/c798c58f..."
-    # We must update these to point to our wrapped vendor dir, otherwise
-    # cargo will look in the original (immutable, no migrations) location.
-    ${pkgs.gnused}/bin/sed -i "s|${baseVendorDir}|$out|g" $out/config.toml
-  '';
 
   # Build args without ABI env vars. Used for the deps-only derivation so an
   # ABI change doesn't bust the cached dependency artifacts -- third-party

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2657,7 +2657,7 @@ mod tests {
         // the exact event shapes/sequence the live system would produce. It
         // emits both `MintRequested` and `MintAccepted`.
         let store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         store

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -83,7 +83,7 @@ async fn build_equity_transfer_services(
 
     let (_vault_store, vault_registry_projection) =
         StoreBuilder::<VaultRegistry>::new(pool.clone())
-            .build(())
+            .build()
             .await?;
 
     let wrapper: Arc<dyn Wrapper> = Arc::new(WrapperService::new(
@@ -106,11 +106,11 @@ async fn build_equity_transfer_services(
     ));
 
     let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-        .build(())
+        .build()
         .await?;
 
     let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
-        .build(())
+        .build()
         .await?;
 
     let transfer = CrossVenueEquityTransfer::new(
@@ -444,7 +444,7 @@ async fn run_usdc_transfer<Writer: Write>(
     };
 
     let usdc_store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-        .build(())
+        .build()
         .await?;
 
     // A resume must target an existing transfer, checked up front before any
@@ -696,7 +696,7 @@ pub(super) async fn fail_usdc_transfer_command<Writer: Write>(
     writeln!(stdout, "Failing pre-burn USDC transfer {id}")?;
 
     let usdc_store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-        .build(())
+        .build()
         .await?;
 
     let Some(state) = usdc_store.load(&id).await? else {
@@ -922,7 +922,7 @@ pub(super) async fn clear_pending_burn_command<Writer: Write>(
     )?;
 
     let usdc_store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-        .build(())
+        .build()
         .await?;
 
     let Some(state) = usdc_store.load(&id).await? else {
@@ -1015,7 +1015,7 @@ pub(super) async fn reconcile_usdc_transfer_command<Writer: Write>(
     writeln!(stdout, "Reconciling stuck USDC transfer id: {id}")?;
 
     let usdc_store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-        .build(())
+        .build()
         .await?;
 
     let Some(state) = usdc_store.load(&id).await? else {
@@ -1432,7 +1432,7 @@ pub(crate) async fn fail_transfer_command<W: Write>(
                 }
             };
 
-            st0x_event_sorcery::send_command::<TokenizedEquityMint>(pool, &mint_id, command, ())
+            st0x_event_sorcery::send_command::<TokenizedEquityMint>(pool, &mint_id, command)
                 .await
                 .map_err(|error| stale_state_context("Mint", id, error))?;
 
@@ -1494,7 +1494,7 @@ pub(crate) async fn fail_transfer_command<W: Write>(
                 }
             };
 
-            st0x_event_sorcery::send_command::<EquityRedemption>(pool, &redemption_id, command, ())
+            st0x_event_sorcery::send_command::<EquityRedemption>(pool, &redemption_id, command)
                 .await
                 .map_err(|error| stale_state_context("Redemption", id, error))?;
 
@@ -1556,7 +1556,6 @@ pub(crate) async fn reconcile_equity_transfer_command<W: Write>(
                 pool,
                 &mint_id,
                 TokenizedEquityMintCommand::Reconcile { reason },
-                (),
             )
             .await?;
 
@@ -1584,7 +1583,6 @@ pub(crate) async fn reconcile_equity_transfer_command<W: Write>(
                 pool,
                 &redemption_id,
                 EquityRedemptionCommand::Reconcile { reason },
-                (),
             )
             .await?;
 
@@ -2315,7 +2313,7 @@ mod tests {
         let id = Uuid::from_u128(7777);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         store
@@ -2360,7 +2358,7 @@ mod tests {
         let id = Uuid::from_u128(99);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         store
@@ -2401,7 +2399,7 @@ mod tests {
         let id = Uuid::from_u128(123);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         store
@@ -2755,7 +2753,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_0001);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_bridging(&store, id).await;
@@ -2778,7 +2776,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_0002);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_bridging(&store, id).await;
@@ -2811,7 +2809,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_0002_000B);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_bridging(&store, id).await;
@@ -2848,7 +2846,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_0003);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -2886,7 +2884,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_0004);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_bridging_submitting(&store, id).await;
@@ -2922,7 +2920,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_0005);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_bridging_submitting(&store, id).await;
@@ -2974,7 +2972,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_0009);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_bridging_submitting(&store, id).await;
@@ -3024,7 +3022,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_000C);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_bridging_submitting(&store, id).await;
@@ -3072,7 +3070,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_000D);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_bridging_submitting(&store, id).await;
@@ -3124,7 +3122,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_0006);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_withdrawal_complete(&store, id).await;
@@ -3289,7 +3287,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_000B);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_bridged(&store, id).await;
@@ -3311,7 +3309,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_000C);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_deposit_initiated(&store, id).await;
@@ -3333,7 +3331,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_000D);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_deposit_confirmed(&store, id).await;
@@ -3385,7 +3383,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_000E);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_conversion_failed_base_to_alpaca(&store, id).await;
@@ -3411,7 +3409,7 @@ mod tests {
     async fn classify_fail_bridging_reload_distinguishes_pre_and_post_burn() {
         let pool = setup_test_db().await;
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -3482,7 +3480,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_0008);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -3517,7 +3515,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_0009);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_deposit_failed(&store, id).await;
@@ -3540,7 +3538,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_000A);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -3603,7 +3601,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_000F);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_conversion_failed_alpaca_to_base(&store, id).await;
@@ -3658,7 +3656,7 @@ mod tests {
         let id = Uuid::from_u128(0xBEEF_0010);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         seed_to_withdrawal_failed(&store, id).await;
@@ -3858,7 +3856,7 @@ mod tests {
         use EquityRedemptionCommand::*;
 
         let store = StoreBuilder::<EquityRedemption>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -3904,7 +3902,7 @@ mod tests {
         seed_redemption_to_withdrawn(pool, id).await;
 
         let store = StoreBuilder::<EquityRedemption>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         store.send(id, UnwrapTokens).await.unwrap();
@@ -3949,7 +3947,7 @@ mod tests {
         command: EquityRedemptionCommand,
     ) {
         let store = StoreBuilder::<EquityRedemption>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         store.send(id, command).await.unwrap();
@@ -4195,7 +4193,7 @@ mod tests {
     /// `TokenizedEquityMint` performs no I/O in its handlers.
     async fn seed_mint_to_failed(pool: &SqlitePool, id: &IssuerRequestId) {
         let store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         store
@@ -4228,7 +4226,7 @@ mod tests {
         command: TokenizedEquityMintCommand,
     ) {
         let store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         store.send(id, command).await.unwrap();

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -1,53 +1,18 @@
 //! Repair CLI commands for manually recovering stuck local CQRS state.
 
 use anyhow::{Context, bail};
-use async_trait::async_trait;
 use rain_math_float::Float;
 use sqlx::SqlitePool;
 use std::io::Write;
-use std::sync::Arc;
 
 use st0x_config::ExecutionThreshold;
 use st0x_event_sorcery::{AggregateError, LifecycleError, StoreBuilder};
-use st0x_execution::{
-    CancellationOutcome, ExecutorOrderId, FractionalShares, LimitOrder, MarketOrder, Symbol,
-};
+use st0x_execution::{FractionalShares, Symbol};
 
 use crate::offchain::order::{
-    OffchainOrder, OffchainOrderCommand, OffchainOrderError, OffchainOrderId, OrderPlacementResult,
-    OrderPlacer,
+    OffchainOrder, OffchainOrderCommand, OffchainOrderError, OffchainOrderId,
 };
 use crate::position::{Position, PositionCommand};
-
-/// An [`OrderPlacer`] for repair commands that must never place or cancel an
-/// order: `MarkFailed` is a pure terminal transition that never touches the
-/// placer. Returns an error on the unreachable placement/cancellation paths
-/// rather than panicking.
-struct RepairOrderPlacer;
-
-#[async_trait]
-impl OrderPlacer for RepairOrderPlacer {
-    async fn place_market_order(
-        &self,
-        _order: MarketOrder,
-    ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
-        Err("repair must not place offchain orders; MarkFailed is terminal-only".into())
-    }
-
-    async fn place_limit_order(
-        &self,
-        _order: LimitOrder,
-    ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
-        Err("repair must not place offchain orders; MarkFailed is terminal-only".into())
-    }
-
-    async fn cancel_order(
-        &self,
-        _executor_order_id: &ExecutorOrderId,
-    ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
-        Err("repair must not cancel offchain orders; MarkFailed is terminal-only".into())
-    }
-}
 
 /// Fails a position's pending offchain order pointer and drives the orphaned
 /// `OffchainOrder` aggregate to `Failed`.
@@ -64,7 +29,7 @@ pub(super) async fn fail_pending_offchain_order_command<W: Write>(
     reason: String,
 ) -> anyhow::Result<()> {
     let (position, projection) = StoreBuilder::<Position>::new(pool.clone())
-        .build(())
+        .build()
         .await
         .context("failed to build position store")?;
 
@@ -313,7 +278,7 @@ async fn fail_offchain_order_aggregate<W: Write>(
     // projection updates immediately -- a stale 'Submitted' row in the view is
     // the very symptom this command exists to repair.
     let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-        .build(Arc::new(RepairOrderPlacer))
+        .build()
         .await
         .context("failed to build offchain order store")?;
     let send_result = store
@@ -403,7 +368,7 @@ pub(super) async fn set_position_command<W: Write>(
     }
 
     let (position, projection) = StoreBuilder::<Position>::new(pool.clone())
-        .build(())
+        .build()
         .await
         .context("failed to build position store")?;
 
@@ -462,10 +427,6 @@ mod tests {
     use crate::position::TradeId;
     use crate::test_utils::{positive_shares, setup_test_db};
 
-    fn repair_order_placer() -> Arc<dyn OrderPlacer> {
-        Arc::new(RepairOrderPlacer)
-    }
-
     /// Seeds a standalone OffchainOrder aggregate for `order_id` into the
     /// non-terminal `Submitted` state (Place -> Placed + Submitted via the noop
     /// placer), so repair can drive it to `Failed`.
@@ -481,7 +442,6 @@ mod tests {
                 client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                 kind: crate::offchain::order::CounterTradeOrderKind::Market,
             },
-            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -499,7 +459,6 @@ mod tests {
                 market_session: st0x_execution::MarketSession::Regular,
                 limit_price: None,
             },
-            crate::offchain::order::noop_order_placer(),
         )
         .await
         .unwrap();
@@ -511,7 +470,7 @@ mod tests {
         offchain_order_id: OffchainOrderId,
     ) {
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let threshold = ExecutionThreshold::whole_share();
@@ -569,7 +528,7 @@ mod tests {
         .unwrap();
 
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let view = projection.load(&symbol).await.unwrap().unwrap();
@@ -602,7 +561,7 @@ mod tests {
 
         // Position pointer cleared.
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         assert_eq!(
@@ -664,7 +623,6 @@ mod tests {
                 price: Usd::new(float!(100)),
                 filled_at: chrono::Utc::now(),
             },
-            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -685,7 +643,7 @@ mod tests {
             "expected a filled-order refusal; got: {error}"
         );
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         assert_eq!(
@@ -723,7 +681,6 @@ mod tests {
                 price: Usd::new(float!(100)),
                 filled_at: chrono::Utc::now(),
             },
-            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -773,7 +730,6 @@ mod tests {
                 avg_price: Usd::new(float!(100)),
                 partially_filled_at: chrono::Utc::now(),
             },
-            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -846,7 +802,6 @@ mod tests {
                 avg_price: Usd::new(float!(100)),
                 partially_filled_at: chrono::Utc::now(),
             },
-            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -868,7 +823,6 @@ mod tests {
                 price: Usd::new(float!(100)),
                 filled_at: chrono::Utc::now(),
             },
-            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -890,7 +844,6 @@ mod tests {
                 error: "bot failed it".to_string(),
                 failed_at: chrono::Utc::now(),
             },
-            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -915,7 +868,7 @@ mod tests {
 
         // Partial prior run cleared the pointer...
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         position
@@ -937,7 +890,6 @@ mod tests {
                 price: Usd::new(float!(100)),
                 filled_at: chrono::Utc::now(),
             },
-            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -979,7 +931,6 @@ mod tests {
                 error: "bot failed it concurrently".to_string(),
                 failed_at: chrono::Utc::now(),
             },
-            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -1031,7 +982,6 @@ mod tests {
                 error: "pre-failed".to_string(),
                 failed_at: chrono::Utc::now(),
             },
-            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -1055,7 +1005,7 @@ mod tests {
 
         // The pointer must still be cleared even when the order needed no fix.
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         assert_eq!(
@@ -1085,7 +1035,7 @@ mod tests {
 
         // Simulate the partial prior run: pointer cleared, order untouched.
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         position
@@ -1155,12 +1105,12 @@ mod tests {
         // Symbol A has a position with a clear pointer; the order belongs to B.
         seed_pending_position(&pool, &symbol_a, OffchainOrderId::new()).await;
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let view = {
             let (_pos, projection) = StoreBuilder::<Position>::new(pool.clone())
-                .build(())
+                .build()
                 .await
                 .unwrap();
             projection.load(&symbol_a).await.unwrap().unwrap()
@@ -1223,7 +1173,6 @@ mod tests {
                 avg_price: Usd::new(float!(100)),
                 partially_filled_at: chrono::Utc::now(),
             },
-            repair_order_placer(),
         )
         .await
         .unwrap();
@@ -1255,7 +1204,7 @@ mod tests {
             "order must remain PartiallyFilled, got {order:?}"
         );
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         assert_eq!(
@@ -1280,7 +1229,7 @@ mod tests {
         seed_pending_position(&pool, &symbol, order_id).await;
 
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         position
@@ -1332,7 +1281,7 @@ mod tests {
         .unwrap();
 
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         assert_eq!(
@@ -1421,7 +1370,7 @@ mod tests {
         );
 
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let view = projection.load(&symbol).await.unwrap().unwrap();
@@ -1433,7 +1382,7 @@ mod tests {
         let pool = setup_test_db().await;
         let symbol = Symbol::new("MSTR").unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -1493,7 +1442,7 @@ mod tests {
         .unwrap();
 
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let view = projection.load(&symbol).await.unwrap().unwrap();
@@ -1512,7 +1461,7 @@ mod tests {
         let pool = setup_test_db().await;
         let symbol = Symbol::new("SPYM").unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -1550,7 +1499,7 @@ mod tests {
         .unwrap();
 
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let view = projection.load(&symbol).await.unwrap().unwrap();
@@ -1590,7 +1539,7 @@ mod tests {
         );
 
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         assert!(
@@ -1623,7 +1572,7 @@ mod tests {
         );
 
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         assert!(
@@ -1654,7 +1603,7 @@ mod tests {
         .unwrap();
 
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let view = projection.load(&symbol).await.unwrap().unwrap();
@@ -1690,7 +1639,7 @@ mod tests {
         );
 
         let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let view = projection.load(&symbol).await.unwrap().unwrap();

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -629,13 +629,12 @@ pub(super) async fn process_found_trade<W: Write>(
     // Build stores. CLI path: per-invocation instances are fine (single-instance
     // rule applies to the server path only; see AGENTS.md).
     let onchain_trade_store = StoreBuilder::<OnChainTrade>::new(pool.clone())
-        .build(())
+        .build()
         .await?;
-    let (position_store, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-        .build(())
-        .await?;
+    let (position_store, position_projection) =
+        StoreBuilder::<Position>::new(pool.clone()).build().await?;
     let (offchain_order_store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-        .build(order_placer.clone())
+        .build()
         .await?;
 
     let Some(block_number) = onchain_trade.block_number else {
@@ -1116,7 +1115,7 @@ mod tests {
         TradeProcessingCqrs, execute_acknowledge_fill, execute_mark_acknowledged,
         process_queued_trade,
     };
-    use crate::offchain::order::{CancellationReason, PollOrderStatusJobQueue, noop_order_placer};
+    use crate::offchain::order::{CancellationReason, PollOrderStatusJobQueue};
     use crate::onchain::trade::RaindexTradeEvent;
     use crate::onchain_trade::{OnChainTrade as OnChainTradeCqrs, OnChainTradeCommand};
     use crate::test_utils::{
@@ -1934,7 +1933,7 @@ mod tests {
 
         // Pre-seed 1: witness + acknowledge the OnChainTrade aggregate.
         let onchain_store = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -1962,7 +1961,7 @@ mod tests {
         // Pre-seed 2: apply the fill to the Position aggregate so there is live
         // unhedged exposure that could trigger hedge placement if we fell through.
         let (pre_position_store, _) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -2034,7 +2033,7 @@ mod tests {
 
         // Pre-seed: witness only (not acknowledged — simulates crash window).
         let store = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -2119,7 +2118,7 @@ mod tests {
 
         // The OnChainTrade aggregate must be acknowledged.
         let store = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let state = store
@@ -2171,15 +2170,15 @@ mod tests {
         // Step 2: Construct TradeProcessingCqrs backed by the same pool so the
         // acknowledged OnChainTrade record written by the CLI is visible.
         let onchain_trade_store = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position_store, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (offchain_order_store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(noop_order_placer())
+            .build()
             .await
             .unwrap();
 
@@ -2373,7 +2372,7 @@ mod tests {
         // pending_offchain_order_id must be cleared: the position must not be
         // permanently stuck after a failed broker placement.
         let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -2397,7 +2396,7 @@ mod tests {
         let block_timestamp = Utc::now();
 
         let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let onchain_trade = OnchainTradeBuilder::default()
@@ -2475,11 +2474,11 @@ mod tests {
             .expect("test trade should have a block timestamp");
 
         let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (offchain_order_store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(noop_order_placer())
+            .build()
             .await
             .unwrap();
 
@@ -2545,7 +2544,7 @@ mod tests {
             .expect("test trade should have a block timestamp");
 
         let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -2633,7 +2632,7 @@ mod tests {
             .expect("test trade should have a block timestamp");
 
         let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -2732,7 +2731,7 @@ mod tests {
         // process_found_trade's internal store loads the aggregate, it will see
         // Some(Witnessed) and resume rather than re-witness.
         let store_a = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -2829,7 +2828,7 @@ mod tests {
 
         // Simulate a concurrent writer that has fully processed the fill.
         let store_a = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -2857,7 +2856,7 @@ mod tests {
         // Apply the fill to the position so there is live unhedged exposure that
         // could trigger hedge placement if we fell through.
         let (pre_position_store, _) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -2948,11 +2947,11 @@ mod tests {
         };
 
         let onchain_store = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -3094,11 +3093,11 @@ mod tests {
         };
 
         let onchain_store = StoreBuilder::<OnChainTradeCqrs>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -3228,7 +3227,7 @@ mod tests {
         // pending_offchain_order_id must be set: the order is submitted to the
         // broker and in flight; only the order-status sweep will clear it.
         let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -3243,7 +3242,7 @@ mod tests {
             .expect("pending_offchain_order_id must be set after successful broker submission");
 
         let (offchain_order_store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(noop_order_placer())
+            .build()
             .await
             .unwrap();
         let offchain_order = offchain_order_store

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -36,7 +36,7 @@ use st0x_config::{
 };
 use st0x_dto::Statement;
 use st0x_event_sorcery::{
-    AggregateError, EventSourced, LifecycleError, Projection, RetryOnBusy, SendError, Store,
+    AggregateError, EventSourced, LifecycleError, Projection, SendError, Store,
     StoreBuilder, compact_events, incremental_vacuum, load_all_ids, load_entity,
 };
 use st0x_evm::{OpenChainErrorRegistry, USDC_BASE, Wallet};
@@ -183,13 +183,9 @@ where
     let order_placer: Arc<dyn OrderPlacer> = Arc::new(ExecutorOrderPlacer(executor.clone()));
     let (offchain_order, offchain_order_projection) =
         StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .with(Arc::new(RetryOnBusy {
-                inner: HedgeLatencyProjection::new(pool.clone()),
-            }))
-            .with(Arc::new(RetryOnBusy {
-                inner: LifecycleFailureProjection::new(pool.clone()),
-            }))
-            .build(order_placer.clone())
+            .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
+            .with(Arc::new(LifecycleFailureProjection::new(pool.clone())))
+            .build()
             .await?;
 
     // Startup recovery runs before any job worker starts, so no concurrent
@@ -554,12 +550,12 @@ impl Conductor {
         let schedulers = RebalancingSchedulers::new(&apalis_pool);
 
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await?;
 
         let (vault_registry, vault_registry_projection) =
             StoreBuilder::<VaultRegistry>::new(pool.clone())
-                .build(())
+                .build()
                 .await?;
 
         let seed_vault_registry_queue = SeedVaultRegistryJobQueue::new(&apalis_pool);
@@ -1306,7 +1302,7 @@ impl PositionAndRebalancing {
             let inventory_projection = Arc::new(InventoryProjection::new(inventory));
             let snapshot = StoreBuilder::<InventorySnapshot>::new(pool.clone())
                 .with(inventory_projection)
-                .build(())
+                .build()
                 .await?;
 
             Ok(Self {
@@ -1776,7 +1772,7 @@ async fn build_equity_recovery_stores<Chain: Wallet + Clone>(
     };
 
     let wrapped_store = StoreBuilder::<WrappedEquityRecovery>::new(pool.clone())
-        .build(())
+        .build()
         .await?;
 
     let unwrapped_services = UnwrappedEquityRecoveryServices {
@@ -1788,7 +1784,7 @@ async fn build_equity_recovery_stores<Chain: Wallet + Clone>(
     };
 
     let unwrapped_store = StoreBuilder::<UnwrappedEquityRecovery>::new(pool.clone())
-        .build(())
+        .build()
         .await?;
 
     Ok((
@@ -2269,10 +2265,8 @@ async fn build_position_cqrs(
 ) -> anyhow::Result<(Arc<Store<Position>>, Arc<Projection<Position>>)> {
     let (store, projection) = StoreBuilder::<Position>::new(pool.clone())
         .with(broadcaster)
-        .with(Arc::new(RetryOnBusy {
-            inner: HedgeLatencyProjection::new(pool.clone()),
-        }))
-        .build(())
+        .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
+        .build()
         .await?;
 
     // Seed the position_shares gauge for already-open positions: a normal
@@ -3808,7 +3802,7 @@ mod tests {
             InventoryView::default(),
             event_sender,
         ));
-        let vault_registry: Arc<Store<VaultRegistry>> = Arc::new(test_store(pool, ()));
+        let vault_registry: Arc<Store<VaultRegistry>> = Arc::new(test_store(pool));
 
         Arc::new(RebalancingService::new(
             RebalancingServiceConfig {
@@ -3845,8 +3839,8 @@ mod tests {
             Arc::new(st0x_tokenization::mock::MockTokenizer::new());
         let vault_lookup = Arc::new(crate::vault_lookup::MockVaultLookup::new());
 
-        let mint_store = Arc::new(test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool, ()));
+        let mint_store = Arc::new(test_store(pool.clone()));
+        let redemption_store = Arc::new(test_store(pool));
 
         CrossVenueEquityTransfer::new(
             raindex,
@@ -4019,8 +4013,8 @@ mod tests {
 
         let tokenizer = Arc::new(MockTokenizer::new());
 
-        let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-        let seeding_redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
+        let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
+        let seeding_redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone()));
 
         seeding_mint_store
             .send(
@@ -4054,7 +4048,7 @@ mod tests {
             crate::inventory::InventoryView::default(),
             event_sender,
         ));
-        let vault_registry: Arc<Store<VaultRegistry>> = Arc::new(test_store(pool.clone(), ()));
+        let vault_registry: Arc<Store<VaultRegistry>> = Arc::new(test_store(pool.clone()));
         let rebalancing_service = RebalancingService::new(
             RebalancingServiceConfig {
                 equity: crate::inventory::ImbalanceThreshold {
@@ -4122,8 +4116,8 @@ mod tests {
         // The recover function only calls store.load() (event replay); it does
         // not invoke tokenizer methods. Use the same services for the function
         // call -- MockTokenizer methods are never called during load().
-        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
+        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
+        let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone()));
         let calls_before = tokenizer.call_count();
 
         // Must complete in under 1 second: no issuer poll blocking.
@@ -4212,8 +4206,8 @@ mod tests {
             &pool,
             &rebalancing_service,
             inventory.as_ref(),
-            Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-            Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
+            Arc::new(test_store::<TokenizedEquityMint>(pool.clone())),
+            Arc::new(test_store::<EquityRedemption>(pool.clone())),
             &mut resume_queue,
         )
         .await
@@ -4230,8 +4224,8 @@ mod tests {
             &pool,
             &rebalancing_service,
             inventory.as_ref(),
-            Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-            Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
+            Arc::new(test_store::<TokenizedEquityMint>(pool.clone())),
+            Arc::new(test_store::<EquityRedemption>(pool.clone())),
             &mut resume_queue,
         )
         .await
@@ -4288,8 +4282,8 @@ mod tests {
             &pool,
             &rebalancing_service,
             inventory.as_ref(),
-            Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-            Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
+            Arc::new(test_store::<TokenizedEquityMint>(pool.clone())),
+            Arc::new(test_store::<EquityRedemption>(pool.clone())),
             &mut resume_queue,
         )
         .await
@@ -4371,8 +4365,8 @@ mod tests {
             &pool,
             &rebalancing_service,
             inventory.as_ref(),
-            Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-            Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
+            Arc::new(test_store::<TokenizedEquityMint>(pool.clone())),
+            Arc::new(test_store::<EquityRedemption>(pool.clone())),
             &mut resume_queue,
         )
         .await
@@ -4420,8 +4414,8 @@ mod tests {
             &pool,
             &rebalancing_service,
             inventory.as_ref(),
-            Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-            Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
+            Arc::new(test_store::<TokenizedEquityMint>(pool.clone())),
+            Arc::new(test_store::<EquityRedemption>(pool.clone())),
             &mut resume_queue,
         )
         .await
@@ -4442,8 +4436,8 @@ mod tests {
             &pool,
             &rebalancing_service,
             inventory.as_ref(),
-            Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-            Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
+            Arc::new(test_store::<TokenizedEquityMint>(pool.clone())),
+            Arc::new(test_store::<EquityRedemption>(pool.clone())),
             &mut resume_queue,
         )
         .await
@@ -4496,7 +4490,7 @@ mod tests {
         let (pool, apalis_pool) = setup_test_pools().await;
         let mint_id = issuer_request_id("pre-wrap-held-mint");
 
-        let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
+        let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
 
         // RecordMintRequested -> MintAccepted state.
         // RecordTokensReceived -> TokensReceived state (pre-wrap).
@@ -4533,7 +4527,7 @@ mod tests {
             crate::inventory::InventoryView::default(),
             event_sender,
         ));
-        let vault_registry: Arc<Store<VaultRegistry>> = Arc::new(test_store(pool.clone(), ()));
+        let vault_registry: Arc<Store<VaultRegistry>> = Arc::new(test_store(pool.clone()));
         let rebalancing_service = RebalancingService::new(
             RebalancingServiceConfig {
                 equity: crate::inventory::ImbalanceThreshold {
@@ -4561,8 +4555,8 @@ mod tests {
             Arc::new(crate::alerts::NoopNotifier),
         );
 
-        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
+        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
+        let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone()));
         let mut resume_queue = ResumeTokenizationJobQueue::new(&apalis_pool);
 
         recover_interrupted_tokenization_aggregates(
@@ -4587,7 +4581,7 @@ mod tests {
         let (pool2, apalis_pool2) = setup_test_pools().await;
         let mint_id2 = issuer_request_id("pre-wrap-active-mint");
 
-        let seeding_mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(pool2.clone(), ()));
+        let seeding_mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(pool2.clone()));
 
         seeding_mint_store2
             .send(
@@ -4622,7 +4616,7 @@ mod tests {
             crate::inventory::InventoryView::default(),
             event_sender2.clone(),
         ));
-        let vault_registry2: Arc<Store<VaultRegistry>> = Arc::new(test_store(pool2.clone(), ()));
+        let vault_registry2: Arc<Store<VaultRegistry>> = Arc::new(test_store(pool2.clone()));
         let rebalancing_service2 = RebalancingService::new(
             RebalancingServiceConfig {
                 equity: crate::inventory::ImbalanceThreshold {
@@ -4650,8 +4644,8 @@ mod tests {
             Arc::new(crate::alerts::NoopNotifier),
         );
 
-        let mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(pool2.clone(), ()));
-        let redemption_store2 = Arc::new(test_store::<EquityRedemption>(pool2.clone(), ()));
+        let mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(pool2.clone()));
+        let redemption_store2 = Arc::new(test_store::<EquityRedemption>(pool2.clone()));
         let mut resume_queue2 = ResumeTokenizationJobQueue::new(&apalis_pool2);
 
         recover_interrupted_tokenization_aggregates(
@@ -5271,7 +5265,7 @@ mod tests {
     #[tokio::test]
     async fn test_discover_vaults_for_trade_discovers_usdc_vault() {
         let pool = setup_test_db().await;
-        let vault_registry: Store<VaultRegistry> = test_store(pool.clone(), ());
+        let vault_registry: Store<VaultRegistry> = test_store(pool.clone());
 
         let alice = create_order_with_usdc_and_equity_vaults(ORDER_OWNER);
         let bob = create_order_with_usdc_and_equity_vaults(OTHER_OWNER);
@@ -5296,7 +5290,7 @@ mod tests {
     #[tokio::test]
     async fn test_discover_vaults_for_trade_discovers_equity_vault() {
         let pool = setup_test_db().await;
-        let vault_registry: Store<VaultRegistry> = test_store(pool.clone(), ());
+        let vault_registry: Store<VaultRegistry> = test_store(pool.clone());
 
         let alice = create_order_with_usdc_and_equity_vaults(ORDER_OWNER);
         let bob = create_order_with_usdc_and_equity_vaults(OTHER_OWNER);
@@ -5321,7 +5315,7 @@ mod tests {
     #[tokio::test]
     async fn test_discover_vaults_for_trade_from_take_event() {
         let pool = setup_test_db().await;
-        let vault_registry: Store<VaultRegistry> = test_store(pool.clone(), ());
+        let vault_registry: Store<VaultRegistry> = test_store(pool.clone());
 
         let order = create_order_with_usdc_and_equity_vaults(ORDER_OWNER);
         let queued_event = create_emitted_take_event(order);
@@ -5352,7 +5346,7 @@ mod tests {
     #[tokio::test]
     async fn test_discover_vaults_for_trade_inventory_trade_discovers_nothing() {
         let pool = setup_test_db().await;
-        let vault_registry: Store<VaultRegistry> = test_store(pool.clone(), ());
+        let vault_registry: Store<VaultRegistry> = test_store(pool.clone());
 
         let queued_event = create_emitted_inventory_event();
         let trade = create_test_trade("MSFT");
@@ -5373,7 +5367,7 @@ mod tests {
     #[tokio::test]
     async fn test_discover_vaults_for_trade_filters_non_owner_vaults() {
         let pool = setup_test_db().await;
-        let vault_registry: Store<VaultRegistry> = test_store(pool.clone(), ());
+        let vault_registry: Store<VaultRegistry> = test_store(pool.clone());
 
         let alice = create_order_with_usdc_and_equity_vaults(OTHER_OWNER);
         let bob = create_order_with_usdc_and_equity_vaults(OTHER_OWNER);
@@ -5396,7 +5390,7 @@ mod tests {
     #[tokio::test]
     async fn test_discover_vaults_for_trade_uses_correct_aggregate_id() {
         let pool = setup_test_db().await;
-        let vault_registry: Store<VaultRegistry> = test_store(pool.clone(), ());
+        let vault_registry: Store<VaultRegistry> = test_store(pool.clone());
 
         let alice = create_order_with_usdc_and_equity_vaults(ORDER_OWNER);
         let bob = create_order_with_usdc_and_equity_vaults(OTHER_OWNER);
@@ -5419,7 +5413,7 @@ mod tests {
     #[tokio::test]
     async fn test_discover_vaults_for_trade_uses_trade_symbol_for_equity() {
         let pool = setup_test_db().await;
-        let vault_registry: Store<VaultRegistry> = test_store(pool.clone(), ());
+        let vault_registry: Store<VaultRegistry> = test_store(pool.clone());
 
         let alice = create_order_with_usdc_and_equity_vaults(ORDER_OWNER);
         let bob = create_order_with_usdc_and_equity_vaults(OTHER_OWNER);
@@ -5500,36 +5494,29 @@ mod tests {
     async fn create_cqrs_frameworks(
         pool: &SqlitePool,
     ) -> (CqrsFrameworks, Arc<Projection<OffchainOrder>>) {
-        create_cqrs_frameworks_with_order_placer(pool, noop_order_placer()).await
-    }
-
-    async fn create_cqrs_frameworks_with_order_placer(
-        pool: &SqlitePool,
-        order_placer: Arc<dyn OrderPlacer>,
-    ) -> (CqrsFrameworks, Arc<Projection<OffchainOrder>>) {
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(order_placer)
+                .build()
                 .await
                 .unwrap();
 
         let (vault_registry, _) = StoreBuilder::<VaultRegistry>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let snapshot = StoreBuilder::<InventorySnapshot>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -7079,8 +7066,7 @@ mod tests {
     #[tokio::test]
     async fn extended_hours_trade_skips_immediate_hedge_without_offchain_inventory() {
         let (pool, apalis_pool) = setup_test_pools().await;
-        let (frameworks, offchain_order_projection) =
-            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let symbol = Symbol::new("AAPL").unwrap();
         let cqrs = trade_processing_cqrs_with_assets(
             &frameworks,
@@ -7150,8 +7136,7 @@ mod tests {
         // job (which has the OrderPlacer for the limit order) rather than place
         // inline or wait for the next CheckPositions scan.
         let (pool, apalis_pool) = setup_test_pools().await;
-        let (frameworks, offchain_order_projection) =
-            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = TradeProcessingCqrs {
             pool: pool.clone(),
             onchain_trade: frameworks.onchain_trade.clone(),
@@ -7266,8 +7251,7 @@ mod tests {
     #[tokio::test]
     async fn extended_hours_trade_enqueues_clamped_immediate_hedge_job() {
         let (pool, apalis_pool) = setup_test_pools().await;
-        let (frameworks, offchain_order_projection) =
-            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let (frameworks, offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let symbol = Symbol::new("AAPL").unwrap();
         let cqrs = trade_processing_cqrs_with_assets(
             &frameworks,
@@ -7331,8 +7315,7 @@ mod tests {
     #[tokio::test]
     async fn extended_hours_enqueue_failure_leaves_position_ready_for_check_positions() {
         let (pool, apalis_pool) = setup_test_pools().await;
-        let (frameworks, _offchain_order_projection) =
-            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
         let symbol = Symbol::new("AAPL").unwrap();
         let cqrs = trade_processing_cqrs_with_assets(
             &frameworks,
@@ -8064,7 +8047,7 @@ mod tests {
         let test_token = address!("0x1234567890123456789012345678901234567890");
 
         // Seed vault registry so the trigger can resolve the token address.
-        let vault_registry: Store<VaultRegistry> = test_store(pool.clone(), ());
+        let vault_registry: Store<VaultRegistry> = test_store(pool.clone());
         vault_registry
             .send(
                 &VaultRegistryId {
@@ -8088,7 +8071,7 @@ mod tests {
             event_sender,
         ));
 
-        let vault_registry = Arc::new(test_store(pool.clone(), ()));
+        let vault_registry = Arc::new(test_store(pool.clone()));
 
         let trigger = Arc::new(RebalancingService::new(
             RebalancingServiceConfig {
@@ -8121,7 +8104,7 @@ mod tests {
 
         let (position_store, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
             .with(Arc::clone(&reactor))
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -8206,7 +8189,7 @@ mod tests {
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(initial_inventory, event_sender));
 
-        let vault_registry = Arc::new(test_store(pool.clone(), ()));
+        let vault_registry = Arc::new(test_store(pool.clone()));
 
         let trigger = Arc::new(RebalancingService::new(
             RebalancingServiceConfig {
@@ -8233,7 +8216,7 @@ mod tests {
 
         let (position_store, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
             .with(Arc::clone(&reactor))
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -8322,7 +8305,7 @@ mod tests {
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(initial_inventory, event_sender));
 
-        let vault_registry = Arc::new(test_store(pool.clone(), ()));
+        let vault_registry = Arc::new(test_store(pool.clone()));
 
         let trigger = Arc::new(RebalancingService::new(
             RebalancingServiceConfig {
@@ -8355,7 +8338,7 @@ mod tests {
 
         let (position_store, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
             .with(reactor.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -8412,7 +8395,7 @@ mod tests {
         let order_owner = address!("0x0000000000000000000000000000000000000002");
         let test_token = address!("0x1234567890123456789012345678901234567890");
 
-        let vault_registry: Store<VaultRegistry> = test_store(pool.clone(), ());
+        let vault_registry: Store<VaultRegistry> = test_store(pool.clone());
         vault_registry
             .send(
                 &VaultRegistryId {
@@ -8463,7 +8446,7 @@ mod tests {
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(initial_inventory, event_sender));
 
-        let vault_registry = Arc::new(test_store(pool.clone(), ()));
+        let vault_registry = Arc::new(test_store(pool.clone()));
 
         let trigger = Arc::new(RebalancingService::new(
             RebalancingServiceConfig {
@@ -8496,7 +8479,7 @@ mod tests {
 
         let (position_store, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
             .with(Arc::clone(&reactor))
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -8736,7 +8719,7 @@ mod tests {
         ));
         let (vault_registry, vault_registry_projection) =
             StoreBuilder::<VaultRegistry>::new(pool.clone())
-                .build(())
+                .build()
                 .await
                 .unwrap();
 
@@ -9119,13 +9102,13 @@ mod tests {
     async fn recover_orphaned_pending_clears_filled_order() {
         let pool = setup_test_db().await;
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
+                .build()
                 .await
                 .unwrap();
 
@@ -9248,13 +9231,13 @@ mod tests {
     async fn recover_orphaned_pending_clears_missing_order_aggregate() {
         let pool = setup_test_db().await;
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
+                .build()
                 .await
                 .unwrap();
 
@@ -9369,13 +9352,13 @@ mod tests {
         let order_placer: Arc<dyn crate::offchain::order::OrderPlacer> = Arc::new(BlockingPlacer);
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
+                .build()
                 .await
                 .unwrap();
 
@@ -9473,13 +9456,13 @@ mod tests {
         let order_placer = noop_order_placer();
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
+                .build()
                 .await
                 .unwrap();
 
@@ -9619,13 +9602,13 @@ mod tests {
         let order_placer = rejecting_order_placer();
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
+                .build()
                 .await
                 .unwrap();
 
@@ -9718,13 +9701,13 @@ mod tests {
     async fn recover_orphaned_pending_clears_failed_order() {
         let pool = setup_test_db().await;
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
+                .build()
                 .await
                 .unwrap();
 
@@ -9822,16 +9805,14 @@ mod tests {
     #[tokio::test]
     async fn recover_orphaned_pending_clears_cancelled_order() {
         let pool = setup_test_db().await;
-        let order_placer = crate::offchain::order::noop_order_placer();
-
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(order_placer)
+                .build()
                 .await
                 .unwrap();
 
@@ -9968,16 +9949,14 @@ mod tests {
     #[tokio::test]
     async fn recover_orphaned_pending_skips_cancelling_order() {
         let pool = setup_test_db().await;
-        let order_placer = crate::offchain::order::noop_order_placer();
-
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(order_placer)
+                .build()
                 .await
                 .unwrap();
 
@@ -10093,16 +10072,14 @@ mod tests {
     #[tokio::test]
     async fn recover_orphaned_pending_completes_cancelled_order_with_partial_fill() {
         let pool = setup_test_db().await;
-        let order_placer = crate::offchain::order::noop_order_placer();
-
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(order_placer)
+                .build()
                 .await
                 .unwrap();
 
@@ -10410,8 +10387,7 @@ mod tests {
         // failure/idempotency anchor stays unset, so the replacement is a
         // fresh order instead of a broker-deduped retry against a dead key.
         let (pool, apalis_pool) = setup_test_pools().await;
-        let (frameworks, _projection) =
-            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let (frameworks, _projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             &pool,
@@ -10810,8 +10786,7 @@ mod tests {
     #[tokio::test]
     async fn dispatch_post_place_state_cancelling_enqueues_poll() {
         let (pool, apalis_pool) = setup_test_pools().await;
-        let (frameworks, _projection) =
-            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let (frameworks, _projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             &pool,
@@ -10867,8 +10842,7 @@ mod tests {
     #[tokio::test]
     async fn dispatch_post_place_state_cancelled_partial_fill_completes_position() {
         let (pool, apalis_pool) = setup_test_pools().await;
-        let (frameworks, _projection) =
-            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let (frameworks, _projection) = create_cqrs_frameworks(&pool).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             &pool,

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -1228,7 +1228,7 @@ mod tests {
         Arc::new(TransferEquityToMarketMakingCtx {
             transfer,
             equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
-            mint_store: Arc::new(test_store(cqrs_pool, ())),
+            mint_store: Arc::new(test_store(cqrs_pool)),
             equities_config: EquitiesConfig::default(),
         })
     }

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -16,7 +16,7 @@
 use sqlx::SqlitePool;
 use std::sync::Arc;
 
-use st0x_event_sorcery::{Projection, RetryOnBusy, Store, StoreBuilder};
+use st0x_event_sorcery::{Projection, Store, StoreBuilder};
 
 use crate::dashboard::Broadcaster;
 use crate::equity_redemption::EquityRedemption;
@@ -38,10 +38,10 @@ use crate::usdc_rebalance::UsdcRebalance;
 pub(super) struct QueryManifest {
     rebalancing_service: Arc<RebalancingService>,
     broadcaster: Arc<Broadcaster>,
-    hedge_latency: Arc<RetryOnBusy<HedgeLatencyProjection>>,
-    rebalance_timing: Arc<RetryOnBusy<RebalanceTimingProjection>>,
-    equity_timing: Arc<RetryOnBusy<EquityTimingProjection>>,
-    lifecycle_failure: Arc<RetryOnBusy<LifecycleFailureProjection>>,
+    hedge_latency: Arc<HedgeLatencyProjection>,
+    rebalance_timing: Arc<RebalanceTimingProjection>,
+    equity_timing: Arc<EquityTimingProjection>,
+    lifecycle_failure: Arc<LifecycleFailureProjection>,
 }
 
 /// Built CQRS frameworks from the wiring process.
@@ -70,18 +70,10 @@ impl QueryManifest {
         Self {
             rebalancing_service,
             broadcaster,
-            hedge_latency: Arc::new(RetryOnBusy {
-                inner: hedge_latency,
-            }),
-            rebalance_timing: Arc::new(RetryOnBusy {
-                inner: rebalance_timing,
-            }),
-            equity_timing: Arc::new(RetryOnBusy {
-                inner: equity_timing,
-            }),
-            lifecycle_failure: Arc::new(RetryOnBusy {
-                inner: lifecycle_failure,
-            }),
+            hedge_latency: Arc::new(hedge_latency),
+            rebalance_timing: Arc::new(rebalance_timing),
+            equity_timing: Arc::new(equity_timing),
+            lifecycle_failure: Arc::new(lifecycle_failure),
         }
     }
 
@@ -104,7 +96,7 @@ impl QueryManifest {
             .with(rebalancing_service.clone())
             .with(broadcaster.clone())
             .with(hedge_latency)
-            .build(())
+            .build()
             .await?;
 
         let mint = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
@@ -112,7 +104,7 @@ impl QueryManifest {
             .with(broadcaster.clone())
             .with(equity_timing.clone())
             .with(lifecycle_failure.clone())
-            .build(())
+            .build()
             .await?;
 
         let redemption = StoreBuilder::<EquityRedemption>::new(pool.clone())
@@ -120,7 +112,7 @@ impl QueryManifest {
             .with(broadcaster.clone())
             .with(equity_timing)
             .with(lifecycle_failure.clone())
-            .build(())
+            .build()
             .await?;
 
         let usdc = StoreBuilder::<UsdcRebalance>::new(pool.clone())
@@ -128,14 +120,14 @@ impl QueryManifest {
             .with(broadcaster)
             .with(rebalance_timing)
             .with(lifecycle_failure)
-            .build(())
+            .build()
             .await?;
 
         // The reactor's underlying trigger owns the snapshot projection
         // internally, so it's the sole subscriber here.
         let snapshot = StoreBuilder::<InventorySnapshot>::new(pool.clone())
             .with(rebalancing_service)
-            .build(())
+            .build()
             .await?;
 
         Ok(BuiltFrameworks {
@@ -201,7 +193,7 @@ mod tests {
         let (pool, apalis_pool) = setup_test_pools().await;
         let (event_sender, _event_receiver) = broadcast::channel(10);
 
-        let vault_registry = Arc::new(test_store(pool.clone(), ()));
+        let vault_registry = Arc::new(test_store(pool.clone()));
 
         let inventory = Arc::new(BroadcastingInventory::new(
             InventoryView::default(),
@@ -257,7 +249,7 @@ mod tests {
         let (pool, apalis_pool) = setup_test_pools().await;
         let (event_sender, _event_receiver) = broadcast::channel(10);
 
-        let vault_registry = Arc::new(test_store(pool.clone(), ()));
+        let vault_registry = Arc::new(test_store(pool.clone()));
 
         let inventory = Arc::new(BroadcastingInventory::new(
             InventoryView::default(),
@@ -332,7 +324,7 @@ mod tests {
         let orderbook = Address::repeat_byte(0xAB);
         let owner = Address::repeat_byte(0xCD);
         let token = Address::repeat_byte(0xEF);
-        let vault_registry = Arc::new(test_store(pool.clone(), ()));
+        let vault_registry = Arc::new(test_store(pool.clone()));
         vault_registry
             .send(
                 &VaultRegistryId { orderbook, owner },

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -250,7 +250,7 @@ mod tests {
     async fn offchain_order_filled_broadcasts_fill() {
         let pool = setup_test_db().await;
         let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(crate::offchain::order::noop_order_placer())
+            .build()
             .await
             .unwrap();
         let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
@@ -326,7 +326,7 @@ mod tests {
     async fn position_update_broadcasts_net_position() {
         let pool = setup_test_db().await;
         let (store, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
@@ -400,7 +400,7 @@ mod tests {
     async fn manual_position_adjustment_broadcasts_adjusted_net() {
         let pool = setup_test_db().await;
         let (store, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
@@ -489,7 +489,7 @@ mod tests {
     async fn reorged_broadcasts_reversed_net() {
         let pool = setup_test_db().await;
         let (store, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (broadcaster, mut receiver) = test_broadcaster(pool.clone());

--- a/src/dashboard/trade_loader.rs
+++ b/src/dashboard/trade_loader.rs
@@ -106,7 +106,7 @@ mod tests {
         };
 
         let store = st0x_event_sorcery::StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -139,7 +139,7 @@ mod tests {
 
         let (store, _projection) =
             st0x_event_sorcery::StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(crate::offchain::order::noop_order_placer())
+                .build()
                 .await
                 .unwrap();
 
@@ -197,7 +197,7 @@ mod tests {
         let pool = setup_test_db().await;
 
         let store = st0x_event_sorcery::StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -259,7 +259,7 @@ mod tests {
         let pool = setup_test_db().await;
 
         let store = st0x_event_sorcery::StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -297,7 +297,7 @@ mod tests {
 
         let (store, _projection) =
             st0x_event_sorcery::StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(crate::offchain::order::noop_order_placer())
+                .build()
                 .await
                 .unwrap();
 

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -51,7 +51,6 @@
 //! - All state transitions are captured as events for complete audit trail
 
 use alloy::primitives::{Address, TxHash, U256};
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rain_math_float::Float;
 use serde::{Deserialize, Serialize};
@@ -63,7 +62,7 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use st0x_dto::{EquityRedemptionOperation, EquityRedemptionStatus, TransferOperation};
-use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
+use st0x_event_sorcery::{DomainEvent, EventSourced, JobQueue, Nil};
 use st0x_execution::Symbol;
 use st0x_finance::{FractionalShares, Id};
 use st0x_tokenization::TokenizationRequestId;
@@ -1296,13 +1295,12 @@ impl EquityRedemption {
     }
 }
 
-#[async_trait]
 impl EventSourced for EquityRedemption {
     type Id = RedemptionAggregateId;
     type Event = EquityRedemptionEvent;
     type Command = EquityRedemptionCommand;
     type Error = EquityRedemptionError;
-    type Services = ();
+    type Jobs = Nil;
     type Materialized = Nil;
 
     const AGGREGATE_TYPE: &'static str = "EquityRedemption";
@@ -1896,9 +1894,9 @@ impl EventSourced for EquityRedemption {
         })
     }
 
-    async fn initialize(
+    fn initialize(
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use EquityRedemptionCommand::*;
         use EquityRedemptionEvent::*;
@@ -1969,10 +1967,10 @@ impl EventSourced for EquityRedemption {
     }
 
     #[allow(clippy::too_many_lines)]
-    async fn transition(
+    fn transition(
         &self,
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use EquityRedemptionCommand::*;
         use EquityRedemptionEvent::*;
@@ -2359,14 +2357,15 @@ impl EquityRedemption {
             Self::UnwrapSubmitted { unwrap_tx_hash, .. } => {
                 // Financial precision validation stays at the aggregate
                 // boundary (fail-fast, no defaults).
-                let quantity = Float::from_fixed_decimal(unwrapped_amount, TOKENIZED_EQUITY_DECIMALS)
-                    .map_err(|error| {
-                        EquityRedemptionError::RaindexWithdrawQuantityConversionFailed {
-                            tx_hash: *unwrap_tx_hash,
-                            amount: unwrapped_amount,
-                            error_message: error.to_string(),
-                        }
-                    })?;
+                let quantity =
+                    Float::from_fixed_decimal(unwrapped_amount, TOKENIZED_EQUITY_DECIMALS)
+                        .map_err(|error| {
+                            EquityRedemptionError::RaindexWithdrawQuantityConversionFailed {
+                                tx_hash: *unwrap_tx_hash,
+                                amount: unwrapped_amount,
+                                error_message: error.to_string(),
+                            }
+                        })?;
 
                 Ok(vec![TokensUnwrapped {
                     quantity: Some(quantity),
@@ -2902,7 +2901,7 @@ mod tests {
 
     #[tokio::test]
     async fn redeem_from_uninitialized_produces_vault_withdraw_pending() {
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given_no_previous_events()
             .when(EquityRedemptionCommand::Redeem {
                 symbol: Symbol::new("AAPL").unwrap(),
@@ -2922,7 +2921,7 @@ mod tests {
 
     #[tokio::test]
     async fn detect_after_tokens_sent_produces_detected() {
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
             .when(EquityRedemptionCommand::Detect {
                 tokenization_request_id: tokenization_request_id("REQ789"),
@@ -2936,7 +2935,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_from_pending_produces_completed() {
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_sent_event(),
@@ -2952,7 +2951,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_redemption_flow_end_to_end() {
-        let store = TestStore::<EquityRedemption>::new(());
+        let store = TestStore::<EquityRedemption>::new();
         let id = redemption_aggregate_id("end-to-end");
 
         store
@@ -3061,7 +3060,7 @@ mod tests {
     async fn submit_withdraw_at_uses_supplied_timestamp() {
         let submitted_at = Utc::now() - chrono::Duration::hours(3);
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![vault_withdraw_pending_event()])
             .when(EquityRedemptionCommand::SubmitWithdrawAt {
                 tx_hash: TxHash::random(),
@@ -3086,7 +3085,7 @@ mod tests {
         let withdrawn_at = Utc::now() - chrono::Duration::hours(2);
         let amount = U256::from(50_250_000_000_000_000_000_u128);
 
-        let store = TestStore::<EquityRedemption>::new(());
+        let store = TestStore::<EquityRedemption>::new();
         let id = redemption_aggregate_id("confirm-withdraw-at");
 
         store
@@ -3138,7 +3137,7 @@ mod tests {
     async fn submit_unwrap_at_uses_supplied_timestamp() {
         let submitted_at = Utc::now() - chrono::Duration::hours(1);
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![withdrawn_from_raindex_event(), unwrap_pending_event()])
             .when(EquityRedemptionCommand::SubmitUnwrapAt {
                 unwrap_tx_hash: TxHash::random(),
@@ -3163,7 +3162,7 @@ mod tests {
         let unwrapped_at = Utc::now() - chrono::Duration::minutes(30);
         let amount = U256::from(50_250_000_000_000_000_000_u128);
 
-        let store = TestStore::<EquityRedemption>::new(());
+        let store = TestStore::<EquityRedemption>::new();
         let id = redemption_aggregate_id("confirm-unwrap-at");
 
         store
@@ -3239,7 +3238,7 @@ mod tests {
     async fn submit_send_at_uses_supplied_timestamp() {
         let submitted_at = Utc::now() - chrono::Duration::minutes(20);
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_unwrapped_event(),
@@ -3270,7 +3269,7 @@ mod tests {
     async fn confirm_send_at_uses_supplied_timestamp() {
         let sent_at = Utc::now() - chrono::Duration::minutes(15);
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_unwrapped_event(),
@@ -3302,7 +3301,7 @@ mod tests {
     async fn redeem_at_uses_supplied_timestamp() {
         let pending_at = Utc::now() - chrono::Duration::hours(4);
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given_no_previous_events()
             .when(EquityRedemptionCommand::RedeemAt {
                 symbol: Symbol::new("AAPL").unwrap(),
@@ -3329,7 +3328,7 @@ mod tests {
     async fn unwrap_tokens_at_uses_supplied_timestamp() {
         let pending_at = Utc::now() - chrono::Duration::hours(3);
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![withdrawn_from_raindex_event()])
             .when(EquityRedemptionCommand::UnwrapTokensAt { pending_at })
             .await
@@ -3349,7 +3348,7 @@ mod tests {
     async fn prepare_send_at_uses_supplied_timestamp() {
         let pending_at = Utc::now() - chrono::Duration::hours(2);
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_unwrapped_event(),
@@ -3372,7 +3371,7 @@ mod tests {
     async fn detect_at_uses_supplied_timestamp() {
         let detected_at = Utc::now() - chrono::Duration::hours(1);
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
             .when(EquityRedemptionCommand::DetectAt {
                 tokenization_request_id: tokenization_request_id("REQ789"),
@@ -3396,7 +3395,7 @@ mod tests {
     async fn complete_at_uses_supplied_timestamp() {
         let completed_at = Utc::now() - chrono::Duration::minutes(45);
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_sent_event(),
@@ -3422,7 +3421,7 @@ mod tests {
     async fn send_records_underlying_token_not_wrapped_token() {
         let wrapped_token = Address::random();
         let underlying_token = Address::random();
-        let store = TestStore::<EquityRedemption>::new(());
+        let store = TestStore::<EquityRedemption>::new();
         let id = redemption_aggregate_id("underlying-token-fix");
 
         store
@@ -3524,7 +3523,7 @@ mod tests {
     async fn confirm_withdraw_collapses_state_amount_to_actual_receipt_amount() {
         let requested = U256::from(37_143_292_455_000_000_000_u128);
         let actual = U256::from(33_681_456_848_531_939_569_u128);
-        let store = TestStore::<EquityRedemption>::new(());
+        let store = TestStore::<EquityRedemption>::new();
         let id = redemption_aggregate_id("partial-withdraw");
 
         store
@@ -3574,7 +3573,7 @@ mod tests {
 
     #[tokio::test]
     async fn confirm_withdraw_rejects_zero_actual_amount() {
-        let store = TestStore::<EquityRedemption>::new(());
+        let store = TestStore::<EquityRedemption>::new();
         let id = redemption_aggregate_id("zero-withdraw");
 
         store
@@ -3623,7 +3622,7 @@ mod tests {
 
     #[tokio::test]
     async fn confirm_unwrap_rejects_zero_amount() {
-        let store = TestStore::<EquityRedemption>::new(());
+        let store = TestStore::<EquityRedemption>::new();
         let id = redemption_aggregate_id("zero-unwrap");
 
         store
@@ -3696,7 +3695,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_detect_before_sending_tokens() {
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given_no_previous_events()
             .when(EquityRedemptionCommand::Detect {
                 tokenization_request_id: tokenization_request_id("REQ789"),
@@ -3712,7 +3711,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_complete_before_pending() {
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given_no_previous_events()
             .when(EquityRedemptionCommand::Complete)
             .await
@@ -3728,7 +3727,7 @@ mod tests {
     async fn fail_detection_from_tokens_sent_state() {
         let history = vec![withdrawn_from_raindex_event(), tokens_sent_event()];
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(history.clone())
             .when(EquityRedemptionCommand::FailDetection {
                 failure: DetectionFailure::Timeout,
@@ -3794,7 +3793,7 @@ mod tests {
         // the replayed `Failed` state.
         let history = vec![withdrawn_from_raindex_event(), tokens_sent_event()];
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(history.clone())
             .when(EquityRedemptionCommand::FailDetection {
                 failure: DetectionFailure::Operator {
@@ -3836,7 +3835,7 @@ mod tests {
             detected_event(),
         ];
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(history.clone())
             .when(EquityRedemptionCommand::RejectRedemption {
                 reason: "test rejection".to_string(),
@@ -3865,7 +3864,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_reject_redemption_before_pending() {
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
             .when(EquityRedemptionCommand::RejectRedemption {
                 reason: "test rejection".to_string(),
@@ -3934,7 +3933,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_fail_detection_before_sending() {
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given_no_previous_events()
             .when(EquityRedemptionCommand::FailDetection {
                 failure: DetectionFailure::Timeout,
@@ -3950,7 +3949,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_reject_redemption_before_sending() {
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given_no_previous_events()
             .when(EquityRedemptionCommand::RejectRedemption {
                 reason: "test rejection".to_string(),
@@ -4087,7 +4086,7 @@ mod tests {
     /// covered separately in `rebalancing::equity`'s `send_to_alpaca` tests.
     #[tokio::test]
     async fn record_send_failed_outcome_records_provider_failure_reason() {
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_unwrapped_event(),
@@ -4111,7 +4110,7 @@ mod tests {
     /// `TransferFailed`.
     #[tokio::test]
     async fn record_wallet_not_configured_outcome_records_configuration_reason() {
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_unwrapped_event(),
@@ -4133,7 +4132,7 @@ mod tests {
 
     #[tokio::test]
     async fn redeem_when_already_started_returns_already_started() {
-        let store = TestStore::<EquityRedemption>::new(());
+        let store = TestStore::<EquityRedemption>::new();
         let id = redemption_aggregate_id("redemption-1");
 
         store
@@ -4170,7 +4169,7 @@ mod tests {
 
     #[tokio::test]
     async fn redeem_when_pending_returns_already_started() {
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_sent_event(),
@@ -4962,7 +4961,7 @@ mod tests {
 
     #[tokio::test]
     async fn recover_provider_completion_rejected_for_active_redemption() {
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given(vec![withdrawn_from_raindex_event()])
             .when(EquityRedemptionCommand::RecoverProviderCompletion {
                 tokenization_request_id: tokenization_request_id("TOK001"),
@@ -4981,7 +4980,7 @@ mod tests {
 
     #[tokio::test]
     async fn recover_provider_completion_rejected_for_completed_redemption() {
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_sent_event(),
@@ -5013,7 +5012,7 @@ mod tests {
             reconciled_at: Utc::now(),
         });
 
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given(history)
             .when(EquityRedemptionCommand::RecoverProviderCompletion {
                 tokenization_request_id: tokenization_request_id("TOK001"),
@@ -5032,7 +5031,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_transfer_from_withdrawn_transitions_to_failed() {
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![withdrawn_from_raindex_event()])
             .when(EquityRedemptionCommand::FailTransfer {
                 reason: "Transfer timed out".to_string(),
@@ -5049,7 +5048,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_transfer_from_unwrapped_transitions_to_failed() {
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(vec![
                 withdrawn_from_raindex_event(),
                 tokens_unwrapped_event(),
@@ -5069,7 +5068,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_transfer_rejected_from_tokens_sent() {
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
             .when(EquityRedemptionCommand::FailTransfer {
                 reason: "should not work".to_string(),
@@ -5085,7 +5084,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_transfer_rejected_before_start() {
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given_no_previous_events()
             .when(EquityRedemptionCommand::FailTransfer {
                 reason: "should not work".to_string(),
@@ -5103,7 +5102,7 @@ mod tests {
     async fn reconcile_from_failed_emits_operator_reconciled_and_replays_to_reconciled() {
         let history = failed_redemption_history();
 
-        let events = TestHarness::<EquityRedemption>::with(())
+        let events = TestHarness::<EquityRedemption>::with()
             .given(history.clone())
             .when(EquityRedemptionCommand::Reconcile {
                 reason: "deposited manually via vault-deposit".to_string(),
@@ -5145,7 +5144,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_from_non_failed_is_rejected() {
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
             .when(EquityRedemptionCommand::Reconcile {
                 reason: "should be rejected".to_string(),
@@ -5164,7 +5163,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_with_blank_reason_is_rejected() {
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given(failed_redemption_history())
             .when(EquityRedemptionCommand::Reconcile {
                 reason: "   ".to_string(),
@@ -5189,7 +5188,7 @@ mod tests {
             reconciled_at: Utc::now(),
         });
 
-        let error = TestHarness::<EquityRedemption>::with(())
+        let error = TestHarness::<EquityRedemption>::with()
             .given(history)
             .when(EquityRedemptionCommand::Reconcile {
                 reason: "second attempt".to_string(),

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -845,10 +845,10 @@ async fn create_test_cqrs_with_assets(
     Arc<Store<crate::offchain::order::OffchainOrder>>,
     Arc<Projection<OffchainOrder>>,
 ) {
-    let onchain_trade = Arc::new(test_store(pool.clone(), ()));
+    let onchain_trade = Arc::new(test_store(pool.clone()));
 
     let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-        .build(())
+        .build()
         .await
         .unwrap();
 
@@ -857,7 +857,7 @@ async fn create_test_cqrs_with_assets(
 
     let (offchain_order, offchain_order_projection) =
         StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(order_placer.clone())
+            .build()
             .await
             .unwrap();
 
@@ -2031,7 +2031,7 @@ async fn take_order_discovers_equity_vault() -> Result<(), Box<dyn std::error::E
     trade1.submit(&cqrs).await?;
 
     // Run vault discovery using the same trade data
-    let vault_registry = test_store(pool.clone(), ());
+    let vault_registry = test_store(pool.clone());
     let context = VaultDiscoveryCtx {
         vault_registry: &vault_registry,
         orderbook: orderbook.orderbook_addr,

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -91,7 +91,7 @@ const TEST_ORDER_OWNER: Address = address!("0x0000000000000000000000000000000000
 async fn seed_vault_registry(pool: &SqlitePool, symbol: &Symbol, token: Address) {
     let vault_id = B256::from(keccak256(symbol.to_string().as_bytes()));
 
-    let cqrs = test_store::<VaultRegistry>(pool.clone(), ());
+    let cqrs = test_store::<VaultRegistry>(pool.clone());
     let id = VaultRegistryId {
         orderbook: TEST_ORDERBOOK,
         owner: TEST_ORDER_OWNER,
@@ -243,7 +243,7 @@ async fn build_position_cqrs_with_service(
 ) -> Arc<Store<Position>> {
     let (store, _projection) = StoreBuilder::<Position>::new(pool.clone())
         .with(Arc::clone(service))
-        .build(())
+        .build()
         .await
         .unwrap();
 
@@ -281,7 +281,7 @@ async fn setup_equity_trigger() -> EquityTriggerFixture {
         event_sender,
     ));
 
-    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
+    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone()));
 
     let wrapper = Arc::new(MockWrapper::new());
 
@@ -463,8 +463,8 @@ fn build_equity_transfer_with_wrapper(
 ) -> Arc<CrossVenueEquityTransfer> {
     let wrapper: Arc<dyn st0x_wrapper::Wrapper> = Arc::new(mock_wrapper);
 
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone()));
     Arc::new(CrossVenueEquityTransfer::new(
         raindex,
         vault_lookup,
@@ -493,13 +493,13 @@ async fn build_equity_transfer_with_service(
 
     let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
         .with(Arc::clone(service))
-        .build(())
+        .build()
         .await
         .unwrap();
 
     let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
         .with(Arc::clone(service))
-        .build(())
+        .build()
         .await
         .unwrap();
 
@@ -656,7 +656,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
             )]));
     });
 
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
     let ctx = TransferEquityToMarketMakingCtx {
         transfer: equity_transfer,
         equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
@@ -1077,7 +1077,7 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
     })
     .await;
 
-    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
+    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone()));
     let wrapper = Arc::new(MockWrapper::new());
 
     let trigger = RebalancingService::new(
@@ -1164,7 +1164,7 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
     })
     .await;
 
-    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
+    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone()));
     let wrapper = Arc::new(MockWrapper::new());
 
     let trigger = RebalancingService::new(
@@ -1262,7 +1262,7 @@ async fn cash_reserve_does_not_shift_rebalancing_ratio() {
         event_sender,
     ));
 
-    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
+    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone()));
     let wrapper = Arc::new(MockWrapper::new());
 
     // Trigger config mirrors prod: reserved is configured here so the
@@ -1297,7 +1297,7 @@ async fn cash_reserve_does_not_shift_rebalancing_ratio() {
     let snapshot_store =
         StoreBuilder::<crate::inventory::snapshot::InventorySnapshot>::new(pool.clone())
             .with(Arc::clone(&service))
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -1419,7 +1419,7 @@ async fn balanced_usdc_without_reserve_triggers_no_rebalancing() {
     })
     .await;
 
-    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
+    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone()));
     let wrapper = Arc::new(MockWrapper::new());
 
     let trigger = RebalancingService::new(
@@ -1478,7 +1478,7 @@ async fn usdc_alpaca_to_base_skips_when_withdrawable_cash_missing_with_reserve()
         cash.reserved = Some(Positive::new(Usd::new(float!(100))).unwrap());
     }
 
-    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
+    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone()));
     let wrapper = Arc::new(MockWrapper::new());
 
     let trigger = RebalancingService::new(
@@ -1524,7 +1524,7 @@ async fn usdc_none_disables_usdc_rebalancing() {
     })
     .await;
 
-    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
+    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone()));
     let wrapper = Arc::new(MockWrapper::new());
 
     let trigger = RebalancingService::new(
@@ -1623,7 +1623,7 @@ async fn mint_api_failure_produces_rejected_event() {
     drain_pending_jobs(&service).await.unwrap();
 
     let job = fetch_pending_equity_mint_job(&apalis_pool).await;
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
     let ctx = TransferEquityToMarketMakingCtx {
         transfer: equity_transfer,
         equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
@@ -1748,7 +1748,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
         assets,
     };
 
-    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
+    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone()));
     let wrapper = Arc::new(MockWrapper::new());
 
     let trigger = RebalancingService::new(
@@ -1880,7 +1880,7 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
         assets,
     };
 
-    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
+    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone()));
     let wrapper = Arc::new(MockWrapper::new());
 
     let trigger = RebalancingService::new(
@@ -1981,7 +1981,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
                 }),
             },
         };
-        let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
+        let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone()));
         let wrapper = Arc::new(MockWrapper::new());
         let trigger = RebalancingService::new(
             wide_config,
@@ -2043,7 +2043,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
                 }),
             },
         };
-        let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
+        let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone()));
         let wrapper = Arc::new(MockWrapper::new());
         let trigger = RebalancingService::new(
             tight_config,
@@ -2204,7 +2204,7 @@ async fn mint_accepted_sets_offchain_inflight() {
     // The poll will return pending, so the mint aggregate will time out or loop,
     // but MintAccepted has already fired by then. We spawn and cancel to
     // get just the MintAccepted event through.
-    let mint_store_for_spawn = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
+    let mint_store_for_spawn = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
     let transfer_handle = tokio::spawn({
         let equity_transfer = Arc::clone(&equity_transfer);
         let mint_store = Arc::clone(&mint_store_for_spawn);
@@ -2410,7 +2410,7 @@ async fn completed_mint_clears_inflight_and_updates_inventory() {
     };
 
     // Execute the full mint lifecycle through the job's perform
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
     let ctx = TransferEquityToMarketMakingCtx {
         transfer: Arc::clone(&equity_transfer) as _,
         equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
@@ -2479,7 +2479,7 @@ async fn transfer_failed_cancels_redemption_inflight() {
     // Build a redemption store wired to the trigger so events flow through
     let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
         .with(Arc::clone(&service))
-        .build(())
+        .build()
         .await
         .unwrap();
 
@@ -2622,8 +2622,8 @@ async fn wrapped_recovery_reschedules_when_held_for_recovery_but_no_balance() {
     let vault_lookup: Arc<dyn VaultLookup> = Arc::new(MockVaultLookup::new());
     let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
 
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone()));
     let transfer = Arc::new(CrossVenueEquityTransfer::new(
         Arc::clone(&raindex),
         Arc::clone(&vault_lookup),
@@ -2639,7 +2639,7 @@ async fn wrapped_recovery_reschedules_when_held_for_recovery_but_no_balance() {
         wrapper,
         transfer,
     };
-    let store = Arc::new(test_store(pool.clone(), ()));
+    let store = Arc::new(test_store(pool.clone()));
 
     let (sender, _receiver) = broadcast::channel(16);
     let inventory = Arc::new(BroadcastingInventory::new(InventoryView::default(), sender));
@@ -2727,8 +2727,8 @@ async fn recovery_job_breaks_deadlock_when_wrap_landed_wrapped_equity_recovery()
     );
     let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
 
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone()));
     let transfer = Arc::new(CrossVenueEquityTransfer::new(
         Arc::clone(&raindex),
         Arc::clone(&vault_lookup),
@@ -2744,7 +2744,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_landed_wrapped_equity_recovery()
         wrapper,
         transfer,
     };
-    let store = Arc::new(test_store(pool.clone(), ()));
+    let store = Arc::new(test_store(pool.clone()));
 
     // Inventory reports WRAPPED balance: the wrap landed, tokens are wtSTOCK
     // in the base wallet outside Raindex.
@@ -2851,8 +2851,8 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_unwrapped_equity_recovery
     );
     let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
 
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone()));
     let transfer = Arc::new(CrossVenueEquityTransfer::new(
         Arc::clone(&raindex),
         Arc::clone(&vault_lookup),
@@ -2869,7 +2869,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_unwrapped_equity_recovery
         transfer,
         wallet: Address::ZERO,
     };
-    let store = Arc::new(test_store::<UnwrappedEquityRecovery>(pool.clone(), ()));
+    let store = Arc::new(test_store::<UnwrappedEquityRecovery>(pool.clone()));
 
     // Inventory reports UNWRAPPED balance: wrap failed, tokens are raw tSTOCK
     // in the base wallet.
@@ -2967,8 +2967,8 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_dispatches_active_mint() 
     );
     let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
 
-    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
+    let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
+    let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone()));
     let transfer = Arc::new(CrossVenueEquityTransfer::new(
         Arc::clone(&raindex),
         Arc::clone(&vault_lookup),
@@ -2985,7 +2985,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_dispatches_active_mint() 
         transfer,
         wallet: Address::ZERO,
     };
-    let store = Arc::new(test_store::<UnwrappedEquityRecovery>(pool.clone(), ()));
+    let store = Arc::new(test_store::<UnwrappedEquityRecovery>(pool.clone()));
 
     // Seed the mint aggregate in TokensReceived (the persisted pre-wrap state)
     // with quantity matching the unwrapped wallet balance, so resume_mint can

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -1410,13 +1410,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -1469,13 +1469,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -1535,13 +1535,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -1594,13 +1594,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -1643,13 +1643,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -1697,13 +1697,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             reserved,
@@ -1758,13 +1758,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             reserved,
@@ -1817,13 +1817,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -1875,13 +1875,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -1914,13 +1914,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -1988,13 +1988,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2037,13 +2037,13 @@ mod tests {
         let service = InventoryPollingService::new(
             create_test_raindex_service(provider),
             MockExecutor::new().with_inventory(inventory),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2094,13 +2094,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2144,13 +2144,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2185,7 +2185,7 @@ mod tests {
         vault_id: B256,
         symbol: Symbol,
     ) {
-        let store = test_store::<VaultRegistry>(pool.clone(), ());
+        let store = test_store::<VaultRegistry>(pool.clone());
         let vault_registry_id = VaultRegistryId {
             orderbook,
             owner: order_owner,
@@ -2211,7 +2211,7 @@ mod tests {
         order_owner: Address,
         vault_id: B256,
     ) {
-        let store = test_store::<VaultRegistry>(pool.clone(), ());
+        let store = test_store::<VaultRegistry>(pool.clone());
         let vault_registry_id = VaultRegistryId {
             orderbook,
             owner: order_owner,
@@ -2242,13 +2242,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2296,13 +2296,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2351,13 +2351,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2414,13 +2414,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: snapshot_owner,
             },
             vault_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2467,13 +2467,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2513,13 +2513,13 @@ mod tests {
         let service = InventoryPollingService::new(
             create_test_raindex_service(provider),
             MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2558,13 +2558,13 @@ mod tests {
         let service = InventoryPollingService::new(
             create_test_raindex_service(provider),
             MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool, ())),
+            Arc::new(test_store(pool)),
             None,
             None,
             Usd::ZERO,
@@ -2599,13 +2599,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2661,13 +2661,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2713,13 +2713,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2762,13 +2762,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             MockExecutor::new().with_inventory(inventory),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2813,10 +2813,10 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             MockExecutor::new().with_inventory(inventory),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             snapshot_id.clone(),
             snapshot_id.owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2857,10 +2857,10 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             MockExecutor::new().with_inventory(inventory),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             snapshot_id.clone(),
             snapshot_id.owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -2901,13 +2901,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             MockExecutor::new().with_inventory(inventory),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             Some(tokenizer),
             Usd::ZERO,
@@ -2981,13 +2981,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             Some(WalletPollingCtx {
                 ethereum: ethereum_wallet,
                 ..mock_wallet_polling_ctx(&server)
@@ -3030,13 +3030,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             Some(WalletPollingCtx {
                 base: base_wallet,
                 ..mock_wallet_polling_ctx(&server)
@@ -3074,13 +3074,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -3116,13 +3116,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -3162,13 +3162,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             Some(WalletPollingCtx {
                 ethereum: ethereum_wallet,
                 ..mock_wallet_polling_ctx(&server)
@@ -3202,13 +3202,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             Some(WalletPollingCtx {
                 base: base_wallet,
                 ..mock_wallet_polling_ctx(&server)
@@ -3248,13 +3248,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             MockExecutor::new().with_inventory(inventory),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             Some(WalletPollingCtx {
                 ethereum: ethereum_wallet,
                 ..mock_wallet_polling_ctx(&server)
@@ -3305,13 +3305,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             Some(WalletPollingCtx {
                 base: base_wallet,
                 unwrapped_equity_token_addresses: equity_tokens,
@@ -3359,13 +3359,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -3415,13 +3415,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             Some(WalletPollingCtx {
                 base: base_wallet,
                 unwrapped_equity_token_addresses: equity_tokens,
@@ -3468,13 +3468,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             Some(WalletPollingCtx {
                 base: base_wallet,
                 unwrapped_equity_token_addresses: equity_tokens,
@@ -3523,13 +3523,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             Some(WalletPollingCtx {
                 base: base_wallet,
                 wrapped_equity_token_addresses: wrapped_equity_tokens,
@@ -3596,13 +3596,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             Some(WalletPollingCtx {
                 base: base_wallet,
                 wrapped_equity_token_addresses: wrapped_equity_tokens,
@@ -3647,13 +3647,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -3703,13 +3703,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             Some(WalletPollingCtx {
                 base: base_wallet,
                 wrapped_equity_token_addresses: wrapped_equity_tokens,
@@ -3759,13 +3759,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             Some(WalletPollingCtx {
                 base: base_wallet,
                 wrapped_equity_token_addresses: wrapped_equity_tokens,
@@ -3807,13 +3807,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -3946,13 +3946,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             Some(tokenizer),
             Usd::ZERO,
@@ -3999,13 +3999,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             Some(tokenizer),
             Usd::ZERO,
@@ -4045,13 +4045,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             None,
             Usd::ZERO,
@@ -4085,13 +4085,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             Some(tokenizer),
             Usd::ZERO,
@@ -4145,13 +4145,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             Some(tokenizer),
             Usd::ZERO,
@@ -4212,13 +4212,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             Some(tokenizer),
             Usd::ZERO,
@@ -4280,13 +4280,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             Some(tokenizer),
             Usd::ZERO,
@@ -4345,13 +4345,13 @@ mod tests {
         let service = InventoryPollingService::new(
             raindex_service,
             executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             InventorySnapshotId {
                 orderbook,
                 owner: order_owner,
             },
             order_owner,
-            Arc::new(test_store(pool.clone(), ())),
+            Arc::new(test_store(pool.clone())),
             None,
             Some(tokenizer),
             Usd::ZERO,

--- a/src/inventory/projection.rs
+++ b/src/inventory/projection.rs
@@ -433,7 +433,7 @@ mod tests {
         let projection = Arc::new(InventoryProjection::new(inventory.clone()));
         let snapshot = StoreBuilder::<InventorySnapshot>::new(pool)
             .with(projection)
-            .build(())
+            .build()
             .await
             .unwrap();
 

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -6,7 +6,6 @@
 
 use alloy::hex::FromHexError;
 use alloy::primitives::Address;
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -16,7 +15,7 @@ use thiserror::Error;
 
 use super::BroadcastingInventory;
 
-use st0x_event_sorcery::{CompactionPolicy, DomainEvent, EventSourced, Never, Nil};
+use st0x_event_sorcery::{CompactionPolicy, DomainEvent, EventSourced, JobQueue, Never, Nil};
 use st0x_execution::{FractionalShares, Symbol};
 use st0x_finance::Usdc;
 
@@ -135,13 +134,12 @@ pub(crate) struct InventorySnapshot {
     pub(crate) last_updated: DateTime<Utc>,
 }
 
-#[async_trait]
 impl EventSourced for InventorySnapshot {
     type Id = InventorySnapshotId;
     type Event = InventorySnapshotEvent;
     type Command = InventorySnapshotCommand;
     type Error = Never;
-    type Services = ();
+    type Jobs = Nil;
     type Materialized = Nil;
 
     const AGGREGATE_TYPE: &'static str = "InventorySnapshot";
@@ -184,9 +182,9 @@ impl EventSourced for InventorySnapshot {
         Ok(Some(snapshot))
     }
 
-    async fn initialize(
+    fn initialize(
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use InventorySnapshotCommand::*;
         let now = Utc::now();
@@ -286,10 +284,10 @@ impl EventSourced for InventorySnapshot {
         }])
     }
 
-    async fn transition(
+    fn transition(
         &self,
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use InventorySnapshotCommand::*;
         let now = Utc::now();
@@ -1031,7 +1029,7 @@ mod tests {
         let mut balances = BTreeMap::new();
         balances.insert(test_symbol("AAPL"), test_shares(100));
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given_no_previous_events()
             .when(InventorySnapshotCommand::OnchainEquity {
                 balances: balances.clone(),
@@ -1056,7 +1054,7 @@ mod tests {
         let mut balances = BTreeMap::new();
         balances.insert(test_symbol("AAPL"), test_shares(100));
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: Usdc::from_str("1000").unwrap(),
                 fetched_at: Utc::now(),
@@ -1083,7 +1081,7 @@ mod tests {
     async fn record_onchain_usdc_emits_event() {
         let usdc_balance = Usdc::from_str("10000.50").unwrap();
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given_no_previous_events()
             .when(InventorySnapshotCommand::OnchainUsdc { usdc_balance })
             .await
@@ -1106,7 +1104,7 @@ mod tests {
         let mut positions = BTreeMap::new();
         positions.insert(test_symbol("AAPL"), test_shares(75));
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given_no_previous_events()
             .when(InventorySnapshotCommand::OffchainEquity {
                 positions: positions.clone(),
@@ -1130,7 +1128,7 @@ mod tests {
     async fn record_offchain_usd_emits_event() {
         let usd_balance_cents = 50_000_000; // $500,000.00
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given_no_previous_events()
             .when(InventorySnapshotCommand::OffchainUsd {
                 usd_balance_cents,
@@ -1155,7 +1153,7 @@ mod tests {
     async fn offchain_cash_buying_power_skips_unchanged_value() {
         let cash_buying_power_cents = Some(3_000_000);
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::OffchainCashBuyingPower {
                 cash_buying_power_cents,
                 fetched_at: Utc::now(),
@@ -1218,7 +1216,7 @@ mod tests {
         ];
 
         for (given, command) in cases {
-            let events = TestHarness::<InventorySnapshot>::with(())
+            let events = TestHarness::<InventorySnapshot>::with()
                 .given(given)
                 .when(command)
                 .await
@@ -1234,7 +1232,7 @@ mod tests {
         let previous_observed_at = Utc::now();
         let observed_at = previous_observed_at + chrono::Duration::seconds(1);
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::SourceObserved {
                 source,
                 observed_at: previous_observed_at,
@@ -1262,7 +1260,7 @@ mod tests {
         let alpaca_usdc = Usdc::from_str("125").unwrap();
         let observed_at = Utc::now();
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given_no_previous_events()
             .when(InventorySnapshotCommand::RecordOffchainObservation {
                 positions: positions.clone(),
@@ -1342,7 +1340,7 @@ mod tests {
             },
         ];
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(previous_events)
             .when(InventorySnapshotCommand::RecordOffchainObservation {
                 positions,
@@ -1371,7 +1369,7 @@ mod tests {
         let observed_at = Utc::now();
         let stale_observed_at = observed_at - chrono::Duration::seconds(1);
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::SourceObserved {
                 source,
                 observed_at,
@@ -1464,7 +1462,7 @@ mod tests {
     async fn ethereum_usdc_command_initializes_aggregate() {
         let usdc_balance = Usdc::from_str("5000.50").unwrap();
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given_no_previous_events()
             .when(InventorySnapshotCommand::EthereumUsdc { usdc_balance })
             .await
@@ -1486,7 +1484,7 @@ mod tests {
     async fn ethereum_usdc_command_emits_event_on_existing_aggregate() {
         let usdc_balance = Usdc::from_str("2500").unwrap();
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: Usdc::from_str("1000").unwrap(),
                 fetched_at: Utc::now(),
@@ -1511,7 +1509,7 @@ mod tests {
     async fn ethereum_usdc_command_skips_event_when_unchanged() {
         let usdc_balance = Usdc::from_str("5000").unwrap();
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::EthereumUsdc {
                 usdc_balance,
                 fetched_at: Utc::now(),
@@ -1544,7 +1542,7 @@ mod tests {
     async fn base_wallet_usdc_initializes_on_first_command() {
         let usdc_balance = Usdc::from_str("500").unwrap();
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given_no_previous_events()
             .when(InventorySnapshotCommand::BaseWalletUsdc { usdc_balance })
             .await
@@ -1566,7 +1564,7 @@ mod tests {
         let old_balance = Usdc::from_str("500").unwrap();
         let new_balance = Usdc::from_str("750").unwrap();
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::BaseWalletUsdc {
                 usdc_balance: old_balance,
                 fetched_at: Utc::now(),
@@ -1592,7 +1590,7 @@ mod tests {
     async fn base_wallet_usdc_skips_when_unchanged() {
         let balance = Usdc::from_str("500").unwrap();
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::BaseWalletUsdc {
                 usdc_balance: balance,
                 fetched_at: Utc::now(),
@@ -1625,7 +1623,7 @@ mod tests {
         let mut balances = BTreeMap::new();
         balances.insert(test_symbol("AAPL"), test_shares(500));
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given_no_previous_events()
             .when(InventorySnapshotCommand::BaseWalletUnwrappedEquity {
                 balances: balances.clone(),
@@ -1655,7 +1653,7 @@ mod tests {
         let mut new_balances = BTreeMap::new();
         new_balances.insert(test_symbol("AAPL"), test_shares(750));
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::BaseWalletUnwrappedEquity {
                 balances: old_balances,
                 fetched_at: Utc::now(),
@@ -1685,7 +1683,7 @@ mod tests {
         let mut balances = BTreeMap::new();
         balances.insert(test_symbol("AAPL"), test_shares(500));
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::BaseWalletUnwrappedEquity {
                 balances: balances.clone(),
                 fetched_at: Utc::now(),
@@ -1718,7 +1716,7 @@ mod tests {
         let mut balances = BTreeMap::new();
         balances.insert(test_symbol("AAPL"), test_shares(500));
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given_no_previous_events()
             .when(InventorySnapshotCommand::BaseWalletWrappedEquity {
                 balances: balances.clone(),
@@ -1748,7 +1746,7 @@ mod tests {
         let mut new_balances = BTreeMap::new();
         new_balances.insert(test_symbol("AAPL"), test_shares(750));
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::BaseWalletWrappedEquity {
                 balances: old_balances,
                 fetched_at: Utc::now(),
@@ -1778,7 +1776,7 @@ mod tests {
         let mut balances = BTreeMap::new();
         balances.insert(test_symbol("AAPL"), test_shares(500));
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::BaseWalletWrappedEquity {
                 balances: balances.clone(),
                 fetched_at: Utc::now(),
@@ -1798,7 +1796,7 @@ mod tests {
         let mut new_balances = BTreeMap::new();
         new_balances.insert(test_symbol("AAPL"), test_shares(0));
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::BaseWalletWrappedEquity {
                 balances: old_balances,
                 fetched_at: Utc::now(),
@@ -1847,7 +1845,7 @@ mod tests {
         let mut redemptions = BTreeMap::new();
         redemptions.insert(test_symbol("TSLA"), test_shares(5));
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given_no_previous_events()
             .when(InventorySnapshotCommand::InflightEquity {
                 mints: mints.clone(),
@@ -1880,7 +1878,7 @@ mod tests {
 
         let mints = BTreeMap::new();
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::InflightEquity {
                 mints: mints.clone(),
                 redemptions: initial_redemptions,
@@ -1911,7 +1909,7 @@ mod tests {
         mints.insert(test_symbol("AAPL"), test_shares(10));
         let fetched_at = Utc::now();
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::InflightEquity {
                 mints: mints.clone(),
                 redemptions: BTreeMap::new(),
@@ -1938,7 +1936,7 @@ mod tests {
         let first_fetched_at = Utc::now();
         let second_fetched_at = first_fetched_at + chrono::Duration::seconds(30);
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::InflightEquity {
                 mints: mints.clone(),
                 redemptions: BTreeMap::new(),
@@ -1964,7 +1962,7 @@ mod tests {
         let first_fetched_at = Utc::now();
         let second_fetched_at = first_fetched_at + chrono::Duration::seconds(30);
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::InflightEquity {
                 mints: BTreeMap::new(),
                 redemptions: BTreeMap::new(),
@@ -1991,7 +1989,7 @@ mod tests {
         let current_fetched_at = Utc::now();
         let stale_fetched_at = current_fetched_at - chrono::Duration::seconds(30);
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::InflightEquity {
                 mints: mints.clone(),
                 redemptions: BTreeMap::new(),
@@ -2022,7 +2020,7 @@ mod tests {
         let current_fetched_at = Utc::now();
         let stale_fetched_at = current_fetched_at - chrono::Duration::seconds(30);
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::InflightEquity {
                 mints: initial_mints,
                 redemptions: BTreeMap::new(),
@@ -2057,7 +2055,7 @@ mod tests {
         let mut updated_mints = BTreeMap::new();
         updated_mints.insert(test_symbol("AAPL"), test_shares(5));
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::InflightEquity {
                 mints: initial_mints,
                 redemptions: BTreeMap::new(),
@@ -2105,7 +2103,7 @@ mod tests {
     async fn initialize_inflight_equity_preserves_fetched_at() {
         let fetched_at = Utc::now();
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given_no_previous_events()
             .when(InventorySnapshotCommand::InflightEquity {
                 mints: BTreeMap::new(),
@@ -2134,7 +2132,7 @@ mod tests {
 
         let fetched_at = Utc::now();
 
-        let events = TestHarness::<InventorySnapshot>::with(())
+        let events = TestHarness::<InventorySnapshot>::with()
             .given(vec![InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: Usdc::from_str("1000").unwrap(),
                 fetched_at: Utc::now(),

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -35,12 +35,13 @@ use chrono::{DateTime, Utc};
 use metrics::{counter, histogram};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+#[cfg(test)]
 use std::sync::Arc;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
 use st0x_dto::{Direction, Trade, TradingVenue};
-use st0x_event_sorcery::{DomainEvent, EventSourced, SendError, Store, Table};
+use st0x_event_sorcery::{DomainEvent, EventSourced, JobQueue, Nil, SendError, Store, Table};
 use st0x_execution::{
     AlpacaBrokerApiError, CancellationOutcome, ClientOrderId, ExecutionError, Executor,
     ExecutorOrderId, FractionalShares, LimitOrder, MarketOrder, MarketSession, OrderState,
@@ -80,6 +81,8 @@ pub(crate) enum JobError {
     Enqueue(#[from] QueuePushError),
     #[error("Offchain order invariant violation: {0}")]
     OffchainOrder(#[from] OffchainOrderError),
+    #[error("Offchain order cancellation error: {0}")]
+    Cancel(#[from] CancelOffchainOrderError),
 }
 
 #[derive(Debug, Clone)]
@@ -545,88 +548,143 @@ fn originate_offchain_order(event: &OffchainOrderEvent) -> Option<OffchainOrder>
     }
 }
 
-async fn cancel_order_events(
-    entity: &OffchainOrder,
-    services: &dyn OrderPlacer,
+/// Why [`cancel_offchain_order`] failed: either the store rejected a command
+/// (including the pure handler's state guards) or the broker I/O around it
+/// failed (`PreCancelStatusFetchFailed`, `CancelFailed`, ...).
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CancelOffchainOrderError {
+    #[error(transparent)]
+    Send(#[from] SendError<OffchainOrder>),
+    #[error(transparent)]
+    Domain(#[from] OffchainOrderError),
+}
+
+/// Broker-side cancellation flow for a live order, invoked by the durable
+/// callers that decide to cancel (the market-open replacement sweep, the poll
+/// loop's unrequested-cancel recovery). The jobs-model handlers are pure, so
+/// the pre-cancel reconciliation and the broker `DELETE` live here, mirroring
+/// the placement path ([`place_offchain_order_at_broker`]); each discovered
+/// outcome is recorded through the aggregate's idempotent outcome commands.
+///
+/// Reconciles the broker's state before cancelling so a fill that landed
+/// between the last poll and the cancel attempt is never dropped:
+/// - a newer broker partial fill is recorded ahead of the cancel request;
+/// - broker `Filled`/`Failed`/`Cancelled` drives the order terminal directly
+///   (any priced fill preserved) and skips the `DELETE`;
+/// - otherwise the broker `DELETE` is issued and `CancelRequested` recorded
+///   (`Cancelling` until the poller confirms); a broker that no longer
+///   recognises the order resolves it terminally cancelled.
+pub(crate) async fn cancel_offchain_order(
+    store: &Store<OffchainOrder>,
+    order_placer: &dyn OrderPlacer,
+    offchain_order_id: &OffchainOrderId,
     reason: CancellationReason,
-) -> Result<Vec<OffchainOrderEvent>, OffchainOrderError> {
-    match entity {
-        OffchainOrder::Submitted {
-            executor_order_id, ..
-        }
-        | OffchainOrder::PartiallyFilled {
-            executor_order_id, ..
-        } => {
-            let mut events = Vec::new();
-            let local_filled = match entity {
-                OffchainOrder::PartiallyFilled { shares_filled, .. } => Some(*shares_filled),
-                _ => None,
-            };
-            let pre_cancel_events =
-                reconcile_pre_cancel(services, executor_order_id, local_filled, reason).await?;
-            let cancel_short_circuit = pre_cancel_events.iter().any(|event| {
-                matches!(
-                    event,
-                    OffchainOrderEvent::Filled { .. }
-                        | OffchainOrderEvent::Failed { .. }
-                        | OffchainOrderEvent::Cancelled { .. }
+) -> Result<(), CancelOffchainOrderError> {
+    let order = store.load(offchain_order_id).await?;
+    let (symbol, executor_order_id, local_filled) = match &order {
+        Some(OffchainOrder::Submitted {
+            symbol,
+            executor_order_id,
+            ..
+        }) => (symbol.clone(), executor_order_id.clone(), None),
+        Some(OffchainOrder::PartiallyFilled {
+            symbol,
+            executor_order_id,
+            shares_filled,
+            ..
+        }) => (
+            symbol.clone(),
+            executor_order_id.clone(),
+            Some(*shares_filled),
+        ),
+        // Any other state: send the pure command so the handler returns the
+        // canonical response for it (no-op from `Cancelling`, `NotSubmitted`
+        // from `Pending`, `AlreadyCompleted` from terminal states, `NotPlaced`
+        // when the aggregate does not exist).
+        Some(
+            OffchainOrder::Pending { .. }
+            | OffchainOrder::Cancelling { .. }
+            | OffchainOrder::Filled { .. }
+            | OffchainOrder::Failed { .. }
+            | OffchainOrder::Cancelled { .. },
+        )
+        | None => {
+            store
+                .send(
+                    offchain_order_id,
+                    OffchainOrderCommand::CancelOrder { reason },
                 )
-            });
-            events.extend(pre_cancel_events);
+                .await?;
+            return Ok(());
+        }
+    };
 
-            if cancel_short_circuit {
-                return Ok(events);
-            }
-
-            match services
-                .cancel_order(executor_order_id)
-                .await
-                .map_err(|error| {
-                    tracing::warn!(
-                        %executor_order_id,
-                        %error,
-                        "Failed to cancel order via broker; will retry"
-                    );
-                    OffchainOrderError::CancelFailed {
-                        executor_order_id: executor_order_id.clone(),
-                    }
-                })? {
-                CancellationOutcome::Requested => {
-                    events.push(OffchainOrderEvent::CancelRequested {
-                        reason,
-                        cancel_requested_at: Utc::now(),
-                    });
+    let fill_updates =
+        match reconcile_pre_cancel(order_placer, &executor_order_id, local_filled, reason).await? {
+            PreCancelReconciliation::AlreadyTerminal(commands) => {
+                for command in commands {
+                    store.send(offchain_order_id, command).await?;
                 }
-                CancellationOutcome::OrderNotFound => {
-                    tracing::warn!(
-                        %executor_order_id,
-                        ?reason,
-                        "Broker no longer recognises order on cancel; resolving as terminally cancelled"
-                    );
-                    events.push(OffchainOrderEvent::Cancelled {
+                return Ok(());
+            }
+            PreCancelReconciliation::Proceed(commands) => commands,
+        };
+
+    for command in fill_updates {
+        store.send(offchain_order_id, command).await?;
+    }
+
+    let outcome = order_placer
+        .cancel_order(&executor_order_id)
+        .await
+        .map_err(|error| {
+            tracing::warn!(
+                %executor_order_id,
+                %error,
+                "Failed to cancel order via broker; will retry"
+            );
+            OffchainOrderError::CancelFailed {
+                executor_order_id: executor_order_id.clone(),
+            }
+        })?;
+
+    match outcome {
+        CancellationOutcome::Requested => {
+            store
+                .send(
+                    offchain_order_id,
+                    OffchainOrderCommand::CancelOrder { reason },
+                )
+                .await?;
+        }
+        CancellationOutcome::OrderNotFound => {
+            tracing::warn!(
+                %executor_order_id,
+                ?reason,
+                "Broker no longer recognises order on cancel; resolving as terminally cancelled"
+            );
+            store
+                .send(
+                    offchain_order_id,
+                    OffchainOrderCommand::RecordBrokerCancellation {
                         reason,
                         cancelled_at: Utc::now(),
-                    });
-                }
-            }
-
-            if reason == CancellationReason::MarketOpenReplacement {
-                tracing::info!(
-                    target: "hedge",
-                    symbol = %entity.symbol(),
-                    %executor_order_id,
-                    "Regular hours: cancelling extended-hours limit order for market-order replacement"
-                );
-            }
-
-            Ok(events)
+                    },
+                )
+                .await?;
         }
-        OffchainOrder::Pending { .. } => Err(OffchainOrderError::NotSubmitted),
-        OffchainOrder::Cancelling { .. } => Ok(Vec::new()),
-        OffchainOrder::Filled { .. }
-        | OffchainOrder::Failed { .. }
-        | OffchainOrder::Cancelled { .. } => Err(OffchainOrderError::AlreadyCompleted),
     }
+
+    if reason == CancellationReason::MarketOpenReplacement {
+        tracing::info!(
+            target: "hedge",
+            %symbol,
+            %executor_order_id,
+            "Regular hours: cancelling extended-hours limit order for market-order replacement"
+        );
+    }
+
+    Ok(())
 }
 
 /// Why an [`OffchainOrder`] was cancelled. Carried on
@@ -647,13 +705,12 @@ pub enum CancellationReason {
     Unrequested,
 }
 
-#[async_trait]
 impl EventSourced for OffchainOrder {
     type Id = OffchainOrderId;
     type Event = OffchainOrderEvent;
     type Command = OffchainOrderCommand;
     type Error = OffchainOrderError;
-    type Services = Arc<dyn OrderPlacer>;
+    type Jobs = Nil;
     type Materialized = Table;
 
     const AGGREGATE_TYPE: &'static str = "OffchainOrder";
@@ -761,9 +818,9 @@ impl EventSourced for OffchainOrder {
         }
     }
 
-    async fn initialize(
+    fn initialize(
         command: Self::Command,
-        _: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use OffchainOrderCommand::*;
         match command {
@@ -811,10 +868,10 @@ impl EventSourced for OffchainOrder {
         }
     }
 
-    async fn transition(
+    fn transition(
         &self,
         command: Self::Command,
-        services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             // Idempotent against a placement retry: the durable path re-sends
@@ -844,9 +901,35 @@ impl EventSourced for OffchainOrder {
                 placed_at: _,
             } => validate_place_replay(self, &symbol, direction, executor),
 
-            OffchainOrderCommand::CancelOrder { reason } => {
-                cancel_order_events(self, services.as_ref(), reason).await
-            }
+            OffchainOrderCommand::CancelOrder { reason } => match self {
+                Self::Submitted { .. } | Self::PartiallyFilled { .. } => {
+                    Ok(vec![OffchainOrderEvent::CancelRequested {
+                        reason,
+                        cancel_requested_at: Utc::now(),
+                    }])
+                }
+                Self::Pending { .. } => Err(OffchainOrderError::NotSubmitted),
+                Self::Cancelling { .. } => Ok(Vec::new()),
+                Self::Filled { .. } | Self::Failed { .. } | Self::Cancelled { .. } => {
+                    Err(OffchainOrderError::AlreadyCompleted)
+                }
+            },
+
+            OffchainOrderCommand::RecordBrokerCancellation {
+                reason,
+                cancelled_at,
+            } => match self {
+                Self::Submitted { .. } | Self::PartiallyFilled { .. } | Self::Cancelling { .. } => {
+                    Ok(vec![OffchainOrderEvent::Cancelled {
+                        reason,
+                        cancelled_at,
+                    }])
+                }
+                Self::Pending { .. } => Err(OffchainOrderError::NotSubmitted),
+                Self::Filled { .. } | Self::Failed { .. } | Self::Cancelled { .. } => {
+                    Err(OffchainOrderError::AlreadyCompleted)
+                }
+            },
 
             OffchainOrderCommand::ConfirmCancellation { cancelled_at } => match self {
                 Self::Cancelling { reason, .. } => Ok(vec![OffchainOrderEvent::Cancelled {
@@ -1763,21 +1846,30 @@ fn broker_fill_exceeds_local(
         })
 }
 
+/// Outcome of pre-cancel reconciliation: either the broker already drove the
+/// order terminal (record the commands and skip the `DELETE`) or the cancel
+/// may proceed after recording any newer broker fill.
+enum PreCancelReconciliation {
+    AlreadyTerminal(Vec<OffchainOrderCommand>),
+    Proceed(Vec<OffchainOrderCommand>),
+}
+
 /// Queries the broker for the current state of an order before cancellation
-/// and emits the appropriate partial-fill / fill events so the local
-/// aggregate is reconciled with the broker before the terminal Cancelled
-/// event. `local_filled` is the cumulative quantity already recorded in
-/// the local PartiallyFilled state (None if the local state is Submitted).
+/// and returns the outcome commands that reconcile the local aggregate with
+/// the broker before the terminal Cancelled event. `local_filled` is the
+/// cumulative quantity already recorded in the local PartiallyFilled state
+/// (None if the local state is Submitted).
 ///
-/// Returns the events that should be emitted *before* the cancel attempt.
-/// If the returned vec contains `Filled`, the caller MUST short-circuit
-/// and not attempt the DELETE (the broker already filled).
+/// The commands must be sent *before* the cancel attempt; an
+/// [`PreCancelReconciliation::AlreadyTerminal`] result means the caller MUST
+/// short-circuit and not attempt the DELETE (the broker already settled the
+/// order).
 async fn reconcile_pre_cancel(
     services: &dyn OrderPlacer,
     executor_order_id: &ExecutorOrderId,
     local_filled: Option<FractionalShares>,
     cancellation_reason: CancellationReason,
-) -> Result<Vec<OffchainOrderEvent>, OffchainOrderError> {
+) -> Result<PreCancelReconciliation, OffchainOrderError> {
     // Propagate read failures so the aggregate stays in its prior state
     // and the caller can retry. Silently bypassing reconciliation would
     // re-introduce the partial-fill loss bug the function exists to fix
@@ -1807,7 +1899,7 @@ async fn reconcile_pre_cancel(
         } => {
             if Positive::new(broker_filled).is_err() {
                 if broker_filled == FractionalShares::ZERO {
-                    return Ok(Vec::new());
+                    return Ok(PreCancelReconciliation::Proceed(Vec::new()));
                 }
 
                 return Err(OffchainOrderError::InvalidTerminalFillQuantity {
@@ -1831,7 +1923,7 @@ async fn reconcile_pre_cancel(
                     %executor_order_id,
                     "Broker partial-fill <= local; skipping pre-cancel reconcile"
                 );
-                return Ok(Vec::new());
+                return Ok(PreCancelReconciliation::Proceed(Vec::new()));
             }
 
             // We need an avg_price for the event. If the broker did not
@@ -1850,11 +1942,13 @@ async fn reconcile_pre_cancel(
                 });
             };
 
-            Ok(vec![OffchainOrderEvent::PartiallyFilled {
-                shares_filled: broker_filled,
-                avg_price: price,
-                partially_filled_at,
-            }])
+            Ok(PreCancelReconciliation::Proceed(vec![
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: broker_filled,
+                    avg_price: price,
+                    partially_filled_at,
+                },
+            ]))
         }
 
         OrderState::Filled {
@@ -1868,10 +1962,12 @@ async fn reconcile_pre_cancel(
                 %executor_order_id,
                 "Broker reports order fully Filled at cancel time; reconciling without DELETE"
             );
-            Ok(vec![OffchainOrderEvent::Filled {
-                price,
-                filled_at: executed_at,
-            }])
+            Ok(PreCancelReconciliation::AlreadyTerminal(vec![
+                OffchainOrderCommand::CompleteFill {
+                    price,
+                    filled_at: executed_at,
+                },
+            ]))
         }
 
         OrderState::Failed {
@@ -1898,8 +1994,9 @@ async fn reconcile_pre_cancel(
                 shares_filled,
                 avg_price,
                 failed_at,
-                OffchainOrderEvent::Failed { error, failed_at },
+                OffchainOrderCommand::MarkFailed { error, failed_at },
             )
+            .map(PreCancelReconciliation::AlreadyTerminal)
         }
 
         OrderState::Cancelled {
@@ -1919,14 +2016,17 @@ async fn reconcile_pre_cancel(
                 Some(shares_filled),
                 avg_price,
                 cancelled_at,
-                OffchainOrderEvent::Cancelled {
+                OffchainOrderCommand::RecordBrokerCancellation {
                     reason: cancellation_reason,
                     cancelled_at,
                 },
             )
+            .map(PreCancelReconciliation::AlreadyTerminal)
         }
 
-        OrderState::Pending | OrderState::Submitted { .. } => Ok(Vec::new()),
+        OrderState::Pending | OrderState::Submitted { .. } => {
+            Ok(PreCancelReconciliation::Proceed(Vec::new()))
+        }
     }
 }
 
@@ -1935,7 +2035,7 @@ async fn reconcile_pre_cancel(
 ///
 /// Encodes two invariants that must not drift between the arms:
 /// - cumulative fills never regress -- a broker fill no newer than the local
-///   record emits only the terminal event;
+///   record emits only the terminal command;
 /// - a positive fill without an average price must NOT be dropped -- it
 ///   blocks with [`OffchainOrderError::PreCancelPartialFillMissingAvgPrice`]
 ///   so the cancel retries once the broker returns a priced fill, instead of
@@ -1949,8 +2049,8 @@ fn reconcile_terminal_fill(
     shares_filled: Option<FractionalShares>,
     avg_price: Option<Usd>,
     broker_timestamp: DateTime<Utc>,
-    terminal_event: OffchainOrderEvent,
-) -> Result<Vec<OffchainOrderEvent>, OffchainOrderError> {
+    terminal_command: OffchainOrderCommand,
+) -> Result<Vec<OffchainOrderCommand>, OffchainOrderError> {
     if let (Some(broker_filled), Some(avg_price)) = (shares_filled, avg_price) {
         // A zero priced fill carries nothing to record; anything else
         // non-positive is a corrupt broker value and must not be persisted
@@ -1958,7 +2058,7 @@ fn reconcile_terminal_fill(
         // NoFill, under-accounting the position).
         if Positive::new(broker_filled).is_err() {
             if broker_filled == FractionalShares::ZERO {
-                return Ok(vec![terminal_event]);
+                return Ok(vec![terminal_command]);
             }
             return Err(OffchainOrderError::InvalidTerminalFillQuantity {
                 executor_order_id: executor_order_id.clone(),
@@ -1969,23 +2069,23 @@ fn reconcile_terminal_fill(
         if let Some(local) = local_filled
             && !broker_fill_exceeds_local(broker_filled, local)?
         {
-            return Ok(vec![terminal_event]);
+            return Ok(vec![terminal_command]);
         }
 
         return Ok(vec![
-            OffchainOrderEvent::PartiallyFilled {
+            OffchainOrderCommand::UpdatePartialFill {
                 shares_filled: broker_filled,
                 avg_price,
                 partially_filled_at: broker_timestamp,
             },
-            terminal_event,
+            terminal_command,
         ]);
     }
 
     if let (Some(shares_filled), None) = (shares_filled, avg_price) {
         if Positive::new(shares_filled).is_err() {
             if shares_filled == FractionalShares::ZERO {
-                return Ok(vec![terminal_event]);
+                return Ok(vec![terminal_command]);
             }
 
             return Err(OffchainOrderError::InvalidTerminalFillQuantity {
@@ -1997,11 +2097,11 @@ fn reconcile_terminal_fill(
         // An unpriced broker fill only blocks when it reports MORE than the
         // local aggregate has already recorded (priced): an equal-or-smaller
         // unpriced fill carries no new information -- the local priced fill
-        // already covers it, so the terminal event can proceed.
+        // already covers it, so the terminal command can proceed.
         if let Some(local) = local_filled
             && !broker_fill_exceeds_local(shares_filled, local)?
         {
-            return Ok(vec![terminal_event]);
+            return Ok(vec![terminal_command]);
         }
 
         return Err(OffchainOrderError::PreCancelPartialFillMissingAvgPrice {
@@ -2010,7 +2110,7 @@ fn reconcile_terminal_fill(
         });
     }
 
-    Ok(vec![terminal_event])
+    Ok(vec![terminal_command])
 }
 
 /// Result of a successful order placement, with the executor-assigned ID
@@ -2281,6 +2381,16 @@ pub enum OffchainOrderCommand {
     CancelOrder {
         reason: CancellationReason,
     },
+    /// Outcome command: the broker reports the order already cancelled --
+    /// discovered by pre-cancel reconciliation, an `OrderNotFound` cancel
+    /// response, or an unrequested broker-side cancel. Unlike
+    /// `ConfirmCancellation` it is valid from the live
+    /// `Submitted`/`PartiallyFilled` states (no local cancel request was
+    /// recorded), carrying the reason explicitly.
+    RecordBrokerCancellation {
+        reason: CancellationReason,
+        cancelled_at: DateTime<Utc>,
+    },
     ConfirmCancellation {
         cancelled_at: DateTime<Utc>,
     },
@@ -2540,10 +2650,13 @@ pub enum OffchainOrderError {
 mod tests {
     use serde_json::json;
 
-    use st0x_event_sorcery::{AggregateError, LifecycleError, StoreBuilder, TestStore, replay};
+    use st0x_event_sorcery::{
+        AggregateError, LifecycleError, StoreBuilder, TestStore, replay, test_store,
+    };
+    use st0x_float_macro::float;
 
     use super::*;
-    use st0x_float_macro::float;
+    use crate::test_utils::setup_test_db;
 
     fn failing_order_placer() -> Arc<dyn OrderPlacer> {
         struct Failing;
@@ -2625,6 +2738,27 @@ mod tests {
     /// `MarkAccepted`. The accepted quantity is `noop_placed_shares(100)`, so
     /// the resulting `Submitted` carries the broker-working amount, not 100.
     async fn place_and_submit(store: &TestStore<OffchainOrder>, id: &OffchainOrderId) {
+        let requested = Positive::new(FractionalShares::new(float!(100))).unwrap();
+        store.send(id, place_command()).await.unwrap();
+        store
+            .send(
+                id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("TEST-ACCEPT"),
+                    placed_shares: noop_placed_shares(requested),
+                    submitted_at: Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    /// [`place_and_submit`] against a pool-backed [`Store`], for tests that
+    /// drive the broker-I/O cancel helper ([`cancel_offchain_order`] takes
+    /// `&Store`, which `TestStore` cannot provide).
+    async fn place_and_submit_pooled(store: &Store<OffchainOrder>, id: &OffchainOrderId) {
         let requested = Positive::new(FractionalShares::new(float!(100))).unwrap();
         store.send(id, place_command()).await.unwrap();
         store
@@ -2857,7 +2991,7 @@ mod tests {
     ) -> Option<OffchainOrder> {
         let pool = crate::test_utils::setup_test_db().await;
         let (store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(noop_order_placer())
+            .build()
             .await
             .unwrap();
 
@@ -3130,7 +3264,7 @@ mod tests {
     async fn place_retry_with_divergent_payload_is_rejected() {
         let pool = crate::test_utils::setup_test_db().await;
         let (store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(noop_order_placer())
+            .build()
             .await
             .unwrap();
         let id = OffchainOrderId::new();
@@ -3165,7 +3299,7 @@ mod tests {
     async fn place_at_broker_skips_broker_when_order_left_pending() {
         let pool = crate::test_utils::setup_test_db().await;
         let (store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(noop_order_placer())
+            .build()
             .await
             .unwrap();
         let id = OffchainOrderId::new();
@@ -3241,7 +3375,7 @@ mod tests {
     async fn place_at_broker_skips_markfailed_when_order_advanced_concurrently() {
         let pool = crate::test_utils::setup_test_db().await;
         let (store, _) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(noop_order_placer())
+            .build()
             .await
             .unwrap();
         let id = OffchainOrderId::new();
@@ -3325,7 +3459,7 @@ mod tests {
 
     #[tokio::test]
     async fn place_is_idempotent_once_placed() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         // The durable placement path re-sends `Place` on retry; an existing
@@ -3365,7 +3499,7 @@ mod tests {
     /// rather than silently falling back to `Utc::now()`.
     #[tokio::test]
     async fn place_at_uses_supplied_timestamp() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
         let placed_at = Utc::now() - chrono::Duration::hours(2);
 
@@ -3398,7 +3532,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_accepted_is_idempotent_on_submitted() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         // The durable placement path re-sends `MarkAccepted` on retry (the broker
@@ -3430,7 +3564,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_failed_is_idempotent_on_failed() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         store.send(&id, place_command()).await.unwrap();
@@ -3468,7 +3602,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_accepted_after_failed_is_noop() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         store.send(&id, place_command()).await.unwrap();
@@ -3509,7 +3643,7 @@ mod tests {
 
     #[tokio::test]
     async fn partial_fill_from_submitted_records_broker_timestamp() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
         // A timestamp distinct from any wall clock the handler could stamp:
         // the persisted event must carry the broker's fill time, not
@@ -3545,7 +3679,7 @@ mod tests {
 
     #[tokio::test]
     async fn partial_fill_updates_shares() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         let latest_partially_filled_at = Utc::now();
@@ -3600,7 +3734,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_fill_from_submitted() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -3621,7 +3755,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_fill_from_partially_filled() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -3656,7 +3790,7 @@ mod tests {
         // Process-isolated under nextest; only this fill is sampled. The default
         // Prometheus summary rendering emits a `_count` series we can assert on.
         let handle = crate::metrics::setup().expect("install Prometheus recorder");
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -3680,7 +3814,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_fill_uninitialized_order() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         let err = store
@@ -3701,7 +3835,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_fill_already_filled() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -3734,7 +3868,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_failed_from_submitted() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -3755,7 +3889,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_failed_from_partially_filled() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -3801,7 +3935,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_placement_failed_fails_a_pending_order() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         // The placement path's broker call errored while the order was still
@@ -3823,7 +3957,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_placement_failed_leaves_a_live_order_untouched() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         // A stale placement attempt's broker error must never fail a live order a
@@ -3853,7 +3987,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_fail_already_filled() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -3886,7 +4020,7 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_order_from_submitted_transitions_to_cancelling() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
         place_and_submit(&store, &id).await;
 
@@ -3983,12 +4117,11 @@ mod tests {
     #[tokio::test]
     async fn cancel_order_from_partially_filled_reconciles_newer_broker_fill() {
         let broker_partially_filled_at = Utc::now() - chrono::Duration::minutes(2);
-        let store = TestStore::<OffchainOrder>::new(broker_partial_fill_placer(
-            float!(60),
-            broker_partially_filled_at,
-        ));
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = broker_partial_fill_placer(float!(60), broker_partially_filled_at);
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
         store
             .send(
                 &id,
@@ -4001,15 +4134,14 @@ mod tests {
             .await
             .unwrap();
 
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap();
+        cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap();
 
         let inner = store.load(&id).await.unwrap().unwrap();
         assert!(
@@ -4038,10 +4170,11 @@ mod tests {
     /// order proceeds to Cancelling carrying the local 50-share fill.
     #[tokio::test]
     async fn cancel_order_from_partially_filled_skips_stale_broker_fill() {
-        let store =
-            TestStore::<OffchainOrder>::new(broker_partial_fill_placer(float!(30), Utc::now()));
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = broker_partial_fill_placer(float!(30), Utc::now());
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
         store
             .send(
                 &id,
@@ -4054,15 +4187,14 @@ mod tests {
             .await
             .unwrap();
 
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap();
+        cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap();
 
         let inner = store.load(&id).await.unwrap().unwrap();
         assert!(
@@ -4085,7 +4217,7 @@ mod tests {
 
     #[tokio::test]
     async fn confirm_cancellation_transitions_cancelling_to_cancelled() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
         place_and_submit(&store, &id).await;
         store
@@ -4174,19 +4306,20 @@ mod tests {
             Arc::new(Placer)
         }
 
-        let store = TestStore::<OffchainOrder>::new(already_cancelled_zero_fill_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = already_cancelled_zero_fill_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap();
+        cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap();
 
         let inner = store.load(&id).await.unwrap().unwrap();
         assert!(
@@ -4247,19 +4380,20 @@ mod tests {
             Arc::new(Placer)
         }
 
-        let store = TestStore::<OffchainOrder>::new(already_cancelled_priced_fill_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = already_cancelled_priced_fill_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap();
+        cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap();
 
         let inner = store.load(&id).await.unwrap().unwrap();
         assert!(
@@ -4336,26 +4470,25 @@ mod tests {
             Arc::new(CancelFailing)
         }
 
-        let store = TestStore::<OffchainOrder>::new(cancel_failing_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = cancel_failing_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        let err = store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap_err();
+        let err = cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap_err();
 
         assert!(
             matches!(
                 err,
-                AggregateError::UserError(LifecycleError::Apply(
-                    OffchainOrderError::CancelFailed { .. }
-                ))
+                CancelOffchainOrderError::Domain(OffchainOrderError::CancelFailed { .. })
             ),
             "Expected CancelFailed, got: {err:?}"
         );
@@ -4424,19 +4557,20 @@ mod tests {
             Arc::new(OrderGone)
         }
 
-        let store = TestStore::<OffchainOrder>::new(order_not_found_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = order_not_found_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap();
+        cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap();
 
         let inner = store.load(&id).await.unwrap().unwrap();
         assert!(
@@ -4473,9 +4607,8 @@ mod tests {
                 OffchainOrderCommand::CancelOrder {
                     reason: CancellationReason::MarketOpenReplacement,
                 },
-                &noop_order_placer(),
+                &mut JobQueue::default(),
             )
-            .await
             .unwrap_err();
 
         assert!(
@@ -4488,7 +4621,7 @@ mod tests {
     async fn cancel_order_on_failed_returns_already_completed() {
         // Placement feedback drives the aggregate to Failed; cancel on a
         // terminal state must reject with AlreadyCompleted.
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
         store.send(&id, place_command()).await.unwrap();
         store
@@ -4600,7 +4733,7 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_order_on_filled_returns_already_completed() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
         place_and_submit(&store, &id).await;
         store
@@ -4689,19 +4822,20 @@ mod tests {
             Arc::new(PartialFillPlacer)
         }
 
-        let store = TestStore::<OffchainOrder>::new(partial_fill_reconciling_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = partial_fill_reconciling_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap();
+        cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap();
 
         let inner = store.load(&id).await.unwrap().unwrap();
         // Must be Cancelling, but the partial-fill event should have been
@@ -4785,26 +4919,27 @@ mod tests {
             Arc::new(Placer)
         }
 
-        let store = TestStore::<OffchainOrder>::new(failed_unpriced_fill_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = failed_unpriced_fill_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        let err = store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap_err();
+        let err = cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap_err();
 
         assert!(
             matches!(
                 err,
-                AggregateError::UserError(LifecycleError::Apply(
+                CancelOffchainOrderError::Domain(
                     OffchainOrderError::PreCancelPartialFillMissingAvgPrice { .. }
-                ))
+                )
             ),
             "Expected PreCancelPartialFillMissingAvgPrice, got: {err:?}"
         );
@@ -4876,26 +5011,27 @@ mod tests {
             Arc::new(Placer)
         }
 
-        let store = TestStore::<OffchainOrder>::new(cancelled_unpriced_fill_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = cancelled_unpriced_fill_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        let err = store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap_err();
+        let err = cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap_err();
 
         assert!(
             matches!(
                 err,
-                AggregateError::UserError(LifecycleError::Apply(
+                CancelOffchainOrderError::Domain(
                     OffchainOrderError::PreCancelPartialFillMissingAvgPrice { .. }
-                ))
+                )
             ),
             "Expected PreCancelPartialFillMissingAvgPrice, got: {err:?}"
         );
@@ -4964,26 +5100,27 @@ mod tests {
             Arc::new(Placer)
         }
 
-        let store = TestStore::<OffchainOrder>::new(partially_filled_unpriced_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = partially_filled_unpriced_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        let err = store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap_err();
+        let err = cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap_err();
 
         assert!(
             matches!(
                 err,
-                AggregateError::UserError(LifecycleError::Apply(
+                CancelOffchainOrderError::Domain(
                     OffchainOrderError::PreCancelPartialFillMissingAvgPrice { .. }
-                ))
+                )
             ),
             "Expected PreCancelPartialFillMissingAvgPrice, got: {err:?}"
         );
@@ -5053,10 +5190,12 @@ mod tests {
             Arc::new(Placer)
         }
 
-        let store = TestStore::<OffchainOrder>::new(cancelled_covered_fill_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = cancelled_covered_fill_placer();
         let id = OffchainOrderId::new();
         let fill_time = Utc::now();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
         store
             .send(
                 &id,
@@ -5069,15 +5208,14 @@ mod tests {
             .await
             .unwrap();
 
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap();
+        cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap();
 
         let inner = store.load(&id).await.unwrap().unwrap();
         let OffchainOrder::Cancelled { retained_fill, .. } = inner else {
@@ -5150,26 +5288,27 @@ mod tests {
             Arc::new(Placer)
         }
 
-        let store = TestStore::<OffchainOrder>::new(status_fetch_failing_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = status_fetch_failing_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        let err = store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap_err();
+        let err = cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap_err();
 
         assert!(
             matches!(
                 err,
-                AggregateError::UserError(LifecycleError::Apply(
+                CancelOffchainOrderError::Domain(
                     OffchainOrderError::PreCancelStatusFetchFailed { .. }
-                ))
+                )
             ),
             "Expected PreCancelStatusFetchFailed, got: {err:?}"
         );
@@ -5236,19 +5375,20 @@ mod tests {
             Arc::new(Placer)
         }
 
-        let store = TestStore::<OffchainOrder>::new(already_filled_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = already_filled_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap();
+        cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap();
 
         let inner = store.load(&id).await.unwrap().unwrap();
         assert!(
@@ -5259,7 +5399,7 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_order_on_already_cancelling_is_idempotent_noop() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
         place_and_submit(&store, &id).await;
         store
@@ -5379,7 +5519,7 @@ mod tests {
     // FIX 3: ConfirmCancellation on a non-Cancelling state must return CancellationNotRequested.
     #[tokio::test]
     async fn confirm_cancellation_on_submitted_returns_cancellation_not_requested() {
-        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let store = TestStore::<OffchainOrder>::new();
         let id = OffchainOrderId::new();
 
         place_and_submit(&store, &id).await;
@@ -5460,26 +5600,27 @@ mod tests {
             Arc::new(Placer)
         }
 
-        let store = TestStore::<OffchainOrder>::new(negative_fill_cancelled_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = negative_fill_cancelled_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        let err = store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap_err();
+        let err = cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap_err();
 
         assert!(
             matches!(
                 err,
-                AggregateError::UserError(LifecycleError::Apply(
+                CancelOffchainOrderError::Domain(
                     OffchainOrderError::InvalidTerminalFillQuantity { .. }
-                ))
+                )
             ),
             "Negative broker fill quantity must return InvalidTerminalFillQuantity, got: {err:?}"
         );
@@ -5537,26 +5678,27 @@ mod tests {
             Arc::new(Placer)
         }
 
-        let store = TestStore::<OffchainOrder>::new(negative_unpriced_cancelled_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = negative_unpriced_cancelled_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        let err = store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap_err();
+        let err = cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap_err();
 
         assert!(
             matches!(
                 err,
-                AggregateError::UserError(LifecycleError::Apply(
+                CancelOffchainOrderError::Domain(
                     OffchainOrderError::InvalidTerminalFillQuantity { .. }
-                ))
+                )
             ),
             "Negative unpriced broker fill must return InvalidTerminalFillQuantity, got: {err:?}"
         );
@@ -5614,26 +5756,27 @@ mod tests {
             Arc::new(Placer)
         }
 
-        let store = TestStore::<OffchainOrder>::new(negative_partial_fill_placer());
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = negative_partial_fill_placer();
         let id = OffchainOrderId::new();
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
 
-        let err = store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap_err();
+        let err = cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap_err();
 
         assert!(
             matches!(
                 err,
-                AggregateError::UserError(LifecycleError::Apply(
+                CancelOffchainOrderError::Domain(
                     OffchainOrderError::InvalidTerminalFillQuantity { .. }
-                ))
+                )
             ),
             "Negative pre-cancel partial fill must return InvalidTerminalFillQuantity, got: {err:?}"
         );
@@ -5645,13 +5788,12 @@ mod tests {
         // Broker reports the same 50-share fill as the local state (stale read);
         // pre-cancel reconciliation skips the update and the order reaches
         // Cancelling carrying the locally-recorded fill.
-        let store = TestStore::<OffchainOrder>::new(broker_partial_fill_placer(
-            float!(50),
-            partially_filled_at,
-        ));
+        let pool = setup_test_db().await;
+        let store = test_store::<OffchainOrder>(pool);
+        let placer = broker_partial_fill_placer(float!(50), partially_filled_at);
         let id = OffchainOrderId::new();
 
-        place_and_submit(&store, &id).await;
+        place_and_submit_pooled(&store, &id).await;
         store
             .send(
                 &id,
@@ -5663,15 +5805,14 @@ mod tests {
             )
             .await
             .unwrap();
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap();
+        cancel_offchain_order(
+            &store,
+            placer.as_ref(),
+            &id,
+            CancellationReason::MarketOpenReplacement,
+        )
+        .await
+        .unwrap();
         store
             .send(
                 &id,

--- a/src/offchain/order/handle_rejection.rs
+++ b/src/offchain/order/handle_rejection.rs
@@ -296,12 +296,12 @@ mod tests {
         let pool = setup_test_db().await;
 
         let (offchain_order, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(crate::offchain::order::noop_order_placer())
+            .build()
             .await
             .unwrap();
 
         let (position, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -25,9 +25,9 @@ use crate::offchain::order::handle_rejection::{
 };
 use crate::offchain::order::reconcile_fill::{ReconcileOrderFill, ReconcileOrderFillJobQueue};
 use crate::offchain::order::{
-    CancellationReason, JobError, OffchainOrder, OffchainOrderCommand, OffchainOrderId,
-    RetainedFill, TerminalPositionFinalization, position_command_for_finalization,
-    terminal_position_finalization,
+    CancellationReason, ExecutorOrderPlacer, JobError, OffchainOrder, OffchainOrderCommand,
+    OffchainOrderId, RetainedFill, TerminalPositionFinalization, cancel_offchain_order,
+    position_command_for_finalization, terminal_position_finalization,
 };
 use crate::position::Position;
 
@@ -572,14 +572,13 @@ impl PollOrderStatus {
         // local reason -- mislabelling a 2pm manual cancel as a market-open
         // replacement would corrupt the cancellation analytics the reason
         // field exists for.
-        ctx.offchain_order_store
-            .send(
-                &self.offchain_order_id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: CancellationReason::Unrequested,
-                },
-            )
-            .await?;
+        cancel_offchain_order(
+            &ctx.offchain_order_store,
+            &ExecutorOrderPlacer(ctx.executor.clone()),
+            &self.offchain_order_id,
+            CancellationReason::Unrequested,
+        )
+        .await?;
 
         let Some(recovered) = ctx
             .offchain_order_store
@@ -883,7 +882,7 @@ mod tests {
 
     use super::*;
     use crate::offchain::order::{
-        NoFillOutcome, OffchainOrderCommand, TerminalPositionFinalization, noop_order_placer,
+        NoFillOutcome, OffchainOrderCommand, TerminalPositionFinalization,
         terminal_position_finalization,
     };
     use crate::position::{Position, PositionCommand, TradeId};
@@ -905,12 +904,12 @@ mod tests {
 
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
+                .build()
                 .await
                 .unwrap();
 
         let (position, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 

--- a/src/offchain/order/reconcile_fill.rs
+++ b/src/offchain/order/reconcile_fill.rs
@@ -164,12 +164,12 @@ mod tests {
         let pool = setup_test_db().await;
 
         let (offchain_order, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .build(crate::offchain::order::noop_order_placer())
+            .build()
             .await
             .unwrap();
 
         let (position, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 

--- a/src/onchain/accumulator.rs
+++ b/src/onchain/accumulator.rs
@@ -208,7 +208,7 @@ mod tests {
         pool: &SqlitePool,
     ) -> (Arc<Store<Position>>, Arc<Projection<Position>>) {
         StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap()
     }

--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -4843,21 +4843,21 @@ mod tests {
         let executor = MockExecutorCtx.try_into_executor().await.unwrap();
 
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
+                .build()
                 .await
                 .unwrap();
         let (vault_registry, _vault_registry_projection) =
             StoreBuilder::<VaultRegistry>::new(pool.clone())
-                .build(())
+                .build()
                 .await
                 .unwrap();
 
@@ -4919,11 +4919,11 @@ mod tests {
         let pool = setup_test_db().await;
 
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -4993,11 +4993,11 @@ mod tests {
         let pool = setup_test_db().await;
 
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -5098,11 +5098,11 @@ mod tests {
         let pool = setup_test_db().await;
 
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -5180,11 +5180,11 @@ mod tests {
         let pool = setup_test_db().await;
 
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -5244,11 +5244,11 @@ mod tests {
         let pool = setup_test_db().await;
 
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -5335,11 +5335,11 @@ mod tests {
         let pool = setup_test_db().await;
 
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -5457,11 +5457,11 @@ mod tests {
     async fn backfill_block_hash_mismatch_reverses_then_reapplies_reorg() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -5559,11 +5559,11 @@ mod tests {
     async fn record_reorg_reverses_then_reapplies_a_reincluded_fill() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -5651,11 +5651,11 @@ mod tests {
     async fn record_reorg_reapply_is_idempotent_across_redelivery() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -5742,11 +5742,11 @@ mod tests {
     async fn record_reorg_resumes_reapply_after_reversal_but_before_rewitness() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -5860,11 +5860,11 @@ mod tests {
     async fn backfill_matching_block_hash_is_not_a_reorg() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -5912,11 +5912,11 @@ mod tests {
     async fn backfill_block_hash_check_skips_when_nothing_to_compare() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -5999,11 +5999,11 @@ mod tests {
     async fn detect_block_hash_reorg_anchors_on_persisted_block_number() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -6189,11 +6189,11 @@ mod tests {
     async fn dropped_fill_with_orphaned_block_is_flagged_reverse_only() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -6262,11 +6262,11 @@ mod tests {
     async fn still_canonical_fill_is_noop() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -6317,11 +6317,11 @@ mod tests {
     async fn re_mined_same_key_is_left_to_block_hash_detector() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -6380,11 +6380,11 @@ mod tests {
     async fn already_reorg_acknowledged_fill_is_idempotent_noop() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -6457,11 +6457,11 @@ mod tests {
     async fn canonical_block_absent_is_deferred_not_reversed() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -6509,11 +6509,11 @@ mod tests {
     async fn finalized_fill_is_outside_the_reverification_window() {
         let pool = setup_test_db().await;
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 

--- a/src/onchain_trade.rs
+++ b/src/onchain_trade.rs
@@ -9,14 +9,13 @@ use std::str::FromStr;
 
 use alloy::hex::FromHexError;
 use alloy::primitives::{B256, TxHash};
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rain_math_float::Float;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use st0x_dto::{Direction, Trade, TradingVenue};
-use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
+use st0x_event_sorcery::{DomainEvent, EventSourced, JobQueue, Nil};
 use st0x_execution::Symbol;
 use st0x_finance::FractionalShares;
 
@@ -110,13 +109,12 @@ pub(crate) struct OnChainTrade {
     pub(crate) reorg_acknowledged_at: Option<DateTime<Utc>>,
 }
 
-#[async_trait]
 impl EventSourced for OnChainTrade {
     type Id = OnChainTradeId;
     type Event = OnChainTradeEvent;
     type Command = OnChainTradeCommand;
     type Error = OnChainTradeError;
-    type Services = ();
+    type Jobs = Nil;
     type Materialized = Nil;
 
     const AGGREGATE_TYPE: &'static str = "OnChainTrade";
@@ -220,9 +218,9 @@ impl EventSourced for OnChainTrade {
         }
     }
 
-    async fn initialize(
+    fn initialize(
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use OnChainTradeCommand::*;
         use OnChainTradeEvent::*;
@@ -275,10 +273,10 @@ impl EventSourced for OnChainTrade {
         }
     }
 
-    async fn transition(
+    fn transition(
         &self,
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use OnChainTradeCommand::*;
         use OnChainTradeEvent::*;
@@ -718,7 +716,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
 
-        let events = TestHarness::<OnChainTrade>::with(())
+        let events = TestHarness::<OnChainTrade>::with()
             .given_no_previous_events()
             .when(OnChainTradeCommand::Witness {
                 symbol: symbol.clone(),
@@ -745,7 +743,7 @@ mod tests {
         let block_timestamp = Utc::now();
         let filled_at = block_timestamp - chrono::Duration::hours(4);
 
-        let events = TestHarness::<OnChainTrade>::with(())
+        let events = TestHarness::<OnChainTrade>::with()
             .given_no_previous_events()
             .when(OnChainTradeCommand::WitnessAt {
                 symbol: symbol.clone(),
@@ -778,7 +776,7 @@ mod tests {
         let block_hash =
             b256!("0xabababababababababababababababababababababababababababababababab");
 
-        let events = TestHarness::<OnChainTrade>::with(())
+        let events = TestHarness::<OnChainTrade>::with()
             .given_no_previous_events()
             .when(OnChainTradeCommand::Witness {
                 symbol,
@@ -816,7 +814,7 @@ mod tests {
             publish_time: now,
         };
 
-        let events = TestHarness::<OnChainTrade>::with(())
+        let events = TestHarness::<OnChainTrade>::with()
             .given(vec![OnChainTradeEvent::Filled {
                 symbol: symbol.clone(),
                 amount: float!(10.5),
@@ -851,7 +849,7 @@ mod tests {
             publish_time: now,
         };
 
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given(vec![
                 OnChainTradeEvent::Filled {
                     symbol: symbol.clone(),
@@ -895,7 +893,7 @@ mod tests {
             publish_time: now,
         };
 
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given_no_previous_events()
             .when(OnChainTradeCommand::Enrich {
                 gas_used: 50000,
@@ -923,7 +921,7 @@ mod tests {
             publish_time: now,
         };
 
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given(vec![OnChainTradeEvent::Filled {
                 symbol,
                 amount: float!("10.5"),
@@ -953,7 +951,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
 
-        let events = TestHarness::<OnChainTrade>::with(())
+        let events = TestHarness::<OnChainTrade>::with()
             .given(vec![OnChainTradeEvent::Filled {
                 symbol,
                 amount: float!(10.5),
@@ -979,7 +977,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
 
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given(vec![
                 OnChainTradeEvent::Filled {
                     symbol,
@@ -1007,7 +1005,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_acknowledge_unwitnessed_trade() {
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given_no_previous_events()
             .when(OnChainTradeCommand::Acknowledge)
             .await
@@ -1024,7 +1022,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
 
-        let events = TestHarness::<OnChainTrade>::with(())
+        let events = TestHarness::<OnChainTrade>::with()
             .given(vec![OnChainTradeEvent::Filled {
                 symbol,
                 amount: float!(10.5),
@@ -1056,7 +1054,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
 
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given(vec![
                 OnChainTradeEvent::Filled {
                     symbol,
@@ -1175,7 +1173,7 @@ mod tests {
         };
 
         // Acknowledge the witnessed fill through the command handler.
-        let acknowledge_events = TestHarness::<OnChainTrade>::with(())
+        let acknowledge_events = TestHarness::<OnChainTrade>::with()
             .given(vec![filled.clone()])
             .when(OnChainTradeCommand::Acknowledge)
             .await
@@ -1189,7 +1187,7 @@ mod tests {
         ));
 
         // RecordReorg the now-acknowledged fill through the command handler.
-        let reorg_events = TestHarness::<OnChainTrade>::with(())
+        let reorg_events = TestHarness::<OnChainTrade>::with()
             .given(vec![filled.clone(), acknowledged.clone()])
             .when(OnChainTradeCommand::RecordReorg { reorg_depth: 4 })
             .await
@@ -1211,7 +1209,7 @@ mod tests {
         assert!(trade.is_acknowledged());
 
         // (b) A retried Acknowledge after the reorg is rejected.
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given(vec![filled, acknowledged.clone(), reorged.clone()])
             .when(OnChainTradeCommand::Acknowledge)
             .await
@@ -1227,7 +1225,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
 
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given(vec![
                 OnChainTradeEvent::Filled {
                     symbol,
@@ -1256,7 +1254,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_reorg_unfilled_trade() {
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given_no_previous_events()
             .when(OnChainTradeCommand::RecordReorg { reorg_depth: 1 })
             .await
@@ -1291,7 +1289,7 @@ mod tests {
     async fn acknowledge_reorg_marks_reversal_complete() {
         let now = Utc::now();
 
-        let events = TestHarness::<OnChainTrade>::with(())
+        let events = TestHarness::<OnChainTrade>::with()
             .given(filled_then_reorged(now))
             .when(OnChainTradeCommand::AcknowledgeReorg)
             .await
@@ -1329,7 +1327,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
 
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given(vec![OnChainTradeEvent::Filled {
                 symbol,
                 amount: float!(10.5),
@@ -1358,7 +1356,7 @@ mod tests {
             reorg_acknowledged_at: now,
         });
 
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given(events)
             .when(OnChainTradeCommand::AcknowledgeReorg)
             .await
@@ -1403,7 +1401,7 @@ mod tests {
         let new_block_hash =
             b256!("0xbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbc");
 
-        let events = TestHarness::<OnChainTrade>::with(())
+        let events = TestHarness::<OnChainTrade>::with()
             .given(filled_acknowledged_reorged_acknowledged(now))
             .when(OnChainTradeCommand::ReWitness {
                 block_number: 99999,
@@ -1434,7 +1432,7 @@ mod tests {
         // desync the `record_reorg` resume keying.
         let now = Utc::now();
 
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given(filled_then_reorged(now))
             .when(OnChainTradeCommand::ReWitness {
                 block_number: 99999,
@@ -1456,7 +1454,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
 
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given(vec![OnChainTradeEvent::Filled {
                 symbol,
                 amount: float!(10.5),
@@ -1538,7 +1536,7 @@ mod tests {
             re_witnessed_at: now,
         });
 
-        let acknowledge_events = TestHarness::<OnChainTrade>::with(())
+        let acknowledge_events = TestHarness::<OnChainTrade>::with()
             .given(events)
             .when(OnChainTradeCommand::Acknowledge)
             .await
@@ -1600,7 +1598,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
 
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given(vec![OnChainTradeEvent::Filled {
                 symbol: symbol.clone(),
                 amount: float!(10.5),
@@ -1641,7 +1639,7 @@ mod tests {
             publish_time: now,
         };
 
-        let error = TestHarness::<OnChainTrade>::with(())
+        let error = TestHarness::<OnChainTrade>::with()
             .given(vec![
                 OnChainTradeEvent::Filled {
                     symbol: symbol.clone(),

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -33,8 +33,6 @@
 #[cfg(any(test, feature = "test-support"))]
 use alloy::primitives::TxHash;
 #[cfg(any(test, feature = "test-support"))]
-use async_trait::async_trait;
-#[cfg(any(test, feature = "test-support"))]
 use chrono::Duration;
 use chrono::{DateTime, Utc};
 #[cfg(any(test, feature = "test-support"))]
@@ -47,12 +45,12 @@ use tracing::warn;
 #[cfg(any(test, feature = "test-support"))]
 use st0x_config::ExecutionThreshold;
 #[cfg(any(test, feature = "test-support"))]
-use st0x_event_sorcery::{RetryOnBusy, StoreBuilder};
+use st0x_event_sorcery::StoreBuilder;
 use st0x_execution::Symbol;
 #[cfg(any(test, feature = "test-support"))]
 use st0x_execution::{
-    CancellationOutcome, ClientOrderId, Direction, ExecutorOrderId, FractionalShares, LimitOrder,
-    MarketOrder, MarketSession, Positive, SupportedExecutor,
+    ClientOrderId, Direction, ExecutorOrderId, FractionalShares, MarketSession, Positive,
+    SupportedExecutor,
 };
 #[cfg(any(test, feature = "test-support"))]
 use st0x_finance::Usd;
@@ -62,7 +60,6 @@ use st0x_float_macro::float;
 #[cfg(any(test, feature = "test-support"))]
 use crate::offchain::order::{
     CounterTradeOrderKind, OffchainOrder, OffchainOrderCommand, OffchainOrderId,
-    OrderPlacementResult, OrderPlacer,
 };
 #[cfg(any(test, feature = "test-support"))]
 use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
@@ -84,40 +81,6 @@ pub(crate) use projection::HedgeLatencyProjection;
 pub(crate) use report::{
     PerformanceError, ReportRange, hedge_latency_report, load_hedge_performance,
 };
-
-/// Minimal [`OrderPlacer`] for [`seed_simulated_hedge_latency_history`]'s
-/// temporary `Store<OffchainOrder>`. The fixture drives the aggregate
-/// directly via `Store::send` (never through
-/// `crate::offchain::order::place_offchain_order_at_broker`), so none of
-/// these methods are ever actually invoked -- they exist only to satisfy
-/// `OffchainOrder::Services`.
-#[cfg(any(test, feature = "test-support"))]
-struct FixtureOrderPlacer;
-
-#[cfg(any(test, feature = "test-support"))]
-#[async_trait]
-impl OrderPlacer for FixtureOrderPlacer {
-    async fn place_market_order(
-        &self,
-        _order: MarketOrder,
-    ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
-        Err("FixtureOrderPlacer never places live orders".into())
-    }
-
-    async fn place_limit_order(
-        &self,
-        _order: LimitOrder,
-    ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
-        Err("FixtureOrderPlacer never places live orders".into())
-    }
-
-    async fn cancel_order(
-        &self,
-        _executor_order_id: &ExecutorOrderId,
-    ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
-        Err("FixtureOrderPlacer never cancels orders".into())
-    }
-}
 
 /// Seeds deterministic hedge history for local dashboard simulation.
 ///
@@ -168,23 +131,18 @@ pub async fn seed_simulated_hedge_latency_history(
     sqlx::migrate!().set_ignore_missing(true).run(pool).await?;
 
     let (position, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
-        .with(Arc::new(RetryOnBusy {
-            inner: HedgeLatencyProjection::new(pool.clone()),
-        }))
-        .build(())
+        .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
+        .build()
         .await?;
 
-    let order_placer: Arc<dyn OrderPlacer> = Arc::new(FixtureOrderPlacer);
     let (offchain_order, _offchain_order_projection) =
         StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .with(Arc::new(RetryOnBusy {
-                inner: HedgeLatencyProjection::new(pool.clone()),
-            }))
-            .build(order_placer)
+            .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
+            .build()
             .await?;
 
     let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-        .build(())
+        .build()
         .await?;
 
     // The dashboard's rolling window queries with `to = now()`, which keeps

--- a/src/performance/equity_timing/mod.rs
+++ b/src/performance/equity_timing/mod.rs
@@ -38,7 +38,7 @@ use st0x_dto::{
     EquityOperationKind, EquityOperationTiming, EquityStageName, EquityStageStats,
     EquityStageTiming, RebalanceTimingStatus, StageOutcome,
 };
-use st0x_event_sorcery::{EntityList, EventSourced, IdempotentReactor, Reactor, deps};
+use st0x_event_sorcery::{EntityList, EventSourced, Reactor, deps};
 use st0x_execution::Symbol;
 use st0x_finance::FractionalShares;
 use st0x_tokenization::IssuerRequestId;
@@ -564,8 +564,6 @@ impl Reactor for EquityTimingProjection {
             .await
     }
 }
-
-impl IdempotentReactor for EquityTimingProjection {}
 
 /// Accumulated per-operation timing state, persisted as JSON.
 ///
@@ -1230,7 +1228,7 @@ mod tests {
         // Seed events directly through a store with NO projection attached,
         // simulating history that accumulated before this projection existed.
         let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let operation_id = issuer_request_id("catch-up-mint");

--- a/src/performance/projection.rs
+++ b/src/performance/projection.rs
@@ -11,7 +11,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
-use st0x_event_sorcery::{EntityList, IdempotentReactor, Reactor, deps};
+use st0x_event_sorcery::{EntityList, Reactor, deps};
 use thiserror::Error;
 use tracing::{debug, warn};
 
@@ -393,8 +393,6 @@ impl Reactor for HedgeLatencyProjection {
             .await
     }
 }
-
-impl IdempotentReactor for HedgeLatencyProjection {}
 
 #[cfg(test)]
 mod tests {

--- a/src/performance/rebalance.rs
+++ b/src/performance/rebalance.rs
@@ -44,7 +44,7 @@ use st0x_dto::{
     AttestationSample, RebalanceOperationTiming, RebalanceStageName, RebalanceStageStats,
     RebalanceStageTiming, RebalanceTimingStatus, RebalanceTimings, StageOutcome,
 };
-use st0x_event_sorcery::{EntityList, EventSourced, IdempotentReactor, Reactor, deps};
+use st0x_event_sorcery::{EntityList, EventSourced, Reactor, deps};
 use st0x_finance::Usdc;
 
 use super::{PerformanceError, ReportRange, latency_stats};
@@ -445,8 +445,6 @@ impl Reactor for RebalanceTimingProjection {
             .await
     }
 }
-
-impl IdempotentReactor for RebalanceTimingProjection {}
 
 /// Accumulated per-operation timing state, persisted as JSON.
 ///
@@ -1156,7 +1154,7 @@ mod tests {
             .with(std::sync::Arc::new(RebalanceTimingProjection::new(
                 pool.clone(),
             )))
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -1258,7 +1256,7 @@ mod tests {
         let pool = setup_test_db().await;
         // No reactor registered: `send` persists events to the store but never
         // writes the read model, leaving it behind the log.
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
 
         let amount = Usdc::new(float!(400.0));
         let burn_tx =
@@ -1390,7 +1388,7 @@ mod tests {
             .with(std::sync::Arc::new(RebalanceTimingProjection::new(
                 pool.clone(),
             )))
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -1503,7 +1501,7 @@ mod tests {
             .with(std::sync::Arc::new(RebalanceTimingProjection::new(
                 pool.clone(),
             )))
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -1599,7 +1597,7 @@ mod tests {
         let pool = setup_test_db().await;
         // No reactor: events persist but the read model stays behind, exactly what
         // catch_up reconciles.
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
 
         let amount = Usdc::new(float!(400.0));
         let burn_tx =
@@ -1728,7 +1726,7 @@ mod tests {
     #[tokio::test]
     async fn catch_up_holds_checkpoint_behind_a_mid_stream_poison_event() {
         let pool = setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
 
         let amount = Usdc::new(float!(400.0));
         let burn_tx =

--- a/src/performance/reliability.rs
+++ b/src/performance/reliability.rs
@@ -49,7 +49,7 @@ use st0x_dto::{
     LogVolumeBucket,
 };
 
-use st0x_event_sorcery::{EntityList, EventSourced, IdempotentReactor, Reactor, deps};
+use st0x_event_sorcery::{EntityList, EventSourced, Reactor, deps};
 
 use super::{PerformanceError, ReportRange};
 use crate::equity_redemption::{EquityRedemption, EquityRedemptionEvent};
@@ -429,8 +429,6 @@ impl Reactor for LifecycleFailureProjection {
     }
 }
 
-impl IdempotentReactor for LifecycleFailureProjection {}
-
 /// Failure signal carried by an `OffchainOrder` event, if any.
 fn offchain_order_failure(event: &OffchainOrderEvent) -> Option<(FailureEventType, DateTime<Utc>)> {
     match event {
@@ -699,20 +697,19 @@ fn count(value: i64) -> Result<usize, PerformanceError> {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
-    use std::time::Duration;
 
     use alloy::primitives::TxHash;
     use chrono::TimeZone;
     use serde_json::json;
     use uuid::Uuid;
 
-    use st0x_event_sorcery::{DomainEvent, ReactorHarness, RetryOnBusy};
+    use st0x_event_sorcery::{DomainEvent, ReactorHarness};
     use st0x_execution::Symbol;
     use st0x_float_macro::float;
 
     use crate::equity_redemption::DetectionFailure;
     use crate::offchain::order::OffchainOrderId;
-    use crate::test_utils::{setup_file_backed_test_db, setup_test_db};
+    use crate::test_utils::setup_test_db;
     use crate::usdc_rebalance::UsdcRebalanceId;
 
     use super::*;
@@ -832,38 +829,6 @@ mod tests {
             error: "rejected".to_string(),
             failed_at: timestamp(failed_offset),
         }
-    }
-
-    #[tokio::test]
-    async fn lifecycle_failure_reactor_survives_transient_sqlite_busy() {
-        let (pool, _apalis_pool, _database_path, _database_guard) =
-            setup_file_backed_test_db(Duration::from_millis(1)).await;
-        let mut blocker = pool.acquire().await.unwrap();
-        sqlx::query("BEGIN IMMEDIATE")
-            .execute(&mut *blocker)
-            .await
-            .unwrap();
-        let release_blocker = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(35)).await;
-            sqlx::query("COMMIT").execute(&mut *blocker).await.unwrap();
-        });
-
-        let harness = ReactorHarness::new(RetryOnBusy {
-            inner: LifecycleFailureProjection::new(pool.clone()),
-        });
-        let order_id = OffchainOrderId::new();
-        let result = harness
-            .receive::<OffchainOrder>(order_id, offchain_order_failed(100))
-            .await;
-
-        release_blocker.await.unwrap();
-        result.unwrap();
-        let failures = load_failure_events(&pool, &range()).await.unwrap();
-        assert_eq!(failures.len(), 1);
-        assert_eq!(
-            failures[0].event_type,
-            FailureEventType::OffchainOrderFailed
-        );
     }
 
     #[tokio::test]

--- a/src/performance/simulated_transfers.rs
+++ b/src/performance/simulated_transfers.rs
@@ -24,7 +24,7 @@ use rain_math_float::Float;
 use sqlx::SqlitePool;
 use std::sync::Arc;
 
-use st0x_event_sorcery::{RetryOnBusy, Store, StoreBuilder};
+use st0x_event_sorcery::{Store, StoreBuilder};
 use st0x_execution::{AlpacaTransferId, ClientOrderId, Symbol};
 use st0x_finance::Usdc;
 use st0x_tokenization::{IssuerRequestId, tokenization_request_id};
@@ -39,7 +39,6 @@ use crate::usdc_rebalance::{
     ConversionAmounts, RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand,
     UsdcRebalanceId,
 };
-
 
 /// Deterministic UUID for this module's fixtures, namespaced separately from
 /// `super::simulated_latency_uuid` so the two fixtures' synthetic ids never
@@ -71,10 +70,8 @@ pub async fn seed_simulated_mint_history(
     sqlx::migrate!().set_ignore_missing(true).run(pool).await?;
 
     let mint = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-        .with(Arc::new(RetryOnBusy {
-            inner: EquityTimingProjection::new(pool.clone()),
-        }))
-        .build(())
+        .with(Arc::new(EquityTimingProjection::new(pool.clone())))
+        .build()
         .await?;
 
     let range_start = now - Duration::days(i64::from(days)) - Duration::days(1);
@@ -177,10 +174,8 @@ pub async fn seed_simulated_usdc_rebalance_history(
     // `Materialized = Table`, which returns a `(Store, Projection)` pair) --
     // the reactor is wired into the store's dispatch either way.
     let rebalance = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-        .with(Arc::new(RetryOnBusy {
-            inner: RebalanceTimingProjection::new(pool.clone()),
-        }))
-        .build(())
+        .with(Arc::new(RebalanceTimingProjection::new(pool.clone())))
+        .build()
         .await?;
 
     let range_start = now - Duration::days(i64::from(days)) - Duration::days(1);
@@ -539,7 +534,6 @@ async fn seed_base_to_alpaca(
     Ok(())
 }
 
-
 /// Seeds deterministic equity-redemption history for local dashboard
 /// simulation.
 ///
@@ -572,10 +566,8 @@ pub async fn seed_simulated_equity_redemption_history(
         let unwrap_block = withdraw_block + 5;
 
         let redemption = StoreBuilder::<EquityRedemption>::new(pool.clone())
-            .with(Arc::new(RetryOnBusy {
-                inner: EquityTimingProjection::new(pool.clone()),
-            }))
-            .build(())
+            .with(Arc::new(EquityTimingProjection::new(pool.clone())))
+            .build()
             .await?;
 
         let id = RedemptionAggregateId(simulated_transfer_uuid("redemption", day));

--- a/src/position.rs
+++ b/src/position.rs
@@ -8,7 +8,6 @@
 use std::collections::BTreeSet;
 
 use alloy::primitives::TxHash;
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use metrics::gauge;
 use rain_math_float::{Float, FloatError};
@@ -16,7 +15,9 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
 use st0x_config::ExecutionThreshold;
-use st0x_event_sorcery::{DomainEvent, EventSourced, Projection, ProjectionError, Table};
+use st0x_event_sorcery::{
+    DomainEvent, EventSourced, JobQueue, Nil, Projection, ProjectionError, Table,
+};
 use st0x_execution::{
     Direction, ExecutorOrderId, FractionalShares, HasZero, Positive, SupportedExecutor, Symbol,
 };
@@ -145,6 +146,35 @@ impl std::fmt::Debug for Position {
 // possible. The precision loss is intentional and acceptable here — this gauge
 // is for monitoring dashboards only. All financial accounting uses the lossless
 // Float arithmetic in the Position aggregate itself.
+/// Shared tail of the Buy/Sell `Reorged` evolve arms: on top of the
+/// direction-specific net/accumulator reversal in `reversed`, prunes the
+/// reorged trade from the fill-dedupe bookkeeping and records it in the
+/// reorg-dedupe slots (ADR 0012), stamping the reorg timestamps.
+fn evolve_reorged(
+    entity: &Position,
+    trade_id: &TradeId,
+    reorged_at: DateTime<Utc>,
+    reversed: Position,
+) -> Position {
+    let mut pending_acknowledged_trade_ids = entity.pending_acknowledged_trade_ids.clone();
+    pending_acknowledged_trade_ids.remove(trade_id);
+    let mut pending_reorged_trade_ids = entity.pending_reorged_trade_ids.clone();
+    pending_reorged_trade_ids.insert(trade_id.clone());
+
+    Position {
+        last_reorged_at: Some(reorged_at),
+        last_acknowledged_trade_id: entity
+            .last_acknowledged_trade_id
+            .clone()
+            .filter(|id| id != trade_id),
+        last_reorged_trade_id: Some(trade_id.clone()),
+        pending_acknowledged_trade_ids,
+        pending_reorged_trade_ids,
+        last_updated: Some(reorged_at),
+        ..reversed
+    }
+}
+
 fn record_position_gauge(symbol: &Symbol, net: &FractionalShares) {
     match net.to_string().parse::<f64>() {
         Ok(value) => gauge!("position_shares", "symbol" => symbol.to_string()).set(value),
@@ -169,13 +199,12 @@ pub(crate) async fn hydrate_position_gauges(
     Ok(())
 }
 
-#[async_trait]
 impl EventSourced for Position {
     type Id = Symbol;
     type Event = PositionEvent;
     type Command = PositionCommand;
     type Error = PositionError;
-    type Services = ();
+    type Jobs = Nil;
     type Materialized = Table;
 
     const AGGREGATE_TYPE: &'static str = "Position";
@@ -303,13 +332,37 @@ impl EventSourced for Position {
             // out-of-order one after a newer reorg advanced the slot (ADR 0012).
             Reorged {
                 trade_id,
-                direction,
+                direction: Buy,
                 amount,
                 reorged_at,
                 ..
-            } => entity
-                .evolve_reorg(trade_id, *direction, *amount, *reorged_at)
-                .map(Some),
+            } => Ok(Some(evolve_reorged(
+                entity,
+                trade_id,
+                *reorged_at,
+                Self {
+                    net: (entity.net - *amount)?,
+                    accumulated_long: (entity.accumulated_long - *amount)?,
+                    ..entity.clone()
+                },
+            ))),
+
+            Reorged {
+                trade_id,
+                direction: Sell,
+                amount,
+                reorged_at,
+                ..
+            } => Ok(Some(evolve_reorged(
+                entity,
+                trade_id,
+                *reorged_at,
+                Self {
+                    net: (entity.net + *amount)?,
+                    accumulated_short: (entity.accumulated_short - *amount)?,
+                    ..entity.clone()
+                },
+            ))),
 
             // Bookkeeping only (ADR 0012): prune the settled reversal from the
             // pending-reorg set without touching net -- the reversal already
@@ -455,9 +508,9 @@ impl EventSourced for Position {
         }
     }
 
-    async fn initialize(
+    fn initialize(
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use PositionCommand::*;
         match command {
@@ -551,10 +604,10 @@ impl EventSourced for Position {
         }
     }
 
-    async fn transition(
+    fn transition(
         &self,
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use PositionCommand::*;
         match command {
@@ -761,93 +814,6 @@ impl EventSourced for Position {
 }
 
 impl Position {
-    fn record_reorg_events(
-        &self,
-        trade_id: TradeId,
-        amount: FractionalShares,
-        direction: Direction,
-        price_usdc: Float,
-        reorg_depth: u64,
-    ) -> Result<Vec<PositionEvent>, PositionError> {
-        Positive::new(amount).map_err(|_| PositionError::NonPositiveReorgAmount { amount })?;
-
-        // Dual guard (ADR 0012, mirroring ADR 0010 for fills): the retained slot
-        // bridges a reorg reversed under pre-set code and left unsettled at the
-        // deploy restart; the set rejects an out-of-order re-drive the single
-        // slot cannot, because a newer reorg advances the slot but never the set.
-        if self.last_reorged_trade_id.as_ref() == Some(&trade_id)
-            || self.pending_reorged_trade_ids.contains(&trade_id)
-        {
-            warn!(
-                target: "hedge",
-                symbol = %self.symbol, %trade_id,
-                "Rejecting re-driven reorg: fill already reversed on this position"
-            );
-            return Err(PositionError::DuplicateReorg { trade_id });
-        }
-
-        warn!(
-            target: "hedge",
-            symbol = %self.symbol,
-            %trade_id,
-            ?direction,
-            %amount,
-            reorg_depth,
-            "Reversing position impact of a reorged fill"
-        );
-
-        Ok(vec![PositionEvent::Reorged {
-            trade_id,
-            amount,
-            direction,
-            price_usdc: Some(price_usdc),
-            reorg_depth,
-            reorged_at: Utc::now(),
-        }])
-    }
-
-    fn evolve_reorg(
-        &self,
-        trade_id: &TradeId,
-        direction: Direction,
-        amount: FractionalShares,
-        reorged_at: DateTime<Utc>,
-    ) -> Result<Self, PositionError> {
-        let mut pending_acknowledged_trade_ids = self.pending_acknowledged_trade_ids.clone();
-        pending_acknowledged_trade_ids.remove(trade_id);
-        let mut pending_reorged_trade_ids = self.pending_reorged_trade_ids.clone();
-        pending_reorged_trade_ids.insert(trade_id.clone());
-
-        let (net, accumulated_long, accumulated_short) = match direction {
-            Direction::Buy => (
-                (self.net - amount)?,
-                (self.accumulated_long - amount)?,
-                self.accumulated_short,
-            ),
-            Direction::Sell => (
-                (self.net + amount)?,
-                self.accumulated_long,
-                (self.accumulated_short - amount)?,
-            ),
-        };
-
-        Ok(Self {
-            net,
-            accumulated_long,
-            accumulated_short,
-            last_reorged_at: Some(reorged_at),
-            last_acknowledged_trade_id: self
-                .last_acknowledged_trade_id
-                .clone()
-                .filter(|id| id != trade_id),
-            last_reorged_trade_id: Some(trade_id.clone()),
-            pending_acknowledged_trade_ids,
-            pending_reorged_trade_ids,
-            last_updated: Some(reorged_at),
-            ..self.clone()
-        })
-    }
-
     fn acknowledge_on_chain_fill_init_events(
         symbol: Symbol,
         threshold: ExecutionThreshold,
@@ -913,6 +879,55 @@ impl Position {
                 applied_at: seen_at,
             },
         ])
+    }
+
+    fn record_reorg_events(
+        &self,
+        trade_id: TradeId,
+        amount: FractionalShares,
+        direction: Direction,
+        price_usdc: Float,
+        reorg_depth: u64,
+    ) -> Result<Vec<PositionEvent>, PositionError> {
+        // A reversal must undo a real (strictly positive) fill amount.
+        // Reject a zero or negative amount rather than appending a
+        // reversal that would corrupt the net position.
+        Positive::new(amount).map_err(|_| PositionError::NonPositiveReorgAmount { amount })?;
+
+        // Dual guard (ADR 0012, mirroring ADR 0010 for fills): the
+        // retained slot bridges a reorg reversed under pre-set code and
+        // left unsettled at the deploy restart; the set rejects an
+        // out-of-order re-drive the single slot cannot, because a newer
+        // reorg advances the slot but never the set entry.
+        if self.last_reorged_trade_id.as_ref() == Some(&trade_id)
+            || self.pending_reorged_trade_ids.contains(&trade_id)
+        {
+            warn!(
+                target: "hedge",
+                symbol = %self.symbol, %trade_id,
+                "Rejecting re-driven reorg: fill already reversed on this position"
+            );
+            return Err(PositionError::DuplicateReorg { trade_id });
+        }
+
+        warn!(
+            target: "hedge",
+            symbol = %self.symbol,
+            %trade_id,
+            ?direction,
+            %amount,
+            reorg_depth,
+            "Reversing position impact of a reorged fill"
+        );
+
+        Ok(vec![PositionEvent::Reorged {
+            trade_id,
+            amount,
+            direction,
+            price_usdc: Some(price_usdc),
+            reorg_depth,
+            reorged_at: Utc::now(),
+        }])
     }
 
     fn place_offchain_order_events(
@@ -2114,7 +2129,7 @@ mod tests {
 
     #[tokio::test]
     async fn first_fill_initializes_and_accumulates() {
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given_no_previous_events()
             .when(PositionCommand::AcknowledgeOnChainFill {
                 symbol: Symbol::new("AAPL").unwrap(),
@@ -2151,7 +2166,7 @@ mod tests {
     async fn acknowledge_onchain_fill_accumulates_position() {
         let threshold = one_share_threshold();
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![PositionEvent::Initialized {
                 symbol: Symbol::new("AAPL").unwrap(),
                 threshold,
@@ -2195,7 +2210,7 @@ mod tests {
     async fn acknowledge_on_chain_fill_at_uses_supplied_timestamp() {
         let seen_at = Utc::now() - chrono::Duration::hours(3);
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given_no_previous_events()
             .when(PositionCommand::AcknowledgeOnChainFillAt {
                 symbol: Symbol::new("AAPL").unwrap(),
@@ -2233,7 +2248,7 @@ mod tests {
             log_index: 1,
         };
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol,
@@ -2303,7 +2318,7 @@ mod tests {
             log_index: 1,
         };
 
-        let error = TestHarness::<Position>::with(())
+        let error = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol,
@@ -2500,7 +2515,7 @@ mod tests {
         };
         let amount = FractionalShares::new(float!(5));
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: symbol.clone(),
@@ -2572,7 +2587,7 @@ mod tests {
         };
         let amount = FractionalShares::new(float!(5));
 
-        let error = TestHarness::<Position>::with(())
+        let error = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: symbol.clone(),
@@ -2631,7 +2646,7 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_reorg_uninitialized_position() {
-        let error = TestHarness::<Position>::with(())
+        let error = TestHarness::<Position>::with()
             .given_no_previous_events()
             .when(PositionCommand::RecordReorg {
                 trade_id: TradeId {
@@ -2663,7 +2678,7 @@ mod tests {
             log_index: 1,
         };
 
-        let error = TestHarness::<Position>::with(())
+        let error = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol,
@@ -2722,7 +2737,7 @@ mod tests {
         };
         let amount = FractionalShares::new(float!(5));
 
-        let error = TestHarness::<Position>::with(())
+        let error = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: symbol.clone(),
@@ -2890,7 +2905,7 @@ mod tests {
             log_index: 1,
         };
 
-        let error = TestHarness::<Position>::with(())
+        let error = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: Symbol::new("AAPL").unwrap(),
@@ -2948,7 +2963,7 @@ mod tests {
         };
         let now = Utc::now();
 
-        let error = TestHarness::<Position>::with(())
+        let error = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: Symbol::new("AAPL").unwrap(),
@@ -3123,7 +3138,7 @@ mod tests {
         };
         let now = Utc::now();
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: Symbol::new("AAPL").unwrap(),
@@ -3163,7 +3178,7 @@ mod tests {
     async fn settle_is_noop_when_not_member() {
         let threshold = one_share_threshold();
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![PositionEvent::Initialized {
                 symbol: Symbol::new("AAPL").unwrap(),
                 threshold,
@@ -3196,7 +3211,7 @@ mod tests {
         };
         let amount = FractionalShares::new(float!(5));
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: symbol.clone(),
@@ -3295,7 +3310,7 @@ mod tests {
     async fn settle_reorg_is_noop_when_not_member() {
         let threshold = one_share_threshold();
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![PositionEvent::Initialized {
                 symbol: Symbol::new("AAPL").unwrap(),
                 threshold,
@@ -3320,7 +3335,7 @@ mod tests {
     async fn shares_threshold_triggers_execution() {
         let threshold = one_share_threshold();
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: Symbol::new("AAPL").unwrap(),
@@ -3372,7 +3387,7 @@ mod tests {
         let threshold = one_share_threshold();
         let placed_at = Utc::now() - chrono::Duration::hours(1);
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: Symbol::new("AAPL").unwrap(),
@@ -3417,7 +3432,7 @@ mod tests {
     async fn place_offchain_order_below_threshold_fails() {
         let threshold = one_share_threshold();
 
-        let error = TestHarness::<Position>::with(())
+        let error = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: Symbol::new("AAPL").unwrap(),
@@ -3457,7 +3472,7 @@ mod tests {
         let threshold = one_share_threshold();
         let offchain_order_id = OffchainOrderId::new();
 
-        let error = TestHarness::<Position>::with(())
+        let error = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: Symbol::new("AAPL").unwrap(),
@@ -3508,7 +3523,7 @@ mod tests {
         let threshold = one_share_threshold();
         let offchain_order_id = OffchainOrderId::new();
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: Symbol::new("AAPL").unwrap(),
@@ -3557,7 +3572,7 @@ mod tests {
         let threshold = one_share_threshold();
         let offchain_order_id = OffchainOrderId::new();
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: Symbol::new("AAPL").unwrap(),
@@ -3603,7 +3618,7 @@ mod tests {
         let offchain_order_id = OffchainOrderId::new();
         let broker_cancelled_at = Utc::now();
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: Symbol::new("AAPL").unwrap(),
@@ -3726,7 +3741,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_threshold_creates_audit_trail() {
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![PositionEvent::Initialized {
                 symbol: Symbol::new("AAPL").unwrap(),
                 threshold: one_share_threshold(),
@@ -3749,7 +3764,7 @@ mod tests {
         let threshold = one_share_threshold();
         let target_net = FractionalShares::new(float!(100));
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given_no_previous_events()
             .when(PositionCommand::ManuallyAdjustPosition {
                 symbol: symbol.clone(),
@@ -3796,7 +3811,7 @@ mod tests {
         let symbol = Symbol::new("SPYM").unwrap();
         let threshold = one_share_threshold();
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: symbol.clone(),
@@ -3849,7 +3864,7 @@ mod tests {
         let threshold = one_share_threshold();
         let offchain_order_id = OffchainOrderId::new();
 
-        let error = TestHarness::<Position>::with(())
+        let error = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: symbol.clone(),
@@ -3991,7 +4006,7 @@ mod tests {
     #[tokio::test]
     async fn hydrate_position_gauges_seeds_open_positions_on_restart() {
         let pool = crate::test_utils::setup_test_db().await;
-        let (store, projection) = StoreBuilder::<Position>::new(pool).build(()).await.unwrap();
+        let (store, projection) = StoreBuilder::<Position>::new(pool).build().await.unwrap();
         let symbol = Symbol::new("AAPL").unwrap();
 
         // Seed an open position with the recorder NOT yet installed, so the
@@ -4036,7 +4051,7 @@ mod tests {
         let symbol = Symbol::new("SPYM").unwrap();
         let threshold = ExecutionThreshold::dollar_value(Usdc::new(float!(1000))).unwrap();
 
-        let error = TestHarness::<Position>::with(())
+        let error = TestHarness::<Position>::with()
             .given_no_previous_events()
             .when(PositionCommand::ManuallyAdjustPosition {
                 symbol,
@@ -4062,7 +4077,7 @@ mod tests {
             let symbol = Symbol::new("SPYM").unwrap();
             let threshold = ExecutionThreshold::dollar_value(Usdc::new(float!(1000))).unwrap();
 
-            let error = TestHarness::<Position>::with(())
+            let error = TestHarness::<Position>::with()
                 .given_no_previous_events()
                 .when(PositionCommand::ManuallyAdjustPosition {
                     symbol,
@@ -4092,7 +4107,7 @@ mod tests {
         let symbol = Symbol::new("SPYM").unwrap();
         let threshold = ExecutionThreshold::dollar_value(Usdc::new(float!(1000))).unwrap();
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given_no_previous_events()
             .when(PositionCommand::ManuallyAdjustPosition {
                 symbol,
@@ -4148,7 +4163,7 @@ mod tests {
         let symbol = Symbol::new("SPYM").unwrap();
         let threshold = ExecutionThreshold::dollar_value(Usdc::new(float!(1000))).unwrap();
 
-        let events = TestHarness::<Position>::with(())
+        let events = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: symbol.clone(),
@@ -4198,7 +4213,7 @@ mod tests {
         let symbol = Symbol::new("SPYM").unwrap();
         let threshold = one_share_threshold();
 
-        let error = TestHarness::<Position>::with(())
+        let error = TestHarness::<Position>::with()
             .given(vec![
                 PositionEvent::Initialized {
                     symbol: symbol.clone(),
@@ -5033,7 +5048,7 @@ mod tests {
     #[tokio::test]
     async fn load_position_returns_none_when_no_aggregate_exists() {
         let pool = crate::test_utils::setup_test_db().await;
-        let (_store, projection) = StoreBuilder::<Position>::new(pool).build(()).await.unwrap();
+        let (_store, projection) = StoreBuilder::<Position>::new(pool).build().await.unwrap();
 
         let result = projection
             .load(&Symbol::new("AAPL").unwrap())
@@ -5049,7 +5064,7 @@ mod tests {
     #[tokio::test]
     async fn load_position_returns_position_for_live_lifecycle() {
         let pool = crate::test_utils::setup_test_db().await;
-        let (store, projection) = StoreBuilder::<Position>::new(pool).build(()).await.unwrap();
+        let (store, projection) = StoreBuilder::<Position>::new(pool).build().await.unwrap();
 
         let symbol = Symbol::new("AAPL").unwrap();
 

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -24,8 +24,8 @@ use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::conductor::{clamp_shares_to_reservation, recover_orphaned_pending_offchain_orders};
 use crate::equity_redemption::symbols_with_active_transfers;
 use crate::offchain::order::{
-    CancellationReason, OffchainOrder, OffchainOrderCommand, OffchainOrderId, OrderPlacer,
-    PollOrderStatusJobQueue, TerminalPositionFinalization, position_command_for_finalization,
+    CancellationReason, OffchainOrder, OffchainOrderId, OrderPlacer, PollOrderStatusJobQueue,
+    TerminalPositionFinalization, cancel_offchain_order, position_command_for_finalization,
     recover_submitted_offchain_orders, terminal_position_finalization,
 };
 use crate::onchain::accumulator::{ExecutionCtx, check_execution_readiness};
@@ -464,15 +464,13 @@ where
                 }
             }
 
-            if let Err(error) = self
-                .offchain_order
-                .send(
-                    &offchain_order_id,
-                    OffchainOrderCommand::CancelOrder {
-                        reason: CancellationReason::MarketOpenReplacement,
-                    },
-                )
-                .await
+            if let Err(error) = cancel_offchain_order(
+                &self.offchain_order,
+                self.order_placer.as_ref(),
+                &offchain_order_id,
+                CancellationReason::MarketOpenReplacement,
+            )
+            .await
             {
                 warn!(%symbol, %offchain_order_id, %error, "Failed to request cancellation of extended-hours order; will retry next tick");
             }
@@ -639,7 +637,7 @@ mod tests {
         Arc<st0x_event_sorcery::Store<Position>>,
     ) {
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -648,7 +646,7 @@ mod tests {
         );
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(order_placer.clone())
+                .build()
                 .await
                 .unwrap();
 
@@ -857,7 +855,7 @@ mod tests {
         let cfg = dry_run_ctx(&["AAPL"], OperationMode::Disabled);
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -876,7 +874,7 @@ mod tests {
         );
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(order_placer.clone())
+                .build()
                 .await
                 .unwrap();
 

--- a/src/rebalancing/equity/job.rs
+++ b/src/rebalancing/equity/job.rs
@@ -458,7 +458,7 @@ mod tests {
         recovery_mode: OperationMode,
     ) -> TransferEquityToMarketMakingCtx {
         let (pool, _apalis_pool) = crate::test_utils::setup_test_pools().await;
-        let mint_store = Arc::new(test_store(pool, ()));
+        let mint_store = Arc::new(test_store(pool));
 
         let aapl_config = EquityAssetConfig {
             tokenized_equity: Address::ZERO,

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -2157,7 +2157,7 @@ mod tests {
                     cash: None,
                 },
             },
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             VaultRegistryId {
                 orderbook: address!("0x0000000000000000000000000000000000000001"),
                 owner: address!("0x0000000000000000000000000000000000000002"),
@@ -2172,19 +2172,19 @@ mod tests {
         // events to the reactor's `on_mint`.
         let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
             .with(service.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
             .with(service.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         service
             .set_stores(
                 mint_store.clone(),
                 redemption_store.clone(),
-                Arc::new(test_store::<UsdcRebalance>(pool.clone(), ())),
+                Arc::new(test_store::<UsdcRebalance>(pool.clone())),
             )
             .await;
 
@@ -2306,7 +2306,7 @@ mod tests {
                     cash: None,
                 },
             },
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             VaultRegistryId {
                 orderbook: address!("0x0000000000000000000000000000000000000001"),
                 owner: address!("0x0000000000000000000000000000000000000002"),
@@ -2319,19 +2319,19 @@ mod tests {
 
         let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
             .with(service.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
             .with(service.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         service
             .set_stores(
                 mint_store.clone(),
                 redemption_store.clone(),
-                Arc::new(test_store::<UsdcRebalance>(pool.clone(), ())),
+                Arc::new(test_store::<UsdcRebalance>(pool.clone())),
             )
             .await;
 
@@ -2635,7 +2635,7 @@ mod tests {
                     cash: None,
                 },
             },
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone())),
             VaultRegistryId {
                 orderbook: address!("0x0000000000000000000000000000000000000001"),
                 owner: address!("0x0000000000000000000000000000000000000002"),
@@ -2648,19 +2648,19 @@ mod tests {
 
         let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
             .with(service.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
             .with(service.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
         service
             .set_stores(
                 mint_store.clone(),
                 redemption_store.clone(),
-                Arc::new(test_store::<UsdcRebalance>(pool.clone(), ())),
+                Arc::new(test_store::<UsdcRebalance>(pool.clone())),
             )
             .await;
 
@@ -2696,8 +2696,8 @@ mod tests {
     ) -> (CrossVenueEquityTransfer, SqlitePool) {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
-        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone(), ()));
+        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
+        let redemption_store = Arc::new(test_store::<EquityRedemption>(pool.clone()));
         let vault_lookup = mock_vault_lookup();
 
         let transfer = CrossVenueEquityTransfer::new(

--- a/src/rebalancing/equity/resume_job.rs
+++ b/src/rebalancing/equity/resume_job.rs
@@ -139,8 +139,8 @@ mod tests {
         let vault_lookup =
             Arc::new(MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO)));
 
-        let mint_store = Arc::new(test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool, ()));
+        let mint_store = Arc::new(test_store(pool.clone()));
+        let redemption_store = Arc::new(test_store(pool));
 
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex,

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -377,7 +377,7 @@ mod tests {
         let (services, _ctx) = make_services_with_mock_wallet(&server).await;
 
         let pool = crate::test_utils::setup_test_db().await;
-        let usdc_store = Arc::new(test_store(pool, ()));
+        let usdc_store = Arc::new(test_store(pool));
 
         let UsdcTransferResumeHandles {
             resume_base_to_alpaca: _,

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -5452,7 +5452,7 @@ mod tests {
 
         Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -5498,7 +5498,7 @@ mod tests {
         let inventory = Arc::new(BroadcastingInventory::new(inventory_view, event_sender));
         let service = RebalancingService::new(
             config,
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -5556,7 +5556,7 @@ mod tests {
         let inventory = Arc::new(BroadcastingInventory::new(inventory_view, event_sender));
         let service = RebalancingService::new(
             config,
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -5614,7 +5614,7 @@ mod tests {
         let inventory = Arc::new(BroadcastingInventory::new(inventory_view, event_sender));
         let service = RebalancingService::new(
             config,
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -5734,7 +5734,7 @@ mod tests {
         let wrapper = Arc::new(MockWrapper::new());
         Arc::new(RebalancingService::new(
             config,
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -7356,7 +7356,7 @@ mod tests {
                     cash: None,
                 },
             },
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -7745,7 +7745,7 @@ mod tests {
     }
 
     async fn seed_vault_registry(pool: &SqlitePool, symbol: &Symbol) {
-        let store = test_store::<VaultRegistry>(pool.clone(), ());
+        let store = test_store::<VaultRegistry>(pool.clone());
         let vault_registry_id = VaultRegistryId {
             orderbook: TEST_ORDERBOOK,
             owner: TEST_ORDER_OWNER,
@@ -7811,7 +7811,7 @@ mod tests {
 
         Arc::new(RebalancingService::new(
             config,
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -8096,7 +8096,7 @@ mod tests {
 
         Arc::new(RebalancingService::new(
             config,
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -8171,7 +8171,7 @@ mod tests {
 
         let trigger = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -11482,7 +11482,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_does_not_relatch_for_reconciled() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
@@ -13742,11 +13742,8 @@ mod tests {
     ) {
         service
             .set_stores(
-                Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-                Arc::new(test_store::<EquityRedemption>(
-                    pool,
-                    (),
-                )),
+                Arc::new(test_store::<TokenizedEquityMint>(pool.clone())),
+                Arc::new(test_store::<EquityRedemption>(pool)),
                 Arc::new(usdc_store),
             )
             .await;
@@ -13757,7 +13754,7 @@ mod tests {
         // A Failed+attempts<max row whose aggregate is already terminal (zombie)
         // must be killed and must NOT suppress a new hedging transfer.
         let pool = crate::test_utils::setup_test_db().await;
-        let usdc_store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let usdc_store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         seed_terminal_usdc_aggregate(&usdc_store, &id).await;
 
@@ -13805,7 +13802,7 @@ mod tests {
     async fn failed_usdc_zombie_with_terminal_aggregate_does_not_block_market_making_enqueue() {
         // Symmetric: a zombie hedging job must not block a market-making enqueue.
         let pool = crate::test_utils::setup_test_db().await;
-        let usdc_store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let usdc_store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         seed_terminal_usdc_aggregate(&usdc_store, &id).await;
 
@@ -13856,7 +13853,7 @@ mod tests {
         // A Failed+attempts<max row whose aggregate is still live (genuine retry)
         // must block enqueue even after the zombie check.
         let pool = crate::test_utils::setup_test_db().await;
-        let usdc_store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let usdc_store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         seed_nonterminal_usdc_aggregate(&usdc_store, &id).await;
 
@@ -13940,7 +13937,7 @@ mod tests {
         // The guard must conservatively treat the row as in-flight.
         let pool = crate::test_utils::setup_test_db().await;
         // Do NOT seed any aggregate -- store is empty.
-        let usdc_store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let usdc_store = test_store::<UsdcRebalance>(pool.clone());
 
         let service = make_trigger_with_inventory(InventoryView::default()).await;
         service
@@ -13983,7 +13980,7 @@ mod tests {
         // store-not-wired check fires first and returns early, so without wiring
         // the test would exercise the wrong branch.
         let pool = crate::test_utils::setup_test_db().await;
-        let usdc_store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let usdc_store = test_store::<UsdcRebalance>(pool.clone());
 
         let service = make_trigger_with_inventory(InventoryView::default()).await;
         service
@@ -14023,7 +14020,7 @@ mod tests {
         // Two Failed+attempts<max rows with terminal aggregates and no Pending row:
         // both must be killed and enqueue must succeed.
         let pool = crate::test_utils::setup_test_db().await;
-        let usdc_store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let usdc_store = test_store::<UsdcRebalance>(pool.clone());
         let id1 = UsdcRebalanceId(Uuid::new_v4());
         let id2 = UsdcRebalanceId(Uuid::new_v4());
         seed_terminal_usdc_aggregate(&usdc_store, &id1).await;
@@ -14175,7 +14172,7 @@ mod tests {
         // This verifies that `in_flight_usdc_transfer` re-queries after killing a
         // zombie rather than blindly treating the cleared zombie as "all clear".
         let pool = crate::test_utils::setup_test_db().await;
-        let usdc_store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let usdc_store = test_store::<UsdcRebalance>(pool.clone());
 
         let zombie_id = UsdcRebalanceId(Uuid::new_v4());
         seed_terminal_usdc_aggregate(&usdc_store, &zombie_id).await;
@@ -14336,7 +14333,7 @@ mod tests {
     /// `RecordMintRequested` emits `MintRequested` + `MintAccepted` without
     /// calling any service, then `FailAcceptance` drives it to `Failed`.
     async fn seed_terminal_mint_aggregate(pool: &SqlitePool, mint_id: &IssuerRequestId) {
-        let store = test_store::<TokenizedEquityMint>(pool.clone(), ());
+        let store = test_store::<TokenizedEquityMint>(pool.clone());
         store
             .send(
                 mint_id,
@@ -14366,7 +14363,7 @@ mod tests {
     /// Same seeding as `seed_terminal_mint_aggregate`; stops before the failure
     /// so the aggregate is still live and holds the duplicate-protection guard.
     async fn seed_nonterminal_mint_aggregate(pool: &SqlitePool, mint_id: &IssuerRequestId) {
-        let store = test_store::<TokenizedEquityMint>(pool.clone(), ());
+        let store = test_store::<TokenizedEquityMint>(pool.clone());
         store
             .send(
                 mint_id,
@@ -14391,8 +14388,7 @@ mod tests {
         pool: &SqlitePool,
         redemption_id: &RedemptionAggregateId,
     ) {
-        let store =
-            test_store::<EquityRedemption>(pool.clone(), ());
+        let store = test_store::<EquityRedemption>(pool.clone());
         store
             .send(
                 redemption_id,
@@ -14422,8 +14418,7 @@ mod tests {
         pool: &SqlitePool,
         redemption_id: &RedemptionAggregateId,
     ) {
-        let store =
-            test_store::<EquityRedemption>(pool.clone(), ());
+        let store = test_store::<EquityRedemption>(pool.clone());
         store
             .send(
                 redemption_id,
@@ -14450,7 +14445,7 @@ mod tests {
             .set_stores(
                 Arc::new(mint_store),
                 Arc::new(redemption_store),
-                Arc::new(test_store::<UsdcRebalance>(pool, ())),
+                Arc::new(test_store::<UsdcRebalance>(pool)),
             )
             .await;
     }
@@ -14557,8 +14552,8 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), ()),
+            test_store::<TokenizedEquityMint>(pool.clone()),
+            test_store::<EquityRedemption>(pool.clone()),
         )
         .await;
 
@@ -14615,8 +14610,8 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), ()),
+            test_store::<TokenizedEquityMint>(pool.clone()),
+            test_store::<EquityRedemption>(pool.clone()),
         )
         .await;
 
@@ -14673,8 +14668,8 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), ()),
+            test_store::<TokenizedEquityMint>(pool.clone()),
+            test_store::<EquityRedemption>(pool.clone()),
         )
         .await;
 
@@ -14727,8 +14722,8 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), ()),
+            test_store::<TokenizedEquityMint>(pool.clone()),
+            test_store::<EquityRedemption>(pool.clone()),
         )
         .await;
 
@@ -14820,8 +14815,8 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), ()),
+            test_store::<TokenizedEquityMint>(pool.clone()),
+            test_store::<EquityRedemption>(pool.clone()),
         )
         .await;
 
@@ -14881,8 +14876,8 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), ()),
+            test_store::<TokenizedEquityMint>(pool.clone()),
+            test_store::<EquityRedemption>(pool.clone()),
         )
         .await;
 
@@ -14933,8 +14928,8 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), ()),
+            test_store::<TokenizedEquityMint>(pool.clone()),
+            test_store::<EquityRedemption>(pool.clone()),
         )
         .await;
 
@@ -14985,8 +14980,8 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), ()),
+            test_store::<TokenizedEquityMint>(pool.clone()),
+            test_store::<EquityRedemption>(pool.clone()),
         )
         .await;
 
@@ -15062,8 +15057,8 @@ mod tests {
         attach_equity_stores(
             &service,
             pool.clone(),
-            test_store::<TokenizedEquityMint>(pool.clone(), ()),
-            test_store::<EquityRedemption>(pool.clone(), ()),
+            test_store::<TokenizedEquityMint>(pool.clone()),
+            test_store::<EquityRedemption>(pool.clone()),
         )
         .await;
 
@@ -15294,7 +15289,7 @@ mod tests {
 
         // Drive a BaseToAlpaca aggregate all the way to DepositFailed, then
         // reconcile it (simulating what the CLI does in a separate process).
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         seed_deposit_failed(
             &store,
@@ -15339,8 +15334,8 @@ mod tests {
 
         trigger
             .set_stores(
-                Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-                Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
+                Arc::new(test_store::<TokenizedEquityMint>(pool.clone())),
+                Arc::new(test_store::<EquityRedemption>(pool.clone())),
                 Arc::new(store),
             )
             .await;
@@ -15418,7 +15413,7 @@ mod tests {
 
         // Drive to DepositFailed then reconcile (simulating CLI in separate
         // process).
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         seed_deposit_failed(
             &store,
@@ -15459,8 +15454,8 @@ mod tests {
 
         trigger
             .set_stores(
-                Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-                Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
+                Arc::new(test_store::<TokenizedEquityMint>(pool.clone())),
+                Arc::new(test_store::<EquityRedemption>(pool.clone())),
                 Arc::new(store),
             )
             .await;
@@ -15525,7 +15520,7 @@ mod tests {
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
         // Drive aggregate to DepositFailed but do NOT reconcile it.
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         seed_deposit_failed(
             &store,
@@ -15554,8 +15549,8 @@ mod tests {
 
         trigger
             .set_stores(
-                Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-                Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
+                Arc::new(test_store::<TokenizedEquityMint>(pool.clone())),
+                Arc::new(test_store::<EquityRedemption>(pool.clone())),
                 Arc::new(store),
             )
             .await;
@@ -15677,7 +15672,7 @@ mod tests {
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
         // Drive to DepositFailed then Reconciled.
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         seed_deposit_failed(
             &store,
@@ -15720,8 +15715,8 @@ mod tests {
         let store = Arc::new(store);
         trigger
             .set_stores(
-                Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ())),
-                Arc::new(test_store::<EquityRedemption>(pool.clone(), ())),
+                Arc::new(test_store::<TokenizedEquityMint>(pool.clone())),
+                Arc::new(test_store::<EquityRedemption>(pool.clone())),
                 Arc::clone(&store),
             )
             .await;
@@ -15819,12 +15814,11 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(unmigrated_pool.clone(), ())),
+                >(unmigrated_pool.clone())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     unmigrated_pool.clone(),
-                    (),
                 )),
-                Arc::new(test_store::<UsdcRebalance>(unmigrated_pool.clone(), ())),
+                Arc::new(test_store::<UsdcRebalance>(unmigrated_pool.clone())),
             )
             .await;
 
@@ -15891,12 +15885,11 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(unmigrated_pool.clone(), ())),
+                >(unmigrated_pool.clone())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     unmigrated_pool.clone(),
-                    (),
                 )),
-                Arc::new(test_store::<UsdcRebalance>(unmigrated_pool.clone(), ())),
+                Arc::new(test_store::<UsdcRebalance>(unmigrated_pool.clone())),
             )
             .await;
 
@@ -15964,7 +15957,7 @@ mod tests {
             fixed_bytes!("0x2222222222222222222222222222222222222222222222222222222222222222");
 
         // Drive an AlpacaToBase aggregate to DepositFailed then Reconciled.
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         seed_deposit_failed(
             &store,
@@ -16005,10 +15998,9 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(pool.clone(), ())),
+                >(pool.clone())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
-                    (),
                 )),
                 Arc::new(store),
             )
@@ -16076,7 +16068,7 @@ mod tests {
     async fn sweep_rearms_withdrawing_alpaca_to_base_instead_of_clearing() {
         let now = Utc::now();
         let pool = crate::test_utils::setup_test_db().await;
-        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone(), ()));
+        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone()));
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(400);
 
@@ -16162,7 +16154,7 @@ mod tests {
     async fn sweep_does_not_duplicate_withdrawing_alpaca_to_base_retryable_failed_job() {
         let now = Utc::now();
         let pool = crate::test_utils::setup_test_db().await;
-        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone(), ()));
+        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone()));
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(400);
 
@@ -16220,7 +16212,7 @@ mod tests {
     async fn sweep_rearms_withdrawal_complete_alpaca_to_base_instead_of_clearing() {
         let now = Utc::now();
         let pool = crate::test_utils::setup_test_db().await;
-        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone(), ()));
+        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone()));
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(400);
 
@@ -16285,7 +16277,7 @@ mod tests {
             fixed_bytes!("0x3333333333333333333333333333333333333333333333333333333333333333");
 
         // Drive a BaseToAlpaca aggregate to DepositFailed (not yet reconciled).
-        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone(), ()));
+        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone()));
         let id = UsdcRebalanceId(Uuid::new_v4());
         seed_deposit_failed(
             &store,
@@ -16352,10 +16344,9 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(pool.clone(), ())),
+                >(pool.clone())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
-                    (),
                 )),
                 Arc::clone(&store),
             )
@@ -16420,7 +16411,7 @@ mod tests {
         // Path: Initiate -> ConfirmWithdrawal -> InitiateBridging ->
         //   ReceiveAttestation -> ConfirmBridging -> InitiateDeposit ->
         //   ConfirmDeposit -> InitiatePostDepositConversion -> FailConversion.
-        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone(), ()));
+        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone()));
         let id = UsdcRebalanceId(Uuid::new_v4());
 
         store
@@ -16549,10 +16540,9 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(pool.clone(), ())),
+                >(pool.clone())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
-                    (),
                 )),
                 Arc::clone(&store),
             )
@@ -16611,7 +16601,7 @@ mod tests {
         // Drive an AlpacaToBase aggregate to BridgingFailed with burn_tx set
         // (post-burn). Path: Initiate{AtB} -> ConfirmWithdrawal ->
         // InitiateBridging -> FailBridging.
-        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone(), ()));
+        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone()));
         let id = UsdcRebalanceId(Uuid::new_v4());
 
         store
@@ -16700,10 +16690,9 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(pool.clone(), ())),
+                >(pool.clone())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
-                    (),
                 )),
                 Arc::clone(&store),
             )
@@ -16757,7 +16746,7 @@ mod tests {
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000030");
 
         // Drive a BaseToAlpaca aggregate to BridgingFailed with burn_tx set.
-        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone(), ()));
+        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone()));
         let id = UsdcRebalanceId(Uuid::new_v4());
 
         seed_post_burn_bridging_failed(
@@ -16945,7 +16934,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_reasserts_guard_for_post_burn_bridging_failure() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000aa");
@@ -17003,7 +16992,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_reasserts_guard_for_bridging_submitting() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000bb");
@@ -17274,10 +17263,9 @@ mod tests {
             .set_stores(
                 Arc::new(test_store::<
                     crate::tokenized_equity_mint::TokenizedEquityMint,
-                >(pool.clone(), ())),
+                >(pool.clone())),
                 Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
                     pool.clone(),
-                    (),
                 )),
                 store,
             )
@@ -17304,7 +17292,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_rearms_withdrawing_alpaca_to_base() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(400);
 
@@ -17378,7 +17366,7 @@ mod tests {
     #[tokio::test]
     async fn recovered_conversion_complete_initiated_event_does_not_debit_snapshot_twice() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let requested = usdc(400);
         let received = usdc(390);
@@ -17459,7 +17447,7 @@ mod tests {
     #[tokio::test]
     async fn recovered_reservation_does_not_overwrite_conflicting_inventory_owner() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let recovered_id = UsdcRebalanceId(Uuid::new_v4());
         let active_id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(400);
@@ -17500,7 +17488,7 @@ mod tests {
     #[tokio::test]
     async fn recovered_reservation_rejects_a_different_job_owner() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let recovered_id = UsdcRebalanceId(Uuid::new_v4());
         let different_id = UsdcRebalanceId(Uuid::new_v4());
 
@@ -17526,7 +17514,7 @@ mod tests {
     #[tokio::test]
     async fn recovery_rejects_multiple_alpaca_to_base_reservation_owners() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let first = UsdcRebalanceId(Uuid::new_v4());
         let second = UsdcRebalanceId(Uuid::new_v4());
 
@@ -17554,7 +17542,7 @@ mod tests {
     #[tokio::test]
     async fn recovered_reservation_settles_terminal_success_without_inflight_underflow() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let initiated = usdc(400);
         let received = usdc(398);
@@ -17617,7 +17605,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_rearms_withdrawal_complete_alpaca_to_base() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(400);
 
@@ -17658,7 +17646,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_does_not_rearm_withdrawing_alpaca_to_base_with_live_job() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(400);
 
@@ -17699,7 +17687,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_does_not_rearm_withdrawing_alpaca_to_base_with_queued_job() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(400);
 
@@ -17747,7 +17735,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_rearms_withdrawing_alpaca_to_base_with_terminal_job_row() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(400);
 
@@ -17799,7 +17787,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_does_not_rearm_withdrawing_alpaca_to_base_with_running_job() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(400);
 
@@ -17848,7 +17836,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_does_not_rearm_withdrawal_submitting_alpaca_to_base() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(300);
 
@@ -17881,7 +17869,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_alerts_on_stranded_withdrawal_submitting_alpaca_to_base() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(300);
 
@@ -17921,7 +17909,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_rearms_bridging_submitting_base_to_alpaca() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
@@ -18037,7 +18025,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_rearms_bridging_submitting_alpaca_to_base() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let withdrawal_tx =
             fixed_bytes!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
@@ -18109,7 +18097,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_rearms_withdrawal_submitting() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(300);
 
@@ -18140,7 +18128,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_does_not_rearm_bridging_submitting_with_job_row() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
@@ -18176,7 +18164,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_does_not_rearm_bridging_submitting_with_failed_job_row() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
@@ -18220,7 +18208,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_alerts_on_bridging_submitting_with_exhausted_failed_job_row() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd");
@@ -18290,7 +18278,7 @@ mod tests {
     async fn recover_usdc_guard_alerts_on_bridging_submitting_alpaca_to_base_with_exhausted_failed_job_row()
      {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let withdrawal_tx =
             fixed_bytes!("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -18363,7 +18351,7 @@ mod tests {
     async fn recover_usdc_guard_does_not_rearm_or_alert_bridging_submitting_with_retryable_failed_job_row()
      {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
@@ -18423,7 +18411,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_does_not_alert_stranded_state_with_live_job_row() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc(300);
 
@@ -18642,7 +18630,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_rearms_stranded_awaiting_attestation() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000dd");
@@ -18686,7 +18674,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_skips_rearm_when_job_already_in_flight() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000ee");
@@ -18732,7 +18720,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_does_not_rearm_when_job_already_failed() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000bb");
@@ -18780,7 +18768,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_rearms_post_burn_bridging_failed() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000901");
@@ -18827,7 +18815,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_rearms_post_burn_bridging_failed_despite_terminal_job_row() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000902");
@@ -18880,7 +18868,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_skips_rearm_for_bridging_failed_when_failed_job_retryable() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000904");
@@ -18929,7 +18917,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_rearms_post_burn_bridging_failed_despite_done_job_row() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000905");
@@ -18976,7 +18964,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_skips_rearm_for_bridging_failed_when_in_flight() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000903");
@@ -19020,7 +19008,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_rearms_stranded_awaiting_attestation_alpaca_to_base() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let burn_tx =
             fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000cc");
@@ -19065,7 +19053,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_leaves_guard_clear_for_pre_burn_failure() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
         let withdrawal =
             fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000cc");
@@ -19115,7 +19103,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_holds_defensively_when_candidate_cannot_load() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let id = UsdcRebalanceId(Uuid::new_v4());
 
         // Persist a guard-relevant event that cannot originate an aggregate (the
@@ -19157,7 +19145,7 @@ mod tests {
     #[tokio::test]
     async fn recover_usdc_guard_holds_defensively_when_candidate_id_is_unparseable() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
 
         // Persist a guard-relevant event whose aggregate_id is not a valid UUID --
         // a corrupt/partially-written durable row. The candidate query surfaces it
@@ -19589,7 +19577,7 @@ mod tests {
                     cash: None,
                 },
             },
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -19988,7 +19976,7 @@ mod tests {
 
         let trigger = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: Address::ZERO,
                 owner: Address::ZERO,
@@ -20217,7 +20205,7 @@ mod tests {
 
         let trigger = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -20286,7 +20274,7 @@ mod tests {
 
         let trigger = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -20365,7 +20353,7 @@ mod tests {
 
         let trigger = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -20428,7 +20416,7 @@ mod tests {
 
         let trigger = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -23163,7 +23151,7 @@ mod tests {
         // Persist two positions through the real command path: AAPL gets a
         // pending offchain hedge order; TSLA only has an onchain fill.
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<Position>(pool.clone(), ());
+        let store = test_store::<Position>(pool.clone());
 
         store
             .send(
@@ -24030,7 +24018,7 @@ mod tests {
         let wrapper = Arc::new(MockWrapper::new());
         let trigger = Arc::new(RebalancingService::new(
             config,
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,
@@ -24113,7 +24101,7 @@ mod tests {
         let wrapper = Arc::new(MockWrapper::new());
         let trigger = Arc::new(RebalancingService::new(
             config,
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool)),
             VaultRegistryId {
                 orderbook: TEST_ORDERBOOK,
                 owner: TEST_ORDER_OWNER,

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -3798,7 +3798,7 @@ mod tests {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
 
-        Arc::new(test_store(pool, ()))
+        Arc::new(test_store(pool))
     }
 
     /// Advances aggregate through: Initiate -> ConfirmWithdrawal ->
@@ -11423,7 +11423,7 @@ mod tests {
     async fn burn_recording_pending_retries_and_succeeds_on_second_attempt() {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
-        let cqrs = Arc::new(test_store(pool.clone(), ()));
+        let cqrs = Arc::new(test_store(pool.clone()));
 
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc("1");
@@ -12784,7 +12784,7 @@ mod tests {
         .await
         .unwrap();
         sqlx::migrate!().run(&writable).await.unwrap();
-        let writable_cqrs = test_store::<UsdcRebalance>(writable.clone(), ());
+        let writable_cqrs = test_store::<UsdcRebalance>(writable.clone());
 
         let base_provider = ProviderBuilder::new()
             .connect(&chains.base_endpoint)
@@ -12808,7 +12808,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let cqrs = Arc::new(test_store(read_only, ()));
+        let cqrs = Arc::new(test_store(read_only));
         let manager = CrossVenueCashTransfer::new(
             alpaca_broker,
             alpaca_wallet,

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -43,7 +43,6 @@
 //! - All state transitions are captured as events for complete audit trail
 
 use alloy::primitives::{Address, TxHash, U256};
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
@@ -51,7 +50,7 @@ use sqlx::SqlitePool;
 use tracing::{info, warn};
 
 use st0x_dto::{EquityMintOperation, EquityMintStatus, TransferOperation};
-use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
+use st0x_event_sorcery::{DomainEvent, EventSourced, JobQueue, Nil};
 use st0x_execution::{FractionalShares, Symbol};
 use st0x_finance::Id;
 use st0x_tokenization::{IssuerRequestId, TokenizationRequestId};
@@ -1403,13 +1402,12 @@ fn quantity_to_u256_18_decimals(value: Float) -> Result<U256, TokenizedEquityMin
         .map_err(TokenizedEquityMintError::from)
 }
 
-#[async_trait]
 impl EventSourced for TokenizedEquityMint {
     type Id = IssuerRequestId;
     type Event = TokenizedEquityMintEvent;
     type Command = TokenizedEquityMintCommand;
     type Error = TokenizedEquityMintError;
-    type Services = ();
+    type Jobs = Nil;
     type Materialized = Nil;
 
     const AGGREGATE_TYPE: &'static str = "TokenizedEquityMint";
@@ -1823,9 +1821,9 @@ impl EventSourced for TokenizedEquityMint {
         })
     }
 
-    async fn initialize(
+    fn initialize(
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use TokenizedEquityMintEvent::*;
 
@@ -1930,10 +1928,10 @@ impl EventSourced for TokenizedEquityMint {
     }
 
     #[allow(clippy::too_many_lines)]
-    async fn transition(
+    fn transition(
         &self,
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use TokenizedEquityMintEvent::*;
         match command {
@@ -2409,7 +2407,7 @@ mod tests {
 
     #[tokio::test]
     async fn initialize_emits_requested_and_accepted() {
-        let events = TestHarness::<TokenizedEquityMint>::with(())
+        let events = TestHarness::<TokenizedEquityMint>::with()
             .given_no_previous_events()
             .when(mint_command())
             .await
@@ -2434,7 +2432,7 @@ mod tests {
 
     #[tokio::test]
     async fn record_tokens_received_after_acceptance_emits_tokens_received() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
 
         let id = issuer_request_id("ISS001");
         store.send(&id, mint_command()).await.unwrap();
@@ -2450,7 +2448,7 @@ mod tests {
     #[tokio::test]
     async fn record_tokens_received_with_fees_propagates_to_tokens_received() {
         let expected_fees = float!("0.25");
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
 
         let id = issuer_request_id("ISS001");
         store.send(&id, mint_command()).await.unwrap();
@@ -2482,7 +2480,7 @@ mod tests {
 
     #[tokio::test]
     async fn record_tokens_received_with_wrong_token_symbol_errors() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -2521,7 +2519,7 @@ mod tests {
 
     #[tokio::test]
     async fn record_tokens_received_with_missing_token_symbol_errors() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -2558,7 +2556,7 @@ mod tests {
 
     #[tokio::test]
     async fn record_tokens_received_with_missing_tx_hash_errors() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -2593,7 +2591,7 @@ mod tests {
 
     #[tokio::test]
     async fn record_mint_requested_is_idempotent_when_redelivered() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         // At-least-once jobs can re-deliver the accept outcome after the
@@ -2611,7 +2609,7 @@ mod tests {
 
     #[tokio::test]
     async fn record_mint_requested_with_conflicting_request_id_errors() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -2642,7 +2640,7 @@ mod tests {
 
     #[tokio::test]
     async fn record_tokens_received_is_idempotent_when_redelivered() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -2659,7 +2657,7 @@ mod tests {
 
     #[tokio::test]
     async fn record_tokens_received_redelivered_with_different_tx_hash_errors() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -2705,7 +2703,7 @@ mod tests {
 
     #[tokio::test]
     async fn reject_mint_request_is_idempotent_when_already_failed() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         let reject = || TokenizedEquityMintCommand::RejectMintRequest {
@@ -2729,7 +2727,7 @@ mod tests {
 
     #[tokio::test]
     async fn reject_mint_request_on_accepted_mint_errors_already_in_progress() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -2768,7 +2766,7 @@ mod tests {
 
     #[tokio::test]
     async fn reject_mint_request_on_completed_mint_errors_already_completed() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -3025,7 +3023,7 @@ mod tests {
 
     #[tokio::test]
     async fn reject_mint_request_emits_rejected() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store
@@ -3105,7 +3103,7 @@ mod tests {
 
     #[tokio::test]
     async fn wrap_tokens_is_pure_state_transition() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -3131,7 +3129,7 @@ mod tests {
 
     #[tokio::test]
     async fn deposit_to_vault_is_pure_state_transition() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -3168,7 +3166,7 @@ mod tests {
     async fn record_tokens_received_at_uses_supplied_timestamp() {
         let received_at = Utc::now() - chrono::Duration::hours(2);
 
-        let events = TestHarness::<TokenizedEquityMint>::with(())
+        let events = TestHarness::<TokenizedEquityMint>::with()
             .given(vec![mint_requested_event(), mint_accepted_event()])
             .when(TokenizedEquityMintCommand::RecordTokensReceivedAt {
                 tx_hash: Some(TxHash::ZERO),
@@ -3194,7 +3192,7 @@ mod tests {
     async fn wrap_tokens_at_uses_supplied_timestamp() {
         let wrapped_at = Utc::now() - chrono::Duration::hours(3);
 
-        let events = TestHarness::<TokenizedEquityMint>::with(())
+        let events = TestHarness::<TokenizedEquityMint>::with()
             .given(vec![
                 mint_requested_event(),
                 mint_accepted_event(),
@@ -3224,7 +3222,7 @@ mod tests {
     async fn deposit_to_vault_at_uses_supplied_timestamp() {
         let deposited_at = Utc::now() - chrono::Duration::hours(4);
 
-        let events = TestHarness::<TokenizedEquityMint>::with(())
+        let events = TestHarness::<TokenizedEquityMint>::with()
             .given(vec![
                 mint_requested_event(),
                 mint_accepted_event(),
@@ -3253,7 +3251,7 @@ mod tests {
     async fn record_mint_requested_at_uses_supplied_timestamp() {
         let requested_at = Utc::now() - chrono::Duration::hours(5);
 
-        let events = TestHarness::<TokenizedEquityMint>::with(())
+        let events = TestHarness::<TokenizedEquityMint>::with()
             .given_no_previous_events()
             .when(TokenizedEquityMintCommand::RecordMintRequestedAt {
                 issuer_request_id: issuer_request_id("ISS001"),
@@ -3585,7 +3583,7 @@ mod tests {
 
     #[tokio::test]
     async fn recover_provider_completion_rejected_for_active_mint() {
-        let error = TestHarness::<TokenizedEquityMint>::with(())
+        let error = TestHarness::<TokenizedEquityMint>::with()
             .given(vec![mint_requested_event()])
             .when(TokenizedEquityMintCommand::RecoverProviderCompletion {
                 issuer_request_id: issuer_request_id("ISS001"),
@@ -3608,7 +3606,7 @@ mod tests {
 
     #[tokio::test]
     async fn recover_provider_completion_rejected_for_completed_mint() {
-        let error = TestHarness::<TokenizedEquityMint>::with(())
+        let error = TestHarness::<TokenizedEquityMint>::with()
             .given(vec![
                 mint_requested_event(),
                 mint_accepted_event(),
@@ -3643,7 +3641,7 @@ mod tests {
             reconciled_at: Utc::now(),
         });
 
-        let error = TestHarness::<TokenizedEquityMint>::with(())
+        let error = TestHarness::<TokenizedEquityMint>::with()
             .given(history)
             .when(TokenizedEquityMintCommand::RecoverProviderCompletion {
                 issuer_request_id: issuer_request_id("ISS001"),
@@ -3666,7 +3664,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_acceptance_from_accepted_transitions_to_failed() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -3696,7 +3694,7 @@ mod tests {
         let history = vec![mint_requested_event()];
 
         let reason = "stuck pre-acceptance; operator force-fail";
-        let events = TestHarness::<TokenizedEquityMint>::with(())
+        let events = TestHarness::<TokenizedEquityMint>::with()
             .given(history.clone())
             .when(TokenizedEquityMintCommand::FailAcceptance {
                 reason: reason.to_string(),
@@ -3735,7 +3733,7 @@ mod tests {
         // FailAcceptance broadened to accept MintRequested/MintAccepted; a mint
         // that moved past acceptance (TokensReceived) must still be rejected, so
         // the success arm did not over-widen.
-        let error = TestHarness::<TokenizedEquityMint>::with(())
+        let error = TestHarness::<TokenizedEquityMint>::with()
             .given(vec![
                 mint_requested_event(),
                 mint_accepted_event(),
@@ -3758,7 +3756,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_wrapping_from_tokens_received_transitions_to_failed() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -3783,7 +3781,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_raindex_deposit_from_tokens_wrapped_transitions_to_failed() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -3819,7 +3817,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_wrapping_rejected_from_wrong_state() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         // MintAccepted state -- FailWrapping requires TokensReceived
@@ -3842,7 +3840,7 @@ mod tests {
 
     #[tokio::test]
     async fn fail_acceptance_rejected_from_terminal_state() {
-        let store = TestStore::<TokenizedEquityMint>::new(());
+        let store = TestStore::<TokenizedEquityMint>::new();
         let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
@@ -3886,7 +3884,7 @@ mod tests {
     async fn reconcile_from_failed_emits_operator_reconciled_and_replays_to_reconciled() {
         let history = failed_mint_history();
 
-        let events = TestHarness::<TokenizedEquityMint>::with(())
+        let events = TestHarness::<TokenizedEquityMint>::with()
             .given(history.clone())
             .when(TokenizedEquityMintCommand::Reconcile {
                 reason: "wrapped manually via wrap-equity".to_string(),
@@ -3951,7 +3949,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_from_non_failed_is_rejected() {
-        let error = TestHarness::<TokenizedEquityMint>::with(())
+        let error = TestHarness::<TokenizedEquityMint>::with()
             .given(vec![mint_requested_event(), mint_accepted_event()])
             .when(TokenizedEquityMintCommand::Reconcile {
                 reason: "should be rejected".to_string(),
@@ -3970,7 +3968,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_with_blank_reason_is_rejected() {
-        let error = TestHarness::<TokenizedEquityMint>::with(())
+        let error = TestHarness::<TokenizedEquityMint>::with()
             .given(failed_mint_history())
             .when(TokenizedEquityMintCommand::Reconcile {
                 reason: "   ".to_string(),
@@ -3995,7 +3993,7 @@ mod tests {
             reconciled_at: Utc::now(),
         });
 
-        let error = TestHarness::<TokenizedEquityMint>::with(())
+        let error = TestHarness::<TokenizedEquityMint>::with()
             .given(history)
             .when(TokenizedEquityMintCommand::Reconcile {
                 reason: "second attempt".to_string(),

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -704,13 +704,13 @@ mod tests {
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(order_placer.clone())
+                .build()
                 .await
                 .unwrap();
 
@@ -1167,13 +1167,13 @@ mod tests {
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(placer.clone())
+                .build()
                 .await
                 .unwrap();
 
@@ -1909,13 +1909,13 @@ mod tests {
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(placer.clone())
+                .build()
                 .await
                 .unwrap();
 

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -498,24 +498,24 @@ mod tests {
         Node: Provider + Clone,
     {
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
         let (offchain_order, _offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
+                .build()
                 .await
                 .unwrap();
 
         let (vault_registry, _vault_registry_projection) =
             StoreBuilder::<VaultRegistry>::new(pool.clone())
-                .build(())
+                .build()
                 .await
                 .unwrap();
 

--- a/src/unwrapped_equity_recovery/aggregate.rs
+++ b/src/unwrapped_equity_recovery/aggregate.rs
@@ -35,7 +35,6 @@
 //! can resume from the persisted tx hash without double-wrapping.
 
 use alloy::primitives::{Address, TxHash, U256};
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -43,7 +42,7 @@ use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
 
-use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
+use st0x_event_sorcery::{DomainEvent, EventSourced, JobQueue, Nil};
 use st0x_execution::{FractionalShares, Symbol};
 use st0x_raindex::Raindex;
 use st0x_tokenization::IssuerRequestId;
@@ -74,7 +73,7 @@ impl FromStr for UnwrappedEquityRecoveryId {
 
 /// Onchain/transfer dependencies the recovery job uses to perform the
 /// recovery's side effects before recording the outcome through the aggregate's
-/// pure commands. (The aggregate itself takes `Services = ()`.)
+/// pure commands. (The aggregate itself takes `Jobs = Nil`.)
 #[derive(Clone)]
 pub(crate) struct UnwrappedEquityRecoveryServices {
     pub(crate) raindex: Arc<dyn Raindex>,
@@ -311,13 +310,12 @@ impl UnwrappedEquityRecovery {
     }
 }
 
-#[async_trait]
 impl EventSourced for UnwrappedEquityRecovery {
     type Id = UnwrappedEquityRecoveryId;
     type Event = UnwrappedEquityRecoveryEvent;
     type Command = UnwrappedEquityRecoveryCommand;
     type Error = UnwrappedEquityRecoveryError;
-    type Services = ();
+    type Jobs = Nil;
     type Materialized = Nil;
 
     const AGGREGATE_TYPE: &'static str = "UnwrappedEquityRecovery";
@@ -488,9 +486,9 @@ impl EventSourced for UnwrappedEquityRecovery {
         })
     }
 
-    async fn initialize(
+    fn initialize(
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             UnwrappedEquityRecoveryCommand::Detect { symbol, shares } => {
@@ -504,10 +502,10 @@ impl EventSourced for UnwrappedEquityRecovery {
         }
     }
 
-    async fn transition(
+    fn transition(
         &self,
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use UnwrappedEquityRecoveryCommand::*;
 
@@ -640,16 +638,15 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn detect_initializes_aggregate_into_detected_state() {
+    #[test]
+    fn detect_initializes_aggregate_into_detected_state() {
         let events = UnwrappedEquityRecovery::initialize(
             UnwrappedEquityRecoveryCommand::Detect {
                 symbol: aapl(),
                 shares: one_share(),
             },
-            &(),
+            &mut JobQueue::default(),
         )
-        .await
         .unwrap();
         let [UnwrappedEquityRecoveryEvent::Detected { symbol, shares, .. }] = events.as_slice()
         else {
@@ -663,17 +660,16 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn dispatch_to_mint_emits_dispatched_to_mint_with_command_id() {
+    #[test]
+    fn dispatch_to_mint_emits_dispatched_to_mint_with_command_id() {
         let mint_id = issuer_request_id("dispatch-mint");
         let events = detected()
             .transition(
                 UnwrappedEquityRecoveryCommand::DispatchToMint {
                     mint_id: mint_id.clone(),
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect("DispatchToMint should succeed from Detected");
         let [
             UnwrappedEquityRecoveryEvent::DispatchedToMint {
@@ -689,8 +685,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn dispatch_to_redemption_emits_dispatched_to_redemption_with_command_id() {
+    #[test]
+    fn dispatch_to_redemption_emits_dispatched_to_redemption_with_command_id() {
         let redemption_id =
             crate::equity_redemption::redemption_aggregate_id("dispatch-redemption");
         let events = detected()
@@ -698,9 +694,8 @@ mod tests {
                 UnwrappedEquityRecoveryCommand::DispatchToRedemption {
                     redemption_id: redemption_id.clone(),
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect("DispatchToRedemption should succeed from Detected");
         let [
             UnwrappedEquityRecoveryEvent::DispatchedToRedemption {
@@ -791,8 +786,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn detect_on_live_aggregate_is_rejected() {
+    #[test]
+    fn detect_on_live_aggregate_is_rejected() {
         let state = UnwrappedEquityRecovery::Detected {
             symbol: aapl(),
             shares: one_share(),
@@ -804,9 +799,8 @@ mod tests {
                     symbol: aapl(),
                     shares: one_share(),
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .unwrap_err();
         assert!(matches!(
             error,
@@ -814,8 +808,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn confirm_orphan_wrap_only_valid_after_submit_wrap() {
+    #[test]
+    fn confirm_orphan_wrap_only_valid_after_submit_wrap() {
         let state = UnwrappedEquityRecovery::Detected {
             symbol: aapl(),
             shares: one_share(),
@@ -827,9 +821,8 @@ mod tests {
                     wrapped_amount: U256::from(1u64),
                     wrap_block: 1,
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .unwrap_err();
         assert!(matches!(
             error,
@@ -837,8 +830,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn submit_orphan_deposit_only_valid_after_confirm_wrap() {
+    #[test]
+    fn submit_orphan_deposit_only_valid_after_confirm_wrap() {
         let state = UnwrappedEquityRecovery::OrphanWrapSubmitted {
             symbol: aapl(),
             shares: one_share(),
@@ -851,9 +844,8 @@ mod tests {
                 UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit {
                     vault_deposit_tx_hash: FAKE_WRAP_TX,
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .unwrap_err();
         assert!(matches!(
             error,
@@ -861,8 +853,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn terminal_state_rejects_further_commands() {
+    #[test]
+    fn terminal_state_rejects_further_commands() {
         let state = UnwrappedEquityRecovery::Failed {
             symbol: aapl(),
             shares: one_share(),
@@ -874,23 +866,21 @@ mod tests {
                 UnwrappedEquityRecoveryCommand::SubmitOrphanWrap {
                     wrap_tx_hash: FAKE_WRAP_TX,
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .unwrap_err();
         assert!(matches!(error, UnwrappedEquityRecoveryError::Terminal));
     }
 
-    #[tokio::test]
-    async fn submit_orphan_wrap_emits_submitted_event() {
+    #[test]
+    fn submit_orphan_wrap_emits_submitted_event() {
         let events = detected()
             .transition(
                 UnwrappedEquityRecoveryCommand::SubmitOrphanWrap {
                     wrap_tx_hash: FAKE_WRAP_TX,
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect("SubmitOrphanWrap should succeed from Detected");
         let [UnwrappedEquityRecoveryEvent::OrphanWrapSubmitted { wrap_tx_hash, .. }] =
             events.as_slice()
@@ -904,8 +894,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn confirm_orphan_wrap_emits_confirmed_wrapped_amount() {
+    #[test]
+    fn confirm_orphan_wrap_emits_confirmed_wrapped_amount() {
         let wrapped_amount = U256::from(7u64);
         let state = UnwrappedEquityRecovery::OrphanWrapSubmitted {
             symbol: aapl(),
@@ -920,9 +910,8 @@ mod tests {
                     wrapped_amount,
                     wrap_block: 5,
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect("ConfirmOrphanWrap should succeed from OrphanWrapSubmitted");
         let [
             UnwrappedEquityRecoveryEvent::OrphanWrapped {
@@ -950,17 +939,16 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn submit_orphan_deposit_emits_submitted_event() {
+    #[test]
+    fn submit_orphan_deposit_emits_submitted_event() {
         let vault_deposit_tx = OTHER_TX;
         let events = orphan_wrapped()
             .transition(
                 UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit {
                     vault_deposit_tx_hash: vault_deposit_tx,
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect("SubmitOrphanDeposit should succeed from OrphanWrapped");
         let [
             UnwrappedEquityRecoveryEvent::OrphanDepositSubmitted {
@@ -978,8 +966,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn confirm_orphan_deposit_completes_orphan_branch() {
+    #[test]
+    fn confirm_orphan_deposit_completes_orphan_branch() {
         let state = UnwrappedEquityRecovery::OrphanDepositSubmitted {
             symbol: aapl(),
             shares: one_share(),
@@ -990,8 +978,10 @@ mod tests {
             deposit_submitted_at: Utc::now(),
         };
         let events = state
-            .transition(UnwrappedEquityRecoveryCommand::ConfirmOrphanDeposit, &())
-            .await
+            .transition(
+                UnwrappedEquityRecoveryCommand::ConfirmOrphanDeposit,
+                &mut JobQueue::default(),
+            )
             .expect("ConfirmOrphanDeposit should succeed from OrphanDepositSubmitted");
         let [
             UnwrappedEquityRecoveryEvent::OrphanDeposited {
@@ -1009,16 +999,15 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn fail_recovery_from_detected_emits_recovery_failed() {
+    #[test]
+    fn fail_recovery_from_detected_emits_recovery_failed() {
         let events = detected()
             .transition(
                 UnwrappedEquityRecoveryCommand::FailRecovery {
                     reason: "operator abort".to_string(),
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect("FailRecovery should succeed from a non-terminal state");
         let [UnwrappedEquityRecoveryEvent::RecoveryFailed { reason, .. }] = events.as_slice()
         else {

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -1030,8 +1030,8 @@ mod tests {
     ) -> UnwrappedEquityRecoveryCtx {
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
-        let mint_store = Arc::new(test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool.clone(), ()));
+        let mint_store = Arc::new(test_store(pool.clone()));
+        let redemption_store = Arc::new(test_store(pool.clone()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
             vault_lookup.clone(),
@@ -1048,7 +1048,7 @@ mod tests {
             transfer,
             wallet: Address::random(),
         };
-        let store = Arc::new(test_store(pool, ()));
+        let store = Arc::new(test_store(pool));
         let (sender, _receiver) = broadcast::channel(16);
         let inventory = Arc::new(BroadcastingInventory::new(view, sender));
 
@@ -1096,8 +1096,8 @@ mod tests {
 
         let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
-        let mint_store = Arc::new(test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool.clone(), ()));
+        let mint_store = Arc::new(test_store(pool.clone()));
+        let redemption_store = Arc::new(test_store(pool.clone()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
             Arc::new(MockVaultLookup::new()),
@@ -1114,7 +1114,7 @@ mod tests {
             transfer,
             wallet: Address::random(),
         };
-        let store = Arc::new(test_store(pool.clone(), ()));
+        let store = Arc::new(test_store(pool.clone()));
 
         let (sender, _receiver) = broadcast::channel(16);
         let inventory = Arc::new(BroadcastingInventory::new(InventoryView::default(), sender));
@@ -1170,8 +1170,8 @@ mod tests {
 
         let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
-        let mint_store = Arc::new(test_store(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool.clone(), ()));
+        let mint_store = Arc::new(test_store(pool.clone()));
+        let redemption_store = Arc::new(test_store(pool.clone()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
             Arc::new(MockVaultLookup::new()),
@@ -1188,7 +1188,7 @@ mod tests {
             transfer,
             wallet: Address::random(),
         };
-        let store = Arc::new(test_store(pool.clone(), ()));
+        let store = Arc::new(test_store(pool.clone()));
 
         // Inventory reports an unwrapped balance (so a snapshot exists) and an
         // active mint for the symbol (so dispatch resolves to `ActiveMint`), but

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -73,7 +73,6 @@
 //! [`AlpacaWalletService`]: st0x_execution::AlpacaWalletService
 
 use alloy::primitives::{B256, TxHash};
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
@@ -83,7 +82,7 @@ use tracing::warn;
 use uuid::Uuid;
 
 use st0x_dto::{TransferOperation, UsdcBridgeOperation, UsdcBridgeStatus};
-use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
+use st0x_event_sorcery::{DomainEvent, EventSourced, JobQueue, Nil};
 use st0x_execution::{AlpacaTransferId, ClientOrderId};
 use st0x_finance::{HasZero, Id, Usdc};
 
@@ -1716,13 +1715,12 @@ pub(crate) async fn interrupted_usdc_rebalance_ids(
     Ok(InterruptedUsdcRebalances { ids, unparseable })
 }
 
-#[async_trait]
 impl EventSourced for UsdcRebalance {
     type Id = UsdcRebalanceId;
     type Event = UsdcRebalanceEvent;
     type Command = UsdcRebalanceCommand;
     type Error = UsdcRebalanceError;
-    type Services = ();
+    type Jobs = Nil;
     type Materialized = Nil;
 
     const AGGREGATE_TYPE: &'static str = "UsdcRebalance";
@@ -2366,9 +2364,9 @@ impl EventSourced for UsdcRebalance {
         Ok(Some(next))
     }
 
-    async fn initialize(
+    fn initialize(
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use UsdcRebalanceCommand::*;
         use UsdcRebalanceEvent::*;
@@ -2487,10 +2485,10 @@ impl EventSourced for UsdcRebalance {
         }
     }
 
-    async fn transition(
+    fn transition(
         &self,
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use UsdcRebalanceCommand::*;
         match command {
@@ -3626,7 +3624,7 @@ mod tests {
     async fn test_initiate_alpaca_to_base() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::Initiate {
                 direction: RebalanceDirection::AlpacaToBase,
@@ -3658,7 +3656,7 @@ mod tests {
         let tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::Initiate {
                 direction: RebalanceDirection::BaseToAlpaca,
@@ -3689,7 +3687,7 @@ mod tests {
     async fn test_cannot_initiate_twice() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(1000.00)),
@@ -3746,7 +3744,7 @@ mod tests {
 
     #[tokio::test]
     async fn begin_withdrawal_from_uninitialized_records_intent_with_chain_head() {
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::BeginWithdrawal {
                 direction: RebalanceDirection::BaseToAlpaca,
@@ -3773,7 +3771,7 @@ mod tests {
 
     #[tokio::test]
     async fn begin_withdrawal_from_uninitialized_rejects_alpaca_to_base() {
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::BeginWithdrawal {
                 direction: RebalanceDirection::AlpacaToBase,
@@ -3794,7 +3792,7 @@ mod tests {
         let tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000abc");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::WithdrawalSubmitting {
                 direction: RebalanceDirection::BaseToAlpaca,
                 amount: Usdc::new(float!(500.00)),
@@ -3821,7 +3819,7 @@ mod tests {
         let tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000abc");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::WithdrawalSubmitting {
                 direction: RebalanceDirection::BaseToAlpaca,
                 amount: Usdc::new(float!(500.00)),
@@ -3844,7 +3842,7 @@ mod tests {
 
     #[tokio::test]
     async fn begin_bridging_from_withdrawal_complete_records_intent_with_chain_head() {
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -3878,7 +3876,7 @@ mod tests {
         let burn_tx =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000bad");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -3934,7 +3932,7 @@ mod tests {
             },
         ];
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(staged.clone())
             .when(UsdcRebalanceCommand::RecordPendingBurn { burn_tx })
             .await
@@ -4015,7 +4013,7 @@ mod tests {
             },
         ];
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(staged.clone())
             .when(UsdcRebalanceCommand::RecordPendingBurn { burn_tx: burn_tx_2 })
             .await
@@ -4052,7 +4050,7 @@ mod tests {
         let burn_tx =
             fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000feedface");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -4114,7 +4112,7 @@ mod tests {
             },
         ];
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(staged.clone())
             .when(UsdcRebalanceCommand::ClearPendingBurn)
             .await
@@ -4151,7 +4149,7 @@ mod tests {
     async fn clear_pending_burn_when_already_none_is_noop() {
         // On the FIRST burn there is no recorded hash yet, so `ClearPendingBurn`
         // must be a no-op that emits ZERO events rather than churning the stream.
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -4189,7 +4187,7 @@ mod tests {
         let burn_tx =
             fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000feedface");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -4229,7 +4227,7 @@ mod tests {
         let burn_tx =
             fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000feedface");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -4338,7 +4336,7 @@ mod tests {
     async fn begin_bridging_with_some_burn_amount_propagates_through_event_and_state() {
         let received = Usdc::new(float!(998.00));
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -4493,7 +4491,7 @@ mod tests {
         let nominal = Usdc::new(float!(1000.00));
         let above = Usdc::new(float!(1000.01));
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -4530,7 +4528,7 @@ mod tests {
         let nominal = Usdc::new(float!(1000.00));
         let zero = Usdc::new(float!(0));
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -4564,7 +4562,7 @@ mod tests {
     async fn test_confirm_withdrawal() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(1000.00)),
@@ -4586,7 +4584,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cannot_confirm_withdrawal_before_initiating() {
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::ConfirmWithdrawal {
                 withdrawal_tx: None,
@@ -4604,7 +4602,7 @@ mod tests {
     async fn test_cannot_confirm_withdrawal_twice() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -4633,7 +4631,7 @@ mod tests {
     async fn test_fail_withdrawal_after_initiation() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(1000.00)),
@@ -4655,7 +4653,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cannot_fail_withdrawal_before_initiating() {
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::FailWithdrawal {
                 reason: "Test failure".to_string(),
@@ -4673,7 +4671,7 @@ mod tests {
     async fn test_cannot_fail_already_confirmed_withdrawal() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -4702,7 +4700,7 @@ mod tests {
     async fn test_cannot_fail_already_failed_withdrawal() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -4733,7 +4731,7 @@ mod tests {
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -4771,7 +4769,7 @@ mod tests {
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
         let retry_deadline_at = Utc::now() + chrono::Duration::hours(24);
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -4905,7 +4903,7 @@ mod tests {
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::InitiateBridging {
                 burn_tx: burn_tx_hash,
@@ -4925,7 +4923,7 @@ mod tests {
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(1000.00)),
@@ -4950,7 +4948,7 @@ mod tests {
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -4981,7 +4979,7 @@ mod tests {
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5018,7 +5016,7 @@ mod tests {
         let attestation = vec![0x01, 0x02, 0x03, 0x04];
         let message = vec![0x05, 0x06, 0x07, 0x08];
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5425,7 +5423,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cannot_receive_attestation_before_bridging() {
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
@@ -5446,7 +5444,7 @@ mod tests {
     async fn test_cannot_receive_attestation_while_withdrawing() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(1000.00)),
@@ -5472,7 +5470,7 @@ mod tests {
     async fn test_cannot_receive_attestation_after_withdrawal_complete() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5504,7 +5502,7 @@ mod tests {
     async fn test_cannot_receive_attestation_after_withdrawal_failed() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5538,7 +5536,7 @@ mod tests {
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5585,7 +5583,7 @@ mod tests {
         let mint_tx_hash =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5637,7 +5635,7 @@ mod tests {
         let mint_tx_hash =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5672,7 +5670,7 @@ mod tests {
     async fn test_fail_bridging_from_withdrawal_complete() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5713,7 +5711,7 @@ mod tests {
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5763,7 +5761,7 @@ mod tests {
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5814,7 +5812,7 @@ mod tests {
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
         let cctp_nonce = TEST_CCTP_NONCE;
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5866,7 +5864,7 @@ mod tests {
         let burn_tx_hash =
             fixed_bytes!("0xabababababababababababababababababababababababababababababababab");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5917,7 +5915,7 @@ mod tests {
         let mint_tx_hash =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -5971,7 +5969,7 @@ mod tests {
         let mint_tx_hash =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -6019,7 +6017,7 @@ mod tests {
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -6065,7 +6063,7 @@ mod tests {
         let mint_tx_hash =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -6125,7 +6123,7 @@ mod tests {
             fixed_bytes!("0x2222222222222222222222222222222222222222222222222222222222222222");
         let deposit_ref = TransferRef::OnchainTx(deposit_tx_hash);
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -6180,7 +6178,7 @@ mod tests {
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
         let deposit_transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -6227,7 +6225,7 @@ mod tests {
         let mint_tx_hash =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -6281,7 +6279,7 @@ mod tests {
         let mint_tx_hash =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -6332,7 +6330,7 @@ mod tests {
         let mint_tx_hash =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -6398,7 +6396,7 @@ mod tests {
             fixed_bytes!("0x2222222222222222222222222222222222222222222222222222222222222222");
         let deposit_ref = TransferRef::OnchainTx(onchain_tx);
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -6460,7 +6458,7 @@ mod tests {
         let deposit_tx =
             fixed_bytes!("0x2222222222222222222222222222222222222222222222222222222222222222");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -6515,7 +6513,7 @@ mod tests {
             fixed_bytes!("0x5555555555555555555555555555555555555555555555555555555555555555");
         let deposit_transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -6562,7 +6560,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_withdrawal_failed_rejects_confirm_withdrawal() {
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -6592,7 +6590,7 @@ mod tests {
         let burn_tx =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -6620,7 +6618,7 @@ mod tests {
         let burn_tx =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -6665,7 +6663,7 @@ mod tests {
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -6736,7 +6734,7 @@ mod tests {
             },
         ];
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(history.clone())
             .when(UsdcRebalanceCommand::RecoverBridging {
                 mint_tx,
@@ -6791,7 +6789,7 @@ mod tests {
 
         // A pre-burn BridgingFailed (no burn tx) has no mint to adopt; recovery
         // must be rejected -- the transfer should be re-initiated, not un-failed.
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -6834,7 +6832,7 @@ mod tests {
         // RecoverBridging is only valid from a post-burn BridgingFailed. From a
         // non-failed state (here mid-bridge, after the burn) it must be rejected
         // as an invalid command, never silently adopting a second mint.
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -7045,7 +7043,7 @@ mod tests {
                 other => panic!("fixture should end in a post-burn failure, got {other:?}"),
             };
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(history.clone())
             .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
                 reason: ReconcileReason::FundsMovedManually,
@@ -7106,7 +7104,7 @@ mod tests {
     async fn reconcile_stuck_rebalance_from_deposit_failed_emits_operator_reconciled() {
         let history = deposit_failed_history();
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(history.clone())
             .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
                 reason: ReconcileReason::FundsMovedManually,
@@ -7208,7 +7206,7 @@ mod tests {
     async fn reconcile_deposit_credited_offline_surfaces_in_dto() {
         let history = deposit_failed_history();
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(history.clone())
             .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
                 reason: ReconcileReason::DepositCreditedOffline,
@@ -7279,7 +7277,7 @@ mod tests {
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -7328,7 +7326,7 @@ mod tests {
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -7376,7 +7374,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconcile_stuck_rebalance_rejected_from_initiated() {
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::BaseToAlpaca,
                 amount: Usdc::new(float!(100.00)),
@@ -7408,7 +7406,7 @@ mod tests {
             reconciled_at: Utc::now(),
         });
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(history)
             .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
                 reason: ReconcileReason::DepositCreditedOffline,
@@ -7431,7 +7429,7 @@ mod tests {
         // burned funds: the failure already reconciles to source, so reconcile
         // must reject it rather than zero source inflight without crediting
         // available (which would lose the never-burned funds).
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -7467,7 +7465,7 @@ mod tests {
         // AlpacaToBase ConversionFailed is the pre-withdrawal (pre-burn)
         // USD->USDC leg: no funds left the source, so reconcile must reject it.
         // It reconciles to source on its own via the normal failure path.
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -7499,7 +7497,7 @@ mod tests {
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -7555,7 +7553,7 @@ mod tests {
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -7614,7 +7612,7 @@ mod tests {
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -7666,7 +7664,7 @@ mod tests {
     async fn test_initiate_conversion_from_uninitialized() {
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::InitiateConversion {
                 direction: RebalanceDirection::AlpacaToBase,
@@ -7696,7 +7694,7 @@ mod tests {
     async fn test_cannot_initiate_conversion_twice() {
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::ConversionInitiated {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(1000.00)),
@@ -7722,7 +7720,7 @@ mod tests {
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
         let conversion = par_conversion(Usdc::new(float!(998)));
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::ConversionInitiated {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(1000.00)),
@@ -7742,7 +7740,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cannot_confirm_conversion_before_initiating() {
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::ConfirmConversion {
                 conversion: par_conversion(Usdc::new(float!(998))),
@@ -7760,7 +7758,7 @@ mod tests {
     async fn test_cannot_confirm_conversion_twice() {
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -7790,7 +7788,7 @@ mod tests {
     async fn test_fail_conversion_from_converting_state() {
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::ConversionInitiated {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(1000.00)),
@@ -7812,7 +7810,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cannot_fail_conversion_before_initiating() {
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::FailConversion {
                 reason: "Test failure".to_string(),
@@ -7830,7 +7828,7 @@ mod tests {
     async fn test_cannot_fail_already_completed_conversion() {
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -7862,7 +7860,7 @@ mod tests {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
         let received_amount = Usdc::new(float!(998));
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -7894,7 +7892,7 @@ mod tests {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
         let received_amount = Usdc::new(float!(998));
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -7934,7 +7932,7 @@ mod tests {
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -8003,7 +8001,7 @@ mod tests {
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -8056,7 +8054,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cannot_initiate_post_deposit_conversion_before_deposit_confirmed() {
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::InitiatePostDepositConversion {
                 order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
@@ -8078,7 +8076,7 @@ mod tests {
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let error = TestHarness::<UsdcRebalance>::with(())
+        let error = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -8143,7 +8141,7 @@ mod tests {
         let initiated_at = Utc::now() - chrono::Duration::hours(3);
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::InitiateConversionAt {
                 direction: RebalanceDirection::AlpacaToBase,
@@ -8171,7 +8169,7 @@ mod tests {
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
         let conversion = par_conversion(Usdc::new(float!(998)));
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::ConversionInitiated {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(1000.00)),
@@ -8204,7 +8202,7 @@ mod tests {
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
         let initiated_at = Utc::now() - chrono::Duration::hours(1);
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -8265,7 +8263,7 @@ mod tests {
     async fn begin_withdrawal_at_uses_supplied_timestamp() {
         let submitting_at = Utc::now() - chrono::Duration::hours(4);
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::BeginWithdrawalAt {
                 direction: RebalanceDirection::BaseToAlpaca,
@@ -8292,7 +8290,7 @@ mod tests {
         let initiated_at = Utc::now() - chrono::Duration::hours(5);
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::WithdrawalSubmitting {
                 direction: RebalanceDirection::BaseToAlpaca,
                 amount: Usdc::new(float!(500.00)),
@@ -8324,7 +8322,7 @@ mod tests {
         let confirmed_at = Utc::now() - chrono::Duration::hours(6);
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::BaseToAlpaca,
                 amount: Usdc::new(float!(500.00)),
@@ -8354,7 +8352,7 @@ mod tests {
         let submitting_at = Utc::now() - chrono::Duration::hours(7);
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -8393,7 +8391,7 @@ mod tests {
         let burn_tx =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -8428,7 +8426,7 @@ mod tests {
         let burn_tx =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -8475,7 +8473,7 @@ mod tests {
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -8528,7 +8526,7 @@ mod tests {
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -8585,7 +8583,7 @@ mod tests {
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -8644,7 +8642,7 @@ mod tests {
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
@@ -10052,7 +10050,7 @@ mod tests {
     #[tokio::test]
     async fn interrupted_usdc_rebalance_ids_excludes_clearable_terminals() {
         let pool = crate::test_utils::setup_test_db().await;
-        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let store = test_store::<UsdcRebalance>(pool.clone());
         let amount = Usdc::new(float!(400.0));
 
         // Clearable terminal (withdrawal failed, pre-burn) -- must be excluded,
@@ -10204,7 +10202,7 @@ mod tests {
             fixed_bytes!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(100.00)),
@@ -10245,7 +10243,7 @@ mod tests {
     async fn confirm_withdrawal_with_none_produces_withdrawal_complete_with_none_tx() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::BaseToAlpaca,
                 amount: Usdc::new(float!(100.00)),
@@ -10396,7 +10394,7 @@ mod tests {
     async fn begin_bridging_from_withdrawal_complete_alpaca_to_base_transitions_correctly() {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -10457,7 +10455,7 @@ mod tests {
             fixed_bytes!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
-        let events = TestHarness::<UsdcRebalance>::with(())
+        let events = TestHarness::<UsdcRebalance>::with()
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
@@ -10747,7 +10745,7 @@ mod tests {
         // Apply the Initiate command; transition_initiate_withdrawal emits
         // Initiated { initiated_at: Utc::now() } at the withdrawal moment.
         let before_initiate = Utc::now();
-        let new_events = TestHarness::<UsdcRebalance>::with(())
+        let new_events = TestHarness::<UsdcRebalance>::with()
             .given(prior_events.clone())
             .when(UsdcRebalanceCommand::Initiate {
                 direction: RebalanceDirection::AlpacaToBase,

--- a/src/vault_lookup.rs
+++ b/src/vault_lookup.rs
@@ -187,7 +187,7 @@ mod tests {
     async fn seeded_lookup() -> VaultRegistryLookup {
         let pool = setup_test_db().await;
         let (store, projection) = StoreBuilder::<VaultRegistry>::new(pool)
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -219,7 +219,7 @@ mod tests {
     async fn vault_id_for_token_returns_primary_vault() {
         let pool = setup_test_db().await;
         let (store, projection) = StoreBuilder::<VaultRegistry>::new(pool)
-            .build(())
+            .build()
             .await
             .unwrap();
         let registry_id = VaultRegistryId {
@@ -278,7 +278,7 @@ mod tests {
     async fn vault_token_for_symbol_rejects_ambiguous_tokens() {
         let pool = setup_test_db().await;
         let (store, projection) = StoreBuilder::<VaultRegistry>::new(pool)
-            .build(())
+            .build()
             .await
             .unwrap();
         let registry_id = VaultRegistryId {
@@ -356,7 +356,7 @@ mod tests {
     async fn empty_registry_is_registry_not_found() {
         let pool = setup_test_db().await;
         let (_store, projection) = StoreBuilder::<VaultRegistry>::new(pool)
-            .build(())
+            .build()
             .await
             .unwrap();
         let lookup = VaultRegistryLookup::new(

--- a/src/vault_registry.rs
+++ b/src/vault_registry.rs
@@ -8,7 +8,6 @@
 
 use alloy::hex::FromHexError;
 use alloy::primitives::{Address, B256, TxHash};
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -20,7 +19,9 @@ use tracing::{debug, info};
 
 use st0x_execution::Symbol;
 
-use st0x_event_sorcery::{DomainEvent, EventSourced, Never, Projection, SendError, Store, Table};
+use st0x_event_sorcery::{
+    DomainEvent, EventSourced, Never, Nil, Projection, SendError, Store, Table,
+};
 
 use st0x_config::{Ctx, CtxError};
 
@@ -72,13 +73,12 @@ impl FromStr for VaultRegistryId {
     }
 }
 
-#[async_trait]
 impl EventSourced for VaultRegistry {
     type Id = VaultRegistryId;
     type Event = VaultRegistryEvent;
     type Command = VaultRegistryCommand;
     type Error = Never;
-    type Services = ();
+    type Jobs = Nil;
     type Materialized = Table;
 
     const AGGREGATE_TYPE: &'static str = "VaultRegistry";
@@ -97,17 +97,19 @@ impl EventSourced for VaultRegistry {
         Ok(Some(new_registry))
     }
 
-    async fn initialize(
+    // Fully-qualified `st0x_event_sorcery::JobQueue` here avoids colliding with
+    // the `crate::conductor::job::JobQueue` imported in this module.
+    fn initialize(
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut st0x_event_sorcery::JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         Ok(vec![Self::command_to_event(command)])
     }
 
-    async fn transition(
+    fn transition(
         &self,
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut st0x_event_sorcery::JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         match &command {
             VaultRegistryCommand::SeedEquityVaultFromConfig {
@@ -767,7 +769,7 @@ mod tests {
 
     #[tokio::test]
     async fn first_equity_discovery_initializes_registry() {
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given_no_previous_events()
             .when(VaultRegistryCommand::DiscoverEquityVault {
                 token: TEST_TOKEN,
@@ -794,7 +796,7 @@ mod tests {
 
     #[tokio::test]
     async fn first_usdc_discovery_initializes_registry() {
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given_no_previous_events()
             .when(VaultRegistryCommand::DiscoverUsdcVault {
                 vault_id: TEST_VAULT_ID,
@@ -813,7 +815,7 @@ mod tests {
 
     #[tokio::test]
     async fn discover_equity_vault_on_existing_registry() {
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given(vec![VaultRegistryEvent::UsdcVaultDiscovered {
                 vault_id: TEST_VAULT_ID,
                 discovered_in: TEST_TX_HASH,
@@ -844,7 +846,7 @@ mod tests {
 
     #[tokio::test]
     async fn discover_usdc_vault_on_existing_registry() {
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given(vec![VaultRegistryEvent::EquityVaultDiscovered {
                 token: TEST_TOKEN,
                 vault_id: TEST_VAULT_ID,
@@ -874,7 +876,7 @@ mod tests {
         let new_tx_hash =
             b256!("0x2222222222222222222222222222222222222222222222222222222222222222");
 
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given(vec![VaultRegistryEvent::EquityVaultDiscovered {
                 token: TEST_TOKEN,
                 vault_id: TEST_VAULT_ID,
@@ -1192,7 +1194,7 @@ mod tests {
 
     #[tokio::test]
     async fn seed_equity_vault_deduplicates_on_same_token_and_vault_id() {
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given(vec![VaultRegistryEvent::EquityVaultSeededFromConfig {
                 token: TEST_TOKEN,
                 vault_id: TEST_VAULT_ID,
@@ -1219,7 +1221,7 @@ mod tests {
         let new_vault_id =
             b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
 
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given(vec![VaultRegistryEvent::EquityVaultSeededFromConfig {
                 token: TEST_TOKEN,
                 vault_id: TEST_VAULT_ID,
@@ -1243,7 +1245,7 @@ mod tests {
 
     #[tokio::test]
     async fn seed_usdc_vault_deduplicates_on_same_vault_id() {
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given(vec![VaultRegistryEvent::UsdcVaultSeededFromConfig {
                 vault_id: TEST_VAULT_ID,
                 seeded_at: Utc::now(),
@@ -1266,7 +1268,7 @@ mod tests {
         let new_vault_id =
             b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
 
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given(vec![VaultRegistryEvent::UsdcVaultSeededFromConfig {
                 vault_id: TEST_VAULT_ID,
                 seeded_at: Utc::now(),
@@ -1286,7 +1288,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_primary_equity_vault_deduplicates_when_config_unchanged() {
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given(vec![
                 VaultRegistryEvent::EquityVaultSeededFromConfig {
                     token: TEST_TOKEN,
@@ -1321,7 +1323,7 @@ mod tests {
         let new_vault_id =
             b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
 
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given(vec![
                 VaultRegistryEvent::EquityVaultSeededFromConfig {
                     token: TEST_TOKEN,
@@ -1364,7 +1366,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_primary_usdc_vault_deduplicates_when_config_unchanged() {
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given(vec![
                 VaultRegistryEvent::UsdcVaultSeededFromConfig {
                     vault_id: TEST_VAULT_ID,
@@ -1393,7 +1395,7 @@ mod tests {
         let new_vault_id =
             b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
 
-        let events = TestHarness::<VaultRegistry>::with(())
+        let events = TestHarness::<VaultRegistry>::with()
             .given(vec![
                 VaultRegistryEvent::UsdcVaultSeededFromConfig {
                     vault_id: TEST_VAULT_ID,
@@ -1439,7 +1441,7 @@ mod tests {
 
         // Phase 1: emit an event with NO reactors
         let (bare_store, _projection) = StoreBuilder::<VaultRegistry>::new(pool.clone())
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -1461,7 +1463,7 @@ mod tests {
         let reactor = EventCounter(counter.clone());
         let (observed_store, _projection) = StoreBuilder::<VaultRegistry>::new(pool.clone())
             .with(Arc::new(reactor))
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -1536,7 +1538,7 @@ mod tests {
 
     async fn seed_ctx_from(pool: sqlx::SqlitePool, ctx: &Ctx) -> Arc<SeedVaultRegistryCtx> {
         let (store, _projection) = StoreBuilder::<VaultRegistry>::new(pool)
-            .build(())
+            .build()
             .await
             .unwrap();
 
@@ -1605,7 +1607,7 @@ mod tests {
 
         let pool = setup_test_db().await;
         let (store, _projection) = StoreBuilder::<VaultRegistry>::new(pool)
-            .build(())
+            .build()
             .await
             .unwrap();
 

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -27,7 +27,7 @@
 //! state. Any non-terminal state can receive `FailRecovery`, transitioning
 //! to `Failed`.
 //!
-//! The handlers are pure event recorders (`Services = ()`): the recovery job
+//! The handlers are pure event recorders (`Jobs = Nil`): the recovery job
 //! ([`WrappedEquityRecoveryJob`](super::job::WrappedEquityRecoveryJob)) performs
 //! the raindex/wrapper/transfer I/O and sends the matching command carrying the
 //! outcome. A terminal service failure is recorded by sending `FailRecovery`; a
@@ -41,7 +41,6 @@
 //! SQLite) and is the same gap the prior atomic-handler design had.
 
 use alloy::primitives::TxHash;
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -49,7 +48,7 @@ use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
 
-use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
+use st0x_event_sorcery::{DomainEvent, EventSourced, JobQueue, Nil};
 use st0x_execution::{FractionalShares, Symbol};
 use st0x_raindex::Raindex;
 use st0x_tokenization::IssuerRequestId;
@@ -80,7 +79,7 @@ impl FromStr for WrappedEquityRecoveryId {
 
 /// Onchain/transfer dependencies the recovery job uses to perform the
 /// recovery's side effects before recording the outcome through the aggregate's
-/// pure commands. (The aggregate itself takes `Services = ()`.)
+/// pure commands. (The aggregate itself takes `Jobs = Nil`.)
 #[derive(Clone)]
 pub(crate) struct WrappedEquityRecoveryServices {
     pub(crate) raindex: Arc<dyn Raindex>,
@@ -257,13 +256,12 @@ impl WrappedEquityRecovery {
     }
 }
 
-#[async_trait]
 impl EventSourced for WrappedEquityRecovery {
     type Id = WrappedEquityRecoveryId;
     type Event = WrappedEquityRecoveryEvent;
     type Command = WrappedEquityRecoveryCommand;
     type Error = WrappedEquityRecoveryError;
-    type Services = ();
+    type Jobs = Nil;
     type Materialized = Nil;
 
     const AGGREGATE_TYPE: &'static str = "WrappedEquityRecovery";
@@ -379,9 +377,9 @@ impl EventSourced for WrappedEquityRecovery {
         })
     }
 
-    async fn initialize(
+    fn initialize(
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             WrappedEquityRecoveryCommand::Detect { symbol, shares } => {
@@ -395,10 +393,10 @@ impl EventSourced for WrappedEquityRecovery {
         }
     }
 
-    async fn transition(
+    fn transition(
         &self,
         command: Self::Command,
-        _services: &Self::Services,
+        _jobs: &mut JobQueue<Self::Jobs>,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use WrappedEquityRecoveryCommand::*;
 
@@ -494,16 +492,15 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn detect_initializes_aggregate_into_detected_state() {
+    #[test]
+    fn detect_initializes_aggregate_into_detected_state() {
         let events = WrappedEquityRecovery::initialize(
             WrappedEquityRecoveryCommand::Detect {
                 symbol: aapl(),
                 shares: one_share(),
             },
-            &(),
+            &mut JobQueue::default(),
         )
-        .await
         .expect("Detect should initialize");
 
         let [WrappedEquityRecoveryEvent::Detected { symbol, .. }] = events.as_slice() else {
@@ -519,17 +516,16 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn detect_rejected_once_initialized() {
+    #[test]
+    fn detect_rejected_once_initialized() {
         let error = detected_state()
             .transition(
                 WrappedEquityRecoveryCommand::Detect {
                     symbol: aapl(),
                     shares: one_share(),
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect_err("Detect on an initialized aggregate should error");
 
         assert!(
@@ -538,8 +534,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn dispatch_to_mint_records_dispatch_with_mint_id() {
+    #[test]
+    fn dispatch_to_mint_records_dispatch_with_mint_id() {
         let mint_id = issuer_request_id("ISS-1");
 
         let events = detected_state()
@@ -547,9 +543,8 @@ mod tests {
                 WrappedEquityRecoveryCommand::DispatchToMint {
                     mint_id: mint_id.clone(),
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect("DispatchToMint should succeed from Detected");
 
         let [
@@ -563,8 +558,8 @@ mod tests {
         assert_eq!(*recorded, mint_id);
     }
 
-    #[tokio::test]
-    async fn dispatch_to_redemption_records_dispatch_with_redemption_id() {
+    #[test]
+    fn dispatch_to_redemption_records_dispatch_with_redemption_id() {
         let redemption_id = redemption_aggregate_id("redemption-1");
 
         let events = detected_state()
@@ -572,9 +567,8 @@ mod tests {
                 WrappedEquityRecoveryCommand::DispatchToRedemption {
                     redemption_id: redemption_id.clone(),
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect("DispatchToRedemption should succeed from Detected");
 
         let [
@@ -589,16 +583,15 @@ mod tests {
         assert_eq!(*recorded, redemption_id);
     }
 
-    #[tokio::test]
-    async fn submit_orphan_deposit_records_submitted_tx_hash() {
+    #[test]
+    fn submit_orphan_deposit_records_submitted_tx_hash() {
         let events = detected_state()
             .transition(
                 WrappedEquityRecoveryCommand::SubmitOrphanDeposit {
                     vault_deposit_tx_hash: FAKE_TX_HASH,
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect("SubmitOrphanDeposit should succeed from Detected");
 
         let [
@@ -613,8 +606,8 @@ mod tests {
         assert_eq!(*vault_deposit_tx_hash, FAKE_TX_HASH);
     }
 
-    #[tokio::test]
-    async fn confirm_orphan_deposit_records_deposit_from_state_tx_hash() {
+    #[test]
+    fn confirm_orphan_deposit_records_deposit_from_state_tx_hash() {
         let submitted = WrappedEquityRecovery::OrphanDepositSubmitted {
             symbol: aapl(),
             shares: one_share(),
@@ -624,8 +617,10 @@ mod tests {
         };
 
         let events = submitted
-            .transition(WrappedEquityRecoveryCommand::ConfirmOrphanDeposit, &())
-            .await
+            .transition(
+                WrappedEquityRecoveryCommand::ConfirmOrphanDeposit,
+                &mut JobQueue::default(),
+            )
             .expect("ConfirmOrphanDeposit should succeed from OrphanDepositSubmitted");
 
         let [
@@ -640,16 +635,15 @@ mod tests {
         assert_eq!(*vault_deposit_tx_hash, FAKE_TX_HASH);
     }
 
-    #[tokio::test]
-    async fn fail_recovery_from_detected_records_failure() {
+    #[test]
+    fn fail_recovery_from_detected_records_failure() {
         let events = detected_state()
             .transition(
                 WrappedEquityRecoveryCommand::FailRecovery {
                     reason: "boom".to_string(),
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect("FailRecovery should succeed from Detected");
 
         let [WrappedEquityRecoveryEvent::RecoveryFailed { reason, .. }] = events.as_slice() else {
@@ -658,8 +652,8 @@ mod tests {
         assert_eq!(reason, "boom");
     }
 
-    #[tokio::test]
-    async fn fail_recovery_from_orphan_deposit_submitted_records_failure() {
+    #[test]
+    fn fail_recovery_from_orphan_deposit_submitted_records_failure() {
         let submitted = WrappedEquityRecovery::OrphanDepositSubmitted {
             symbol: aapl(),
             shares: one_share(),
@@ -673,9 +667,8 @@ mod tests {
                 WrappedEquityRecoveryCommand::FailRecovery {
                     reason: "deposit confirmation dropped".to_string(),
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect("FailRecovery should succeed from OrphanDepositSubmitted");
 
         let [WrappedEquityRecoveryEvent::RecoveryFailed { reason, .. }] = events.as_slice() else {
@@ -687,11 +680,13 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn confirm_orphan_deposit_rejected_from_detected() {
+    #[test]
+    fn confirm_orphan_deposit_rejected_from_detected() {
         let error = detected_state()
-            .transition(WrappedEquityRecoveryCommand::ConfirmOrphanDeposit, &())
-            .await
+            .transition(
+                WrappedEquityRecoveryCommand::ConfirmOrphanDeposit,
+                &mut JobQueue::default(),
+            )
             .expect_err("ConfirmOrphanDeposit from Detected should be an invalid transition");
 
         assert!(
@@ -700,8 +695,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn fail_recovery_rejected_from_terminal_state() {
+    #[test]
+    fn fail_recovery_rejected_from_terminal_state() {
         let deposited = WrappedEquityRecovery::OrphanDeposited {
             symbol: aapl(),
             shares: one_share(),
@@ -716,9 +711,8 @@ mod tests {
                 WrappedEquityRecoveryCommand::FailRecovery {
                     reason: "should be rejected".to_string(),
                 },
-                &(),
+                &mut JobQueue::default(),
             )
-            .await
             .expect_err("FailRecovery on a terminal state should error");
 
         assert!(

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -770,8 +770,8 @@ mod tests {
         let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
         let vault_lookup: Arc<dyn VaultLookup> = Arc::new(MockVaultLookup::new());
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
-        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool.clone(), ()));
+        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
+        let redemption_store = Arc::new(test_store(pool.clone()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
             vault_lookup.clone(),
@@ -787,7 +787,7 @@ mod tests {
             wrapper,
             transfer,
         };
-        let store = Arc::new(test_store(pool.clone(), ()));
+        let store = Arc::new(test_store(pool.clone()));
 
         let (sender, _receiver) = broadcast::channel(16);
         let inventory = Arc::new(BroadcastingInventory::new(InventoryView::default(), sender));
@@ -893,8 +893,8 @@ mod tests {
     ) -> WrappedEquityRecoveryCtx {
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
-        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone(), ()));
-        let redemption_store = Arc::new(test_store(pool.clone(), ()));
+        let mint_store = Arc::new(test_store::<TokenizedEquityMint>(pool.clone()));
+        let redemption_store = Arc::new(test_store(pool.clone()));
         let transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex.clone(),
             vault_lookup.clone(),
@@ -910,7 +910,7 @@ mod tests {
             wrapper,
             transfer,
         };
-        let store = Arc::new(test_store(pool, ()));
+        let store = Arc::new(test_store(pool));
         let (sender, _receiver) = broadcast::channel(16);
         let inventory = Arc::new(BroadcastingInventory::new(view, sender));
 


### PR DESCRIPTION
## What

RAI-924. Bumps st0x.liquidity to **event-sorcery 0.2.0-rc2** and adopts the
jobs-model `EventSourced` trait across all ten aggregates. This is the terminal
PR of the side-effect-extraction stack (RAI-926 → 927 → 928 → 929 → 930 → 931
made every handler pure); with no handler performing I/O, the bump is mechanical.

## Why

The pre-jobs event-sorcery made every handler `async` for no reason and forced a
vestigial `type Services` on each impl. 0.2.0-rc2 drops `type Services` for
`type Jobs: JobList` and makes `initialize`/`transition` synchronous (taking a
buffered `JobQueue` rather than services), so a future enqueue can commit inside
the event transaction (ADR-0001 crash-safety). It also makes sqlite-es
self-contained (in-crate migrations).

## How

- **Dependency**: pin `event-sorcery`/`sqlite-es` to tag `0.2.0-rc2`;
  `cargo update`; refresh the `rust.nix` `outputHashes` entry for the new rev.
- **Aggregates (10)**: every `impl EventSourced` drops `#[async_trait]`, swaps
  `type Services = ();` for `type Jobs = Nil;`, and converts `initialize`/
  `transition` to sync `fn`s taking `_jobs: &mut JobQueue<Self::Jobs>`. All ten
  are pure event recorders post-extraction, so all are `Nil`.
- **Call sites**: `StoreBuilder::build(())` → `build()`; `test_store(pool, ())`
  → `test_store(pool)`; `TestStore::new(())`/`TestHarness::with(())` → no-arg;
  `send_command(.., ())` → no services arg; direct handler test calls
  `.transition(cmd, &()).await` → `.transition(cmd, &mut JobQueue::default())`
  (sync, no await).
- **Nix**: removed the `../../migrations` vendor workaround — 0.2.0-rc2's
  sqlite-es embeds `./migrations` in-crate and survives `cargo package`, so the
  vendored crate carries its own schema; `cargoVendorDir` is now the plain
  `vendorCargoDeps` result.

No business-logic changes — the extraction PRs already moved every side effect
into the durable jobs.

## Testing

- `cargo check --workspace` + `--tests`: clean.
- `cargo nextest run --workspace`: 2843/2844 pass; the one miss
  (`e2e interrupted_mint_resumes_after_restart`) is e2e flakiness under the
  full-suite parallel load — it passes in isolation (verified).
- `cargo clippy --workspace --all-targets --all-features` + `cargo fmt`: clean.
- `nix build .#st0x-cli`: green — confirms the new vendor hash and the
  migration-workaround removal build under Nix.

## Anything else

Top of the equity-extraction stack (on #936). Next: RAI-925 excises the local
`conductor::job` machinery (which is why this PR fully-qualifies
`st0x_event_sorcery::JobQueue` in `vault_registry.rs`, where the local
`JobQueue` name still collides).
