### PR TITLE
fix: redrive inconclusive Alpaca withdrawals

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2381,6 +2381,13 @@ terminal states only.
   ID) before entering `WithdrawalSubmitting` and adding a corresponding resume
   arm in `resume_alpaca_to_base`. This is deferred work; for now the operator is
   alerted and must reconcile manually.
+- **`Withdrawing{AlpacaToBase}` / `WithdrawalComplete{AlpacaToBase}` ARE
+  auto-re-armed on startup**: The Alpaca transfer ID is durably recorded in
+  `Withdrawing`; `resume_alpaca_to_base` re-polls the same transfer
+  (idempotent). `WithdrawalComplete` means the source withdrawal already moved
+  funds into the market-maker wallet; resume scans for an existing CCTP burn
+  before submitting one. Startup recovery enqueues a fresh
+  `TransferUsdcToMarketMaking` job for either state when no live job row exists.
 - **Unresolved/unparseable aggregate IDs**: Aggregates that are missing from the
   store or have unparseable IDs also latch the guard with an operator alert.
   These indicate store inconsistency and require manual investigation.
@@ -2399,6 +2406,34 @@ Alpaca to Base:
 2. Poll Alpaca until conversion order is filled
 3. Initiate USDC withdrawal from Alpaca (get transfer_id)
 4. Poll Alpaca API until withdrawal status is COMPLETE
+   - **Poll inconclusive durability**: if `poll_transfer_until_complete` returns
+     any indeterminate error (30-minute timeout, transport/network error,
+     non-retried API error), the job does NOT emit `FailWithdrawal`. The
+     aggregate stays in `Withdrawing` (guard held, Alpaca transfer ID recorded).
+     The job schedules an unbounded delayed redrive (like
+     `SettlementCheckTransient`). On re-pickup, `resume_alpaca_to_base` re-polls
+     the same Alpaca transfer via the recorded ID: if Alpaca now reports
+     Complete the withdrawal is adopted; if Failed with no returned tx hash,
+     `FailWithdrawal` is emitted normally; if Failed with a tx hash, or if still
+     in progress, another delayed redrive fires. Only `TransferStatus::Failed`
+     with no returned tx hash (Alpaca's determinate terminal for a withdrawal
+     that did not broadcast on-chain) is safe to auto-emit `FailWithdrawal`.
+
+     This closes the re-withdrawal window: `Withdrawing` holds the guard so no
+     new withdrawal starts while the prior one may still be in progress. If the
+     chain later strands at `WithdrawalComplete`, the guard is also preserved
+     and the same market-making redrive resumes from the recorded state.
+     Re-polling is idempotent (reads only; never re-initiates the withdrawal),
+     so unbounded redrives are safe. An operator can interrupt via
+     `transfer resume` at any time to manually re-drive.
+
+     **Operator alert (deadline-based)**: at or after 4 hours of inconclusive
+     polling (measured from `Withdrawing.initiated_at`, a durable aggregate
+     field that survives restarts) the job begins paging the operator on every
+     redrive while still keeping the guard held and continuing to re-poll. The
+     4-hour threshold gives headroom above the 30-minute internal poll timeout
+     while ensuring a permanent failure (rotated credentials, Alpaca API shape
+     change) surfaces well before it becomes a multi-day outage.
    - **Settlement gate (before proceeding):** wait for the withdrawal tx to
      reach the required confirmations on Ethereum. Alpaca marks a withdrawal
      "Complete" before the on-chain tx is settled network-wide on load-balanced
@@ -3150,8 +3185,9 @@ event state on startup, so a restart between a post-burn failure and settlement
 cannot re-open the re-burn window. Any aggregate not in a clearable-terminal
 state (success, or a pre-burn failure that reconciles to source) re-asserts the
 guard at boot and blocks new USDC rebalancing until it settles or an operator
-recovers it. USDC bridges are not auto-resumed on restart, so the guard is held
-until manual recovery.
+recovers it. Supported stranded states are re-armed with idempotent transfer
+jobs on startup; unsupported states keep the guard held and page the operator
+for manual recovery.
 
 **Operator recovery of a pre-burn stranded guard latch**: A USDC rebalance can
 become stranded in `WithdrawalComplete` (pre-bridging, no burn intent recorded)

--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -493,6 +493,7 @@ impl AlpacaBrokerMock {
         register_whitelist_post_endpoint(&self.server, &self.state);
         register_wallet_transfers_post_endpoint(&self.server, &self.state);
         register_wallet_transfers_get_endpoint(&self.server, &self.state);
+        register_wallet_transfer_get_by_id_endpoint(&self.server, &self.state);
     }
 
     /// Returns a snapshot of all wallet transfers.
@@ -1758,57 +1759,99 @@ fn register_wallet_transfers_get_endpoint(server: &MockServer, state: &Arc<Mutex
                 let mut state = lock(&state);
 
                 for transfer in &mut state.wallet_transfers {
-                    let is_pending = matches!(
-                        transfer.status,
-                        TransferStatus::Pending | TransferStatus::Processing
-                    );
-                    if is_pending {
-                        transfer.poll_count += 1;
-
-                        if transfer.poll_count >= transfer.polls_until_complete {
-                            transfer.status = TransferStatus::Complete;
-                            if transfer.tx_hash.is_empty() {
-                                transfer.tx_hash = format!("0x{}", "cd".repeat(32));
-                            }
-                        } else {
-                            transfer.status = TransferStatus::Processing;
-                        }
-                    }
+                    advance_wallet_transfer_status(transfer);
                 }
 
                 state
                     .wallet_transfers
                     .iter()
-                    .map(|transfer| {
-                        let tx_hash: Value = if transfer.tx_hash.is_empty() {
-                            Value::Null
-                        } else {
-                            Value::String(transfer.tx_hash.clone())
-                        };
-                        let amount = format_float_with_fallback(&transfer.amount);
-
-                        json!({
-                            "id": transfer.transfer_id,
-                            "direction": transfer.direction.to_string(),
-                            "amount": amount.as_str(),
-                            "usd_value": amount.as_str(),
-                            "asset": transfer.asset,
-                            "chain": "ETH",
-                            "from_address": transfer.from_address,
-                            "to_address": transfer.to_address,
-                            "status": transfer.status.to_string(),
-                            "tx_hash": tx_hash,
-                            "created_at": "2025-01-01T00:00:00Z",
-                            "network_fee": "0",
-                            "fees": "0"
-                        })
-                    })
+                    .map(wallet_transfer_response)
                     .collect()
             };
 
             json_response(200, &Value::Array(transfers))
         });
     });
+}
+
+fn register_wallet_transfer_get_by_id_endpoint(server: &MockServer, state: &Arc<Mutex<MockState>>) {
+    let state = Arc::clone(state);
+    let prefix = format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/");
+
+    server.mock(|when, then| {
+        when.method(GET).path_prefix(&prefix);
+        then.respond_with(move |request: &HttpMockRequest| {
+            let path = request.uri().path().to_string();
+            let transfer_id = path.strip_prefix(&prefix).unwrap_or("");
+
+            if transfer_id.is_empty() || transfer_id.contains('/') {
+                return json_response(404, &json!({"message": "transfer not found"}));
+            }
+
+            let Some(response_body) = wallet_transfer_response_by_id(&state, transfer_id) else {
+                return json_response(404, &json!({"message": "transfer not found"}));
+            };
+
+            json_response(200, &response_body)
+        });
+    });
+}
+
+fn wallet_transfer_response_by_id(state: &Mutex<MockState>, transfer_id: &str) -> Option<Value> {
+    let mut state = lock(state);
+    let transfer = state
+        .wallet_transfers
+        .iter_mut()
+        .find(|transfer| transfer.transfer_id == transfer_id)?;
+
+    advance_wallet_transfer_status(transfer);
+    let response = wallet_transfer_response(transfer);
+    drop(state);
+
+    Some(response)
+}
+
+fn advance_wallet_transfer_status(transfer: &mut MockWalletTransfer) {
+    match transfer.status {
+        TransferStatus::Pending | TransferStatus::Processing => {}
+        TransferStatus::Complete => return,
+    }
+
+    transfer.poll_count += 1;
+
+    if transfer.poll_count >= transfer.polls_until_complete {
+        transfer.status = TransferStatus::Complete;
+        if transfer.tx_hash.is_empty() {
+            transfer.tx_hash = format!("0x{}", "cd".repeat(32));
+        }
+    } else {
+        transfer.status = TransferStatus::Processing;
+    }
+}
+
+fn wallet_transfer_response(transfer: &MockWalletTransfer) -> Value {
+    let tx_hash: Value = if transfer.tx_hash.is_empty() {
+        Value::Null
+    } else {
+        Value::String(transfer.tx_hash.clone())
+    };
+    let amount = format_float_with_fallback(&transfer.amount);
+
+    json!({
+        "id": transfer.transfer_id,
+        "direction": transfer.direction.to_string(),
+        "amount": amount.as_str(),
+        "usd_value": amount.as_str(),
+        "asset": transfer.asset,
+        "chain": "ETH",
+        "from_address": transfer.from_address,
+        "to_address": transfer.to_address,
+        "status": transfer.status.to_string(),
+        "tx_hash": tx_hash,
+        "created_at": "2025-01-01T00:00:00Z",
+        "network_fee": "0",
+        "fees": "0"
+    })
 }
 
 /// Formats a U256 raw amount as a USDC decimal string (6 decimal places).
