### PR TITLE
fix: stop truncating to_cents/to_whole_shares above 1e9

### DIFF
--- a/crates/finance/src/lib.rs
+++ b/crates/finance/src/lib.rs
@@ -171,7 +171,10 @@ impl Positive<FractionalShares> {
             return Err(ToWholeSharesError::Fractional(inner));
         }
 
-        let formatted = inner.inner().format().map_err(ToWholeSharesError::Float)?;
+        let formatted = inner
+            .inner()
+            .format_with_scientific(false)
+            .map_err(ToWholeSharesError::Float)?;
 
         let integer_str = formatted.split('.').next().unwrap_or(&formatted);
         integer_str
@@ -259,6 +262,16 @@ mod tests {
         let positive = Positive::new(FractionalShares::new(float!(1.5))).unwrap();
         let error = positive.to_whole_shares().unwrap_err();
         assert!(matches!(error, ToWholeSharesError::Fractional(_)));
+    }
+
+    #[test]
+    fn to_whole_shares_handles_values_above_one_billion() {
+        // Float::format() switches to scientific notation ("1e10") for
+        // magnitudes above 1e9, so extracting the integer part before the
+        // '.' produced the wrong value. A non-scientific formatter must be
+        // used instead.
+        let positive = Positive::new(FractionalShares::new(float!(10000000000))).unwrap();
+        assert_eq!(positive.to_whole_shares().unwrap(), 10_000_000_000);
     }
 
     #[test]

--- a/crates/finance/src/usd.rs
+++ b/crates/finance/src/usd.rs
@@ -67,7 +67,7 @@ impl Usd {
             return Err(UsdToCentsError::SubCentPrecision(self));
         }
 
-        let formatted = scaled.format()?;
+        let formatted = scaled.format_with_scientific(false)?;
         let integer_str = formatted.split('.').next().unwrap_or(&formatted);
         integer_str
             .parse::<i64>()
@@ -258,6 +258,25 @@ mod tests {
     #[test]
     fn to_cents_converts_zero() {
         assert_eq!(Usd::ZERO.to_cents().unwrap(), 0);
+    }
+
+    #[test]
+    fn to_cents_handles_values_above_one_billion_cents() {
+        // $10,000,001 -> 1,000,000,100 cents. Float::format() switches to
+        // scientific notation ("1.0000001e9") for magnitudes above 1e9, so
+        // extracting the integer part before the '.' truncated the result
+        // to 1 cent. A non-scientific formatter must be used instead.
+        let usd = Usd::new(float!(10000001));
+        assert_eq!(usd.to_cents().unwrap(), 1_000_000_100);
+    }
+
+    #[test]
+    fn to_cents_handles_negative_values_below_negative_one_billion_cents() {
+        // to_cents returns a signed i64, and the scientific-notation truncation
+        // hit negative magnitudes just as badly (-1.0000001e9 -> -1). Lock in
+        // the negative side of the fix too.
+        let usd = Usd::new(float!(-10000001));
+        assert_eq!(usd.to_cents().unwrap(), -1_000_000_100);
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`Usd::to_cents` and `Positive<FractionalShares>::to_whole_shares` derive an
integer by formatting the inner `Float` with `Float::format()` and parsing the
text before the decimal point. `Float::format()` switches to scientific notation
for magnitudes above ~1e9, so the segment before the `.` is wrong for large
values:

- `$10,000,001` should give `1,000,000,100` cents, but `format()` yields
  `"1.0000001e9"` whose integer part is `"1"` -> **1 cent** returned.
- A whole-share count of `1e10` formats as `"1e10"` -> parsed as the wrong value.

Both conversions feed financial outputs — cent-denominated accounting
(`to_cents`) and whole-share broker order quantities (`to_whole_shares`) — so
this silently corrupts financial data with no error surfaced, violating the
repo's financial-integrity rule (no silent precision loss / truncation).

## Solution

Format with `Float::format_with_scientific(false)` (the plain-decimal formatter
`st0x-float-serde` already uses for wire serialization) instead of
`Float::format()`. Both call sites already guarantee a whole-number value before
formatting, so a plain-decimal string parses cleanly; values genuinely out of
`i64`/`u64` range still surface `Overflow`.

Adds regression tests for both conversions at magnitudes above 1e9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved large-value conversions so whole shares and cents are calculated correctly even for very large amounts.
  * Prevented formatting-related errors that could occur when numbers switch to scientific notation.
  * Added coverage for values above one billion to confirm accurate conversion results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->