### PR TITLE
fix: correct AfterClearV2 pairing and reject zero-price equity fills

### DIFF
--- a/.sqlx/query-3f243c25f1105c535dcdafd1c595af9e4e519a6a6b652f9fca0f97c2a24842e4.json
+++ b/.sqlx/query-3f243c25f1105c535dcdafd1c595af9e4e519a6a6b652f9fca0f97c2a24842e4.json
@@ -1,0 +1,74 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT tx_hash, log_index, event_type, reason, detail FROM skipped_fills ORDER BY log_index",
+  "describe": {
+    "columns": [
+      {
+        "name": "tx_hash",
+        "ordinal": 0,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "skipped_fills",
+            "name": "tx_hash"
+          }
+        }
+      },
+      {
+        "name": "log_index",
+        "ordinal": 1,
+        "type_info": "Integer",
+        "origin": {
+          "Table": {
+            "table": "skipped_fills",
+            "name": "log_index"
+          }
+        }
+      },
+      {
+        "name": "event_type",
+        "ordinal": 2,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "skipped_fills",
+            "name": "event_type"
+          }
+        }
+      },
+      {
+        "name": "reason",
+        "ordinal": 3,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "skipped_fills",
+            "name": "reason"
+          }
+        }
+      },
+      {
+        "name": "detail",
+        "ordinal": 4,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "skipped_fills",
+            "name": "detail"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3f243c25f1105c535dcdafd1c595af9e4e519a6a6b652f9fca0f97c2a24842e4"
+}

--- a/.sqlx/query-85a861786d2eae4ed7862ee51ddb0f60fdaed523e60a29ac7cab6889b8cbae56.json
+++ b/.sqlx/query-85a861786d2eae4ed7862ee51ddb0f60fdaed523e60a29ac7cab6889b8cbae56.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO skipped_fills (tx_hash, log_index, event_type, reason, detail, skipped_at) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT (tx_hash, log_index) DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 6
+    },
+    "nullable": []
+  },
+  "hash": "85a861786d2eae4ed7862ee51ddb0f60fdaed523e60a29ac7cab6889b8cbae56"
+}

--- a/migrations/20260701021546_skipped_fills.sql
+++ b/migrations/20260701021546_skipped_fills.sql
@@ -1,0 +1,23 @@
+-- Durable operational record of on-chain fills the accountant intentionally
+-- skipped instead of hedging: unpriceable fills (non-zero equity at a
+-- non-positive USDC/share price) and non-hedgeable token pairs. The accountant
+-- swallows these to keep one anomalous fill from tripping the conductor-wide
+-- fail-stop, so without this table the only trace is an `error!` log line that
+-- rotation could erase, leaving the fill silently unhedged. Operators query
+-- this table to reconcile skipped fills by hand.
+--
+-- (tx_hash, log_index) is the fill identity and therefore the PRIMARY KEY: a
+-- backfill re-scan re-processes the same fill, and the writer's
+-- `ON CONFLICT DO NOTHING` keeps it a single row rather than duplicating it on
+-- every pass. `reason` is a closed set the writer maps from the skip cause;
+-- `detail` carries the human-readable specifics (the computed price, or the
+-- input/output symbols) for reconciliation.
+CREATE TABLE skipped_fills (
+    tx_hash TEXT NOT NULL,
+    log_index INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    detail TEXT NOT NULL,
+    skipped_at TEXT NOT NULL,
+    PRIMARY KEY (tx_hash, log_index)
+);