@@ -1946,6 +1989,70 @@ mod tests {
         // Beyond u64::MAX - the bug the refactor fixed
         let beyond_u64 = U256::from(u64::MAX) + U256::from(1);
         assert_eq!(format_u256_as_usdc(beyond_u64), "18446744073709.551616");
+    }
+
+    #[tokio::test]
+    async fn wallet_transfer_by_id_endpoint_returns_single_transfer_and_advances_status() {
+        let broker = AlpacaBrokerMock::start()
+            .symbol_fill_prices(vec![])
+            .symbol_positions(vec![])
+            .call()
+            .await;
+        let owner = Address::random();
+        broker.set_wallet_usdc_balance(float!(25));
+        broker.register_wallet_endpoints(owner);
+
+        let client = reqwest::Client::new();
+        let transfer_url = format!(
+            "{}/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers",
+            broker.base_url()
+        );
+        let created: serde_json::Value = client
+            .post(&transfer_url)
+            .json(&serde_json::json!({
+                "amount": "12.5",
+                "asset": "USDC",
+                "address": format!("{owner:#x}")
+            }))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let transfer_id = created["id"].as_str().unwrap();
+        let by_id_url = format!("{transfer_url}/{transfer_id}");
+
+        let first_poll: serde_json::Value = client
+            .get(&by_id_url)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(first_poll["id"], transfer_id);
+        assert_eq!(first_poll["status"], "PROCESSING");
+        assert!(first_poll["tx_hash"].is_null());
+
+        let second_poll: serde_json::Value = client
+            .get(&by_id_url)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(second_poll["id"], transfer_id);
+        assert_eq!(second_poll["status"], "COMPLETE");
+        assert!(second_poll["tx_hash"].as_str().unwrap().starts_with("0x"));
+
+        let missing = client
+            .get(format!("{transfer_url}/missing-transfer-id"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(missing.status().as_u16(), 404);
     }
 
     #[test]

--- a/crates/execution/src/alpaca_wallet/client.rs
+++ b/crates/execution/src/alpaca_wallet/client.rs
@@ -25,6 +25,11 @@ pub enum AlpacaWalletError {
     FromHex(#[from] FromHexError),
     #[error("Transfer not found: {transfer_id}")]
     TransferNotFound { transfer_id: AlpacaTransferId },
+    #[error("Transfer {transfer_id} failed but reported on-chain tx {tx_hash}")]
+    FailedTransferHasTx {
+        transfer_id: AlpacaTransferId,
+        tx_hash: TxHash,
+    },
     #[error("Transfer {transfer_id} timed out after {elapsed:?}")]
     TransferTimeout {
         transfer_id: AlpacaTransferId,

--- a/crates/execution/src/alpaca_wallet/mod.rs
+++ b/crates/execution/src/alpaca_wallet/mod.rs
@@ -401,11 +401,12 @@ mod tests {
         let transfer_id = Uuid::new_v4();
 
         let status_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+            when.method(GET).path(format!(
+                "/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers/{transfer_id}"
+            ));
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!([{
+                .json_body(json!({
                     "id": transfer_id,
                     "direction": "OUTGOING",
                     "amount": "100",
@@ -419,7 +420,7 @@ mod tests {
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0.5",
                     "fees": "0"
-                }]));
+                }));
         });
 
         let tid = transfer::AlpacaTransferId::from(transfer_id);

--- a/crates/execution/src/alpaca_wallet/status.rs
+++ b/crates/execution/src/alpaca_wallet/status.rs
@@ -290,11 +290,12 @@ mod tests {
         let transfer_id = Uuid::new_v4();
 
         let complete_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body_obj(&json!([{
+                .json_body_obj(&json!({
                     "id": transfer_id,
                     "direction": "OUTGOING",
                     "amount": "100.0",
@@ -308,7 +309,7 @@ mod tests {
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0.5",
                     "fees": "0"
-                }]));
+                }));
         });
 
         let client = AlpacaWalletClient::new(
@@ -341,11 +342,12 @@ mod tests {
         let transfer_id = Uuid::new_v4();
 
         let status_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body_obj(&json!([{
+                .json_body_obj(&json!({
                     "id": transfer_id,
                     "direction": "OUTGOING",
                     "amount": "100.0",
@@ -359,7 +361,7 @@ mod tests {
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0",
                     "fees": "0"
-                }]));
+                }));
         });
 
         let client = AlpacaWalletClient::new(
@@ -392,11 +394,12 @@ mod tests {
         let transfer_id = Uuid::new_v4();
 
         let status_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body_obj(&json!([{
+                .json_body_obj(&json!({
                     "id": transfer_id,
                     "direction": "OUTGOING",
                     "amount": "100.0",
@@ -410,7 +413,7 @@ mod tests {
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0.5",
                     "fees": "0"
-                }]));
+                }));
         });
 
         let client = AlpacaWalletClient::new(
@@ -443,8 +446,9 @@ mod tests {
         let transfer_id = Uuid::new_v4();
 
         let error_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(503).body("Service Unavailable");
         });
 
@@ -489,11 +493,12 @@ mod tests {
         ));
 
         let mut processing_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body_obj(&json!([{
+                .json_body_obj(&json!({
                     "id": transfer_id,
                     "direction": "OUTGOING",
                     "amount": "100.0",
@@ -507,7 +512,7 @@ mod tests {
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0.5",
                     "fees": "0"
-                }]));
+                }));
         });
 
         let config = PollingConfig {
@@ -531,11 +536,12 @@ mod tests {
         processing_mock.delete();
 
         let pending_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body_obj(&json!([{
+                .json_body_obj(&json!({
                     "id": transfer_id,
                     "direction": "OUTGOING",
                     "amount": "100.0",
@@ -549,7 +555,7 @@ mod tests {
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0.5",
                     "fees": "0"
-                }]));
+                }));
         });
 
         let error = poll_handle.await.unwrap().unwrap_err();

--- a/crates/execution/src/alpaca_wallet/transfer.rs
+++ b/crates/execution/src/alpaca_wallet/transfer.rs
@@ -6,6 +6,7 @@
 
 use alloy::primitives::{Address, TxHash};
 use chrono::{DateTime, Utc};
+use reqwest::StatusCode;
 use serde::{Deserialize, Deserializer, Serialize};
 use uuid::Uuid;
 
@@ -199,19 +200,27 @@ pub(super) async fn get_transfer_status(
     client: &AlpacaWalletClient,
     transfer_id: &AlpacaTransferId,
 ) -> Result<Transfer, AlpacaWalletError> {
-    // Fetch all transfers and filter by ID on our side.
-    // The API's transfer_id query param appears to be unreliable.
-    let path = format!("/v1/accounts/{}/wallets/transfers", client.account_id());
+    // Use the documented by-id endpoint for a single transfer:
+    // https://docs.alpaca.markets/us/reference/getcryptofundingtransfer-1.
+    // The list endpoint returns an account-wide array and has no documented
+    // transfer_id filter, so status polling must not depend on client-side
+    // filtering of a potentially capped transfer list.
+    let path = format!(
+        "/v1/accounts/{}/wallets/transfers/{}",
+        client.account_id(),
+        transfer_id
+    );
 
-    let body = client.get(&path).await?;
-    let transfers: Vec<Transfer> = serde_json::from_str(&body)?;
+    let body = client.get(&path).await.map_err(|error| match error {
+        AlpacaWalletError::ApiError { status, .. } if status == StatusCode::NOT_FOUND => {
+            AlpacaWalletError::TransferNotFound {
+                transfer_id: *transfer_id,
+            }
+        }
+        error => error,
+    })?;
 
-    transfers
-        .into_iter()
-        .find(|transfer| transfer.id == *transfer_id)
-        .ok_or_else(|| AlpacaWalletError::TransferNotFound {
-            transfer_id: *transfer_id,
-        })
+    Ok(serde_json::from_str(&body)?)
 }
 
 /// Lists all transfers for the account.
@@ -461,44 +470,27 @@ mod tests {
     async fn test_get_transfer_status_pending() {
         let server = MockServer::start();
         let transfer_id = Uuid::new_v4();
-        let other_transfer_id = Uuid::new_v4();
         let status_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!([
-                    {
-                        "id": other_transfer_id,
-                        "direction": "INCOMING",
-                        "amount": "50.0",
-                        "usd_value": "49.99",
-                        "chain": "ETH",
-                        "asset": "USDC",
-                        "from_address": "0x9999999999999999999999999999999999999999",
-                        "to_address": "0x1234567890abcdef1234567890abcdef12345678",
-                        "status": "COMPLETE",
-                        "tx_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-                        "created_at": "2024-01-01T00:00:00Z",
-                        "network_fee": "0",
-                        "fees": "0"
-                    },
-                    {
-                        "id": transfer_id,
-                        "direction": "OUTGOING",
-                        "amount": "100.0",
-                        "usd_value": "99.98",
-                        "chain": "ETH",
-                        "asset": "USDC",
-                        "from_address": "0xabcdef1234567890abcdef1234567890abcdef12",
-                        "to_address": "0x1234567890abcdef1234567890abcdef12345678",
-                        "status": "PENDING",
-                        "tx_hash": null,
-                        "created_at": "2024-01-01T00:00:00Z",
-                        "network_fee": "0.5",
-                        "fees": "0"
-                    }
-                ]));
+                .json_body(json!({
+                    "id": transfer_id,
+                    "direction": "OUTGOING",
+                    "amount": "100.0",
+                    "usd_value": "99.98",
+                    "chain": "ETH",
+                    "asset": "USDC",
+                    "from_address": "0xabcdef1234567890abcdef1234567890abcdef12",
+                    "to_address": "0x1234567890abcdef1234567890abcdef12345678",
+                    "status": "PENDING",
+                    "tx_hash": null,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0.5",
+                    "fees": "0"
+                }));
         });
 
         let client = AlpacaWalletClient::new(
@@ -523,11 +515,12 @@ mod tests {
         let server = MockServer::start();
         let transfer_id = Uuid::new_v4();
         let status_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!([{
+                .json_body(json!({
                     "id": transfer_id,
                     "direction": "OUTGOING",
                     "amount": "100.0",
@@ -541,7 +534,7 @@ mod tests {
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0.5",
                     "fees": "0"
-                }]));
+                }));
         });
 
         let client = AlpacaWalletClient::new(
@@ -566,11 +559,12 @@ mod tests {
         let server = MockServer::start();
         let transfer_id = Uuid::new_v4();
         let status_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!([{
+                .json_body(json!({
                     "id": transfer_id,
                     "direction": "OUTGOING",
                     "amount": "100.0",
@@ -584,7 +578,7 @@ mod tests {
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0.5",
                     "fees": "0"
-                }]));
+                }));
         });
 
         let client = AlpacaWalletClient::new(
@@ -608,11 +602,12 @@ mod tests {
         let server = MockServer::start();
         let transfer_id = Uuid::new_v4();
         let status_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!([{
+                .json_body(json!({
                     "id": transfer_id,
                     "direction": "OUTGOING",
                     "amount": "100.0",
@@ -626,7 +621,7 @@ mod tests {
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0",
                     "fees": "0"
-                }]));
+                }));
         });
 
         let client = AlpacaWalletClient::new(
@@ -649,27 +644,13 @@ mod tests {
     async fn test_get_transfer_status_not_found() {
         let server = MockServer::start();
         let transfer_id = Uuid::new_v4();
-        let other_transfer_id = Uuid::new_v4();
         let status_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
-            then.status(200)
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
+            then.status(404)
                 .header("content-type", "application/json")
-                .json_body(json!([{
-                    "id": other_transfer_id,
-                    "direction": "INCOMING",
-                    "amount": "50.0",
-                    "usd_value": "49.99",
-                    "chain": "ETH",
-                    "asset": "USDC",
-                    "from_address": "0x9999999999999999999999999999999999999999",
-                    "to_address": "0x1234567890abcdef1234567890abcdef12345678",
-                    "status": "COMPLETE",
-                    "tx_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-                    "created_at": "2024-01-01T00:00:00Z",
-                    "network_fee": "0",
-                    "fees": "0"
-                }]));
+                .json_body(json!({ "message": "transfer not found" }));
         });
 
         let client = AlpacaWalletClient::new(
@@ -693,8 +674,9 @@ mod tests {
         let server = MockServer::start();
         let transfer_id = Uuid::new_v4();
         let status_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(500).body("Internal Server Error");
         });
 
@@ -722,8 +704,9 @@ mod tests {
         let server = MockServer::start();
         let transfer_id = Uuid::new_v4();
         let status_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(200)
                 .header("content-type", "application/json")
                 .body("not valid json");
@@ -745,83 +728,34 @@ mod tests {
         status_mock.assert();
     }
 
-    /// Regression test: The Alpaca API ignores the transfer_id query parameter
-    /// and returns all transfers. A previous bug blindly took the first
-    /// transfer from the response, causing the wrong transfer to be returned.
-    /// This test verifies we correctly filter by transfer ID on our side.
+    /// Regression test: status polling must use Alpaca's by-id endpoint rather
+    /// than the list endpoint, so an account-wide response cap cannot hide an
+    /// older in-flight withdrawal.
     #[tokio::test]
-    async fn test_get_transfer_status_finds_correct_transfer_among_many() {
+    async fn test_get_transfer_status_uses_by_id_endpoint() {
         let server = MockServer::start();
-        let target_transfer_id = Uuid::new_v4();
+        let transfer_id = Uuid::new_v4();
 
-        // Simulate the API returning many transfers in arbitrary order.
-        // The target transfer is buried in the middle.
         let status_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            when.method(GET).path(format!(
+                "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers/{transfer_id}"
+            ));
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!([
-                    {
-                        "id": Uuid::new_v4(),
-                        "direction": "INCOMING",
-                        "amount": "0.01",
-                        "usd_value": "0.01",
-                        "chain": "ETH",
-                        "asset": "USDC",
-                        "from_address": "0x1111111111111111111111111111111111111111",
-                        "to_address": "0xF48c3Bcb8981ed53DcA2455D7462EAAAC20ee760",
-                        "status": "COMPLETE",
-                        "tx_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-                        "created_at": "2024-12-19T22:29:36Z",
-                        "network_fee": "0",
-                        "fees": "0"
-                    },
-                    {
-                        "id": Uuid::new_v4(),
-                        "direction": "INCOMING",
-                        "amount": "0.01",
-                        "usd_value": "0.01",
-                        "chain": "ETH",
-                        "asset": "USDC",
-                        "from_address": "0x2222222222222222222222222222222222222222",
-                        "to_address": "0xF48c3Bcb8981ed53DcA2455D7462EAAAC20ee760",
-                        "status": "COMPLETE",
-                        "tx_hash": "0x2222222222222222222222222222222222222222222222222222222222222222",
-                        "created_at": "2024-12-20T10:00:00Z",
-                        "network_fee": "0",
-                        "fees": "0"
-                    },
-                    {
-                        "id": target_transfer_id,
-                        "direction": "OUTGOING",
-                        "amount": "100",
-                        "usd_value": "99.98",
-                        "chain": "ETH",
-                        "asset": "USDC",
-                        "from_address": "0xA0D2C7210D7e2112A4F7888B8658CB579226dB3B",
-                        "to_address": "0x5A379C330c84Af97864507FfeA4c23aEAF3476d9",
-                        "status": "PROCESSING",
-                        "created_at": "2024-12-26T20:43:29Z",
-                        "network_fee": "0.5",
-                        "fees": "0"
-                    },
-                    {
-                        "id": Uuid::new_v4(),
-                        "direction": "INCOMING",
-                        "amount": "0.01",
-                        "usd_value": "0.01",
-                        "chain": "ETH",
-                        "asset": "USDC",
-                        "from_address": "0x3333333333333333333333333333333333333333",
-                        "to_address": "0xF48c3Bcb8981ed53DcA2455D7462EAAAC20ee760",
-                        "status": "COMPLETE",
-                        "tx_hash": "0x3333333333333333333333333333333333333333333333333333333333333333",
-                        "created_at": "2024-12-21T15:00:00Z",
-                        "network_fee": "0",
-                        "fees": "0"
-                    }
-                ]));
+                .json_body(json!({
+                    "id": transfer_id,
+                    "direction": "OUTGOING",
+                    "amount": "100",
+                    "usd_value": "99.98",
+                    "chain": "ETH",
+                    "asset": "USDC",
+                    "from_address": "0xA0D2C7210D7e2112A4F7888B8658CB579226dB3B",
+                    "to_address": "0x5A379C330c84Af97864507FfeA4c23aEAF3476d9",
+                    "status": "PROCESSING",
+                    "created_at": "2024-12-26T20:43:29Z",
+                    "network_fee": "0.5",
+                    "fees": "0"
+                }));
         });
 
         let client = AlpacaWalletClient::new(
@@ -831,18 +765,18 @@ mod tests {
             "test_secret_key".to_string(),
         );
 
-        let transfer = get_transfer_status(&client, &AlpacaTransferId::from(target_transfer_id))
+        let transfer = get_transfer_status(&client, &AlpacaTransferId::from(transfer_id))
             .await
             .unwrap();
 
         assert_eq!(
             transfer.id,
-            AlpacaTransferId::from(target_transfer_id),
-            "Should return the transfer with matching ID, not the first one in the list"
+            AlpacaTransferId::from(transfer_id),
+            "status polling must request the transfer by ID"
         );
         assert!(
             transfer.amount.eq(float!(100)).unwrap(),
-            "Should return the 100 USDC withdrawal, not a 0.01 USDC deposit"
+            "status polling must parse the by-id transfer payload"
         );
         assert_eq!(transfer.direction, TransferDirection::Outgoing);
         assert_eq!(transfer.status, TransferStatus::Processing);

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -260,6 +260,46 @@ Not covered by `transfer recheck` yet:
   per-id filter; each succeeds or fails independently and failures are reported
   as counts with a non-zero exit). Requires the bot to be running.
 
+### Withdrawal poll inconclusive (Alpaca->Base stuck at `Withdrawing`)
+
+An Alpaca withdrawal poll that returns an indeterminate error (timeout, network
+failure, non-retried API error) leaves the aggregate in `Withdrawing` with the
+guard held. It does NOT send `FailWithdrawal` and does NOT release the guard.
+The job schedules an unbounded delayed redrive that re-polls the same Alpaca
+transfer ID (idempotent -- never re-initiates the withdrawal).
+
+**Operator alert after 4 hours**: if polling remains inconclusive for more than
+4 hours from `Withdrawing.initiated_at` (a durable aggregate timestamp -- the
+countdown survives bot restarts), the job begins paging the operator on every
+redrive while still keeping the guard held and continuing to re-poll
+automatically. The alert message includes the transfer UUID and the elapsed
+time. Normal transient outages (< 4 hours) never fire an alert.
+
+When alerted, first check whether Alpaca connectivity/credentials are intact:
+
+    # Check the withdrawal status directly via the Alpaca API or dashboard.
+    # To manually re-poll immediately:
+    stox transfer resume --kind usdc --id <uuid> --direction to-raindex
+
+This re-polls Alpaca for the recorded transfer and proceeds normally if the
+withdrawal has completed (the common case), or emits `FailWithdrawal` if Alpaca
+reports Failed with no tx hash. If Alpaca reports Failed with a tx hash, polling
+stays inconclusive and the guard remains held. The `--direction` must be
+`to-raindex` for AlpacaToBase.
+
+**Known limitation -- permanent `TransferNotFound`**: if `transfer resume`
+consistently reports inconclusive and Alpaca's dashboard confirms the withdrawal
+UUID was never initiated or is genuinely absent from Alpaca's records, the
+automatic re-poll will loop indefinitely. This is intentional and safe: the
+guard stays held, no re-withdrawal occurs, and funds are not stranded. However,
+rebalancing remains blocked until resolved. Distinguish this from a transient
+Alpaca outage (where re-poll will eventually succeed) by verifying directly on
+the Alpaca dashboard or API that no withdrawal with the recorded UUID exists. A
+force-fail recovery verb for this exact case is a tracked follow-up. No current
+CLI command clears a `Withdrawing` aggregate whose Alpaca UUID is genuinely
+absent; escalate to the on-call engineer for direct recovery after confirming no
+funds moved.
+
 ### Clearing a pre-burn guard latch
 
 Use `fail-usdc-transfer` when a USDC rebalance is stranded at

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -203,12 +203,12 @@ const CLI_ATTESTATION_REDRIVE_DELAY: Duration = Duration::from_secs(60);
 ///
 /// `resume` is re-invoked with the same `UsdcRebalanceId` on every attempt, so a
 /// retry resumes the existing transfer instead of starting a second
-/// fund-moving one. The retryable set mirrors the worker:
-/// `AttestationTimedOut` plus the settlement-wait errors
-/// (`WithdrawalTxUnderconfirmed`, `WalletUsdcInsufficient`,
-/// `SettlementCheckTransient`). Any other error -- including
-/// `AttestationRetryDeadlineElapsed` and a previously-failed aggregate -- is
-/// terminal and returned to the caller.
+/// fund-moving one. The retryable set mirrors the worker: `AttestationTimedOut`,
+/// `WithdrawalPollInconclusive` (Alpaca API unreachable or returned a transient
+/// error), plus the settlement-wait errors (`WithdrawalTxUnderconfirmed`,
+/// `WalletUsdcInsufficient`, `SettlementCheckTransient`). Errors not in this set
+/// -- including `AttestationRetryDeadlineElapsed` and a previously-failed
+/// aggregate -- are terminal and returned to the caller.
 async fn redrive_transfer_until_settled<Resume, Fut>(
     redrive_delay: Duration,
     mut resume: Resume,
@@ -240,6 +240,21 @@ where
                     ?redrive_delay,
                     "USDC transfer settlement not yet durable for manual transfer; \
                      retrying after delay"
+                );
+                tokio::time::sleep(redrive_delay).await;
+            }
+            // WithdrawalPollInconclusive is non-terminal: Alpaca was unreachable or
+            // returned an error. The aggregate stays in Withdrawing (guard held);
+            // the automatic delayed redrive continues in the background. Retry here
+            // so the CLI polls periodically without spinning, matching the behaviour
+            // of AttestationTimedOut for Circle unavailability.
+            Err(UsdcTransferError::WithdrawalPollInconclusive { id, .. }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    ?redrive_delay,
+                    "Alpaca withdrawal poll inconclusive; Alpaca may be unreachable -- \
+                     retrying after delay (aggregate stays in Withdrawing, guard held)"
                 );
                 tokio::time::sleep(redrive_delay).await;
             }
@@ -1624,7 +1639,8 @@ mod tests {
     use st0x_config::{EvmCtx, IngestionCutoff};
     use st0x_event_sorcery::LifecycleError;
     use st0x_execution::{
-        AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, ClientOrderId, TimeInForce,
+        AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, AlpacaTransferId,
+        AlpacaWalletError, ClientOrderId, TimeInForce,
     };
     use st0x_finance::Usdc;
     use st0x_float_macro::float;
@@ -1730,6 +1746,43 @@ mod tests {
             "a deadline-elapsed outcome must surface, not be retried; got {error:?}",
         );
         assert_eq!(calls.get(), 1, "a terminal error must not be retried");
+    }
+
+    /// The manual redrive loop must also retry `WithdrawalPollInconclusive` --
+    /// otherwise a manual `stox transfer resume --kind usdc --direction to-raindex`
+    /// invocation would exit when Alpaca is temporarily unreachable instead of
+    /// waiting for recovery, leaving the operator unable to drive the stuck
+    /// withdrawal to completion via the CLI.
+    #[tokio::test]
+    async fn redrive_loop_retries_withdrawal_poll_inconclusive_then_succeeds() {
+        let calls = std::cell::Cell::new(0u32);
+
+        let result = redrive_transfer_until_settled(Duration::from_millis(0), || {
+            let attempt = calls.get() + 1;
+            calls.set(attempt);
+            async move {
+                if attempt == 1 {
+                    Err(UsdcTransferError::WithdrawalPollInconclusive {
+                        id: UsdcRebalanceId(Uuid::from_u128(42)),
+                        initiated_at: chrono::Utc::now(),
+                        source: AlpacaWalletError::TransferTimeout {
+                            transfer_id: AlpacaTransferId::from(Uuid::from_u128(1)),
+                            elapsed: std::time::Duration::from_secs(1800),
+                        },
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await;
+
+        result.expect("redrive must succeed once Alpaca becomes reachable again");
+        assert_eq!(
+            calls.get(),
+            2,
+            "the loop must retry exactly once after the inconclusive poll, then succeed",
+        );
     }
 
     /// `transfer resume --kind equity` against a mocked bot endpoint: the

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -556,6 +556,17 @@ enum UsdcTimeoutCleanup {
         tracking: usdc::UsdcRebalanceTracking,
         elapsed: Duration,
     },
+    /// The timed-out aggregate is in an Alpaca-to-Base pre-burn state whose
+    /// source withdrawal may already have moved funds, with no live apalis job.
+    /// The caller must re-enqueue a fresh `TransferUsdcToMarketMaking` redrive
+    /// rather than clearing the guard. Resume is idempotent for these states:
+    /// `Withdrawing` only re-polls Alpaca, and `WithdrawalComplete` scans for an
+    /// existing burn before submitting one. The guard stays held throughout.
+    ReArmAlpacaToBaseWithdrawal {
+        tracking: usdc::UsdcRebalanceTracking,
+        elapsed: Duration,
+        amount: Usdc,
+    },
 }
 
 /// How [`RebalancingService::rearm_stranded_transfers`] gates re-arm for a
@@ -575,6 +586,13 @@ enum RearmPolicy {
     /// means the redrive budget is exhausted with no driver -- strand it for an
     /// operator alert rather than silently resetting the counter to zero.
     MidFlightPreBurn,
+    /// Alpaca-to-Base states after the source withdrawal may have moved funds:
+    /// re-arm whenever no LIVE job row exists. Unlike `MidFlightPreBurn`, a
+    /// terminal (exhausted/Killed) job row does NOT block re-arm. Resume is
+    /// idempotent from these states and never starts a second Alpaca withdrawal,
+    /// so job-budget exhaustion means the chain lost its driver, not that the
+    /// transfer is unrecoverable.
+    AlpacaToBaseIdempotentRedrive,
 }
 
 /// A stranded USDC rebalance to re-arm on startup, with the [`RearmPolicy`] that
@@ -964,20 +982,35 @@ impl RebalancingService {
         };
 
         for id in candidate_ids {
-            // A timed-out transfer whose apalis row is still in flight is NOT
+            // A timed-out transfer whose apalis row is still live is NOT
             // abandoned: the job will resume and may have an irreversible on-chain
-            // withdraw/burn already submitted. Skip the cleanup entirely so we
-            // neither clear the in-progress guard / inventory inflight nor mark it
-            // timed-out (which would make the reactor ignore its eventual terminal
-            // event and latch the guard forever). Let apalis drive it to terminal.
-            if self.transfer_in_flight_for_id(&id).await {
-                warn!(
-                    target: "rebalance",
-                    aggregate_id = %id,
-                    "USDC transfer exceeded its timeout but its apalis row is still in \
-                     flight; deferring cleanup to the job rather than clearing the guard"
-                );
-                continue;
+            // withdraw/burn already submitted. "Live" includes retryable Failed
+            // rows (`attempts < max_attempts`), because apalis will re-fetch them
+            // on its own. Skip the cleanup entirely so we neither clear the
+            // in-progress guard / inventory inflight nor mark it timed-out (which
+            // would make the reactor ignore its eventual terminal event and latch
+            // the guard forever). Let apalis drive it to terminal.
+            match self.transfer_live_job_for_id(&id).await {
+                Ok(true) => {
+                    warn!(
+                        target: "rebalance",
+                        aggregate_id = %id,
+                        "USDC transfer exceeded its timeout but its apalis row is still live; \
+                         deferring cleanup to the job rather than clearing the guard"
+                    );
+                    continue;
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    warn!(
+                        target: "rebalance",
+                        aggregate_id = %id,
+                        ?error,
+                        "Failed to query live USDC transfer job row; treating transfer as live \
+                         for this sweep tick to avoid unsafe timeout cleanup"
+                    );
+                    continue;
+                }
             }
 
             let Some(cleanup) = self.cleanup_timed_out_usdc_rebalance(&id, now).await? else {
@@ -1047,74 +1080,42 @@ impl RebalancingService {
                         }
                     }
                 }
+                UsdcTimeoutCleanup::ReArmAlpacaToBaseWithdrawal {
+                    tracking,
+                    elapsed,
+                    amount,
+                } => {
+                    // An Alpaca-to-Base pre-burn state timed out with no live job:
+                    // re-arm a fresh `TransferUsdcToMarketMaking` redrive instead
+                    // of clearing the guard. Resume is idempotent from these states
+                    // and never starts a second Alpaca withdrawal.
+                    warn!(
+                        target: "rebalance",
+                        aggregate_id = %id,
+                        direction = ?tracking.direction,
+                        ?elapsed,
+                        "AlpacaToBase withdrawal state timed out with no live job; \
+                         re-arming TransferUsdcToMarketMaking redrive (guard preserved)"
+                    );
+                    self.transfer_usdc_to_market_making_queue
+                        .clone()
+                        .push(TransferUsdcToMarketMaking {
+                            id: id.clone(),
+                            amount,
+                            revert_redrive_attempts: 0,
+                        })
+                        .await?;
+                    self.usdc_in_progress.store(true, Ordering::SeqCst);
+                }
             }
         }
 
         Ok(())
     }
 
-    /// Returns true if a USDC transfer apalis row for `id` -- in *either*
-    /// direction -- is still non-terminal (Pending/Queued/Running). The timeout
-    /// sweeper must not clear the `usdc_in_progress` guard while such a row exists:
-    /// the resuming job may have an irreversible withdraw/burn/mint already
-    /// submitted, and clearing the guard would let a second transfer touch the same
-    /// vault/wallet.
-    ///
-    /// Checks BOTH directions (mirroring [`Self::in_flight_usdc_transfer`]): an
-    /// `AlpacaToBase` rebalance is driven by a `TransferUsdcToMarketMaking` job, so
-    /// checking only the hedging queue would miss it and clear the guard while a
-    /// market-making transfer is still in flight. Scoped to the aggregate `id`
-    /// (carried in the job payload) so an unrelated in-flight transfer never defers
-    /// this id's cleanup. On query/decode failure the safe default is to report
-    /// "in flight" so automation stays latched.
-    async fn transfer_in_flight_for_id(&self, id: &UsdcRebalanceId) -> bool {
-        // Both transfer payloads serialize as `{ id, amount, .. }`; only the id is
-        // needed to scope the sweep, so decode just that field for either direction.
-        #[derive(serde::Deserialize)]
-        struct TransferJobId {
-            id: UsdcRebalanceId,
-        }
-
-        let rows: Result<Vec<(Vec<u8>,)>, _> = sqlx_apalis::query_as(
-            "SELECT job FROM Jobs \
-             WHERE job_type IN (?, ?) \
-             AND status IN ('Pending', 'Queued', 'Running')",
-        )
-        .bind(std::any::type_name::<TransferUsdcToHedging>())
-        .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
-        .fetch_all(self.transfer_usdc_to_hedging_queue.pool())
-        .await;
-
-        match rows {
-            Ok(rows) => rows.iter().any(|(payload,)| {
-                match serde_json::from_slice::<TransferJobId>(payload) {
-                    Ok(job) => job.id == *id,
-                    Err(error) => {
-                        warn!(
-                            target: "rebalance",
-                            %error,
-                            "Failed to decode a non-terminal USDC transfer payload during \
-                             timeout sweep; treating as in flight to stay latched"
-                        );
-                        true
-                    }
-                }
-            }),
-            Err(error) => {
-                warn!(
-                    target: "rebalance",
-                    %error,
-                    "Failed to query in-flight USDC transfer rows during timeout sweep; \
-                     keeping the in-progress guard latched to avoid re-arming"
-                );
-                true
-            }
-        }
-    }
-
     /// Whether a USDC transfer apalis row for `id` exists in *either* direction in
     /// ANY status -- including terminal `Failed`/`Done`, unlike
-    /// [`Self::transfer_in_flight_for_id`].
+    /// [`Self::transfer_live_job_for_id`].
     ///
     /// Used by startup re-arm for the pre-mint-confirmation post-burn states to
     /// fire only for the true "no job row at all" strand (a failed redrive
@@ -1126,7 +1127,7 @@ impl RebalancingService {
     /// transfer is the manual `transfer resume --kind usdc` CLI, not an automatic re-arm.
     ///
     /// A recoverable post-burn `BridgingFailed` is the exception: it gates on
-    /// [`Self::transfer_in_flight_for_id`] instead (only an in-flight row blocks),
+    /// [`Self::transfer_live_job_for_id`] instead (only a live row blocks),
     /// because recovery is new work rather than a continuation of the exhausted
     /// budget. See [`Self::rearm_stranded_transfers`].
     ///
@@ -1362,8 +1363,8 @@ impl RebalancingService {
             // that a CLI `transfer reconcile` issued before the failed
             // transfer ages past `transfer_timeout` takes effect on the next
             // sweep tick rather than waiting for the full timeout window.
-            let usdc_store_guard = self.usdc_store.read().await;
-            if let Some(store) = usdc_store_guard.as_ref() {
+            let usdc_store = self.usdc_store.read().await.as_ref().map(Arc::clone);
+            if let Some(store) = usdc_store {
                 match store.load(id).await {
                     Ok(Some(UsdcRebalance::Reconciled { .. })) => {
                         // Durable state is Reconciled: the CLI's separate-process
@@ -1388,7 +1389,6 @@ impl RebalancingService {
                         // set.
                         tracking_guard.remove(id);
                         drop(tracking_guard);
-                        drop(usdc_store_guard);
 
                         let mut inventory = self.inventory.write().await;
                         let result = inventory
@@ -1429,7 +1429,6 @@ impl RebalancingService {
                     Ok(Some(_) | None) => {
                         // Guard-holding state or aggregate not yet in store:
                         // fall through to the timeout gate below.
-                        drop(usdc_store_guard);
                     }
                     Err(load_error) => {
                         // Store read failed (I/O error, deserialization error,
@@ -1445,7 +1444,6 @@ impl RebalancingService {
                             "Failed to load UsdcRebalance from store during \
                              post-burn sweep; preserving guard"
                         );
-                        drop(usdc_store_guard);
                         return Ok(Some(UsdcTimeoutCleanup::PreservedPostBurn {
                             tracking,
                             elapsed,
@@ -1471,6 +1469,52 @@ impl RebalancingService {
         // Pre-burn path: only act after the timeout has elapsed.
         if elapsed < self.config.transfer_timeout {
             return Ok(None);
+        }
+
+        // Before clearing the guard for a pre-burn timeout, check the
+        // aggregate's durable state. If the aggregate is an Alpaca-to-Base
+        // state after the source withdrawal may have moved funds, the guard must
+        // NOT be cleared. Return `ReArmAlpacaToBaseWithdrawal` so the caller
+        // re-enqueues a fresh `TransferUsdcToMarketMaking` redrive instead of
+        // releasing the guard and potentially triggering a re-withdrawal on the
+        // next tick.
+        let usdc_store = self.usdc_store.read().await.as_ref().map(Arc::clone);
+        if let Some(store) = usdc_store {
+            match store.load(id).await {
+                Ok(Some(
+                    UsdcRebalance::Withdrawing {
+                        direction: RebalanceDirection::AlpacaToBase,
+                        amount,
+                        ..
+                    }
+                    | UsdcRebalance::WithdrawalComplete {
+                        direction: RebalanceDirection::AlpacaToBase,
+                        amount,
+                        ..
+                    },
+                )) => {
+                    drop(tracking_guard);
+                    return Ok(Some(UsdcTimeoutCleanup::ReArmAlpacaToBaseWithdrawal {
+                        tracking,
+                        elapsed,
+                        amount,
+                    }));
+                }
+                Ok(_) => {}
+                Err(load_error) => {
+                    // Store read failed. Fail safe: skip cleanup so a
+                    // possibly-retryable Alpaca-to-Base aggregate does not
+                    // have its guard cleared. The next sweep tick retries.
+                    warn!(
+                        target: "rebalance",
+                        id = %id,
+                        ?load_error,
+                        "Failed to load UsdcRebalance from store during pre-burn \
+                         sweep; skipping cleanup to preserve guard"
+                    );
+                    return Ok(None);
+                }
+            }
         }
 
         let mut inventory = self.inventory.write().await;
@@ -3580,10 +3624,10 @@ impl RebalancingService {
     /// after its `TimeoutAttestation` already committed (or a crash in that
     /// window) leaves the aggregate durably `AwaitingAttestation`/`Attested` with
     /// no job to retry it -- the guard would then stay latched forever. So for
-    /// each post-burn resumable aggregate with no in-flight job row, this
-    /// re-enqueues a transfer job keyed by the existing id. The
-    /// `transfer_in_flight_for_id` check makes this idempotent with apalis's own
-    /// re-pick of still-pending rows. See ADR 2.
+    /// each post-burn resumable aggregate with no blocking job row, this
+    /// re-enqueues a transfer job keyed by the existing id. The live/row-existence
+    /// checks make this idempotent with apalis's own re-pick of still-owned rows.
+    /// See ADR 2.
     pub(crate) async fn recover_usdc_guard(
         &self,
         pool: &SqlitePool,
@@ -3654,24 +3698,56 @@ impl RebalancingService {
                     }
 
                     if let Some((direction, amount)) = entity.resumable_post_burn_transfer() {
+                        let policy = match &entity {
+                            UsdcRebalance::BridgingFailed {
+                                direction: RebalanceDirection::BaseToAlpaca,
+                                burn_tx_hash: Some(_),
+                                ..
+                            } => RearmPolicy::RecoverableFailure,
+                            UsdcRebalance::Bridging { .. }
+                            | UsdcRebalance::AwaitingAttestation { .. }
+                            | UsdcRebalance::Attested { .. } => RearmPolicy::PostBurnResumable,
+                            // Listing every unreachable variant mirrors the
+                            // mid-flight policy match below: if a new aggregate
+                            // variant is later added and classified as resumable,
+                            // this match must assign it a policy at compile time.
+                            UsdcRebalance::Converting { .. }
+                            | UsdcRebalance::ConversionComplete { .. }
+                            | UsdcRebalance::ConversionFailed { .. }
+                            | UsdcRebalance::WithdrawalSubmitting { .. }
+                            | UsdcRebalance::Withdrawing { .. }
+                            | UsdcRebalance::WithdrawalComplete { .. }
+                            | UsdcRebalance::WithdrawalFailed { .. }
+                            | UsdcRebalance::BridgingSubmitting { .. }
+                            | UsdcRebalance::Bridged { .. }
+                            | UsdcRebalance::DepositInitiated { .. }
+                            | UsdcRebalance::DepositConfirmed { .. }
+                            | UsdcRebalance::DepositFailed { .. }
+                            | UsdcRebalance::BridgingFailed { .. }
+                            | UsdcRebalance::Reconciled { .. } => unreachable!(
+                                "only BridgingFailed{{BaseToAlpaca,burn_tx=Some}}, Bridging, AwaitingAttestation, and Attested reach here via resumable_post_burn_transfer"
+                            ),
+                        };
                         rearm_candidates.push(RearmCandidate {
-                            policy: if matches!(&entity, UsdcRebalance::BridgingFailed { .. }) {
-                                RearmPolicy::RecoverableFailure
-                            } else {
-                                RearmPolicy::PostBurnResumable
-                            },
                             id,
                             direction,
                             amount,
+                            policy,
                         });
                     } else if let Some((direction, amount)) = entity.is_resumable_mid_flight_data()
                     {
-                        // Pre-burn states (BridgingSubmitting / WithdrawalSubmitting{BaseToAlpaca})
-                        // with no job row: the process crashed before the enqueue
-                        // committed or before the tx was submitted. Safe to re-arm
+                        // Pre-burn states (BridgingSubmitting / WithdrawalSubmitting{BaseToAlpaca}
+                        // / Withdrawing{AlpacaToBase}) with no job row: the process crashed before
+                        // the enqueue committed or before the tx was submitted. Safe to re-arm
                         // because these states are non-terminal and resumable: the
                         // resume path scans for any existing on-chain effect before
                         // re-attempting.
+                        //
+                        // Withdrawing{AlpacaToBase} IS re-armed here: the AlpacaTransferId is
+                        // durably recorded in Withdrawing; resume_alpaca_to_base re-polls the
+                        // same transfer (idempotent). This is the fix for the re-withdrawal
+                        // window: the guard stays held in Withdrawing so no fresh withdrawal
+                        // starts while the prior one may still be in progress.
                         //
                         // WithdrawalSubmitting{AlpacaToBase} is excluded by
                         // is_resumable_mid_flight_data: resume_alpaca_to_base returns
@@ -3688,11 +3764,67 @@ impl RebalancingService {
                         // The transfer_has_job_row_for_id gate below provides idempotency
                         // on the very first check; we collect here and gate in
                         // rearm_stranded_transfers.
+                        // Alpaca-to-Base states whose source withdrawal may have
+                        // moved funds use a separate policy: resume is idempotent,
+                        // so a terminal job row does NOT indicate the transfer is
+                        // unrecoverable. All other mid-flight pre-burn states use
+                        // MidFlightPreBurn.
+                        let policy = match &entity {
+                            UsdcRebalance::Withdrawing {
+                                direction: RebalanceDirection::AlpacaToBase,
+                                ..
+                            }
+                            | UsdcRebalance::WithdrawalComplete {
+                                direction: RebalanceDirection::AlpacaToBase,
+                                ..
+                            } => RearmPolicy::AlpacaToBaseIdempotentRedrive,
+                            UsdcRebalance::WithdrawalSubmitting {
+                                direction: RebalanceDirection::BaseToAlpaca,
+                                ..
+                            }
+                            | UsdcRebalance::BridgingSubmitting { .. } => {
+                                RearmPolicy::MidFlightPreBurn
+                            }
+                            // is_resumable_mid_flight_data is fully exhaustive (no
+                            // wildcard `None` arm). Listing every unreachable variant
+                            // here turns a future "added to Some but forgot to assign
+                            // a policy" mistake into a compile error rather than a
+                            // runtime unreachable panic.
+                            UsdcRebalance::WithdrawalSubmitting {
+                                direction: RebalanceDirection::AlpacaToBase,
+                                ..
+                            }
+                            | UsdcRebalance::Converting { .. }
+                            | UsdcRebalance::ConversionComplete { .. }
+                            | UsdcRebalance::ConversionFailed { .. }
+                            | UsdcRebalance::Withdrawing {
+                                direction: RebalanceDirection::BaseToAlpaca,
+                                ..
+                            }
+                            | UsdcRebalance::WithdrawalComplete {
+                                direction: RebalanceDirection::BaseToAlpaca,
+                                ..
+                            }
+                            | UsdcRebalance::WithdrawalFailed { .. }
+                            | UsdcRebalance::Bridging { .. }
+                            | UsdcRebalance::AwaitingAttestation { .. }
+                            | UsdcRebalance::Attested { .. }
+                            | UsdcRebalance::Bridged { .. }
+                            | UsdcRebalance::DepositInitiated { .. }
+                            | UsdcRebalance::DepositConfirmed { .. }
+                            | UsdcRebalance::DepositFailed { .. }
+                            | UsdcRebalance::BridgingFailed { .. }
+                            | UsdcRebalance::Reconciled { .. } => unreachable!(
+                                "filtered by is_resumable_mid_flight_data; only AlpacaToBase \
+                                 Withdrawing/WithdrawalComplete, WithdrawalSubmitting{{BaseToAlpaca}}, \
+                                 and BridgingSubmitting reach here"
+                            ),
+                        };
                         rearm_candidates.push(RearmCandidate {
-                            policy: RearmPolicy::MidFlightPreBurn,
                             id,
                             direction,
                             amount,
+                            policy,
                         });
                     } else if entity.holds_rebalance_guard()
                         && entity.guard_recovery_tracking_data().is_none()
@@ -3842,6 +3974,13 @@ impl RebalancingService {
     ///   terminal-only row means the redrive budget is exhausted with no driver:
     ///   rather than silently re-arming with a fresh budget, the id is stranded
     ///   and returned for the operator alert.
+    /// - [`RearmPolicy::AlpacaToBaseIdempotentRedrive`] (`Withdrawing` or
+    ///   `WithdrawalComplete` for `AlpacaToBase`): re-arm whenever no LIVE job
+    ///   exists (same gate as `RecoverableFailure`). A terminal job row does NOT
+    ///   block re-arm: resume is idempotent and never starts a second Alpaca
+    ///   withdrawal, so job-budget exhaustion means only that the chain lost its
+    ///   driver. Stranding here would latch the guard with no driver, defeating
+    ///   the durable-withdrawal guarantee.
     ///
     /// An enqueue failure (or a probe failure) is propagated so startup recovery
     /// fails fast and the supervisor retries -- consistent with the
@@ -3861,7 +4000,9 @@ impl RebalancingService {
         } in candidates
         {
             let blocked = match policy {
-                RearmPolicy::RecoverableFailure => self.transfer_live_job_for_id(&id).await?,
+                RearmPolicy::RecoverableFailure | RearmPolicy::AlpacaToBaseIdempotentRedrive => {
+                    self.transfer_live_job_for_id(&id).await?
+                }
                 RearmPolicy::PostBurnResumable => self.transfer_has_job_row_for_id(&id).await?,
                 RearmPolicy::MidFlightPreBurn => {
                     let live = self.transfer_live_job_for_id(&id).await?;
@@ -7295,6 +7436,21 @@ mod tests {
         .fetch_one(service.transfer_usdc_to_market_making_queue.pool())
         .await
         .expect("count pending TransferUsdcToMarketMaking jobs")
+    }
+
+    async fn pending_transfer_usdc_to_market_making_job(
+        service: &RebalancingService,
+    ) -> TransferUsdcToMarketMaking {
+        let job_type = std::any::type_name::<TransferUsdcToMarketMaking>();
+        let payload: Vec<u8> = sqlx_apalis::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(job_type)
+        .fetch_one(service.transfer_usdc_to_market_making_queue.pool())
+        .await
+        .expect("fetch pending TransferUsdcToMarketMaking job");
+
+        serde_json::from_slice(&payload).expect("deserialize TransferUsdcToMarketMaking")
     }
 
     /// Counts pending `TransferEquityToMarketMaking` rows in the apalis Jobs
@@ -12313,7 +12469,69 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transfer_in_flight_check_is_scoped_to_aggregate_id() {
+    async fn timeout_preserves_guard_when_transfer_live_job_probe_errors() {
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(900), usdc(100))
+            .update_usdc(
+                Inventory::transfer(Venue::MarketMaking, TransferOp::Start, usdc(400)),
+                Utc::now(),
+            )
+            .unwrap();
+        let trigger = make_trigger_with_inventory_config(
+            inventory,
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::BaseToAlpaca,
+                initiated_amount: usdc(400),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::Initiated,
+                last_progress_at: Utc::now() - ChronoDuration::minutes(31),
+            },
+        );
+
+        trigger.transfer_usdc_to_hedging_queue.pool().close().await;
+
+        trigger.check_and_trigger_usdc().await;
+
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "a live-job probe error must preserve the guard for this sweep tick"
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "a live-job probe error must not drop USDC tracking"
+        );
+        assert!(
+            !trigger
+                .timed_out_usdc_rebalances
+                .read()
+                .await
+                .contains_key(&id),
+            "a live-job probe error must not mark the transfer timed out"
+        );
+
+        let marketmaking_inflight = trigger
+            .inventory
+            .read()
+            .await
+            .usdc_inflight(Venue::MarketMaking);
+
+        assert_eq!(
+            marketmaking_inflight,
+            Some(usdc(400)),
+            "a live-job probe error must preserve source-side inflight"
+        );
+    }
+
+    #[tokio::test]
+    async fn transfer_live_job_check_is_scoped_to_aggregate_id() {
         let trigger = make_trigger_with_inventory_config(
             InventoryView::default(),
             test_config_with_timeout(Duration::from_secs(1)),
@@ -12333,17 +12551,17 @@ mod tests {
             .unwrap();
 
         assert!(
-            trigger.transfer_in_flight_for_id(&id).await,
-            "a non-terminal transfer row for this id must report in flight",
+            trigger.transfer_live_job_for_id(&id).await.unwrap(),
+            "a live transfer row for this id must report live",
         );
         assert!(
-            !trigger.transfer_in_flight_for_id(&other_id).await,
-            "a transfer row for a different aggregate id must NOT report this id as in flight",
+            !trigger.transfer_live_job_for_id(&other_id).await.unwrap(),
+            "a transfer row for a different aggregate id must NOT report this id as live",
         );
     }
 
     #[tokio::test]
-    async fn transfer_in_flight_for_id_checks_market_making_direction() {
+    async fn transfer_live_job_for_id_checks_market_making_direction() {
         let trigger = make_trigger_with_inventory_config(
             InventoryView::default(),
             test_config_with_timeout(Duration::from_secs(1)),
@@ -12367,8 +12585,8 @@ mod tests {
             .unwrap();
 
         assert!(
-            trigger.transfer_in_flight_for_id(&id).await,
-            "a non-terminal market-making (Alpaca->Base) transfer row must report this id as in flight",
+            trigger.transfer_live_job_for_id(&id).await.unwrap(),
+            "a market-making (Alpaca->Base) transfer row must report this id as live",
         );
     }
 
@@ -12394,11 +12612,13 @@ mod tests {
             })
             .await
             .unwrap();
-        sqlx_apalis::query("UPDATE Jobs SET status = 'Failed' WHERE job_type = ?")
-            .bind(std::any::type_name::<TransferUsdcToHedging>())
-            .execute(queue.pool())
-            .await
-            .unwrap();
+        sqlx_apalis::query(
+            "UPDATE Jobs SET status = 'Failed', attempts = max_attempts WHERE job_type = ?",
+        )
+        .bind(std::any::type_name::<TransferUsdcToHedging>())
+        .execute(queue.pool())
+        .await
+        .unwrap();
 
         trigger.usdc_in_progress.store(true, Ordering::SeqCst);
         trigger.usdc_tracking.write().await.insert(
@@ -14766,6 +14986,92 @@ mod tests {
         drop(inventory);
     }
 
+    /// A pre-burn Alpaca-to-Base transfer whose store load fails must also
+    /// preserve the guard. This pins the `Err(load_error) => Ok(None)` arm in
+    /// the pre-burn cleanup path; the post-burn branch is covered above.
+    #[tokio::test]
+    async fn sweep_preserves_pre_burn_alpaca_to_base_guard_on_store_load_error() {
+        let now = Utc::now();
+        let amount = usdc(400);
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(100), usdc(900))
+            .update_usdc(
+                Inventory::transfer(Venue::Hedging, TransferOp::Start, amount),
+                now,
+            )
+            .unwrap();
+        let trigger = make_trigger_with_inventory_config(
+            inventory,
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+
+        let unmigrated_pool = SqlitePool::connect(":memory:").await.unwrap();
+        trigger
+            .set_stores(
+                Arc::new(test_store::<
+                    crate::tokenized_equity_mint::TokenizedEquityMint,
+                >(
+                    unmigrated_pool.clone(),
+                    crate::rebalancing::equity::EquityTransferServices::panicking(),
+                )),
+                Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
+                    unmigrated_pool.clone(),
+                    crate::rebalancing::equity::EquityTransferServices::panicking(),
+                )),
+                Arc::new(test_store::<UsdcRebalance>(unmigrated_pool.clone(), ())),
+            )
+            .await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: amount,
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::Initiated,
+                last_progress_at: now - ChronoDuration::minutes(31),
+            },
+        );
+
+        trigger
+            .expire_stuck_usdc_rebalances(Utc::now())
+            .await
+            .unwrap();
+
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "pre-burn store-load errors must preserve the guard"
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "pre-burn store-load errors must preserve tracking for a retry"
+        );
+        assert!(
+            !trigger
+                .timed_out_usdc_rebalances
+                .read()
+                .await
+                .contains_key(&id),
+            "pre-burn store-load errors must not tombstone an active transfer"
+        );
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&trigger).await,
+            0,
+            "pre-burn store-load errors must skip cleanup rather than enqueue a redrive"
+        );
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_inflight(Venue::Hedging),
+            Some(amount),
+            "pre-burn store-load errors must leave source-venue inflight unchanged"
+        );
+        drop(inventory);
+    }
+
     /// AlpacaToBase direction: sweep clears the Hedging-venue inflight when
     /// durable state is Reconciled, mirroring
     /// `sweep_clears_guard_after_cli_reconcile_without_restart` for the
@@ -14880,6 +15186,213 @@ mod tests {
             "sweep must clear active_usdc_rebalance after reconcile"
         );
         drop(inventory);
+    }
+
+    /// A `Withdrawing{AlpacaToBase}` aggregate that has timed out (elapsed >=
+    /// `transfer_timeout`) with NO in-flight apalis job must NOT have its guard
+    /// cleared. Instead the sweeper must re-enqueue a fresh
+    /// `TransferUsdcToMarketMaking` redrive so the idempotent poll chain
+    /// continues. This is the runtime complement to the startup
+    /// `RearmPolicy::AlpacaToBaseIdempotentRedrive` path in `recover_usdc_guard`.
+    ///
+    /// A cleared guard would allow the next rebalancing tick to start a fresh
+    /// Alpaca withdrawal while the prior one may still be settling -- exactly
+    /// the re-withdrawal scenario this branch was created to prevent.
+    #[tokio::test]
+    async fn sweep_rearms_withdrawing_alpaca_to_base_instead_of_clearing() {
+        let now = Utc::now();
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone(), ()));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(400);
+
+        // Drive aggregate to Withdrawing{AlpacaToBase} -- no apalis job row exists.
+        seed_withdrawing_alpaca_to_base(&store, &id, amount).await;
+
+        let trigger = make_trigger_with_timed_out_alpaca_to_base_tracking(
+            &pool,
+            store,
+            &id,
+            amount,
+            usdc::UsdcRebalanceStage::Initiated,
+            now,
+        )
+        .await;
+
+        trigger
+            .expire_stuck_usdc_rebalances(Utc::now())
+            .await
+            .unwrap();
+
+        // Guard must STAY held -- the withdrawal may still be settling.
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "guard must stay latched for Withdrawing{{AlpacaToBase}} on timeout; releasing would allow a re-withdrawal"
+        );
+
+        // A fresh TransferUsdcToMarketMaking redrive must be enqueued.
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&trigger).await,
+            1,
+            "sweep must re-arm a TransferUsdcToMarketMaking job for Withdrawing{{AlpacaToBase}} instead of clearing the guard"
+        );
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&trigger).await,
+            0,
+            "Withdrawing{{AlpacaToBase}} sweep re-arm must enqueue a market-making job, not a hedging job"
+        );
+        let rescheduled = pending_transfer_usdc_to_market_making_job(&trigger).await;
+        assert_eq!(
+            rescheduled.id, id,
+            "sweep re-arm must resume the same aggregate id",
+        );
+        assert!(
+            rescheduled.amount.eq(&amount).unwrap(),
+            "sweep re-arm must carry the same USDC amount",
+        );
+        assert_eq!(
+            rescheduled.revert_redrive_attempts, 0,
+            "withdrawal re-poll redrive must reset the burn-revert budget",
+        );
+
+        // Tracking must NOT be removed (the sweep left it for future ticks).
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "tracking must be preserved for Withdrawing{{AlpacaToBase}} on timeout re-arm"
+        );
+
+        // The id must NOT be tombstoned (the transfer is still active).
+        assert!(
+            !trigger
+                .timed_out_usdc_rebalances
+                .read()
+                .await
+                .contains_key(&id),
+            "must not tombstone a Withdrawing{{AlpacaToBase}} aggregate on timeout re-arm"
+        );
+
+        // Source-venue inflight must remain unchanged -- the guard was not cleared.
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_inflight(Venue::Hedging),
+            Some(amount),
+            "source-venue inflight must not be zeroed for re-arm path"
+        );
+        drop(inventory);
+    }
+
+    /// A retryable `Failed` apalis row (`attempts < max_attempts`) is still
+    /// live: apalis will re-fetch it. The timeout sweep must not enqueue a
+    /// duplicate redrive while that row still owns the transfer.
+    #[tokio::test]
+    async fn sweep_does_not_duplicate_withdrawing_alpaca_to_base_retryable_failed_job() {
+        let now = Utc::now();
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone(), ()));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(400);
+
+        seed_withdrawing_alpaca_to_base(&store, &id, amount).await;
+        let trigger = make_trigger_with_timed_out_alpaca_to_base_tracking(
+            &pool,
+            store,
+            &id,
+            amount,
+            usdc::UsdcRebalanceStage::Initiated,
+            now,
+        )
+        .await;
+
+        trigger
+            .transfer_usdc_to_market_making_queue
+            .clone()
+            .push(TransferUsdcToMarketMaking {
+                id: id.clone(),
+                amount,
+                revert_redrive_attempts: 0,
+            })
+            .await
+            .unwrap();
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Failed' WHERE job_type = ?")
+            .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+            .execute(trigger.transfer_usdc_to_market_making_queue.pool())
+            .await
+            .unwrap();
+
+        trigger
+            .expire_stuck_usdc_rebalances(Utc::now())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&trigger).await,
+            0,
+            "sweep must not enqueue a duplicate Pending job while apalis owns a retryable Failed row",
+        );
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "guard must stay latched while the retryable Failed row remains live",
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "tracking must stay present while live apalis retry owns the transfer",
+        );
+    }
+
+    /// `WithdrawalComplete{AlpacaToBase}` has already moved funds out of Alpaca.
+    /// If its redrive chain dies before the CCTP burn, the runtime sweep must
+    /// preserve the guard and re-arm the market-making resume job.
+    #[tokio::test]
+    async fn sweep_rearms_withdrawal_complete_alpaca_to_base_instead_of_clearing() {
+        let now = Utc::now();
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = Arc::new(test_store::<UsdcRebalance>(pool.clone(), ()));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(400);
+
+        seed_withdrawal_complete_alpaca_to_base(&store, &id, amount).await;
+        let trigger = make_trigger_with_timed_out_alpaca_to_base_tracking(
+            &pool,
+            store,
+            &id,
+            amount,
+            usdc::UsdcRebalanceStage::WithdrawalConfirmed,
+            now,
+        )
+        .await;
+
+        trigger
+            .expire_stuck_usdc_rebalances(Utc::now())
+            .await
+            .unwrap();
+
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "guard must stay latched for WithdrawalComplete{{AlpacaToBase}} on timeout",
+        );
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&trigger).await,
+            1,
+            "sweep must re-arm a market-making job for timed-out WithdrawalComplete{{AlpacaToBase}}",
+        );
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&trigger).await,
+            0,
+            "WithdrawalComplete{{AlpacaToBase}} must be resumed through the market-making queue",
+        );
+        let rescheduled = pending_transfer_usdc_to_market_making_job(&trigger).await;
+        assert_eq!(
+            rescheduled.id, id,
+            "WithdrawalComplete sweep re-arm must resume the same aggregate id",
+        );
+        assert!(
+            rescheduled.amount.eq(&amount).unwrap(),
+            "WithdrawalComplete sweep re-arm must carry the same USDC amount",
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "tracking must be preserved for WithdrawalComplete{{AlpacaToBase}} timeout re-arm",
+        );
     }
 
     /// Exercises the real restart-then-CLI-reconcile path end-to-end:
@@ -15779,6 +16292,380 @@ mod tests {
             )
             .await
             .unwrap();
+    }
+
+    /// Seeds a `Withdrawing{AlpacaToBase}` aggregate using the real production
+    /// event path: `InitiateConversion -> ConfirmConversion -> Initiate`.
+    /// This mirrors `initiate_alpaca_withdrawal` in manager.rs, which emits
+    /// `Initiate{AlpacaToBase}` directly from `ConversionComplete` without
+    /// going through `BeginWithdrawal` (that step is BaseToAlpaca only).
+    async fn seed_withdrawing_alpaca_to_base(
+        store: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) {
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::InitiateConversion {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount,
+                    order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::ConfirmConversion {
+                    conversion: ConversionAmounts::new(amount, amount),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount,
+                    withdrawal: TransferRef::AlpacaId(transfer_id),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn seed_withdrawal_complete_alpaca_to_base(
+        store: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) {
+        seed_withdrawing_alpaca_to_base(store, id, amount).await;
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn make_trigger_with_timed_out_alpaca_to_base_tracking(
+        pool: &SqlitePool,
+        store: Arc<Store<UsdcRebalance>>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        stage: usdc::UsdcRebalanceStage,
+        now: DateTime<Utc>,
+    ) -> Arc<RebalancingService> {
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(500), usdc(900))
+            .update_usdc(
+                Inventory::transfer(Venue::Hedging, TransferOp::Start, amount),
+                now,
+            )
+            .unwrap()
+            .set_active_usdc_rebalance(id.clone());
+        let trigger = make_trigger_with_inventory_config(
+            inventory,
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+
+        trigger
+            .set_stores(
+                Arc::new(test_store::<
+                    crate::tokenized_equity_mint::TokenizedEquityMint,
+                >(
+                    pool.clone(),
+                    crate::rebalancing::equity::EquityTransferServices::panicking(),
+                )),
+                Arc::new(test_store::<crate::equity_redemption::EquityRedemption>(
+                    pool.clone(),
+                    crate::rebalancing::equity::EquityTransferServices::panicking(),
+                )),
+                store,
+            )
+            .await;
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: amount,
+                bridged_amount_received: None,
+                stage,
+                last_progress_at: now - ChronoDuration::minutes(31),
+            },
+        );
+
+        trigger
+    }
+
+    /// `Withdrawing{AlpacaToBase}` with no live job row must be re-armed on
+    /// startup as a market-making job. The AlpacaTransferId is durably recorded
+    /// in `Withdrawing`; `resume_alpaca_to_base` re-polls the same transfer.
+    #[tokio::test]
+    async fn recover_usdc_guard_rearms_withdrawing_alpaca_to_base() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(400);
+
+        seed_withdrawing_alpaca_to_base(&store, &id, amount).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&service).await,
+            1,
+            "a Withdrawing{{AlpacaToBase}} with no job row must be re-armed as a market-making job",
+        );
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&service).await,
+            0,
+            "Withdrawing{{AlpacaToBase}} must NOT be re-armed as a hedging job",
+        );
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress must be latched after re-arming a Withdrawing{{AlpacaToBase}} job",
+        );
+    }
+
+    /// `WithdrawalComplete{AlpacaToBase}` with no live job row must be re-armed
+    /// on startup as a market-making job. The source withdrawal has already moved
+    /// funds out of Alpaca; clearing the guard or merely alerting would leave the
+    /// wallet-funded transfer stranded with no automated driver.
+    #[tokio::test]
+    async fn recover_usdc_guard_rearms_withdrawal_complete_alpaca_to_base() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(400);
+
+        seed_withdrawal_complete_alpaca_to_base(&store, &id, amount).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&service).await,
+            1,
+            "a WithdrawalComplete{{AlpacaToBase}} with no job row must be re-armed as a market-making job",
+        );
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&service).await,
+            0,
+            "WithdrawalComplete{{AlpacaToBase}} must NOT be re-armed as a hedging job",
+        );
+        let rescheduled = pending_transfer_usdc_to_market_making_job(&service).await;
+        assert_eq!(
+            rescheduled.id, id,
+            "the re-armed job must resume the same aggregate id",
+        );
+        assert!(
+            rescheduled.amount.eq(&amount).unwrap(),
+            "the re-armed job must carry the same amount",
+        );
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress must be latched after re-arming a WithdrawalComplete{{AlpacaToBase}} job",
+        );
+    }
+
+    /// A `Withdrawing{AlpacaToBase}` aggregate with an existing Pending
+    /// job row (e.g. a delayed redrive already enqueued by the inconclusive arm)
+    /// must NOT be re-armed again. Idempotency is enforced by
+    /// `transfer_live_job_for_id` (checks Pending/Queued/Running status).
+    #[tokio::test]
+    async fn recover_usdc_guard_does_not_rearm_withdrawing_alpaca_to_base_with_live_job() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(400);
+
+        seed_withdrawing_alpaca_to_base(&store, &id, amount).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        // Pre-seed a Pending job row (as the delayed-redrive enqueue would have).
+        service
+            .transfer_usdc_to_market_making_queue
+            .clone()
+            .push(TransferUsdcToMarketMaking {
+                id: id.clone(),
+                amount,
+                revert_redrive_attempts: 0,
+            })
+            .await
+            .unwrap();
+
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&service).await,
+            1,
+            "a Withdrawing{{AlpacaToBase}} with an existing Pending job row must NOT \
+             be re-armed again (idempotency via transfer_live_job_for_id)",
+        );
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress must be latched even when no re-arm is enqueued \
+             (Withdrawing{{AlpacaToBase}} holds the guard regardless)",
+        );
+    }
+
+    /// `Withdrawing{AlpacaToBase}` with a Queued job row must NOT be re-armed.
+    /// `transfer_live_job_for_id` checks Pending, Queued, and Running -- this
+    /// test pins the Queued branch so a refactor that accidentally narrows the
+    /// IN clause to only Pending cannot go undetected.
+    #[tokio::test]
+    async fn recover_usdc_guard_does_not_rearm_withdrawing_alpaca_to_base_with_queued_job() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(400);
+
+        seed_withdrawing_alpaca_to_base(&store, &id, amount).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        // Push (Pending), then UPDATE to Queued -- same pattern as apalis re-dispatch.
+        service
+            .transfer_usdc_to_market_making_queue
+            .clone()
+            .push(TransferUsdcToMarketMaking {
+                id: id.clone(),
+                amount,
+                revert_redrive_attempts: 0,
+            })
+            .await
+            .unwrap();
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Queued' WHERE job_type = ?")
+            .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+            .execute(service.transfer_usdc_to_market_making_queue.pool())
+            .await
+            .unwrap();
+
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        let pending = count_pending_transfer_usdc_to_market_making_jobs(&service).await;
+        assert_eq!(
+            pending, 0,
+            "a Withdrawing{{AlpacaToBase}} with a Queued job row must NOT enqueue an additional \
+             Pending job (transfer_live_job_for_id must treat Queued as live)"
+        );
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress must be latched even when no re-arm is enqueued \
+             (Withdrawing{{AlpacaToBase}} holds the guard regardless)",
+        );
+    }
+
+    /// `Withdrawing{AlpacaToBase}` with a terminal (Failed, exhausted) job row
+    /// MUST be re-armed on startup. The Alpaca-to-Base idempotent policy gates
+    /// only on a LIVE job (Pending/Queued/Running/retryable Failed); a terminal row means the
+    /// delayed-push path failed to re-enqueue, NOT that the withdrawal is
+    /// unrecoverable. Stranding here would latch the guard with no driver,
+    /// defeating the durable-withdrawal guarantee.
+    #[tokio::test]
+    async fn recover_usdc_guard_rearms_withdrawing_alpaca_to_base_with_terminal_job_row() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(400);
+
+        seed_withdrawing_alpaca_to_base(&store, &id, amount).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        // Push (Pending), then UPDATE to Failed with attempts == max_attempts
+        // (exhausted budget -- no retries remaining, i.e., terminal).
+        service
+            .transfer_usdc_to_market_making_queue
+            .clone()
+            .push(TransferUsdcToMarketMaking {
+                id: id.clone(),
+                amount,
+                revert_redrive_attempts: 0,
+            })
+            .await
+            .unwrap();
+        sqlx_apalis::query(
+            "UPDATE Jobs SET status = 'Failed', attempts = max_attempts, \
+             done_at = strftime('%s','now') \
+             WHERE job_type = ?",
+        )
+        .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+        .execute(service.transfer_usdc_to_market_making_queue.pool())
+        .await
+        .unwrap();
+
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&service).await,
+            1,
+            "a Withdrawing{{AlpacaToBase}} with only a terminal job row must be re-armed \
+             (AlpacaToBaseIdempotentRedrive policy; terminal row does not block)",
+        );
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress must be latched after re-arming a Withdrawing{{AlpacaToBase}} \
+             with a terminal job row"
+        );
+    }
+
+    /// `Withdrawing{AlpacaToBase}` with a Running job row must NOT be re-armed.
+    /// `transfer_live_job_for_id` checks Pending, Queued, and Running; this test
+    /// pins the Running branch so a refactor that accidentally narrows the IN clause
+    /// cannot go undetected (a duplicate re-arm while a Running job owns the same
+    /// transfer ID would be unsafe).
+    #[tokio::test]
+    async fn recover_usdc_guard_does_not_rearm_withdrawing_alpaca_to_base_with_running_job() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(400);
+
+        seed_withdrawing_alpaca_to_base(&store, &id, amount).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        // Push (Pending), then UPDATE to Running -- simulates a job currently executing.
+        service
+            .transfer_usdc_to_market_making_queue
+            .clone()
+            .push(TransferUsdcToMarketMaking {
+                id: id.clone(),
+                amount,
+                revert_redrive_attempts: 0,
+            })
+            .await
+            .unwrap();
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Running' WHERE job_type = ?")
+            .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+            .execute(service.transfer_usdc_to_market_making_queue.pool())
+            .await
+            .unwrap();
+
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&service).await,
+            0,
+            "a Withdrawing{{AlpacaToBase}} with a Running job row must NOT enqueue an \
+             additional Pending job (transfer_live_job_for_id must treat Running as live)"
+        );
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress must be latched even when no re-arm is enqueued \
+             (Withdrawing{{AlpacaToBase}} holds the guard regardless)",
+        );
     }
 
     /// KNOWN LIMITATION: `WithdrawalSubmitting{AlpacaToBase}` is deliberately

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -20,11 +20,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{error, warn};
 
 use st0x_evm::Wallet;
