### PR TITLE
chore: set wallet re-alert interval to twice daily

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -80,7 +80,8 @@ low_balance_threshold = "0.05"
 # Seconds between native-balance polls.
 poll_interval = 300
 # Minimum seconds between repeated alerts while the balance stays below threshold.
-realert_interval = 3600
+# 43200 = 12 hours.
+realert_interval = 43200
 
 # USDC vault and rebalancing settings.
 [assets.cash]

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -74,7 +74,8 @@ low_balance_threshold = "0.05"
 # Seconds between native-balance polls.
 poll_interval = 300
 # Minimum seconds between repeated alerts while the balance stays below threshold.
-realert_interval = 3600
+# 43200 = 12 hours.
+realert_interval = 43200
 
 # USDC vault and rebalancing settings.
 [assets.cash]

--- a/example.config.toml
+++ b/example.config.toml
@@ -126,8 +126,9 @@ rebalancing = "enabled"
 # low_balance_threshold = "0.05"
 # Seconds between native-balance polls.
 # poll_interval = 300
-# Minimum seconds between repeated low-balance alerts while still low.
-# realert_interval = 3600
+# Minimum seconds between repeated low-balance alerts while still low; 12h
+# (twice daily) keeps a persistent low balance from being noisy.
+# realert_interval = 43200
 # Optional forum topic to deliver alerts into (a forum supergroup's
 # message_thread_id). Omit to post to the chat's default (General) topic.
 # message_thread_id = 42


### PR DESCRIPTION
## What

- [RAI-1182](https://linear.app/makeitrain/issue/RAI-1182/change-wallet-balance-re-alert-interval-from-hourly-to-twice-daily-12h)
- Set the wallet low-balance `realert_interval` from `3600` to `43200` seconds in `config/prod/st0x-hedge.toml` and `config/staging/st0x-hedge.toml`.
- Update `example.config.toml` so the sample `[alerts]` block documents the same 12h / twice-daily cadence.

## Why

- Hourly Telegram re-alerts are noisy while a wallet remains below its threshold, and the intended operator cadence is at most twice per day.
- The initial low-balance alert remains unchanged; only repeated alerts while still low are spaced out.

## How

- Config-only change: the existing `realert_interval` field is consumed by `GasMonitor` via `now.duration_since(last_alerted) >= realert_interval`.
- No code path or secrets schema changed.

## Testing

- No new tests — config/comment-only change.
- Verified with `nix develop -c cargo check -p st0x-config`.
- Verified with `nix develop -c taplo fmt --check config/staging/st0x-hedge.toml config/prod/st0x-hedge.toml example.config.toml`.
- Verified with `nix develop -c cargo nextest run -p st0x-config --features wallet-private-key alerts`.

## Screenshots

N/A.

## Anything else

- This changes prod and staging plaintext config; deploy will be required for the new cadence to take effect on running services.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785330343&installation_id=125569124&pr_number=949&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F949&signature=d2fc5ebcf7bbf339163147ed2eec394ec39b2b203bfa6cbcfb5ea99f3f092852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

