### PR TITLE
docs: document missing CLI commands in cli-ops.md

### DIFF
--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -179,10 +179,15 @@ stox alpaca-convert -d to-usdc -a 1000   # USD -> USDC (for withdrawals)
 Addresses must be whitelisted before Alpaca will send withdrawals to them:
 
 ```
-stox alpaca-whitelist -a 0x...       # Whitelist an address
-stox alpaca-whitelist-list           # List whitelisted addresses
-stox alpaca-unwhitelist -a 0x...     # Remove an address
+stox alpaca-whitelist -a 0x...              # Whitelist an address
+stox alpaca-whitelist-list                  # List whitelisted addresses
+stox alpaca-unwhitelist -a 0x...            # Remove an address
+stox alpaca-whitelist-patch-travel-rule     # Patch travel rule info on all whitelisted addresses
 ```
+
+`alpaca-whitelist-patch-travel-rule` updates every whitelisted address with the
+beneficiary identity from `[broker.travel_rule]` in the config. Required for
+addresses whitelisted before the travel rule deadline took effect.
 
 ### Transfer History
 
@@ -195,6 +200,16 @@ stox alpaca-transfers --pending      # Only pending transfers
 
 ```
 stox alpaca-tokenization-requests
+```
+
+### Equity Journaling Between Accounts
+
+Use `alpaca-journal` to transfer equity shares from the configured Alpaca
+account to another account under the same broker firm via a security journal
+(JNLS):
+
+```
+stox alpaca-journal --to <destination-account-id> -s COIN -q 10
 ```
 
 ### Rechecking Failed Equity Transfers
@@ -237,7 +252,8 @@ The command prints the recovery outcome: `recovered`, `resumed`,
 Not covered by `transfer recheck` yet:
 
 - Mint requests rejected before Alpaca acceptance. There is no provider
-  completion to discover.
+  completion to discover. Use `transfer fail --kind mint` (see below) to
+  force-fail a mint stuck at `MintRequested`.
 - Mints that failed after receiving tokens (wrapping/deposit failures). The
   tokens already left the issuer, so provider-completion recovery does not
   apply.
@@ -259,6 +275,25 @@ Not covered by `transfer recheck` yet:
   `/transfers/resume` endpoint (always resumes ALL interrupted transfers, no
   per-id filter; each succeeds or fails independently and failures are reported
   as counts with a non-zero exit). Requires the bot to be running.
+
+### Force-Failing Stuck Mint or Redemption Transfers
+
+Use `transfer fail` to force a stuck mint or redemption to the terminal `Failed`
+state when no automatic recovery path applies. Operates directly on the local
+CQRS state; the bot need not be running, but must not be concurrently driving
+the same id. `--reason` is required and persisted as the audit record.
+
+```
+# Force-fail a mint stuck at MintRequested (provider never accepted it)
+stox transfer fail --kind mint --id <issuer-request-id> --reason "rejected by provider, no fill"
+
+# Force-fail a redemption stuck without a recovery path
+stox transfer fail --kind redemption --id <redemption-aggregate-id> --reason "stuck, handled manually"
+```
+
+After force-failing, use `transfer reconcile` (see "Reconciling Stuck Failed
+Transfers" below) if the stranded funds were already handled out-of-band and the
+transfer should be marked resolved rather than left in `Failed`.
 
 ### Withdrawal poll inconclusive (Alpaca->Base stuck at `Withdrawing`)
 


### PR DESCRIPTION
## What

Documents three CLI commands and one operator recovery path that exist in the
code but were absent from `docs/cli-ops.md`:

- `alpaca-whitelist-patch-travel-rule` — patches travel rule info on all
  whitelisted addresses (added to the Address Whitelisting section)
- `alpaca-journal` — journals equity shares between Alpaca accounts (new
  section)
- `transfer fail --kind mint/redemption` — force-fails a stuck mint or
  redemption to the terminal `Failed` state (new section)
- Updates the "Not covered by `transfer recheck` yet" bullet for
  `MintRequested` mints to point to `transfer fail` (added in #818)

## Why

These commands have been live in the binary but undocumented, so operators
relying on `docs/cli-ops.md` as the runbook had no reference for them.
In particular, the `transfer fail --kind mint` path for mints stuck at
`MintRequested` (#818) closed the last gap in the recovery-CLI coverage matrix
but left the cli-ops "not covered" list stale.

## How

Pure documentation change — no code modifications. Each addition was verified
against the CLI source (`src/cli/mod.rs`, `src/cli/alpaca_wallet.rs`,
`src/cli/rebalancing.rs`) to confirm command names, flags, and behavior.

## Testing

No code changed; docs-only. Verified against CLI source.

## Anything else

`crates/execution/AGENTS.md`, `docs/domain.md`, `docs/cqrs.md`,
`docs/conductor.md`, `docs/alloy.md`, `docs/float.md`, and `docs/observability.md`
were reviewed and found current — no changes needed there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9cuS2qqjTXwMpduqFmhwD)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785208180&installation_id=125569124&pr_number=946&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F946&signature=145d3676ae5967851155434487f2260428034a99a06836235f42c947f813d3eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded operator CLI guidance for Alpaca workflows, including explicit address whitelisting and travel-rule behavior.
  * Added instructions for equity journaling between accounts and provided example commands.
  * Clarified handling of failed equity transfers, including what can’t be recovered via recheck and how to use failure commands for stuck mint/redemption transfers, plus reconciliation follow-ups when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->