+use st0x_execution::AlpacaWalletError;
 use st0x_finance::Usdc;
 
 use super::UsdcTransferError;
@@ -61,6 +63,33 @@ const TIMEOUT_REDRIVE_DELAY: Duration = Duration::from_secs(30);
 /// avoid materially delaying the transfer.
 const SETTLEMENT_REDRIVE_DELAY: Duration = Duration::from_secs(30);
 
+/// Delay before re-polling an Alpaca withdrawal when the poll outcome was
+/// inconclusive (Alpaca API unreachable or returned an error). 30 seconds
+/// gives Alpaca time to recover from a transient outage without hammering the
+/// API during a prolonged failure. Distinct from `SETTLEMENT_REDRIVE_DELAY`
+/// (Ethereum block timing) so the two can evolve independently.
+const WITHDRAWAL_POLL_REDRIVE_DELAY: Duration = Duration::from_secs(30);
+
+/// Duration after which repeated `WithdrawalPollInconclusive` redrives page
+/// the operator via the notifier. The deadline is durable: it is derived from
+/// `Withdrawing.initiated_at` (stored in the CQRS aggregate, survives restarts)
+/// so the countdown is not reset by a bot restart.
+///
+/// 4 hours gives substantial headroom above the 30-minute internal poll timeout
+/// (the longest a healthy Alpaca withdrawal can take), while ensuring a
+/// permanently-stuck poll (rotated credentials, Alpaca API shape change, etc.)
+/// is surfaced well before it becomes a multi-day outage.
+const WITHDRAWAL_POLL_ALERT_DEADLINE: Duration = Duration::from_secs(4 * 60 * 60);
+
+/// Redrive delay used AFTER the 4-hour operator alert deadline has elapsed.
+/// Much longer than `WITHDRAWAL_POLL_REDRIVE_DELAY` (30 s) to prevent alert
+/// fatigue: a permanently-stuck poll at 30 s cadence pages ~120 times/hour,
+/// drowning out other alerts on the shared Telegram channel. At 30 minutes the
+/// operator receives at most ~2 pages/hour while the guard stays held and
+/// re-polling continues. The re-poll itself is idempotent (same transfer ID),
+/// so a slower post-deadline cadence is harmless for funds in transit.
+const WITHDRAWAL_POLL_POST_DEADLINE_REDRIVE_DELAY: Duration = Duration::from_secs(30 * 60);
+
 /// Returns the warn-threshold attempt count at which an early operator alert
 /// fires, or `None` when there is no room for a distinct early warning.
 ///
