### PR TITLE
feat: reverse dropped-fill reorgs via active block re-verification

### DIFF
--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -7,6 +7,7 @@
 //! downtime. A persisted checkpoint records the last block that was fully
 //! enqueued.
 
+use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::{B256, TxHash};
 use alloy::providers::Provider;
 use alloy::rpc::types::{Filter, Log};
@@ -300,20 +301,37 @@ where
         .await?;
 
         // A `removed: true` log is the legacy (now-inert over `eth_getLogs`)
-        // reorg signal; the authoritative one is a present log re-served on a
-        // different block_hash than the witnessed fill persisted. Both funnel
-        // through the same exactly-once `record_reorg` reversal.
+        // reorg signal; the authoritative re-mined signal is a present log
+        // re-served on a different block_hash than the witnessed fill persisted.
+        // Both funnel through the same exactly-once `record_reorg` reversal.
         let mut reorged = scan.removed;
         reorged.extend(detect_block_hash_reorgs(&ctx.cqrs.onchain_trade, &scan.present).await?);
 
-        if reorged.is_empty() {
-            return Ok(());
-        }
-
-        // Depth is measured from the current tip: the dropped block is gone, so
-        // the reorg spans at least `tip - block_number` blocks. Fetched once and
-        // reused for every reversal in this batch.
+        // The tip anchors both the unfinalized window the re-verification scans and
+        // the reorg depth recorded per reversal (the dropped block is gone, so the
+        // reorg spans at least `tip - block_number`). Read once and reused for every
+        // reversal in this batch.
         let tip = ctx.evm.provider().get_block_number().await?;
+
+        // `detect_block_hash_reorgs` only fires when a witnessed `(tx_hash,
+        // log_index)` is RE-observed on a different block, so a fill the chain
+        // DROPPED (orphaned, never re-mined) is structurally invisible to it. This
+        // pass drives from the witnessed-fills side and actively re-reads each
+        // unfinalized fill's canonical block by number -- INDEPENDENT of the forward
+        // scan, which never re-covers a dropped block below the checkpoint. It runs
+        // every tick (not gated on the scan) so a drop is caught even when the scan
+        // is empty; the reversal is reverse-ONLY through the same `record_reorg`.
+        reorged.extend(
+            detect_dropped_fill_reorgs(
+                &ctx.cqrs.onchain_trade,
+                &ctx.pool,
+                ctx.evm.provider(),
+                &scan.present,
+                tip,
+                ctx.ctx.evm.required_confirmations,
+            )
+            .await?,
+        );
 
         for removed_trade in reorged {
             // A tip behind the removed block would saturate `reorg_depth` to 0 --
@@ -434,6 +452,204 @@ async fn detect_block_hash_reorgs(
                 }),
             });
         }