--- a/src/onchain/clear.rs
+++ b/src/onchain/clear.rs
@@ -143,10 +143,26 @@ async fn fetch_after_clear_event(
 
     let after_clear_logs = evm.provider().get_logs(&filter).await?;
 
-    if let Some(after_clear_log) = after_clear_logs.iter().find(|after_clear_log| {
-        after_clear_log.transaction_hash == log.transaction_hash
-            && after_clear_log.log_index > log.log_index
-    }) {
+    // Pair this ClearV3 with its IMMEDIATELY following AfterClearV2: the smallest
+    // log_index strictly greater than the clear's. A single transaction can carry
+    // multiple ClearV3/AfterClearV2 pairs, and get_logs ordering is not guaranteed,
+    // so taking the first match by iteration order could adopt a later pair's
+    // AfterClearV2 and account this fill with the wrong state change.
+    //
+    // "Immediately following" pairs correctly because the orderbook's clear call
+    // emits the ClearV3 and then its AfterClearV2 consecutively (Solidity emits
+    // events in statement order within a call), and a multicall runs each clear to
+    // completion before the next begins. Pairs therefore never interleave -- a
+    // ClearV3 at index i is always followed by ITS AfterClearV2 before any other
+    // pair's events -- so the nearest higher-index AfterClearV2 is this clear's.
+    if let Some(after_clear_log) = after_clear_logs
+        .iter()
+        .filter(|after_clear_log| {
+            after_clear_log.transaction_hash == log.transaction_hash
+                && after_clear_log.log_index > log.log_index
+        })
+        .min_by_key(|after_clear_log| after_clear_log.log_index)
+    {
         return Ok(after_clear_log.log_decode::<AfterClearV2>()?.data().clone());
     }
 
@@ -163,32 +179,33 @@ async fn fetch_after_clear_event(
         .into());
     };
 
-    // Find the AfterClearV2 log in the receipt with log_index > clear_log_index
-    for receipt_log in tx_receipt.inner.logs() {
-        if receipt_log.address() != evm_ctx.orderbook {
-            continue;
-        }
+    // Pair with the IMMEDIATELY following AfterClearV2 in the receipt -- the
+    // smallest log_index strictly greater than the clear's -- exactly as the
+    // get_logs path above. Canonical receipts return logs in ascending log_index
+    // order, but this fallback exists precisely for nodes that do not behave
+    // canonically, so a multi-pair transaction must not rely on receipt log
+    // ordering to pair each clear with ITS state change.
+    let immediate_after_clear = tx_receipt
+        .inner
+        .logs()
+        .iter()
+        .filter(|receipt_log| {
+            receipt_log.address() == evm_ctx.orderbook
+                && receipt_log.topics().first() == Some(&AfterClearV2::SIGNATURE_HASH)
+                && receipt_log
+                    .log_index
+                    .is_some_and(|receipt_log_index| receipt_log_index > clear_log_index)
+        })
+        .min_by_key(|receipt_log| receipt_log.log_index);
 
-        if receipt_log.topics().first() != Some(&AfterClearV2::SIGNATURE_HASH) {
-            continue;
-        }
-
-        let Some(receipt_log_index) = receipt_log.log_index else {
-            continue;
-        };
-
-        if receipt_log_index <= clear_log_index {
-            continue;
-        }
-
-        // Found it - decode and return
+    if let Some(receipt_log) = immediate_after_clear {
         let decoded = receipt_log.log_decode::<AfterClearV2>()?;
         debug!(
             target: "hedge",
             block_number,
             %tx_hash,
             clear_log_index,
-            receipt_log_index,
+            receipt_log_index = ?receipt_log.log_index,
             "Extracted AfterClearV2 from tx receipt (get_logs returned incomplete data)"
         );
         return Ok(decoded.data().clone());
@@ -476,6 +493,170 @@ mod tests {
         // Bob's order takes wtAAPL in / USDC out -> bought tokenized equity
         // onchain, the opposite of alice; the hedge direction must flip.
         assert_eq!(trade.direction, Direction::Buy);
+    }
+
+    fn after_clear_with(alice_input_usdc: u64, alice_output_equity: u64) -> AfterClearV2 {
+        AfterClearV2 {
+            sender: address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            clearStateChange: ClearStateChangeV2 {
+                aliceOutput: Float::from_fixed_decimal(U256::from(alice_output_equity), 0)
+                    .unwrap()
+                    .get_inner(),
+                bobOutput: Float::from_fixed_decimal(uint!(100_U256), 0)
+                    .unwrap()
+                    .get_inner(),
+                aliceInput: Float::from_fixed_decimal(U256::from(alice_input_usdc), 0)
+                    .unwrap()
+                    .get_inner(),
+                bobInput: Float::from_fixed_decimal(uint!(9_U256), 0)
+                    .unwrap()
+                    .get_inner(),
+            },
+        }
+    }
+
+    fn after_clear_log_at(
+        orderbook: Address,
+        tx_hash: TxHash,
+        log_index: u64,
+        event: AfterClearV2,
+    ) -> Log {
+        Log {
+            inner: alloy::primitives::Log {
+                address: orderbook,
+                data: event.into_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(1),
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(log_index),
+            removed: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn try_from_clear_v3_pairs_immediate_after_clear_not_first_in_iteration() {
+        let ctx = create_test_ctx();
+        let cache = SymbolCache::default();
+        crate::test_utils::seed_get_test_order_token_symbols(&cache);
+
+        let order = get_test_order();
+        let different_order = {
+            let mut order = get_test_order();
+            order.nonce =
+                fixed_bytes!("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+            order
+        };
+
+        let clear_event = create_clear_event(order.clone(), different_order);
+        let orderbook = address!("0x1111111111111111111111111111111111111111");
+        let tx_hash =
+            fixed_bytes!("0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+        let clear_log = Log {
+            inner: alloy::primitives::Log {
+                address: orderbook,
+                data: clear_event.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(1),
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(1),
+            removed: false,
+        };
+
+        // The AfterClearV2 immediately after the clear (index 2) credits alice 9
+        // shares; a later pair's AfterClearV2 (index 4) credits 50. get_logs is
+        // returned newest-first to prove pairing does not rely on iteration order.
+        let immediate_log = after_clear_log_at(orderbook, tx_hash, 2, after_clear_with(100, 9));
+        let later_log = after_clear_log_at(orderbook, tx_hash, 4, after_clear_with(100, 50));
+
+        let asserter = Asserter::new();
+        asserter.push_success(&json!([later_log, immediate_log]));
+        asserter.push_success(&mocked_receipt_hex(tx_hash));
+        let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
+        let pyth_feed_ids = PythFeedIds::default();
+
+        let trade = OnchainTrade::try_from_clear_v3(
+            &ctx,
+            &cache,
+            &evm,
+            clear_event,
+            clear_log,
+            &pyth_feed_ids,
+            get_test_order().owner,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        // Must use the immediate AfterClearV2 (9 shares), not the later pair's 50.
+        assert_eq!(trade.amount, FractionalShares::new(float!(9)));
+    }
+
+    #[tokio::test]
+    async fn try_from_clear_v3_errors_on_non_positive_price() {
+        let ctx = create_test_ctx();
+        let cache = SymbolCache::default();
+        crate::test_utils::seed_get_test_order_token_symbols(&cache);
+
+        let order = get_test_order();
+        let different_order = {
+            let mut order = get_test_order();
+            order.nonce =
+                fixed_bytes!("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+            order
+        };
+
+        let clear_event = create_clear_event(order.clone(), different_order);
+        let orderbook = address!("0x1111111111111111111111111111111111111111");
+        let tx_hash =
+            fixed_bytes!("0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+        let clear_log = Log {
+            inner: alloy::primitives::Log {
+                address: orderbook,
+                data: clear_event.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(1),
+            block_timestamp: Some(TEST_BLOCK_TIMESTAMP),
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(1),
+            removed: false,
+        };
+
+        // Alice receives 9 wtAAPL but pays 0 USDC -> price computes to zero. A real
+        // equity movement that cannot be priced must error, not be silently dropped.
+        let after_clear_log = after_clear_log_at(orderbook, tx_hash, 2, after_clear_with(0, 9));
+
+        let asserter = Asserter::new();
+        asserter.push_success(&json!([after_clear_log]));
+        asserter.push_success(&mocked_receipt_hex(tx_hash));
+        let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
+        let pyth_feed_ids = PythFeedIds::default();
+
+        let error = OnchainTrade::try_from_clear_v3(
+            &ctx,
+            &cache,
+            &evm,
+            clear_event,
+            clear_log,
+            &pyth_feed_ids,
+            get_test_order().owner,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            OnChainError::Validation(TradeValidationError::NonPositivePrice(_))
+        ));
     }
 
     #[tokio::test]
@@ -923,7 +1104,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fetch_after_clear_multiple_logs_picks_first_match() {
+    async fn test_fetch_after_clear_multiple_logs_picks_min_log_index() {
         let ctx = create_test_ctx();
         let cache = SymbolCache::default();
         crate::test_utils::seed_get_test_order_token_symbols(&cache);
@@ -943,16 +1124,20 @@ mod tests {
 
         let clear_log = create_test_log(orderbook, tx_hash, clear_event.to_log_data(), 5);
 
-        let after_clear_event_1 = create_parameterized_after_clear_event(0xaa, 9, 100);
-        let after_clear_event_2 = create_parameterized_after_clear_event(0xbb, 5, 50);
+        // The immediate AfterClearV2 (index 6) credits 9 shares; a later pair's
+        // (index 7) credits 5. get_logs returns them newest-first so first-match
+        // by iteration order would wrongly pick index 7 -- only min-by-log-index
+        // selects the immediate pair.
+        let immediate_after_clear = create_parameterized_after_clear_event(0xaa, 9, 100);
+        let later_after_clear = create_parameterized_after_clear_event(0xbb, 5, 50);
 
-        let after_clear_log_1 =
-            create_test_log(orderbook, tx_hash, after_clear_event_1.to_log_data(), 6);
-        let after_clear_log_2 =
-            create_test_log(orderbook, tx_hash, after_clear_event_2.to_log_data(), 7);
+        let immediate_after_clear_log =
+            create_test_log(orderbook, tx_hash, immediate_after_clear.to_log_data(), 6);
+        let later_after_clear_log =
+            create_test_log(orderbook, tx_hash, later_after_clear.to_log_data(), 7);
 
         let asserter = Asserter::new();
-        asserter.push_success(&json!([after_clear_log_1, after_clear_log_2])); // get_logs returns multiple AfterClearV2
+        asserter.push_success(&json!([later_after_clear_log, immediate_after_clear_log]));
         let receipt_json = create_receipt_json_with_logs(tx_hash, &[]);
         asserter.push_success(&receipt_json); // receipt for gas info
         let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
@@ -1247,6 +1432,81 @@ mod tests {
             trade.symbol,
             tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
         );
+        assert_eq!(trade.amount, FractionalShares::new(float!(9)));
+    }
+
+    #[tokio::test]
+    async fn test_fallback_receipt_picks_min_log_index_when_out_of_order() {
+        let ctx = create_test_ctx();
+        let cache = SymbolCache::default();
+        crate::test_utils::seed_get_test_order_token_symbols(&cache);
+
+        let order = get_test_order();
+        let different_order = {
+            let mut order = get_test_order();
+            order.nonce =
+                fixed_bytes!("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+            order
+        };
+
+        let clear_event = create_clear_event(order.clone(), different_order);
+        let orderbook = address!("0x1111111111111111111111111111111111111111");
+        let tx_hash =
+            fixed_bytes!("0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+        let clear_log = create_test_log(orderbook, tx_hash, clear_event.to_log_data(), 1);
+
+        // Two AfterClearV2 pairs in the receipt, both with log_index > the clear's:
+        // the immediate pair (index 2) credits 9 shares, a later pair (index 4)
+        // credits 5. The receipt lists them newest-first, so a first-match-by-
+        // iteration fallback would wrongly pick the later pair's 5 shares -- only
+        // min-by-log-index selects the immediate pair.
+        let immediate_after_clear =
+            create_parameterized_after_clear_event(0xaa, 9, 100).to_log_data();
+        let later_after_clear = create_parameterized_after_clear_event(0xbb, 5, 50).to_log_data();
+
+        let immediate_receipt_log = create_receipt_log_json(
+            orderbook,
+            tx_hash,
+            2,
+            immediate_after_clear.topics(),
+            immediate_after_clear.data.clone(),
+        );
+        let later_receipt_log = create_receipt_log_json(
+            orderbook,
+            tx_hash,
+            4,
+            later_after_clear.topics(),
+            later_after_clear.data.clone(),
+        );
+        let receipt =
+            create_receipt_json_with_logs(tx_hash, &[later_receipt_log, immediate_receipt_log]);
+
+        let asserter = Asserter::new();
+        asserter.push_success(&json!([])); // get_logs returns empty -> receipt fallback
+        asserter.push_success(&receipt); // receipt for fallback AfterClearV2 extraction
+        asserter.push_success(&receipt); // receipt for gas info in try_from_order_and_fill_details
+        let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
+        let pyth_feed_ids = PythFeedIds::default();
+
+        let result = OnchainTrade::try_from_clear_v3(
+            &ctx,
+            &cache,
+            &evm,
+            clear_event,
+            clear_log,
+            &pyth_feed_ids,
+            get_test_order().owner,
+        )
+        .await
+        .unwrap();
+
+        let trade = result.unwrap();
+        assert_eq!(
+            trade.symbol,
+            tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
+        );
+        // Must use the immediate AfterClearV2 (9 shares), not the later pair's 5.
         assert_eq!(trade.amount, FractionalShares::new(float!(9)));
     }
 

--- a/src/onchain/trade.rs
+++ b/src/onchain/trade.rs
@@ -266,6 +266,12 @@ impl OnchainTrade {
         )?;
 
         if trade_details.equity_amount().is_zero()? {
+            debug!(
+                target: "hedge",
+                %tx_hash,
+                log_index,
+                "Skipping fill with zero equity amount; not a tokenized-equity trade"
+            );
             return Ok(None);
         }
 
@@ -273,8 +279,11 @@ impl OnchainTrade {
         let price_per_share_usdc =
             (trade_details.usdc_amount().value() / trade_details.equity_amount().inner())?;
 
+        // Equity is non-zero (checked above), so a non-positive price is a real
+        // equity movement we cannot price. Reject it rather than silently dropping
+        // it, which would leave the resulting position unhedged.
         if price_per_share_usdc.lt(Float::zero()?)? || price_per_share_usdc.is_zero()? {
-            return Ok(None);
+            return Err(TradeValidationError::NonPositivePrice(price_per_share_usdc).into());
         }
 
         let (equity_symbol_str, equity_token) = if onchain_input_symbol == "USDC" {
@@ -498,6 +507,11 @@ pub(crate) enum TradeValidationError {
     NegativeShares(Float),
     #[error("Negative USDC amount: {}", format_float_with_fallback(.0))]
     NegativeUsdc(Float),
+    #[error(
+        "fill has non-zero equity but a non-positive USDC/share price: {}",
+        format_float_with_fallback(.0)
+    )]
+    NonPositivePrice(Float),
     #[error("Float error: {0}")]
     Float(#[from] FloatError),
     #[error(

--- a/src/trading/onchain.rs
+++ b/src/trading/onchain.rs
@@ -1,5 +1,7 @@
 //! On-chain trade processing: [`inclusion`] validates blockchain event
-//! metadata, [`trade_accountant`] accounts for DEX fills via CQRS commands.
+//! metadata, [`trade_accountant`] accounts for DEX fills via CQRS commands, and
+//! [`skipped_fill`] durably records fills the accountant chose to skip.
 
 pub(crate) mod inclusion;
+pub(crate) mod skipped_fill;
 pub(crate) mod trade_accountant;

--- a/src/trading/onchain/skipped_fill.rs
+++ b/src/trading/onchain/skipped_fill.rs
@@ -1,0 +1,202 @@
+//! Durable record of on-chain fills the accountant skipped instead of hedging.
+//!
+//! [`AccountForDexTrade`] swallows unpriceable fills and non-hedgeable pairs so a
+//! single anomalous (or crafted) fill cannot trip the conductor-wide fail-stop.
+//! Persisting them here means a skipped fill survives log rotation and can be
+//! reconciled by hand, rather than being visible only in an `error!` line.
+//!
+//! [`AccountForDexTrade`]: super::trade_accountant::AccountForDexTrade
+
+use alloy::primitives::TxHash;
+use chrono::Utc;
+use sqlx::SqlitePool;
+
+/// Why the accountant skipped a fill instead of hedging it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SkipReason {
+    /// Non-zero equity moved at a non-positive USDC/share price.
+    UnpriceableFill,
+    /// The fill's token pair is not one the bot hedges.
+    NonHedgeablePair,
+}
+
+impl SkipReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::UnpriceableFill => "unpriceable_fill",
+            Self::NonHedgeablePair => "non_hedgeable_pair",
+        }
+    }
+}
+
+/// Failure persisting a skipped fill.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SkippedFillError {
+    #[error("log_index {log_index} exceeds i64::MAX")]
+    LogIndexOutOfRange { log_index: u64 },
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+}
+
+/// Persist a fill the accountant skipped, for manual reconciliation. Idempotent
+/// on `(tx_hash, log_index)` -- the fill identity -- so a backfill re-scan that
+/// re-processes the same fill records a single row rather than duplicating it on
+/// every pass.
+pub(crate) async fn record_skipped_fill(
+    pool: &SqlitePool,
+    tx_hash: TxHash,
+    log_index: u64,
+    event_type: &str,
+    reason: SkipReason,
+    detail: &str,
+) -> Result<(), SkippedFillError> {
+    let tx_hash = tx_hash.to_string();
+    let log_index =
+        i64::try_from(log_index).map_err(|_| SkippedFillError::LogIndexOutOfRange { log_index })?;
+    let reason = reason.as_str();
+    let skipped_at = Utc::now().to_rfc3339();
+
+    sqlx::query!(
+        "INSERT INTO skipped_fills \
+         (tx_hash, log_index, event_type, reason, detail, skipped_at) \
+         VALUES (?, ?, ?, ?, ?, ?) \
+         ON CONFLICT (tx_hash, log_index) DO NOTHING",
+        tx_hash,
+        log_index,
+        event_type,
+        reason,
+        detail,
+        skipped_at,
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::b256;
+
+    use super::*;
+    use crate::test_utils::setup_test_pools;
+
+    struct SkippedRow {
+        tx_hash: String,
+        log_index: i64,
+        event_type: String,
+        reason: String,
+        detail: String,
+    }
+
+    async fn skipped_rows(pool: &SqlitePool) -> Vec<SkippedRow> {
+        sqlx::query!(
+            "SELECT tx_hash, log_index, event_type, reason, detail FROM skipped_fills \
+             ORDER BY log_index"
+        )
+        .fetch_all(pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| SkippedRow {
+            tx_hash: row.tx_hash,
+            log_index: row.log_index,
+            event_type: row.event_type,
+            reason: row.reason,
+            detail: row.detail,
+        })
+        .collect()
+    }
+
+    #[tokio::test]
+    async fn record_persists_the_skipped_fill() {
+        let (pool, _apalis) = setup_test_pools().await;
+        let tx_hash = b256!("0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+        record_skipped_fill(
+            &pool,
+            tx_hash,
+            7,
+            "ClearV3",
+            SkipReason::UnpriceableFill,
+            "price=0",
+        )
+        .await
+        .unwrap();
+
+        let rows = skipped_rows(&pool).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].tx_hash, tx_hash.to_string());
+        assert_eq!(rows[0].log_index, 7);
+        assert_eq!(rows[0].event_type, "ClearV3");
+        assert_eq!(rows[0].reason, "unpriceable_fill");
+        assert_eq!(rows[0].detail, "price=0");
+    }
+
+    #[tokio::test]
+    async fn record_is_idempotent_per_fill_identity() {
+        let (pool, _apalis) = setup_test_pools().await;
+        let tx_hash = b256!("0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+        record_skipped_fill(
+            &pool,
+            tx_hash,
+            7,
+            "ClearV3",
+            SkipReason::UnpriceableFill,
+            "first",
+        )
+        .await
+        .unwrap();
+        // Re-scan of the same (tx_hash, log_index) must not add a second row.
+        record_skipped_fill(
+            &pool,
+            tx_hash,
+            7,
+            "ClearV3",
+            SkipReason::NonHedgeablePair,
+            "second",
+        )
+        .await
+        .unwrap();
+
+        let rows = skipped_rows(&pool).await;
+        assert_eq!(rows.len(), 1);
+        // First write wins under ON CONFLICT DO NOTHING.
+        assert_eq!(rows[0].reason, "unpriceable_fill");
+        assert_eq!(rows[0].detail, "first");
+    }
+
+    #[tokio::test]
+    async fn distinct_fills_are_separate_rows() {
+        let (pool, _apalis) = setup_test_pools().await;
+        let tx_hash = b256!("0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+        record_skipped_fill(
+            &pool,
+            tx_hash,
+            7,
+            "ClearV3",
+            SkipReason::UnpriceableFill,
+            "a",
+        )
+        .await
+        .unwrap();
+        record_skipped_fill(
+            &pool,
+            tx_hash,
+            8,
+            "TakeOrderV3",
+            SkipReason::NonHedgeablePair,
+            "b",
+        )
+        .await
+        .unwrap();
+
+        let rows = skipped_rows(&pool).await;
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].log_index, 7);
+        assert_eq!(rows[1].log_index, 8);
+        assert_eq!(rows[1].reason, "non_hedgeable_pair");
+    }
+}

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -12,7 +12,7 @@ use alloy::rpc::types::Log;
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 use st0x_config::Ctx;
 use st0x_event_sorcery::{SendError, Store};
@@ -22,6 +22,7 @@ use st0x_execution::{ExecutionError, Executor};
 use st0x_registry::{SymbolCache, get_symbol_lock};
 
 use super::inclusion::EmittedOnChain;
+use super::skipped_fill::{SkipReason, record_skipped_fill};
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::conductor::{
     TradeProcessingCqrs, VaultDiscoveryCtx, discover_vaults_for_trade, process_queued_trade,
@@ -132,6 +133,37 @@ where
                     output,
                     "Skipping event with non-hedgeable token pair"
                 );
+                persist_skipped_fill(
+                    &ctx.pool,
+                    trade_event,
+                    SkipReason::NonHedgeablePair,
+                    &format!("input {input}, output {output}"),
+                )
+                .await;
+                return Ok(());
+            }
+            Err(OnChainError::Validation(error @ TradeValidationError::NonPositivePrice(_))) => {
+                // An unpriceable fill (non-zero equity moved at a non-positive
+                // USDC/share price) is anomalous and possibly adversarial. Surface
+                // it loudly and skip THIS fill only -- propagating the error would
+                // exhaust the worker retries and trip the conductor-wide fail-stop,
+                // letting one crafted on-chain fill take the whole bot down.
+                error!(
+                    target: "hedge",
+                    event_type = trade_event.event.kind(),
+                    tx_hash = ?trade_event.tx_hash,
+                    log_index = trade_event.log_index,
+                    %error,
+                    "Skipping unpriceable on-chain fill; it is left unhedged and must be \
+                     reconciled manually"
+                );
+                persist_skipped_fill(
+                    &ctx.pool,
+                    trade_event,
+                    SkipReason::UnpriceableFill,
+                    &error.to_string(),
+                )
+                .await;
                 return Ok(());
             }
             Err(err) => return Err(err.into()),
@@ -182,6 +214,36 @@ where
         .await?;
 
         Ok(())
+    }
+}
+
+/// Best-effort durable record of a skipped fill for manual reconciliation. A
+/// persistence failure is logged but never propagated: the whole point of the
+/// skip is to not fail the job, so a write hiccup must not resurrect the
+/// fail-stop it exists to avoid.
+async fn persist_skipped_fill(
+    pool: &SqlitePool,
+    trade_event: &EmittedOnChain<RaindexTradeEvent>,
+    reason: SkipReason,
+    detail: &str,
+) {
+    if let Err(persist_error) = record_skipped_fill(
+        pool,
+        trade_event.tx_hash,
+        trade_event.log_index,
+        trade_event.event.kind(),
+        reason,
+        detail,
+    )
+    .await
+    {
+        error!(
+            target: "hedge",
+            ?persist_error,
+            tx_hash = ?trade_event.tx_hash,
+            log_index = trade_event.log_index,
+            "Failed to persist skipped fill for reconciliation"
+        );
     }
 }
 
@@ -285,7 +347,8 @@ mod tests {
     use super::*;
     use crate::bindings::IRaindexV6;
     use crate::bindings::IRaindexV6::{
-        ClearConfigV2, SignedContextV1, TakeOrderConfigV4, TakeOrderV3 as TakeOrderV3Event,
+        AfterClearV2, ClearConfigV2, ClearStateChangeV2, SignedContextV1, TakeOrderConfigV4,
+        TakeOrderV3 as TakeOrderV3Event,
     };
     use crate::offchain::order::{OffchainOrder, noop_order_placer};
     use crate::onchain_trade::OnChainTrade;
@@ -516,5 +579,187 @@ mod tests {
 
         // Should succeed (skip) rather than error.
         job.perform(&accountant_ctx).await.unwrap();
+    }
+
+    /// A fill whose USDC/share price is non-positive (zero USDC against non-zero
+    /// equity) is anomalous and possibly adversarial. `perform` must surface it
+    /// and skip THIS fill only -- returning Ok(()) -- rather than propagating the
+    /// error, which would exhaust the worker retries and trip the conductor-wide
+    /// fail-stop, letting one crafted fill take the whole bot down.
+    #[tokio::test]
+    async fn perform_skips_unpriceable_fill() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let asserter = Asserter::new();
+
+        let order = get_test_order();
+        let order_owner = order.owner;
+        let orderbook = address!("0x1111111111111111111111111111111111111111");
+        let tx_hash = alloy::primitives::fixed_bytes!(
+            "0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        );
+
+        let clear_event = IRaindexV6::ClearV3 {
+            sender: orderbook,
+            alice: order.clone(),
+            bob: order,
+            clearConfig: ClearConfigV2 {
+                aliceInputIOIndex: U256::from(0),
+                aliceOutputIOIndex: U256::from(1),
+                bobInputIOIndex: U256::from(1),
+                bobOutputIOIndex: U256::from(0),
+                aliceBountyVaultId: B256::ZERO,
+                bobBountyVaultId: B256::ZERO,
+            },
+        };
+
+        let clear_log = Log {
+            inner: alloy::primitives::Log {
+                address: orderbook,
+                data: clear_event.clone().into_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(1),
+            block_timestamp: None,
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(1),
+            removed: false,
+        };
+
+        let event = RaindexTradeEvent::ClearV3(Box::new(clear_event));
+        let job = AccountForDexTrade {
+            trade: EmittedOnChain::from_log(event, &clear_log).unwrap(),
+        };
+
+        // AfterClearV2 crediting alice 9 shares (aliceOutput) for 0 USDC
+        // (aliceInput): a non-zero equity movement at a zero price -> the price
+        // per share computes to zero -> NonPositivePrice.
+        let after_clear = AfterClearV2 {
+            sender: address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            clearStateChange: ClearStateChangeV2 {
+                aliceOutput: Float::from_fixed_decimal(U256::from(9), 0)
+                    .unwrap()
+                    .get_inner(),
+                bobOutput: Float::from_fixed_decimal(U256::from(100), 0)
+                    .unwrap()
+                    .get_inner(),
+                aliceInput: Float::from_fixed_decimal(U256::from(0), 0)
+                    .unwrap()
+                    .get_inner(),
+                bobInput: Float::from_fixed_decimal(U256::from(9), 0)
+                    .unwrap()
+                    .get_inner(),
+            },
+        };
+
+        let after_clear_log = Log {
+            inner: alloy::primitives::Log {
+                address: orderbook,
+                data: after_clear.into_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(1),
+            block_timestamp: None,
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(2),
+            removed: false,
+        };
+
+        // get_logs returns the AfterClearV2, then a receipt for gas. Symbols come
+        // from the pre-seeded address cache below (not RPC mocks): resolving
+        // input/output concurrently via tokio::try_join! means two positional
+        // decimals()+symbol() mocks are not guaranteed to land on the token that
+        // actually queried them, which can silently swap which side is "equity"
+        // and mask the very zero-price case this test exists to catch.
+        asserter.push_success(&serde_json::json!([after_clear_log]));
+        asserter.push_success(&serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x1",
+            "blockHash": "0x1234567890123456789012345678901234567890123456789012345678901234",
+            "blockNumber": "0x1",
+            "from": "0x1234567890123456789012345678901234567890",
+            "to": "0x5678901234567890123456789012345678901234",
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x77359400",
+            "cumulativeGasUsed": "0x5208",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "logs": []
+        }));
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let ctx = create_test_ctx_with_order_owner(order_owner);
+        let cache = SymbolCache::default();
+        crate::test_utils::seed_get_test_order_token_symbols(&cache);
+
+        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (offchain_order, _offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(noop_order_placer())
+                .await
+                .unwrap();
+
+        let (vault_registry, _vault_registry_projection) =
+            StoreBuilder::<VaultRegistry>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+
+        let cqrs = TradeProcessingCqrs {
+            pool: pool.clone(),
+            onchain_trade,
+            position,
+            position_projection,
+            offchain_order,
+            order_placer: noop_order_placer(),
+            execution_threshold: ExecutionThreshold::whole_share(),
+            assets: ctx.assets.clone(),
+            counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
+            poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(&apalis_pool),
+            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&apalis_pool),
+        };
+
+        let job_queue = DexTradeAccountingJobQueue::new(&apalis_pool);
+
+        let accountant_ctx = AccountantCtx {
+            orderbook: ctx.evm.orderbook,
+            ctx,
+            cache,
+            pyth_feed_ids: PythFeedIds::default(),
+            evm: st0x_evm::ReadOnlyEvm::new(provider),
+            cqrs,
+            vault_registry,
+            executor,
+            pool: pool.clone(),
+            job_queue,
+        };
+
+        // Should surface and skip (Ok) rather than propagate the error.
+        job.perform(&accountant_ctx).await.unwrap();
+
+        // ...and durably record the skipped fill for manual reconciliation,
+        // not leave it visible only in a log line.
+        let recorded = sqlx::query!(
+            "SELECT tx_hash, log_index, event_type, reason, detail FROM skipped_fills \
+             ORDER BY log_index"
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].log_index, 1);
+        assert_eq!(recorded[0].reason, "unpriceable_fill");
     }
 }


### PR DESCRIPTION
## Motivation

Two correctness gaps in ClearV3 trade parsing:

1. **AfterClearV2 pairing.** `fetch_after_clear_event` paired a ClearV3 with its
   AfterClearV2 via `.find(log_index > clear_log_index)` — the first match in
   `eth_getLogs` iteration order. A transaction can carry multiple
   ClearV3/AfterClearV2 pairs, and `get_logs` ordering is not guaranteed, so this
   could pair a fill with a *different* pair's state change and account it with
   the wrong amounts/direction. The receipt fallback had the same first-match flaw.

2. **Unpriceable fills silently dropped.** `try_from_order_and_fill_details`
   returned `Ok(None)` when the computed price per share was `<= 0`. The
   zero-equity case is already handled earlier, so reaching this point means a
   *non-zero* equity movement that cannot be priced (e.g. zero USDC against
   non-zero shares). Dropping it silently leaves the resulting position unhedged,
   with no error or log. The zero-equity skip was also silent, violating the
   "log before an early return" rule.

## Solution

1. Pair each ClearV3 with its **immediate** AfterClearV2 — the smallest
   `log_index` strictly greater than the clear's — correct regardless of
   `get_logs` ordering or how many pairs the transaction holds. The receipt
   fallback applies the same immediate-pairing rule, because it exists for
   non-canonical providers and must not depend on receipt log ordering either.
2. Return a new `TradeValidationError::NonPositivePrice` for a non-zero-equity
   fill with a non-positive price (fail fast per financial-integrity rules), and
   log the legitimate zero-equity skip at `debug`. The trade accountant surfaces
   such a fill (logs at `error`, returns `Ok`) and skips it rather than
   propagating and tripping the conductor-wide fail-stop.
3. **Durably record every accountant skip.** Both swallowed skips (the
   unpriceable fill above and the pre-existing non-hedgeable-pair skip) now write
   to a new `skipped_fills` table, idempotent on `(tx_hash, log_index)` so a
   backfill re-scan does not duplicate the row. A skipped fill therefore survives
   log rotation and can be reconciled by hand, instead of being visible only in an
   `error!` line the way it was before. The write is best-effort: a persistence
   failure is logged, never propagated, so it cannot resurrect the fail-stop the
   skip exists to avoid.

Adds tests: the immediate AfterClearV2 wins over a later pair's on both the
`get_logs` and receipt-fallback paths (logs returned newest-first to prove
order-independence), a zero-USDC / non-zero-equity fill errors with
`NonPositivePrice`, the trade accountant returns `Ok` (skips) for such a fill
instead of tripping the fail-stop and **persists a `skipped_fills` row** for it,
plus direct coverage of the writer's idempotency and distinct-fill behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trade processing when multiple matching after-clear events appear in the same transaction by selecting the immediate next event using log index ordering.
  * Trades with a non-positive USDC/share price (zero or negative) are now rejected with a clear validation error instead of being silently ignored.
  * The trade accounting job now treats this specific non-positive price validation failure as recoverable, logging an error and skipping only the problematic fill for manual reconciliation.
* **New Features**
  * Added durable persistence for intentionally skipped fills, including reason, details, and stable idempotency on transaction hash + log index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
