### PR TITLE
refactor: unify per-asset config guards onto AssetsConfig

### DIFF
--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1095,14 +1095,20 @@ impl Ctx {
             })
             .collect()
     }
+}
 
+/// Per-symbol equity config guards. All six live on `AssetsConfig` (the owner
+/// of the `[assets.equities]` map) so callers use one convention --
+/// `assets.X(symbol)` or `ctx.assets.X(symbol)` -- rather than mixing
+/// `ctx.X(symbol)` with `ctx.assets.X(symbol)`. Code that holds only an
+/// `&AssetsConfig` (e.g. the accumulator) can reach every guard without a `Ctx`.
+impl AssetsConfig {
     /// Returns whether trading is enabled for the given equity.
     ///
     /// Fail-closed: assets not present in the config are treated as
     /// trading-disabled.
     pub fn is_trading_enabled(&self, symbol: &Symbol) -> bool {
-        self.assets
-            .equities
+        self.equities
             .symbols
             .get(symbol)
             .is_some_and(|config| config.trading == OperationMode::Enabled)
@@ -1113,8 +1119,7 @@ impl Ctx {
     /// Assets not present in the config are treated as rebalancing-disabled
     /// by default.
     pub fn is_rebalancing_enabled(&self, symbol: &Symbol) -> bool {
-        self.assets
-            .equities
+        self.equities
             .symbols
             .get(symbol)
             .is_some_and(|config| config.rebalancing == OperationMode::Enabled)
@@ -1127,8 +1132,7 @@ impl Ctx {
     /// keeping automatic rebalancing disabled. Assets not present in the
     /// config are treated as recovery-disabled by default.
     pub fn is_wrapped_equity_recovery_enabled(&self, symbol: &Symbol) -> bool {
-        self.assets
-            .equities
+        self.equities
             .symbols
             .get(symbol)
             .is_some_and(|config| config.wrapped_equity_recovery == OperationMode::Enabled)
@@ -1139,15 +1143,12 @@ impl Ctx {
     /// `[assets.equities]`. Lets operator commands resolve the token from the
     /// ticker instead of taking an error-prone address argument.
     pub fn tokenized_equity(&self, symbol: &Symbol) -> Option<Address> {
-        self.assets
-            .equities
+        self.equities
             .symbols
             .get(symbol)
             .map(|config| config.tokenized_equity)
     }
-}
 
-impl AssetsConfig {
     /// Returns whether extended-hours counter-trading is enabled for the
     /// given equity.
     ///
@@ -4272,7 +4273,7 @@ mod tests {
         };
 
         assert!(
-            !ctx.is_trading_enabled(&Symbol::new("RKLB").unwrap()),
+            !ctx.assets.is_trading_enabled(&Symbol::new("RKLB").unwrap()),
             "RKLB trading should be disabled"
         );
     }
@@ -4284,7 +4285,8 @@ mod tests {
         ));
 
         assert!(
-            !ctx.is_trading_enabled(&Symbol::new("UNKNOWN").unwrap()),
+            !ctx.assets
+                .is_trading_enabled(&Symbol::new("UNKNOWN").unwrap()),
             "Unknown assets should default to trading disabled (fail-closed)"
         );
     }
@@ -4383,7 +4385,8 @@ mod tests {
         };
 
         assert!(
-            ctx.is_rebalancing_enabled(&Symbol::new("RKLB").unwrap()),
+            ctx.assets
+                .is_rebalancing_enabled(&Symbol::new("RKLB").unwrap()),
             "RKLB rebalancing should be enabled"
         );
     }
@@ -4395,7 +4398,8 @@ mod tests {
         ));
 
         assert!(
-            !ctx.is_rebalancing_enabled(&Symbol::new("UNKNOWN").unwrap()),
+            !ctx.assets
+                .is_rebalancing_enabled(&Symbol::new("UNKNOWN").unwrap()),
             "Unknown assets should default to rebalancing disabled"
         );
     }
@@ -4433,15 +4437,16 @@ mod tests {
 
         let aapl = Symbol::new("AAPL").unwrap();
         assert!(
-            ctx.is_wrapped_equity_recovery_enabled(&aapl),
+            ctx.assets.is_wrapped_equity_recovery_enabled(&aapl),
             "Recovery should follow wrapped_equity_recovery config"
         );
         assert!(
-            !ctx.is_rebalancing_enabled(&aapl),
+            !ctx.assets.is_rebalancing_enabled(&aapl),
             "Recovery-enabled symbol must not imply rebalancing is enabled"
         );
         assert!(
-            !ctx.is_wrapped_equity_recovery_enabled(&Symbol::new("UNKNOWN").unwrap()),
+            !ctx.assets
+                .is_wrapped_equity_recovery_enabled(&Symbol::new("UNKNOWN").unwrap()),
             "Unknown assets should default to recovery disabled"
         );
     }
@@ -4482,7 +4487,7 @@ mod tests {
 
         // The lookup uses base symbol "SPYM" which matches the config key
         assert!(
-            !ctx.is_trading_enabled(&Symbol::new("SPYM").unwrap()),
+            !ctx.assets.is_trading_enabled(&Symbol::new("SPYM").unwrap()),
             "SPYM trading should be disabled per config"
         );
     }

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -975,6 +975,7 @@ pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clon
     writeln!(stdout, "   Quantity: {quantity}")?;
 
     let token = ctx
+        .assets
         .tokenized_equity(&symbol)
         .ok_or_else(|| anyhow::anyhow!("equity {symbol} is not configured in [assets.equities]"))?;
     writeln!(stdout, "   Token: {token}")?;
@@ -1109,6 +1110,7 @@ pub(super) async fn alpaca_redeem_command<Writer: Write>(
     writeln!(stdout, "   Quantity: {quantity}")?;
 
     let token = ctx
+        .assets
         .tokenized_equity(&symbol)
         .ok_or_else(|| anyhow::anyhow!("equity {symbol} is not configured in [assets.equities]"))?;
     writeln!(stdout, "   Token: {token}")?;
@@ -3534,12 +3536,12 @@ mod tests {
         );
 
         assert_eq!(
-            ctx.tokenized_equity(&Symbol::new("COIN").unwrap()),
+            ctx.assets.tokenized_equity(&Symbol::new("COIN").unwrap()),
             Some(token),
             "a configured symbol must resolve to its tokenized_equity address",
         );
         assert_eq!(
-            ctx.tokenized_equity(&Symbol::new("AAPL").unwrap()),
+            ctx.assets.tokenized_equity(&Symbol::new("AAPL").unwrap()),
             None,
             "an unconfigured symbol must resolve to None, never a default address",
         );

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -676,7 +676,7 @@ pub(super) async fn process_found_trade<W: Write>(
         }
     }
 
-    let trading_enabled = ctx.is_trading_enabled(base_symbol);
+    let trading_enabled = ctx.assets.is_trading_enabled(base_symbol);
 
     if !trading_enabled {
         writeln!(

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -892,9 +892,9 @@ fn build_unwrapped_equity_recovery_ctx(
 }
 
 fn base_wallet_equity_recovery_enabled(ctx: &Ctx, symbol: &Symbol) -> bool {
-    ctx.is_trading_enabled(symbol)
-        || ctx.is_rebalancing_enabled(symbol)
-        || ctx.is_wrapped_equity_recovery_enabled(symbol)
+    ctx.assets.is_trading_enabled(symbol)
+        || ctx.assets.is_rebalancing_enabled(symbol)
+        || ctx.assets.is_wrapped_equity_recovery_enabled(symbol)
 }
 
 fn base_wallet_unwrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
@@ -949,7 +949,9 @@ async fn grant_startup_token_approvals(ctx: &Ctx) -> anyhow::Result<()> {
         .equities
         .symbols
         .keys()
-        .filter(|symbol| ctx.is_trading_enabled(symbol) || ctx.is_rebalancing_enabled(symbol))
+        .filter(|symbol| {
+            ctx.assets.is_trading_enabled(symbol) || ctx.assets.is_rebalancing_enabled(symbol)
+        })
         .cloned();
 
     let targets = build_approval_targets(&wrapper, symbols, ctx.evm.orderbook, USDC_BASE)?;

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -118,7 +118,9 @@ fn configured_inventory_vaults(ctx: &Ctx) -> ConfiguredInventoryVaults {
         .equities
         .symbols
         .keys()
-        .filter(|symbol| ctx.is_trading_enabled(symbol) || ctx.is_rebalancing_enabled(symbol))
+        .filter(|symbol| {
+            ctx.assets.is_trading_enabled(symbol) || ctx.assets.is_rebalancing_enabled(symbol)
+        })
         .cloned()
         .collect();
 

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -197,7 +197,7 @@ where
 
         let eligible: Vec<Symbol> = all_positions
             .iter()
-            .filter(|(symbol, _)| self.ctx.is_trading_enabled(symbol))
+            .filter(|(symbol, _)| self.ctx.assets.is_trading_enabled(symbol))
             .filter(|(symbol, _)| {
                 if active_transfers.contains(symbol) {
                     debug!(%symbol, "Skipping hedge: equity transfer in progress");

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1774,7 +1774,7 @@ impl RebalancingService {
                     if *amount == FractionalShares::ZERO {
                         continue;
                     }
-                    if !self.is_wrapped_equity_recovery_enabled(symbol) {
+                    if !self.config.assets.is_wrapped_equity_recovery_enabled(symbol) {
                         continue;
                     }
 
@@ -1844,7 +1844,7 @@ impl RebalancingService {
                     if *amount == FractionalShares::ZERO {
                         continue;
                     }
-                    if !self.is_wrapped_equity_recovery_enabled(symbol) {
+                    if !self.config.assets.is_wrapped_equity_recovery_enabled(symbol) {
                         continue;
                     }
 
@@ -2508,15 +2508,6 @@ impl RebalancingService {
             } => FractionalShares::from_u256_18_decimals(*unwrapped_amount),
             Completed { .. } | Failed { .. } | Reconciled { .. } => Ok(FractionalShares::ZERO),
         }
-    }
-
-    fn is_wrapped_equity_recovery_enabled(&self, symbol: &Symbol) -> bool {
-        self.config
-            .assets
-            .equities
-            .symbols
-            .get(symbol)
-            .is_some_and(|config| config.wrapped_equity_recovery == OperationMode::Enabled)
     }
 
     /// Checks inventory for equity imbalance and triggers operation if needed.
@@ -4041,7 +4032,11 @@ impl RebalancingService {
                 let is_pre_wrap_post_receipt_state =
                     matches!(entity, TokensReceived { .. } | WrapSubmitted { .. });
 
-                if is_pre_wrap_post_receipt_state && self.is_wrapped_equity_recovery_enabled(symbol)
+                if is_pre_wrap_post_receipt_state
+                    && self
+                        .config
+                        .assets
+                        .is_wrapped_equity_recovery_enabled(symbol)
                 {
                     self.mark_equity_held_for_recovery(symbol);
                 } else {

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -171,7 +171,7 @@ where
         let symbol_lock = get_symbol_lock(trade.symbol.base()).await;
         let _guard = symbol_lock.lock().await;
 
-        let trading_enabled = ctx.ctx.is_trading_enabled(trade.symbol.base());
+        let trading_enabled = ctx.ctx.assets.is_trading_enabled(trade.symbol.base());
 
         process_queued_trade(
             &ctx.executor,

--- a/src/vault_registry.rs
+++ b/src/vault_registry.rs
@@ -570,7 +570,7 @@ impl SeedVaultRegistryCtx {
         ctx: &Ctx,
     ) -> Result<Self, Box<CtxError>> {
         for (symbol, equity_config) in &ctx.assets.equities.symbols {
-            if equity_config.vault_ids.is_empty() && ctx.is_rebalancing_enabled(symbol) {
+            if equity_config.vault_ids.is_empty() && ctx.assets.is_rebalancing_enabled(symbol) {
                 return Err(Box::new(CtxError::MissingEquityVaultId {
                     symbol: symbol.clone(),
                 }));


### PR DESCRIPTION
## What

- Move the four per-asset config guards `is_trading_enabled`, `is_rebalancing_enabled`, `is_wrapped_equity_recovery_enabled`, and `tokenized_equity` from `impl Ctx` onto `impl AssetsConfig`, joining `is_extended_hours_enabled` / `any_extended_hours_enabled` which already lived there.
- Every caller now uses one convention — `ctx.assets.X(symbol)` (or `assets.X(symbol)` where only an `&AssetsConfig` is in scope) — instead of mixing `ctx.is_trading_enabled(sym)` with `ctx.assets.is_extended_hours_enabled(sym)`.
- Delete the rebalancing trigger's duplicate `is_wrapped_equity_recovery_enabled` reimplementation and route its callers through the shared guard.

## Why

- The two extended-hours guards lived on `AssetsConfig` while the four siblings lived on `Ctx`, so callers holding a `Ctx` mixed two conventions. Flagged in every review pass of #915. Closes [RAI-1174](https://linear.app/makeitrain/issue/RAI-1174).
- `AssetsConfig` owns the `[assets.equities]` map, so it is the natural home: code holding only an `&AssetsConfig` (e.g. `onchain/accumulator.rs`) can reach every guard without threading a `Ctx`.

## How

- Guards moved verbatim (logic unchanged), retargeting `self.assets.equities` to `self.equities`.
- Call sites swept to `ctx.assets.X` across `conductor.rs`, `position_check.rs`, `trade_accountant.rs`, `conductor/builder.rs`, `vault_registry.rs`, `cli/trading.rs`, `cli/rebalancing.rs`, and the `loader.rs` config tests.
- `rebalancing/trigger/mod.rs`: removed the struct's own copy of the guard; its three call sites now use `self.config.assets.is_wrapped_equity_recovery_enabled`.

## Testing

- Pure refactor — no new tests. Existing config guard tests pass against the relocated methods; 381 trigger / vault_registry / position_check tests pass; workspace clippy + fmt clean.

## Anything else

- No behavior, schema, or config change. Stacked on #932.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of per-symbol feature gating for trading, rebalancing, and wrapped-equity recovery across CLI flows, trading execution, recovery eligibility, and periodic position checks.
  * Updated tokenization/redemption token address resolution to use the latest configuration source for configured symbols, keeping the same `None` behavior for unknown ones.
  * Refined symbol selection used for startup approvals, inventory polling, and vault validation.
* **Tests**
  * Adjusted unit tests to match the updated symbol enablement lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->