@@ -75,6 +104,10 @@ const SETTLEMENT_REDRIVE_DELAY: Duration = Duration::from_secs(30);
 fn warn_threshold(max_redrives: u32) -> Option<u32> {
     let threshold = max_redrives / 2 + 1;
     (threshold < max_redrives).then_some(threshold)
+}
+
+fn withdrawal_poll_deadline_elapsed(elapsed: Option<Duration>) -> Option<Duration> {
+    elapsed.filter(|elapsed| *elapsed >= WITHDRAWAL_POLL_ALERT_DEADLINE)
 }
 
 /// Apalis queue type for [`TransferUsdcToHedging`].
@@ -773,6 +806,24 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
                     warn!(target: "rebalance", ?error, "Failed to deliver USDC market-making ambient-balance alert");
                 }
             }
+            // Indeterminate withdrawal poll: the Alpaca poll timed out or returned
+            // a transport/API error without observing a terminal status. The
+            // aggregate is in Withdrawing (guard held, AlpacaTransferId recorded)
+            // -- NOT WithdrawalFailed. Re-polling is idempotent (reads only; never
+            // re-initiates the withdrawal). Schedule an unbounded delayed redrive
+            // (like SettlementCheckTransient): return Ok so apalis does not
+            // consume the retry budget, and enqueue a new job after the delay so
+            // the same transfer ID is re-polled. Before the alert deadline only
+            // a warn log fires; at or after the deadline the operator is paged on
+            // every redrive while the guard stays held and re-polling continues.
+            Err(UsdcTransferError::WithdrawalPollInconclusive {
+                id,
+                initiated_at,
+                source,
+            }) => {
+                self.handle_withdrawal_poll_inconclusive(ctx, id, initiated_at, source)
+                    .await?;
+            }
             // Revert-class burn failures: safe to redrive because
             // `resume_bridging_submitting` scans for an existing burn before
             // re-burning (the scan lower bound is durably recorded). The safety