+    }
+
+    Ok(reorged)
+}
+
+/// How many blocks below the chain tip the dropped-fill re-verification still
+/// re-checks each tick. A witnessed fill whose block is deeper than this is
+/// treated as final and dropped from consideration, keeping the pass
+/// O(unfinalized fills) rather than O(all history).
+///
+/// Sized to cover the `safe`-cutoff reorg window with margin: a `safe` OP-stack
+/// L2 block is batch-posted but not yet L1-finalized, so it can still be reorged
+/// until its batch finalizes on L1 -- on Base that is ~hundreds of L2 blocks
+/// (~2s/block against ~13 min L1 finality). The work is O(fills in the window),
+/// not O(blocks), so a wide window stays cheap. The exact value is a deliberate
+/// estimate pending measured fleet data, like the `SAFE_CUTOFF_QUIET_SKEW` band
+/// in the fill monitor.
+const REORG_REVERIFICATION_WINDOW: u64 = 1024;
+
+/// Detects witnessed fills the canonical chain DROPPED -- orphaned by a reorg and
+/// never re-mined -- which [`detect_block_hash_reorgs`] structurally cannot catch.
+/// That detector only fires when a witnessed `(tx_hash, log_index)` is RE-observed
+/// on a different `block_hash`; a dropped fill is never re-observed, so it is never
+/// compared and a naked hedge is left behind. This pass instead drives from the
+/// witnessed-fills side and ACTIVELY RE-VERIFIES each unfinalized fill against the
+/// chain: it re-reads the fill's block by number and asks whether the block the
+/// fill was accounted against is still canonical.
+///
+/// For each candidate fill `F` (`block_number`, persisted `block_hash`, not yet
+/// reorg-acknowledged) inside the unfinalized window:
+/// - fetch the current canonical block at `F.block_number` via
+///   [`Provider::get_block_by_number`];
+/// - if its hash EQUALS `F`'s persisted hash, the block is still canonical -- no-op;
+/// - if its hash DIFFERS, the block was orphaned. When `F`'s own
+///   `(tx_hash, log_index)` is ALSO absent from the current scan (not re-mined under
+///   the same key, which is [`detect_block_hash_reorgs`]'s reverse-then-reapply
+///   job), the fill was dropped -> flag reverse-ONLY (`reinclusion: None`).
+///
+/// This is INDEPENDENT of the forward scan / checkpoint: the canonical block is read
+/// directly by number, so a fill whose block sits BELOW the checkpoint -- which the
+/// forward scan never re-covers -- is still re-verified. The scan's present logs are
+/// consulted ONLY to partition a re-mined-same-key fill (key re-observed) away from
+/// this detector, so within a pass a fill is flagged by at most one detector.
+///
+/// Confirmation-respecting: a fill within `required_confirmations` of the tip is too
+/// close to trust the canonical view (a near-tip fork may itself reorg back), so it
+/// is deferred to a later tick once buried deep enough. Combined with the
+/// [`REORG_REVERIFICATION_WINDOW`] floor, only fills in
+/// `(tip - WINDOW, tip - required_confirmations]` are re-verified, keeping the pass
+/// O(unfinalized fills).
+///
+/// Exactly-once across ticks: a fill whose reorg reversal is already acknowledged
+/// (`is_reorg_acknowledged`) is skipped, mirroring [`detect_block_hash_reorgs`]. A
+/// reversal that began but did not finish (reorged, not yet acknowledged) is
+/// re-flagged so `record_reorg`'s idempotent resume completes it. `OnChainTrade` has
+/// no projection, so candidates come straight from the event log; the authoritative
+/// block/hash/reorg state is read from the loaded aggregate.
+async fn detect_dropped_fill_reorgs<P: Provider>(
+    onchain_trade: &Store<OnChainTrade>,
+    pool: &SqlitePool,
+    provider: &P,
+    present: &[PresentLog],
+    tip: u64,
+    required_confirmations: u64,
+) -> Result<Vec<RemovedTrade>, OnChainError> {
+    let finalized_tip = tip.saturating_sub(REORG_REVERIFICATION_WINDOW);
+    let finalized_tip_bound = i64::try_from(finalized_tip)?;
+
+    // A fill closer to the tip than the confirmation depth is not yet buried deep
+    // enough to trust the canonical view -- a near-tip fork can still reorg back.
+    // Re-verify only at or below this ceiling; a fresher fill is re-checked on a
+    // later tick once it is confirmed-deep.
+    let confirmed_ceiling = tip.saturating_sub(required_confirmations);
+
+    // Candidate ids: witnessed fills whose latest block (its `Filled`, or its
+    // `ReWitnessed` after a re-mine) is still above the finality boundary. Filtered
+    // in SQL so only the unfinalized fills are loaded.
+    let candidates = sqlx::query_as::<_, (String,)>(
+        "SELECT aggregate_id FROM events \
+         WHERE aggregate_type = 'OnChainTrade' \
+           AND event_type IN ('OnChainTradeEvent::Filled', 'OnChainTradeEvent::ReWitnessed') \
+         GROUP BY aggregate_id \
+         HAVING MAX(COALESCE( \
+             json_extract(payload, '$.Filled.block_number'), \
+             json_extract(payload, '$.ReWitnessed.block_number') \
+         )) > ?",
+    )
+    .bind(finalized_tip_bound)
+    .fetch_all(pool)
+    .await?;
+
+    let mut reorged = Vec::new();
+
+    for (aggregate_id,) in candidates {
+        let trade_id = match aggregate_id.parse::<OnChainTradeId>() {
+            Ok(trade_id) => trade_id,
+            Err(error) => {
+                warn!(
+                    target: "orderbook",
+                    %aggregate_id,
+                    %error,
+                    "Skipping unparseable OnChainTrade aggregate id during dropped-fill \
+                     re-verification"
+                );
+                continue;
+            }
+        };
+
+        let Some(trade) = onchain_trade.load(&trade_id).await? else {
+            continue;
+        };
+
+        // Already fully reversed (and, for a re-mined fill, since re-witnessed):
+        // nothing to do. Mirrors `detect_block_hash_reorgs`'s acknowledged guard so
+        // the reversal stays exactly-once across ticks.
+        if trade.is_reorg_acknowledged() {
+            continue;
+        }
+
+        let (Some(block_number), Some(persisted_block_hash)) =
+            (trade.block_number, trade.block_hash)
+        else {
+            // No persisted block hash to compare against (a legacy fill, or one
+            // whose source log carried none): the orphaning cannot be proven, so do
+            // not flag -- matches `detect_block_hash_reorgs`.
+            continue;
+        };
+
+        // The SQL bound is on the event log's block number; re-check against the
+        // authoritative loaded block so a fill that finalized between the query and
+        // the load is not reversed.
+        if block_number <= finalized_tip {
+            continue;
+        }
+
+        // Too close to the tip to trust the canonical view yet: defer to a later
+        // tick. The re-verification re-runs every tick, so deferring keeps the
+        // reversal exactly-once rather than dropping it.
+        if block_number > confirmed_ceiling {
+            continue;
+        }
+
+        // The fill's own key is still on the chain (re-observed): either still
+        // canonical, or re-mined under the SAME key -- which is
+        // `detect_block_hash_reorgs`'s job (reverse-then-reapply). Not a drop, and
+        // checked before the canonical read so a re-mine is never reverse-only here.
+        let key_reobserved = present
+            .iter()
+            .any(|log| log.tx_hash == trade_id.tx_hash && log.log_index == trade_id.log_index);
+        if key_reobserved {
+            continue;
+        }
+
+        // Active canonical re-verification: read the block the fill was accounted
+        // against by number and compare its CURRENT hash to the one persisted. This
+        // is the authoritative orphan signal, independent of the forward scan -- it
+        // surfaces a drop even when the fill's block sits below the checkpoint the
+        // scan never re-covers.
+        let Some(canonical_block) = provider
+            .get_block_by_number(BlockNumberOrTag::Number(block_number))
+            .await?
+        else {
+            // The node has not surfaced a block at this height (a lagging or
+            // cold-start node): the orphaning cannot be proven, so do not reverse an
+            // already-hedged fill. A later tick re-checks against a caught-up node.
+            warn!(
+                target: "orderbook",
+                tx_hash = ?trade_id.tx_hash,
+                log_index = trade_id.log_index,
+                block_number,
+                "Canonical block absent during dropped-fill re-verification; deferring -- \
+                 cannot prove the fill's block was orphaned"
+            );
+            continue;
+        };
+
+        // The fill's block is still canonical (its hash is unchanged): not a drop.
+        if canonical_block.header.hash == persisted_block_hash {
+            continue;
+        }
+
+        warn!(
+            target: "orderbook",
+            tx_hash = ?trade_id.tx_hash,
+            log_index = trade_id.log_index,
+            block_number,
+            ?persisted_block_hash,
+            canonical_block_hash = ?canonical_block.header.hash,
+            "Witnessed fill's block was orphaned (canonical hash differs) and the fill's \
+             identity did not re-appear -- dropped by a reorg; recording reverse-only reversal"
+        );
+        reorged.push(RemovedTrade {
+            trade_id,
+            block_number,
+            // Truly dropped: the canonical chain no longer holds the fill, so there
+            // is nothing to re-apply -- reverse only.
+            reinclusion: None,
+        });
     }
 
     Ok(reorged)
@@ -1406,7 +1622,7 @@ mod tests {
         uint,
     };
     use alloy::providers::{ProviderBuilder, mock::Asserter};
-    use alloy::rpc::types::Log;
+    use alloy::rpc::types::{Block, Log, Transaction};
     use chrono::Utc;
     use rain_math_float::Float;
     use st0x_config::{
@@ -5924,5 +6140,429 @@ mod tests {
         assert_eq!(present.tx_hash, expected_tx_hash);
         assert_eq!(present.log_index, 1);
         assert_eq!(present.block_number, 50);
+    }
+
+    /// Tip far above the seed block (100) so the fill is comfortably inside the
+    /// unfinalized window in the dropped-fill tests below.
+    const UNFINALIZED_TIP: u64 = 1_000;
+
+    /// Confirmations used by the dropped-fill unit tests: zero, matching the e2e
+    /// chain config, so the confirmation ceiling is the tip and never gates the
+    /// in-window seed block.
+    const NO_CONFIRMATIONS: u64 = 0;
+
+    /// Mock provider answering exactly one `eth_getBlockByNumber` with a block at
+    /// `number` carrying `hash` -- the canonical block the dropped-fill
+    /// re-verification reads to compare against a fill's persisted hash.
+    fn provider_with_block(number: u64, hash: B256) -> impl Provider + Clone {
+        let mut block = Block::<Transaction>::default();
+        block.header.inner.number = number;
+        block.header.hash = hash;
+
+        let asserter = Asserter::new();
+        asserter.push_success(&block);
+        ProviderBuilder::new().connect_mocked_client(asserter)
+    }
+
+    /// Mock provider answering one `eth_getBlockByNumber` with a JSON null -- the
+    /// node has not surfaced a block at the requested height yet.
+    fn provider_without_block() -> impl Provider + Clone {
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::Null);
+        ProviderBuilder::new().connect_mocked_client(asserter)
+    }
+
+    /// Mock provider with no queued responses: any RPC call panics the test. Used
+    /// where the re-verification must short-circuit BEFORE the canonical block read
+    /// (re-mined-same-key, already-acknowledged, finalized window).
+    fn provider_never_called() -> impl Provider + Clone {
+        ProviderBuilder::new().connect_mocked_client(Asserter::new())
+    }
+
+    /// The dropped-fill re-verification reverses (reverse-ONLY) a witnessed, hedged
+    /// fill whose block the canonical chain orphaned: the canonical block at the
+    /// fill's height now carries a DIFFERENT hash than the one persisted, and the
+    /// fill's own `(tx_hash, log_index)` never re-appeared in the scan, so it is
+    /// flagged with NO re-inclusion. This is the gap `detect_block_hash_reorgs`
+    /// cannot close.
+    #[tokio::test]
+    async fn dropped_fill_with_orphaned_block_is_flagged_reverse_only() {
+        let pool = setup_test_db().await;
+        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let tx_hash = TxHash::repeat_byte(0xab);
+        let log_index = 7;
+        let persisted_block_hash = B256::repeat_byte(0xaa);
+        let now = Utc::now();
+
+        seed_witnessed_fill_with_block_hash(
+            &onchain_trade,
+            &position,
+            &symbol,
+            tx_hash,
+            log_index,
+            Some(persisted_block_hash),
+            now,
+        )
+        .await;
+
+        // The orphan-block marker the chaos `ForkDrop` getLogs drop serves: the
+        // fill's block height under a competing hash, but a DIFFERENT transaction
+        // identity -- the fill's own key never re-appears, so the re-mine detector
+        // cannot claim it.
+        let present = vec![PresentLog {
+            tx_hash: TxHash::repeat_byte(0xdd),
+            log_index,
+            block_number: 100,
+            block_hash: Some(B256::repeat_byte(0xff)),
+            block_timestamp: Some(now),
+        }];
+
+        // The canonical block at the fill's height now carries a competing hash, so
+        // the active re-verification sees hash != persisted and flags the drop.
+        let provider = provider_with_block(100, B256::repeat_byte(0xff));
+
+        let reorged = detect_dropped_fill_reorgs(
+            &onchain_trade,
+            &pool,
+            &provider,
+            &present,
+            UNFINALIZED_TIP,
+            NO_CONFIRMATIONS,
+        )
+        .await
+        .unwrap();
+
+        let [removed] = reorged.as_slice() else {
+            panic!(
+                "a dropped fill with an orphaned block must surface exactly one reorg, got {reorged:?}"
+            );
+        };
+        assert_eq!(removed.trade_id.tx_hash, tx_hash);
+        assert_eq!(removed.trade_id.log_index, log_index);
+        assert_eq!(removed.block_number, 100);
+        assert!(
+            removed.reinclusion.is_none(),
+            "a dropped fill must be reverse-only -- no re-inclusion to re-apply",
+        );
+    }
+
+    /// A witnessed fill whose key never re-appears but whose canonical block STILL
+    /// carries its persisted hash was not orphaned: the active re-verification reads
+    /// the block by number, sees the hash is unchanged, and leaves the fill alone.
+    #[tokio::test]
+    async fn still_canonical_fill_is_noop() {
+        let pool = setup_test_db().await;
+        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let tx_hash = TxHash::repeat_byte(0xab);
+        let log_index = 7;
+        let persisted_block_hash = B256::repeat_byte(0xaa);
+        let now = Utc::now();
+
+        seed_witnessed_fill_with_block_hash(
+            &onchain_trade,
+            &position,
+            &symbol,
+            tx_hash,
+            log_index,
+            Some(persisted_block_hash),
+            now,
+        )
+        .await;
+
+        // The fill's key never re-appears, so the pass falls through to the canonical
+        // read -- which returns the SAME hash the fill persisted.
+        let provider = provider_with_block(100, persisted_block_hash);
+
+        let reorged = detect_dropped_fill_reorgs(
+            &onchain_trade,
+            &pool,
+            &provider,
+            &[],
+            UNFINALIZED_TIP,
+            NO_CONFIRMATIONS,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            reorged.is_empty(),
+            "a fill whose canonical block hash is unchanged is still canonical, \
+             not dropped, got {reorged:?}",
+        );
+    }
+
+    /// A fill re-mined under the SAME key on a competing block is the re-mined
+    /// case `detect_block_hash_reorgs` owns (reverse-then-reapply). Because its key
+    /// is re-observed, the dropped-fill pass must skip it BEFORE the canonical read
+    /// -- avoiding a double revert, so the provider must never be consulted.
+    #[tokio::test]
+    async fn re_mined_same_key_is_left_to_block_hash_detector() {
+        let pool = setup_test_db().await;
+        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let tx_hash = TxHash::repeat_byte(0xab);
+        let log_index = 7;
+        let persisted_block_hash = B256::repeat_byte(0xaa);
+        let now = Utc::now();
+
+        seed_witnessed_fill_with_block_hash(
+            &onchain_trade,
+            &position,
+            &symbol,
+            tx_hash,
+            log_index,
+            Some(persisted_block_hash),
+            now,
+        )
+        .await;
+
+        // Same key, competing block hash: a re-mine. The block-hash detector flags
+        // this; the dropped-fill pass defers via the key-reobserved guard.
+        let present = vec![PresentLog {
+            tx_hash,
+            log_index,
+            block_number: 100,
+            block_hash: Some(B256::repeat_byte(0xff)),
+            block_timestamp: Some(now),
+        }];
+
+        // The key-reobserved guard short-circuits before any canonical read.
+        let provider = provider_never_called();
+
+        let reorged = detect_dropped_fill_reorgs(
+            &onchain_trade,
+            &pool,
+            &provider,
+            &present,
+            UNFINALIZED_TIP,
+            NO_CONFIRMATIONS,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            reorged.is_empty(),
+            "a re-mined same-key fill is `detect_block_hash_reorgs`'s job and must not \
+             be double-reverted here, got {reorged:?}",
+        );
+    }
+
+    /// A fill whose reorg reversal is already acknowledged must never be re-flagged
+    /// -- the reverse-only reversal stays exactly-once across poll ticks even while
+    /// the orphan marker keeps re-appearing.
+    #[tokio::test]
+    async fn already_reorg_acknowledged_fill_is_idempotent_noop() {
+        let pool = setup_test_db().await;
+        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let tx_hash = TxHash::repeat_byte(0xab);
+        let log_index = 7;
+        let persisted_block_hash = B256::repeat_byte(0xaa);
+        let now = Utc::now();
+
+        seed_witnessed_fill_with_block_hash(
+            &onchain_trade,
+            &position,
+            &symbol,
+            tx_hash,
+            log_index,
+            Some(persisted_block_hash),
+            now,
+        )
+        .await;
+
+        let trade_id = OnChainTradeId { tx_hash, log_index };
+        onchain_trade
+            .send(
+                &trade_id,
+                OnChainTradeCommand::RecordReorg { reorg_depth: 5 },
+            )
+            .await
+            .unwrap();
+        onchain_trade
+            .send(&trade_id, OnChainTradeCommand::AcknowledgeReorg)
+            .await
+            .unwrap();
+
+        // The orphan marker is still being served, but the reversal is already
+        // complete, so the pass must short-circuit on the acknowledged guard before
+        // ever reading the canonical block.
+        let present = vec![PresentLog {
+            tx_hash: TxHash::repeat_byte(0xdd),
+            log_index,
+            block_number: 100,
+            block_hash: Some(B256::repeat_byte(0xff)),
+            block_timestamp: Some(now),
+        }];
+
+        // The acknowledged guard short-circuits before any canonical read.
+        let provider = provider_never_called();
+
+        let reorged = detect_dropped_fill_reorgs(
+            &onchain_trade,
+            &pool,
+            &provider,
+            &present,
+            UNFINALIZED_TIP,
+            NO_CONFIRMATIONS,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            reorged.is_empty(),
+            "an already reorg-acknowledged fill must not be re-flagged, got {reorged:?}",
+        );
+    }
+
+    /// When the node has not surfaced a block at the fill's height (a lagging or
+    /// cold-start node returning a null `eth_getBlockByNumber`), the orphaning
+    /// cannot be proven, so an already-hedged fill must NOT be reversed -- the pass
+    /// defers to a later tick against a caught-up node.
+    #[tokio::test]
+    async fn canonical_block_absent_is_deferred_not_reversed() {
+        let pool = setup_test_db().await;
+        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let tx_hash = TxHash::repeat_byte(0xab);
+        let log_index = 7;
+        let now = Utc::now();
+
+        seed_witnessed_fill_with_block_hash(
+            &onchain_trade,
+            &position,
+            &symbol,
+            tx_hash,
+            log_index,
+            Some(B256::repeat_byte(0xaa)),
+            now,
+        )
+        .await;
+
+        // The fill's key is absent (no re-mine), but the node returns no block at the
+        // fill's height -- the orphaning is unproven, so the fill must be left alone.
+        let provider = provider_without_block();
+
+        let reorged = detect_dropped_fill_reorgs(
+            &onchain_trade,
+            &pool,
+            &provider,
+            &[],
+            UNFINALIZED_TIP,
+            NO_CONFIRMATIONS,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            reorged.is_empty(),
+            "an unproven orphaning (no canonical block) must never reverse a fill, got {reorged:?}",
+        );
+    }
+
+    /// Fills whose block has finalized (deeper than [`REORG_REVERIFICATION_WINDOW`]
+    /// below the tip) are dropped from consideration, keeping the pass bounded to
+    /// the unfinalized window -- even when an orphan marker is still present.
+    #[tokio::test]
+    async fn finalized_fill_is_outside_the_reverification_window() {
+        let pool = setup_test_db().await;
+        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let tx_hash = TxHash::repeat_byte(0xab);
+        let log_index = 7;
+        let now = Utc::now();
+
+        // The seed witnesses on block 100.
+        seed_witnessed_fill_with_block_hash(
+            &onchain_trade,
+            &position,
+            &symbol,
+            tx_hash,
+            log_index,
+            Some(B256::repeat_byte(0xaa)),
+            now,
+        )
+        .await;
+
+        let present = vec![PresentLog {
+            tx_hash: TxHash::repeat_byte(0xdd),
+            log_index,
+            block_number: 100,
+            block_hash: Some(B256::repeat_byte(0xff)),
+            block_timestamp: Some(now),
+        }];
+
+        // The finality-window floor short-circuits before any canonical read.
+        let provider = provider_never_called();
+
+        // Tip far enough ahead that block 100 is below the finality boundary
+        // (100 <= tip - REORG_REVERIFICATION_WINDOW), so the fill is final.
+        let tip_past_finality = 100 + REORG_REVERIFICATION_WINDOW + 1;
+        let reorged = detect_dropped_fill_reorgs(
+            &onchain_trade,
+            &pool,
+            &provider,
+            &present,
+            tip_past_finality,
+            NO_CONFIRMATIONS,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            reorged.is_empty(),
+            "a finalized fill is outside the unfinalized window and must not be re-verified, \
+             got {reorged:?}",
+        );
     }
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -307,59 +307,13 @@ impl EventSourced for Position {
             // out-of-order one after a newer reorg advanced the slot (ADR 0012).
             Reorged {
                 trade_id,
-                direction: Buy,
+                direction,
                 amount,
                 reorged_at,
                 ..
-            } => {
-                let mut pending_acknowledged_trade_ids =
-                    entity.pending_acknowledged_trade_ids.clone();
-                pending_acknowledged_trade_ids.remove(trade_id);
-                let mut pending_reorged_trade_ids = entity.pending_reorged_trade_ids.clone();
-                pending_reorged_trade_ids.insert(trade_id.clone());
-                Ok(Some(Self {
-                    net: (entity.net - *amount)?,
-                    accumulated_long: (entity.accumulated_long - *amount)?,
-                    last_reorged_at: Some(*reorged_at),
-                    last_acknowledged_trade_id: entity
-                        .last_acknowledged_trade_id
-                        .clone()
-                        .filter(|id| id != trade_id),
-                    last_reorged_trade_id: Some(trade_id.clone()),
-                    pending_acknowledged_trade_ids,
-                    pending_reorged_trade_ids,
-                    last_updated: Some(*reorged_at),
-                    ..entity.clone()
-                }))
-            }
-
-            Reorged {
-                trade_id,
-                direction: Sell,
-                amount,
-                reorged_at,
-                ..
-            } => {
-                let mut pending_acknowledged_trade_ids =
-                    entity.pending_acknowledged_trade_ids.clone();
-                pending_acknowledged_trade_ids.remove(trade_id);
-                let mut pending_reorged_trade_ids = entity.pending_reorged_trade_ids.clone();
-                pending_reorged_trade_ids.insert(trade_id.clone());
-                Ok(Some(Self {
-                    net: (entity.net + *amount)?,
-                    accumulated_short: (entity.accumulated_short - *amount)?,
-                    last_reorged_at: Some(*reorged_at),
-                    last_acknowledged_trade_id: entity
-                        .last_acknowledged_trade_id
-                        .clone()
-                        .filter(|id| id != trade_id),
-                    last_reorged_trade_id: Some(trade_id.clone()),
-                    pending_acknowledged_trade_ids,
-                    pending_reorged_trade_ids,
-                    last_updated: Some(*reorged_at),
-                    ..entity.clone()
-                }))
-            }
+            } => entity
+                .evolve_reorg(trade_id, *direction, *amount, *reorged_at)
+                .map(Some),
 
             // Bookkeeping only (ADR 0012): prune the settled reversal from the
             // pending-reorg set without touching net -- the reversal already
@@ -659,48 +613,7 @@ impl EventSourced for Position {
                 direction,
                 price_usdc,
                 reorg_depth,
-            } => {
-                // A reversal must undo a real (strictly positive) fill amount.
-                // Reject a zero or negative amount rather than appending a
-                // reversal that would corrupt the net position.
-                Positive::new(amount)
-                    .map_err(|_| PositionError::NonPositiveReorgAmount { amount })?;
-
-                // Dual guard (ADR 0012, mirroring ADR 0010 for fills): the
-                // retained slot bridges a reorg reversed under pre-set code and
-                // left unsettled at the deploy restart; the set rejects an
-                // out-of-order re-drive the single slot cannot, because a newer
-                // reorg advances the slot but never the set entry.
-                if self.last_reorged_trade_id.as_ref() == Some(&trade_id)
-                    || self.pending_reorged_trade_ids.contains(&trade_id)
-                {
-                    warn!(
-                        target: "hedge",
-                        symbol = %self.symbol, %trade_id,
-                        "Rejecting re-driven reorg: fill already reversed on this position"
-                    );
-                    return Err(PositionError::DuplicateReorg { trade_id });
-                }
-
-                warn!(
-                    target: "hedge",
-                    symbol = %self.symbol,
-                    %trade_id,
-                    ?direction,
-                    %amount,
-                    reorg_depth,
-                    "Reversing position impact of a reorged fill"
-                );
-
-                Ok(vec![PositionEvent::Reorged {
-                    trade_id,
-                    amount,
-                    direction,
-                    price_usdc: Some(price_usdc),
-                    reorg_depth,
-                    reorged_at: Utc::now(),
-                }])
-            }
+            } => self.record_reorg_events(trade_id, amount, direction, price_usdc, reorg_depth),
 
             SettleReorg { trade_id } => {
                 if self.pending_reorged_trade_ids.contains(&trade_id) {
@@ -852,6 +765,93 @@ impl EventSourced for Position {
 }
 
 impl Position {
+    fn record_reorg_events(
+        &self,
+        trade_id: TradeId,
+        amount: FractionalShares,
+        direction: Direction,
+        price_usdc: Float,
+        reorg_depth: u64,
+    ) -> Result<Vec<PositionEvent>, PositionError> {
+        Positive::new(amount).map_err(|_| PositionError::NonPositiveReorgAmount { amount })?;
+
+        // Dual guard (ADR 0012, mirroring ADR 0010 for fills): the retained slot
+        // bridges a reorg reversed under pre-set code and left unsettled at the
+        // deploy restart; the set rejects an out-of-order re-drive the single
+        // slot cannot, because a newer reorg advances the slot but never the set.
+        if self.last_reorged_trade_id.as_ref() == Some(&trade_id)
+            || self.pending_reorged_trade_ids.contains(&trade_id)
+        {
+            warn!(
+                target: "hedge",
+                symbol = %self.symbol, %trade_id,
+                "Rejecting re-driven reorg: fill already reversed on this position"
+            );
+            return Err(PositionError::DuplicateReorg { trade_id });
+        }
+
+        warn!(
+            target: "hedge",
+            symbol = %self.symbol,
+            %trade_id,
+            ?direction,
+            %amount,
+            reorg_depth,
+            "Reversing position impact of a reorged fill"
+        );
+
+        Ok(vec![PositionEvent::Reorged {
+            trade_id,
+            amount,
+            direction,
+            price_usdc: Some(price_usdc),
+            reorg_depth,
+            reorged_at: Utc::now(),
+        }])
+    }
+
+    fn evolve_reorg(
+        &self,
+        trade_id: &TradeId,
+        direction: Direction,
+        amount: FractionalShares,
+        reorged_at: DateTime<Utc>,
+    ) -> Result<Self, PositionError> {
+        let mut pending_acknowledged_trade_ids = self.pending_acknowledged_trade_ids.clone();
+        pending_acknowledged_trade_ids.remove(trade_id);
+        let mut pending_reorged_trade_ids = self.pending_reorged_trade_ids.clone();
+        pending_reorged_trade_ids.insert(trade_id.clone());
+
+        let (net, accumulated_long, accumulated_short) = match direction {
+            Direction::Buy => (
+                (self.net - amount)?,
+                (self.accumulated_long - amount)?,
+                self.accumulated_short,
+            ),
+            Direction::Sell => (
+                (self.net + amount)?,
+                self.accumulated_long,
+                (self.accumulated_short - amount)?,
+            ),
+        };
+
+        Ok(Self {
+            net,
+            accumulated_long,
+            accumulated_short,
+            last_reorged_at: Some(reorged_at),
+            last_acknowledged_trade_id: self
+                .last_acknowledged_trade_id
+                .clone()
+                .filter(|id| id != trade_id),
+            last_reorged_trade_id: Some(trade_id.clone()),
+            pending_acknowledged_trade_ids,
+            pending_reorged_trade_ids,
+            last_updated: Some(reorged_at),
+            ..self.clone()
+        })
+    }
+
     fn acknowledge_on_chain_fill_init_events(
         symbol: Symbol,
         threshold: ExecutionThreshold,

--- a/tests/e2e/chaos.rs
+++ b/tests/e2e/chaos.rs
@@ -65,7 +65,28 @@ pub(crate) enum ChaosBehaviour {
     /// RPC node on a forked branch re-serving an already-ingested fill's
     /// log under the fork's block -- the reorg the consumer detects via
     /// block-hash mismatch against the hash it persisted at ingestion.
+    /// `eth_getBlockByNumber` for the re-served block's height is also
+    /// stamped with [`FORK_BLOCK_HASH`] (see [`Perturbation::ForkBlockHash`])
+    /// so the consumer's canonical-ancestry re-verification reads the same
+    /// swapped block the getLogs re-serve advertises.
     ForkReplay,
+    /// Models a fill the reorg DROPPED rather than re-mined: the witnessed
+    /// fill never re-appears under its own `(tx_hash, log_index)`, yet the
+    /// block at its height is replaced by a competing one. Each cached fill
+    /// log is re-served at its original block height carrying
+    /// [`FORK_BLOCK_HASH`] but with the fill's transaction identity replaced
+    /// by [`ORPHAN_DROP_TX_HASH`] and its event topics cleared -- the
+    /// orphaned block's unrelated content, not the fill. The consumer thus
+    /// sees the fill's block orphaned (a competing hash at that height) while
+    /// the fill's own identity is gone, so the block-hash-mismatch detector --
+    /// which only fires on a re-observed witnessed identity -- never flags it.
+    /// This is the dropped-and-not-reappearing reorg the `removed: true` path
+    /// is inert against over `eth_getLogs`. In addition, `eth_getBlockByNumber`
+    /// for the dropped fill's block height is stamped with [`FORK_BLOCK_HASH`]
+    /// (see [`Perturbation::ForkBlockHash`]): the consumer's canonical-ancestry
+    /// re-verification reads the fill's block by number and must see the competing
+    /// hash there, since the orphaned block never re-appears over `eth_getLogs`.
+    ForkDrop,
 }
 
 /// Block hash the [`ChaosBehaviour::ForkReplay`] perturbation stamps onto
@@ -74,6 +95,14 @@ pub(crate) enum ChaosBehaviour {
 /// mismatch and treats the re-served fill as reorged off the canonical
 /// chain.
 const FORK_BLOCK_HASH: &str = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+/// Transaction hash the [`ChaosBehaviour::ForkDrop`] perturbation stamps onto
+/// the orphan-block marker it serves in place of a dropped fill. All-`0xdd`
+/// cannot collide with a real Anvil transaction hash, so the consumer can never
+/// match the marker to the witnessed fill's own `(tx_hash, log_index)` -- the
+/// fill stays dropped (never re-observed) rather than detected as re-mined.
+const ORPHAN_DROP_TX_HASH: &str =
+    "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
 
 /// Knob describing which method to perturb and for how many calls.
 ///
@@ -264,6 +293,26 @@ impl ChaosProxy {
         *self.config.lock().await = Some(ChaosConfig {
             method: "eth_getLogs".to_owned(),
             behaviour: ChaosBehaviour::ForkReplay,
+            remaining: count,
+            pending_stale_tips: 0,
+        });
+    }
+
+    /// Convenience: for the next `count` `eth_getLogs` responses, replace the
+    /// last non-empty result for the same event signature with an orphan-block
+    /// marker -- the cached fill re-served at its original block height under
+    /// [`FORK_BLOCK_HASH`], with [`ORPHAN_DROP_TX_HASH`] for its transaction and
+    /// its event topics cleared -- modelling a fill the reorg DROPPED. Unlike
+    /// [`ChaosProxy::fork_replay_get_logs`], the witnessed fill's own
+    /// `(tx_hash, log_index)` never re-appears, so the consumer's block-hash
+    /// reorg detector (which keys off a re-observed witnessed identity) cannot
+    /// flag it: this exercises the gap where a dropped-and-not-reappearing fill
+    /// leaves a naked hedge. A generous `count` covers both event-signature
+    /// polls across several rounds.
+    pub(crate) async fn fork_drop_get_logs(&self, count: usize) {
+        *self.config.lock().await = Some(ChaosConfig {
+            method: "eth_getLogs".to_owned(),
+            behaviour: ChaosBehaviour::ForkDrop,
             remaining: count,
             pending_stale_tips: 0,
         });
@@ -619,6 +668,14 @@ enum Perturbation {
     /// Forward upstream, then merge previously-cached logs for the same
     /// event signature into the response, in the given mode.
     ReplayResponse(ReplayMode),
+    /// Forward the `eth_getBlockByNumber` upstream, then overwrite the returned
+    /// block's `hash` with [`FORK_BLOCK_HASH`]. Pairs the fork perturbations'
+    /// getLogs re-serve with the block-by-number read the consumer's
+    /// canonical-ancestry re-verification issues: under both [`ChaosBehaviour::ForkReplay`]
+    /// (re-mine) and [`ChaosBehaviour::ForkDrop`] (drop) the fill's block at that
+    /// height must show the competing fork hash, so the re-verification sees
+    /// `hash != persisted` and agrees with the getLogs signal.
+    ForkBlockHash,
 }
 
 /// How [`replay_cached_logs`] re-serves cached logs.
@@ -631,6 +688,12 @@ enum ReplayMode {
     /// [`FORK_BLOCK_HASH`], modelling a node on a competing fork
     /// ([`ChaosBehaviour::ForkReplay`]).
     Forked,
+    /// Re-serve cached logs as orphan-block markers: their `blockHash`
+    /// rewritten to [`FORK_BLOCK_HASH`], their `transactionHash` replaced by
+    /// [`ORPHAN_DROP_TX_HASH`], and their `topics` cleared. Models a fill the
+    /// reorg DROPPED -- the fill's block is orphaned but the fill's own
+    /// identity never re-appears ([`ChaosBehaviour::ForkDrop`]).
+    Dropped,
 }
 
 /// Decide a single JSON-RPC request: synthesize, delay, or replay a
@@ -650,7 +713,7 @@ async fn process_one(state: &ProxyState, request: Value) -> Value {
     let is_get_logs = method.as_deref() == Some("eth_getLogs");
 
     let perturbation = match method {
-        Some(method) => perturb(state, &method, &id).await,
+        Some(method) => perturb(state, &method, &request, &id).await,
         None => None,
     };
 
@@ -664,6 +727,10 @@ async fn process_one(state: &ProxyState, request: Value) -> Value {
         Some(Perturbation::ReplayResponse(mode)) => {
             let response = forward_or_rpc_error(state, &request, id).await;
             replay_cached_logs(state, &request, response, mode).await
+        }
+        Some(Perturbation::ForkBlockHash) => {
+            let response = forward_or_rpc_error(state, &request, id).await;
+            rewrite_block_hash(response, FORK_BLOCK_HASH)
         }
         None => {
             let response = forward_or_rpc_error(state, &request, id).await;
@@ -711,7 +778,11 @@ async fn cache_get_logs_result(state: &ProxyState, request: &Value, response: &V
 /// The merged response models a stale node re-serving logs from outside
 /// the requested block range. Under [`ReplayMode::Forked`] each re-served
 /// log's `blockHash` is rewritten to [`FORK_BLOCK_HASH`] so the merge
-/// models a competing fork rather than the same chain.
+/// models a competing fork rather than the same chain. Under
+/// [`ReplayMode::Dropped`] each re-served log is additionally stripped of
+/// the fill's identity ([`ORPHAN_DROP_TX_HASH`], topics cleared) so the
+/// height shows a competing block whose content is no longer the witnessed
+/// fill -- a dropped, not re-mined, reorg.
 async fn replay_cached_logs(
     state: &ProxyState,
     request: &Value,
@@ -769,6 +840,18 @@ async fn replay_cached_logs(
                 log["blockHash"] = json!(FORK_BLOCK_HASH);
             }
         }
+        ReplayMode::Dropped => {
+            // Present the competing block at the fill's height while dropping
+            // the fill itself: keep the cached log's `blockNumber`, stamp the
+            // fork hash, but replace the transaction identity and clear the
+            // topics so the marker is neither matched to the witnessed fill
+            // (no re-mined re-application) nor re-decoded as a fresh fill.
+            for log in &mut replayed {
+                log["blockHash"] = json!(FORK_BLOCK_HASH);
+                log["transactionHash"] = json!(ORPHAN_DROP_TX_HASH);
+                log["topics"] = json!([]);
+            }
+        }
         ReplayMode::SameChain => {}
     }
 
@@ -797,7 +880,26 @@ async fn forward_or_rpc_error(state: &ProxyState, request: &Value, id: Value) ->
 
 /// Returns the perturbation the active chaos config applies to this
 /// method, or `None` to forward untouched.
-async fn perturb(state: &ProxyState, method: &str, id: &Value) -> Option<Perturbation> {
+async fn perturb(
+    state: &ProxyState,
+    method: &str,
+    request: &Value,
+    id: &Value,
+) -> Option<Perturbation> {
+    // A `ForkReplay`/`ForkDrop` arm swaps the block at the cached fill's height for
+    // the competing fork's. The consumer re-verifies a witnessed fill by reading
+    // that block by number, so `eth_getBlockByNumber` for the height must agree with
+    // the getLogs re-serve and carry the same `FORK_BLOCK_HASH`. Independent of the
+    // getLogs drop budget (the re-verification polls repeatedly; the reversal is
+    // exactly-once) and limited to the cached fill's height so unrelated reads -- the
+    // `safe`/`finalized` cutoff tag, other blocks -- pass through untouched.
+    if method == "eth_getBlockByNumber"
+        && forked_block_hash_armed(state).await
+        && requested_block_is_cached_fill_height(state, request).await
+    {
+        return Some(Perturbation::ForkBlockHash);
+    }
+
     let mut guard = state.config.lock().await;
 
     let result = match guard.as_mut() {
@@ -840,6 +942,10 @@ async fn perturb(state: &ProxyState, method: &str, id: &Value) -> Option<Perturb
                         cfg.remaining -= 1;
                         Some(Perturbation::ReplayResponse(ReplayMode::Forked))
                     }
+                    ChaosBehaviour::ForkDrop => {
+                        cfg.remaining -= 1;
+                        Some(Perturbation::ReplayResponse(ReplayMode::Dropped))
+                    }
                 }
             } else {
                 None
@@ -849,6 +955,58 @@ async fn perturb(state: &ProxyState, method: &str, id: &Value) -> Option<Perturb
 
     drop(guard);
     result
+}
+
+/// True when the active chaos behaviour presents the cached fill's block under the
+/// competing [`FORK_BLOCK_HASH`]: both the re-mine ([`ChaosBehaviour::ForkReplay`])
+/// and the drop ([`ChaosBehaviour::ForkDrop`]) model the fork swapping the block at
+/// the fill's height, so a canonical-ancestry read of that height must see the fork
+/// hash too.
+async fn forked_block_hash_armed(state: &ProxyState) -> bool {
+    matches!(
+        state.config.lock().await.as_ref(),
+        Some(ChaosConfig {
+            behaviour: ChaosBehaviour::ForkReplay | ChaosBehaviour::ForkDrop,
+            ..
+        })
+    )
+}
+
+/// True when `request` is an `eth_getBlockByNumber` for a numeric height matching
+/// the `blockNumber` of a cached fill log. A block tag (`safe`, `finalized`,
+/// `latest`, ...) is never a specific fill height, so tag reads return `false` and
+/// are left untouched.
+async fn requested_block_is_cached_fill_height(state: &ProxyState, request: &Value) -> bool {
+    let Some(requested) = request["params"][0].as_str().and_then(parse_hex_quantity) else {
+        return false;
+    };
+
+    state
+        .logs_cache
+        .lock()
+        .await
+        .values()
+        .flatten()
+        .any(|log| log["blockNumber"].as_str().and_then(parse_hex_quantity) == Some(requested))
+}
+
+/// Parses a `0x`-prefixed JSON-RPC hex quantity into a `u64`.
+fn parse_hex_quantity(value: &str) -> Option<u64> {
+    u64::from_str_radix(value.strip_prefix("0x")?, 16).ok()
+}
+
+/// Overwrites the `hash` of a block returned by `eth_getBlockByNumber` with `hash`,
+/// modelling the competing fork swapping the canonical block at that height. A null
+/// result (block not found) is left untouched.
+fn rewrite_block_hash(mut response: Value, hash: &str) -> Value {
+    if let Some(block) = response
+        .get_mut("result")
+        .filter(|result| result.is_object())
+    {
+        block["hash"] = json!(hash);
+    }
+
+    response
 }
 
 /// Forward a single parsed JSON-RPC request to the upstream node and
@@ -901,13 +1059,16 @@ fn json_response(value: &Value) -> Response {
 #[cfg(test)]
 mod tests {
     use reqwest::Client;
-    use serde_json::json;
+    use serde_json::{Value, json};
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::Mutex;
     use url::Url;
 
-    use super::{ProxyState, ReplayMode, replay_cached_logs};
+    use super::{
+        ChaosBehaviour, ChaosConfig, FORK_BLOCK_HASH, Perturbation, ProxyState, ReplayMode,
+        forked_block_hash_armed, perturb, replay_cached_logs, rewrite_block_hash,
+    };
 
     /// Pins the [`ChaosBehaviour::ForkReplay`] harness contract the reorg e2e
     /// depends on: a fill log cached from an earlier witnessing round is re-served
@@ -991,6 +1152,287 @@ mod tests {
             json!(canonical_block_hash),
             "the re-served block hash must differ from the canonical hash the bot \
              persisted, so the bot detects the block-hash mismatch",
+        );
+    }
+
+    /// Pins the [`ChaosBehaviour::ForkDrop`] harness contract the dropped-fill
+    /// reorg e2e depends on: a fill log cached from an earlier witnessing round
+    /// is re-served on a later `eth_getLogs` round as an *orphan-block marker* --
+    /// the fill's block height under a competing block hash, but with the fill's
+    /// own transaction identity replaced and its topics cleared. The bot's reorg
+    /// detection keys off a re-observed *witnessed* `(tx_hash, log_index)`, so a
+    /// marker that no longer carries the fill's identity must leave the fill
+    /// dropped and never flagged. If the transform ever stopped replacing the
+    /// identity (re-serving the witnessed fill) or stopped clearing the topics
+    /// (letting the marker re-ingest as a fresh fill), the e2e would stop
+    /// exercising the dropped-and-not-reappearing reorg gap.
+    ///
+    /// This exercises [`replay_cached_logs`] directly under
+    /// [`ReplayMode::Dropped`] -- the proxy's response transform -- without the
+    /// upstream node or the full bot: the only collaborator it needs is the
+    /// pre-seeded logs cache.
+    #[tokio::test]
+    async fn fork_drop_orphans_witnessed_fill_without_re_serving_its_identity() {
+        let signature =
+            "0x1111111111111111111111111111111111111111111111111111111111111111".to_owned();
+        let canonical_block_hash =
+            "0x00000000000000000000000000000000000000000000000000000000000000aa";
+        let transaction_hash = "0x00000000000000000000000000000000000000000000000000000000000000bb";
+        let log_index = "0x0";
+        let block_number = "0x2a";
+
+        // The fill the bot already ingested, cached by the proxy under its event
+        // signature during the witnessing round, on its original canonical block.
+        let cached_log = json!({
+            "transactionHash": transaction_hash,
+            "logIndex": log_index,
+            "blockNumber": block_number,
+            "blockHash": canonical_block_hash,
+            "topics": [signature],
+        });
+
+        let state = ProxyState {
+            config: Arc::new(Mutex::new(None)),
+            logs_cache: Arc::new(Mutex::new(HashMap::from([(
+                signature.clone(),
+                vec![cached_log],
+            )]))),
+            // Never used by `replay_cached_logs` (it transforms an already-received
+            // response), but required to build the handler state.
+            upstream: Url::parse("http://127.0.0.1:1").unwrap(),
+            client: Client::new(),
+        };
+
+        // A later poll round whose live result is empty: the forked node serves
+        // no new logs in the requested range and the dropped fill never returns.
+        let request = json!({ "params": [{ "topics": [signature] }] });
+        let live_response = json!({ "jsonrpc": "2.0", "id": 1, "result": [] });
+
+        let dropped =
+            replay_cached_logs(&state, &request, live_response, ReplayMode::Dropped).await;
+
+        let result = dropped["result"]
+            .as_array()
+            .expect("the response must carry a result array");
+        assert_eq!(
+            result.len(),
+            1,
+            "ForkDrop must serve a single orphan-block marker at the fill's height",
+        );
+
+        let marker = &result[0];
+
+        // The witnessed fill's own transaction identity must be gone: the fill is
+        // dropped, never re-observed, so the block-hash detector cannot flag it.
+        assert_ne!(
+            marker["transactionHash"],
+            json!(transaction_hash),
+            "the dropped fill's transaction identity must NOT be re-served",
+        );
+        // 32 bytes of 0xdd, derived independently of the production constant so the
+        // assertion pins the value rather than comparing the code against itself.
+        let orphan_tx_hash = format!("0x{}", "d".repeat(64));
+        assert_eq!(
+            marker["transactionHash"],
+            json!(orphan_tx_hash),
+            "the orphan marker must carry the sentinel drop transaction hash",
+        );
+
+        // The block at the fill's height is orphaned: same number, competing hash.
+        assert_eq!(
+            marker["blockNumber"],
+            json!(block_number),
+            "the orphan marker must sit at the dropped fill's block height",
+        );
+        // 32 bytes of 0xff, derived independently of the production constant.
+        let competing_fork_hash = format!("0x{}", "f".repeat(64));
+        assert_eq!(
+            marker["blockHash"],
+            json!(competing_fork_hash),
+            "ForkDrop must present a competing block hash at the fill's height",
+        );
+        assert_ne!(
+            marker["blockHash"],
+            json!(canonical_block_hash),
+            "the orphaned block hash must differ from the canonical hash the bot \
+             persisted at ingestion",
+        );
+
+        // Topics cleared so the marker fails event decoding and is never
+        // re-ingested as a brand-new fill that would inflate the fill count.
+        assert_eq!(
+            marker["topics"],
+            json!([]),
+            "the orphan marker's topics must be cleared so it cannot re-ingest as a fill",
+        );
+    }
+
+    /// Builds a handler state with the given chaos config and logs cache. The
+    /// upstream is never reached by the decision/transform helpers under test.
+    fn proxy_state(
+        config: Option<ChaosConfig>,
+        logs_cache: HashMap<String, Vec<Value>>,
+    ) -> ProxyState {
+        ProxyState {
+            config: Arc::new(Mutex::new(config)),
+            logs_cache: Arc::new(Mutex::new(logs_cache)),
+            upstream: Url::parse("http://127.0.0.1:1").unwrap(),
+            client: Client::new(),
+        }
+    }
+
+    fn fork_config(behaviour: ChaosBehaviour) -> ChaosConfig {
+        ChaosConfig {
+            method: "eth_getLogs".to_owned(),
+            behaviour,
+            remaining: 10,
+            pending_stale_tips: 0,
+        }
+    }
+
+    /// Pins which behaviours arm the `eth_getBlockByNumber` rewrite: both fork
+    /// perturbations (re-mine and drop) present the cached fill's block under the
+    /// competing hash, so the consumer's canonical-ancestry re-verification must see
+    /// it; the stale/empty behaviours and an unarmed proxy leave block reads alone.
+    #[tokio::test]
+    async fn forked_block_hash_armed_covers_only_fork_behaviours() {
+        let no_logs = HashMap::new();
+
+        for behaviour in [ChaosBehaviour::ForkReplay, ChaosBehaviour::ForkDrop] {
+            let state = proxy_state(Some(fork_config(behaviour.clone())), no_logs.clone());
+            assert!(
+                forked_block_hash_armed(&state).await,
+                "a fork perturbation must arm the block-by-number rewrite: {behaviour:?}",
+            );
+        }
+
+        let replay = proxy_state(
+            Some(fork_config(ChaosBehaviour::ReplayLogs)),
+            no_logs.clone(),
+        );
+        assert!(
+            !forked_block_hash_armed(&replay).await,
+            "same-chain replay must NOT touch block reads",
+        );
+
+        let empty = proxy_state(
+            Some(fork_config(ChaosBehaviour::EmptyResult)),
+            no_logs.clone(),
+        );
+        assert!(
+            !forked_block_hash_armed(&empty).await,
+            "empty-result chaos must NOT touch block reads",
+        );
+
+        let unarmed = proxy_state(None, no_logs);
+        assert!(
+            !forked_block_hash_armed(&unarmed).await,
+            "an unarmed proxy must NOT touch block reads",
+        );
+    }
+
+    /// Pins the [`Perturbation::ForkBlockHash`] decision: under a fork arm, an
+    /// `eth_getBlockByNumber` for the CACHED fill's height is perturbed, but a read
+    /// of any other height -- and crucially the `safe`/`finalized` cutoff TAG the
+    /// fill monitor uses -- passes through untouched. The cached fill sits at block
+    /// `0x2a`.
+    #[tokio::test]
+    async fn fork_block_perturbation_targets_only_the_cached_fill_height() {
+        let signature =
+            "0x1111111111111111111111111111111111111111111111111111111111111111".to_owned();
+        let cached_fill_height = "0x2a";
+        let cached_log = json!({
+            "transactionHash": "0x00000000000000000000000000000000000000000000000000000000000000bb",
+            "logIndex": "0x0",
+            "blockNumber": cached_fill_height,
+            "blockHash": "0x00000000000000000000000000000000000000000000000000000000000000aa",
+            "topics": [signature],
+        });
+        let state = proxy_state(
+            Some(fork_config(ChaosBehaviour::ForkDrop)),
+            HashMap::from([(signature, vec![cached_log])]),
+        );
+        let id = json!(1);
+
+        // A read of the dropped fill's own block height is perturbed.
+        let at_fill = json!({
+            "method": "eth_getBlockByNumber",
+            "params": [cached_fill_height, false],
+        });
+        assert!(
+            matches!(
+                perturb(&state, "eth_getBlockByNumber", &at_fill, &id).await,
+                Some(Perturbation::ForkBlockHash),
+            ),
+            "a block read at the cached fill's height must be perturbed",
+        );
+
+        // A read of an unrelated height is forwarded untouched.
+        let elsewhere = json!({
+            "method": "eth_getBlockByNumber",
+            "params": ["0x99", false],
+        });
+        let elsewhere_perturbation = perturb(&state, "eth_getBlockByNumber", &elsewhere, &id).await;
+        assert!(
+            elsewhere_perturbation.is_none(),
+            "a block read at an unrelated height must NOT be perturbed",
+        );
+
+        // The `safe` cutoff tag is never a specific fill height: the fill monitor's
+        // cutoff read must pass through so it is not corrupted by the drop.
+        let cutoff_tag = json!({
+            "method": "eth_getBlockByNumber",
+            "params": ["safe", false],
+        });
+        let cutoff_perturbation = perturb(&state, "eth_getBlockByNumber", &cutoff_tag, &id).await;
+        assert!(
+            cutoff_perturbation.is_none(),
+            "a block-tag cutoff read must NOT be perturbed",
+        );
+    }
+
+    /// Pins the [`Perturbation::ForkBlockHash`] transform: the returned block's
+    /// `hash` is overwritten with the competing fork hash while the rest of the
+    /// block is preserved, and a null result (block not found) is left untouched.
+    #[tokio::test]
+    async fn fork_block_hash_stamps_competing_hash_onto_block_result() {
+        let canonical_block_hash =
+            "0x00000000000000000000000000000000000000000000000000000000000000aa";
+        let block_number = "0x2a";
+        let upstream_block = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": { "number": block_number, "hash": canonical_block_hash },
+        });
+
+        let stamped = rewrite_block_hash(upstream_block, FORK_BLOCK_HASH);
+
+        // 32 bytes of 0xff, derived independently of the production constant so the
+        // assertion pins the value rather than comparing the code against itself.
+        let competing_fork_hash = format!("0x{}", "f".repeat(64));
+        assert_eq!(
+            stamped["result"]["hash"],
+            json!(competing_fork_hash),
+            "the canonical block's hash must be swapped for the competing fork hash",
+        );
+        assert_ne!(
+            stamped["result"]["hash"],
+            json!(canonical_block_hash),
+            "the stamped hash must differ from the canonical hash the bot persisted",
+        );
+        assert_eq!(
+            stamped["result"]["number"],
+            json!(block_number),
+            "the block's other fields must be preserved -- only the hash is swapped",
+        );
+
+        // A null result (the node has no block at this height) must pass through.
+        let absent = json!({ "jsonrpc": "2.0", "id": 1, "result": null });
+        let untouched = rewrite_block_hash(absent, FORK_BLOCK_HASH);
+        assert_eq!(
+            untouched["result"],
+            json!(null),
+            "a null block result must be left untouched -- there is nothing to swap",
         );
     }
 }

--- a/tests/e2e/hedging/assertions.rs
+++ b/tests/e2e/hedging/assertions.rs
@@ -129,6 +129,60 @@ pub(crate) async fn poll_for_hedged_position(
     }
 }
 
+/// Polls until the Position projection for `symbol` reports `net ==
+/// expected`, crash-checking the bot.
+///
+/// `Projection::load` reads the `position_view` materialized view, which
+/// is updated asynchronously: the projection is registered as a reactor
+/// dispatched AFTER the command's event commit and writes the view in a
+/// separate transaction. A test that gates on a `PositionEvent` via
+/// `poll_for_events` (which counts the `events` table) therefore observes
+/// the event before the view reflects it, so reading `net` immediately can
+/// return the pre-reversal value. Wait on this before asserting `net`.
+pub(crate) async fn poll_for_position_net(
+    bot: &mut JoinHandle<anyhow::Result<()>>,
+    db_path: &std::path::Path,
+    symbol: &str,
+    expected: FractionalShares,
+) {
+    let url = format!("sqlite:{}", db_path.display());
+    let timeout = Duration::from_secs(DEFAULT_POLL_TIMEOUT_SECS);
+    let deadline = tokio::time::Instant::now() + timeout;
+    let context = format!("Position({symbol}) net == {expected}");
+    let target_symbol = Symbol::new(symbol.to_owned()).unwrap();
+
+    loop {
+        sleep_or_crash(bot, &context).await;
+
+        let Ok(pool) = SqlitePool::connect(&url).await else {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timed out after {timeout:?} waiting for {context} (database not ready)",
+            );
+            continue;
+        };
+
+        let net = {
+            let projection = Projection::<Position>::sqlite(pool.clone());
+            match projection.load(&target_symbol).await {
+                Ok(maybe_position) => maybe_position.map(|position| position.net),
+                Err(load_error) => panic!("failed to load Position projection: {load_error}"),
+            }
+        };
+
+        pool.close().await;
+
+        if net == Some(expected) {
+            return;
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out after {timeout:?} waiting for {context} (current net: {net:?})",
+        );
+    }
+}
+
 /// Comprehensive end-to-end assertions covering broker state, onchain
 /// vaults, and CQRS events/views for one or more symbols.
 ///

--- a/tests/e2e/reorg.rs
+++ b/tests/e2e/reorg.rs
@@ -19,6 +19,12 @@
 //! returns to exactly what it was before the reorg. Every step is append-only
 //! -- the original `Filled` events survive and the reversal and re-application
 //! are recorded as new events, never by deleting a row.
+//!
+//! [`reorg_reverts_dropped_fill`] is the companion case: a fill that the reorg
+//! DROPS rather than re-mines. It never re-appears, so the correct recovery is
+//! reverse-ONLY (no re-application), restoring the position to its pre-fill net.
+//! That test pins a KNOWN GAP and is expected to fail against the current
+//! detector (which only flags re-observed fills); see its own doc comment.
 
 use alloy::providers::Provider;
 use std::time::Duration;
@@ -27,7 +33,8 @@ use st0x_float_macro::float;
 
 use crate::chaos::ChaosProxy;
 use crate::hedging::assertions::{
-    Position, Projection, Symbol, TakeDirection, TestInfra, build_ctx, spawn_bot,
+    FractionalShares, Position, Projection, Symbol, TakeDirection, TestInfra, build_ctx,
+    poll_for_position_net, spawn_bot,
 };
 use crate::poll::{connect_db, count_events_of_type, poll_for_events};
 
@@ -157,6 +164,160 @@ async fn reorg_reverts_witnessed_fill() -> anyhow::Result<()> {
         post_reorg_net, pre_reorg_net,
         "reverse-then-reapply must restore the position to its pre-reorg net \
          (pre={pre_reorg_net}, post={post_reorg_net})",
+    );
+
+    pool.close().await;
+    bot.abort();
+    Ok(())
+}
+
+/// Pins the DROPPED-fill reorg gap: a fill the bot has witnessed and hedged is
+/// orphaned by a reorg and -- unlike the re-mined case in
+/// [`reorg_reverts_witnessed_fill`] -- never re-appears on the canonical chain.
+///
+/// The correct end state is a reverse-ONLY recovery: the fill's position impact
+/// is backed out (`OnChainTradeEvent::Reorged` + `PositionEvent::Reorged`, each
+/// exactly once), the original `Filled` events are preserved (append-only), and
+/// there is NO re-application -- `OnChainTradeEvent::ReWitnessed` stays at zero
+/// and the position's `OnChainOrderFilled` stays at the original one. The net
+/// returns to the PRE-FILL value rather than the post-fill value: the dropped
+/// fill is gone for good and is never replayed.
+///
+/// The drop is injected through the [`ChaosProxy::fork_drop_get_logs`]
+/// perturbation: a forked RPC node serves the fill's block height under a
+/// competing block hash but no longer carries the witnessed fill's own
+/// `(tx_hash, log_index)` -- the fill is orphaned and never re-observed.
+///
+/// This test is EXPECTED TO FAIL against the current production detector. The
+/// authoritative reorg detector, `detect_block_hash_reorgs`, only flags a fill
+/// whose SAME `(tx_hash, log_index)` is re-observed on a different `block_hash`
+/// (the re-mined case). A fill that is dropped and never re-appears is never
+/// re-observed, so it is never compared and never flagged; the `removed: true`
+/// path that would otherwise catch it is inert because `eth_getLogs` range
+/// queries never return removed logs, and the forward scan never regresses
+/// below the checkpoint. The bot therefore emits no `Reorged` events and the
+/// `poll_for_events` waits below time out -- the dropped fill leaves a naked
+/// hedge in production. It should go green once absence / ancestry
+/// re-verification of unfinalized witnessed fills is added to the design.
+#[test_log::test(tokio::test)]
+async fn reorg_reverts_dropped_fill() -> anyhow::Result<()> {
+    let symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let amount = float!(10.0);
+
+    let infra = TestInfra::start(vec![(symbol, broker_fill_price)], vec![]).await?;
+    let chaos = ChaosProxy::start(infra.base_chain.endpoint().parse()?).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .rpc_url_override(chaos.endpoint.clone())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Capture the PRE-FILL net. Before the first fill the symbol has no position
+    // at all -- the aggregate is created by the witness, so `Position::load`
+    // returns `None` and the net is zero by definition. Bind it directly rather
+    // than reading the database: the bot may still be running migrations this
+    // early (the poll helpers below tolerate a not-yet-ready DB for the same
+    // reason). A reverse-only reorg (drop, no re-application) must restore
+    // exactly this pre-fill net: the dropped fill is backed out and never
+    // replayed.
+    let pre_fill_net = FractionalShares::ZERO;
+
+    // Ingest a fill and let the bot witness and hedge it. Witnessing serves the
+    // fill's log through the proxy, which caches it for the drop perturbation
+    // below to re-serve as an orphan-block marker under a competing block hash.
+    infra
+        .base_chain
+        .take_order()
+        .symbol(symbol)
+        .amount(amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_events(&mut bot, &infra.db_path, "OnChainTradeEvent::Filled", 1).await;
+    poll_for_events(&mut bot, &infra.db_path, "OffchainOrderEvent::Filled", 1).await;
+
+    // Simulate the DROP: a forked RPC node serves the fill's block height under a
+    // competing block hash but no longer carries the witnessed fill -- the fill
+    // is orphaned and never re-appears. The count covers both event-signature
+    // polls across several rounds.
+    chaos.fork_drop_get_logs(10).await;
+
+    // The bot must detect the orphaned fill and reverse it exactly once across
+    // both aggregates. This is where the test fails against current production:
+    // the dropped fill is never re-observed, so `detect_block_hash_reorgs` never
+    // flags it and these waits time out.
+    poll_for_events(&mut bot, &infra.db_path, "OnChainTradeEvent::Reorged", 1).await;
+    poll_for_events(&mut bot, &infra.db_path, "PositionEvent::Reorged", 1).await;
+
+    // `poll_for_events` gates on the `events` table, but the final net assertion
+    // reads `net` via `Projection::load`, which reads the `position_view`
+    // materialized view. The view is updated by a reactor dispatched after the
+    // event commit, in a separate transaction, so the `PositionEvent::Reorged`
+    // row can be visible in `events` before the view reflects the reversal --
+    // reading `net` here without waiting would observe the still-applied fill
+    // net, not the reverse-only result. Wait until the reversal lands in the
+    // view's net before asserting. (The witnessed case gates on a later position
+    // event, which gives the view time to catch up; the dropped case has no such
+    // later event, so it must wait explicitly.)
+    poll_for_position_net(&mut bot, &infra.db_path, symbol, pre_fill_net).await;
+
+    let pool = connect_db(&infra.db_path).await?;
+
+    // The reversal is append-only and asserted against the event stream: the
+    // original witness survives, the reversal is a new event, nothing is deleted.
+    assert_eq!(
+        count_events_of_type(&pool, "OnChainTradeEvent::Filled").await?,
+        1,
+        "the original witness must be preserved, not deleted",
+    );
+    assert_eq!(
+        count_events_of_type(&pool, "OnChainTradeEvent::Reorged").await?,
+        1,
+        "the dropped fill must be marked reorged exactly once, not removed",
+    );
+    assert_eq!(
+        count_events_of_type(&pool, "PositionEvent::Reorged").await?,
+        1,
+        "the reversal must back out the fill's position impact exactly once",
+    );
+
+    // A dropped fill is gone for good: unlike the re-mined case there is no
+    // re-witness and no second position fill -- the original is the only one.
+    assert_eq!(
+        count_events_of_type(&pool, "OnChainTradeEvent::ReWitnessed").await?,
+        0,
+        "a dropped fill must never be re-witnessed -- it does not re-appear",
+    );
+    assert_eq!(
+        count_events_of_type(&pool, "PositionEvent::OnChainOrderFilled").await?,
+        1,
+        "the dropped fill must be applied exactly once and never re-applied",
+    );
+
+    // The core invariant: reverse-only restores the position to its PRE-FILL net.
+    // The fill is backed out and never re-applied, so the position returns to
+    // exactly where it was before the fill -- not to the post-fill value.
+    let post_reorg_net = Projection::<Position>::sqlite(pool.clone())
+        .load(&Symbol::new(symbol)?)
+        .await?
+        .expect("Position should still exist after the reversal")
+        .net;
+    assert_eq!(
+        post_reorg_net, pre_fill_net,
+        "reverse-only must restore the position to its pre-fill net \
+         (pre={pre_fill_net}, post={post_reorg_net})",
     );
 
     pool.close().await;


### PR DESCRIPTION
## What

- Detects and reverses witnessed fills a reorg **drops** (orphaned, never re-mined), the gap the existing re-observation-based `detect_block_hash_reorgs` structurally cannot catch.
- Adds `detect_dropped_fill_reorgs`: an active per-tick re-verification that drives from the witnessed-fills side and re-reads each unfinalized fill's canonical block by number.
- Adds the `ForkDrop` chaos perturbation and the `reorg_reverts_dropped_fill` e2e covering the dropped (not re-mined) reorg case end to end.
- Advances the Reorg protection epic ([RAI-294](https://linear.app/makeitrain/issue/RAI-294)); stacked on the chaos-proxy e2e harness from #934 ([RAI-807](https://linear.app/makeitrain/issue/RAI-807)).

## Why

- `detect_block_hash_reorgs` only fires when a witnessed `(tx_hash, log_index)` is re-observed on a different `block_hash` (the re-mined case). A fill the chain drops and never re-mines is never re-observed, so it is never compared, leaving a naked hedge with no onchain fill behind it.
- The legacy `removed: true` getLogs signal is inert (range queries never return removed logs) and the forward scan never regresses below the checkpoint, so neither existing path closes the dropped-fill gap.

## How

- Candidate unfinalized fills come straight from the event log (SQL-filtered to fills whose latest block is above the finality floor); each aggregate is loaded for the authoritative block/hash/reorg state.
- Each candidate's canonical block is re-read by number via `get_block_by_number`; a hash mismatch with the fill's `(tx_hash, log_index)` absent from the current scan means the fill was dropped, flagged reverse-only (`reinclusion: None`) through the same exactly-once `record_reorg` path.
- Bounded to `(tip - REORG_REVERIFICATION_WINDOW, tip - required_confirmations]`, so the pass is O(unfinalized fills), defers near-tip fills, and respects confirmations.
- Independent of the forward scan/checkpoint (reads by number), runs every tick even when the scan is empty, and partitions re-mined-same-key fills back to `detect_block_hash_reorgs` so a fill is flagged by at most one detector.
- An absent canonical block (lagging/cold node) or a missing persisted hash defers rather than reverses, so an already-hedged fill is never backed out on unproven evidence.
- Chaos harness: `ForkDrop` re-serves each cached fill at its height under a competing hash with the fill's identity replaced (`ORPHAN_DROP_TX_HASH`) and topics cleared; a paired `ForkBlockHash` rewrite stamps the same competing hash on the by-number read so re-verification agrees with the getLogs re-serve.

## Testing

- Unit coverage for `detect_dropped_fill_reorgs`: orphaned-block reverse-only flag, still-canonical no-op, re-mined-same-key deferred to the block-hash detector, already-acknowledged idempotent no-op, absent-canonical-block deferred (not reversed), and finalized-fill outside the window.
- Chaos-proxy unit coverage pinning the `ForkDrop` transform and the `ForkBlockHash` decision/transform (only the cached fill's height is perturbed; `safe`/`finalized` tags and unrelated heights pass through).
- `reorg_reverts_dropped_fill` e2e: drops a witnessed and hedged fill via `fork_drop_get_logs`, then asserts exactly one `OnChainTradeEvent::Reorged` + `PositionEvent::Reorged`, zero `ReWitnessed`, the original `Filled` preserved (append-only), and the position net restored to its pre-fill value.
- Adds `poll_for_position_net` so the e2e waits on the asynchronously-updated `position_view` before asserting net.

## Screenshots

N/A.

## Anything else

- Reverse-only by construction: a dropped fill has nothing to re-apply, and reuse of `record_reorg` keeps the reversal exactly-once across ticks and both aggregates.
- `REORG_REVERIFICATION_WINDOW` (1024) is a deliberate estimate sized to cover the `safe`-cutoff reorg window with margin, pending measured fleet data (like `SAFE_CUTOFF_QUIET_SKEW`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785364130&installation_id=125569124&pr_number=954&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F954&signature=59d21f2a9f0290e9b5e65e72c4515e74d5ebaf2699f34a6bd0f99615406c54d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
