### PR TITLE
refactor: move tokenization request-id types to the integration module

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -30,7 +30,8 @@ use crate::performance::reliability::{
 use crate::performance::{ReportRange, hedge_latency_report, load_hedge_performance};
 use crate::rebalancing::RebalancingService;
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, RecheckError, RecheckOutcome};
-use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMintEvent};
+use crate::tokenization::IssuerRequestId;
+use crate::tokenized_equity_mint::TokenizedEquityMintEvent;
 
 /// Comma-separated filter for transfer kinds in query parameters.
 ///
@@ -1686,7 +1687,7 @@ mod tests {
     use crate::inventory::{self, BroadcastingInventory};
     use crate::offchain::order::{OffchainOrder, OffchainOrderEvent, OffchainOrderId};
     use crate::performance::reliability::LifecycleFailureProjection;
-    use crate::tokenized_equity_mint::issuer_request_id;
+    use crate::tokenization::issuer_request_id;
 
     async fn empty_app_state(ctx: Ctx) -> AppState {
         let (sender, _) = broadcast::channel(16);
@@ -3353,7 +3354,7 @@ mod tests {
     #[test]
     fn recheck_error_response_distinguishes_recoverability() {
         use crate::tokenization::{MintVerificationError, TokenizerError};
-        use crate::tokenized_equity_mint::{TokenizationRequestId, issuer_request_id};
+        use crate::tokenization::{TokenizationRequestId, issuer_request_id};
 
         // Not-recoverable: the persisted aggregate state forbids recovery, so
         // retrying will not help -> 422 carrying the typed reason.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1061,9 +1061,8 @@ pub async fn seed_mint_at_tokens_wrapped_for_test(
     use chrono::Utc;
     use st0x_event_sorcery::DomainEvent;
 
-    use crate::tokenized_equity_mint::{
-        IssuerRequestId, TokenizationRequestId, TokenizedEquityMintEvent,
-    };
+    use crate::tokenization::{IssuerRequestId, TokenizationRequestId};
+    use crate::tokenized_equity_mint::TokenizedEquityMintEvent;
 
     let symbol = Symbol::new(symbol_str.to_string())?;
     let mint_id: IssuerRequestId = mint_id_str.parse()?;

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -33,11 +33,10 @@ use crate::rebalancing::usdc::{CrossVenueCashTransfer, UsdcSettlementParams, Usd
 use crate::telemetry::TelemetrySender;
 use crate::telemetry::broker::InstrumentedAlpacaBroker;
 use crate::tokenization::{
-    AlpacaTokenizationService, TokenizationRequest, TokenizationRequestStatus, Tokenizer,
+    AlpacaTokenizationService, IssuerRequestId, TokenizationRequest, TokenizationRequestStatus,
+    Tokenizer,
 };
-use crate::tokenized_equity_mint::{
-    IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintCommand,
-};
+use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintCommand};
 use crate::usdc_rebalance::{
     RebalanceDirection, ReconcileReason, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
 };
@@ -1636,7 +1635,7 @@ mod tests {
     use crate::onchain::mock::MockRaindex;
     use crate::test_utils::setup_test_db;
     use crate::tokenization::mock::MockTokenizer;
-    use crate::tokenized_equity_mint::{TokenizationRequestId, issuer_request_id};
+    use crate::tokenization::{TokenizationRequestId, issuer_request_id};
     use crate::usdc_rebalance::{ReconcileReason, TransferRef, UsdcRebalanceCommand};
     use crate::vault_lookup::MockVaultLookup;
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -3403,9 +3403,8 @@ mod tests {
         setup_test_db, setup_test_pools,
     };
     use crate::tokenization::mock::MockTokenizer;
-    use crate::tokenized_equity_mint::{
-        TokenizationRequestId, TokenizedEquityMintCommand, issuer_request_id,
-    };
+    use crate::tokenization::{TokenizationRequestId, issuer_request_id};
+    use crate::tokenized_equity_mint::TokenizedEquityMintCommand;
     use crate::trading::onchain::inclusion::EmittedOnChain;
     use crate::trading::onchain::trade_accountant::AccountForDexTrade;
     use crate::unwrapped_equity_recovery::UnwrappedEquityRecoveryJob;
@@ -3512,7 +3511,7 @@ mod tests {
         pool: sqlx::SqlitePool,
         apalis_pool: apalis_sqlite::SqlitePool,
         services: crate::rebalancing::equity::EquityTransferServices,
-        mint_id: crate::tokenized_equity_mint::IssuerRequestId,
+        mint_id: crate::tokenization::IssuerRequestId,
         redemption_id: crate::equity_redemption::RedemptionAggregateId,
         tokenizer: Arc<crate::tokenization::mock::MockTokenizer>,
         rebalancing_service: RebalancingService,

--- a/src/dashboard/transfer_loader.rs
+++ b/src/dashboard/transfer_loader.rs
@@ -359,9 +359,8 @@ mod tests {
     use crate::equity_redemption::{
         EquityRedemptionEvent, RedemptionAggregateId, redemption_aggregate_id,
     };
-    use crate::tokenized_equity_mint::{
-        IssuerRequestId, TokenizedEquityMintEvent, issuer_request_id,
-    };
+    use crate::tokenization::{IssuerRequestId, issuer_request_id};
+    use crate::tokenized_equity_mint::TokenizedEquityMintEvent;
     use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalanceEvent};
 
     fn mint_transfer(status: EquityMintStatus) -> TransferOperation {

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -77,15 +77,15 @@ use st0x_finance::{FractionalShares, Id};
 use st0x_wrapper::WrapperError;
 
 use crate::rebalancing::equity::EquityTransferServices;
+use crate::tokenization::TokenizationRequestId;
 use crate::tokenization::Tokenizer;
-use crate::tokenized_equity_mint::TokenizationRequestId;
 
 /// Our tokenized equity tokens use 18 decimals.
 const TOKENIZED_EQUITY_DECIMALS: u8 = 18;
 
 /// Unique identifier for a redemption aggregate instance.
 ///
-/// Mirrors [`crate::tokenized_equity_mint::IssuerRequestId`]: a UUID chosen at
+/// Mirrors [`crate::tokenization::IssuerRequestId`]: a UUID chosen at
 /// enqueue time so apalis retries and bot restarts always target the same
 /// aggregate.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -64,9 +64,8 @@ use crate::tokenization::alpaca::tests::{
     tokenization_requests_path,
 };
 use crate::tokenization::mock::MockTokenizer;
-use crate::tokenized_equity_mint::{
-    IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintCommand, issuer_request_id,
-};
+use crate::tokenization::{IssuerRequestId, issuer_request_id};
+use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintCommand};
 use crate::unwrapped_equity_recovery::aggregate::{
     UnwrappedEquityRecovery, UnwrappedEquityRecoveryId, UnwrappedEquityRecoveryServices,
 };

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -26,8 +26,8 @@ use crate::inventory::snapshot::{
     InventorySnapshot, InventorySnapshotCommand, InventorySnapshotId,
 };
 use crate::rebalancing::usdc::{UsdcTransferError, u256_to_usdc};
+use crate::tokenization::{IssuerRequestId, TokenizationRequestId};
 use crate::tokenization::{TokenizationRequestType, Tokenizer, TokenizerError};
-use crate::tokenized_equity_mint::{IssuerRequestId, TokenizationRequestId};
 use crate::vault_registry::{VaultRegistry, VaultRegistryId};
 
 /// Pending mints and redemptions aggregated by symbol.
@@ -977,7 +977,7 @@ mod tests {
     use super::*;
     use crate::inventory::snapshot::InventorySnapshotEvent;
     use crate::test_utils::setup_test_db;
-    use crate::tokenized_equity_mint::issuer_request_id;
+    use crate::tokenization::issuer_request_id;
     use crate::vault_registry::{VaultRegistry, VaultRegistryCommand};
 
     #[derive(Clone, Default)]

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -19,7 +19,7 @@ use st0x_wrapper::{RatioError, UnderlyingPerWrapped};
 use super::snapshot::InventorySnapshotEvent;
 use super::venue_balance::{InventoryError, VenueBalance};
 use crate::equity_redemption::RedemptionAggregateId;
-use crate::tokenized_equity_mint::IssuerRequestId;
+use crate::tokenization::IssuerRequestId;
 use crate::usdc_rebalance::UsdcRebalanceId;
 
 /// Error type for inventory view operations.

--- a/src/rebalancing/equity/job.rs
+++ b/src/rebalancing/equity/job.rs
@@ -35,7 +35,8 @@ use super::{CrossVenueEquityTransfer, MintTransferError, RedemptionError};
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::equity_redemption::RedemptionAggregateId;
 use crate::rebalancing::trigger::GuardState;
-use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMint};
+use crate::tokenization::IssuerRequestId;
+use crate::tokenized_equity_mint::TokenizedEquityMint;
 
 /// Apalis queue type for [`TransferEquityToMarketMaking`].
 pub(crate) type TransferEquityToMarketMakingJobQueue = JobQueue<TransferEquityToMarketMaking>;
@@ -444,8 +445,9 @@ mod tests {
     use crate::equity_redemption::redemption_aggregate_id;
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::{EquityTransferServices, MintError};
+    use crate::tokenization::issuer_request_id;
     use crate::tokenization::mock::MockTokenizer;
-    use crate::tokenized_equity_mint::{TokenizedEquityMintCommand, issuer_request_id};
+    use crate::tokenized_equity_mint::TokenizedEquityMintCommand;
     use crate::vault_lookup::MockVaultLookup;
 
     /// Builds a test ctx with recovery enabled for AAPL and an empty guard map.

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -47,12 +47,11 @@ use crate::equity_redemption::{
     DetectionFailure, EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId,
 };
 use crate::tokenization::{
-    AlpacaTokenizationError, MintVerificationError, TokenizationRequest, TokenizationRequestStatus,
-    Tokenizer, TokenizerError,
+    AlpacaTokenizationError, IssuerRequestId, MintVerificationError, TokenizationRequest,
+    TokenizationRequestId, TokenizationRequestStatus, Tokenizer, TokenizerError,
 };
 use crate::tokenized_equity_mint::{
-    IssuerRequestId, TOKENIZED_EQUITY_DECIMALS, TokenizationRequestId, TokenizedEquityMint,
-    TokenizedEquityMintCommand,
+    TOKENIZED_EQUITY_DECIMALS, TokenizedEquityMint, TokenizedEquityMintCommand,
 };
 use crate::vault_lookup::{VaultLookup, VaultLookupError};
 
@@ -1701,10 +1700,11 @@ mod tests {
     };
     use crate::onchain::mock::{DepositBehavior, MockRaindex};
     use crate::rebalancing::{RebalancingSchedulers, RebalancingServiceConfig};
+    use crate::tokenization::issuer_request_id;
     use crate::tokenization::mock::{
         MockCompletionOutcome, MockDetectionOutcome, MockTokenizer, MockVerificationOutcome,
     };
-    use crate::tokenized_equity_mint::{TokenizedEquityMintEvent, issuer_request_id};
+    use crate::tokenized_equity_mint::TokenizedEquityMintEvent;
     use crate::usdc_rebalance::UsdcRebalance;
     use crate::vault_lookup::MockVaultLookup;
     use crate::vault_registry::VaultRegistry;

--- a/src/rebalancing/equity/resume_job.rs
+++ b/src/rebalancing/equity/resume_job.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 use super::{CrossVenueEquityTransfer, MintError, RedemptionError};
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::equity_redemption::RedemptionAggregateId;
-use crate::tokenized_equity_mint::IssuerRequestId;
+use crate::tokenization::IssuerRequestId;
 
 /// Apalis queue type for [`ResumeTokenizationAggregate`].
 pub(crate) type ResumeTokenizationJobQueue = JobQueue<ResumeTokenizationAggregate>;
@@ -107,9 +107,8 @@ mod tests {
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenization::mock::{MockCompletionOutcome, MockDetectionOutcome, MockTokenizer};
-    use crate::tokenized_equity_mint::{
-        TokenizationRequestId, TokenizedEquityMint, TokenizedEquityMintCommand, issuer_request_id,
-    };
+    use crate::tokenization::{TokenizationRequestId, issuer_request_id};
+    use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintCommand};
     use crate::vault_lookup::MockVaultLookup;
 
     /// Builds a [`ResumeTokenizationCtx`] backed by in-memory stores, plus

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -51,8 +51,9 @@ use crate::rebalancing::usdc::{
     TransferUsdcToHedging, TransferUsdcToHedgingJobQueue, TransferUsdcToMarketMaking,
     TransferUsdcToMarketMakingJobQueue,
 };
+use crate::tokenization::IssuerRequestId;
 use crate::tokenized_equity_mint::{
-    IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintCommand, TokenizedEquityMintEvent,
+    TokenizedEquityMint, TokenizedEquityMintCommand, TokenizedEquityMintEvent,
 };
 use crate::unwrapped_equity_recovery::aggregate::UnwrappedEquityRecoveryId;
 use crate::unwrapped_equity_recovery::{
@@ -198,7 +199,7 @@ impl std::fmt::Display for MintTrackingStage {
 struct MintTracking {
     symbol: Symbol,
     quantity: FractionalShares,
-    tokenization_request_id: Option<crate::tokenized_equity_mint::TokenizationRequestId>,
+    tokenization_request_id: Option<crate::tokenization::TokenizationRequestId>,
     stage: MintTrackingStage,
     last_progress_at: DateTime<Utc>,
 }
@@ -298,7 +299,7 @@ impl std::fmt::Display for RedemptionTrackingStage {
 struct RedemptionTracking {
     symbol: Symbol,
     quantity: FractionalShares,
-    tokenization_request_id: Option<crate::tokenized_equity_mint::TokenizationRequestId>,
+    tokenization_request_id: Option<crate::tokenization::TokenizationRequestId>,
     redemption_tx: Option<TxHash>,
     stage: RedemptionTrackingStage,
     last_progress_at: DateTime<Utc>,
@@ -420,7 +421,7 @@ impl RedemptionTracking {
 
 fn mint_event_tokenization_request_id(
     event: &TokenizedEquityMintEvent,
-) -> Option<&crate::tokenized_equity_mint::TokenizationRequestId> {
+) -> Option<&crate::tokenization::TokenizationRequestId> {
     match event {
         TokenizedEquityMintEvent::MintAccepted {
             tokenization_request_id,
@@ -4075,7 +4076,7 @@ impl RebalancingService {
         &self,
         id: &IssuerRequestId,
         entity: &TokenizedEquityMint,
-        tokenization_request_id: crate::tokenized_equity_mint::TokenizationRequestId,
+        tokenization_request_id: crate::tokenization::TokenizationRequestId,
     ) -> Result<RecoveryClaim, RebalancingServiceError> {
         let TokenizedEquityMint::Failed {
             symbol, quantity, ..
@@ -4845,9 +4846,8 @@ mod tests {
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::test_utils::rebalancing_enabled_equities;
     use crate::tokenization::mock::MockTokenizer;
-    use crate::tokenized_equity_mint::{
-        TokenizationRequestId, TokenizedEquityMintCommand, issuer_request_id,
-    };
+    use crate::tokenization::{TokenizationRequestId, issuer_request_id};
+    use crate::tokenized_equity_mint::TokenizedEquityMintCommand;
     use crate::usdc_rebalance::{
         ConversionAmounts, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
     };

--- a/src/tokenization.rs
+++ b/src/tokenization.rs
@@ -12,6 +12,11 @@ pub(crate) mod mock;
 
 use alloy::primitives::{Address, TxHash, U256};
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use std::str::FromStr;
+use uuid::Uuid;
+
 use st0x_evm::EvmError;
 use st0x_execution::{FractionalShares, Symbol};
 
@@ -20,7 +25,49 @@ pub(crate) use alpaca::{
     TokenizationRequestStatus, TokenizationRequestType,
 };
 
-use crate::tokenized_equity_mint::{IssuerRequestId, TokenizationRequestId};
+/// Our internal tracking id for a tokenized equity mint, chosen at enqueue time.
+///
+/// Mirrors [`crate::usdc_rebalance::UsdcRebalanceId`]: a UUID so invalid ids are
+/// unrepresentable and apalis/CLI retries always target the same aggregate.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub(crate) struct IssuerRequestId(pub(crate) Uuid);
+
+impl IssuerRequestId {
+    pub(crate) fn generate() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Display for IssuerRequestId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for IssuerRequestId {
+    type Err = uuid::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Uuid::parse_str(value)?))
+    }
+}
+
+/// Deterministic issuer request id for tests. Maps a human-readable label to a
+/// UUID v5 so test aggregate ids stay valid [`IssuerRequestId`] values.
+#[cfg(test)]
+pub(crate) fn issuer_request_id(label: &str) -> IssuerRequestId {
+    IssuerRequestId(Uuid::new_v5(&Uuid::NAMESPACE_OID, label.as_bytes()))
+}
+
+/// Alpaca tokenization request identifier used to track the mint operation through their API.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub(crate) struct TokenizationRequestId(pub(crate) String);
+
+impl std::fmt::Display for TokenizationRequestId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 /// Error type for Tokenizer operations.
 #[derive(Debug, thiserror::Error)]

--- a/src/tokenization/alpaca.rs
+++ b/src/tokenization/alpaca.rs
@@ -43,8 +43,9 @@ use st0x_evm::{
 };
 use st0x_execution::{AlpacaAccountId, FractionalShares, Network, PollingConfig, Symbol};
 
-use super::{MintVerificationError, Tokenizer, TokenizerError};
-use crate::tokenized_equity_mint::{IssuerRequestId, TokenizationRequestId};
+use super::{
+    IssuerRequestId, MintVerificationError, TokenizationRequestId, Tokenizer, TokenizerError,
+};
 
 /// High-level service for Alpaca tokenization operations.
 ///
@@ -1032,7 +1033,7 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::bindings::TestERC20;
-    use crate::tokenized_equity_mint::issuer_request_id;
+    use crate::tokenization::issuer_request_id;
     use st0x_float_macro::float;
 
     pub(crate) const TEST_REDEMPTION_WALLET: Address =

--- a/src/tokenization/mock.rs
+++ b/src/tokenization/mock.rs
@@ -11,10 +11,9 @@ use st0x_evm::{EvmError, NODE_SYNC_MAX_ATTEMPTS};
 use st0x_execution::{FractionalShares, Symbol};
 
 use super::{
-    AlpacaTokenizationError, MintVerificationError, TokenizationRequest, TokenizationRequestStatus,
-    Tokenizer, TokenizerError,
+    AlpacaTokenizationError, IssuerRequestId, MintVerificationError, TokenizationRequest,
+    TokenizationRequestId, TokenizationRequestStatus, Tokenizer, TokenizerError,
 };
-use crate::tokenized_equity_mint::{IssuerRequestId, TokenizationRequestId};
 
 /// Configurable outcome for mint request.
 #[derive(Clone, Copy)]

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -44,10 +44,7 @@ use chrono::{DateTime, Utc};
 use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
-use std::fmt::Display;
-use std::str::FromStr;
 use tracing::{info, warn};
-use uuid::Uuid;
 
 use st0x_dto::{EquityMintOperation, EquityMintStatus, TransferOperation};
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
@@ -55,51 +52,7 @@ use st0x_execution::{FractionalShares, Symbol};
 use st0x_finance::Id;
 
 use crate::rebalancing::equity::EquityTransferServices;
-use crate::tokenization::TokenizationRequestStatus;
-
-/// Our internal tracking id for a tokenized equity mint, chosen at enqueue time.
-///
-/// Mirrors [`crate::usdc_rebalance::UsdcRebalanceId`]: a UUID so invalid ids are
-/// unrepresentable and apalis/CLI retries always target the same aggregate.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub(crate) struct IssuerRequestId(pub(crate) Uuid);
-
-impl IssuerRequestId {
-    pub(crate) fn generate() -> Self {
-        Self(Uuid::new_v4())
-    }
-}
-
-impl Display for IssuerRequestId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl FromStr for IssuerRequestId {
-    type Err = uuid::Error;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(Self(Uuid::parse_str(value)?))
-    }
-}
-
-/// Deterministic issuer request id for tests. Maps a human-readable label to a
-/// UUID v5 so test aggregate ids stay valid [`IssuerRequestId`] values.
-#[cfg(test)]
-pub(crate) fn issuer_request_id(label: &str) -> IssuerRequestId {
-    IssuerRequestId(Uuid::new_v5(&Uuid::NAMESPACE_OID, label.as_bytes()))
-}
-
-/// Alpaca tokenization request identifier used to track the mint operation through their API.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub(crate) struct TokenizationRequestId(pub(crate) String);
-
-impl std::fmt::Display for TokenizationRequestId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
+use crate::tokenization::{IssuerRequestId, TokenizationRequestId, TokenizationRequestStatus};
 
 /// Errors that can occur during tokenized equity mint operations.
 ///
@@ -2232,8 +2185,8 @@ mod tests {
 
     use super::*;
     use crate::onchain::mock::MockRaindex;
-    use crate::tokenization::Tokenizer;
     use crate::tokenization::mock::{MockMintPollOutcome, MockMintRequestOutcome, MockTokenizer};
+    use crate::tokenization::{Tokenizer, issuer_request_id};
     use crate::vault_lookup::MockVaultLookup;
 
     fn mock_vault_lookup() -> MockVaultLookup {
@@ -2352,7 +2305,7 @@ mod tests {
             matches!(
                 &events[1],
                 TokenizedEquityMintEvent::MintAccepted { issuer_request_id, .. }
-                    if *issuer_request_id == super::issuer_request_id("ISS001")
+                    if *issuer_request_id == crate::tokenization::issuer_request_id("ISS001")
             ),
             "Expected MintAccepted with ISS001, got: {:?}",
             events[1]

--- a/src/unwrapped_equity_recovery/aggregate.rs
+++ b/src/unwrapped_equity_recovery/aggregate.rs
@@ -51,7 +51,8 @@ use st0x_wrapper::{WrapConfirmation, Wrapper, WrapperError, node_sync_attempts};
 
 use crate::equity_redemption::RedemptionAggregateId;
 use crate::rebalancing::equity::CrossVenueEquityTransfer;
-use crate::tokenized_equity_mint::{IssuerRequestId, TOKENIZED_EQUITY_DECIMALS};
+use crate::tokenization::IssuerRequestId;
+use crate::tokenized_equity_mint::TOKENIZED_EQUITY_DECIMALS;
 use crate::vault_lookup::VaultLookup;
 
 /// Aggregate identifier. Each detection creates a fresh UUID; multiple
@@ -854,8 +855,8 @@ mod tests {
     use crate::equity_redemption::redemption_aggregate_id;
     use crate::onchain::mock::{ConfirmTxBehavior, DepositBehavior, DepositCall, MockRaindex};
     use crate::rebalancing::equity::EquityTransferServices;
+    use crate::tokenization::issuer_request_id;
     use crate::tokenization::mock::MockTokenizer;
-    use crate::tokenized_equity_mint::issuer_request_id;
     use crate::vault_lookup::{MockVaultLookup, VaultLookup};
 
     use super::*;

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -51,7 +51,8 @@ use crate::equity_redemption::{EquityRedemption, RedemptionAggregateId};
 use crate::inventory::BroadcastingInventory;
 use crate::inventory::view::{InFlightEquityLocation, InventoryView};
 use crate::rebalancing::trigger::{GuardState, claim_guard_for_recovery_or_orphan};
-use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMint};
+use crate::tokenization::IssuerRequestId;
+use crate::tokenized_equity_mint::TokenizedEquityMint;
 
 /// Apalis queue type for [`UnwrappedEquityRecoveryJob`].
 pub(crate) type UnwrappedEquityRecoveryJobQueue = JobQueue<UnwrappedEquityRecoveryJob>;
@@ -709,10 +710,9 @@ mod tests {
     use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
     use crate::rebalancing::trigger::InProgressGuard;
     use crate::tokenization::Tokenizer;
+    use crate::tokenization::issuer_request_id;
     use crate::tokenization::mock::{MockCompletionOutcome, MockDetectionOutcome, MockTokenizer};
-    use crate::tokenized_equity_mint::{
-        TokenizedEquityMint, TokenizedEquityMintCommand, issuer_request_id,
-    };
+    use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintCommand};
     use crate::vault_lookup::MockVaultLookup;
 
     use super::super::aggregate::UnwrappedEquityRecoveryServices;

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -46,7 +46,8 @@ use st0x_wrapper::Wrapper;
 
 use crate::equity_redemption::RedemptionAggregateId;
 use crate::rebalancing::equity::CrossVenueEquityTransfer;
-use crate::tokenized_equity_mint::{IssuerRequestId, TOKENIZED_EQUITY_DECIMALS};
+use crate::tokenization::IssuerRequestId;
+use crate::tokenized_equity_mint::TOKENIZED_EQUITY_DECIMALS;
 use crate::vault_lookup::VaultLookup;
 
 /// Aggregate identifier. Each detection creates a fresh UUID; multiple
@@ -586,8 +587,8 @@ mod tests {
     use crate::equity_redemption::redemption_aggregate_id;
     use crate::onchain::mock::{DepositBehavior, MockRaindex};
     use crate::rebalancing::equity::EquityTransferServices;
+    use crate::tokenization::issuer_request_id;
     use crate::tokenization::mock::MockTokenizer;
-    use crate::tokenized_equity_mint::issuer_request_id;
     use crate::vault_lookup::MockVaultLookup;
 
     use super::*;

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -44,7 +44,8 @@ use crate::equity_redemption::{EquityRedemption, RedemptionAggregateId};
 use crate::inventory::BroadcastingInventory;
 use crate::inventory::view::{InFlightEquityLocation, InventoryView};
 use crate::rebalancing::trigger::{GuardState, claim_guard_for_recovery_or_orphan};
-use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMint};
+use crate::tokenization::IssuerRequestId;
+use crate::tokenized_equity_mint::TokenizedEquityMint;
 
 /// Apalis queue type for [`WrappedEquityRecoveryJob`].
 pub(crate) type WrappedEquityRecoveryJobQueue = JobQueue<WrappedEquityRecoveryJob>;


### PR DESCRIPTION
## What

Moves `IssuerRequestId` and `TokenizationRequestId` (plus the `#[cfg(test)]`
`issuer_request_id` helper) from the mint aggregate (`src/tokenized_equity_mint.rs`)
into the tokenization integration module (`src/tokenization.rs`), reversing the
dependency direction. Advances the Workspace crate extraction project (RAI-744).
Stacked on #960.

## Why

The tokenization integration layer (the `Tokenizer` trait + Alpaca/mock clients)
imported these request-id types *backward* from the domain aggregate that consumes
the client. Co-locating them with the client lets the eventual `st0x-tokenization`
crate (RAI-47) own them outright instead of importing upward from the domain layer.

## How

- Defined `IssuerRequestId`/`TokenizationRequestId` and the `#[cfg(test)]`
  `issuer_request_id` helper in `src/tokenization.rs`, where the `Tokenizer` trait
  already uses them.
- Removed them from `src/tokenized_equity_mint.rs`; the aggregate now imports them
  from `crate::tokenization`.
- Rewired every consumer (~25 sites) to `crate::tokenization::`.
- After the move the tokenization module has no remaining imports from the mint
  aggregate — the dependency now points domain -> integration, not the reverse.

## Testing

- `cargo check -p st0x-hedge --all-targets --all-features` and `cargo clippy` are
  clean.
- The 50 `tokenized_equity_mint` aggregate tests pass; they exercise the moved
  `IssuerRequestId` end-to-end through the `Tokenizer` trait (including
  `request_mint_passes_issuer_request_id_to_tokenizer`).

## Anything else

Pure move — no behavior change. Stacked on #960 (the `st0x-registry` extraction);
both branch off `master`.