@@ -878,6 +929,64 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
 }
 
 impl TransferUsdcToMarketMaking {
+    async fn handle_withdrawal_poll_inconclusive(
+        &self,
+        ctx: &TransferUsdcToMarketMakingCtx,
+        id: UsdcRebalanceId,
+        initiated_at: DateTime<Utc>,
+        source: AlpacaWalletError,
+    ) -> Result<(), TransferUsdcToMarketMakingJobError> {
+        // Mirror the `.ok()` pattern for `signed_duration_since`: if
+        // `initiated_at` is in the future (e.g., clock skew after restart),
+        // `to_std()` returns `Err` and we treat elapsed as `None`; the deadline
+        // check is then false (no spurious alert).
+        let elapsed = Utc::now().signed_duration_since(initiated_at).to_std().ok();
+
+        // Once past the deadline, slow the redrive cadence from 30 s to 30 min
+        // so the operator page repeats at ~2/hour rather than ~120/hour. The
+        // re-poll is idempotent so a slower cadence is safe.
+        let deadline_elapsed = withdrawal_poll_deadline_elapsed(elapsed);
+        let redrive_delay = if deadline_elapsed.is_some() {
+            WITHDRAWAL_POLL_POST_DEADLINE_REDRIVE_DELAY
+        } else {
+            WITHDRAWAL_POLL_REDRIVE_DELAY
+        };
+
+        warn!(
+            target: "rebalance",
+            %id,
+            %source,
+            ?elapsed,
+            delay = ?redrive_delay,
+            "Alpaca withdrawal polling inconclusive; rescheduling for re-poll \
+             (aggregate stays in Withdrawing, guard held)"
+        );
+
+        if let Some(elapsed) = deadline_elapsed {
+            let message = format!(
+                "Alpaca->Base USDC transfer {id}: withdrawal polling inconclusive \
+                 for {elapsed:?} (>{WITHDRAWAL_POLL_ALERT_DEADLINE:?}). Alpaca may \
+                 be unreachable or credentials may have changed ({source}). Aggregate stays in \
+                 Withdrawing (guard held). Use `stox transfer resume --kind usdc --id \
+                 {id} --direction to-raindex` to manually re-poll, or investigate \
+                 Alpaca connectivity."
+            );
+            if let Err(notify_err) = ctx.notifier.notify(&message).await {
+                warn!(
+                    target: "rebalance",
+                    ?notify_err,
+                    "Failed to deliver withdrawal-poll-deadline-elapsed alert"
+                );
+            }
+        }
+
+        ctx.job_queue
+            .clone()
+            .push_with_delay(self.clone(), redrive_delay)
+            .await?;
+        Ok(())
+    }
+
     /// Handles a revert-class burn error by either opening the circuit (when the
     /// redrive limit is reached) or scheduling a delayed redrive attempt. Extracted
     /// to keep `Job::perform` under the line-count lint threshold.
@@ -986,17 +1095,29 @@ impl TransferUsdcToMarketMaking {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::TxHash;
-    use chrono::Utc;
+    use chrono::{DateTime, Utc};
     use reqwest::StatusCode;
-    use st0x_bridge::cctp::CctpError;
-    use st0x_evm::EvmError;
     use uuid::Uuid;
 
+    use st0x_bridge::cctp::CctpError;
+    use st0x_evm::EvmError;
+    use st0x_execution::{AlpacaTransferId, AlpacaWalletError};
     use st0x_float_macro::float;
 
     use super::*;
     use crate::alerts::{CapturingNotifier, NoopNotifier};
     use crate::test_utils::setup_test_apalis_pool;
+
+    #[test]
+    fn withdrawal_poll_deadline_elapsed_includes_exact_boundary() {
+        let elapsed = Some(WITHDRAWAL_POLL_ALERT_DEADLINE);
+
+        assert_eq!(
+            withdrawal_poll_deadline_elapsed(elapsed),
+            Some(WITHDRAWAL_POLL_ALERT_DEADLINE),
+            "the alert deadline comparison must be inclusive"
+        );
+    }
 
     /// Builds a `TransferUsdcToHedgingCtx` with test-safe defaults for the
     /// notifier and redrive-limit fields.
@@ -1126,6 +1247,64 @@ mod tests {
             _amount: Usdc,
         ) -> Result<(), UsdcTransferError> {
             Err(self.0.into_error(id))
+        }
+    }
+
+    /// Stub that returns `WithdrawalPollInconclusive` for every resume call.
+    /// `initiated_at` controls whether the deadline check in the job handler
+    /// fires an operator alert (past deadline) or only logs a warning (before).
+    struct InconclusiveAlpacaToBase {
+        initiated_at: DateTime<Utc>,
+    }
+
+    impl InconclusiveAlpacaToBase {
+        fn before_deadline() -> Self {
+            Self {
+                initiated_at: Utc::now(),
+            }
+        }
+
+        fn future_initiated_at() -> Self {
+            Self {
+                initiated_at: Utc::now() + chrono::Duration::minutes(5),
+            }
+        }
+
+        fn after_deadline() -> Self {
+            Self {
+                initiated_at: Utc::now()
+                    - chrono::Duration::from_std(WITHDRAWAL_POLL_ALERT_DEADLINE).unwrap()
+                    - chrono::Duration::seconds(1),
+            }
+        }
+
+        /// Nominally at the deadline boundary. The handler computes elapsed later,
+        /// so this exercises the job path at or just beyond the boundary; the pure
+        /// helper test pins the exact `elapsed == WITHDRAWAL_POLL_ALERT_DEADLINE`
+        /// comparison.
+        fn at_deadline() -> Self {
+            Self {
+                initiated_at: Utc::now()
+                    - chrono::Duration::from_std(WITHDRAWAL_POLL_ALERT_DEADLINE).unwrap(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ResumeAlpacaToBase for InconclusiveAlpacaToBase {
+        async fn resume_alpaca_to_base(
+            &self,
+            id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(UsdcTransferError::WithdrawalPollInconclusive {
+                id: id.clone(),
+                initiated_at: self.initiated_at,
+                source: AlpacaWalletError::TransferTimeout {
+                    transfer_id: AlpacaTransferId::from(Uuid::new_v4()),
+                    elapsed: Duration::from_secs(1800),
+                },
+            })
         }
     }
 
@@ -1337,6 +1516,248 @@ mod tests {
             run_at >= before + 55 && run_at <= after + 65,
             "redrive must be delayed by ~{ATTESTATION_REDRIVE_DELAY:?} -- neither immediate nor \
              excessive: run_at={run_at} before={before} after={after}"
+        );
+    }
+
+    /// `WithdrawalPollInconclusive` before the alert deadline must schedule a
+    /// delayed redrive (one Pending job row with `WITHDRAWAL_POLL_REDRIVE_DELAY`) and
+    /// return `Ok` so the apalis retry budget is not consumed -- warn log only,
+    /// no operator alert. `revert_redrive_attempts` must not be incremented
+    /// (the re-poll redrive is unbounded and independent of the burn-revert budget).
+    #[tokio::test]
+    async fn market_making_job_redrives_on_withdrawal_poll_inconclusive() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(InconclusiveAlpacaToBase::before_deadline()),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let before = Utc::now().timestamp();
+        job.perform(&ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "WithdrawalPollInconclusive must enqueue exactly one delayed redrive job"
+        );
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        let rescheduled: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.id, job.id,
+            "the rescheduled job must resume the same aggregate id"
+        );
+        assert!(
+            rescheduled.amount.eq(&job.amount).unwrap(),
+            "the rescheduled job must carry the same amount, got {} vs {}",
+            rescheduled.amount,
+            job.amount
+        );
+        assert!(
+            run_at >= before + i64::try_from(WITHDRAWAL_POLL_REDRIVE_DELAY.as_secs()).unwrap() - 5
+                && run_at
+                    <= after + i64::try_from(WITHDRAWAL_POLL_REDRIVE_DELAY.as_secs()).unwrap() + 5,
+            "redrive must be delayed by ~{WITHDRAWAL_POLL_REDRIVE_DELAY:?} -- \
+             run_at={run_at} before={before} after={after}"
+        );
+        // No alert before the deadline: this is a normal transient outcome.
+        assert!(
+            notifier.messages().is_empty(),
+            "WithdrawalPollInconclusive before deadline must not fire an operator alert, \
+             got: {:?}",
+            notifier.messages()
+        );
+        // The burn-revert budget must not be touched by a withdrawal re-poll.
+        assert_eq!(
+            rescheduled.revert_redrive_attempts, 0,
+            "WithdrawalPollInconclusive must not increment revert_redrive_attempts: \
+             the re-poll redrive is unbounded and independent of the burn-revert budget"
+        );
+    }
+
+    /// A future `initiated_at` can happen after clock skew on restart. The
+    /// elapsed calculation must treat it as `None`, which keeps the transfer on
+    /// the pre-deadline cadence and avoids a spurious operator page.
+    #[tokio::test]
+    async fn market_making_job_redrives_future_initiated_at_without_alert() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(InconclusiveAlpacaToBase::future_initiated_at()),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let before = Utc::now().timestamp();
+        job.perform(&ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            withdrawal_poll_deadline_elapsed(None),
+            None,
+            "future initiated_at maps to elapsed=None, so the deadline is not elapsed"
+        );
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "future initiated_at must still enqueue one delayed redrive"
+        );
+
+        let (_payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        assert!(
+            run_at >= before + i64::try_from(WITHDRAWAL_POLL_REDRIVE_DELAY.as_secs()).unwrap() - 5
+                && run_at
+                    <= after + i64::try_from(WITHDRAWAL_POLL_REDRIVE_DELAY.as_secs()).unwrap() + 5,
+            "future initiated_at must use the pre-deadline delay -- \
+             run_at={run_at} before={before} after={after}"
+        );
+        assert!(
+            notifier.messages().is_empty(),
+            "future initiated_at must not fire an operator alert, got: {:?}",
+            notifier.messages()
+        );
+    }
+
+    /// `WithdrawalPollInconclusive` at or after the alert deadline must fire an
+    /// operator alert via the notifier while STILL scheduling the delayed redrive
+    /// and returning `Ok`. The guard stays held and re-polling continues.
+    #[tokio::test]
+    async fn market_making_job_fires_alert_on_withdrawal_poll_deadline_elapsed() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(InconclusiveAlpacaToBase::after_deadline()),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        // perform must still return Ok: deadline-elapsed does NOT consume the
+        // apalis retry budget or emit FailWithdrawal.
+        let before = Utc::now().timestamp();
+        job.perform(&ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        // The delayed redrive must still be enqueued (re-polling continues),
+        // but at the post-deadline cadence (30 min) to prevent alert fatigue.
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "deadline-elapsed must still enqueue a delayed redrive job (guard stays held)"
+        );
+        let (_payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        assert!(
+            run_at
+                >= before
+                    + i64::try_from(WITHDRAWAL_POLL_POST_DEADLINE_REDRIVE_DELAY.as_secs()).unwrap()
+                    - 5
+                && run_at
+                    <= after
+                        + i64::try_from(WITHDRAWAL_POLL_POST_DEADLINE_REDRIVE_DELAY.as_secs())
+                            .unwrap()
+                        + 5,
+            "post-deadline redrive must use the longer {WITHDRAWAL_POLL_POST_DEADLINE_REDRIVE_DELAY:?} \
+             delay to prevent alert fatigue -- run_at={run_at} before={before} after={after}"
+        );
+
+        // Exactly one alert must fire with the correct operator instructions.
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "WithdrawalPollInconclusive past deadline must fire exactly one operator alert, \
+             got: {messages:?}"
+        );
+        let alert = &messages[0];
+        assert!(
+            alert.contains(&job.id.to_string()),
+            "alert must contain the transfer id so the operator can act on it; got: {alert:?}"
+        );
+        assert!(
+            alert.contains("stox transfer resume"),
+            "alert must contain the recovery command; got: {alert:?}"
+        );
+        assert!(
+            alert.contains("to-raindex"),
+            "alert must contain the --direction flag; got: {alert:?}"
+        );
+        assert!(
+            alert.contains("timed out after 1800s"),
+            "alert must contain the underlying Alpaca polling error; got: {alert:?}"
+        );
+    }
+
+    /// `WithdrawalPollInconclusive` at the deadline boundary must fire the operator
+    /// alert and use the post-deadline redrive delay.
+    #[tokio::test]
+    async fn market_making_job_fires_alert_at_exact_deadline_boundary() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(InconclusiveAlpacaToBase::at_deadline()),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        // perform must return Ok even at the exact boundary.
+        let before = Utc::now().timestamp();
+        job.perform(&ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        // Redrive at post-deadline cadence (30 min).
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "exact-boundary must still enqueue a delayed redrive (guard held)"
+        );
+        let (_payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        assert!(
+            run_at
+                >= before
+                    + i64::try_from(WITHDRAWAL_POLL_POST_DEADLINE_REDRIVE_DELAY.as_secs()).unwrap()
+                    - 5
+                && run_at
+                    <= after
+                        + i64::try_from(WITHDRAWAL_POLL_POST_DEADLINE_REDRIVE_DELAY.as_secs())
+                            .unwrap()
+                        + 5,
+            "exact-boundary redrive must use the post-deadline delay -- run_at={run_at} before={before} after={after}"
+        );
+
+        // Alert must fire at the exact boundary (>=, not >).
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "WithdrawalPollInconclusive at exact deadline boundary must fire the operator alert \
+             (>= comparison); got: {messages:?}"
         );
     }
 
