### PR TITLE
RAI-1183: USDC rebalance withdrawable-cash cap should always apply

### DIFF
--- a/crates/execution/src/alpaca_broker_api/positions.rs
+++ b/crates/execution/src/alpaca_broker_api/positions.rs
@@ -90,6 +90,10 @@ struct AccountDetailsResponse {
     cash: Float,
     /// Settled cash that can be withdrawn -- excludes T+1 unsettled
     /// equity-sale proceeds. `None` if the broker omits the field.
+    /// Alpaca documents this field on the trading-account response and defines
+    /// it as cash available to withdraw, excluding unsettled memoposts:
+    /// https://docs.alpaca.markets/us/reference/gettradingaccount
+    /// https://docs.alpaca.markets/us/docs/instant-funding-1
     #[serde(
         default,
         deserialize_with = "deserialize_option_float_from_number_or_string"

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -106,6 +106,12 @@ mid-execution reset their own orphaned rows at startup, before the monitor
 spawns (where every `Running` row is by definition orphaned): see
 `JobQueue::requeue_orphaned`, wired for the Base->Alpaca USDC transfer.
 
+apalis also defaults to fetching multiple rows per poll and marking the whole
+batch `Queued` before the single-concurrency worker can run them. A process kill
+then loses the in-memory fetch buffer while the durable rows are no longer
+`Pending`. Use `Config::set_buffer_size(1)` for these workers so SQLite
+reservation matches actual handler execution.
+
 ### apalis Jobs table: status semantics and payload encoding
 
 **Status lifecycle** (apalis-sqlite v1.0.0-rc.8, source-verified via
@@ -201,7 +207,10 @@ WorkerBuilder::new(name)
 - **`.break_circuit_with(config)`** — opens the circuit after
   `failure_threshold` errors, returning `Poll::Pending` from `poll_ready` to
   block new job pickup. Use `failure_threshold(1)` + very long
-  `recovery_timeout` for fail-stop.
+  `recovery_timeout` for fail-stop. Do not install this layer on best-effort
+  workers: in apalis-core 1.0.0-rc.9, an open circuit can return `Poll::Pending`
+  without scheduling a wakeup, so a short `recovery_timeout` does not guarantee
+  the worker will resume.
 - **`.on_event()`** — fires on `Event::Error` (after retries exhaust),
   `Event::Success`, `Event::Start`, `Event::Stop`. Use for logging AND for
   calling `ctx.stop()` on terminal failure. The circuit breaker alone only

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -542,21 +542,6 @@ where
         let fail_stop_for_transfer_usdc_to_market_making = fail_stop.clone();
         let fail_stop_for_transfer_equity_to_market_making = fail_stop.clone();
         let fail_stop_for_transfer_equity_to_hedging = fail_stop.clone();
-        // Best-effort workers must not latch idle after failures. We WANT a
-        // never-opening circuit, but apalis-core 1.0.0-rc.9's live worker path
-        // (`CircuitBreakerService::call`) hardcodes `failure_count >= 5` and
-        // never consults the configured `failure_threshold`, so `u32::MAX` does
-        // NOT keep the circuit closed: after 5 failed calls (e.g. interrupted
-        // aggregates exhausting retries while the issuer is down) the circuit
-        // opens and throttles resume. The short `recovery_timeout` is the real
-        // bound -- it IS honored by `call`, so the open state self-heals within
-        // 10s and resume keeps making progress instead of latching idle. The
-        // `with_failure_threshold(u32::MAX)` records the intended behavior and
-        // takes effect only if a future apalis release honors the config.
-        let best_effort_circuit = CircuitBreakerConfig::default()
-            .with_failure_threshold(u32::MAX)
-            .with_recovery_timeout(std::time::Duration::from_secs(10));
-
         let accountant_ctx_for_backfill = accountant_ctx.clone();
 
         tokio::spawn(async move {
@@ -757,7 +742,6 @@ where
                 apalis_monitor,
                 resume_tokenization_ctx,
                 resume_tokenization_queue,
-                BestEffortCircuit(best_effort_circuit),
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_resume_tokenization,
             );
@@ -841,12 +825,6 @@ fn log_optional_task_status(task_name: &str, is_configured: bool) {
 /// worker-registration site -- passing the wrong one would be a compile error
 /// rather than a silent freeze.
 struct FailStopCircuit(CircuitBreakerConfig);
-
-/// A circuit-breaker config for a BEST-EFFORT worker: a failing job must not
-/// latch the worker idle (see `spawn_apalis_monitor` for the apalis caveat on
-/// the hardcoded open threshold). A distinct type from [`FailStopCircuit`] so
-/// the two policies cannot be cross-assigned.
-struct BestEffortCircuit(CircuitBreakerConfig);
 
 /// Conditionally registers the wrapped-equity recovery worker against the
 /// apalis monitor. Extracted because this is the only `Option`-gated worker
@@ -1053,7 +1031,6 @@ fn register_resume_tokenization_worker(
     monitor: Monitor,
     resume_ctx: Option<Arc<ResumeTokenizationCtx>>,
     resume_queue: ResumeTokenizationJobQueue,
-    BestEffortCircuit(circuit): BestEffortCircuit,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
     let Some(resume_ctx) = resume_ctx else {
@@ -1070,7 +1047,6 @@ fn register_resume_tokenization_worker(
             index,
             resume_queue.clone(),
             resume_ctx.clone(),
-            circuit.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector.clone(),
         )

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -86,7 +86,7 @@ impl<Task> Clone for JobQueue<Task> {
     }
 }
 
-/// Pickup latency SLO for queued jobs.
+/// Pickup latency and reservation SLO for queued jobs.
 ///
 /// Hedge placement (and the upstream trade-processing pipeline) needs
 /// to react to events on the order of a single second: a missed window
@@ -99,6 +99,13 @@ impl<Task> Clone for JobQueue<Task> {
 ///
 /// We cap the polling interval at 1s end-to-end so the worst-case
 /// pickup latency matches the SLO regardless of prior queue state.
+///
+/// Apalis also defaults to fetching 10 rows per worker poll. Our workers are
+/// single-concurrency, so a larger fetch buffer reserves extra rows as
+/// `Queued` in SQLite before the handler can run them. If the process dies or
+/// the in-memory fetch buffer is dropped, those rows are no longer `Pending`
+/// and the deterministic worker heartbeat keeps them from aging out. Fetch one
+/// row at a time so durable queue state mirrors actual handler execution.
 fn build_poll_config<T: 'static>() -> Config {
     let strategy = StrategyBuilder::new()
         .apply(
@@ -107,7 +114,9 @@ fn build_poll_config<T: 'static>() -> Config {
         )
         .build();
 
-    Config::new(std::any::type_name::<T>()).with_poll_interval(strategy)
+    Config::new(std::any::type_name::<T>())
+        .set_buffer_size(1)
+        .with_poll_interval(strategy)
 }
 
 impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static> JobQueue<Task> {
@@ -267,14 +276,14 @@ where
     async fn perform(&self, ctx: &Ctx) -> Result<Self::Output, Self::Error>;
 }
 
-/// Shared worker-construction body for [`build_supervised_worker!`] and
-/// [`build_best_effort_worker!`]. Not part of the public crate API; always
-/// called via one of the two public macros. Must be exported so the outer
-/// macros can call it from expansion sites in sibling modules.
+/// Shared worker-construction body for [`build_supervised_worker!`]. Not part
+/// of the public crate API; always called via the public macro. Must be
+/// exported so the outer macro can call it from expansion sites in sibling
+/// modules.
 ///
 /// `$on_event:expr` must be a value of type
 /// `impl Fn(&WorkerContext, &Event) + Send + Sync + 'static`, produced by
-/// either [`on_terminal_failure`] or [`on_terminal_failure_log_only`].
+/// [`on_terminal_failure`].
 macro_rules! build_worker_inner {
     (
         ::<$ctx_type:ty, $job:ty>,
@@ -361,16 +370,11 @@ pub(crate) use build_supervised_worker;
 
 /// Builds a best-effort `Worker` for a `Job<Ctx>` impl.
 ///
-/// Identical to [`build_supervised_worker!`] but uses
-/// [`on_terminal_failure_log_only`] instead of [`on_terminal_failure`]:
-/// a terminal job failure is logged at `error!` level but does NOT trip the
-/// conductor-wide fail-stop and does NOT stop the worker.
-///
-/// Callers MUST pass a permissive `CircuitBreakerConfig` (e.g. high
-/// `failure_threshold`, short `recovery_timeout`) so a single failing job
-/// does not latch the worker idle for a long period. Passing the conductor-wide
-/// fail-stop config (threshold 1, 1-year timeout) would silently neutralise
-/// the best-effort guarantee.
+/// A terminal job failure is logged at `error!` level but does NOT trip the
+/// conductor-wide fail-stop, does NOT stop the worker, and does NOT install an
+/// Apalis circuit breaker. The circuit breaker can latch a single-concurrency
+/// worker idle after retries are exhausted because `poll_ready` returns
+/// `Pending` without scheduling a wakeup when the circuit is open.
 ///
 /// Use for background recovery workers (e.g. `ResumeTokenizationAggregate`)
 /// where a persistently failing individual job must not block processing of
@@ -380,21 +384,39 @@ macro_rules! build_best_effort_worker {
         ::<$ctx_type:ty, $job:ty>,
         $index:expr,
         $queue:expr,
-        $ctx:expr,
-        $circuit:expr
+        $ctx:expr
         $(, $failure_injector:expr)? $(,)?
     ) => {{
-        build_worker_inner!(
-            ::<$ctx_type, $job>,
+        use ::apalis::layers::WorkerBuilderExt;
+        use ::apalis::layers::retry::RetryPolicy;
+        use ::apalis::prelude::WorkerBuilder;
+        use ::apalis_core::worker::ext::event_listener::EventListenerExt;
+
+        let builder = WorkerBuilder::new(format!(
+            "{}-{}",
+            <$job as $crate::conductor::job::Job<$ctx_type>>::WORKER_NAME,
             $index,
-            $queue,
-            $ctx,
-            $circuit,
-            $crate::conductor::job::on_terminal_failure_log_only(
-                <$job as $crate::conductor::job::Job<$ctx_type>>::TERMINAL_FAILURE_MSG,
+        ))
+        .backend($queue.into_storage())
+        .data($ctx);
+
+        $(
+            #[cfg(any(test, feature = "test-support"))]
+            let builder = builder.data($failure_injector).data(
+                <$job as $crate::conductor::job::Job<$ctx_type>>::JOB_KIND,
+            );
+        )?
+
+        builder
+            .concurrency(1)
+            .retry(
+                RetryPolicy::retries(3)
+                    .with_backoff($crate::conductor::job::RETRY_BACKOFF.clone()),
             )
-            $(, $failure_injector)?
-        )
+            .on_event($crate::conductor::job::on_terminal_failure_log_only(
+                <$job as $crate::conductor::job::Job<$ctx_type>>::TERMINAL_FAILURE_MSG,
+            ))
+            .build($crate::conductor::job::work::<$ctx_type, $job>)
     }};
 }
 
@@ -669,8 +691,8 @@ pub(crate) fn on_terminal_failure(
 /// `failure_notify.notify_waiters()` and does NOT call `ctx.stop()`.
 /// Used for best-effort background workers (e.g. `ResumeTokenizationAggregate`)
 /// where a persistently failing individual job should not bring down hedging
-/// and fill detection. The worker circuit-breaker config must also be
-/// permissive — see [`build_best_effort_worker!`].
+/// and fill detection. See [`build_best_effort_worker!`] for why these workers
+/// do not install Apalis' circuit-breaker layer.
 ///
 /// Structural invariant: unlike [`on_terminal_failure`], this function takes
 /// no `Notify` argument and therefore can never call `notify_waiters()` or
@@ -724,6 +746,18 @@ mod tests {
         assert!(
             !queue.has_in_flight().await.unwrap(),
             "a Done job is terminal and not in flight"
+        );
+    }
+
+    #[test]
+    fn poll_config_fetches_one_row_per_single_concurrency_worker() {
+        let config = build_poll_config::<u32>();
+
+        assert_eq!(
+            config.buffer_size(),
+            1,
+            "workers run with concurrency(1), so the SQLite fetch buffer must \
+             not reserve extra rows as Queued before a handler can execute them",
         );
     }
 
@@ -991,6 +1025,42 @@ mod tests {
             .unwrap()
     }
 
+    async fn job_rows_for_assertion(
+        apalis_pool: &apalis_sqlite::SqlitePool,
+    ) -> Vec<(String, String, i64, i64, Option<String>)> {
+        sqlx_apalis::query_as(
+            "SELECT id, status, attempts, max_attempts, lock_by \
+             FROM Jobs ORDER BY id",
+        )
+        .fetch_all(apalis_pool)
+        .await
+        .unwrap()
+    }
+
+    async fn wait_for_terminal_test_job(apalis_pool: &apalis_sqlite::SqlitePool) {
+        let terminal = tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                let rows = job_rows_for_assertion(apalis_pool).await;
+                if rows.iter().any(|(_, status, attempts, max_attempts, _)| {
+                    (status == &Status::Killed.to_string() || status == &Status::Failed.to_string())
+                        && attempts >= max_attempts
+                }) {
+                    return;
+                }
+
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await;
+
+        assert!(
+            terminal.is_ok(),
+            "failing job should reach terminal state before sibling is enqueued; \
+             job rows at timeout: {:?}",
+            job_rows_for_assertion(apalis_pool).await
+        );
+    }
+
     #[tokio::test]
     async fn cleanup_finished_jobs_deletes_terminal_rows() {
         let apalis_pool = setup_test_apalis_pool().await;
@@ -1027,28 +1097,25 @@ mod tests {
         );
     }
 
-    /// With a permissive circuit-breaker config, a terminally-failing job does
-    /// NOT latch the worker idle: the circuit opens briefly (short
-    /// `recovery_timeout`) and then closes so subsequent jobs can run. This is
-    /// the key behavioral contract of the best-effort worker design.
+    /// A terminally-failing best-effort job does NOT latch the worker idle:
+    /// subsequent jobs must still run. This is the key behavioral contract of
+    /// the best-effort worker design.
     ///
-    /// Regression test: the previous code passed the conductor-wide fail-stop
-    /// config (threshold 1, 1-year timeout) to the best-effort worker,
-    /// permanently blocking all sibling jobs after the first terminal failure.
+    /// Regression test: installing Apalis' circuit-breaker layer on a
+    /// best-effort worker can permanently block sibling jobs after retries are
+    /// exhausted because an open circuit returns `Poll::Pending` without
+    /// scheduling a wakeup.
     ///
-    /// Goes through `build_best_effort_worker!` with the same permissive
-    /// `CircuitBreakerConfig` that `register_resume_tokenization_worker` in
-    /// `conductor/builder.rs` constructs, so the test validates the real
-    /// production path.
+    /// Goes through `build_best_effort_worker!`, so the test validates the real
+    /// production path used by `register_resume_tokenization_worker` in
+    /// `conductor/builder.rs`.
     #[tokio::test]
-    async fn best_effort_circuit_does_not_latch_on_single_terminal_failure() {
+    async fn best_effort_worker_does_not_latch_on_single_terminal_failure() {
         let apalis_pool = setup_test_apalis_pool().await;
 
         let mut queue: JobQueue<TestJob> = JobQueue::new(&apalis_pool);
-        // Failing job first, then a successful one. With a permissive circuit
-        // breaker (threshold = u32::MAX), the second job must still complete.
         queue.push(TestJob { should_fail: true }).await.unwrap();
-        queue.push(TestJob { should_fail: false }).await.unwrap();
+        let mut push_queue = queue.clone();
 
         // success_notify is wired into TestCtx; TestJob::perform calls
         // notify_waiters() after each successful run.
@@ -1059,13 +1126,6 @@ mod tests {
         });
         let ctx_for_assert = ctx.clone();
 
-        // Mirror the production config from register_resume_tokenization_worker:
-        // high threshold + short recovery so a single failure reopens the circuit
-        // quickly but does not permanently latch the worker idle.
-        let best_effort_circuit = CircuitBreakerConfig::default()
-            .with_failure_threshold(u32::MAX)
-            .with_recovery_timeout(Duration::from_secs(10));
-
         let monitor_handle = tokio::spawn({
             let monitor = Monitor::new()
                 .should_restart(|_ctx, _error, _attempt| false)
@@ -1075,25 +1135,31 @@ mod tests {
                         index,
                         queue.clone(),
                         ctx.clone(),
-                        best_effort_circuit.clone(),
                         FailureInjector::new(),
                     )
                 });
             async move { monitor.run().await }
         });
 
+        wait_for_terminal_test_job(&apalis_pool).await;
+        push_queue
+            .push(TestJob { should_fail: false })
+            .await
+            .unwrap();
+
         // Wait deterministically for the successful job to complete.
         // TestJob::perform fires success_notify after incrementing success_count,
         // so this unblocks as soon as job 2 succeeds -- no fixed sleep needed.
-        //
-        // The 30s budget accounts for the production RETRY_BACKOFF baked into
-        // build_best_effort_worker! via build_worker_inner!: 3 retries at 1s,
-        // 2s, 4s = 7s before the failing job goes terminal, plus the 10s
-        // recovery_timeout before the circuit closes. 30s gives ~3x headroom
-        // over the 17s worst case so the test is not flaky under CI load.
-        tokio::time::timeout(Duration::from_secs(30), success_notify.notified())
+        if tokio::time::timeout(Duration::from_secs(10), success_notify.notified())
             .await
-            .expect("second job must complete within 30s; circuit must not latch indefinitely");
+            .is_err()
+        {
+            panic!(
+                "second job must complete after the first job reaches terminal state; \
+                 job rows at timeout: {:?}",
+                job_rows_for_assertion(&apalis_pool).await
+            );
+        }
 
         monitor_handle.abort();
 

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -25,6 +25,25 @@ pub(super) enum UsdcRebalanceOperation {
     BaseToAlpaca { amount: Usdc },
 }
 
+/// Internal decision built inside the inventory read-lock, coupling each
+/// imbalance variant with its pre-computed capacity data. This eliminates
+/// the outer `Option<Option<_>>` and makes the post-lock dispatch exhaustive.
+enum UsdcImbalanceDecision {
+    NoImbalance,
+    TooMuchOffchain {
+        excess: Usdc,
+        withdrawable_capacity: WithdrawableCapacity,
+    },
+    TooMuchOnchain {
+        excess: Usdc,
+    },
+}
+
+enum WithdrawableCapacity {
+    Missing,
+    Available(Usdc),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum UsdcTrackingEvent {
     Initiated,
@@ -236,13 +255,17 @@ const USDC_TRANSFER_MAX_DECIMAL_PLACES: u8 = 6;
 pub(crate) enum UsdcTriggerSkip {
     /// No USDC imbalance detected.
     NoImbalance,
-    /// Alpaca did not report settled withdrawable cash, so outbound
-    /// Alpaca-to-Base capacity cannot be proven reserve-safe.
+    /// Alpaca did not report settled withdrawable cash, so the withdrawable cap
+    /// cannot be applied and the transfer amount cannot be safely bounded.
     MissingWithdrawableCash,
-    /// Withdrawable cash is at or below the configured reserve, so no
-    /// Alpaca-to-Base capacity is available. Operators should investigate;
-    /// the reserve may need to be lowered or the broker rebalanced.
+    /// Withdrawable cash, after subtracting the configured reserve, leaves
+    /// capacity below the Alpaca minimum withdrawal. Lower the reserve or
+    /// rebalance the broker.
     ReserveCapacityExhausted,
+    /// Alpaca's withdrawable cash itself is below the Alpaca minimum withdrawal.
+    /// No reserve is configured; the broker simply has too little settled cash.
+    /// No operator action is needed; this clears once the broker settles more.
+    WithdrawableBelowMinimum,
     /// Imbalance exists but amount is below Alpaca's minimum withdrawal ($51).
     BelowMinimumWithdrawal { excess: Usdc },
     /// Arithmetic error during imbalance calculation.
@@ -301,7 +324,7 @@ pub(super) async fn check_imbalance_and_build_operation(
     usdc_limit: Option<Usdc>,
     reserved: Option<Usd>,
 ) -> Result<UsdcRebalanceOperation, UsdcTriggerSkip> {
-    let imbalance_check = {
+    let decision = {
         let inventory = inventory.read().await;
         let imbalance = inventory
             .check_usdc_imbalance_with_gross_offchain(threshold, reserved)
@@ -313,16 +336,18 @@ pub(super) async fn check_imbalance_and_build_operation(
                 );
                 UsdcTriggerSkip::ArithmeticError
             })?;
-        // Only compute the Alpaca-to-Base capacity when we will actually use
-        // it: the imbalance is offchain-heavy AND a reserve is configured.
-        // Capacity reads parse `withdrawable_cash_cents`, so binding it to
-        // unrelated branches would let a malformed withdrawable value block
-        // Base-to-Alpaca rebalancing, which is supposed to be independent of
-        // withdrawable cash. Holding the same read guard while computing both
-        // values preserves TOCTOU safety against polling-driven updates.
-        let capacity = match (&imbalance, reserved) {
-            (Some(Imbalance::TooMuchOffchain { .. }), Some(_)) => Some(
-                inventory
+        // Compute the Alpaca-to-Base capacity for every TooMuchOffchain
+        // imbalance; the cap applies regardless of whether a reserve is
+        // configured. `alpaca_to_base_usdc_capacity` treats `None` reserve
+        // as zero, so "no reserve" means the full withdrawable cash is
+        // available as capacity. Capacity reads parse `withdrawable_cash_cents`,
+        // so binding the call to TooMuchOffchain only keeps Base-to-Alpaca
+        // rebalancing independent of withdrawable cash (which it must be).
+        // Holding one read guard for both values preserves TOCTOU safety.
+        let decision = match imbalance {
+            None => UsdcImbalanceDecision::NoImbalance,
+            Some(Imbalance::TooMuchOffchain { excess }) => {
+                let withdrawable_capacity = inventory
                     .alpaca_to_base_usdc_capacity(reserved)
                     .map_err(|error| {
                         warn!(
@@ -331,75 +356,91 @@ pub(super) async fn check_imbalance_and_build_operation(
                             "USDC Alpaca-to-Base capacity check failed due to inventory error"
                         );
                         UsdcTriggerSkip::ArithmeticError
-                    })?,
-            ),
-            _ => None,
+                    })?
+                    .map_or(
+                        WithdrawableCapacity::Missing,
+                        WithdrawableCapacity::Available,
+                    );
+                UsdcImbalanceDecision::TooMuchOffchain {
+                    excess,
+                    withdrawable_capacity,
+                }
+            }
+            Some(Imbalance::TooMuchOnchain { excess }) => {
+                UsdcImbalanceDecision::TooMuchOnchain { excess }
+            }
         };
         drop(inventory);
-        (imbalance, capacity)
-    };
-    let (imbalance, alpaca_to_base_capacity) = imbalance_check;
-
-    let Some(imbalance) = imbalance else {
-        trace!(target: "rebalance", "No USDC imbalance detected (balanced, partial data, or inflight)");
-        return Err(UsdcTriggerSkip::NoImbalance);
+        decision
     };
 
-    match imbalance {
-        Imbalance::TooMuchOffchain { excess } => {
-            // `alpaca_to_base_capacity` is `Some(capacity)` only when a
-            // reserve is configured (see the capacity computation above);
-            // when reserved is `None`, there is no reserve to protect and
-            // the transfer is constrained only by `usdc_limit` and the
-            // Alpaca minimum withdrawal.
-            let capped_by_capacity = match alpaca_to_base_capacity {
-                Some(capacity_opt) => {
-                    let Some(capacity) = capacity_opt else {
-                        warn!(
-                            target: "rebalance",
-                            excess = ?excess,
-                            "Skipping Alpaca-to-Base USDC rebalance: broker did not report withdrawable cash; reserve-safety cannot be proven"
-                        );
-                        return Err(UsdcTriggerSkip::MissingWithdrawableCash);
-                    };
-
-                    // A reserve that leaves capacity below the Alpaca minimum
-                    // withdrawal is operationally equivalent to capacity == 0
-                    // — the bot cannot make ANY reserve-safe transfer. Report
-                    // it with the precise reason rather than letting the
-                    // result fall through to BelowMinimumWithdrawal, which
-                    // would be misleading.
-                    if capacity.lt(&ALPACA_MINIMUM_WITHDRAWAL).map_err(|error| {
-                        warn!(
-                            target: "rebalance",
-                            ?error,
-                            "USDC capacity minimum-comparison failed"
-                        );
-                        UsdcTriggerSkip::ArithmeticError
-                    })? {
-                        warn!(
-                            target: "rebalance",
-                            excess = ?excess,
-                            ?reserved,
-                            ?capacity,
-                            minimum = ?*ALPACA_MINIMUM_WITHDRAWAL,
-                            "Skipping Alpaca-to-Base USDC rebalance: reserve leaves withdrawable capacity below Alpaca minimum withdrawal"
-                        );
-                        return Err(UsdcTriggerSkip::ReserveCapacityExhausted);
-                    }
-
-                    let capped = cap_usdc(excess, usdc_limit);
-                    cap_usdc_by_alpaca_capacity(capped, capacity).map_err(|error| {
-                        warn!(
-                            target: "rebalance",
-                            ?error,
-                            "USDC Alpaca capacity comparison failed"
-                        );
-                        UsdcTriggerSkip::ArithmeticError
-                    })?
+    match decision {
+        UsdcImbalanceDecision::NoImbalance => {
+            trace!(target: "rebalance", "No USDC imbalance detected (balanced, partial data, or inflight)");
+            Err(UsdcTriggerSkip::NoImbalance)
+        }
+        UsdcImbalanceDecision::TooMuchOffchain {
+            excess,
+            withdrawable_capacity,
+        } => {
+            let capacity = match withdrawable_capacity {
+                WithdrawableCapacity::Missing => {
+                    warn!(
+                        target: "rebalance",
+                        excess = ?excess,
+                        "Skipping Alpaca-to-Base USDC rebalance: broker did not report withdrawable cash; withdrawable cap cannot be applied"
+                    );
+                    return Err(UsdcTriggerSkip::MissingWithdrawableCash);
                 }
-                None => cap_usdc(excess, usdc_limit),
+                WithdrawableCapacity::Available(capacity) => capacity,
             };
+
+            // Capacity below the Alpaca minimum withdrawal is operationally
+            // equivalent to zero. Report it with
+            // the precise reason rather than letting the result fall through
+            // to BelowMinimumWithdrawal, which would be misleading.
+            if capacity.lt(&ALPACA_MINIMUM_WITHDRAWAL).map_err(|error| {
+                warn!(
+                    target: "rebalance",
+                    ?error,
+                    "USDC capacity minimum-comparison failed"
+                );
+                UsdcTriggerSkip::ArithmeticError
+            })? {
+                let Some(reserve) = reserved else {
+                    warn!(
+                        target: "rebalance",
+                        excess = ?excess,
+                        ?capacity,
+                        minimum = ?*ALPACA_MINIMUM_WITHDRAWAL,
+                        "Skipping Alpaca-to-Base USDC rebalance: Alpaca withdrawable \
+                         cash is below the minimum withdrawal amount"
+                    );
+                    return Err(UsdcTriggerSkip::WithdrawableBelowMinimum);
+                };
+
+                warn!(
+                    target: "rebalance",
+                    excess = ?excess,
+                    reserved = ?reserve,
+                    ?capacity,
+                    minimum = ?*ALPACA_MINIMUM_WITHDRAWAL,
+                    "Skipping Alpaca-to-Base USDC rebalance: withdrawable capacity \
+                     after reserve is below Alpaca minimum withdrawal"
+                );
+                return Err(UsdcTriggerSkip::ReserveCapacityExhausted);
+            }
+
+            let capped = cap_usdc(excess, usdc_limit);
+            let capped_by_capacity =
+                cap_usdc_by_alpaca_capacity(capped, capacity).map_err(|error| {
+                    warn!(
+                        target: "rebalance",
+                        ?error,
+                        "USDC Alpaca capacity comparison failed"
+                    );
+                    UsdcTriggerSkip::ArithmeticError
+                })?;
 
             let capped = truncate_for_transfer(capped_by_capacity).map_err(|error| {
                 warn!(
@@ -429,7 +470,7 @@ pub(super) async fn check_imbalance_and_build_operation(
                 Ok(UsdcRebalanceOperation::AlpacaToBase { amount: capped })
             }
         }
-        Imbalance::TooMuchOnchain { excess } => {
+        UsdcImbalanceDecision::TooMuchOnchain { excess } => {
             let amount = truncate_for_transfer(cap_usdc(excess, usdc_limit)).map_err(|error| {
                 warn!(
                     target: "rebalance",
@@ -1301,9 +1342,12 @@ mod tests {
 
         let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
 
-        assert!(
-            matches!(result, Ok(UsdcRebalanceOperation::AlpacaToBase { amount }) if !amount.inner().lt(float!(51)).unwrap_or(true)),
-            "Expected AlpacaToBase with amount >= 51, got {result:?}"
+        assert_eq!(
+            result,
+            Ok(UsdcRebalanceOperation::AlpacaToBase {
+                amount: Usdc::new(float!(200))
+            }),
+            "Expected AlpacaToBase with amount == 200, got {result:?}"
         );
     }
 
@@ -1325,8 +1369,11 @@ mod tests {
 
         let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
 
-        assert!(
-            matches!(result, Ok(UsdcRebalanceOperation::AlpacaToBase { amount }) if amount == Usdc::new(float!(51))),
+        assert_eq!(
+            result,
+            Ok(UsdcRebalanceOperation::AlpacaToBase {
+                amount: Usdc::new(float!(51))
+            }),
             "Expected AlpacaToBase with amount = 51, got {result:?}"
         );
     }
@@ -1349,8 +1396,11 @@ mod tests {
 
         let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
 
-        assert!(
-            matches!(result, Ok(UsdcRebalanceOperation::BaseToAlpaca { amount }) if amount == Usdc::new(float!(40))),
+        assert_eq!(
+            result,
+            Ok(UsdcRebalanceOperation::BaseToAlpaca {
+                amount: Usdc::new(float!(40))
+            }),
             "Expected BaseToAlpaca with amount = 40 (no minimum for deposits), got {result:?}"
         );
     }
@@ -1371,8 +1421,11 @@ mod tests {
         let result =
             check_imbalance_and_build_operation(&threshold, &inventory, usdc_limit, None).await;
 
-        assert!(
-            matches!(result, Ok(UsdcRebalanceOperation::AlpacaToBase { amount }) if amount == Usdc::new(float!(100))),
+        assert_eq!(
+            result,
+            Ok(UsdcRebalanceOperation::AlpacaToBase {
+                amount: Usdc::new(float!(100))
+            }),
             "Operational limit should cap USDC transfer to 100, got {result:?}"
         );
     }
@@ -1396,8 +1449,11 @@ mod tests {
 
         let first =
             check_imbalance_and_build_operation(&threshold, &inventory, usdc_limit, None).await;
-        assert!(
-            matches!(first, Ok(UsdcRebalanceOperation::AlpacaToBase { amount }) if amount == Usdc::new(float!(100))),
+        assert_eq!(
+            first,
+            Ok(UsdcRebalanceOperation::AlpacaToBase {
+                amount: Usdc::new(float!(100))
+            }),
             "First transfer capped to 100, got {first:?}"
         );
 
@@ -1432,8 +1488,11 @@ mod tests {
         let third =
             check_imbalance_and_build_operation(&threshold, &partially_resolved, usdc_limit, None)
                 .await;
-        assert!(
-            matches!(third, Ok(UsdcRebalanceOperation::AlpacaToBase { amount }) if amount == Usdc::new(float!(100))),
+        assert_eq!(
+            third,
+            Ok(UsdcRebalanceOperation::AlpacaToBase {
+                amount: Usdc::new(float!(100))
+            }),
             "Remaining imbalance triggers another capped transfer, got {third:?}"
         );
     }
@@ -1547,8 +1606,11 @@ mod tests {
         )
         .await;
 
-        assert!(
-            matches!(result, Ok(UsdcRebalanceOperation::AlpacaToBase { amount }) if amount == Usdc::new(float!(100))),
+        assert_eq!(
+            result,
+            Ok(UsdcRebalanceOperation::AlpacaToBase {
+                amount: Usdc::new(float!(100))
+            }),
             "Expected reserve-adjusted withdrawable capacity to cap transfer to 100, got {result:?}"
         );
     }
@@ -1658,8 +1720,11 @@ mod tests {
 
         let after =
             check_imbalance_and_build_operation(&threshold, &inventory, None, reserved).await;
-        assert!(
-            matches!(after, Ok(UsdcRebalanceOperation::AlpacaToBase { amount }) if amount == Usdc::new(float!(100))),
+        assert_eq!(
+            after,
+            Ok(UsdcRebalanceOperation::AlpacaToBase {
+                amount: Usdc::new(float!(100))
+            }),
             "Post-recovery trigger must dispatch the reserve-aware capped transfer, got {after:?}"
         );
     }
@@ -1717,9 +1782,151 @@ mod tests {
         )
         .await;
 
-        assert!(
-            matches!(result, Ok(UsdcRebalanceOperation::BaseToAlpaca { amount }) if amount == Usdc::new(float!(400))),
+        assert_eq!(
+            result,
+            Ok(UsdcRebalanceOperation::BaseToAlpaca {
+                amount: Usdc::new(float!(400))
+            }),
             "Expected Base-to-Alpaca transfer to ignore reserve and withdrawable cash, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_is_capped_by_withdrawable_cash_with_no_reserve() {
+        // 100 onchain / 500 offchain -> excess = 200; withdrawable = $150 (below excess).
+        // With no reserve, the withdrawable cap must still apply -> transfer capped at 150.
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_offchain_gross_usd_cents(50_000)
+                .with_withdrawable_cash_cents(15_000),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
+
+        assert_eq!(
+            result,
+            Ok(UsdcRebalanceOperation::AlpacaToBase {
+                amount: Usdc::new(float!(150))
+            }),
+            "Withdrawable cap must apply even with no reserve configured; expected 150, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_proceeds_when_withdrawable_exactly_at_minimum_no_reserve() {
+        // 100 onchain / 500 offchain -> excess = 200; withdrawable = $51 (exactly the minimum).
+        // The capacity check uses strict `lt` (not `le`), so withdrawable exactly at the minimum
+        // must NOT skip; it must produce a transfer capped at $51 (the binding capacity).
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_offchain_gross_usd_cents(50_000)
+                .with_withdrawable_cash_cents(5_100),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
+
+        assert_eq!(
+            result,
+            Ok(UsdcRebalanceOperation::AlpacaToBase {
+                amount: Usdc::new(float!(51))
+            }),
+            "Withdrawable exactly at $51 minimum must not skip; expected AlpacaToBase {{ amount: 51 }}, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_withdrawable_binds_below_operational_limit_with_no_reserve() {
+        // 100 onchain / 900 offchain -> excess = 400; usdc_limit = $200; withdrawable = $150.
+        // Both the $200 operational limit and $150 withdrawable are below the $400 excess.
+        // Withdrawable ($150) is the tighter bound and must be the final transfer amount.
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(900)))
+                .with_offchain_gross_usd_cents(90_000)
+                .with_withdrawable_cash_cents(15_000),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+        let usdc_limit = Some(Usdc::new(float!(200)));
+
+        let result =
+            check_imbalance_and_build_operation(&threshold, &inventory, usdc_limit, None).await;
+
+        assert_eq!(
+            result,
+            Ok(UsdcRebalanceOperation::AlpacaToBase {
+                amount: Usdc::new(float!(150))
+            }),
+            "Withdrawable ($150) must bind below the operational limit ($200); expected 150, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_skips_when_withdrawable_missing_and_no_reserve() {
+        // No reserve configured, no withdrawable_cash_cents -> capacity unknown -> skip.
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_offchain_gross_usd_cents(50_000),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
+
+        assert_eq!(
+            result,
+            Err(UsdcTriggerSkip::MissingWithdrawableCash),
+            "Missing withdrawable cash must skip regardless of reserve configuration, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_skips_when_withdrawable_below_minimum_and_no_reserve() {
+        // No reserve configured; withdrawable = $30, below $51 Alpaca minimum.
+        // Must return WithdrawableBelowMinimum: the broker has too little settled
+        // cash and no reserve is in play.
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_offchain_gross_usd_cents(50_000)
+                .with_withdrawable_cash_cents(3_000),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
+
+        assert_eq!(
+            result,
+            Err(UsdcTriggerSkip::WithdrawableBelowMinimum),
+            "Withdrawable below $51 minimum with no reserve must return WithdrawableBelowMinimum, got {result:?}"
         );
     }
 

--- a/tests/e2e/chaos_load.rs
+++ b/tests/e2e/chaos_load.rs
@@ -299,8 +299,16 @@ async fn kill_mid_burst_recovers_every_take_exactly_once() -> anyhow::Result<()>
     // Kill while the queue is still mid-drain: a couple of trades witnessed,
     // the rest of the burst still Queued/Running behind the throttled receipts.
     poll_for_events(&mut bot, &infra.db_path, "OnChainTradeEvent::Filled", 2).await;
+    // Let the tail-block backfill enqueue its accounting job before the kill.
+    // This covers the harder recovery case: the checkpoint has advanced, so
+    // restart must recover from the persisted job row rather than rescanning.
+    tokio::time::sleep(Duration::from_millis(500)).await;
     bot.abort();
     let _ = bot.await;
+    // The e2e "kill" is an in-process task abort. Give the abort guard one
+    // scheduling window to stop detached child tasks before starting the next
+    // conductor, matching a real process restart where the old process is gone.
+    tokio::time::sleep(Duration::from_millis(200)).await;
 
     let ctx2 = build_ctx()
         .chain(&infra.base_chain)


### PR DESCRIPTION
## What

Implements [RAI-1183](https://linear.app/makeitrain/issue/RAI-1183/usdc-rebalance-withdrawable-cash-cap-skipped-when-no-reserve).

This updates Alpaca-to-Base USDC trigger sizing so Alpaca withdrawable cash always caps the transfer amount, even when no cash reserve is configured.

## Why

When `reserved = None`, the trigger previously skipped the withdrawable-cash cap and sized transfers from gross offchain imbalance, bounded only by the operational limit. In production on 2026-06-29, that allowed the bot to size a transfer above Alpaca's actual withdrawable cash, causing the USD->USDC conversion path to fail and leaving the USDC rebalance guard stuck until manual intervention.

## How

- Computes Alpaca-to-Base withdrawable capacity for every offchain USDC excess, treating an omitted reserve as `0`.
- Keeps missing withdrawable cash as a hard skip because the transfer cannot be safely bounded.
- Splits the below-minimum cases so reserve-exhausted capacity and naturally low withdrawable cash report different skip reasons.
- Adds boundary coverage for exactly `$51` withdrawable cash and for withdrawable cash binding below the configured operational limit.

## Testing

- `nix develop .#ci-backend -c cargo check -p st0x-hedge`
- `nix develop .#ci-backend -c cargo clippy -p st0x-hedge --all-targets`
- `nix develop .#ci-backend -c cargo nextest run -p st0x-hedge alpaca_to_base`
- `nix develop .#ci-backend -c cargo nextest run -p st0x-hedge usdc`
- `nix run .#ci`
- GitHub CI for PR #950: green

## Screenshots

N/A

## Anything else

PR #950 was submitted through Graphite as v2.