@@ -3005,7 +3426,7 @@ mod tests {
 
         assert!(
             matches!(error, TransferUsdcToHedgingJobError::Transfer(_)),
-            "a mint-path Cctp revert must propagate as terminal Transfer,              not redrive; got {error:?}",
+            "a mint-path Cctp revert must propagate as terminal Transfer, not redrive; got {error:?}",
         );
         assert_eq!(
             pending_job_count::<TransferUsdcToHedging>(&pool).await,
@@ -3064,7 +3485,7 @@ mod tests {
 
         assert!(
             matches!(error, TransferUsdcToMarketMakingJobError::Transfer(_)),
-            "a mint-path Cctp revert in market-making must propagate as terminal Transfer;              got {error:?}",
+            "a mint-path Cctp revert in market-making must propagate as terminal Transfer; got {error:?}",
         );
         assert_eq!(
             pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -18,8 +18,8 @@ use st0x_event_sorcery::Store;
 use st0x_evm::{USDC_BASE, Wallet};
 use st0x_execution::alpaca_broker_api::CryptoOrderResponse;
 use st0x_execution::{
-    AlpacaTransferId, AlpacaWalletService, ClientOrderId, ConversionDirection, CryptoOrderOutcome,
-    Network, Positive, TokenSymbol, Transfer, TransferStatus,
+    AlpacaTransferId, AlpacaWalletError, AlpacaWalletService, ClientOrderId, ConversionDirection,
+    CryptoOrderOutcome, Network, Positive, TokenSymbol, Transfer, TransferStatus,
 };
 use st0x_finance::Usdc;
 use st0x_raindex::{Raindex, RaindexService, RaindexVaultId};
@@ -699,13 +699,16 @@ impl<
                 direction: AlpacaToBase,
                 amount,
                 withdrawal_ref,
+                initiated_at,
                 ..
             }) => {
                 let TransferRef::AlpacaId(transfer_id) = withdrawal_ref else {
                     return Err(UsdcTransferError::WithdrawalRefMustBeAlpacaId { id: id.clone() });
                 };
 
-                let withdrawal_tx = self.poll_and_confirm_withdrawal(id, &transfer_id).await?;
+                let withdrawal_tx = self
+                    .poll_and_confirm_withdrawal(id, &transfer_id, initiated_at)
+                    .await?;
                 // Thread the confirmed withdrawal_tx so the burn-scan lower bound
                 // is derived from the withdrawal tx block (not the raw chain head).
                 self.continue_alpaca_to_base_from_withdrawal_complete(id, amount, withdrawal_tx)
@@ -969,7 +972,14 @@ impl<
     ) -> Result<(), UsdcTransferError> {
         let transfer = self.initiate_alpaca_withdrawal(id, filled_amount).await?;
 
-        let withdrawal_tx = self.poll_and_confirm_withdrawal(id, &transfer.id).await?;
+        // Approximate initiated_at: the aggregate's initiated_at was just set
+        // moments ago by the Initiate command handler. Reading it back from the
+        // aggregate is not worth an extra DB round-trip; on any re-poll redrive,
+        // resume_alpaca_to_base reads the exact aggregate value anyway. The
+        // 4-hour operator-alert deadline absorbs any sub-second discrepancy here.
+        let withdrawal_tx = self
+            .poll_and_confirm_withdrawal(id, &transfer.id, Utc::now())
+            .await?;
         // Thread the confirmed withdrawal_tx so the burn-scan lower bound
         // is derived from the withdrawal tx block (not the raw chain head).
         self.continue_alpaca_to_base_from_withdrawal_complete(id, filled_amount, withdrawal_tx)
@@ -1376,7 +1386,13 @@ impl<
 
         let transfer = self.initiate_alpaca_withdrawal(id, usdc_amount).await?;
 
-        let withdrawal_tx = self.poll_and_confirm_withdrawal(id, &transfer.id).await?;
+        // Approximate initiated_at: same reasoning as
+        // continue_alpaca_to_base_from_conversion_complete -- the aggregate's value
+        // was set moments ago; resume_alpaca_to_base uses the exact stored value on
+        // any re-poll redrive.
+        let withdrawal_tx = self
+            .poll_and_confirm_withdrawal(id, &transfer.id, Utc::now())
+            .await?;
 
         // Thread the confirmed withdrawal_tx so the burn-scan lower bound is
         // derived from the withdrawal tx block (not the raw chain head).
@@ -1428,6 +1444,7 @@ impl<
         &self,
         id: &UsdcRebalanceId,
         transfer_id: &AlpacaTransferId,
+        initiated_at: DateTime<Utc>,
     ) -> Result<Option<alloy::primitives::TxHash>, UsdcTransferError> {
         let transfer = match self
             .alpaca_wallet
@@ -1436,18 +1453,72 @@ impl<
         {
             Ok(transfer) => transfer,
             Err(error) => {
-                warn!(target: "rebalance", "Alpaca withdrawal polling failed: {error}");
-                self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::FailWithdrawal {
-                            reason: format!("Polling failed: {error}"),
-                        },
-                    )
-                    .await?;
-                return Err(UsdcTransferError::AlpacaWallet(error));
+                // CONSERVATIVE FAIL-CLOSED: every `AlpacaWalletError` returned by
+                // `poll_transfer_until_complete` (including ApiError{4xx/5xx},
+                // TransferTimeout, Reqwest, ParseError, TransferNotFound, and
+                // InvalidStatusTransition) is treated as INDETERMINATE -- the
+                // withdrawal may have already succeeded on Alpaca's side even if
+                // the poll did not confirm it. This is intentional: Alpaca's
+                // documented determinate terminal failure is delivered as
+                // `Ok(transfer)` with `status == TransferStatus::Failed` and no
+                // tx hash, which is handled below. Error responses from the polling
+                // endpoint do NOT constitute a determinate "funds never left" signal
+                // in the Alpaca Broker API, so we never emit `FailWithdrawal` on an
+                // error path.
+                //
+                // TransferNotFound specifically (the by-id endpoint returns 404)
+                // is also classified as INDETERMINATE here. This is intentionally
+                // fail-closed: an absent transfer ID does not confirm the
+                // withdrawal never left. Guard is held, re-poll continues. Recovery
+                // for a permanently-absent UUID is operational (see docs/cli-ops.md
+                // "Withdrawal poll inconclusive"), not automated.
+                //
+                // Alpaca Broker API: GET
+                // /v1/accounts/{account_id}/wallets/transfers/{transfer_id}
+                // (docs.alpaca.markets/us/reference/getcryptofundingtransfer-1).
+                // The transfer lifecycle terminates in COMPLETE or FAILED status
+                // delivered as a Transfer payload. HTTP 4xx/5xx responses are
+                // transient (auth, network, Alpaca-side load) and do not indicate
+                // the transfer's ultimate fate -- the same transfer ID must be
+                // re-polled to determine the outcome.
+                //
+                // Consequence of the conservative assumption: if a poll error is
+                // encountered the aggregate stays in Withdrawing (guard held,
+                // AlpacaTransferId recorded). The job redrive re-polls the same
+                // transfer ID. After 4 hours of failed polls the operator is paged.
+                // Worst case: a stuck operator page + manual intervention. No funds
+                // are lost and no re-withdrawal can occur, which is the correct
+                // safe failure direction for a money-movement operation.
+                warn!(
+                    target: "rebalance",
+                    %id, %transfer_id,
+                    "Alpaca withdrawal polling inconclusive; keeping Withdrawing \
+                     state for delayed redrive (will re-poll same transfer ID): {error}"
+                );
+                return Err(UsdcTransferError::WithdrawalPollInconclusive {
+                    id: id.clone(),
+                    initiated_at,
+                    source: error,
+                });
             }
         };
+
+        if let (TransferStatus::Failed, Some(tx_hash)) = (transfer.status, transfer.tx) {
+            warn!(
+                target: "rebalance",
+                %id, %transfer_id, %tx_hash,
+                "Alpaca withdrawal reported Failed with an on-chain tx hash; treating as \
+                 inconclusive and keeping Withdrawing state for delayed redrive"
+            );
+            return Err(UsdcTransferError::WithdrawalPollInconclusive {
+                id: id.clone(),
+                initiated_at,
+                source: AlpacaWalletError::FailedTransferHasTx {
+                    transfer_id: *transfer_id,
+                    tx_hash,
+                },
+            });
+        }
 
         if transfer.status != TransferStatus::Complete {
             let status = format!("{:?}", transfer.status);
@@ -9163,10 +9234,12 @@ mod tests {
 
         server.mock(|when, then| {
             when.method(GET)
-                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+                .path(format!(
+                    "/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers/{transfer_uuid}"
+                ));
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!([{
+                .json_body(json!({
                     "id": transfer_uuid.to_string(),
                     "direction": "OUTGOING",
                     "amount": "100",
@@ -9180,7 +9253,7 @@ mod tests {
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0",
                     "fees": "0"
-                }]));
+                }));
         })
     }
 
@@ -9246,7 +9319,7 @@ mod tests {
         .unwrap();
 
         let error = manager
-            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
             .await
             .unwrap_err();
 
@@ -9332,7 +9405,7 @@ mod tests {
         .unwrap();
 
         let error = manager
-            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
             .await
             .unwrap_err();
 
@@ -9425,7 +9498,7 @@ mod tests {
         .unwrap();
 
         let error = manager
-            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
             .await
             .unwrap_err();
 
@@ -9516,7 +9589,7 @@ mod tests {
         .unwrap();
 
         manager
-            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
             .await
             .unwrap();
 
@@ -9587,7 +9660,7 @@ mod tests {
 
         // Falls through to ConfirmWithdrawal even without a tx hash.
         manager
-            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
             .await
             .unwrap();
 
@@ -9661,7 +9734,7 @@ mod tests {
         // poll_and_confirm_withdrawal succeeds (no tx hash to check) and advances
         // the aggregate to WithdrawalComplete.
         manager
-            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
             .await
             .unwrap();
 
@@ -9703,6 +9776,688 @@ mod tests {
                 }
             ),
             "Aggregate must remain WithdrawalComplete after zero balance; got: {state:?}"
+        );
+    }
+
+    /// Hypothesis: on ANY poll error (ApiError, TransferTimeout, reqwest::Error),
+    /// `poll_and_confirm_withdrawal` returns `WithdrawalPollInconclusive` WITHOUT
+    /// emitting `FailWithdrawal`. The aggregate stays in `Withdrawing` with the
+    /// guard held so no fresh re-withdrawal can be started on the next tick.
+    #[tokio::test]
+    async fn poll_and_confirm_withdrawal_on_poll_error_returns_inconclusive_without_failing() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+        let withdrawal_uuid = Uuid::new_v4();
+        let withdrawal_id = AlpacaTransferId::from(withdrawal_uuid);
+
+        // Mock the transfers endpoint to return a 400 Bad Request, triggering
+        // AlpacaWalletError::ApiError -- an indeterminate poll error.
+        let _error_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!(
+                    "/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers/{withdrawal_uuid}"
+                ));
+            then.status(400)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({"message": "bad request"}));
+        });
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        // Stage aggregate at Withdrawing{AlpacaToBase}.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                conversion: par_conversion(amount),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
+            .await
+            .unwrap_err();
+
+        // The error must be WithdrawalPollInconclusive, NOT AlpacaWallet or
+        // WithdrawalFailed. The indeterminate path does not emit FailWithdrawal.
+        assert!(
+            matches!(error, UsdcTransferError::WithdrawalPollInconclusive { .. }),
+            "Expected WithdrawalPollInconclusive on poll error, got: {error:?}"
+        );
+
+        // Aggregate must still be Withdrawing (guard held, no FailWithdrawal emitted).
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::Withdrawing {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must stay in Withdrawing on inconclusive poll error; got: {state:?}"
+        );
+        assert!(
+            state.holds_rebalance_guard(),
+            "Guard must stay held when poll is inconclusive (Withdrawing state)"
+        );
+    }
+
+    /// Hypothesis: a DETERMINATE poll failure (Alpaca returns
+    /// TransferStatus::Failed with no tx hash) still sends FailWithdrawal and moves
+    /// the aggregate to WithdrawalFailed (guard released).
+    #[tokio::test]
+    async fn poll_and_confirm_withdrawal_on_alpaca_transfer_failed_sends_fail_withdrawal() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let transfer_uuid = Uuid::new_v4();
+        // Mock Alpaca to return a FAILED terminal status with no on-chain tx.
+        let _failed_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!(
+                    "/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers/{transfer_uuid}"
+                ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({
+                    "id": transfer_uuid.to_string(),
+                    "direction": "OUTGOING",
+                    "amount": "100",
+                    "usd_value": "100",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": "0x0000000000000000000000000000000000000001",
+                    "to_address": "0x2222222222222222222222222222222222222222",
+                    "status": "FAILED",
+                    "tx_hash": null,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                }));
+        });
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        let withdrawal_id = AlpacaTransferId::from(transfer_uuid);
+
+        // Stage aggregate at Withdrawing{AlpacaToBase}.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                conversion: par_conversion(amount),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
+            .await
+            .unwrap_err();
+
+        // Determinate Alpaca FAILED -> WithdrawalFailed error returned.
+        assert!(
+            matches!(error, UsdcTransferError::WithdrawalFailed { .. }),
+            "Expected WithdrawalFailed on determinate Alpaca Failed status, got: {error:?}"
+        );
+
+        // Aggregate must be in WithdrawalFailed (guard released).
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalFailed {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must be in WithdrawalFailed after determinate Alpaca Failed; got: {state:?}"
+        );
+        assert!(
+            !state.holds_rebalance_guard(),
+            "Guard must be released after WithdrawalFailed"
+        );
+    }
+
+    /// Hypothesis: a FAILED Alpaca withdrawal that includes an on-chain tx hash is
+    /// not a determinate "funds never left" signal. The aggregate stays in
+    /// Withdrawing with the guard held so the same transfer can be re-polled.
+    #[tokio::test]
+    async fn poll_and_confirm_withdrawal_on_failed_transfer_with_tx_returns_inconclusive() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let transfer_uuid = Uuid::new_v4();
+        let tx_hash = b256!("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+        let _failed_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!(
+                    "/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers/{transfer_uuid}"
+                ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({
+                    "id": transfer_uuid.to_string(),
+                    "direction": "OUTGOING",
+                    "amount": "100",
+                    "usd_value": "100",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": "0x0000000000000000000000000000000000000001",
+                    "to_address": "0x2222222222222222222222222222222222222222",
+                    "status": "FAILED",
+                    "tx_hash": format!("{tx_hash:#x}"),
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                }));
+        });
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        let withdrawal_id = AlpacaTransferId::from(transfer_uuid);
+
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                conversion: par_conversion(amount),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::WithdrawalPollInconclusive {
+                    source: AlpacaWalletError::FailedTransferHasTx { tx_hash: observed, .. },
+                    ..
+                } if observed == tx_hash
+            ),
+            "FAILED with a tx hash must be treated as inconclusive, got: {error:?}"
+        );
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::Withdrawing {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must stay Withdrawing when FAILED carries a tx hash; got: {state:?}"
+        );
+        assert!(
+            state.holds_rebalance_guard(),
+            "Guard must stay held when FAILED carries a tx hash"
+        );
+    }
+
+    /// Hypothesis: Alpaca returning 404 for the by-id transfer lookup
+    /// (`TransferNotFound`) does NOT emit `FailWithdrawal`. The aggregate stays
+    /// in `Withdrawing` with the guard held.
+    ///
+    /// This pins the contract that only `Ok(transfer)` with
+    /// `TransferStatus::Failed` and no tx hash is a determinate terminal that
+    /// yields `FailWithdrawal`. A missing UUID is intentionally fail-closed: the
+    /// transfer may still be in progress and the UUID absence does not confirm
+    /// funds never left. Recovery is operational (see docs/cli-ops.md).
+    #[tokio::test]
+    async fn poll_and_confirm_withdrawal_on_transfer_not_found_returns_inconclusive() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let transfer_uuid = Uuid::new_v4();
+        let _not_found_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!(
+                    "/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers/{transfer_uuid}"
+                ));
+            then.status(404)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({"message": "transfer not found"}));
+        });
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        let withdrawal_id = AlpacaTransferId::from(transfer_uuid);
+
+        // Stage aggregate at Withdrawing{AlpacaToBase}.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                conversion: par_conversion(amount),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
+            .await
+            .unwrap_err();
+
+        // TransferNotFound -> WithdrawalPollInconclusive, NOT WithdrawalFailed.
+        // The guard stays held.
+        assert!(
+            matches!(error, UsdcTransferError::WithdrawalPollInconclusive { .. }),
+            "TransferNotFound must map to WithdrawalPollInconclusive (not FailWithdrawal); got: {error:?}"
+        );
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::Withdrawing {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must stay Withdrawing on TransferNotFound (guard held); got: {state:?}"
+        );
+        assert!(
+            state.holds_rebalance_guard(),
+            "Guard must stay held on TransferNotFound -- UUID absence is not a determinate failure signal"
+        );
+    }
+
+    /// Hypothesis: after a prior inconclusive poll (aggregate stays Withdrawing),
+    /// a resumed call that finds Alpaca now reports Complete advances the aggregate
+    /// to WithdrawalComplete. Re-polling the same AlpacaTransferId is idempotent
+    /// and the withdraw is adopted.
+    #[tokio::test]
+    async fn poll_and_confirm_withdrawal_after_prior_inconclusive_adopts_complete() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let transfer_uuid = Uuid::new_v4();
+        let withdrawal_id = AlpacaTransferId::from(transfer_uuid);
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        // Stage aggregate at Withdrawing{AlpacaToBase}.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                conversion: par_conversion(amount),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        // First call: poll returns a 400 error -> inconclusive, aggregate stays Withdrawing.
+        let mut error_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!(
+                    "/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers/{transfer_uuid}"
+                ));
+            then.status(400)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({"message": "bad request"}));
+        });
+
+        let error = manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, UsdcTransferError::WithdrawalPollInconclusive { .. }),
+            "First call must return WithdrawalPollInconclusive, got: {error:?}"
+        );
+        error_mock.assert();
+        // Explicitly delete the 400 mock before registering the 200 mock so the
+        // second call is not matched by the still-registered 400 handler.
+        error_mock.delete();
+
+        // Second call (simulating the delayed-redrive re-poll): Alpaca now reports COMPLETE.
+        // No tx hash so the aggregate goes to WithdrawalComplete without a confirmation check.
+        let complete_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!(
+                    "/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers/{transfer_uuid}"
+                ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({
+                    "id": transfer_uuid.to_string(),
+                    "direction": "OUTGOING",
+                    "amount": "100",
+                    "usd_value": "100",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": "0x0000000000000000000000000000000000000001",
+                    "to_address": "0x2222222222222222222222222222222222222222",
+                    "status": "COMPLETE",
+                    "tx_hash": null,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                }));
+        });
+
+        manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
+            .await
+            .unwrap();
+
+        complete_mock.assert();
+
+        // Aggregate must have advanced to WithdrawalComplete.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must advance to WithdrawalComplete after second (Complete) poll; got: {state:?}"
+        );
+    }
+
+    /// Regression: `resume_alpaca_to_base` from `Withdrawing{AlpacaToBase}` must
+    /// thread the aggregate's stored `initiated_at` into `WithdrawalPollInconclusive`,
+    /// NOT a fresh `Utc::now()`. The durable 4-hour operator-alert deadline is derived
+    /// from this field and must survive restarts without resetting. A regression that
+    /// changed manager.rs line 719 from `initiated_at` (destructured from the aggregate)
+    /// to `Utc::now()` would silently pass all other tests while breaking the guarantee.
+    #[tokio::test]
+    async fn resume_alpaca_to_base_from_withdrawing_threads_aggregate_initiated_at() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+        let withdrawal_uuid = Uuid::new_v4();
+        let withdrawal_id = AlpacaTransferId::from(withdrawal_uuid);
+
+        // Mock Alpaca's transfers endpoint to return a 400 -- triggers
+        // WithdrawalPollInconclusive via the fail-closed indeterminate error path.
+        let _error_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!(
+                    "/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers/{withdrawal_uuid}"
+                ));
+            then.status(400)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({"message": "bad request"}));
+        });
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        // Stage at Withdrawing{AlpacaToBase} via the real CQRS store.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                conversion: par_conversion(amount),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Load the aggregate to read the stored initiated_at (withdrawal initiation time).
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        let UsdcRebalance::Withdrawing {
+            initiated_at: aggregate_initiated_at,
+            ..
+        } = state
+        else {
+            panic!("Expected Withdrawing state; got: {state:?}");
+        };
+
+        // Call resume_alpaca_to_base (the full path, not just poll_and_confirm_withdrawal).
+        // This is the path that destructures initiated_at from the aggregate.
+        let error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        let UsdcTransferError::WithdrawalPollInconclusive {
+            initiated_at: error_initiated_at,
+            ..
+        } = error
+        else {
+            panic!("Expected WithdrawalPollInconclusive; got: {error:?}");
+        };
+
+        // The error's initiated_at must equal the aggregate's stored value.
+        // If this path were changed to Utc::now(), the timestamps would differ
+        // and this assertion would catch the regression.
+        assert_eq!(
+            error_initiated_at, aggregate_initiated_at,
+            "resume_alpaca_to_base must thread the aggregate's stored initiated_at \
+             into WithdrawalPollInconclusive, not a fresh Utc::now()"
+        );
+    }
+
+    /// Hypothesis: `ConfirmWithdrawal` from a non-Withdrawing state (e.g.
+    /// WithdrawalComplete) is rejected by the aggregate cleanly via a SendError.
+    /// The guard stays held; no double-adoption or panic occurs.
+    #[tokio::test]
+    async fn confirm_withdrawal_rejected_from_non_withdrawing_state() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        // Seed aggregate to WithdrawalComplete.
+        advance_to_withdrawal_complete_alpaca_to_base(&cqrs, &id, amount).await;
+
+        let transfer_uuid = Uuid::new_v4();
+        let withdrawal_id = AlpacaTransferId::from(transfer_uuid);
+
+        // Mock Alpaca to return COMPLETE (poll call will succeed, but ConfirmWithdrawal
+        // command will be rejected by the aggregate).
+        let _complete_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!(
+                    "/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers/{transfer_uuid}"
+                ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({
+                    "id": transfer_uuid.to_string(),
+                    "direction": "OUTGOING",
+                    "amount": "100",
+                    "usd_value": "100",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": "0x0000000000000000000000000000000000000001",
+                    "to_address": "0x2222222222222222222222222222222222222222",
+                    "status": "COMPLETE",
+                    "tx_hash": null,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                }));
+        });
+
+        let result = manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
+            .await;
+
+        // ConfirmWithdrawal from WithdrawalComplete is rejected by the aggregate.
+        // The error propagates as UsdcTransferError::Aggregate (no panic, no guard corruption).
+        assert!(
+            matches!(result, Err(UsdcTransferError::Aggregate(_))),
+            "Expected Aggregate error when ConfirmWithdrawal is rejected from WithdrawalComplete, \
+             got: {result:?}"
+        );
+
+        // Aggregate must still be in WithdrawalComplete (no corruption, guard held).
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must remain WithdrawalComplete after rejected ConfirmWithdrawal; got: {state:?}"
+        );
+        assert!(
+            state.holds_rebalance_guard(),
+            "Guard must remain held after rejected ConfirmWithdrawal"
         );
     }
 
@@ -12010,7 +12765,7 @@ mod tests {
         } = error
         else {
             panic!(
-                "a burn that broadcasts but whose pending-burn record never commits                  must fail closed as BurnRecordFailed; got: {error:?}"
+                "a burn that broadcasts but whose pending-burn record never commits must fail closed as BurnRecordFailed; got: {error:?}"
             );
         };
         assert_eq!(
@@ -12683,7 +13438,7 @@ mod tests {
         .unwrap();
 
         let error = manager
-            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id, Utc::now())
             .await
             .unwrap_err();
 

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -18,6 +18,7 @@ pub(crate) use manager::{CrossVenueCashTransfer, UsdcSettlementParams, u256_to_u
 use std::time::Duration;
 
 use alloy::primitives::TxHash;
+use chrono::{DateTime, Utc};
 use rain_math_float::FloatError;
 use thiserror::Error;
 
@@ -103,6 +104,34 @@ pub(crate) enum UsdcTransferError {
          operator reconciliation"
     )]
     AttestationRetryDeadlineElapsed { id: UsdcRebalanceId },
+    /// Alpaca withdrawal polling returned an indeterminate result: the poll timed
+    /// out or returned a transport/API error without observing a terminal status
+    /// (`Complete` or `Failed`). The aggregate stays in `Withdrawing` (guard
+    /// held, Alpaca transfer ID recorded). This is NOT a terminal failure: a
+    /// delayed redrive re-polls the same Alpaca transfer ID (idempotent). Only
+    /// `TransferStatus::Failed` with no tx hash (Alpaca's determinate terminal
+    /// for a failed withdrawal that did not broadcast on-chain) produces
+    /// `FailWithdrawal`; `Failed` with a tx hash stays indeterminate.
+    ///
+    /// Mirrors `SettlementCheckTransient` / `WithdrawalTxUnderconfirmed` in
+    /// redrive semantics: unbounded, returns `Ok` from the job.
+    ///
+    /// `initiated_at` is the `Withdrawing.initiated_at` timestamp from the
+    /// aggregate, threaded here so the job handler can compute a durable
+    /// deadline: before the deadline only a warn log fires; at or after the
+    /// deadline the operator is paged (while the guard stays held and
+    /// re-polling continues).
+    #[error(
+        "USDC rebalance {id}: Alpaca withdrawal polling inconclusive \
+         (timeout or transient error); transfer may still be in progress \
+         (Alpaca transfer ID preserved in Withdrawing state)"
+    )]
+    WithdrawalPollInconclusive {
+        id: UsdcRebalanceId,
+        initiated_at: DateTime<Utc>,
+        #[source]
+        source: AlpacaWalletError,
+    },
     #[error(
         "USDC rebalance {id} attestation retry deadline duration {retry_deadline:?} \
          cannot be represented as an absolute timestamp"

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -1364,9 +1364,17 @@ impl UsdcRebalance {
     /// `WithdrawalSubmitting` is resumable only for `BaseToAlpaca`:
     /// `resume_base_to_alpaca` handles it; `resume_alpaca_to_base` returns
     /// `ResumeDirectionMismatch` for `WithdrawalSubmitting{AlpacaToBase}`.
+    /// `Withdrawing{AlpacaToBase, AlpacaId}` is resumable: the
+    /// `AlpacaTransferId` is durably recorded and `resume_alpaca_to_base`
+    /// re-polls the same transfer (idempotent). `WithdrawalComplete` in the
+    /// `AlpacaToBase` direction is also resumable: the source withdrawal has
+    /// already moved funds and the resume path scans for an existing burn before
+    /// submitting one. `Withdrawing{BaseToAlpaca}`,
+    /// `Withdrawing{AlpacaToBase, OnchainTx}`, and
+    /// `WithdrawalComplete{BaseToAlpaca}` are NOT resumable here: those paths
+    /// use on-chain txs, handled by the post-burn path.
     ///
-    /// This method covers ONLY pre-burn / pre-withdrawal-tx states: post-burn
-    /// states (`Bridging`, `AwaitingAttestation`, `Attested`) are already
+    /// Post-burn states (`Bridging`, `AwaitingAttestation`, `Attested`) are
     /// handled by `resumable_post_burn_transfer`.
     pub(crate) fn is_resumable_mid_flight_data(&self) -> Option<(RebalanceDirection, Usdc)> {
         match self {
@@ -1375,6 +1383,24 @@ impl UsdcRebalance {
             // ResumeDirectionMismatch for this state regardless of direction.
             Self::WithdrawalSubmitting {
                 direction: direction @ RebalanceDirection::BaseToAlpaca,
+                amount,
+                ..
+            }
+            // AlpacaToBase `Withdrawing`: the AlpacaTransferId is durably
+            // recorded; `resume_alpaca_to_base` re-polls the same transfer
+            // (idempotent). `WithdrawalComplete{AlpacaToBase}` is one step
+            // further: funds have left Alpaca, and resume scans for any existing
+            // burn before submitting one. Both are safe to re-arm on startup.
+            // `WithdrawalSubmitting{AlpacaToBase}` remains non-re-armable
+            // because the Alpaca transfer ID is not persisted in that state.
+            | Self::Withdrawing {
+                direction: direction @ RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal_ref: TransferRef::AlpacaId(_),
+                ..
+            }
+            | Self::WithdrawalComplete {
+                direction: direction @ RebalanceDirection::AlpacaToBase,
                 amount,
                 ..
             }
@@ -1389,7 +1415,10 @@ impl UsdcRebalance {
             | Self::ConversionComplete { .. }
             | Self::ConversionFailed { .. }
             | Self::Withdrawing { .. }
-            | Self::WithdrawalComplete { .. }
+            | Self::WithdrawalComplete {
+                direction: RebalanceDirection::BaseToAlpaca,
+                ..
+            }
             | Self::WithdrawalFailed { .. }
             | Self::Bridging { .. }
             | Self::AwaitingAttestation { .. }
@@ -1529,7 +1558,13 @@ impl EventSourced for UsdcRebalance {
     // `ConversionConfirmed` event now carry `ConversionAmounts` (source +
     // received) instead of a single `filled_amount`. Bumped to clear stale
     // snapshots so they rebuild under the new schema.
-    const SCHEMA_VERSION: u64 = 7;
+    // v8: `Withdrawing.initiated_at` semantics changed -- it now records the
+    // withdrawal initiation time (from the `Initiated` event's `initiated_at`
+    // field) rather than the overall rebalance start. Stale `Withdrawing`
+    // snapshots carry the old timestamp, which would skew the 4-hour operator
+    // alert deadline. Bumped so snapshots are cleared and `initiated_at` is
+    // rebuilt from events on the next load.
+    const SCHEMA_VERSION: u64 = 8;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use UsdcRebalanceEvent::*;
@@ -1650,33 +1685,41 @@ impl EventSourced for UsdcRebalance {
             },
 
             (
-                Initiated { withdrawal_ref, .. },
-                Self::WithdrawalSubmitting {
-                    direction,
-                    amount,
-                    initiated_at,
+                Initiated {
+                    withdrawal_ref,
+                    initiated_at: withdrawal_initiated_at,
                     ..
+                },
+                Self::WithdrawalSubmitting {
+                    direction, amount, ..
                 },
             ) => Self::Withdrawing {
                 direction: *direction,
                 amount: *amount,
                 withdrawal_ref: withdrawal_ref.clone(),
-                initiated_at: *initiated_at,
+                // Use the event's initiated_at (set by transition_initiate_withdrawal to
+                // Utc::now() at the moment the Alpaca withdrawal is initiated), NOT the
+                // prior state's initiated_at which tracks the overall rebalance start.
+                // This is the correct epoch for the durable 4-hour operator alert deadline.
+                initiated_at: *withdrawal_initiated_at,
             },
 
             (
-                Initiated { withdrawal_ref, .. },
+                Initiated {
+                    withdrawal_ref,
+                    initiated_at: withdrawal_initiated_at,
+                    ..
+                },
                 Self::ConversionComplete {
                     direction,
                     conversion,
-                    initiated_at,
                     ..
                 },
             ) => Self::Withdrawing {
                 direction: *direction,
                 amount: conversion.received_amount,
                 withdrawal_ref: withdrawal_ref.clone(),
-                initiated_at: *initiated_at,
+                initiated_at: *withdrawal_initiated_at,
             },
 
             (
@@ -7861,12 +7904,18 @@ mod tests {
         assert_eq!(bridge.updated_at, original_initiated_at);
     }
 
+    /// After the fix that makes `Withdrawing.initiated_at` reflect the actual
+    /// Alpaca withdrawal initiation time (from the `Initiated` event), the DTO's
+    /// `started_at` and `updated_at` fields reflect when the withdrawal step began,
+    /// not when the overall rebalance started. This is correct: the deadline alert
+    /// is anchored to the withdrawal start, and the display is more precise.
     #[test]
-    fn to_dto_preserves_original_initiated_at_when_withdrawal_begins_after_conversion() {
+    fn to_dto_uses_withdrawal_initiation_time_not_rebalance_start_when_withdrawing() {
         let id = UsdcRebalanceId(Uuid::new_v4());
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
         let original_initiated_at = Utc::now();
         let conversion_completed_at = original_initiated_at + chrono::Duration::seconds(30);
+        let withdrawal_initiated_at = original_initiated_at + chrono::Duration::seconds(60);
         let state = replay::<UsdcRebalance>(vec![
             UsdcRebalanceEvent::ConversionInitiated {
                 direction: RebalanceDirection::AlpacaToBase,
@@ -7883,7 +7932,7 @@ mod tests {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(999.99)),
                 withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
-                initiated_at: original_initiated_at + chrono::Duration::seconds(60),
+                initiated_at: withdrawal_initiated_at,
             },
         ])
         .expect("event stream should replay into withdrawing state");
@@ -7895,11 +7944,17 @@ mod tests {
         };
 
         assert!(matches!(bridge.status, UsdcBridgeStatus::Withdrawing));
+        // Withdrawing.initiated_at now reflects when the Alpaca withdrawal was initiated
+        // (from the Initiated event), so the DTO's started_at and updated_at reflect
+        // the withdrawal start time, not the overall rebalance start.
         assert_eq!(
-            bridge.started_at, original_initiated_at,
-            "initiated_at should remain anchored to the original rebalance initiation time"
+            bridge.started_at, withdrawal_initiated_at,
+            "started_at must reflect the withdrawal initiation time (from the Initiated event)"
         );
-        assert_eq!(bridge.updated_at, original_initiated_at);
+        assert_eq!(
+            bridge.updated_at, withdrawal_initiated_at,
+            "updated_at must reflect the withdrawal initiation time in Withdrawing state"
+        );
     }
 
     #[test]
@@ -9670,6 +9725,205 @@ mod tests {
             result, None,
             "WithdrawalSubmitting AlpacaToBase must NOT be resumable \
              (resume_alpaca_to_base returns ResumeDirectionMismatch)"
+        );
+    }
+
+    /// `Withdrawing{AlpacaToBase}` is resumable mid-flight: the AlpacaTransferId
+    /// is durably recorded and `resume_alpaca_to_base` re-polls the same transfer.
+    /// The returned `(direction, amount)` tuple must match exactly.
+    #[test]
+    fn withdrawing_alpaca_to_base_is_resumable_mid_flight_data() {
+        let amount = Usdc::new(float!(100));
+        let state = UsdcRebalance::Withdrawing {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount,
+            withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+            initiated_at: Utc::now(),
+        };
+
+        assert_eq!(
+            state.is_resumable_mid_flight_data(),
+            Some((RebalanceDirection::AlpacaToBase, amount)),
+            "Withdrawing{{AlpacaToBase}} must be resumable mid-flight with the correct amount"
+        );
+    }
+
+    /// A malformed persisted `Withdrawing{AlpacaToBase}` carrying an on-chain
+    /// withdrawal ref has no Alpaca transfer ID to re-poll, so startup recovery
+    /// must not re-arm it as a mid-flight Alpaca withdrawal.
+    #[test]
+    fn withdrawing_alpaca_to_base_onchain_ref_is_not_resumable_mid_flight_data() {
+        let state = UsdcRebalance::Withdrawing {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: Usdc::new(float!(100)),
+            withdrawal_ref: TransferRef::OnchainTx(alloy::primitives::TxHash::ZERO),
+            initiated_at: Utc::now(),
+        };
+
+        assert_eq!(
+            state.is_resumable_mid_flight_data(),
+            None,
+            "Withdrawing{{AlpacaToBase}} with an on-chain withdrawal ref must not be \
+             auto-rearmed without an Alpaca transfer id"
+        );
+    }
+
+    /// `WithdrawalComplete{AlpacaToBase}` is resumable mid-flight: Alpaca has
+    /// already moved the source funds, and `resume_alpaca_to_base` scans for an
+    /// existing burn before submitting one.
+    #[test]
+    fn withdrawal_complete_alpaca_to_base_is_resumable_mid_flight_data() {
+        let amount = Usdc::new(float!(100));
+        let state = UsdcRebalance::WithdrawalComplete {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount,
+            initiated_at: Utc::now(),
+            confirmed_at: Utc::now(),
+            withdrawal_tx: None,
+        };
+
+        assert_eq!(
+            state.is_resumable_mid_flight_data(),
+            Some((RebalanceDirection::AlpacaToBase, amount)),
+            "WithdrawalComplete{{AlpacaToBase}} must be resumable mid-flight with the correct amount"
+        );
+    }
+
+    /// `Withdrawing{BaseToAlpaca}` is NOT resumable mid-flight. BaseToAlpaca
+    /// reaches Withdrawing via an on-chain tx (handled by the post-burn path,
+    /// not the mid-flight re-arm path).
+    #[test]
+    fn withdrawing_base_to_alpaca_is_not_resumable_mid_flight_data() {
+        let state = UsdcRebalance::Withdrawing {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(100)),
+            withdrawal_ref: TransferRef::OnchainTx(alloy::primitives::TxHash::ZERO),
+            initiated_at: Utc::now(),
+        };
+
+        assert_eq!(
+            state.is_resumable_mid_flight_data(),
+            None,
+            "Withdrawing{{BaseToAlpaca}} must not be resumable mid-flight"
+        );
+    }
+
+    /// `WithdrawalComplete{BaseToAlpaca}` is NOT resumable mid-flight. That
+    /// direction's post-withdrawal leg is handled by the post-burn recovery path.
+    #[test]
+    fn withdrawal_complete_base_to_alpaca_is_not_resumable_mid_flight_data() {
+        let state = UsdcRebalance::WithdrawalComplete {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(100)),
+            initiated_at: Utc::now(),
+            confirmed_at: Utc::now(),
+            withdrawal_tx: Some(alloy::primitives::TxHash::ZERO),
+        };
+
+        assert_eq!(
+            state.is_resumable_mid_flight_data(),
+            None,
+            "WithdrawalComplete{{BaseToAlpaca}} must not be resumable mid-flight"
+        );
+    }
+
+    /// `WithdrawalSubmitting{AlpacaToBase}` STILL returns None after this change
+    /// -- regression pin. It must not accidentally become resumable.
+    #[test]
+    fn withdrawal_submitting_alpaca_to_base_remains_not_resumable_mid_flight() {
+        assert_eq!(
+            withdrawal_submitting_alpaca_to_base().is_resumable_mid_flight_data(),
+            None,
+            "WithdrawalSubmitting{{AlpacaToBase}} must still not be resumable mid-flight \
+             (transfer ID not yet persisted in that state)"
+        );
+    }
+
+    /// Regression: `Withdrawing.initiated_at` must come from the `Initiated`
+    /// event's timestamp (set at withdrawal initiation time in
+    /// `transition_initiate_withdrawal`), NOT from the prior state's `initiated_at`
+    /// which tracks the overall rebalance start. Before this fix both evolve arms
+    /// for `AlpacaToBase` copied the prior state's value, so a rebalance with a
+    /// long conversion phase would have an already-elapsed 4-hour operator-alert
+    /// deadline at the first inconclusive withdrawal poll after restart.
+    #[tokio::test]
+    async fn withdrawing_alpaca_to_base_initiated_at_reflects_withdrawal_time_not_rebalance_start()
+    {
+        // Represent the rebalance start as 5 hours ago -- well past the 4-hour
+        // operator-alert deadline. After the fix, Withdrawing.initiated_at must be
+        // the withdrawal initiation time (recent), not the old rebalance start.
+        let old_rebalance_start = Utc::now() - chrono::Duration::hours(5);
+        let amount = Usdc::new(float!(100));
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+
+        let prior_events = vec![
+            UsdcRebalanceEvent::ConversionInitiated {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                initiated_at: old_rebalance_start,
+            },
+            UsdcRebalanceEvent::ConversionConfirmed {
+                direction: RebalanceDirection::AlpacaToBase,
+                conversion: par_conversion(amount),
+                converted_at: old_rebalance_start + chrono::Duration::minutes(10),
+            },
+        ];
+
+        // Apply the Initiate command; transition_initiate_withdrawal emits
+        // Initiated { initiated_at: Utc::now() } at the withdrawal moment.
+        let before_initiate = Utc::now();
+        let new_events = TestHarness::<UsdcRebalance>::with(())
+            .given(prior_events.clone())
+            .when(UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(transfer_id),
+            })
+            .await
+            .events();
+        let after_initiate = Utc::now();
+
+        assert_eq!(
+            new_events.len(),
+            1,
+            "Initiate must emit exactly one Initiated event"
+        );
+
+        // Extract the event's initiated_at before consuming new_events in the replay.
+        let event_initiated_at = match &new_events[0] {
+            UsdcRebalanceEvent::Initiated { initiated_at, .. } => *initiated_at,
+            other => panic!("Expected Initiated event, got {other:?}"),
+        };
+
+        // Replay all events to get the Withdrawing state.
+        let all_events: Vec<_> = prior_events.into_iter().chain(new_events).collect();
+        let state = replay::<UsdcRebalance>(all_events)
+            .expect("events must replay cleanly into Withdrawing")
+            .expect("aggregate must have state after events");
+
+        let UsdcRebalance::Withdrawing {
+            initiated_at: withdrawing_initiated_at,
+            ..
+        } = state
+        else {
+            panic!("Expected Withdrawing state, got: {state:?}");
+        };
+
+        // The Withdrawing state's initiated_at must equal the event's timestamp.
+        assert_eq!(
+            withdrawing_initiated_at, event_initiated_at,
+            "Withdrawing.initiated_at must match the Initiated event's initiated_at \
+             (withdrawal initiation time), not the prior ConversionComplete.initiated_at"
+        );
+
+        // The withdrawal initiation time must be recent (near the Initiate call),
+        // not the old rebalance start (5 hours ago).
+        assert!(
+            withdrawing_initiated_at >= before_initiate
+                && withdrawing_initiated_at <= after_initiate,
+            "Withdrawing.initiated_at must be the withdrawal initiation time (recent), \
+             not the old rebalance start {old_rebalance_start:?}; got {withdrawing_initiated_at:?}"
         );
     }
 


### PR DESCRIPTION
## What

- Closes [RAI-1177](https://linear.app/makeitrain/issue/RAI-1177/alpaca-usdc-withdrawal-poll-timeout-false-negative-re-withdraws-and).
- Makes Alpaca->Base USDC withdrawals durable when Alpaca polling is inconclusive: `poll_and_confirm_withdrawal` returns `WithdrawalPollInconclusive` instead of emitting `FailWithdrawal`, so `UsdcRebalance::Withdrawing` and the USDC guard stay held.
- Re-polls the same Alpaca transfer ID through `TransferUsdcToMarketMaking` redrives, with a 4h operator alert deadline and slower 30m post-deadline cadence.
- Re-arms stranded `Withdrawing{AlpacaToBase}` and `WithdrawalComplete{AlpacaToBase}` states on startup and timeout sweep instead of clearing the guard.
- Updates manual `stox transfer resume` retry behavior and the operator runbook for inconclusive withdrawal polls.

## Why

- A withdrawal poll timeout used to look terminal even when Alpaca may have completed the transfer, which released the guard and let the next rebalance tick start another withdrawal.
- Prod incident 2026-06-26 (~14:13-14:28 UTC) stranded ~7,321 USDC in the bridging wallet, drained Alpaca USD, and blocked USDC rebalancing for ~28h until manual recovery.
- Alpaca's explicit `TransferStatus::Failed` is the determinate failure signal; API errors, timeouts, and missing UUIDs are not proof that funds never moved.
- This is the Alpaca-withdrawal counterpart to [RAI-1168](https://linear.app/makeitrain/issue/RAI-1168), which made CCTP burn tracking durable.

## How

- Adds `UsdcTransferError::WithdrawalPollInconclusive { id, initiated_at, source }` and maps indeterminate Alpaca poll errors to it while preserving the existing `TransferStatus::Failed` -> `FailWithdrawal` path.
- Handles `WithdrawalPollInconclusive` in `TransferUsdcToMarketMaking::perform` by enqueueing a delayed redrive and returning `Ok(())`, so apalis retry budget is not consumed for safe re-polls.
- Extends `UsdcRebalance::is_resumable_mid_flight_data` so `Withdrawing{AlpacaToBase}` and `WithdrawalComplete{AlpacaToBase}` are resumable, while `WithdrawalSubmitting{AlpacaToBase}` remains excluded because it has no persisted Alpaca transfer ID.
- Changes `RebalancingService` timeout/startup recovery to use `transfer_live_job_for_id` and `RearmPolicy::AlpacaToBaseIdempotentRedrive`, blocking duplicate redrives for live apalis rows including retryable `Failed` rows.
- Threads `Withdrawing.initiated_at` through resume errors and uses the withdrawal initiation timestamp for the 4h alert deadline.

## Testing

- `nix run .#ci` passed end to end: workspace checks, `cargo nextest run --workspace --all-features` (`3037` passed, `5` skipped, `2` flaky passed on retry), clippy, fmt, DTO generation, dashboard lint, and `svelte-check`.
- Added coverage for indeterminate Alpaca poll errors, `TransferNotFound`, explicit Alpaca `Failed`, complete-after-inconclusive, persisted `initiated_at`, deadline alert behavior, startup/sweep re-arm behavior, live-job gating, and CLI redrive retry behavior.

## Screenshots

N/A.

## Anything else

- `UsdcRebalance::SCHEMA_VERSION` bumps from 5 to 6 so stale snapshots rebuild with the corrected `Withdrawing.initiated_at` semantics.
- A permanently absent Alpaca UUID still requires direct operator recovery after verifying no funds moved; the runbook documents this limitation and keeps the guard held rather than risking a re-withdrawal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785329075&installation_id=125569124&pr_number=948&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F948&signature=b55a233d7084c81a3a530ce5088403a3a2eaf9a4f690d8a37c4c822315823728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * USDC rebalancing now idempotently re-arms and resumes Alpaca→Base withdrawals after restarts, including reconciling when a CCTP burn is already present.
  * Indeterminate Alpaca withdrawal polling continues via delayed redrive, with operator paging after 4 hours.

* **Bug Fixes**
  * Prevents immediate failures for inconclusive polling outcomes, including cases where Alpaca reports a failure with an on-chain tx hash.
  * Corrects withdrawal initiation/timing semantics so resumed retries use the original initiation time.

* **Documentation**
  * Updated the CLI Operations Guide with manual recovery steps and expected outcomes for stuck withdrawals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->