### PR TITLE
feat: hedge cross-venue fills via RaindexInventory events

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -206,6 +206,42 @@ excellent async ecosystem for handling concurrent trading flows.
   tracking (idempotent ingestion -- overlapping ranges dedupe by
   `(tx_hash, log_index)`)
 
+##### InventoryTrade: a third fill source
+
+Alongside `Clear`/`TakeOrder`, the backfill worker also fetches
+`OperatorDeposit`/`OperatorWithdraw` logs from the shared `RaindexInventory`
+(`managed` inventory mode only; see "Shared-Inventory Settlement" above) for the
+same block range and cutoff. Any settlement a venue adapter (Bebop hook, univ4
+hook, or a future venue holding `OPERATOR_ROLE`) routes through the inventory
+surfaces as one deposit + one withdraw on the same tx -- the vault deltas
+themselves are the trade, agnostic to which adapter routed it, so a new venue is
+hedged for free without adapter-specific integration work.
+
+Pairing rules:
+
+- `OperatorDeposit`s are bucketed by settlement tx; each `OperatorWithdraw` is
+  matched against its same-tx bucket.
+- A leg whose `operator` is the bot's own signing wallet is the bot's own
+  rebalancing (`deposit4`/`withdraw4`), not a venue fill, and is filtered out
+  before pairing.
+- `deposit4`/`withdraw4` are independent contract calls with no atomic settle
+  entrypoint linking a deposit to its withdraw. A tx with more than one
+  `OperatorDeposit` cannot be safely paired, so the whole tx is quarantined
+  (fail closed) rather than risk overwriting a real amount and mis-hedging. An
+  unpaired leg (a deposit or withdraw with no counterpart in the batch) is
+  likewise dropped.
+- Both quarantine cases emit no `InventoryTrade` and increment
+  `inventory_ambiguous_settlement_total` / `inventory_unpaired_settlement_total`
+  (labeled by leg) so a dropped settlement is observable, not silent.
+- The manual `process-tx` recovery CLI command supports `InventoryTrade`
+  settlements too, using the same pairing rules.
+
+RUNBOOK: the persisted backfill checkpoint predates inventory ingestion, so
+resuming from it silently skips any inventory fills mined before this code's
+deploy block. On rollout to an already-running deployment, manually rewind the
+checkpoint to the inventory deploy block (or run a one-shot backfill over that
+range) so pre-deploy inventory fills get ingested.
+
 #### Orchestration
 
 Orchestration is split into two layers:
@@ -3517,6 +3553,12 @@ checkpoint as `AccountForDexTrade` jobs into the same queue. The worker starts
 after backfill completes, so historical jobs are enqueued before live events are
 processed. Successful backfill advances the checkpoint to the cutoff block.
 
+The diagram above shows `ClearV3`/`TakeOrderV3`, the direct-orderbook fill
+source. In `managed` inventory mode, `OperatorDeposit`/`OperatorWithdraw`
+settlement pairs on the shared `RaindexInventory` are a third fill source pushed
+into the same `AccountForDexTrade` queue as an `InventoryTrade`; see
+"InventoryTrade: a third fill source" above for the pairing rules.
+
 **Target Flow** (lifecycle workflows, future):
 
 ```mermaid
@@ -3587,10 +3629,10 @@ All work managed by the Conductor falls into one of these categories:
 
 **Long-running services** (streaming, restart on failure):
 
-| Service             | Description                                               |
-| ------------------- | --------------------------------------------------------- |
-| Order fill monitor  | WS subscription to ClearV3/TakeOrderV3, pushes trade jobs |
-| Rebalancing trigger | Detects inventory imbalances, pushes rebalancing jobs     |
+| Service             | Description                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------------- |
+| Order fill monitor  | Polls ClearV3/TakeOrderV3 and inventory OperatorDeposit/OperatorWithdraw settlements, pushes trade jobs |
+| Rebalancing trigger | Detects inventory imbalances, pushes rebalancing jobs                                                   |
 
 **Scheduled jobs** (periodic, future — currently long-running with sleep loops):
 

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1228,6 +1228,16 @@ impl Ctx {
         trading_mode: TradingMode,
         order_owner: Address,
         wallet: Option<crate::wallet::OnchainWalletCtx>,
+        /// Rebalancing settlement mode. Defaults to `Legacy` (bot-EOA-owned
+        /// vaults settling directly against the orderbook), matching every
+        /// e2e test that predates the shared-inventory migration. Tests that
+        /// need a distinct `RaindexInventory` (e.g. InventoryTrade fills from
+        /// a venue adapter) pass `Managed { inventory }` explicitly; the
+        /// vault owner then becomes the inventory address (mirroring
+        /// `crate::onchain::raindex_contracts`'s production wiring) instead
+        /// of `order_owner`.
+        #[builder(default = InventoryMode::Legacy)]
+        inventory_mode: InventoryMode,
         assets: AssetsConfig,
         #[builder(default = 2)] inventory_poll_interval: u64,
         #[builder(default = 3600)] apalis_finished_job_cleanup_interval_secs: u64,
@@ -1252,6 +1262,18 @@ impl Ctx {
             return Err(CtxError::MissingTokenization);
         }
 
+        // Legacy: tests simulate the pre-migration state where the bot owns
+        // the vaults and settles on the orderbook, so the startup
+        // OPERATOR_ROLE preflight is skipped (there is no distinct inventory
+        // contract) and the vault owner is the bot's own order-owner address.
+        // Managed: a distinct RaindexInventory owns the vaults (production
+        // wiring in `crate::onchain::raindex_contracts`), so the vault owner
+        // becomes the inventory address instead.
+        let vault_owner = match inventory_mode {
+            InventoryMode::Legacy => order_owner,
+            InventoryMode::Managed { inventory } => inventory,
+        };
+
         Ok(Self {
             database_url,
             log_level: LogLevel::Debug,
@@ -1261,13 +1283,8 @@ impl Ctx {
             evm: EvmCtx {
                 rpc_url,
                 orderbook,
-                // Legacy: tests simulate the pre-migration state where the bot
-                // owns the vaults and settles on the orderbook, so the startup
-                // OPERATOR_ROLE preflight is skipped (there is no distinct
-                // inventory contract). inventory_address() resolves to the
-                // orderbook, unchanged from before the InventoryMode split.
-                inventory: InventoryMode::Legacy,
-                vault_owner: order_owner,
+                inventory: inventory_mode,
+                vault_owner,
                 deployment_block,
                 required_confirmations,
                 ingestion_cutoff: IngestionCutoff::Safe,
@@ -1587,6 +1604,53 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(content.as_bytes()).unwrap();
         file
+    }
+
+    /// `Ctx::for_test`'s `vault_owner` derivation mirrors the production
+    /// `EvmCtx` wiring: `Legacy` (no distinct inventory contract) resolves to
+    /// `order_owner`, `Managed` resolves to the inventory address. A swapped
+    /// branch would misattribute which vaults the bot considers its own for
+    /// ClearV3/TakeOrderV3 matching and inventory-mode discovery.
+    #[test]
+    fn for_test_vault_owner_matches_legacy_order_owner() {
+        let order_owner = address!("0x1111111111111111111111111111111111111111");
+
+        let ctx = Ctx::for_test()
+            .database_url(":memory:".to_owned())
+            .rpc_url(url::Url::parse("http://localhost:8545").unwrap())
+            .orderbook(address!("0x2222222222222222222222222222222222222222"))
+            .deployment_block(1)
+            .broker(BrokerCtx::DryRun)
+            .trading_mode(TradingMode::Standalone)
+            .order_owner(order_owner)
+            .assets(AssetsConfig::default())
+            .call()
+            .unwrap();
+
+        assert_eq!(ctx.evm.inventory, InventoryMode::Legacy);
+        assert_eq!(ctx.evm.vault_owner, order_owner);
+    }
+
+    #[test]
+    fn for_test_vault_owner_matches_managed_inventory_address() {
+        let order_owner = address!("0x1111111111111111111111111111111111111111");
+        let inventory = address!("0x3333333333333333333333333333333333333333");
+
+        let ctx = Ctx::for_test()
+            .database_url(":memory:".to_owned())
+            .rpc_url(url::Url::parse("http://localhost:8545").unwrap())
+            .orderbook(address!("0x2222222222222222222222222222222222222222"))
+            .deployment_block(1)
+            .broker(BrokerCtx::DryRun)
+            .trading_mode(TradingMode::Standalone)
+            .order_owner(order_owner)
+            .assets(AssetsConfig::default())
+            .inventory_mode(InventoryMode::Managed { inventory })
+            .call()
+            .unwrap();
+
+        assert_eq!(ctx.evm.inventory, InventoryMode::Managed { inventory });
+        assert_eq!(ctx.evm.vault_owner, inventory);
     }
 
     /// Pins the first line of defense against database contention: every

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -13,6 +13,12 @@ sol!(
 sol!(
     #![sol(all_derives = true, rpc)]
     #[derive(serde::Serialize, serde::Deserialize)]
+    IRaindexInventory, env!("ST0X_RAINDEX_INVENTORY_ABI")
+);
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     IERC4626, env!("ST0X_IERC4626_ABI")
 );
 

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -31,6 +31,7 @@ use crate::offchain::order::{
 };
 use crate::onchain::accumulator::check_execution_readiness;
 use crate::onchain::pyth::PythFeedIds;
+use crate::onchain::trade::BotOperator;
 use crate::onchain::{OnChainError, OnchainTrade, TradeValidationError};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeId};
 use crate::position::{Position, PositionCommand};
@@ -433,6 +434,9 @@ pub(super) async fn process_tx_with_provider<W: Write, P: Provider + Clone + 'st
     // Matches ClearV3/TakeOrderV3 fills to our Raindex orders -- owned by the
     // inventory contract post-migration, the bot EOA before it.
     let order_owner = ctx.vault_owner();
+    // Filters the bot's own inventory rebalancing legs out of an
+    // InventoryTrade settlement recovery, same as the backfill path.
+    let bot_operator = BotOperator(ctx.order_owner());
     let read_evm = ReadOnlyEvm::new(provider.clone());
 
     match OnchainTrade::try_from_tx_hash(
@@ -440,8 +444,10 @@ pub(super) async fn process_tx_with_provider<W: Write, P: Provider + Clone + 'st
         &read_evm,
         cache,
         evm_ctx,
+        &ctx.assets,
         &pyth_feed_ids,
         order_owner,
+        bot_operator,
     )
     .await
     {

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -2198,6 +2198,11 @@ pub(crate) async fn discover_vaults_for_trade(
             take_event.config.inputIOIndex,
             take_event.config.outputIOIndex,
         ),
+        // InventoryTrade events settle on vaults owned by the inventory
+        // contract; those vaults reach the registry via the Raindex ClearV3
+        // / TakeOrderV3 that first funded them, so nothing new to auto-
+        // discover here.
+        RaindexTradeEvent::InventoryTrade(_) => Vec::new(),
     };
 
     let our_vaults = owned_vaults
@@ -3525,6 +3530,7 @@ mod tests {
     use st0x_wrapper::{MockWrapper, RATIO_ONE, UnderlyingPerWrapped, Wrapper};
 
     use super::*;
+    use crate::bindings::IRaindexInventory::{OperatorDeposit, OperatorWithdraw};
     use crate::bindings::IRaindexV6::{
         ClearConfigV2, ClearV3, EvaluableV4, IOV2, OrderV4, TakeOrderConfigV4, TakeOrderV3,
     };
@@ -3534,7 +3540,7 @@ mod tests {
     use crate::inventory::{ImbalanceThreshold, Inventory, InventoryView, Venue};
     use crate::offchain::order::{CancellationReason, OrderPlacementResult, RetainedFill};
     use crate::onchain::mock::MockRaindex;
-    use crate::onchain::trade::OnchainTrade;
+    use crate::onchain::trade::{InventoryTrade, OnchainTrade};
     use crate::rebalancing::equity::{
         EquityTransferServices, ResumeTokenizationAggregate, ResumeTokenizationJobQueue,
         ResumeTokenizationTarget, TransferEquityToHedging, TransferEquityToMarketMaking,
@@ -4838,6 +4844,29 @@ mod tests {
         .unwrap()
     }
 
+    fn create_emitted_inventory_event() -> EmittedOnChain<RaindexTradeEvent> {
+        let inventory_trade = InventoryTrade {
+            deposit: OperatorDeposit {
+                operator: address!("0x1111111111111111111111111111111111111111"),
+                token: address!("0x2222222222222222222222222222222222222222"),
+                vaultId: B256::ZERO,
+                amount: U256::from(1u64),
+            },
+            withdraw: OperatorWithdraw {
+                operator: address!("0x1111111111111111111111111111111111111111"),
+                token: address!("0x3333333333333333333333333333333333333333"),
+                vaultId: B256::ZERO,
+                amount: U256::from(1u64),
+            },
+        };
+
+        EmittedOnChain::from_log(
+            RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade)),
+            &get_test_log(),
+        )
+        .unwrap()
+    }
+
     async fn load_vault_registry(vault_registry: &Store<VaultRegistry>) -> Option<VaultRegistry> {
         let registry_id = VaultRegistryId {
             orderbook: TEST_ORDERBOOK,
@@ -4988,6 +5017,30 @@ mod tests {
         assert!(
             !registry.equity_vaults.is_empty(),
             "Expected equity vault to be discovered from take order"
+        );
+    }
+
+    /// An `InventoryTrade` event never auto-discovers vaults: its vaults are
+    /// owned by the inventory contract and reach the registry via the
+    /// ClearV3/TakeOrderV3 that first funded them, not via this path.
+    #[tokio::test]
+    async fn test_discover_vaults_for_trade_inventory_trade_discovers_nothing() {
+        let pool = setup_test_db().await;
+        let vault_registry: Store<VaultRegistry> = test_store(pool.clone(), ());
+
+        let queued_event = create_emitted_inventory_event();
+        let trade = create_test_trade("MSFT");
+
+        let context = create_vault_discovery_context(&vault_registry);
+        discover_vaults_for_trade(&queued_event, &trade, &context)
+            .await
+            .expect("InventoryTrade must not error even though it discovers nothing");
+
+        let registry = load_vault_registry(&vault_registry).await;
+
+        assert!(
+            registry.is_none(),
+            "InventoryTrade events must never auto-discover a vault registry"
         );
     }
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -328,7 +328,7 @@ where
     let maintenance_interval = context.executor.maintenance_interval();
 
     let accountant_ctx = Arc::new(AccountantCtx {
-        orderbook: context.ctx.evm.orderbook,
+        contracts: crate::onchain::raindex_contracts(&context.ctx.evm),
         ctx: context.ctx.clone(),
         cache: context.cache,
         pyth_feed_ids: PythFeedIds::new(context.ctx.pyth_feed_ids()),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,11 +34,21 @@ pub(crate) fn setup() -> Result<PrometheusHandle, BuildError> {
     );
     metrics::describe_counter!(
         "onchain_events_total",
-        "ClearV3 and TakeOrderV3 events received from Raindex, by event_type"
+        "ClearV3, TakeOrderV3 and InventoryTrade events received from Raindex, by event_type"
     );
     metrics::describe_counter!(
         "broker_errors_total",
         "Broker API errors, by symbol and kind"
+    );
+    metrics::describe_counter!(
+        "inventory_ambiguous_settlement_total",
+        "Inventory settlements quarantined because a tx emitted multiple \
+         OperatorDeposits or multiple OperatorWithdraws and could not be safely paired"
+    );
+    metrics::describe_counter!(
+        "inventory_unpaired_settlement_total",
+        "Inventory OperatorDeposit/OperatorWithdraw legs with no same-tx counterpart in the \
+         batch, by leg"
     );
 
     let _ = HANDLE.set(handle.clone());

--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -1,12 +1,15 @@
 //! Historical onchain event backfill with retry logic.
 //!
-//! Scans past blocks for `ClearV3` and `TakeOrderV3` events and pushes them
-//! into the apalis job queue for processing, ensuring no trades are missed
-//! after downtime. A persisted checkpoint records the last block that was
-//! fully enqueued.
+//! Scans past blocks for `ClearV3` and `TakeOrderV3` events on the OrderBook,
+//! plus `OperatorDeposit`/`OperatorWithdraw` events on the shared
+//! `RaindexInventory` (paired into `InventoryTrade`s), and pushes them into the
+//! apalis job queue for processing, ensuring no trades are missed after
+//! downtime. A persisted checkpoint records the last block that was fully
+//! enqueued.
 
+use alloy::primitives::TxHash;
 use alloy::providers::Provider;
-use alloy::rpc::types::Filter;
+use alloy::rpc::types::{Filter, Log};
 use alloy::sol_types::SolEvent;
 use backon::{BackoffBuilder, ExponentialBuilder, Retryable};
 use futures_util::future;
@@ -14,17 +17,20 @@ use itertools::Itertools;
 use metrics::counter;
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::time::Duration;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use st0x_config::EvmCtx;
 use st0x_evm::Evm;
 use st0x_execution::Executor;
 
 use super::OnChainError;
+use crate::bindings::IRaindexInventory::{OperatorDeposit, OperatorWithdraw};
 use crate::bindings::IRaindexV6::{ClearV3, TakeOrderV3};
 use crate::conductor::job::{Job, Label};
-use crate::onchain::trade::RaindexTradeEvent;
+use crate::onchain::trade::{BotOperator, InventoryTrade, RaindexTradeEvent};
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::{
     AccountForDexTrade, AccountantCtx, DexTradeAccountingJobQueue, TradeAccountingError,
@@ -57,6 +63,7 @@ pub(crate) fn get_backfill_retry_strat() -> ExponentialBuilder {
 pub(crate) async fn backfill_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
     provider: &P,
     evm_ctx: &EvmCtx,
+    bot_operator: BotOperator,
     pool: &SqlitePool,
     end_block: u64,
     retry_strategy: B,
@@ -67,6 +74,7 @@ pub(crate) async fn backfill_events<P: Provider + Clone, B: BackoffBuilder + Clo
     backfill_range(
         provider,
         evm_ctx,
+        bot_operator,
         pool,
         start_block,
         end_block,
@@ -76,9 +84,12 @@ pub(crate) async fn backfill_events<P: Provider + Clone, B: BackoffBuilder + Clo
     .await
 }
 
-/// Fetches `ClearV3` / `TakeOrderV3` logs in `[from_block, to_block]`,
-/// pushes an `AccountForDexTrade` job for each, and advances the
-/// backfill checkpoint to `to_block` on success.
+/// Fetches `ClearV3` / `TakeOrderV3` logs from the OrderBook and
+/// `OperatorDeposit` / `OperatorWithdraw` logs from the shared
+/// `RaindexInventory` in `[from_block, to_block]`, pushes an
+/// `AccountForDexTrade` job for each (inventory legs first paired into a single
+/// `InventoryTrade` per settlement tx), and advances the backfill checkpoint to
+/// `to_block` on success.
 ///
 /// Skips RPC calls when `from_block > to_block` (already caught up),
 /// but still moves the checkpoint forward so a stale row does not
@@ -92,6 +103,7 @@ pub(crate) async fn backfill_events<P: Provider + Clone, B: BackoffBuilder + Clo
 pub(crate) async fn backfill_range<P: Provider + Clone, B: BackoffBuilder + Clone>(
     provider: &P,
     evm_ctx: &EvmCtx,
+    bot_operator: BotOperator,
     pool: &SqlitePool,
     from_block: u64,
     to_block: u64,
@@ -124,6 +136,7 @@ pub(crate) async fn backfill_range<P: Provider + Clone, B: BackoffBuilder + Clon
         let enqueued = enqueue_batch_events(
             provider,
             evm_ctx,
+            bot_operator,
             batch_start,
             batch_end,
             retry_strategy.clone(),
@@ -143,8 +156,9 @@ pub(crate) async fn backfill_range<P: Provider + Clone, B: BackoffBuilder + Clon
 /// Persistent job queue for backfill jobs.
 pub(crate) type BackfillJobQueue = crate::conductor::job::JobQueue<BackfillRange>;
 
-/// Apalis job that backfills missed `ClearV3` / `TakeOrderV3` events
-/// between `from_block` and `to_block` (inclusive).
+/// Apalis job that backfills missed `ClearV3` / `TakeOrderV3` orderbook fills
+/// and `OperatorDeposit` / `OperatorWithdraw` inventory settlements between
+/// `from_block` and `to_block` (inclusive).
 ///
 /// Enqueued by `OrderFillMonitor::run` on every (re)connect to cover
 /// the gap between the previously checkpointed block and the cutoff
@@ -187,6 +201,7 @@ where
         backfill_range(
             ctx.evm.provider(),
             &ctx.ctx.evm,
+            BotOperator(ctx.ctx.order_owner()),
             &ctx.pool,
             self.from_block,
             self.to_block,
@@ -202,6 +217,12 @@ where
 /// a cold start with no checkpoint begins at `deployment_block`. Pure so a
 /// caller that already holds the checkpoint (the fill monitor's poll loop) can
 /// reuse it without a second read.
+///
+/// RUNBOOK: the persisted checkpoint predates inventory (`OperatorDeposit` /
+/// `OperatorWithdraw`) ingestion, so resuming from it silently skips any
+/// adapter/inventory fills mined before this code's deploy block. On rollout,
+/// rewind the checkpoint to the inventory deploy block (or run a one-shot
+/// backfill over that range) so pre-deploy inventory fills are ingested.
 pub(crate) fn backfill_start_from_checkpoint(
     checkpoint: Option<u64>,
     deployment_block: u64,
@@ -268,6 +289,302 @@ pub(crate) async fn save_backfill_checkpoint(
     Ok(())
 }
 
+/// A settlement tx's `OperatorDeposit` bucket: either exactly one deposit, or
+/// `Ambiguous` because a second same-tx deposit landed. `deposit4`/`withdraw4`
+/// are independent `RaindexInventory` calls with no atomic "settle" entrypoint
+/// pairing them, so once a tx has more than one deposit there is no reliable
+/// way to know which one a same-tx withdraw actually belongs to. Rather than
+/// silently overwriting (and mis-hedging) a real amount, the whole tx is
+/// quarantined: no `InventoryTrade` is ever built from an `Ambiguous` bucket.
+pub(crate) enum DepositBucket {
+    Single(OperatorDeposit),
+    Ambiguous,
+}
+
+/// A settlement tx's `OperatorWithdraw` bucket, symmetric to [`DepositBucket`].
+/// A tx with two `OperatorWithdraw`s is exactly as ambiguous as one with two
+/// `OperatorDeposit`s -- the single deposit could belong to either withdraw --
+/// so it is quarantined the same way. Carries the triggering `Log` alongside
+/// `Single` so the pairing pass can build `EmittedOnChain` metadata without a
+/// second lookup.
+pub(crate) enum WithdrawBucket {
+    Single(OperatorWithdraw, Box<Log>),
+    Ambiguous,
+}
+
+/// Splits a batch's raw inventory logs into per-tx `OperatorDeposit` and
+/// `OperatorWithdraw` buckets keyed by settlement tx, so the pairing pass
+/// ([`pair_inventory_settlements`]) can match each tx's deposit to its
+/// withdraw without an extra RPC round-trip. Drops the bot's own rebalancing
+/// legs (treasury moves, not venue fills), `removed: true` logs (reorg), and
+/// undecodable logs; quarantines any tx that emits multiple deposits or
+/// multiple withdraws.
+///
+/// `pub(crate)`: also reused by `OnchainTrade::try_from_tx_hash` (the manual
+/// `process-tx` recovery path) so both ingestion paths pair
+/// `OperatorDeposit`/`OperatorWithdraw` under the exact same rules.
+pub(crate) fn bucket_inventory_logs(
+    inv_logs: Vec<Log>,
+    bot_operator: BotOperator,
+) -> (
+    HashMap<TxHash, DepositBucket>,
+    HashMap<TxHash, WithdrawBucket>,
+) {
+    let BotOperator(bot_operator) = bot_operator;
+    let mut deposits_by_tx: HashMap<TxHash, DepositBucket> = HashMap::new();
+    let mut withdraws_by_tx: HashMap<TxHash, WithdrawBucket> = HashMap::new();
+    for log in inv_logs {
+        let Some(topic0) = log.topic0().copied() else {
+            continue;
+        };
+        if topic0 == OperatorDeposit::SIGNATURE_HASH {
+            // Callers cap `to_block` at the ingestion cutoff block, so a
+            // `removed: true` OperatorDeposit here implies a reorg -- mirror
+            // the same guard applied to ClearV3/TakeOrderV3/OperatorWithdraw
+            // logs below rather than bucketing a vanished event.
+            if log.removed {
+                warn!(
+                    target: "inventory",
+                    tx_hash = ?log.transaction_hash,
+                    log_index = ?log.log_index,
+                    block_number = ?log.block_number,
+                    "Backfill returned `removed: true` for an OperatorDeposit log; \
+                     reorg detected, skipping",
+                );
+                continue;
+            }
+
+            let (Ok(decoded), Some(tx_hash)) =
+                (log.log_decode::<OperatorDeposit>(), log.transaction_hash)
+            else {
+                warn!(
+                    target: "inventory",
+                    "Skipping OperatorDeposit that failed to decode / had no tx hash",
+                );
+                continue;
+            };
+            let deposit = decoded.data().clone();
+
+            // The bot's own rebalancing also calls deposit4/withdraw4 on the
+            // inventory, emitting OperatorDeposit/OperatorWithdraw whose
+            // operator is the bot's signing wallet. Those are treasury moves, not
+            // venue fills to hedge -- drop them before bucketing/pairing.
+            if deposit.operator == bot_operator {
+                debug!(
+                    target: "inventory",
+                    ?tx_hash,
+                    "Skipping inventory event emitted by the bot's own rebalancing",
+                );
+                continue;
+            }
+
+            match deposits_by_tx.entry(tx_hash) {
+                Entry::Vacant(entry) => {
+                    entry.insert(DepositBucket::Single(deposit));
+                }
+                Entry::Occupied(mut entry) => {
+                    // deposit4/withdraw4 are independent contract calls with no
+                    // atomic settle entrypoint pairing them, so a second same-tx
+                    // deposit means this settlement cannot be safely paired 1:1.
+                    // Quarantine the whole tx (fail closed) instead of silently
+                    // overwriting a real amount and mis-hedging.
+                    error!(
+                        target: "inventory",
+                        ?tx_hash,
+                        "Multiple OperatorDeposits in one tx; settlement is ambiguous \
+                         and cannot be safely paired, quarantining the whole tx",
+                    );
+                    counter!("inventory_ambiguous_settlement_total").increment(1);
+                    entry.insert(DepositBucket::Ambiguous);
+                }
+            }
+        } else if topic0 == OperatorWithdraw::SIGNATURE_HASH {
+            // Mirror the deposit branch's reorg guard: callers cap `to_block`
+            // at the ingestion cutoff block, so `removed: true` here implies a
+            // reorg rather than a routine result.
+            if log.removed {
+                warn!(
+                    target: "inventory",
+                    tx_hash = ?log.transaction_hash,
+                    log_index = ?log.log_index,
+                    block_number = ?log.block_number,
+                    "Backfill returned `removed: true` for an OperatorWithdraw log; \
+                     reorg detected, skipping",
+                );
+                continue;
+            }
+
+            let (Ok(decoded), Some(tx_hash)) =
+                (log.log_decode::<OperatorWithdraw>(), log.transaction_hash)
+            else {
+                warn!(
+                    target: "inventory",
+                    "Skipping OperatorWithdraw that failed to decode / had no tx hash",
+                );
+                continue;
+            };
+            let withdraw = decoded.data().clone();
+
+            // Skip the bot's own rebalancing withdraws (see the deposit branch);
+            // a lone rebalance withdraw would otherwise fire the "no paired
+            // deposit" warn on every routine rebalance.
+            if withdraw.operator == bot_operator {
+                debug!(
+                    target: "inventory",
+                    ?tx_hash,
+                    "Skipping inventory event emitted by the bot's own rebalancing",
+                );
+                continue;
+            }
+
+            match withdraws_by_tx.entry(tx_hash) {
+                Entry::Vacant(entry) => {
+                    entry.insert(WithdrawBucket::Single(withdraw, Box::new(log)));
+                }
+                Entry::Occupied(mut entry) => {
+                    // Symmetric to the deposit branch: a second same-tx
+                    // withdraw is exactly as ambiguous as a second deposit --
+                    // the single deposit could fund either withdraw -- so
+                    // quarantine the whole tx (fail closed) rather than
+                    // arbitrarily pairing the first one encountered.
+                    error!(
+                        target: "inventory",
+                        ?tx_hash,
+                        "Multiple OperatorWithdraws in one tx; settlement is ambiguous \
+                         and cannot be safely paired, quarantining the whole tx",
+                    );
+                    counter!("inventory_ambiguous_settlement_total").increment(1);
+                    entry.insert(WithdrawBucket::Ambiguous);
+                }
+            }
+        }
+    }
+
+    (deposits_by_tx, withdraws_by_tx)
+}
+
+/// Pairs bucketed deposits and withdraws into `InventoryTrade` events, one
+/// per tx that has EXACTLY one deposit and exactly one withdraw. Any other
+/// combination (an ambiguous bucket on either side, or a leg with no
+/// counterpart at all) is quarantined -- fail closed, zero `InventoryTrade`s
+/// built for that tx -- since `deposit4`/`withdraw4` are independent calls
+/// with no atomic settlement id linking them.
+///
+/// `pub(crate)`: shared by both the batch backfill path
+/// ([`enqueue_batch_events`]) and `OnchainTrade::try_from_tx_hash` (the
+/// manual `process-tx` recovery path) so a multi-leg settlement is
+/// quarantined identically regardless of which path discovers it.
+pub(crate) fn pair_inventory_settlements(
+    deposits_by_tx: HashMap<TxHash, DepositBucket>,
+    withdraws_by_tx: HashMap<TxHash, WithdrawBucket>,
+) -> Vec<(RaindexTradeEvent, Log)> {
+    let mut buckets_by_tx: HashMap<TxHash, (Option<DepositBucket>, Option<WithdrawBucket>)> =
+        HashMap::new();
+    for (tx_hash, deposit_bucket) in deposits_by_tx {
+        buckets_by_tx.entry(tx_hash).or_default().0 = Some(deposit_bucket);
+    }
+    for (tx_hash, withdraw_bucket) in withdraws_by_tx {
+        buckets_by_tx.entry(tx_hash).or_default().1 = Some(withdraw_bucket);
+    }
+
+    // A plain loop rather than a `filter_map`: every non-pairing arm below has
+    // to log and increment a counter, and burying those side effects inside a
+    // transform hides the quarantine logic that is the whole point of this
+    // function.
+    let mut paired = Vec::new();
+    for (tx_hash, (deposit_bucket, withdraw_bucket)) in buckets_by_tx {
+        match (deposit_bucket, withdraw_bucket) {
+            (Some(DepositBucket::Single(deposit)), Some(WithdrawBucket::Single(withdraw, log)))
+                if deposit.operator == withdraw.operator =>
+            {
+                let inv = InventoryTrade { deposit, withdraw };
+                paired.push((RaindexTradeEvent::InventoryTrade(Box::new(inv)), *log));
+            }
+            (Some(DepositBucket::Single(deposit)), Some(WithdrawBucket::Single(withdraw, _))) => {
+                // The single deposit and single withdraw in this tx were emitted
+                // by different OPERATOR_ROLE holders, so they are not the two
+                // legs of the same settlement -- pairing them would fabricate a
+                // vault delta between two unrelated actions and produce a wrong
+                // hedge. Quarantine, same fail-closed treatment as a multi-leg
+                // ambiguous tx.
+                error!(
+                    target: "inventory",
+                    ?tx_hash,
+                    deposit_operator = ?deposit.operator,
+                    withdraw_operator = ?withdraw.operator,
+                    "Settlement quarantined: OperatorDeposit and OperatorWithdraw in this \
+                     tx were emitted by different operators and cannot be safely paired; \
+                     no hedge emitted",
+                );
+                counter!("inventory_ambiguous_settlement_total").increment(1);
+            }
+            (Some(DepositBucket::Ambiguous), Some(WithdrawBucket::Ambiguous)) => {
+                error!(
+                    target: "inventory",
+                    ?tx_hash,
+                    "Settlement quarantined: both OperatorDeposit and OperatorWithdraw \
+                     are ambiguous (multiple of each) in this tx; no hedge emitted",
+                );
+            }
+            (Some(DepositBucket::Ambiguous), Some(WithdrawBucket::Single(..))) => {
+                error!(
+                    target: "inventory",
+                    ?tx_hash,
+                    "Settlement quarantined: ambiguous multi-deposit tx; no hedge emitted",
+                );
+            }
+            (Some(DepositBucket::Ambiguous), None) => {
+                error!(
+                    target: "inventory",
+                    ?tx_hash,
+                    "Settlement quarantined: ambiguous multi-deposit tx never claimed by \
+                     an OperatorWithdraw; no hedge emitted",
+                );
+            }
+            (Some(DepositBucket::Single(_)), Some(WithdrawBucket::Ambiguous)) => {
+                error!(
+                    target: "inventory",
+                    ?tx_hash,
+                    "Settlement quarantined: ambiguous multi-withdraw tx; no hedge emitted",
+                );
+            }
+            (None, Some(WithdrawBucket::Ambiguous)) => {
+                error!(
+                    target: "inventory",
+                    ?tx_hash,
+                    "Settlement quarantined: ambiguous multi-withdraw tx with no \
+                     OperatorDeposit; no hedge emitted",
+                );
+            }
+            (Some(DepositBucket::Single(deposit)), None) => {
+                warn!(
+                    target: "inventory",
+                    ?tx_hash,
+                    vault_id = ?deposit.vaultId,
+                    token = ?deposit.token,
+                    "OperatorDeposit without a paired OperatorWithdraw in the same batch; \
+                     skipping",
+                );
+                counter!("inventory_unpaired_settlement_total", "leg" => "deposit").increment(1);
+            }
+            (None, Some(WithdrawBucket::Single(withdraw, _))) => {
+                warn!(
+                    target: "inventory",
+                    ?tx_hash,
+                    vault_id = ?withdraw.vaultId,
+                    token = ?withdraw.token,
+                    "OperatorWithdraw without a paired OperatorDeposit in the same batch; \
+                     skipping",
+                );
+                counter!("inventory_unpaired_settlement_total", "leg" => "withdraw").increment(1);
+            }
+            (None, None) => {}
+        }
+    }
+
+    paired
+}
+
 #[tracing::instrument(
     target = "orderbook",
     skip(provider, evm_ctx, retry_strategy, job_queue),
@@ -277,6 +594,7 @@ pub(crate) async fn save_backfill_checkpoint(
 async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
     provider: &P,
     evm_ctx: &EvmCtx,
+    bot_operator: BotOperator,
     batch_start: u64,
     batch_end: u64,
     retry_strategy: B,
@@ -294,10 +612,25 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
         .to_block(batch_end)
         .event_signature(TakeOrderV3::SIGNATURE_HASH);
 
+    // Inventory events: OperatorDeposit + OperatorWithdraw are emitted as a
+    // pair per settlement tx that routes through the shared inventory (Bebop
+    // adapter, univ4 hook, or any future venue). The pair -- one deposit +
+    // one withdraw, one side equity + one side USDC -- is the trade to hedge.
+    let inventory_filter = Filter::new()
+        .address(evm_ctx.inventory_address())
+        .from_block(batch_start)
+        .to_block(batch_end)
+        .event_signature(vec![
+            OperatorDeposit::SIGNATURE_HASH,
+            OperatorWithdraw::SIGNATURE_HASH,
+        ]);
+
     let provider_clear = provider.clone();
     let provider_take = provider.clone();
+    let provider_inv = provider.clone();
     let clear_filter_clone = clear_filter.clone();
     let take_filter_clone = take_filter.clone();
+    let inv_filter_clone = inventory_filter.clone();
 
     let get_clear_logs = move || {
         let provider = provider_clear.clone();
@@ -309,17 +642,27 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
         let filter = take_filter_clone.clone();
         async move { fetch_logs_with_tip_check(&provider, &filter, batch_end).await }
     };
+    let get_inv_logs = move || {
+        let provider = provider_inv.clone();
+        let filter = inv_filter_clone.clone();
+        async move { fetch_logs_with_tip_check(&provider, &filter, batch_end).await }
+    };
 
-    let (clear_logs, take_logs) = future::try_join(
+    let (clear_logs, take_logs, inv_logs) = future::try_join3(
         get_clear_logs
             .retry(retry_strategy.clone().build())
             .notify(|err, dur| {
                 trace!(target: "orderbook", "Retrying clear_logs for blocks between {batch_start}-{batch_end} after error: {err} (waiting {dur:?})");
             }),
         get_take_logs
-            .retry(retry_strategy.build())
+            .retry(retry_strategy.clone().build())
             .notify(|err, dur| {
                 trace!(target: "orderbook", "Retrying take_logs for blocks between {batch_start}-{batch_end} after error: {err} (waiting {dur:?})");
+            }),
+        get_inv_logs
+            .retry(retry_strategy.build())
+            .notify(|err, dur| {
+                trace!(target: "inventory", "Retrying inv_logs for blocks between {batch_start}-{batch_end} after error: {err} (waiting {dur:?})");
             }),
     )
     .await?;
@@ -328,13 +671,18 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
         target: "orderbook",
         total_clear_logs = %clear_logs.len(),
         total_take_logs = %take_logs.len(),
+        total_inventory_logs = %inv_logs.len(),
         "Processed a batch of blocks from {batch_start} to {batch_end}",
     );
+
+    // Bucket inventory logs by tx so deposits and withdraws can be paired
+    // (or quarantined) per settlement without an extra RPC round-trip.
+    let (deposits_by_tx, withdraws_by_tx) = bucket_inventory_logs(inv_logs, bot_operator);
+    let inventory_trade_events = pair_inventory_settlements(deposits_by_tx, withdraws_by_tx);
 
     let trade_events = clear_logs
         .into_iter()
         .chain(take_logs)
-        .sorted_by_key(|log| (log.block_number, log.log_index))
         .filter(|log| {
             // Callers cap `to_block` at the ingestion cutoff block.
             // Under `finalized`, this block cannot reorg, so `removed: true`
@@ -368,6 +716,8 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
                 None
             }
         })
+        .chain(inventory_trade_events)
+        .sorted_by_key(|(_, log)| (log.block_number, log.log_index))
         .filter_map(|(event, log)| {
             EmittedOnChain::<RaindexTradeEvent>::from_log(event, &log)
                 .inspect_err(
@@ -384,7 +734,8 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
         // event type, so ingestion volume is observable even before any hedge is
         // placed downstream. This counts enqueue attempts, not unique fills: a
         // backfill replay re-enqueues already-processed events (the pipeline
-        // dedupes on (tx_hash, log_index)). `kind()` yields "ClearV3"/"TakeOrderV3".
+        // dedupes on (tx_hash, log_index)). `kind()` yields
+        // "ClearV3"/"TakeOrderV3"/"InventoryTrade".
         counter!("onchain_events_total", "event_type" => trade_event.event.kind()).increment(1);
         job_queue
             .push(AccountForDexTrade { trade: trade_event })
@@ -451,6 +802,11 @@ mod tests {
     use super::*;
     use crate::bindings::IRaindexV6;
     use crate::test_utils::{get_test_order, setup_test_db, setup_test_pools};
+
+    /// A bot-operator address distinct from every event operator seeded in
+    /// these tests, so the T13 "skip the bot's own rebalancing events" filter
+    /// never matches unless a test deliberately uses this address.
+    const TEST_BOT_OPERATOR: Address = address!("0x00000000000000000000000000000000000000b0");
 
     fn test_retry_strategy() -> ExponentialBuilder {
         ExponentialBuilder::default()
@@ -565,7 +921,8 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
         push_tip_response(&asserter);
-
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
@@ -582,6 +939,7 @@ mod tests {
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -623,6 +981,7 @@ mod tests {
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -664,6 +1023,7 @@ mod tests {
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             99,
             test_retry_strategy(),
@@ -854,12 +1214,14 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
         push_tip_response(&asserter);
-
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -927,12 +1289,14 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log])); // take events
         push_tip_response(&asserter);
-
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -1031,12 +1395,15 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log]));
         push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -1079,6 +1446,7 @@ mod tests {
         let result = backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -1114,12 +1482,14 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
         push_tip_response(&asserter);
-
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -1231,11 +1601,14 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!(reversed));
         push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -1325,12 +1698,15 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log2, take_log1]));
         push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -1365,11 +1741,15 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
         push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
 
         // Batch 2: blocks 2000-2500
         asserter.push_success(&serde_json::json!([]));
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
         push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
@@ -1377,6 +1757,7 @@ mod tests {
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             2500,
             test_retry_strategy(),
@@ -1411,11 +1792,15 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
         push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
 
         // Batch 2: blocks 1500-1900
         asserter.push_success(&serde_json::json!([]));
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
         push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
@@ -1423,6 +1808,7 @@ mod tests {
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             1900,
             get_backfill_retry_strat(),
@@ -1465,12 +1851,15 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log]));
         push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         let enqueued_count = enqueue_batch_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             100,
             200,
             test_retry_strategy(),
@@ -1506,6 +1895,8 @@ mod tests {
             push_tip_response(&asserter);
             asserter.push_success(&serde_json::json!([]));
             push_tip_response(&asserter);
+            asserter.push_success(&serde_json::json!([])); // inventory events
+            push_tip_response(&asserter);
         }
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
@@ -1513,6 +1904,7 @@ mod tests {
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             3000,
             get_backfill_retry_strat(),
@@ -1570,12 +1962,15 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([valid_log, invalid_log]));
         push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -1655,12 +2050,15 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log]));
         push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -1696,12 +2094,14 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
         push_tip_response(&asserter);
-
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         let result = enqueue_batch_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             100,
             200,
             test_retry_strategy(),
@@ -1744,6 +2144,7 @@ mod tests {
         let result = enqueue_batch_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             100,
             200,
             test_retry_strategy(),
@@ -1781,6 +2182,8 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take logs
         push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
 
         // Second batch fails completely (after retries)
         // Need double the failures since clear_logs and take_logs retry in parallel
@@ -1797,6 +2200,7 @@ mod tests {
         let result = backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             25000,
             test_retry_strategy(),
@@ -1851,12 +2255,15 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
         push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -1904,12 +2311,15 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([removed_log]));
         push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -1946,12 +2356,15 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
         push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             42,
             test_retry_strategy(),
@@ -1997,7 +2410,8 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log])); // take events
         push_tip_response(&asserter);
-
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         // Close the apalis pool to simulate job-queue connection failure.
@@ -2006,6 +2420,7 @@ mod tests {
         let result = enqueue_batch_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             100,
             200,
             test_retry_strategy(),
@@ -2050,6 +2465,7 @@ mod tests {
         let result = enqueue_batch_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             1,
             100,
             ExponentialBuilder::default().with_max_times(0),
@@ -2092,12 +2508,14 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
         push_tip_response(&asserter);
-
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         let result = enqueue_batch_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             100,
             150,
             test_retry_strategy(),
@@ -2155,12 +2573,14 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log1, take_log2])); // take events
         push_tip_response(&asserter);
-
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         let result = enqueue_batch_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             100,
             200,
             test_retry_strategy(),
@@ -2213,6 +2633,8 @@ mod tests {
                 asserter.push_success(&serde_json::json!([])); // take events
             }
             push_tip_response(&asserter);
+            asserter.push_success(&serde_json::json!([])); // inventory events
+            push_tip_response(&asserter);
         }
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
@@ -2220,6 +2642,7 @@ mod tests {
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             3000,
             test_retry_strategy(),
@@ -2256,13 +2679,15 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events (retry)
         push_tip_response(&asserter);
-
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         let start_time = std::time::Instant::now();
         let result = enqueue_batch_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             100,
             200,
             test_retry_strategy(),
@@ -2301,6 +2726,7 @@ mod tests {
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             50,
             test_retry_strategy(),
@@ -2381,12 +2807,14 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log])); // take events
         push_tip_response(&asserter);
-
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         let result = enqueue_batch_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             100,
             200,
             test_retry_strategy(),
@@ -2431,12 +2859,14 @@ mod tests {
         push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events for 50-100
         push_tip_response(&asserter);
-
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         backfill_events(
             &provider,
             &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
             &pool,
             100,
             test_retry_strategy(),
@@ -2446,5 +2876,949 @@ mod tests {
         .unwrap();
 
         assert_eq!(job_count(&apalis_pool).await, 0);
+    }
+
+    fn operator_deposit_log(
+        inventory: Address,
+        operator: Address,
+        token: Address,
+        amount: U256,
+        block_number: u64,
+        tx_hash: TxHash,
+        log_index: u64,
+    ) -> Log {
+        let event = OperatorDeposit {
+            operator,
+            token,
+            vaultId: B256::ZERO,
+            amount,
+        };
+
+        Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: event.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(block_number),
+            block_timestamp: None,
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(log_index),
+            removed: false,
+        }
+    }
+
+    fn operator_withdraw_log(
+        inventory: Address,
+        operator: Address,
+        token: Address,
+        amount: U256,
+        block_number: u64,
+        tx_hash: TxHash,
+        log_index: u64,
+    ) -> Log {
+        let event = OperatorWithdraw {
+            operator,
+            token,
+            vaultId: B256::ZERO,
+            amount,
+        };
+
+        Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: event.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(block_number),
+            block_timestamp: None,
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(log_index),
+            removed: false,
+        }
+    }
+
+    fn inventory_test_evm_ctx() -> EvmCtx {
+        EvmCtx {
+            rpc_url: Url::parse("http://localhost:8545").unwrap(),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            inventory: InventoryMode::Managed {
+                inventory: address!("0x2222222222222222222222222222222222222222"),
+            },
+            vault_owner: address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 1,
+            required_confirmations: 0,
+            ingestion_cutoff: IngestionCutoff::Safe,
+        }
+    }
+
+    /// A venue-driven settlement (operator != the bot) surfaces as one
+    /// `OperatorDeposit` + `OperatorWithdraw` pair on the same tx, which must
+    /// collapse into exactly one `InventoryTrade` job.
+    #[tokio::test]
+    async fn inventory_pair_enqueues_one_job() {
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let evm_ctx = inventory_test_evm_ctx();
+        let inventory = evm_ctx.inventory_address();
+
+        let venue_operator = address!("0x00000000000000000000000000000000000000a1");
+        let usdc = address!("0x00000000000000000000000000000000000000dc");
+        let equity = address!("0x00000000000000000000000000000000000000e9");
+        let tx_hash =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        let deposit_log = operator_deposit_log(
+            inventory,
+            venue_operator,
+            usdc,
+            uint!(1_000_000_U256),
+            50,
+            tx_hash,
+            0,
+        );
+        let withdraw_log = operator_withdraw_log(
+            inventory,
+            venue_operator,
+            equity,
+            uint!(9_000_000_000_000_000_000_U256),
+            50,
+            tx_hash,
+            1,
+        );
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([deposit_log, withdraw_log])); // inventory
+        push_tip_response(&asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let enqueued = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            1,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            enqueued, 1,
+            "one deposit+withdraw pair is one InventoryTrade"
+        );
+        assert_eq!(job_count(&apalis_pool).await, 1);
+    }
+
+    /// An `OperatorWithdraw` with no same-tx `OperatorDeposit` cannot form a
+    /// trade and must be dropped rather than enqueued.
+    #[tokio::test]
+    async fn unpaired_inventory_withdraw_is_skipped() {
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let evm_ctx = inventory_test_evm_ctx();
+        let inventory = evm_ctx.inventory_address();
+
+        let venue_operator = address!("0x00000000000000000000000000000000000000a1");
+        let equity = address!("0x00000000000000000000000000000000000000e9");
+        let tx_hash =
+            fixed_bytes!("0x3333333333333333333333333333333333333333333333333333333333333333");
+
+        let withdraw_log = operator_withdraw_log(
+            inventory,
+            venue_operator,
+            equity,
+            uint!(9_000_000_000_000_000_000_U256),
+            50,
+            tx_hash,
+            1,
+        );
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([withdraw_log])); // inventory
+        push_tip_response(&asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let enqueued = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            1,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(enqueued, 0, "an unpaired OperatorWithdraw enqueues nothing");
+        assert_eq!(job_count(&apalis_pool).await, 0);
+    }
+
+    /// A deposit+withdraw pair whose operator IS the bot's signing wallet is the
+    /// bot's own rebalancing (it also calls deposit4/withdraw4 on the
+    /// inventory), not a venue fill; it must be skipped entirely before pairing.
+    #[tokio::test]
+    async fn bot_operator_inventory_pair_is_skipped() {
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let evm_ctx = inventory_test_evm_ctx();
+        let inventory = evm_ctx.inventory_address();
+
+        let usdc = address!("0x00000000000000000000000000000000000000dc");
+        let equity = address!("0x00000000000000000000000000000000000000e9");
+        let tx_hash =
+            fixed_bytes!("0x4444444444444444444444444444444444444444444444444444444444444444");
+
+        let deposit_log = operator_deposit_log(
+            inventory,
+            TEST_BOT_OPERATOR,
+            usdc,
+            uint!(1_000_000_U256),
+            50,
+            tx_hash,
+            0,
+        );
+        let withdraw_log = operator_withdraw_log(
+            inventory,
+            TEST_BOT_OPERATOR,
+            equity,
+            uint!(9_000_000_000_000_000_000_U256),
+            50,
+            tx_hash,
+            1,
+        );
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([deposit_log, withdraw_log])); // inventory
+        push_tip_response(&asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let enqueued = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            1,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            enqueued, 0,
+            "the bot's own rebalancing deposit+withdraw must be skipped"
+        );
+        assert_eq!(job_count(&apalis_pool).await, 0);
+    }
+
+    /// A `removed: true` `OperatorDeposit` (a reorg) must be dropped during
+    /// bucketing rather than paired with its same-tx `OperatorWithdraw` --
+    /// mirroring `test_backfill_skips_removed_logs`'s ClearV3/TakeOrderV3
+    /// reorg-guard coverage, but for the inventory ingestion path.
+    #[tokio::test]
+    async fn removed_operator_deposit_is_dropped_and_leaves_withdraw_unpaired() {
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let evm_ctx = inventory_test_evm_ctx();
+        let inventory = evm_ctx.inventory_address();
+
+        let venue_operator = address!("0x00000000000000000000000000000000000000a1");
+        let usdc = address!("0x00000000000000000000000000000000000000dc");
+        let equity = address!("0x00000000000000000000000000000000000000e9");
+        let tx_hash =
+            fixed_bytes!("0x5555555555555555555555555555555555555555555555555555555555555555");
+
+        let mut deposit_log = operator_deposit_log(
+            inventory,
+            venue_operator,
+            usdc,
+            uint!(1_000_000_U256),
+            50,
+            tx_hash,
+            0,
+        );
+        deposit_log.removed = true;
+        let withdraw_log = operator_withdraw_log(
+            inventory,
+            venue_operator,
+            equity,
+            uint!(9_000_000_000_000_000_000_U256),
+            50,
+            tx_hash,
+            1,
+        );
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([deposit_log, withdraw_log])); // inventory
+        push_tip_response(&asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let enqueued = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            1,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            enqueued, 0,
+            "a removed OperatorDeposit must not be bucketed, leaving the withdraw unpaired"
+        );
+        assert_eq!(job_count(&apalis_pool).await, 0);
+    }
+
+    /// An inventory pair and a `TakeOrderV3` in the same batch must enqueue in
+    /// chronological `(block, log_index)` order: the inventory settlement at the
+    /// earlier block before the later take.
+    #[tokio::test]
+    async fn inventory_pair_and_take_order_enqueue_in_chronological_order() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let order = get_test_order();
+        let evm_ctx = inventory_test_evm_ctx();
+        let inventory = evm_ctx.inventory_address();
+
+        let venue_operator = address!("0x00000000000000000000000000000000000000a1");
+        let usdc = address!("0x00000000000000000000000000000000000000dc");
+        let equity = address!("0x00000000000000000000000000000000000000e9");
+        let inv_tx_hash =
+            fixed_bytes!("0x5555555555555555555555555555555555555555555555555555555555555555");
+        let take_tx_hash =
+            fixed_bytes!("0x6666666666666666666666666666666666666666666666666666666666666666");
+
+        // Inventory pair at block 50 (withdraw at log_index 3).
+        let deposit_log = operator_deposit_log(
+            inventory,
+            venue_operator,
+            usdc,
+            uint!(1_000_000_U256),
+            50,
+            inv_tx_hash,
+            2,
+        );
+        let withdraw_log = operator_withdraw_log(
+            inventory,
+            venue_operator,
+            equity,
+            uint!(9_000_000_000_000_000_000_U256),
+            50,
+            inv_tx_hash,
+            3,
+        );
+
+        // Take order at the later block 60 (log_index 1 via create_test_log).
+        let take_event = create_test_take_event(
+            &order,
+            uint!(100_000_000_U256),
+            uint!(9_000_000_000_000_000_000_U256),
+        );
+        let take_log = create_test_log(evm_ctx.orderbook, &take_event, 60, take_tx_hash);
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([take_log])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([deposit_log, withdraw_log])); // inventory
+        push_tip_response(&asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let enqueued = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            1,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(enqueued, 2, "one InventoryTrade plus one TakeOrderV3");
+
+        let payloads: Vec<Vec<u8>> = sqlx::query_scalar("SELECT job FROM Jobs ORDER BY rowid ASC")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        let enqueue_order: Vec<(u64, u64)> = payloads
+            .iter()
+            .map(|payload| {
+                let job: AccountForDexTrade = serde_json::from_slice(payload).unwrap();
+                (job.trade.block_number, job.trade.log_index)
+            })
+            .collect();
+
+        assert_eq!(
+            enqueue_order,
+            vec![(50, 3), (60, 1)],
+            "inventory settlement (block 50) must precede the take (block 60)"
+        );
+    }
+
+    /// Two `OperatorDeposit`s in the same tx make the settlement ambiguous:
+    /// `deposit4`/`withdraw4` are independent contract calls with no atomic
+    /// settle entrypoint pairing them, so there is no reliable way to know
+    /// which deposit the withdraw actually belongs to. The whole tx must be
+    /// quarantined -- no `InventoryTrade` job, and no silent mis-hedge from
+    /// guessing which amount is real.
+    #[tokio::test]
+    async fn duplicate_operator_deposit_in_one_tx_is_ambiguous_and_skipped() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let evm_ctx = inventory_test_evm_ctx();
+        let inventory = evm_ctx.inventory_address();
+
+        let venue_operator = address!("0x00000000000000000000000000000000000000a1");
+        let usdc = address!("0x00000000000000000000000000000000000000dc");
+        let equity = address!("0x00000000000000000000000000000000000000e9");
+        let tx_hash =
+            fixed_bytes!("0x7777777777777777777777777777777777777777777777777777777777777777");
+
+        let first_deposit_log = operator_deposit_log(
+            inventory,
+            venue_operator,
+            usdc,
+            uint!(1_000_000_U256),
+            50,
+            tx_hash,
+            0,
+        );
+        let second_deposit_log = operator_deposit_log(
+            inventory,
+            venue_operator,
+            usdc,
+            uint!(2_000_000_U256),
+            50,
+            tx_hash,
+            1,
+        );
+        let withdraw_log = operator_withdraw_log(
+            inventory,
+            venue_operator,
+            equity,
+            uint!(9_000_000_000_000_000_000_U256),
+            50,
+            tx_hash,
+            2,
+        );
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([
+            first_deposit_log,
+            second_deposit_log,
+            withdraw_log
+        ])); // inventory
+        push_tip_response(&asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let enqueued = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            1,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            enqueued, 0,
+            "an ambiguous multi-deposit settlement must not enqueue a hedge"
+        );
+        assert_eq!(job_count(&apalis_pool).await, 0);
+
+        let job_rows: Vec<Vec<u8>> = sqlx::query_scalar("SELECT job FROM Jobs")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert!(
+            job_rows.is_empty(),
+            "no InventoryTrade job may be built from an ambiguous settlement, \
+             even one carrying the second deposit's amount"
+        );
+    }
+
+    /// Two `OperatorWithdraw`s in the same tx are exactly as ambiguous as two
+    /// `OperatorDeposit`s (mirrors `duplicate_operator_deposit_in_one_tx_is_ambiguous_and_skipped`):
+    /// the single deposit could belong to either withdraw, so the whole tx
+    /// must be quarantined -- zero `InventoryTrade` jobs, not one built by
+    /// arbitrarily pairing the first withdraw encountered.
+    #[tokio::test]
+    async fn second_withdraw_in_one_tx_is_ambiguous_and_quarantined() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let evm_ctx = inventory_test_evm_ctx();
+        let inventory = evm_ctx.inventory_address();
+        let metrics_handle = crate::metrics::setup().expect("install test metrics recorder");
+
+        let venue_operator = address!("0x00000000000000000000000000000000000000a1");
+        let usdc = address!("0x00000000000000000000000000000000000000dc");
+        let equity = address!("0x00000000000000000000000000000000000000e9");
+        let tx_hash =
+            fixed_bytes!("0x8888888888888888888888888888888888888888888888888888888888888888");
+
+        let deposit_log = operator_deposit_log(
+            inventory,
+            venue_operator,
+            usdc,
+            uint!(1_000_000_U256),
+            50,
+            tx_hash,
+            0,
+        );
+        let first_withdraw_log = operator_withdraw_log(
+            inventory,
+            venue_operator,
+            equity,
+            uint!(9_000_000_000_000_000_000_U256),
+            50,
+            tx_hash,
+            1,
+        );
+        let second_withdraw_log = operator_withdraw_log(
+            inventory,
+            venue_operator,
+            equity,
+            uint!(3_000_000_000_000_000_000_U256),
+            50,
+            tx_hash,
+            2,
+        );
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([
+            deposit_log,
+            first_withdraw_log,
+            second_withdraw_log
+        ])); // inventory
+        push_tip_response(&asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let enqueued = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            1,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            enqueued, 0,
+            "an ambiguous multi-withdraw settlement must not enqueue a hedge"
+        );
+        assert_eq!(job_count(&apalis_pool).await, 0);
+
+        let job_rows: Vec<Vec<u8>> = sqlx::query_scalar("SELECT job FROM Jobs")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert!(
+            job_rows.is_empty(),
+            "no InventoryTrade job may be built from an ambiguous multi-withdraw settlement, \
+             even one carrying the first withdraw's amount"
+        );
+
+        let rendered = metrics_handle.render();
+        assert!(
+            rendered.contains("inventory_ambiguous_settlement_total"),
+            "the ambiguous-settlement counter must fire for a quarantined multi-withdraw tx, \
+             got:\n{rendered}"
+        );
+    }
+
+    /// A tx with exactly one `OperatorDeposit` and one `OperatorWithdraw` is
+    /// only unambiguous if both legs share the same `operator` -- a deposit
+    /// from operator A paired with an unrelated withdraw from operator B is
+    /// just as fabricated a vault delta as the multi-leg ambiguous cases
+    /// above, and must be quarantined the same way rather than hedged.
+    #[tokio::test]
+    async fn mismatched_operator_deposit_and_withdraw_is_ambiguous_and_quarantined() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let evm_ctx = inventory_test_evm_ctx();
+        let inventory = evm_ctx.inventory_address();
+        let metrics_handle = crate::metrics::setup().expect("install test metrics recorder");
+
+        let deposit_operator = address!("0x00000000000000000000000000000000000000a1");
+        let withdraw_operator = address!("0x00000000000000000000000000000000000000b2");
+        let usdc = address!("0x00000000000000000000000000000000000000dc");
+        let equity = address!("0x00000000000000000000000000000000000000e9");
+        let tx_hash =
+            fixed_bytes!("0x7777777777777777777777777777777777777777777777777777777777777777");
+
+        let deposit_log = operator_deposit_log(
+            inventory,
+            deposit_operator,
+            usdc,
+            uint!(1_000_000_U256),
+            50,
+            tx_hash,
+            0,
+        );
+        let withdraw_log = operator_withdraw_log(
+            inventory,
+            withdraw_operator,
+            equity,
+            uint!(9_000_000_000_000_000_000_U256),
+            50,
+            tx_hash,
+            1,
+        );
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([deposit_log, withdraw_log])); // inventory
+        push_tip_response(&asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let enqueued = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            1,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            enqueued, 0,
+            "a deposit and withdraw from different operators must not be paired into a hedge"
+        );
+        assert_eq!(job_count(&apalis_pool).await, 0);
+
+        let job_rows: Vec<Vec<u8>> = sqlx::query_scalar("SELECT job FROM Jobs")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert!(
+            job_rows.is_empty(),
+            "no InventoryTrade job may be built from a deposit/withdraw pair with mismatched \
+             operators"
+        );
+
+        let rendered = metrics_handle.render();
+        assert!(
+            rendered.contains("inventory_ambiguous_settlement_total"),
+            "the ambiguous-settlement counter must fire for a mismatched-operator tx, \
+             got:\n{rendered}"
+        );
+    }
+
+    /// An `OperatorDeposit` whose tx never surfaces a matching
+    /// `OperatorWithdraw` in the batch must not enqueue a trade; the
+    /// leftover deposit is dropped after the batch (with a `warn!`, see
+    /// `enqueue_batch_events`) rather than pairing against nothing.
+    #[tokio::test]
+    async fn unpaired_operator_deposit_enqueues_nothing() {
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let evm_ctx = inventory_test_evm_ctx();
+        let inventory = evm_ctx.inventory_address();
+
+        let venue_operator = address!("0x00000000000000000000000000000000000000a1");
+        let usdc = address!("0x00000000000000000000000000000000000000dc");
+        let tx_hash =
+            fixed_bytes!("0x9999999999999999999999999999999999999999999999999999999999999999");
+
+        let deposit_log = operator_deposit_log(
+            inventory,
+            venue_operator,
+            usdc,
+            uint!(1_000_000_U256),
+            50,
+            tx_hash,
+            0,
+        );
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([deposit_log])); // inventory
+        push_tip_response(&asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let enqueued = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            1,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(enqueued, 0, "an unpaired OperatorDeposit enqueues nothing");
+        assert_eq!(job_count(&apalis_pool).await, 0);
+    }
+
+    /// Real prod fill on Base mainnet (tx
+    /// 0xe13a11de734768f08a9c1ef66e8de3bcb9072f8cdabce9f1d819e1ae9909d4b9,
+    /// captured via `cast receipt <tx> --rpc-url https://mainnet.base.org`):
+    /// a Bebop-routed settlement against the shared RaindexInventory at
+    /// 0x6b7b523fadd1677413ad92c9404c8f0796bacf6f. Real vaultIds, real
+    /// USDC/wtCOIN token addresses, and real amounts drive the same
+    /// pairing/ingestion path the synthetic tests above exercise, pinning
+    /// the backfill logic against the contract's actual event shape.
+    #[tokio::test]
+    async fn real_bebop_settlement_pairs_and_enqueues_one_job() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let evm_ctx = inventory_test_evm_ctx();
+        let inventory = evm_ctx.inventory_address();
+
+        let operator = address!("0x8b8b6e0507c125934c6129563f48e48c66f86475");
+        let usdc = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+        let wtcoin = address!("0x5CdA0E1cA4ce2Af96315F7F8963c85399c172204");
+        let tx_hash =
+            fixed_bytes!("0xe13a11de734768f08a9c1ef66e8de3bcb9072f8cdabce9f1d819e1ae9909d4b9");
+
+        let deposit_event = OperatorDeposit {
+            operator,
+            token: usdc,
+            vaultId: fixed_bytes!(
+                "0x0000000000000000000000000000000000000000000000000000000000000004"
+            ),
+            amount: uint!(5_000_000_U256), // 5 USDC, 6 decimals
+        };
+        let withdraw_event = OperatorWithdraw {
+            operator,
+            token: wtcoin,
+            vaultId: fixed_bytes!(
+                "0x0000000000000000000000000000000000000000000000000000000000000003"
+            ),
+            amount: uint!(34_172_366_621_067_031_U256), // 0.034172366621067031 wtCOIN, 18 decimals
+        };
+
+        let deposit_log = Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: deposit_event.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(48_030_415),
+            block_timestamp: None,
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(0xa7),
+            removed: false,
+        };
+        let withdraw_log = Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: withdraw_event.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(48_030_415),
+            block_timestamp: None,
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(0x9b),
+            removed: false,
+        };
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([deposit_log, withdraw_log])); // inventory
+        push_tip_response(&asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let enqueued = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            48_030_415,
+            48_030_415,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            enqueued, 1,
+            "the real deposit+withdraw pair is one InventoryTrade"
+        );
+        assert_eq!(job_count(&apalis_pool).await, 1);
+
+        let payload: Vec<u8> = sqlx::query_scalar("SELECT job FROM Jobs ORDER BY rowid ASC")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let job: AccountForDexTrade = serde_json::from_slice(&payload).unwrap();
+        match &job.trade.event {
+            RaindexTradeEvent::InventoryTrade(inventory_trade) => {
+                assert_eq!(inventory_trade.deposit.token, usdc);
+                assert_eq!(inventory_trade.deposit.amount, uint!(5_000_000_U256));
+                assert_eq!(inventory_trade.withdraw.token, wtcoin);
+                assert_eq!(
+                    inventory_trade.withdraw.amount,
+                    uint!(34_172_366_621_067_031_U256)
+                );
+            }
+            other => panic!("expected InventoryTrade event, got {other:?}"),
+        }
+    }
+
+    /// Real prod fill on Base mainnet (tx
+    /// 0x9ee8e401a6f12227df1a30a236b60ac83c72b2b1eb610d83cf292ae789eb0805,
+    /// captured via `cast receipt <tx> --rpc-url https://mainnet.base.org`):
+    /// a univ4-routed settlement against the shared RaindexInventory,
+    /// mirroring the Bebop coverage above (`real_bebop_settlement_pairs_and_enqueues_one_job`)
+    /// but with equity on the deposit side (pool bought equity, hedges Buy).
+    #[tokio::test]
+    async fn real_univ4_settlement_pairs_and_enqueues_one_job() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let evm_ctx = inventory_test_evm_ctx();
+        let inventory = evm_ctx.inventory_address();
+
+        let operator = address!("0x36ebb1e5149c60111dd035f0417a4b00d39caa88");
+        let usdc = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+        let wtcoin = address!("0x5CdA0E1cA4ce2Af96315F7F8963c85399c172204");
+        let tx_hash =
+            fixed_bytes!("0x9ee8e401a6f12227df1a30a236b60ac83c72b2b1eb610d83cf292ae789eb0805");
+
+        let deposit_event = OperatorDeposit {
+            operator,
+            token: wtcoin,
+            vaultId: fixed_bytes!(
+                "0x0000000000000000000000000000000000000000000000000000000000000003"
+            ),
+            amount: uint!(10_000_000_000_000_000_U256), // 0.01 wtCOIN, 18 decimals
+        };
+        let withdraw_event = OperatorWithdraw {
+            operator,
+            token: usdc,
+            vaultId: fixed_bytes!(
+                "0x0000000000000000000000000000000000000000000000000000000000000004"
+            ),
+            amount: uint!(2_000_000_U256), // 2 USDC, 6 decimals
+        };
+
+        let deposit_log = Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: deposit_event.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(48_051_940),
+            block_timestamp: None,
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(0xe1),
+            removed: false,
+        };
+        let withdraw_log = Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: withdraw_event.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(48_051_940),
+            block_timestamp: None,
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(0xf4),
+            removed: false,
+        };
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([deposit_log, withdraw_log])); // inventory
+        push_tip_response(&asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let enqueued = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            48_051_940,
+            48_051_940,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            enqueued, 1,
+            "the real deposit+withdraw pair is one InventoryTrade"
+        );
+        assert_eq!(job_count(&apalis_pool).await, 1);
+
+        let payload: Vec<u8> = sqlx::query_scalar("SELECT job FROM Jobs ORDER BY rowid ASC")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let job: AccountForDexTrade = serde_json::from_slice(&payload).unwrap();
+        match &job.trade.event {
+            RaindexTradeEvent::InventoryTrade(inventory_trade) => {
+                assert_eq!(inventory_trade.deposit.token, wtcoin);
+                assert_eq!(
+                    inventory_trade.deposit.amount,
+                    uint!(10_000_000_000_000_000_U256)
+                );
+                assert_eq!(inventory_trade.withdraw.token, usdc);
+                assert_eq!(inventory_trade.withdraw.amount, uint!(2_000_000_U256));
+            }
+            other => panic!("expected InventoryTrade event, got {other:?}"),
+        }
     }
 }

--- a/src/onchain/io.rs
+++ b/src/onchain/io.rs
@@ -10,6 +10,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::str::FromStr;
 
+use alloy::primitives::Address;
 use rain_math_float::{Float, FloatError};
 use st0x_execution::{Direction, FractionalShares, Symbol};
 
@@ -144,20 +145,60 @@ impl<Form: TokenizationForm> FromStr for TokenizedSymbol<Form> {
     }
 }
 
+/// Distinguishes the input-side token address from the output-side token
+/// address in [`TradeDetails::try_from_io`]. Both sides are plain `Address`,
+/// so without this wrapper a positional swap at the call site would compile
+/// silently and misattribute the equity token to the wrong side of the trade.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InputToken(pub(crate) Address);
+
+/// See [`InputToken`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OutputToken(pub(crate) Address);
+
 /// Trade details extracted from symbol pair processing
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct TradeDetails {
-    ticker: Symbol,
+    equity_symbol: TokenizedSymbol<WrappedTokenizedShares>,
+    equity_token: Address,
+    usdc_token: Address,
     equity_amount: FractionalShares,
     usdc_amount: Usdc,
     direction: Direction,
 }
 
 impl TradeDetails {
-    /// Gets the ticker symbol
+    /// Gets the base ticker symbol (e.g. `AAPL`), derived from the wrapped
+    /// equity symbol.
     #[cfg(test)]
     pub(crate) fn ticker(&self) -> &Symbol {
-        &self.ticker
+        self.equity_symbol.base()
+    }
+
+    /// Gets the wrapped tokenized-equity symbol (e.g. `wtAAPL`). Used in
+    /// production by the `InventoryTrade` path to look up the configured
+    /// canonical derivative address for the resolved symbol.
+    pub(crate) fn equity_symbol(&self) -> &TokenizedSymbol<WrappedTokenizedShares> {
+        &self.equity_symbol
+    }
+
+    /// Consumes `self` and returns the wrapped tokenized-equity symbol
+    /// without cloning. For callers that already own a `TradeDetails` and
+    /// only need the other fields' `Copy` values (see `equity_token`,
+    /// `equity_amount`, `direction`), this avoids a heap-allocating clone of
+    /// the underlying `Symbol` string on every processed fill.
+    pub(crate) fn into_equity_symbol(self) -> TokenizedSymbol<WrappedTokenizedShares> {
+        self.equity_symbol
+    }
+
+    /// Gets the ERC20 address of the tokenized-equity side of the trade.
+    pub(crate) fn equity_token(&self) -> Address {
+        self.equity_token
+    }
+
+    /// Gets the ERC20 address of the USDC side of the trade.
+    pub(crate) fn usdc_token(&self) -> Address {
+        self.usdc_token
     }
 
     /// Gets the equity amount
@@ -179,21 +220,27 @@ impl TradeDetails {
     /// (wtTICKER), since Raindex orders always involve wrapped tokens.
     pub(crate) fn try_from_io(
         input_symbol: &str,
+        input_token: InputToken,
         input_amount: Float,
         output_symbol: &str,
+        output_token: OutputToken,
         output_amount: Float,
     ) -> Result<Self, OnChainError> {
-        let (ticker, direction) = determine_trade_details(input_symbol, output_symbol)?;
+        let InputToken(input_token) = input_token;
+        let OutputToken(output_token) = output_token;
+
+        let (equity_symbol, direction) = determine_trade_details(input_symbol, output_symbol)?;
 
         let is_wrapped_equity =
             |symbol: &str| TokenizedSymbol::<WrappedTokenizedShares>::parse(symbol).is_ok();
 
-        // Extract equity and USDC amounts based on which side is the tokenized equity
-        let (equity_amount_raw, usdc_amount_raw) =
+        // Extract the equity/USDC amounts and the equity/USDC token addresses
+        // based on which side is the tokenized equity.
+        let (equity_amount_raw, usdc_amount_raw, equity_token, usdc_token) =
             if input_symbol == "USDC" && is_wrapped_equity(output_symbol) {
-                (output_amount, input_amount)
+                (output_amount, input_amount, output_token, input_token)
             } else if output_symbol == "USDC" && is_wrapped_equity(input_symbol) {
-                (input_amount, output_amount)
+                (input_amount, output_amount, input_token, output_token)
             } else {
                 return Err(TradeValidationError::InvalidSymbolConfiguration(
                     input_symbol.to_string(),
@@ -228,7 +275,9 @@ impl TradeDetails {
             Usdc::new(truncate_to_dp(usdc_amount_raw, 6).map_err(TradeValidationError::Float)?)?;
 
         Ok(Self {
-            ticker,
+            equity_symbol,
+            equity_token,
+            usdc_token,
             equity_amount,
             usdc_amount,
             direction,
@@ -245,8 +294,8 @@ fn truncate_to_dp(value: Float, decimal_places: u8) -> Result<Float, FloatError>
     Float::from_fixed_decimal(fixed, decimal_places)
 }
 
-/// Determines onchain trade direction and ticker based on onchain
-/// symbol configuration.
+/// Determines onchain trade direction and the parsed tokenized-equity ticker
+/// based on onchain symbol configuration.
 ///
 /// If the on-chain order has USDC as input and a wrapped tokenized
 /// equity (wt prefix) as output, the order sold tokenized equity
@@ -254,17 +303,17 @@ fn truncate_to_dp(value: Float, decimal_places: u8) -> Result<Float, FloatError>
 fn determine_trade_details(
     onchain_input_symbol: &str,
     onchain_output_symbol: &str,
-) -> Result<(Symbol, Direction), OnChainError> {
+) -> Result<(TokenizedSymbol<WrappedTokenizedShares>, Direction), OnChainError> {
     if onchain_input_symbol == "USDC"
         && let Ok(equity) = TokenizedSymbol::<WrappedTokenizedShares>::parse(onchain_output_symbol)
     {
-        return Ok((equity.base().clone(), Direction::Sell));
+        return Ok((equity, Direction::Sell));
     }
 
     if onchain_output_symbol == "USDC"
         && let Ok(equity) = TokenizedSymbol::<WrappedTokenizedShares>::parse(onchain_input_symbol)
     {
-        return Ok((equity.base().clone(), Direction::Buy));
+        return Ok((equity, Direction::Buy));
     }
 
     Err(TradeValidationError::InvalidSymbolConfiguration(
@@ -276,8 +325,13 @@ fn determine_trade_details(
 
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::address;
+
     use super::*;
     use st0x_float_macro::float;
+
+    const USDC_TOKEN: Address = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    const EQUITY_TOKEN: Address = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
     #[test]
     fn test_tokenized_equity_symbol_parse() {
@@ -425,30 +479,30 @@ mod tests {
     #[test]
     fn test_determine_trade_details_usdc_to_wrapped() {
         let result = determine_trade_details("USDC", "wtAAPL").unwrap();
-        assert_eq!(result.0, symbol!("AAPL"));
+        assert_eq!(result.0.base(), &symbol!("AAPL"));
         assert_eq!(result.1, Direction::Sell);
 
         let result = determine_trade_details("USDC", "wtTSLA").unwrap();
-        assert_eq!(result.0, symbol!("TSLA"));
+        assert_eq!(result.0.base(), &symbol!("TSLA"));
         assert_eq!(result.1, Direction::Sell);
 
         let result = determine_trade_details("USDC", "wtGME").unwrap();
-        assert_eq!(result.0, symbol!("GME"));
+        assert_eq!(result.0.base(), &symbol!("GME"));
         assert_eq!(result.1, Direction::Sell);
     }
 
     #[test]
     fn test_determine_trade_details_wrapped_to_usdc() {
         let result = determine_trade_details("wtAAPL", "USDC").unwrap();
-        assert_eq!(result.0, symbol!("AAPL"));
+        assert_eq!(result.0.base(), &symbol!("AAPL"));
         assert_eq!(result.1, Direction::Buy);
 
         let result = determine_trade_details("wtTSLA", "USDC").unwrap();
-        assert_eq!(result.0, symbol!("TSLA"));
+        assert_eq!(result.0.base(), &symbol!("TSLA"));
         assert_eq!(result.1, Direction::Buy);
 
         let result = determine_trade_details("wtGME", "USDC").unwrap();
-        assert_eq!(result.0, symbol!("GME"));
+        assert_eq!(result.0.base(), &symbol!("GME"));
         assert_eq!(result.1, Direction::Buy);
     }
 
@@ -496,10 +550,20 @@ mod tests {
 
     #[test]
     fn test_trade_details_try_from_io_usdc_to_wrapped() {
-        let details =
-            TradeDetails::try_from_io("USDC", float!(100), "wtAAPL", float!(0.5)).unwrap();
+        let details = TradeDetails::try_from_io(
+            "USDC",
+            InputToken(USDC_TOKEN),
+            float!(100),
+            "wtAAPL",
+            OutputToken(EQUITY_TOKEN),
+            float!(0.5),
+        )
+        .unwrap();
 
         assert_eq!(details.ticker(), &symbol!("AAPL"));
+        assert_eq!(details.equity_symbol().to_string(), "wtAAPL");
+        // Equity is the output side here, so the equity token is the output token.
+        assert_eq!(details.equity_token(), EQUITY_TOKEN);
         assert!(details.equity_amount().inner().eq(float!(0.5)).unwrap());
         assert!(details.usdc_amount().value().eq(float!(100)).unwrap());
         assert_eq!(details.direction(), Direction::Sell);
@@ -507,10 +571,20 @@ mod tests {
 
     #[test]
     fn test_trade_details_try_from_io_wrapped_to_usdc() {
-        let details =
-            TradeDetails::try_from_io("wtAAPL", float!(0.5), "USDC", float!(100)).unwrap();
+        let details = TradeDetails::try_from_io(
+            "wtAAPL",
+            InputToken(EQUITY_TOKEN),
+            float!(0.5),
+            "USDC",
+            OutputToken(USDC_TOKEN),
+            float!(100),
+        )
+        .unwrap();
 
         assert_eq!(details.ticker(), &symbol!("AAPL"));
+        assert_eq!(details.equity_symbol().to_string(), "wtAAPL");
+        // Equity is the input side here, so the equity token is the input token.
+        assert_eq!(details.equity_token(), EQUITY_TOKEN);
         assert!(details.equity_amount().inner().eq(float!(0.5)).unwrap());
         assert!(details.usdc_amount().value().eq(float!(100)).unwrap());
         assert_eq!(details.direction(), Direction::Buy);
@@ -518,16 +592,30 @@ mod tests {
 
     #[test]
     fn test_trade_details_try_from_io_nvda() {
-        let details =
-            TradeDetails::try_from_io("USDC", float!(64.17), "wtNVDA", float!(0.374)).unwrap();
+        let details = TradeDetails::try_from_io(
+            "USDC",
+            InputToken(USDC_TOKEN),
+            float!(64.17),
+            "wtNVDA",
+            OutputToken(EQUITY_TOKEN),
+            float!(0.374),
+        )
+        .unwrap();
 
         assert_eq!(details.ticker(), &symbol!("NVDA"));
         assert!(details.equity_amount().inner().eq(float!(0.374)).unwrap());
         assert!(details.usdc_amount().value().eq(float!(64.17)).unwrap());
         assert_eq!(details.direction(), Direction::Sell);
 
-        let details =
-            TradeDetails::try_from_io("wtNVDA", float!(0.374), "USDC", float!(64.17)).unwrap();
+        let details = TradeDetails::try_from_io(
+            "wtNVDA",
+            InputToken(EQUITY_TOKEN),
+            float!(0.374),
+            "USDC",
+            OutputToken(USDC_TOKEN),
+            float!(64.17),
+        )
+        .unwrap();
 
         assert_eq!(details.ticker(), &symbol!("NVDA"));
         assert!(details.equity_amount().inner().eq(float!(0.374)).unwrap());
@@ -537,13 +625,27 @@ mod tests {
 
     #[test]
     fn test_trade_details_try_from_io_invalid_configurations() {
-        let result = TradeDetails::try_from_io("USDC", float!(100), "USDC", float!(100));
+        let result = TradeDetails::try_from_io(
+            "USDC",
+            InputToken(USDC_TOKEN),
+            float!(100),
+            "USDC",
+            OutputToken(USDC_TOKEN),
+            float!(100),
+        );
         assert!(matches!(
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::InvalidSymbolConfiguration(_, _))
         ));
 
-        let result = TradeDetails::try_from_io("BTC", float!(1), "ETH", float!(3000));
+        let result = TradeDetails::try_from_io(
+            "BTC",
+            InputToken(Address::ZERO),
+            float!(1),
+            "ETH",
+            OutputToken(Address::ZERO),
+            float!(3000),
+        );
         assert!(matches!(
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::InvalidSymbolConfiguration(_, _))
@@ -552,13 +654,27 @@ mod tests {
 
     #[test]
     fn test_trade_details_negative_amount_validation() {
-        let result = TradeDetails::try_from_io("USDC", float!(100), "wtAAPL", float!(-0.5));
+        let result = TradeDetails::try_from_io(
+            "USDC",
+            InputToken(USDC_TOKEN),
+            float!(100),
+            "wtAAPL",
+            OutputToken(EQUITY_TOKEN),
+            float!(-0.5),
+        );
         assert!(matches!(
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::NegativeShares(_))
         ));
 
-        let result = TradeDetails::try_from_io("USDC", float!(-100), "wtAAPL", float!(0.5));
+        let result = TradeDetails::try_from_io(
+            "USDC",
+            InputToken(USDC_TOKEN),
+            float!(-100),
+            "wtAAPL",
+            OutputToken(EQUITY_TOKEN),
+            float!(0.5),
+        );
         assert!(matches!(
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::NegativeUsdc(_))
@@ -597,8 +713,15 @@ mod tests {
     fn test_real_transaction_nvda_amount_extraction() {
         // Real transaction: 0.374 wtNVDA sold for 64.169234 USDC
         // Verifies equity vs USDC amounts are not swapped
-        let details =
-            TradeDetails::try_from_io("USDC", float!(64.169234), "wtNVDA", float!(0.374)).unwrap();
+        let details = TradeDetails::try_from_io(
+            "USDC",
+            InputToken(USDC_TOKEN),
+            float!(64.169234),
+            "wtNVDA",
+            OutputToken(EQUITY_TOKEN),
+            float!(0.374),
+        )
+        .unwrap();
 
         assert_eq!(details.ticker(), &symbol!("NVDA"));
         assert!(details.equity_amount().inner().eq(float!(0.374)).unwrap());
@@ -615,8 +738,15 @@ mod tests {
         let usdc_with_dust = float!(&"64.169234000001".to_string());
         let shares_with_dust = float!(&"0.374000000000000000001".to_string());
 
-        let details =
-            TradeDetails::try_from_io("USDC", usdc_with_dust, "wtNVDA", shares_with_dust).unwrap();
+        let details = TradeDetails::try_from_io(
+            "USDC",
+            InputToken(USDC_TOKEN),
+            usdc_with_dust,
+            "wtNVDA",
+            OutputToken(EQUITY_TOKEN),
+            shares_with_dust,
+        )
+        .unwrap();
 
         assert!(details.usdc_amount().value().eq(float!(64.169234)).unwrap());
         assert!(details.equity_amount().inner().eq(float!(0.374)).unwrap());
@@ -635,8 +765,10 @@ mod tests {
 
         let details = TradeDetails::try_from_io(
             "USDC",
+            InputToken(USDC_TOKEN),
             float!(&"34.645024000001".to_string()),
             "wtNVDA",
+            OutputToken(EQUITY_TOKEN),
             shares_with_dust,
         )
         .unwrap();
@@ -647,8 +779,15 @@ mod tests {
 
     #[test]
     fn test_edge_case_validation_very_small_amounts() {
-        let details =
-            TradeDetails::try_from_io("USDC", float!(0.01), "wtAAPL", float!(0.0001)).unwrap();
+        let details = TradeDetails::try_from_io(
+            "USDC",
+            InputToken(USDC_TOKEN),
+            float!(0.01),
+            "wtAAPL",
+            OutputToken(EQUITY_TOKEN),
+            float!(0.0001),
+        )
+        .unwrap();
         assert_eq!(details.ticker(), &symbol!("AAPL"));
         assert!(details.equity_amount().inner().eq(float!(0.0001)).unwrap());
         assert!(details.usdc_amount().value().eq(float!(0.01)).unwrap());
@@ -656,8 +795,15 @@ mod tests {
 
     #[test]
     fn test_edge_case_validation_very_large_amounts() {
-        let details =
-            TradeDetails::try_from_io("USDC", float!(1000000), "wtBRK", float!(100)).unwrap();
+        let details = TradeDetails::try_from_io(
+            "USDC",
+            InputToken(USDC_TOKEN),
+            float!(1000000),
+            "wtBRK",
+            OutputToken(EQUITY_TOKEN),
+            float!(100),
+        )
+        .unwrap();
         assert_eq!(details.ticker(), &symbol!("BRK"));
         assert!(details.equity_amount().inner().eq(float!(100)).unwrap());
         assert!(details.usdc_amount().value().eq(float!(1000000)).unwrap());
@@ -690,13 +836,27 @@ mod tests {
 
     #[test]
     fn test_trade_details_rejects_unwrapped_prefix() {
-        let result = TradeDetails::try_from_io("USDC", float!(100), "tAAPL", float!(0.5));
+        let result = TradeDetails::try_from_io(
+            "USDC",
+            InputToken(USDC_TOKEN),
+            float!(100),
+            "tAAPL",
+            OutputToken(EQUITY_TOKEN),
+            float!(0.5),
+        );
         assert!(matches!(
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::InvalidSymbolConfiguration(_, _))
         ));
 
-        let result = TradeDetails::try_from_io("tAAPL", float!(0.5), "USDC", float!(100));
+        let result = TradeDetails::try_from_io(
+            "tAAPL",
+            InputToken(EQUITY_TOKEN),
+            float!(0.5),
+            "USDC",
+            OutputToken(USDC_TOKEN),
+            float!(100),
+        );
         assert!(matches!(
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::InvalidSymbolConfiguration(_, _))

--- a/src/onchain/io.rs
+++ b/src/onchain/io.rs
@@ -327,8 +327,9 @@ fn determine_trade_details(
 mod tests {
     use alloy::primitives::address;
 
-    use super::*;
     use st0x_float_macro::float;
+
+    use super::*;
 
     const USDC_TOKEN: Address = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     const EQUITY_TOKEN: Address = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");

--- a/src/onchain/trade.rs
+++ b/src/onchain/trade.rs
@@ -8,30 +8,56 @@ use alloy::primitives::{Address, B256, TxHash, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::Log;
 use alloy::sol_types::SolEvent;
+use backon::{ExponentialBuilder, Retryable};
 use chrono::{DateTime, Utc};
 use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
-use st0x_config::EvmCtx;
-use st0x_evm::Evm;
+use st0x_config::{AssetsConfig, EvmCtx};
+use st0x_evm::{Evm, EvmError, IERC20, OpenChainErrorRegistry, USDC_BASE};
 use st0x_execution::{Direction, FractionalShares, HasZero, Symbol};
 use st0x_float_serde::format_float_with_fallback;
 use st0x_registry::SymbolCache;
 
 use super::pyth::{extract_pyth_price, raw_price_to_pyth_price};
+use crate::bindings::IRaindexInventory::{OperatorDeposit, OperatorWithdraw};
 use crate::bindings::IRaindexV6::{ClearV3, OrderV4, TakeOrderV3};
 use crate::onchain::OnChainError;
-use crate::onchain::io::{TokenizedSymbol, TradeDetails, Usdc, WrappedTokenizedShares};
+use crate::onchain::backfill::{bucket_inventory_logs, pair_inventory_settlements};
+use crate::onchain::io::{
+    InputToken, OutputToken, TokenizedSymbol, TradeDetails, Usdc, WrappedTokenizedShares,
+};
 use crate::onchain::pyth::PythFeedIds;
 use crate::onchain_trade::PythPrice;
 
-/// Onchain trade event emitted by the Raindex orderbook, wrapping either
-/// a `ClearV3` or `TakeOrderV3` payload for downstream processing.
+/// Onchain trade event feeding the hedge pipeline.
+///
+/// * `ClearV3` / `TakeOrderV3` -- direct Raindex clears against the orderbook.
+///   Emitted when a solver clears a Raindex order the bot owns; unchanged path.
+/// * `InventoryTrade` -- settlement through the shared `RaindexInventory` on
+///   behalf of a venue adapter (Bebop hook, univ4 hook, or any future venue
+///   holding `OPERATOR_ROLE`). Emitted as a pair of `OperatorWithdraw` +
+///   `OperatorDeposit` events on the same tx: the vault deltas ARE the trade,
+///   agnostic to which adapter routed it. The `operator` topic identifies the
+///   venue for attribution but is not used as a hedge signal.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RaindexTradeEvent {
     ClearV3(Box<ClearV3>),
     TakeOrderV3(Box<TakeOrderV3>),
+    InventoryTrade(Box<InventoryTrade>),
+}
+
+/// One venue-driven settlement against the shared inventory: the vault
+/// balances went down by `withdraw.amount` for `withdraw.token` and up by
+/// `deposit.amount` for `deposit.token`, both within the same tx. Direction
+/// is determined by which side is the equity token (non-USDC): a withdraw of
+/// the equity vault means the pool sent equity out (bot is now short) and a
+/// deposit means the pool received equity (bot is now long).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InventoryTrade {
+    pub deposit: OperatorDeposit,
+    pub withdraw: OperatorWithdraw,
 }
 
 impl RaindexTradeEvent {
@@ -39,9 +65,22 @@ impl RaindexTradeEvent {
         match self {
             Self::ClearV3(_) => "ClearV3",
             Self::TakeOrderV3(_) => "TakeOrderV3",
+            Self::InventoryTrade(_) => "InventoryTrade",
         }
     }
 }
+
+/// The bot's own signing wallet address. The bot's rebalancing also calls
+/// `deposit4`/`withdraw4` on the shared inventory (treasury moves, not venue
+/// fills), so `InventoryTrade` pairing must filter out any `OperatorDeposit`/
+/// `OperatorWithdraw` whose `operator` is this address. Distinct from the
+/// Raindex order/vault owner (`order_owner`/`vault_owner`) even though both
+/// are plain `Address` -- without this wrapper a positional swap at a call
+/// site (e.g. `OnchainTrade::try_from_tx_hash`) would compile silently and
+/// misattribute which legs are "the bot's own", the same risk `InputToken`/
+/// `OutputToken` guard against in `io.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BotOperator(pub(crate) Address);
 
 /// Information about a vault extracted from an order's IO specification.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -215,6 +254,114 @@ async fn enrich_with_pyth_price<P: Provider>(
     }
 }
 
+/// Number of retries for `fetch_inventory_token_decimals`'s `decimals()`
+/// call. Matches `SymbolCache::resolve_symbol`'s retry budget (which
+/// `resolve_inventory_token_symbol` inherits) so a single transient RPC blip
+/// on either introspection call gets the same bounded number of attempts
+/// before the fill is either hedged or genuinely skipped.
+pub(crate) const INVENTORY_TOKEN_DECIMALS_MAX_RETRIES: usize = 3;
+
+/// Classifies an `EvmError` from `InventoryTrade` token introspection
+/// (`decimals()`/`symbol()` on a venue-supplied token) into either a caught,
+/// skippable [`TradeValidationError::TokenIntrospectionFailed`] or a
+/// retryable [`OnChainError::Evm`].
+///
+/// `trade.deposit.token`/`trade.withdraw.token` come from `OperatorDeposit`/
+/// `OperatorWithdraw` events emitted by *any* `OPERATOR_ROLE` holder on the
+/// shared inventory (Bebop hook, univ4 hook, or any future venue) -- not the
+/// bot's own trusted order config. A non-standard token (reverts, has no
+/// code, or returns malformed data) is a genuine defect in that token and
+/// must not surface as an opaque `OnChainError::Evm`: `perform()` doesn't
+/// catch that variant, so apalis retries would exhaust and trip the
+/// conductor-wide fail-stop over a single misbehaving third-party token.
+///
+/// But `EvmError::Contract` is *also* produced for pure transport failures
+/// (connection reset, timeout) when no revert data could be decoded --
+/// `is_revert()` disambiguates by checking for actual on-chain revert data.
+/// A transient transport failure on an otherwise-fine, already-configured
+/// token must not permanently drop a legitimate fill: it is reclassified
+/// back to `OnChainError::Evm` so `perform()` leaves it uncaught and apalis
+/// retries with backoff, same as the trusted ClearV3/TakeOrderV3 path.
+/// `EvmError::AbiDecode` is treated as a genuine token defect (not
+/// transient): it means the token returned data that could not be decoded as
+/// the expected return type, e.g. a non-standard `decimals()`/`symbol()`
+/// implementation.
+fn classify_inventory_token_introspection_error(source: EvmError, token: Address) -> OnChainError {
+    if source.is_revert() || matches!(source, EvmError::AbiDecode(_)) {
+        OnChainError::Validation(TradeValidationError::TokenIntrospectionFailed {
+            token,
+            source: Box::new(source),
+        })
+    } else {
+        OnChainError::Evm(source)
+    }
+}
+
+/// Introspects an `InventoryTrade`-supplied token's `decimals()`, retrying a
+/// bounded number of times (matching `SymbolCache::resolve_symbol`'s retry
+/// budget) before classifying a persistent failure via
+/// [`classify_inventory_token_introspection_error`].
+async fn fetch_inventory_token_decimals<E: Evm>(
+    evm: &E,
+    token: Address,
+) -> Result<u8, OnChainError> {
+    (|| async {
+        evm.call::<OpenChainErrorRegistry, _>(token, IERC20::decimalsCall {})
+            .await
+    })
+    .retry(ExponentialBuilder::new().with_max_times(INVENTORY_TOKEN_DECIMALS_MAX_RETRIES))
+    .await
+    .map_err(|source| classify_inventory_token_introspection_error(source, token))
+}
+
+/// Resolves an `InventoryTrade`-supplied token's symbol (`SymbolCache::resolve_symbol`
+/// already retries internally), classifying a persistent failure via
+/// [`classify_inventory_token_introspection_error`] for the same reason as
+/// [`fetch_inventory_token_decimals`].
+async fn resolve_inventory_token_symbol<E: Evm>(
+    cache: &SymbolCache,
+    evm: &E,
+    token: Address,
+) -> Result<String, OnChainError> {
+    cache
+        .resolve_symbol(evm, token)
+        .await
+        .map_err(|source| classify_inventory_token_introspection_error(source, token))
+}
+
+/// Gas/price/block-number metadata derived from a transaction receipt, used
+/// by both `OnchainTrade` constructors to fill in `TradeMetadata`. Also lets
+/// a caller that already fetched the receipt (the `process-tx` recovery
+/// path) pass it into `try_from_inventory_trade` instead of triggering a
+/// second `eth_getTransactionReceipt` for the same tx.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ReceiptMetadata {
+    gas_used: Option<u64>,
+    effective_gas_price: Option<u128>,
+    block_number: Option<u64>,
+}
+
+/// Fetches the triggering transaction's gas/price/block-number metadata,
+/// tolerating a missing receipt (all `None`) rather than failing the trade.
+/// Shared by both `OnchainTrade` constructors.
+async fn fetch_receipt_metadata<P: Provider>(
+    provider: &P,
+    tx_hash: TxHash,
+) -> Result<ReceiptMetadata, OnChainError> {
+    Ok(match provider.get_transaction_receipt(tx_hash).await? {
+        Some(receipt) => ReceiptMetadata {
+            gas_used: Some(receipt.gas_used),
+            effective_gas_price: Some(receipt.effective_gas_price),
+            block_number: receipt.block_number,
+        },
+        None => ReceiptMetadata {
+            gas_used: None,
+            effective_gas_price: None,
+            block_number: None,
+        },
+    })
+}
+
 impl OnchainTrade {
     /// Core parsing logic for converting blockchain events to trades
     pub(crate) async fn try_from_order_and_fill_details<EvmImpl: Evm>(
@@ -228,15 +375,11 @@ impl OnchainTrade {
         let tx_hash = log.transaction_hash.ok_or(TradeValidationError::NoTxHash)?;
         let log_index = log.log_index.ok_or(TradeValidationError::NoLogIndex)?;
 
-        let receipt = evm.provider().get_transaction_receipt(tx_hash).await?;
-        let (gas_used, effective_gas_price, receipt_block_number) = match receipt {
-            Some(receipt) => (
-                Some(receipt.gas_used),
-                Some(receipt.effective_gas_price),
-                receipt.block_number,
-            ),
-            None => (None, None, None),
-        };
+        let ReceiptMetadata {
+            gas_used,
+            effective_gas_price,
+            block_number: receipt_block_number,
+        } = fetch_receipt_metadata(evm.provider(), tx_hash).await?;
 
         let input = order
             .validInputs
@@ -248,6 +391,10 @@ impl OnchainTrade {
             .get(fill.output_index)
             .ok_or(TradeValidationError::NoOutputAtIndex(fill.output_index))?;
 
+        // ClearV3/TakeOrderV3 fill amounts are already rain-Float-encoded by the
+        // orderbook, so they decode straight off the raw bytes -- contrast with
+        // `try_from_inventory_trade` below, whose `amount` fields are raw
+        // fixed-decimal token integers.
         let onchain_input_amount = Float::from_raw(fill.input_amount);
 
         let onchain_output_amount = Float::from_raw(fill.output_amount);
@@ -260,81 +407,155 @@ impl OnchainTrade {
         // Use centralized TradeDetails::try_from_io to extract all trade data consistently
         let trade_details = TradeDetails::try_from_io(
             &onchain_input_symbol,
+            InputToken(input.token),
             onchain_input_amount,
             &onchain_output_symbol,
+            OutputToken(output.token),
             onchain_output_amount,
         )?;
 
-        if trade_details.equity_amount().is_zero()? {
-            debug!(
-                target: "hedge",
-                %tx_hash,
-                log_index,
-                "Skipping fill with zero equity amount; not a tokenized-equity trade"
-            );
-            return Ok(None);
-        }
-
-        // Calculate price per share in USDC (always USDC amount / equity amount)
-        let price_per_share_usdc =
-            (trade_details.usdc_amount().value() / trade_details.equity_amount().inner())?;
-
-        // Equity is non-zero (checked above), so a non-positive price is a real
-        // equity movement we cannot price. Reject it rather than silently dropping
-        // it, which would leave the resulting position unhedged.
-        if price_per_share_usdc.lt(Float::zero()?)? || price_per_share_usdc.is_zero()? {
-            return Err(TradeValidationError::NonPositivePrice(price_per_share_usdc).into());
-        }
-
-        let (equity_symbol_str, equity_token) = if onchain_input_symbol == "USDC" {
-            (onchain_output_symbol, output.token)
-        } else {
-            (onchain_input_symbol, input.token)
-        };
-        let equity_symbol = TokenizedSymbol::<WrappedTokenizedShares>::parse(&equity_symbol_str)?;
-
-        let block_number = log.block_number.or(receipt_block_number);
-        let block_timestamp =
-            resolve_block_timestamp(evm.provider(), log.block_timestamp, block_number).await?;
-
-        let pyth_price = enrich_with_pyth_price(
+        finalize_onchain_trade(
             evm.provider(),
             pyth_feed_ids,
-            equity_symbol.base(),
-            block_number,
-            tx_hash,
+            trade_details,
+            TradeMetadata {
+                tx_hash,
+                log_index,
+                gas_used,
+                effective_gas_price,
+                block_number: log.block_number.or(receipt_block_number),
+                log_timestamp: log.block_timestamp,
+            },
         )
-        .await;
+        .await
+    }
 
-        let price = Usdc::new(price_per_share_usdc)?;
+    /// Converts a paired [`InventoryTrade`] (an `OperatorDeposit` +
+    /// `OperatorWithdraw` for the same tx on the shared inventory) into an
+    /// [`OnchainTrade`] the hedge pipeline can consume.
+    ///
+    /// The pool received `deposit.amount` of `deposit.token` and sent
+    /// `withdraw.amount` of `withdraw.token` out. One side must be USDC and
+    /// the other a tokenized-equity ERC20; anything else fails validation the
+    /// same way a mis-shaped Raindex clear would. Both leg addresses are also
+    /// validated against `assets`' configured canonical addresses -- see
+    /// [`validate_inventory_token_addresses`].
+    ///
+    /// `receipt_metadata`: `None` fetches the tx receipt internally (the
+    /// batch backfill/live-monitor path, which has no receipt in hand yet);
+    /// `Some` reuses a receipt the caller already fetched (the `process-tx`
+    /// recovery path via `try_from_tx_hash`), avoiding a second
+    /// `eth_getTransactionReceipt` round-trip for the same tx.
+    pub(crate) async fn try_from_inventory_trade<EvmImpl: Evm>(
+        cache: &SymbolCache,
+        evm: &EvmImpl,
+        assets: &AssetsConfig,
+        trade: &InventoryTrade,
+        log: Log,
+        pyth_feed_ids: &PythFeedIds,
+        receipt_metadata: Option<ReceiptMetadata>,
+    ) -> Result<Option<Self>, OnChainError> {
+        let tx_hash = log.transaction_hash.ok_or(TradeValidationError::NoTxHash)?;
+        let log_index = log.log_index.ok_or(TradeValidationError::NoLogIndex)?;
 
-        let trade = Self {
-            tx_hash,
-            log_index,
-            symbol: equity_symbol,
-            equity_token,
-            amount: trade_details.equity_amount(),
-            direction: trade_details.direction(),
-            price,
-            block_timestamp,
-            block_number,
+        let ReceiptMetadata {
             gas_used,
             effective_gas_price,
-            pyth_price,
+            block_number: receipt_block_number,
+        } = match receipt_metadata {
+            Some(metadata) => metadata,
+            None => fetch_receipt_metadata(evm.provider(), tx_hash).await?,
         };
 
-        Ok(Some(trade))
+        // Deposit is IN (pool received), Withdraw is OUT (pool sent) --
+        // mirroring the input/output convention `TradeDetails::try_from_io`
+        // expects for the ClearV3/TakeOrderV3 path. Both sides are
+        // externally-supplied token addresses (any OPERATOR_ROLE holder), so
+        // introspection failures are mapped to `TokenIntrospectionFailed`
+        // rather than left as an opaque `OnChainError::Evm`. Symbol
+        // resolution and decimals introspection are independent RPC calls
+        // (decimals does not depend on the resolved symbol), so all four run
+        // in a single concurrent batch rather than two sequential waves.
+        let (input_symbol, output_symbol, deposit_decimals, withdraw_decimals) = tokio::try_join!(
+            resolve_inventory_token_symbol(cache, evm, trade.deposit.token),
+            resolve_inventory_token_symbol(cache, evm, trade.withdraw.token),
+            fetch_inventory_token_decimals(evm, trade.deposit.token),
+            fetch_inventory_token_decimals(evm, trade.withdraw.token),
+        )?;
+
+        // `from_fixed_decimal` reverts on a coefficient/exponent that cannot
+        // be losslessly represented as a rain-math-float value (e.g. an
+        // extreme raw amount from a misbehaving venue). Reclassified into
+        // `InvalidInventoryAmount` rather than the top-level
+        // `OnChainError::FloatConversion` `?` would otherwise resolve to, so
+        // `perform()` can skip this fill instead of fail-stopping.
+        //
+        // Unlike the ClearV3/TakeOrderV3 path's `Float::from_raw` above,
+        // `OperatorDeposit`/`OperatorWithdraw` amounts are raw fixed-decimal
+        // token integers, not rain-Float-encoded values: RaindexInventory.sol
+        // emits `OperatorWithdraw.amount` as the raw ERC20 `balanceOf` delta,
+        // and `OperatorDeposit.amount` as `_fromFloat(depositAmount, token)`,
+        // i.e. `depositAmount.toFixedDecimalLossy(IERC20Metadata(token).decimals())`.
+        // So both sides must be scaled back to `Float` via the token's onchain
+        // `decimals()` rather than decoded straight off the raw bytes.
+        let input_amount = Float::from_fixed_decimal(trade.deposit.amount, deposit_decimals)
+            .map_err(TradeValidationError::InvalidInventoryAmount)?;
+        let output_amount = Float::from_fixed_decimal(trade.withdraw.amount, withdraw_decimals)
+            .map_err(TradeValidationError::InvalidInventoryAmount)?;
+
+        // `try_from_io` is shared with the trusted ClearV3/TakeOrderV3 path
+        // (`try_from_order_and_fill_details` above, which calls it directly
+        // and leaves its Float-conversion failures uncaught by `perform()` --
+        // there they come from the bot's own trusted order config, so such a
+        // failure indicates a real bug worth fail-stopping on). Here the
+        // amounts are externally supplied, so reclassify only the
+        // Float-conversion failures into the caught `InvalidInventoryAmount`
+        // variant; everything else (e.g. `InvalidSymbolConfiguration`) passes
+        // through unchanged.
+        let trade_details = TradeDetails::try_from_io(
+            &input_symbol,
+            InputToken(trade.deposit.token),
+            input_amount,
+            &output_symbol,
+            OutputToken(trade.withdraw.token),
+            output_amount,
+        )
+        .map_err(reclassify_inventory_float_error)?;
+
+        validate_inventory_token_addresses(assets, &trade_details)?;
+
+        finalize_onchain_trade(
+            evm.provider(),
+            pyth_feed_ids,
+            trade_details,
+            TradeMetadata {
+                tx_hash,
+                log_index,
+                gas_used,
+                effective_gas_price,
+                block_number: log.block_number.or(receipt_block_number),
+                log_timestamp: log.block_timestamp,
+            },
+        )
+        .await
     }
 
     /// Attempts to create an OnchainTrade from a transaction hash by looking up
-    /// the transaction receipt and parsing relevant orderbook events.
+    /// the transaction receipt and parsing relevant orderbook or inventory
+    /// events. Tries `ClearV3`/`TakeOrderV3` orderbook fills first; if none
+    /// match, falls back to an `OperatorDeposit`/`OperatorWithdraw`
+    /// `InventoryTrade` settlement, paired via the same [`bucket_inventory_logs`]
+    /// rules the backfill path uses -- so the manual `process-tx` recovery
+    /// path can recover both fill sources this bot hedges.
     pub async fn try_from_tx_hash<EvmImpl: Evm>(
         tx_hash: TxHash,
         evm: &EvmImpl,
         cache: &SymbolCache,
         ctx: &EvmCtx,
+        assets: &AssetsConfig,
         pyth_feed_ids: &PythFeedIds,
         order_owner: Address,
+        bot_operator: BotOperator,
     ) -> Result<Option<Self>, OnChainError> {
         let receipt = evm
             .provider()
@@ -344,9 +565,9 @@ impl OnchainTrade {
                 OnChainError::Validation(TradeValidationError::TransactionNotFound(tx_hash))
             })?;
 
-        let trades: Vec<_> = receipt
-            .inner
-            .logs()
+        let logs = receipt.inner.logs();
+
+        let trades: Vec<_> = logs
             .iter()
             .filter(|log| {
                 (log.topic0() == Some(&ClearV3::SIGNATURE_HASH)
@@ -372,8 +593,248 @@ impl OnchainTrade {
             }
         }
 
-        Ok(None)
+        // The receipt is already in hand here, so pass its gas/price/block
+        // metadata through instead of letting `try_from_inventory_trade`
+        // re-fetch the same receipt via a second `eth_getTransactionReceipt`.
+        let receipt_metadata = ReceiptMetadata {
+            gas_used: Some(receipt.gas_used),
+            effective_gas_price: Some(receipt.effective_gas_price),
+            block_number: receipt.block_number,
+        };
+        let recovery_config = InventoryRecoveryConfig {
+            cache,
+            evm_ctx: ctx,
+            assets,
+            pyth_feed_ids,
+        };
+
+        Self::try_inventory_trade_from_receipt_logs(
+            tx_hash,
+            evm,
+            &recovery_config,
+            bot_operator,
+            logs,
+            receipt_metadata,
+        )
+        .await
     }
+
+    /// Fallback half of [`Self::try_from_tx_hash`]: looks for an
+    /// `OperatorDeposit`/`OperatorWithdraw` pair emitted by the shared
+    /// inventory among the receipt's logs, using the exact same
+    /// [`bucket_inventory_logs`]/[`pair_inventory_settlements`]
+    /// pairing/quarantine rules as backfill -- an ambiguous multi-deposit or
+    /// multi-withdraw settlement is quarantined here identically, never
+    /// resolved by picking an arbitrary "first match".
+    async fn try_inventory_trade_from_receipt_logs<EvmImpl: Evm>(
+        tx_hash: TxHash,
+        evm: &EvmImpl,
+        config: &InventoryRecoveryConfig<'_>,
+        bot_operator: BotOperator,
+        logs: &[Log],
+        receipt_metadata: ReceiptMetadata,
+    ) -> Result<Option<Self>, OnChainError> {
+        let inventory_logs: Vec<Log> = logs
+            .iter()
+            .filter(|log| {
+                log.address() == config.evm_ctx.inventory_address()
+                    && (log.topic0() == Some(&OperatorDeposit::SIGNATURE_HASH)
+                        || log.topic0() == Some(&OperatorWithdraw::SIGNATURE_HASH))
+            })
+            .cloned()
+            .collect();
+
+        if inventory_logs.is_empty() {
+            return Ok(None);
+        }
+
+        let (deposits_by_tx, withdraws_by_tx) = bucket_inventory_logs(inventory_logs, bot_operator);
+        // All logs above share `tx_hash` (filtered from a single receipt), so
+        // this pairs into at most one `InventoryTrade`; a quarantined or
+        // unpaired settlement surfaces as an empty result here, already
+        // logged/counted by `pair_inventory_settlements`.
+        let paired = pair_inventory_settlements(deposits_by_tx, withdraws_by_tx);
+
+        let Some((RaindexTradeEvent::InventoryTrade(inv), withdraw_log)) =
+            paired.into_iter().next()
+        else {
+            debug!(
+                target: "hedge",
+                %tx_hash,
+                "No pairable OperatorDeposit/OperatorWithdraw settlement in this tx; see \
+                 prior inventory warnings/errors for the reason",
+            );
+            return Ok(None);
+        };
+
+        Self::try_from_inventory_trade(
+            config.cache,
+            evm,
+            config.assets,
+            &inv,
+            withdraw_log,
+            config.pyth_feed_ids,
+            Some(receipt_metadata),
+        )
+        .await
+    }
+}
+
+/// Read-only config bundled for [`OnchainTrade::try_inventory_trade_from_receipt_logs`],
+/// keeping its argument count under the clippy threshold.
+struct InventoryRecoveryConfig<'config> {
+    cache: &'config SymbolCache,
+    evm_ctx: &'config EvmCtx,
+    assets: &'config AssetsConfig,
+    pyth_feed_ids: &'config PythFeedIds,
+}
+
+/// Reclassifies a Float-conversion failure surfaced by the shared
+/// `TradeDetails::try_from_io` into [`TradeValidationError::InvalidInventoryAmount`]
+/// so `perform()` can skip the fill instead of fail-stopping. Only called
+/// from [`OnchainTrade::try_from_inventory_trade`] -- the ClearV3/TakeOrderV3
+/// path calls `try_from_io` directly and leaves these variants uncaught,
+/// since a Float-conversion failure there comes from the bot's own trusted
+/// order config and indicates a real bug rather than an external anomaly.
+/// Any other error (e.g. `InvalidSymbolConfiguration`) passes through
+/// unchanged.
+fn reclassify_inventory_float_error(error: OnChainError) -> OnChainError {
+    match error {
+        OnChainError::Validation(TradeValidationError::Float(float_error))
+        | OnChainError::FloatConversion(float_error) => {
+            OnChainError::Validation(TradeValidationError::InvalidInventoryAmount(float_error))
+        }
+        other => other,
+    }
+}
+
+/// Validates that an `InventoryTrade`'s USDC and equity leg addresses match
+/// this bot's configured canonical addresses, not just their self-reported
+/// `symbol()`.
+///
+/// Unlike ClearV3/TakeOrderV3 (whose token addresses come from the bot's own
+/// trusted order config), `InventoryTrade` legs are supplied by any
+/// `OPERATOR_ROLE` holder on the shared inventory (Bebop hook, univ4 hook, or
+/// any future venue adapter). A compromised or buggy adapter could deploy a
+/// spoof token whose `symbol()` returns "USDC" or "wt<SYMBOL>" without being
+/// the real thing -- `TradeDetails::try_from_io`'s symbol-only classification
+/// would accept it, causing the bot to hedge (and, on a withdraw, pay out of
+/// the shared vault against) a fabricated leg. Only called from the
+/// `InventoryTrade` path; the trusted ClearV3/TakeOrderV3 path never needs
+/// this since its token addresses already come from the bot's own orders.
+fn validate_inventory_token_addresses(
+    assets: &AssetsConfig,
+    trade_details: &TradeDetails,
+) -> Result<(), TradeValidationError> {
+    let usdc_token = trade_details.usdc_token();
+    if usdc_token != USDC_BASE {
+        return Err(TradeValidationError::UnrecognizedInventoryToken {
+            token: usdc_token,
+            claimed_symbol: "USDC".to_string(),
+        });
+    }
+
+    let equity_symbol = trade_details.equity_symbol();
+    let equity_token = trade_details.equity_token();
+    let configured_derivative = assets
+        .equities
+        .symbols
+        .get(equity_symbol.base())
+        .map(|equity| equity.tokenized_equity_derivative);
+
+    if configured_derivative != Some(equity_token) {
+        return Err(TradeValidationError::UnrecognizedInventoryToken {
+            token: equity_token,
+            claimed_symbol: equity_symbol.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Metadata derived from the triggering log and its transaction receipt,
+/// needed by [`finalize_onchain_trade`] to finish constructing an
+/// [`OnchainTrade`] once `TradeDetails` has been resolved.
+struct TradeMetadata {
+    tx_hash: TxHash,
+    log_index: u64,
+    gas_used: Option<u64>,
+    effective_gas_price: Option<u128>,
+    block_number: Option<u64>,
+    log_timestamp: Option<u64>,
+}
+
+/// Shared tail of `try_from_order_and_fill_details` and
+/// `try_from_inventory_trade`: validates the resolved `TradeDetails`, prices
+/// the fill, resolves the block timestamp, and enriches with Pyth.
+async fn finalize_onchain_trade<P: Provider>(
+    provider: &P,
+    pyth_feed_ids: &PythFeedIds,
+    trade_details: TradeDetails,
+    metadata: TradeMetadata,
+) -> Result<Option<OnchainTrade>, OnChainError> {
+    let TradeMetadata {
+        tx_hash,
+        log_index,
+        gas_used,
+        effective_gas_price,
+        block_number,
+        log_timestamp,
+    } = metadata;
+
+    if trade_details.equity_amount().is_zero()? {
+        debug!(
+            target: "hedge",
+            %tx_hash,
+            log_index,
+            "Skipping trade with zero equity amount; not a tokenized-equity trade"
+        );
+        return Ok(None);
+    }
+
+    // Calculate price per share in USDC (always USDC amount / equity amount)
+    let price_per_share_usdc =
+        (trade_details.usdc_amount().value() / trade_details.equity_amount().inner())?;
+
+    // Equity is non-zero (checked above), so a non-positive price is a real
+    // equity movement we cannot price. Reject it rather than silently dropping
+    // it, which would leave the resulting position unhedged.
+    if price_per_share_usdc.lt(Float::zero()?)? || price_per_share_usdc.is_zero()? {
+        return Err(TradeValidationError::NonPositivePrice(price_per_share_usdc).into());
+    }
+
+    let equity_token = trade_details.equity_token();
+    let equity_amount = trade_details.equity_amount();
+    let direction = trade_details.direction();
+    let equity_symbol = trade_details.into_equity_symbol();
+
+    let block_timestamp = resolve_block_timestamp(provider, log_timestamp, block_number).await?;
+
+    let pyth_price = enrich_with_pyth_price(
+        provider,
+        pyth_feed_ids,
+        equity_symbol.base(),
+        block_number,
+        tx_hash,
+    )
+    .await;
+
+    let price = Usdc::new(price_per_share_usdc)?;
+
+    Ok(Some(OnchainTrade {
+        tx_hash,
+        log_index,
+        symbol: equity_symbol,
+        equity_token,
+        amount: equity_amount,
+        direction,
+        price,
+        block_timestamp,
+        block_number,
+        gas_used,
+        effective_gas_price,
+        pyth_price,
+    }))
 }
 
 #[derive(Debug)]
@@ -519,19 +980,56 @@ pub(crate) enum TradeValidationError {
          (must have 't' or 'wt' prefix, e.g. tAAPL, wtCOIN)"
     )]
     NotTokenizedEquity { symbol_provided: String },
+    /// Symbol/decimals introspection failed for a token supplied by an
+    /// `InventoryTrade` settlement (`OperatorDeposit`/`OperatorWithdraw`).
+    /// Unlike ClearV3/TakeOrderV3, whose token addresses come from the bot's
+    /// own trusted order config, these addresses come from any `OPERATOR_ROLE`
+    /// holder on the shared inventory -- a non-standard or misconfigured
+    /// third-party token must not trip the conductor-wide fail-stop.
+    #[error("Failed to introspect InventoryTrade token {token}: {source}")]
+    TokenIntrospectionFailed {
+        token: Address,
+        #[source]
+        source: Box<EvmError>,
+    },
+    /// A fixed-decimal amount/decimals conversion failed for an
+    /// `InventoryTrade`-supplied deposit or withdraw amount. Same threat
+    /// model as `TokenIntrospectionFailed`: `OperatorDeposit`/
+    /// `OperatorWithdraw` amounts come from any `OPERATOR_ROLE` holder, not
+    /// the bot's own trusted order config, so a malformed or extreme
+    /// amount/decimals pair must not trip the conductor-wide fail-stop.
+    #[error("Failed to convert InventoryTrade amount: {0}")]
+    InvalidInventoryAmount(#[source] FloatError),
+    /// An `InventoryTrade` leg's token address does not match the configured
+    /// canonical address for the symbol its `symbol()` claims to be. Unlike
+    /// ClearV3/TakeOrderV3, whose token addresses come from the bot's own
+    /// trusted order config, these addresses come from any `OPERATOR_ROLE`
+    /// holder on the shared inventory -- a spoofed or misconfigured token
+    /// must not trip the conductor-wide fail-stop.
+    #[error(
+        "InventoryTrade token {token} claims symbol '{claimed_symbol}' but does not match \
+         the configured canonical address for that symbol"
+    )]
+    UnrecognizedInventoryToken {
+        token: Address,
+        claimed_symbol: String,
+    },
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
-    use alloy::primitives::{Address, Bytes, U256, address, b256, fixed_bytes, uint};
+    use alloy::primitives::{Address, Bytes, IntoLogData, U256, address, b256, fixed_bytes, uint};
     use alloy::providers::{ProviderBuilder, mock::Asserter};
     use alloy::rpc::types::{Block, Transaction};
     use alloy::sol_types::SolCall;
     use rain_math_float::Float;
 
-    use st0x_config::{EvmCtx, IngestionCutoff, InventoryMode};
+    use st0x_config::{
+        EquitiesConfig, EquityAssetConfig, EvmCtx, IngestionCutoff, InventoryMode, OperationMode,
+    };
+    use st0x_evm::IERC20::decimalsCall;
     use st0x_evm::IPyth::getPriceUnsafeCall;
     use st0x_evm::PythStructs::Price;
     use st0x_evm::ReadOnlyEvm;
@@ -540,6 +1038,7 @@ mod tests {
 
     use super::*;
     use crate::bindings::IRaindexV6;
+    use crate::test_utils::panic_revert_payload;
 
     #[tokio::test]
     async fn resolve_block_timestamp_fetches_header_when_log_timestamp_missing() {
@@ -891,8 +1390,10 @@ mod tests {
             &ReadOnlyEvm::new(provider),
             &cache,
             &ctx,
+            &AssetsConfig::default(),
             &pyth_feed_ids,
             Address::ZERO,
+            BotOperator(Address::ZERO),
         )
         .await;
 
@@ -900,6 +1401,357 @@ mod tests {
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::TransactionNotFound(_))
         ));
+    }
+
+    /// `try_from_tx_hash` must recover an `InventoryTrade` settlement (no
+    /// `ClearV3`/`TakeOrderV3` in the receipt) by pairing the receipt's
+    /// `OperatorDeposit`/`OperatorWithdraw` logs -- the manual `process-tx`
+    /// recovery path must support this fill source, not just orderbook
+    /// clears. Reuses the real Bebop-routed prod settlement fixture also
+    /// pinned in `try_from_inventory_trade_real_bebop_fill_is_sell`.
+    #[tokio::test]
+    async fn try_from_tx_hash_recovers_real_inventory_trade_settlement() {
+        let inventory = address!("0xbeb0009aca35087ce7ccf11637e24dd1aad3bf2a");
+        let orderbook = address!("0x1111111111111111111111111111111111111111");
+        let bot_operator = address!("0x679df30b30ac2947aa3143490add6717af81dcc3");
+
+        let cache = SymbolCache::default();
+        cache.preload_symbol(REAL_USDC_BASE, "USDC");
+        cache.preload_symbol(REAL_WTCOIN_BASE, "wtCOIN");
+
+        let tx_hash =
+            fixed_bytes!("0xe13a11de734768f08a9c1ef66e8de3bcb9072f8cdabce9f1d819e1ae9909d4b9");
+        let venue_operator = address!("0x8b8b6e0507c125934c6129563f48e48c66f86475");
+
+        let deposit = OperatorDeposit {
+            operator: venue_operator,
+            token: REAL_USDC_BASE,
+            vaultId: b256!("0x0000000000000000000000000000000000000000000000000000000000000004"),
+            amount: uint!(5_000_000_U256), // 5 USDC, 6 decimals
+        };
+        let withdraw = OperatorWithdraw {
+            operator: venue_operator,
+            token: REAL_WTCOIN_BASE,
+            vaultId: b256!("0x0000000000000000000000000000000000000000000000000000000000000003"),
+            amount: uint!(34_172_366_621_067_031_U256), // 0.034172366621067031 wtCOIN, 18 decimals
+        };
+
+        let deposit_log = alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: deposit.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(48_030_415),
+            block_timestamp: Some(1_782_850_177),
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(0),
+            removed: false,
+        };
+        let withdraw_log = alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: withdraw.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(48_030_415),
+            block_timestamp: Some(1_782_850_177),
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(1),
+            removed: false,
+        };
+
+        let receipt = serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x3b",
+            "blockHash": "0x373307a0e2154c2de6b046e349fc27f9bb02b01fdddbb15eeba57f3ce3b24973",
+            "blockNumber": "0x2dce2cf",
+            "from": bot_operator,
+            "to": inventory,
+            "gasUsed": "0x7a62d",
+            "effectiveGasPrice": "0x57bcf0",
+            "cumulativeGasUsed": "0xa00b4e",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "logs": [deposit_log, withdraw_log]
+        });
+
+        let asserter = Asserter::new();
+        // `try_from_tx_hash` fetches this receipt once and threads its
+        // gas/price/block metadata into `try_from_inventory_trade`, so only
+        // one `get_transaction_receipt` response is needed.
+        asserter.push_success(&receipt); // get_transaction_receipt
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&6u8)); // USDC
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&18u8)); // wtCOIN
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let ctx = EvmCtx {
+            rpc_url: "http://localhost:8545".parse().unwrap(),
+            orderbook,
+            inventory: InventoryMode::Managed { inventory },
+            vault_owner: inventory,
+            deployment_block: 0,
+            required_confirmations: 0,
+            ingestion_cutoff: IngestionCutoff::Safe,
+        };
+        let assets = assets_config_with_equity("COIN", REAL_WTCOIN_BASE);
+
+        let trade = OnchainTrade::try_from_tx_hash(
+            tx_hash,
+            &ReadOnlyEvm::new(provider),
+            &cache,
+            &ctx,
+            &assets,
+            &PythFeedIds::default(),
+            inventory,
+            BotOperator(bot_operator),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(trade.symbol.to_string(), "wtCOIN");
+        assert_eq!(trade.direction, Direction::Sell);
+        assert_eq!(trade.equity_token, REAL_WTCOIN_BASE);
+        let expected_amount =
+            Float::from_fixed_decimal(uint!(34_172_366_621_067_031_U256), 18).unwrap();
+        assert!(trade.amount.inner().eq(expected_amount).unwrap());
+    }
+
+    /// The manual `process-tx` recovery path must quarantine a tx with one
+    /// `OperatorDeposit` and two `OperatorWithdraw`s exactly like the batch
+    /// backfill path does (`second_withdraw_in_one_tx_is_ambiguous_and_quarantined`
+    /// in `backfill.rs`) -- never resolve the ambiguity by picking an
+    /// arbitrary "first match" withdraw.
+    #[tokio::test]
+    async fn try_from_tx_hash_quarantines_ambiguous_multi_withdraw_settlement() {
+        let inventory = address!("0xbeb0009aca35087ce7ccf11637e24dd1aad3bf2a");
+        let orderbook = address!("0x1111111111111111111111111111111111111111");
+        let bot_operator = address!("0x679df30b30ac2947aa3143490add6717af81dcc3");
+        let venue_operator = address!("0x8b8b6e0507c125934c6129563f48e48c66f86475");
+
+        let cache = SymbolCache::default();
+        let tx_hash =
+            fixed_bytes!("0xa1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1");
+
+        let deposit = OperatorDeposit {
+            operator: venue_operator,
+            token: REAL_USDC_BASE,
+            vaultId: b256!("0x0000000000000000000000000000000000000000000000000000000000000004"),
+            amount: uint!(5_000_000_U256),
+        };
+        let first_withdraw = OperatorWithdraw {
+            operator: venue_operator,
+            token: REAL_WTCOIN_BASE,
+            vaultId: b256!("0x0000000000000000000000000000000000000000000000000000000000000003"),
+            amount: uint!(34_172_366_621_067_031_U256),
+        };
+        let second_withdraw = OperatorWithdraw {
+            operator: venue_operator,
+            token: REAL_WTCOIN_BASE,
+            vaultId: b256!("0x0000000000000000000000000000000000000000000000000000000000000003"),
+            amount: uint!(1_000_000_000_000_000_U256),
+        };
+
+        let deposit_log = alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: deposit.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(48_030_415),
+            block_timestamp: Some(1_782_850_177),
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(0),
+            removed: false,
+        };
+        let first_withdraw_log = alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: first_withdraw.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(48_030_415),
+            block_timestamp: Some(1_782_850_177),
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(1),
+            removed: false,
+        };
+        let second_withdraw_log = alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: second_withdraw.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(48_030_415),
+            block_timestamp: Some(1_782_850_177),
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(2),
+            removed: false,
+        };
+
+        let receipt = serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x3b",
+            "blockHash": "0x373307a0e2154c2de6b046e349fc27f9bb02b01fdddbb15eeba57f3ce3b24973",
+            "blockNumber": "0x2dce2cf",
+            "from": bot_operator,
+            "to": inventory,
+            "gasUsed": "0x7a62d",
+            "effectiveGasPrice": "0x57bcf0",
+            "cumulativeGasUsed": "0xa00b4e",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "logs": [deposit_log, first_withdraw_log, second_withdraw_log]
+        });
+
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt); // get_transaction_receipt
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let ctx = EvmCtx {
+            rpc_url: "http://localhost:8545".parse().unwrap(),
+            orderbook,
+            inventory: InventoryMode::Managed { inventory },
+            vault_owner: inventory,
+            deployment_block: 0,
+            required_confirmations: 0,
+            ingestion_cutoff: IngestionCutoff::Safe,
+        };
+
+        let trade = OnchainTrade::try_from_tx_hash(
+            tx_hash,
+            &ReadOnlyEvm::new(provider),
+            &cache,
+            &ctx,
+            &AssetsConfig::default(),
+            &PythFeedIds::default(),
+            inventory,
+            BotOperator(bot_operator),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            trade.is_none(),
+            "an ambiguous multi-withdraw settlement must be quarantined, not recovered by \
+             picking an arbitrary first withdraw"
+        );
+    }
+
+    /// The manual `process-tx` recovery path must quarantine a tx whose
+    /// single `OperatorDeposit` and single `OperatorWithdraw` were emitted by
+    /// different operators, exactly like the batch backfill path does
+    /// (`mismatched_operator_deposit_and_withdraw_is_ambiguous_and_quarantined`
+    /// in `backfill.rs`) -- pairing them would fabricate a vault delta
+    /// between two unrelated venue actions.
+    #[tokio::test]
+    async fn try_from_tx_hash_quarantines_mismatched_operator_settlement() {
+        let inventory = address!("0xbeb0009aca35087ce7ccf11637e24dd1aad3bf2a");
+        let orderbook = address!("0x1111111111111111111111111111111111111111");
+        let bot_operator = address!("0x679df30b30ac2947aa3143490add6717af81dcc3");
+        let deposit_operator = address!("0x8b8b6e0507c125934c6129563f48e48c66f86475");
+        let withdraw_operator = address!("0x9c9c6e0507c125934c6129563f48e48c66f8647a");
+
+        let cache = SymbolCache::default();
+        let tx_hash =
+            fixed_bytes!("0xb2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2");
+
+        let deposit = OperatorDeposit {
+            operator: deposit_operator,
+            token: REAL_USDC_BASE,
+            vaultId: b256!("0x0000000000000000000000000000000000000000000000000000000000000004"),
+            amount: uint!(5_000_000_U256),
+        };
+        let withdraw = OperatorWithdraw {
+            operator: withdraw_operator,
+            token: REAL_WTCOIN_BASE,
+            vaultId: b256!("0x0000000000000000000000000000000000000000000000000000000000000003"),
+            amount: uint!(34_172_366_621_067_031_U256),
+        };
+
+        let deposit_log = alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: deposit.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(48_030_415),
+            block_timestamp: Some(1_782_850_177),
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(0),
+            removed: false,
+        };
+        let withdraw_log = alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: inventory,
+                data: withdraw.to_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(48_030_415),
+            block_timestamp: Some(1_782_850_177),
+            transaction_hash: Some(tx_hash),
+            transaction_index: None,
+            log_index: Some(1),
+            removed: false,
+        };
+
+        let receipt = serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x3b",
+            "blockHash": "0x373307a0e2154c2de6b046e349fc27f9bb02b01fdddbb15eeba57f3ce3b24973",
+            "blockNumber": "0x2dce2cf",
+            "from": bot_operator,
+            "to": inventory,
+            "gasUsed": "0x7a62d",
+            "effectiveGasPrice": "0x57bcf0",
+            "cumulativeGasUsed": "0xa00b4e",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "logs": [deposit_log, withdraw_log]
+        });
+
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt); // get_transaction_receipt
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let ctx = EvmCtx {
+            rpc_url: "http://localhost:8545".parse().unwrap(),
+            orderbook,
+            inventory: InventoryMode::Managed { inventory },
+            vault_owner: inventory,
+            deployment_block: 0,
+            required_confirmations: 0,
+            ingestion_cutoff: IngestionCutoff::Safe,
+        };
+
+        let trade = OnchainTrade::try_from_tx_hash(
+            tx_hash,
+            &ReadOnlyEvm::new(provider),
+            &cache,
+            &ctx,
+            &AssetsConfig::default(),
+            &PythFeedIds::default(),
+            inventory,
+            BotOperator(bot_operator),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            trade.is_none(),
+            "a deposit and withdraw emitted by different operators must be quarantined, not \
+             paired into a fabricated hedge"
+        );
     }
 
     fn make_io(token: Address, vault_id: B256) -> IRaindexV6::IOV2 {
@@ -1074,5 +1926,587 @@ mod tests {
 
         let vaults = extract_owned_vaults(&order, uint!(0_U256), uint!(0_U256));
         assert!(vaults.is_empty());
+    }
+
+    // `try_from_inventory_trade` validates the USDC leg against the
+    // hardcoded canonical `USDC_BASE` address, so the InventoryTrade tests'
+    // USDC leg must use it too, not an arbitrary placeholder.
+    const INVENTORY_USDC: Address = USDC_BASE;
+    const INVENTORY_EQUITY: Address = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+    /// Builds an `AssetsConfig` with a single configured equity symbol,
+    /// whose `tokenized_equity_derivative` is the canonical address
+    /// `try_from_inventory_trade` validates the equity leg against.
+    fn assets_config_with_equity(
+        symbol: &str,
+        tokenized_equity_derivative: Address,
+    ) -> AssetsConfig {
+        let mut symbols = HashMap::new();
+        symbols.insert(
+            Symbol::new(symbol).unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: Address::ZERO,
+                tokenized_equity_derivative,
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                extended_hours_counter_trading: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+        AssetsConfig {
+            equities: EquitiesConfig {
+                operational_limit: None,
+                symbols,
+            },
+            cash: None,
+        }
+    }
+
+    fn operator_deposit(token: Address, amount: U256) -> OperatorDeposit {
+        OperatorDeposit {
+            operator: Address::ZERO,
+            token,
+            vaultId: B256::ZERO,
+            amount,
+        }
+    }
+
+    fn operator_withdraw(token: Address, amount: U256) -> OperatorWithdraw {
+        OperatorWithdraw {
+            operator: Address::ZERO,
+            token,
+            vaultId: B256::ZERO,
+            amount,
+        }
+    }
+
+    fn inventory_receipt(tx_hash: TxHash) -> serde_json::Value {
+        serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x1",
+            "blockHash": "0x1234567890123456789012345678901234567890123456789012345678901234",
+            "blockNumber": "0x1",
+            "from": "0x1234567890123456789012345678901234567890",
+            "to": "0x5678901234567890123456789012345678901234",
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x77359400",
+            "cumulativeGasUsed": "0x5208",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "logs": []
+        })
+    }
+
+    /// Drives `try_from_inventory_trade` with a pre-seeded symbol cache (so
+    /// symbol resolution makes no RPC) and a deterministic mock queue:
+    /// receipt, then the deposit-token then withdraw-token `decimals()` calls.
+    async fn run_inventory_parser(
+        deposit: OperatorDeposit,
+        deposit_decimals: u8,
+        withdraw: OperatorWithdraw,
+        withdraw_decimals: u8,
+    ) -> Result<Option<OnchainTrade>, OnChainError> {
+        let cache = SymbolCache::default();
+        cache.preload_symbol(INVENTORY_USDC, "USDC");
+        cache.preload_symbol(INVENTORY_EQUITY, "wtAAPL");
+        let assets = assets_config_with_equity("AAPL", INVENTORY_EQUITY);
+
+        let tx_hash =
+            fixed_bytes!("0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+        let asserter = Asserter::new();
+        asserter.push_success(&inventory_receipt(tx_hash));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(
+            &deposit_decimals,
+        ));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(
+            &withdraw_decimals,
+        ));
+        let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
+
+        let log = crate::test_utils::create_log(7);
+        let inv = InventoryTrade { deposit, withdraw };
+
+        OnchainTrade::try_from_inventory_trade(
+            &cache,
+            &evm,
+            &assets,
+            &inv,
+            log,
+            &PythFeedIds::default(),
+            None,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn try_from_inventory_trade_happy_path_usdc_withdraw_is_buy() {
+        // Pool received 2 wtAAPL (deposit) and sent 160 USDC (withdraw): it
+        // bought equity onchain, so the bot is now long and must hedge Buy.
+        let trade = run_inventory_parser(
+            operator_deposit(INVENTORY_EQUITY, uint!(2000000000000000000_U256)),
+            18,
+            operator_withdraw(INVENTORY_USDC, uint!(160000000_U256)),
+            6,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(trade.symbol.to_string(), "wtAAPL");
+        assert_eq!(trade.direction, Direction::Buy);
+        assert_eq!(trade.equity_token, INVENTORY_EQUITY);
+        assert_eq!(trade.amount, FractionalShares::new(float!(2)));
+        assert!(trade.price.value().eq(float!(80)).unwrap());
+        // block_timestamp resolves from the log's timestamp (no header fetch).
+        assert_eq!(
+            trade.block_timestamp,
+            DateTime::from_timestamp(1_700_000_000, 0)
+        );
+    }
+
+    #[tokio::test]
+    async fn try_from_inventory_trade_usdc_deposit_flips_direction_to_sell() {
+        // USDC on the deposit side: pool received 160 USDC and sent 2 wtAAPL
+        // out, i.e. it sold equity onchain -> hedge Sell (mirror of happy path).
+        let trade = run_inventory_parser(
+            operator_deposit(INVENTORY_USDC, uint!(160000000_U256)),
+            6,
+            operator_withdraw(INVENTORY_EQUITY, uint!(2000000000000000000_U256)),
+            18,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(trade.symbol.to_string(), "wtAAPL");
+        assert_eq!(trade.direction, Direction::Sell);
+        assert_eq!(trade.equity_token, INVENTORY_EQUITY);
+        assert_eq!(trade.amount, FractionalShares::new(float!(2)));
+        assert!(trade.price.value().eq(float!(80)).unwrap());
+    }
+
+    /// A spoof token whose `symbol()` reports "USDC" but whose address is NOT
+    /// the configured canonical `USDC_BASE` must be rejected -- accepting it
+    /// on symbol alone would let a compromised/buggy `OPERATOR_ROLE` holder
+    /// trick the bot into hedging (and paying out of the shared vault
+    /// against) a fabricated leg.
+    #[tokio::test]
+    async fn try_from_inventory_trade_rejects_spoofed_usdc_symbol() {
+        let spoof_usdc = address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+
+        let cache = SymbolCache::default();
+        cache.preload_symbol(spoof_usdc, "USDC");
+        cache.preload_symbol(INVENTORY_EQUITY, "wtAAPL");
+        let assets = assets_config_with_equity("AAPL", INVENTORY_EQUITY);
+
+        let tx_hash =
+            fixed_bytes!("0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+        let asserter = Asserter::new();
+        asserter.push_success(&inventory_receipt(tx_hash));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&6u8));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&18u8));
+        let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
+
+        let inv = InventoryTrade {
+            deposit: operator_deposit(spoof_usdc, uint!(160000000_U256)),
+            withdraw: operator_withdraw(INVENTORY_EQUITY, uint!(2000000000000000000_U256)),
+        };
+        let log = crate::test_utils::create_log(7);
+
+        let error = OnchainTrade::try_from_inventory_trade(
+            &cache,
+            &evm,
+            &assets,
+            &inv,
+            log,
+            &PythFeedIds::default(),
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        match error {
+            OnChainError::Validation(TradeValidationError::UnrecognizedInventoryToken {
+                token,
+                claimed_symbol,
+            }) => {
+                assert_eq!(token, spoof_usdc);
+                assert_eq!(claimed_symbol, "USDC");
+            }
+            other => panic!("expected UnrecognizedInventoryToken, got {other:?}"),
+        }
+    }
+
+    /// A spoof token whose `symbol()` reports "wtCOIN" but whose address does
+    /// not match the configured `tokenized_equity_derivative` for COIN must
+    /// be rejected the same way as a spoofed USDC leg.
+    #[tokio::test]
+    async fn try_from_inventory_trade_rejects_spoofed_equity_symbol() {
+        let spoof_equity = address!("0xbadbadbadbadbadbadbadbadbadbadbadbadbad0");
+
+        let cache = SymbolCache::default();
+        cache.preload_symbol(REAL_USDC_BASE, "USDC");
+        cache.preload_symbol(spoof_equity, "wtCOIN");
+        let assets = assets_config_with_equity("COIN", REAL_WTCOIN_BASE);
+
+        let tx_hash =
+            fixed_bytes!("0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+        let asserter = Asserter::new();
+        asserter.push_success(&inventory_receipt(tx_hash));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&6u8));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&18u8));
+        let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
+
+        let inv = InventoryTrade {
+            deposit: operator_deposit(REAL_USDC_BASE, uint!(5_000_000_U256)),
+            withdraw: operator_withdraw(spoof_equity, uint!(34_172_366_621_067_031_U256)),
+        };
+        let log = crate::test_utils::create_log(7);
+
+        let error = OnchainTrade::try_from_inventory_trade(
+            &cache,
+            &evm,
+            &assets,
+            &inv,
+            log,
+            &PythFeedIds::default(),
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        match error {
+            OnChainError::Validation(TradeValidationError::UnrecognizedInventoryToken {
+                token,
+                claimed_symbol,
+            }) => {
+                assert_eq!(token, spoof_equity);
+                assert_eq!(claimed_symbol, "wtCOIN");
+            }
+            other => panic!("expected UnrecognizedInventoryToken, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn try_from_inventory_trade_zero_equity_returns_none() {
+        // The equity side moved zero shares: not a tokenized-equity trade, skip.
+        let result = run_inventory_parser(
+            operator_deposit(INVENTORY_USDC, uint!(160000000_U256)),
+            6,
+            operator_withdraw(INVENTORY_EQUITY, U256::ZERO),
+            18,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.is_none(),
+            "a zero-equity inventory settlement must be skipped, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn try_from_inventory_trade_non_positive_price_errors() {
+        // Non-zero equity moved at a zero USDC price -> unpriceable. Must error
+        // (mirroring the ClearV3/TakeOrderV3 path) rather than silently drop it,
+        // which would leave the position unhedged.
+        let error = run_inventory_parser(
+            operator_deposit(INVENTORY_USDC, U256::ZERO),
+            6,
+            operator_withdraw(INVENTORY_EQUITY, uint!(2000000000000000000_U256)),
+            18,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            OnChainError::Validation(TradeValidationError::NonPositivePrice(_))
+        ));
+    }
+
+    // Real prod fills on Base mainnet, captured via
+    // `cast receipt <tx> --rpc-url https://mainnet.base.org` against the
+    // shared RaindexInventory at 0x6b7b523fadd1677413ad92c9404c8f0796bacf6f.
+    // Pins the parser against the actual contract's event shape/amounts
+    // rather than a hand-picked round number.
+    const REAL_USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+    const REAL_WTCOIN_BASE: Address = address!("0x5CdA0E1cA4ce2Af96315F7F8963c85399c172204");
+
+    #[tokio::test]
+    async fn try_from_inventory_trade_real_bebop_fill_is_sell() {
+        // tx 0xe13a11de734768f08a9c1ef66e8de3bcb9072f8cdabce9f1d819e1ae9909d4b9:
+        // Bebop-routed settlement. The pool received 5 USDC (deposit) and
+        // sent 0.034172366621067031 wtCOIN (withdraw), i.e. it sold equity
+        // onchain, so it must hedge Sell (USDC on the deposit side).
+        let cache = SymbolCache::default();
+        cache.preload_symbol(REAL_USDC_BASE, "USDC");
+        cache.preload_symbol(REAL_WTCOIN_BASE, "wtCOIN");
+
+        let tx_hash =
+            fixed_bytes!("0xe13a11de734768f08a9c1ef66e8de3bcb9072f8cdabce9f1d819e1ae9909d4b9");
+        let operator = address!("0x8b8b6e0507c125934c6129563f48e48c66f86475");
+
+        let deposit = OperatorDeposit {
+            operator,
+            token: REAL_USDC_BASE,
+            vaultId: b256!("0x0000000000000000000000000000000000000000000000000000000000000004"),
+            amount: uint!(5_000_000_U256), // 5 USDC, 6 decimals
+        };
+        let withdraw = OperatorWithdraw {
+            operator,
+            token: REAL_WTCOIN_BASE,
+            vaultId: b256!("0x0000000000000000000000000000000000000000000000000000000000000003"),
+            amount: uint!(34_172_366_621_067_031_U256), // 0.034172366621067031 wtCOIN, 18 decimals
+        };
+
+        let receipt = serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x3b",
+            "blockHash": "0x373307a0e2154c2de6b046e349fc27f9bb02b01fdddbb15eeba57f3ce3b24973",
+            "blockNumber": "0x2dce2cf",
+            "from": "0x679df30b30ac2947aa3143490add6717af81dcc3",
+            "to": "0xbeb0009aca35087ce7ccf11637e24dd1aad3bf2a",
+            "gasUsed": "0x7a62d",
+            "effectiveGasPrice": "0x57bcf0",
+            "cumulativeGasUsed": "0xa00b4e",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "logs": []
+        });
+
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt);
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&6u8)); // USDC
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&18u8)); // wtCOIN
+        let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
+
+        let mut log = crate::test_utils::create_log(0x97);
+        log.transaction_hash = Some(tx_hash);
+        log.block_number = Some(48_030_415);
+        log.block_timestamp = Some(1_782_850_177);
+
+        let inv = InventoryTrade { deposit, withdraw };
+        let assets = assets_config_with_equity("COIN", REAL_WTCOIN_BASE);
+
+        let trade = OnchainTrade::try_from_inventory_trade(
+            &cache,
+            &evm,
+            &assets,
+            &inv,
+            log,
+            &PythFeedIds::default(),
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(trade.symbol.to_string(), "wtCOIN");
+        assert_eq!(trade.direction, Direction::Sell);
+        assert_eq!(trade.equity_token, REAL_WTCOIN_BASE);
+        let expected_amount =
+            Float::from_fixed_decimal(uint!(34_172_366_621_067_031_U256), 18).unwrap();
+        assert!(trade.amount.inner().eq(expected_amount).unwrap());
+        // 5 USDC / 0.034172366621067031 wtCOIN ~= 146.317 USDC/share.
+        let price_diff = (trade.price.value() - float!(146.317))
+            .unwrap()
+            .abs()
+            .unwrap();
+        assert!(price_diff.lt(float!(0.001)).unwrap());
+    }
+
+    #[tokio::test]
+    async fn try_from_inventory_trade_real_univ4_fill_is_buy() {
+        // tx 0x9ee8e401a6f12227df1a30a236b60ac83c72b2b1eb610d83cf292ae789eb0805:
+        // univ4-routed settlement. The pool received 0.01 wtCOIN (deposit)
+        // and sent 2 USDC (withdraw), i.e. it bought equity onchain, so it
+        // must hedge Buy (equity on the deposit side, mirroring the
+        // happy-path unit test above).
+        let cache = SymbolCache::default();
+        cache.preload_symbol(REAL_USDC_BASE, "USDC");
+        cache.preload_symbol(REAL_WTCOIN_BASE, "wtCOIN");
+
+        let tx_hash =
+            fixed_bytes!("0x9ee8e401a6f12227df1a30a236b60ac83c72b2b1eb610d83cf292ae789eb0805");
+        let operator = address!("0x36ebb1e5149c60111dd035f0417a4b00d39caa88");
+
+        let deposit = OperatorDeposit {
+            operator,
+            token: REAL_WTCOIN_BASE,
+            vaultId: b256!("0x0000000000000000000000000000000000000000000000000000000000000003"),
+            amount: uint!(10_000_000_000_000_000_U256), // 0.01 wtCOIN, 18 decimals
+        };
+        let withdraw = OperatorWithdraw {
+            operator,
+            token: REAL_USDC_BASE,
+            vaultId: b256!("0x0000000000000000000000000000000000000000000000000000000000000004"),
+            amount: uint!(2_000_000_U256), // 2 USDC, 6 decimals
+        };
+
+        let receipt = serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x41",
+            "blockHash": "0x4fb86ed2edeee5845f379874a140df6ed78a5553877a4a480878f2eb70f0efeb",
+            "blockNumber": "0x2dd36e4",
+            "from": "0x679df30b30ac2947aa3143490add6717af81dcc3",
+            "to": "0xe23457189a0186b23e9f325eb11364b3733c2c89",
+            "gasUsed": "0x54025",
+            "effectiveGasPrice": "0x59a538",
+            "cumulativeGasUsed": "0xa481c7",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "logs": []
+        });
+
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt);
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&18u8)); // wtCOIN
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&6u8)); // USDC
+        let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
+
+        let mut log = crate::test_utils::create_log(0xf4);
+        log.transaction_hash = Some(tx_hash);
+        log.block_number = Some(48_051_940);
+        log.block_timestamp = Some(1_782_893_227);
+
+        let inv = InventoryTrade { deposit, withdraw };
+        let assets = assets_config_with_equity("COIN", REAL_WTCOIN_BASE);
+
+        let trade = OnchainTrade::try_from_inventory_trade(
+            &cache,
+            &evm,
+            &assets,
+            &inv,
+            log,
+            &PythFeedIds::default(),
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(trade.symbol.to_string(), "wtCOIN");
+        assert_eq!(trade.direction, Direction::Buy);
+        assert_eq!(trade.equity_token, REAL_WTCOIN_BASE);
+        assert!(trade.amount.inner().eq(float!(0.01)).unwrap());
+        // 2 USDC / 0.01 wtCOIN = 200 USDC/share exactly.
+        assert!(trade.price.value().eq(float!(200)).unwrap());
+    }
+
+    /// A transient/transport-style RPC failure (connection reset, timeout,
+    /// or here: the mock queue draining to empty mid-retry) on `decimals()`
+    /// must not be classified as `TokenIntrospectionFailed` -- it must
+    /// surface as a retryable `OnChainError::Evm` so apalis retries with
+    /// backoff instead of permanently dropping a legitimate fill.
+    #[tokio::test]
+    async fn fetch_inventory_token_decimals_surfaces_transient_error_as_retryable() {
+        let asserter = Asserter::new();
+        // INVENTORY_TOKEN_DECIMALS_MAX_RETRIES retries = one more than that
+        // many total attempts; push a failure for every attempt so the
+        // final (returned) error is guaranteed to be the transient one.
+        for _ in 0..=INVENTORY_TOKEN_DECIMALS_MAX_RETRIES {
+            asserter.push_failure_msg("connection reset by peer");
+        }
+        let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
+
+        let error = fetch_inventory_token_decimals(&evm, INVENTORY_EQUITY)
+            .await
+            .unwrap_err();
+
+        match error {
+            OnChainError::Evm(_) => {}
+            other => panic!("expected OnChainError::Evm for a transient failure, got {other:?}"),
+        }
+    }
+
+    /// A genuine revert (malformed/malicious token) on `decimals()` must
+    /// still be classified as `TokenIntrospectionFailed` so the fill is
+    /// caught and skipped, rather than retried forever and eventually
+    /// tripping the conductor-wide fail-stop.
+    #[tokio::test]
+    async fn fetch_inventory_token_decimals_classifies_genuine_revert_as_token_introspection_failed()
+     {
+        let asserter = Asserter::new();
+        for _ in 0..=INVENTORY_TOKEN_DECIMALS_MAX_RETRIES {
+            asserter.push_failure(panic_revert_payload());
+        }
+        let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
+
+        let error = fetch_inventory_token_decimals(&evm, INVENTORY_EQUITY)
+            .await
+            .unwrap_err();
+
+        match error {
+            OnChainError::Validation(TradeValidationError::TokenIntrospectionFailed {
+                token,
+                ..
+            }) => {
+                assert_eq!(token, INVENTORY_EQUITY);
+            }
+            other => {
+                panic!("expected TokenIntrospectionFailed for a genuine revert, got {other:?}")
+            }
+        }
+    }
+
+    /// Mirrors `fetch_inventory_token_decimals_surfaces_transient_error_as_retryable`:
+    /// a transient failure resolving an `InventoryTrade` token's symbol must
+    /// also surface as a retryable `OnChainError::Evm`, not a permanent skip.
+    #[tokio::test]
+    async fn resolve_inventory_token_symbol_surfaces_transient_error_as_retryable() {
+        let cache = SymbolCache::default();
+        let asserter = Asserter::new();
+        // SymbolCache::resolve_symbol's internal retry budget matches
+        // INVENTORY_TOKEN_DECIMALS_MAX_RETRIES (see that constant's doc).
+        for _ in 0..=INVENTORY_TOKEN_DECIMALS_MAX_RETRIES {
+            asserter.push_failure_msg("connection reset by peer");
+        }
+        let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
+
+        let error = resolve_inventory_token_symbol(&cache, &evm, INVENTORY_EQUITY)
+            .await
+            .unwrap_err();
+
+        match error {
+            OnChainError::Evm(_) => {}
+            other => panic!("expected OnChainError::Evm for a transient failure, got {other:?}"),
+        }
+    }
+
+    /// Mirrors the decimals variant of this test: a genuine revert resolving
+    /// an `InventoryTrade` token's symbol must still yield
+    /// `TokenIntrospectionFailed` so the fill is skipped.
+    #[tokio::test]
+    async fn resolve_inventory_token_symbol_classifies_genuine_revert_as_token_introspection_failed()
+     {
+        let cache = SymbolCache::default();
+        let asserter = Asserter::new();
+        for _ in 0..=INVENTORY_TOKEN_DECIMALS_MAX_RETRIES {
+            asserter.push_failure(panic_revert_payload());
+        }
+        let evm = ReadOnlyEvm::new(ProviderBuilder::new().connect_mocked_client(asserter));
+
+        let error = resolve_inventory_token_symbol(&cache, &evm, INVENTORY_EQUITY)
+            .await
+            .unwrap_err();
+
+        match error {
+            OnChainError::Validation(TradeValidationError::TokenIntrospectionFailed {
+                token,
+                ..
+            }) => {
+                assert_eq!(token, INVENTORY_EQUITY);
+            }
+            other => {
+                panic!("expected TokenIntrospectionFailed for a genuine revert, got {other:?}")
+            }
+        }
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -229,6 +229,24 @@ pub(crate) fn seed_get_test_order_token_symbols(cache: &st0x_registry::SymbolCac
     );
 }
 
+/// Builds a JSON-RPC error payload for a genuine on-chain revert
+/// (`Panic(uint256)` with the arithmetic-overflow reason `0x11`).
+/// `decode_panic` resolves this selector synchronously without a registry
+/// lookup, so pushing it never triggers a real HTTP call to the OpenChain
+/// selector registry that token introspection uses in production.
+///
+/// Only a payload carrying revert *data* satisfies `EvmError::is_revert`, so a
+/// bare `push_failure_msg` is not a substitute: it lands as a transport error
+/// and is classified retryable rather than as a genuine revert.
+pub(crate) fn panic_revert_payload() -> alloy::rpc::json_rpc::ErrorPayload {
+    let revert_data = format!("0x4e487b71{:064x}", 0x11u8);
+    alloy::rpc::json_rpc::ErrorPayload {
+        code: 3,
+        message: "execution reverted".into(),
+        data: Some(serde_json::value::to_raw_value(&revert_data).expect("valid json")),
+    }
+}
+
 /// Creates a generic `Log` stub with the supplied log index. This helper is
 /// useful when the concrete value of most fields is irrelevant for the
 /// assertion being performed.

--- a/src/trading/onchain/skipped_fill.rs
+++ b/src/trading/onchain/skipped_fill.rs
@@ -18,6 +18,16 @@ pub(crate) enum SkipReason {
     UnpriceableFill,
     /// The fill's token pair is not one the bot hedges.
     NonHedgeablePair,
+    /// An `InventoryTrade`-supplied token failed symbol/decimals
+    /// introspection (non-standard ERC20, no code, or a reverting call).
+    UnintrospectableToken,
+    /// An `InventoryTrade`-supplied deposit/withdraw amount could not be
+    /// converted to a `Float` (a malformed or extreme fixed-decimal value).
+    InvalidInventoryAmount,
+    /// An `InventoryTrade` leg's token address did not match the configured
+    /// canonical address for the symbol its `symbol()` claims to be (a
+    /// spoofed or misconfigured token supplied by an `OPERATOR_ROLE` holder).
+    UnrecognizedInventoryToken,
 }
 
 impl SkipReason {
@@ -25,6 +35,9 @@ impl SkipReason {
         match self {
             Self::UnpriceableFill => "unpriceable_fill",
             Self::NonHedgeablePair => "non_hedgeable_pair",
+            Self::UnintrospectableToken => "unintrospectable_token",
+            Self::InvalidInventoryAmount => "invalid_inventory_amount",
+            Self::UnrecognizedInventoryToken => "unrecognized_inventory_token",
         }
     }
 }

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -6,7 +6,7 @@
 //!
 //! [`perform`]: Job::perform
 
-use alloy::primitives::{Address, IntoLogData};
+use alloy::primitives::IntoLogData;
 use alloy::providers::Provider;
 use alloy::rpc::types::Log;
 use serde::{Deserialize, Serialize};
@@ -19,6 +19,7 @@ use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::alpaca_broker_api::AlpacaBrokerApiError;
 use st0x_execution::{ExecutionError, Executor};
+use st0x_raindex::RaindexContracts;
 use st0x_registry::{SymbolCache, get_symbol_lock};
 
 use super::inclusion::EmittedOnChain;
@@ -49,7 +50,11 @@ pub(crate) struct AccountantCtx<Node, Exec> {
     pub(crate) ctx: Ctx,
     pub(crate) cache: SymbolCache,
     pub(crate) pyth_feed_ids: PythFeedIds,
-    pub(crate) orderbook: Address,
+    /// Orderbook and shared `RaindexInventory` addresses -- the latter is the
+    /// source contract for `InventoryTrade` events
+    /// (`OperatorDeposit`/`OperatorWithdraw`). Used to reconstruct the
+    /// emitting log's address for downstream processing.
+    pub(crate) contracts: RaindexContracts,
     pub(crate) evm: ReadOnlyEvm<Node>,
     pub(crate) cqrs: TradeProcessingCqrs,
     pub(crate) vault_registry: Arc<Store<VaultRegistry>>,
@@ -85,14 +90,14 @@ where
 
     #[allow(clippy::cognitive_complexity)]
     async fn perform(&self, ctx: &AccountantCtx<Node, Exec>) -> Result<Self::Output, Self::Error> {
-        use RaindexTradeEvent::{ClearV3, TakeOrderV3};
+        use RaindexTradeEvent::{ClearV3, InventoryTrade, TakeOrderV3};
 
         let trade_event = &self.trade;
         // The Raindex order/vault owner -- the inventory contract post-migration,
         // the bot EOA before it. Used to match ClearV3/TakeOrderV3 fills to our
         // orders and to scope vault discovery.
         let order_owner = ctx.ctx.vault_owner();
-        let reconstructed_log = reconstruct_log(ctx.orderbook, trade_event);
+        let reconstructed_log = reconstruct_log(ctx.contracts, trade_event);
 
         let trade_result = match &trade_event.event {
             ClearV3(clear_event) => {
@@ -116,6 +121,22 @@ where
                     reconstructed_log,
                     order_owner,
                     &ctx.pyth_feed_ids,
+                )
+                .await
+            }
+
+            InventoryTrade(inv) => {
+                // No pre-fetched receipt here (this event may be reconstructed
+                // from a stored backfill log, not a fresh RPC round-trip), so
+                // `try_from_inventory_trade` fetches its own receipt metadata.
+                OnchainTrade::try_from_inventory_trade(
+                    &ctx.cache,
+                    &ctx.evm,
+                    &ctx.ctx.assets,
+                    inv.as_ref(),
+                    reconstructed_log,
+                    &ctx.pyth_feed_ids,
+                    None,
                 )
                 .await
             }
@@ -169,6 +190,87 @@ where
                 .await;
                 return Ok(());
             }
+            Err(OnChainError::Validation(
+                error @ TradeValidationError::TokenIntrospectionFailed { .. },
+            )) => {
+                // InventoryTrade token addresses come from any OPERATOR_ROLE
+                // holder on the shared inventory (Bebop hook, univ4 hook, or a
+                // future venue), not the bot's own trusted order config. A
+                // non-standard token there must not be allowed to exhaust
+                // worker retries and trip the conductor-wide fail-stop --
+                // skip THIS fill only, same as an unpriceable fill.
+                error!(
+                    target: "hedge",
+                    event_type = trade_event.event.kind(),
+                    tx_hash = ?trade_event.tx_hash,
+                    log_index = trade_event.log_index,
+                    %error,
+                    "Skipping InventoryTrade fill with an unintrospectable token; it is \
+                     left unhedged and must be reconciled manually"
+                );
+                persist_skipped_fill(
+                    &ctx.pool,
+                    trade_event,
+                    SkipReason::UnintrospectableToken,
+                    &error.to_string(),
+                )
+                .await;
+                return Ok(());
+            }
+            Err(OnChainError::Validation(
+                error @ TradeValidationError::UnrecognizedInventoryToken { .. },
+            )) => {
+                // An InventoryTrade leg's address didn't match the configured
+                // canonical address for the symbol it claims to be (USDC or
+                // the resolved equity). Same threat model as
+                // TokenIntrospectionFailed: any OPERATOR_ROLE holder can
+                // supply this token, so a spoofed/misconfigured one must not
+                // exhaust worker retries and trip the conductor-wide
+                // fail-stop -- skip THIS fill only.
+                error!(
+                    target: "hedge",
+                    event_type = trade_event.event.kind(),
+                    tx_hash = ?trade_event.tx_hash,
+                    log_index = trade_event.log_index,
+                    %error,
+                    "Skipping InventoryTrade fill with an unrecognized token address; it is \
+                     left unhedged and must be reconciled manually"
+                );
+                persist_skipped_fill(
+                    &ctx.pool,
+                    trade_event,
+                    SkipReason::UnrecognizedInventoryToken,
+                    &error.to_string(),
+                )
+                .await;
+                return Ok(());
+            }
+            Err(OnChainError::Validation(
+                error @ TradeValidationError::InvalidInventoryAmount(_),
+            )) => {
+                // InventoryTrade deposit/withdraw amounts come from any
+                // OPERATOR_ROLE holder on the shared inventory, same threat
+                // model as TokenIntrospectionFailed above: a malformed or
+                // extreme amount must not exhaust worker retries and trip
+                // the conductor-wide fail-stop -- skip THIS fill only.
+                error!(
+                    target: "hedge",
+                    event_type = trade_event.event.kind(),
+                    tx_hash = ?trade_event.tx_hash,
+                    log_index = trade_event.log_index,
+                    %error,
+                    "Skipping InventoryTrade fill with an unconvertible amount; it is \
+                     left unhedged and must be reconciled manually"
+                );
+                persist_skipped_fill(
+                    &ctx.pool,
+                    trade_event,
+                    SkipReason::InvalidInventoryAmount,
+                    &error.to_string(),
+                )
+                .await;
+                return Ok(());
+            }
             Err(err) => return Err(err.into()),
         };
 
@@ -186,7 +288,7 @@ where
 
         let vault_discovery_ctx = VaultDiscoveryCtx {
             vault_registry: &ctx.vault_registry,
-            orderbook: ctx.orderbook,
+            orderbook: ctx.contracts.orderbook,
             order_owner,
         };
 
@@ -250,12 +352,23 @@ async fn persist_skipped_fill(
     }
 }
 
-fn reconstruct_log(orderbook: Address, trade: &EmittedOnChain<RaindexTradeEvent>) -> Log {
-    use RaindexTradeEvent::{ClearV3, TakeOrderV3};
+fn reconstruct_log(contracts: RaindexContracts, trade: &EmittedOnChain<RaindexTradeEvent>) -> Log {
+    use RaindexTradeEvent::{ClearV3, InventoryTrade, TakeOrderV3};
 
-    let log_data = match &trade.event {
-        ClearV3(clear_event) => clear_event.as_ref().clone().into_log_data(),
-        TakeOrderV3(take_event) => take_event.as_ref().clone().into_log_data(),
+    // Pick the emitting contract for each event type. InventoryTrade events
+    // are emitted by the inventory contract; the paired-event log data
+    // encodes the OperatorWithdraw (the equity-side change the hedge cares
+    // about), which is enough for the downstream parser.
+    let (address, log_data) = match &trade.event {
+        ClearV3(clear_event) => (
+            contracts.orderbook,
+            clear_event.as_ref().clone().into_log_data(),
+        ),
+        TakeOrderV3(take_event) => (
+            contracts.orderbook,
+            take_event.as_ref().clone().into_log_data(),
+        ),
+        InventoryTrade(inv) => (contracts.inventory, inv.withdraw.clone().into_log_data()),
     };
 
     let block_timestamp = trade
@@ -264,7 +377,7 @@ fn reconstruct_log(orderbook: Address, trade: &EmittedOnChain<RaindexTradeEvent>
 
     Log {
         inner: alloy::primitives::Log {
-            address: orderbook,
+            address,
             data: log_data,
         },
         block_hash: None,
@@ -335,6 +448,8 @@ pub(crate) enum TradeAccountingError {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use alloy::primitives::{Address, B256, U256, address};
     use alloy::providers::mock::Asserter;
     use alloy::providers::{ProviderBuilder, RootProvider};
@@ -343,20 +458,96 @@ mod tests {
 
     use st0x_config::ExecutionThreshold;
     use st0x_config::create_test_ctx_with_order_owner;
+    use st0x_config::{AssetsConfig, EquitiesConfig, EquityAssetConfig, OperationMode};
     use st0x_event_sorcery::StoreBuilder;
     use st0x_evm::IERC20::{decimalsCall, symbolCall};
-    use st0x_execution::{MockExecutor, MockExecutorCtx, TryIntoExecutor};
+    use st0x_execution::{
+        FractionalShares, MockExecutor, MockExecutorCtx, Positive, Symbol, TryIntoExecutor,
+    };
+    use st0x_float_macro::float;
 
     use super::*;
+    use crate::bindings::IRaindexInventory::{OperatorDeposit, OperatorWithdraw};
     use crate::bindings::IRaindexV6;
     use crate::bindings::IRaindexV6::{
         AfterClearV2, ClearConfigV2, ClearStateChangeV2, SignedContextV1, TakeOrderConfigV4,
         TakeOrderV3 as TakeOrderV3Event,
     };
     use crate::offchain::order::{OffchainOrder, noop_order_placer};
+    use crate::onchain::trade::{INVENTORY_TOKEN_DECIMALS_MAX_RETRIES, InventoryTrade};
     use crate::onchain_trade::OnChainTrade;
     use crate::position::Position;
-    use crate::test_utils::{get_test_log, get_test_order, setup_test_pools};
+    use crate::test_utils::{get_test_log, get_test_order, panic_revert_payload, setup_test_pools};
+
+    /// Builds the CQRS stores, job queue, and `AccountantCtx` shared by every
+    /// `perform()` test in this module -- callers supply only what actually
+    /// varies per test (config `ctx`, symbol cache, provider, executor, and
+    /// execution threshold). Extracted because this ~30-line wiring block was
+    /// duplicated verbatim across every InventoryTrade/ClearV3/TakeOrderV3
+    /// `perform()` test.
+    async fn build_test_accountant_ctx<Node, Exec>(
+        pool: SqlitePool,
+        apalis_pool: &apalis_sqlite::SqlitePool,
+        ctx: Ctx,
+        cache: SymbolCache,
+        provider: Node,
+        executor: Exec,
+        execution_threshold: ExecutionThreshold,
+    ) -> AccountantCtx<Node, Exec>
+    where
+        Node: Provider + Clone,
+    {
+        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (offchain_order, _offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(noop_order_placer())
+                .await
+                .unwrap();
+
+        let (vault_registry, _vault_registry_projection) =
+            StoreBuilder::<VaultRegistry>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+
+        let cqrs = TradeProcessingCqrs {
+            pool: pool.clone(),
+            onchain_trade,
+            position,
+            position_projection,
+            offchain_order,
+            order_placer: noop_order_placer(),
+            execution_threshold,
+            assets: ctx.assets.clone(),
+            counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
+            poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(apalis_pool),
+            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(apalis_pool),
+        };
+
+        let job_queue = DexTradeAccountingJobQueue::new(apalis_pool);
+
+        AccountantCtx {
+            contracts: crate::onchain::raindex_contracts(&ctx.evm),
+            ctx,
+            cache,
+            pyth_feed_ids: PythFeedIds::default(),
+            evm: st0x_evm::ReadOnlyEvm::new(provider),
+            cqrs,
+            vault_registry,
+            executor,
+            pool,
+            job_queue,
+        }
+    }
 
     fn test_job() -> AccountForDexTrade {
         let log = get_test_log();
@@ -399,56 +590,16 @@ mod tests {
         // order_owner = Address::ZERO won't match test orders (owned by 0xdddd...)
         let ctx = create_test_ctx_with_order_owner(Address::ZERO);
 
-        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-
-        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-
-        let (offchain_order, _offchain_order_projection) =
-            StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
-                .await
-                .unwrap();
-
-        let (vault_registry, _vault_registry_projection) =
-            StoreBuilder::<VaultRegistry>::new(pool.clone())
-                .build(())
-                .await
-                .unwrap();
-
-        let cqrs = TradeProcessingCqrs {
-            pool: pool.clone(),
-            onchain_trade,
-            position,
-            position_projection,
-            offchain_order,
-            order_placer: noop_order_placer(),
-            execution_threshold: ExecutionThreshold::whole_share(),
-            assets: ctx.assets.clone(),
-            counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
-            poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(&apalis_pool),
-            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&apalis_pool),
-        };
-
-        let job_queue = DexTradeAccountingJobQueue::new(&apalis_pool);
-
-        let accountant_ctx = AccountantCtx {
-            orderbook: ctx.evm.orderbook,
+        let accountant_ctx = build_test_accountant_ctx(
+            pool,
+            &apalis_pool,
             ctx,
-            cache: SymbolCache::default(),
-            pyth_feed_ids: PythFeedIds::default(),
-            evm: st0x_evm::ReadOnlyEvm::new(provider),
-            cqrs,
-            vault_registry,
+            SymbolCache::default(),
+            provider,
             executor,
-            pool: pool.clone(),
-            job_queue,
-        };
+            ExecutionThreshold::whole_share(),
+        )
+        .await;
 
         let job = test_job();
         job.perform(&accountant_ctx).await.unwrap();
@@ -529,56 +680,16 @@ mod tests {
         let executor = MockExecutorCtx.try_into_executor().await.unwrap();
         let ctx = create_test_ctx_with_order_owner(order_owner);
 
-        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-
-        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-
-        let (offchain_order, _offchain_order_projection) =
-            StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
-                .await
-                .unwrap();
-
-        let (vault_registry, _vault_registry_projection) =
-            StoreBuilder::<VaultRegistry>::new(pool.clone())
-                .build(())
-                .await
-                .unwrap();
-
-        let cqrs = TradeProcessingCqrs {
-            pool: pool.clone(),
-            onchain_trade,
-            position,
-            position_projection,
-            offchain_order,
-            order_placer: noop_order_placer(),
-            execution_threshold: ExecutionThreshold::whole_share(),
-            assets: ctx.assets.clone(),
-            counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
-            poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(&apalis_pool),
-            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&apalis_pool),
-        };
-
-        let job_queue = DexTradeAccountingJobQueue::new(&apalis_pool);
-
-        let accountant_ctx = AccountantCtx {
-            orderbook: ctx.evm.orderbook,
+        let accountant_ctx = build_test_accountant_ctx(
+            pool,
+            &apalis_pool,
             ctx,
-            cache: SymbolCache::default(),
-            pyth_feed_ids: PythFeedIds::default(),
-            evm: st0x_evm::ReadOnlyEvm::new(provider),
-            cqrs,
-            vault_registry,
+            SymbolCache::default(),
+            provider,
             executor,
-            pool: pool.clone(),
-            job_queue,
-        };
+            ExecutionThreshold::whole_share(),
+        )
+        .await;
 
         // Should succeed (skip) rather than error.
         job.perform(&accountant_ctx).await.unwrap();
@@ -698,56 +809,16 @@ mod tests {
         let cache = SymbolCache::default();
         crate::test_utils::seed_get_test_order_token_symbols(&cache);
 
-        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-
-        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .build(())
-            .await
-            .unwrap();
-
-        let (offchain_order, _offchain_order_projection) =
-            StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(noop_order_placer())
-                .await
-                .unwrap();
-
-        let (vault_registry, _vault_registry_projection) =
-            StoreBuilder::<VaultRegistry>::new(pool.clone())
-                .build(())
-                .await
-                .unwrap();
-
-        let cqrs = TradeProcessingCqrs {
-            pool: pool.clone(),
-            onchain_trade,
-            position,
-            position_projection,
-            offchain_order,
-            order_placer: noop_order_placer(),
-            execution_threshold: ExecutionThreshold::whole_share(),
-            assets: ctx.assets.clone(),
-            counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
-            poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(&apalis_pool),
-            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&apalis_pool),
-        };
-
-        let job_queue = DexTradeAccountingJobQueue::new(&apalis_pool);
-
-        let accountant_ctx = AccountantCtx {
-            orderbook: ctx.evm.orderbook,
+        let accountant_ctx = build_test_accountant_ctx(
+            pool.clone(),
+            &apalis_pool,
             ctx,
             cache,
-            pyth_feed_ids: PythFeedIds::default(),
-            evm: st0x_evm::ReadOnlyEvm::new(provider),
-            cqrs,
-            vault_registry,
+            provider,
             executor,
-            pool: pool.clone(),
-            job_queue,
-        };
+            ExecutionThreshold::whole_share(),
+        )
+        .await;
 
         // Should surface and skip (Ok) rather than propagate the error.
         job.perform(&accountant_ctx).await.unwrap();
@@ -764,5 +835,769 @@ mod tests {
         assert_eq!(recorded.len(), 1);
         assert_eq!(recorded[0].log_index, 1);
         assert_eq!(recorded[0].reason, "unpriceable_fill");
+    }
+
+    /// An `InventoryTrade` whose two vault deltas are the same non-USDC token
+    /// (a non-hedgeable pair) must be routed through `try_from_inventory_trade`
+    /// and skipped gracefully -- exercising the InventoryTrade accounting arm
+    /// end to end without tripping the fail-stop.
+    #[tokio::test]
+    async fn perform_skips_inventory_trade_with_non_hedgeable_pair() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let asserter = Asserter::new();
+
+        // Both sides are 0xbbbb... (wtAAPL): no USDC leg, so the pair is
+        // non-hedgeable and TradeDetails::try_from_io rejects it.
+        let equity_token = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let inventory_trade = InventoryTrade {
+            deposit: OperatorDeposit {
+                operator: Address::ZERO,
+                token: equity_token,
+                vaultId: B256::ZERO,
+                amount: alloy::primitives::uint!(2000000000000000000_U256),
+            },
+            withdraw: OperatorWithdraw {
+                operator: Address::ZERO,
+                token: equity_token,
+                vaultId: B256::ZERO,
+                amount: alloy::primitives::uint!(2000000000000000000_U256),
+            },
+        };
+
+        let log = get_test_log();
+        let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
+        let job = AccountForDexTrade {
+            trade: EmittedOnChain::from_log(event, &log).unwrap(),
+        };
+
+        // Reconstructed log's tx_hash is get_test_log's; the parser fetches the
+        // receipt, then the deposit- then withdraw-token decimals() (both 18).
+        let tx_hash = alloy::primitives::fixed_bytes!(
+            "0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        );
+        asserter.push_success(&serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x1",
+            "blockHash": "0x1234567890123456789012345678901234567890123456789012345678901234",
+            "blockNumber": "0x1",
+            "from": "0x1234567890123456789012345678901234567890",
+            "to": "0x5678901234567890123456789012345678901234",
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x77359400",
+            "cumulativeGasUsed": "0x5208",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "logs": []
+        }));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&18u8));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&18u8));
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let cache = SymbolCache::default();
+        crate::test_utils::seed_get_test_order_token_symbols(&cache);
+
+        let accountant_ctx = build_test_accountant_ctx(
+            pool.clone(),
+            &apalis_pool,
+            ctx,
+            cache,
+            provider,
+            executor,
+            ExecutionThreshold::whole_share(),
+        )
+        .await;
+
+        // Should succeed (skip) rather than error.
+        job.perform(&accountant_ctx).await.unwrap();
+
+        // ...and durably record the skipped inventory fill for reconciliation.
+        let recorded = sqlx::query!(
+            "SELECT tx_hash, log_index, event_type, reason, detail FROM skipped_fills \
+             ORDER BY log_index"
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].event_type, "InventoryTrade");
+        assert_eq!(recorded[0].reason, "non_hedgeable_pair");
+    }
+
+    /// An `InventoryTrade` whose USDC leg address does not match the
+    /// configured canonical `USDC_BASE` -- even though its `symbol()`
+    /// reports "USDC" -- must be classified as `UnrecognizedInventoryToken`
+    /// and skipped gracefully through `perform()`, never hedged as if it
+    /// were real USDC.
+    #[tokio::test]
+    async fn perform_skips_inventory_trade_with_unrecognized_token() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let asserter = Asserter::new();
+
+        // 0xaaaa... resolves to "USDC" via the seeded cache but is NOT the
+        // configured canonical USDC_BASE address -- a spoof.
+        let spoof_usdc = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let equity_token = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let inventory_trade = InventoryTrade {
+            deposit: OperatorDeposit {
+                operator: Address::ZERO,
+                token: spoof_usdc,
+                vaultId: B256::ZERO,
+                amount: alloy::primitives::uint!(160000000_U256),
+            },
+            withdraw: OperatorWithdraw {
+                operator: Address::ZERO,
+                token: equity_token,
+                vaultId: B256::ZERO,
+                amount: alloy::primitives::uint!(2000000000000000000_U256),
+            },
+        };
+
+        let log = get_test_log();
+        let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
+        let job = AccountForDexTrade {
+            trade: EmittedOnChain::from_log(event, &log).unwrap(),
+        };
+
+        let tx_hash = alloy::primitives::fixed_bytes!(
+            "0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        );
+        asserter.push_success(&serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x1",
+            "blockHash": "0x1234567890123456789012345678901234567890123456789012345678901234",
+            "blockNumber": "0x1",
+            "from": "0x1234567890123456789012345678901234567890",
+            "to": "0x5678901234567890123456789012345678901234",
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x77359400",
+            "cumulativeGasUsed": "0x5208",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "logs": []
+        }));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&6u8));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&18u8));
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let cache = SymbolCache::default();
+        crate::test_utils::seed_get_test_order_token_symbols(&cache);
+
+        let accountant_ctx = build_test_accountant_ctx(
+            pool.clone(),
+            &apalis_pool,
+            ctx,
+            cache,
+            provider,
+            executor,
+            ExecutionThreshold::whole_share(),
+        )
+        .await;
+
+        // Should succeed (skip) rather than error -- a spoofed token address
+        // must not trip the fail-stop.
+        job.perform(&accountant_ctx).await.unwrap();
+
+        let recorded = sqlx::query!(
+            "SELECT tx_hash, log_index, event_type, reason, detail FROM skipped_fills \
+             ORDER BY log_index"
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].event_type, "InventoryTrade");
+        assert_eq!(recorded[0].reason, "unrecognized_inventory_token");
+    }
+
+    /// An `InventoryTrade` whose deposit token fails `decimals()`
+    /// introspection (a non-standard or reverting ERC20 -- these addresses
+    /// come from any OPERATOR_ROLE holder, not the bot's own trusted order
+    /// config) must be classified as `TokenIntrospectionFailed` and skipped
+    /// gracefully through `perform()` rather than tripping the fail-stop.
+    #[tokio::test]
+    async fn perform_skips_inventory_trade_with_unintrospectable_token() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let asserter = Asserter::new();
+
+        let usdc_token = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let equity_token = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let inventory_trade = InventoryTrade {
+            deposit: OperatorDeposit {
+                operator: Address::ZERO,
+                token: usdc_token,
+                vaultId: B256::ZERO,
+                amount: alloy::primitives::uint!(5_000_000_U256),
+            },
+            withdraw: OperatorWithdraw {
+                operator: Address::ZERO,
+                token: equity_token,
+                vaultId: B256::ZERO,
+                amount: alloy::primitives::uint!(2_000_000_000_000_000_000_U256),
+            },
+        };
+
+        let log = get_test_log();
+        let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
+        let job = AccountForDexTrade {
+            trade: EmittedOnChain::from_log(event, &log).unwrap(),
+        };
+
+        let tx_hash = alloy::primitives::fixed_bytes!(
+            "0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        );
+        asserter.push_success(&serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x1",
+            "blockHash": "0x1234567890123456789012345678901234567890123456789012345678901234",
+            "blockNumber": "0x1",
+            "from": "0x1234567890123456789012345678901234567890",
+            "to": "0x5678901234567890123456789012345678901234",
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x77359400",
+            "cumulativeGasUsed": "0x5208",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "logs": []
+        }));
+        // Both token symbols are preloaded into the cache below, so the only
+        // RPC introspection left is the two decimals() calls, each of which
+        // makes 1 + INVENTORY_TOKEN_DECIMALS_MAX_RETRIES attempts. Seed a
+        // genuine revert for every attempt of both legs: whichever leg
+        // tokio::try_join! resolves first then fails with the same
+        // TokenIntrospectionFailed classification, so the skip reason is
+        // deterministic regardless of polling order. A bare push_failure_msg
+        // would not do -- only a payload carrying revert data is classified as
+        // a revert rather than a retryable transport blip.
+        for _ in 0..2 * (1 + INVENTORY_TOKEN_DECIMALS_MAX_RETRIES) {
+            asserter.push_failure(panic_revert_payload());
+        }
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let cache = SymbolCache::default();
+        crate::test_utils::seed_get_test_order_token_symbols(&cache);
+
+        let accountant_ctx = build_test_accountant_ctx(
+            pool.clone(),
+            &apalis_pool,
+            ctx,
+            cache,
+            provider,
+            executor,
+            ExecutionThreshold::whole_share(),
+        )
+        .await;
+
+        // Should succeed (skip) rather than error, so a misbehaving
+        // third-party token cannot exhaust retries and trip the fail-stop.
+        job.perform(&accountant_ctx).await.unwrap();
+
+        let recorded = sqlx::query!(
+            "SELECT tx_hash, log_index, event_type, reason, detail FROM skipped_fills \
+             ORDER BY log_index"
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].event_type, "InventoryTrade");
+        assert_eq!(recorded[0].reason, "unintrospectable_token");
+    }
+
+    /// An `InventoryTrade` deposit amount that cannot be losslessly
+    /// represented as a `rain_math_float` value (here `U256::MAX`, which
+    /// deterministically overflows `Float::from_fixed_decimal` regardless of
+    /// decimals) must be classified as `InvalidInventoryAmount` and skipped
+    /// gracefully through `perform()` rather than tripping the fail-stop.
+    #[tokio::test]
+    async fn perform_skips_inventory_trade_with_invalid_amount() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let asserter = Asserter::new();
+
+        let usdc_token = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let equity_token = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let inventory_trade = InventoryTrade {
+            deposit: OperatorDeposit {
+                operator: Address::ZERO,
+                token: usdc_token,
+                vaultId: B256::ZERO,
+                amount: U256::MAX,
+            },
+            withdraw: OperatorWithdraw {
+                operator: Address::ZERO,
+                token: equity_token,
+                vaultId: B256::ZERO,
+                amount: alloy::primitives::uint!(2_000_000_000_000_000_000_U256),
+            },
+        };
+
+        let log = get_test_log();
+        let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
+        let job = AccountForDexTrade {
+            trade: EmittedOnChain::from_log(event, &log).unwrap(),
+        };
+
+        let tx_hash = alloy::primitives::fixed_bytes!(
+            "0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        );
+        asserter.push_success(&serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x1",
+            "blockHash": "0x1234567890123456789012345678901234567890123456789012345678901234",
+            "blockNumber": "0x1",
+            "from": "0x1234567890123456789012345678901234567890",
+            "to": "0x5678901234567890123456789012345678901234",
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x77359400",
+            "cumulativeGasUsed": "0x5208",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "logs": []
+        }));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&6u8));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&18u8));
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let cache = SymbolCache::default();
+        crate::test_utils::seed_get_test_order_token_symbols(&cache);
+
+        let accountant_ctx = build_test_accountant_ctx(
+            pool.clone(),
+            &apalis_pool,
+            ctx,
+            cache,
+            provider,
+            executor,
+            ExecutionThreshold::whole_share(),
+        )
+        .await;
+
+        // Should succeed (skip) rather than error, so a malformed external
+        // amount cannot exhaust retries and trip the fail-stop.
+        job.perform(&accountant_ctx).await.unwrap();
+
+        let recorded = sqlx::query!(
+            "SELECT tx_hash, log_index, event_type, reason, detail FROM skipped_fills \
+             ORDER BY log_index"
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].event_type, "InventoryTrade");
+        assert_eq!(recorded[0].reason, "invalid_inventory_amount");
+    }
+
+    /// A hedgeable `InventoryTrade` (real USDC leg + real equity leg, from
+    /// the real Bebop-routed prod settlement `0xe13a11de734768f08a9c1ef66e8de3bcb9072f8cdabce9f1d819e1ae9909d4b9`
+    /// also pinned at the parser level in `onchain::trade`'s
+    /// `try_from_inventory_trade_real_bebop_fill_is_sell`) must flow all the
+    /// way through `perform()`: the fill is recorded as an `OnChainTrade`,
+    /// `Position` advances by the exact real fractional share amount, and --
+    /// because that amount clears the (fractional, for this test)
+    /// execution threshold -- a hedge order is placed inline. This is the
+    /// InventoryTrade happy path; `perform_skips_inventory_trade_with_non_hedgeable_pair`
+    /// above only covers the skip branch.
+    #[tokio::test]
+    async fn perform_hedges_inventory_trade_with_hedgeable_pair() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let asserter = Asserter::new();
+
+        // Real Base-mainnet USDC and wtCOIN addresses (same as
+        // `onchain::trade`'s real-fixture tests).
+        let usdc_token = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+        let equity_token = address!("0x5CdA0E1cA4ce2Af96315F7F8963c85399c172204");
+        let operator = address!("0x8b8b6e0507c125934c6129563f48e48c66f86475");
+
+        // The pool received 5 USDC (deposit) and sent 0.034172366621067031
+        // wtCOIN (withdraw): it sold equity onchain, so it must hedge Sell.
+        let inventory_trade = InventoryTrade {
+            deposit: OperatorDeposit {
+                operator,
+                token: usdc_token,
+                vaultId: alloy::primitives::b256!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000004"
+                ),
+                amount: alloy::primitives::uint!(5_000_000_U256), // 5 USDC, 6 decimals
+            },
+            withdraw: OperatorWithdraw {
+                operator,
+                token: equity_token,
+                vaultId: alloy::primitives::b256!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000003"
+                ),
+                // 0.034172366621067031 wtCOIN, 18 decimals
+                amount: alloy::primitives::uint!(34_172_366_621_067_031_U256),
+            },
+        };
+
+        let tx_hash = alloy::primitives::fixed_bytes!(
+            "0xe13a11de734768f08a9c1ef66e8de3bcb9072f8cdabce9f1d819e1ae9909d4b9"
+        );
+        let mut log = crate::test_utils::create_log(0x97);
+        log.transaction_hash = Some(tx_hash);
+        log.block_number = Some(48_030_415);
+        log.block_timestamp = Some(1_782_850_177);
+
+        let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
+        let job = AccountForDexTrade {
+            trade: EmittedOnChain::from_log(event, &log).unwrap(),
+        };
+
+        // The parser fetches the receipt, then the deposit- (USDC, 6dp)
+        // then withdraw-token (wtCOIN, 18dp) decimals().
+        asserter.push_success(&serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x3b",
+            "blockHash": "0x373307a0e2154c2de6b046e349fc27f9bb02b01fdddbb15eeba57f3ce3b24973",
+            "blockNumber": "0x2dce2cf",
+            "from": "0x679df30b30ac2947aa3143490add6717af81dcc3",
+            "to": "0xbeb0009aca35087ce7ccf11637e24dd1aad3bf2a",
+            "gasUsed": "0x7a62d",
+            "effectiveGasPrice": "0x57bcf0",
+            "cumulativeGasUsed": "0xa00b4e",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "logs": []
+        }));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&6u8)); // USDC
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&18u8)); // wtCOIN
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
+
+        // Trading must be explicitly enabled for COIN: `perform` computes
+        // `trading_enabled` from `ctx.assets.is_trading_enabled`, which
+        // defaults to disabled for any symbol absent from the config.
+        // `tokenized_equity_derivative` must equal the real wtCOIN address
+        // used above -- `try_from_inventory_trade` now validates the
+        // InventoryTrade equity leg's address against this configured
+        // canonical address, not just its self-reported symbol().
+        let mut symbols = HashMap::new();
+        symbols.insert(
+            Symbol::new("COIN").unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: Address::ZERO,
+                tokenized_equity_derivative: equity_token,
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                extended_hours_counter_trading: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+        ctx.assets = AssetsConfig {
+            equities: EquitiesConfig {
+                operational_limit: None,
+                symbols,
+            },
+            cash: None,
+        };
+
+        let cache = SymbolCache::default();
+        cache.preload_symbol(usdc_token, "USDC");
+        cache.preload_symbol(equity_token, "wtCOIN");
+
+        let accountant_ctx = build_test_accountant_ctx(
+            pool.clone(),
+            &apalis_pool,
+            ctx,
+            cache,
+            provider,
+            executor,
+            // Below the real Bebop fill's 0.034172366621067031 wtCOIN so the
+            // fractional real amount still clears the threshold and triggers
+            // an inline hedge (the real fill is not a whole share).
+            ExecutionThreshold::shares(Positive::new(FractionalShares::new(float!(0.01))).unwrap()),
+        )
+        .await;
+
+        job.perform(&accountant_ctx).await.unwrap();
+
+        // The fill was persisted as an OnChainTrade.
+        let (fill_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("OnChainTradeEvent::Filled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            fill_count, 1,
+            "the hedgeable fill must be recorded as an OnChainTrade"
+        );
+
+        // Position advanced by the exact real fractional amount (Sell
+        // decreases net, increases accumulated_short), immediately hit the
+        // execution threshold, and claimed a pending hedge.
+        let expected_amount =
+            Float::from_fixed_decimal(alloy::primitives::uint!(34_172_366_621_067_031_U256), 18)
+                .unwrap();
+        let expected_shares = FractionalShares::new(expected_amount);
+
+        let symbol = Symbol::new("COIN").unwrap();
+        let position = accountant_ctx
+            .cqrs
+            .position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("Position should exist");
+        assert_eq!(
+            position.net,
+            (FractionalShares::ZERO - expected_shares).unwrap()
+        );
+        assert_eq!(position.accumulated_short, expected_shares);
+        assert_eq!(position.accumulated_long, FractionalShares::ZERO);
+        assert!(
+            position.pending_offchain_order_id.is_some(),
+            "clearing the execution threshold must claim a pending hedge"
+        );
+
+        // ...and a hedge order was actually placed (not skipped).
+        let (order_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM events WHERE event_type = 'OffchainOrderEvent::Placed'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(order_count, 1, "the hedge order must be placed");
+    }
+
+    /// The real univ4-routed prod settlement (`0x9ee8e401a6f12227df1a30a236b60ac83c72b2b1eb610d83cf292ae789eb0805`,
+    /// also pinned at the parser level in `onchain::trade`'s
+    /// `try_from_inventory_trade_real_univ4_fill_is_buy`) must flow all the
+    /// way through `perform()` too: the pool received wtCOIN (deposit) and
+    /// sent USDC (withdraw), i.e. it bought equity onchain, so `Position`
+    /// must advance in the Buy direction and a hedge order must be placed.
+    /// `perform_hedges_inventory_trade_with_hedgeable_pair` above only
+    /// exercises the Sell-direction real fixture; this is the only real
+    /// fixture that proves the deposit-side-equity (Buy) wiring end to end.
+    #[tokio::test]
+    async fn perform_hedges_inventory_trade_with_real_univ4_buy_fixture() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let asserter = Asserter::new();
+
+        // Real Base-mainnet wtCOIN and USDC addresses (same as
+        // `onchain::trade`'s real-fixture tests).
+        let equity_token = address!("0x5CdA0E1cA4ce2Af96315F7F8963c85399c172204");
+        let usdc_token = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+        let operator = address!("0x36ebb1e5149c60111dd035f0417a4b00d39caa88");
+
+        // The pool received 0.01 wtCOIN (deposit) and sent 2 USDC (withdraw):
+        // it bought equity onchain, so it must hedge Buy.
+        let inventory_trade = InventoryTrade {
+            deposit: OperatorDeposit {
+                operator,
+                token: equity_token,
+                vaultId: alloy::primitives::b256!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000003"
+                ),
+                amount: alloy::primitives::uint!(10_000_000_000_000_000_U256), // 0.01 wtCOIN, 18dp
+            },
+            withdraw: OperatorWithdraw {
+                operator,
+                token: usdc_token,
+                vaultId: alloy::primitives::b256!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000004"
+                ),
+                amount: alloy::primitives::uint!(2_000_000_U256), // 2 USDC, 6dp
+            },
+        };
+
+        let tx_hash = alloy::primitives::fixed_bytes!(
+            "0x9ee8e401a6f12227df1a30a236b60ac83c72b2b1eb610d83cf292ae789eb0805"
+        );
+        let mut log = crate::test_utils::create_log(0xf4);
+        log.transaction_hash = Some(tx_hash);
+        log.block_number = Some(48_051_940);
+        log.block_timestamp = Some(1_782_893_227);
+
+        let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
+        let job = AccountForDexTrade {
+            trade: EmittedOnChain::from_log(event, &log).unwrap(),
+        };
+
+        // The parser fetches the receipt, then the deposit- (wtCOIN, 18dp)
+        // then withdraw-token (USDC, 6dp) decimals().
+        asserter.push_success(&serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x41",
+            "blockHash": "0x4fb86ed2edeee5845f379874a140df6ed78a5553877a4a480878f2eb70f0efeb",
+            "blockNumber": "0x2dd36e4",
+            "from": "0x679df30b30ac2947aa3143490add6717af81dcc3",
+            "to": "0xe23457189a0186b23e9f325eb11364b3733c2c89",
+            "gasUsed": "0x54025",
+            "effectiveGasPrice": "0x59a538",
+            "cumulativeGasUsed": "0xa481c7",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "logs": []
+        }));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&18u8)); // wtCOIN
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&6u8)); // USDC
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
+
+        // Trading must be explicitly enabled for COIN: `perform` computes
+        // `trading_enabled` from `ctx.assets.is_trading_enabled`, which
+        // defaults to disabled for any symbol absent from the config.
+        // `tokenized_equity_derivative` must equal the real wtCOIN address
+        // used above -- `try_from_inventory_trade` now validates the
+        // InventoryTrade equity leg's address against this configured
+        // canonical address, not just its self-reported symbol().
+        let mut symbols = HashMap::new();
+        symbols.insert(
+            Symbol::new("COIN").unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: Address::ZERO,
+                tokenized_equity_derivative: equity_token,
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                extended_hours_counter_trading: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+        ctx.assets = AssetsConfig {
+            equities: EquitiesConfig {
+                operational_limit: None,
+                symbols,
+            },
+            cash: None,
+        };
+
+        let cache = SymbolCache::default();
+        cache.preload_symbol(equity_token, "wtCOIN");
+        cache.preload_symbol(usdc_token, "USDC");
+
+        let accountant_ctx = build_test_accountant_ctx(
+            pool.clone(),
+            &apalis_pool,
+            ctx,
+            cache,
+            provider,
+            executor,
+            // Below the real univ4 fill's 0.01 wtCOIN so it still clears the
+            // threshold and triggers an inline hedge.
+            ExecutionThreshold::shares(
+                Positive::new(FractionalShares::new(float!(0.001))).unwrap(),
+            ),
+        )
+        .await;
+
+        job.perform(&accountant_ctx).await.unwrap();
+
+        // The fill was persisted as an OnChainTrade.
+        let (fill_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("OnChainTradeEvent::Filled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            fill_count, 1,
+            "the hedgeable fill must be recorded as an OnChainTrade"
+        );
+
+        // Position advanced by the exact real fractional amount (Buy
+        // increases net and accumulated_long), immediately hit the
+        // execution threshold, and claimed a pending hedge.
+        let expected_amount =
+            Float::from_fixed_decimal(alloy::primitives::uint!(10_000_000_000_000_000_U256), 18)
+                .unwrap();
+        let expected_shares = FractionalShares::new(expected_amount);
+
+        let symbol = Symbol::new("COIN").unwrap();
+        let position = accountant_ctx
+            .cqrs
+            .position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("Position should exist");
+        assert_eq!(position.net, expected_shares);
+        assert_eq!(position.accumulated_long, expected_shares);
+        assert_eq!(position.accumulated_short, FractionalShares::ZERO);
+        assert!(
+            position.pending_offchain_order_id.is_some(),
+            "clearing the execution threshold must claim a pending hedge"
+        );
+
+        // ...and a hedge order was actually placed (not skipped).
+        let (order_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM events WHERE event_type = 'OffchainOrderEvent::Placed'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(order_count, 1, "the hedge order must be placed");
+    }
+
+    /// `reconstruct_log` must attribute an `InventoryTrade` to the inventory
+    /// contract (not the orderbook) and encode the `OperatorWithdraw` -- the
+    /// equity-side change the downstream parser decodes.
+    #[test]
+    fn reconstruct_log_for_inventory_trade_uses_inventory_address_and_round_trips_withdraw() {
+        let orderbook = address!("0x1111111111111111111111111111111111111111");
+        let inventory = address!("0x2222222222222222222222222222222222222222");
+
+        let withdraw = OperatorWithdraw {
+            operator: address!("0x3333333333333333333333333333333333333333"),
+            token: address!("0x4444444444444444444444444444444444444444"),
+            vaultId: B256::ZERO,
+            amount: U256::from(42u64),
+        };
+        let deposit = OperatorDeposit {
+            operator: withdraw.operator,
+            token: address!("0x5555555555555555555555555555555555555555"),
+            vaultId: B256::ZERO,
+            amount: U256::from(100u64),
+        };
+
+        let event = RaindexTradeEvent::InventoryTrade(Box::new(InventoryTrade {
+            deposit,
+            withdraw: withdraw.clone(),
+        }));
+        let emitted = EmittedOnChain::from_log(event, &get_test_log()).unwrap();
+
+        let reconstructed = reconstruct_log(
+            RaindexContracts {
+                orderbook,
+                inventory,
+            },
+            &emitted,
+        );
+
+        assert_eq!(reconstructed.address(), inventory);
+
+        let decoded = reconstructed
+            .log_decode::<OperatorWithdraw>()
+            .unwrap()
+            .data()
+            .clone();
+        assert_eq!(decoded.operator, withdraw.operator);
+        assert_eq!(decoded.token, withdraw.token);
+        assert_eq!(decoded.vaultId, withdraw.vaultId);
+        assert_eq!(decoded.amount, withdraw.amount);
     }
 }

--- a/tests/e2e/base_chain.rs
+++ b/tests/e2e/base_chain.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use st0x_evm::test_chain::{evm_mapping_slot, solidity_short_string};
 pub use st0x_evm::{IERC20, USDC_BASE};
 pub use st0x_hedge::bindings::DeployableERC20;
+use st0x_hedge::bindings::IRaindexInventory;
 use st0x_hedge::bindings::IRaindexV6::{self, TakeOrderV3};
 use st0x_hedge::bindings::{Deployer, Interpreter, Parser, RaindexV6, Store as RainStore};
 
@@ -951,6 +952,122 @@ impl<P: Provider + Clone> BaseChain<P> {
             output_vault_balance_after_take,
         })
     }
+
+    /// Deploys a `RaindexInventory` (raindex.governance) pointing at this
+    /// chain's OrderBook, with `self.owner` as `DEFAULT_ADMIN_ROLE` holder.
+    /// Used by inventory e2e tests to exercise `OperatorDeposit`/
+    /// `OperatorWithdraw` settlements from a venue adapter that isn't the
+    /// bot itself.
+    pub async fn deploy_inventory(&self) -> anyhow::Result<Address> {
+        let inventory = IRaindexInventory::deploy(&self.provider, self.owner, self.orderbook)
+            .await?
+            .address()
+            .to_owned();
+        Ok(inventory)
+    }
+
+    /// Grants `OPERATOR_ROLE` on `inventory` to `operator`, signed by
+    /// `self.owner` (the inventory's `DEFAULT_ADMIN_ROLE` holder).
+    pub async fn grant_inventory_operator(
+        &self,
+        inventory: Address,
+        operator: Address,
+    ) -> anyhow::Result<()> {
+        let inventory_instance = IRaindexInventory::new(inventory, &self.provider);
+        let operator_role = inventory_instance.OPERATOR_ROLE().call().await?;
+        inventory_instance
+            .grantRole(operator_role, operator)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        Ok(())
+    }
+
+    /// Seeds `inventory`'s `vault_id` for `token` with `amount` (raw units,
+    /// `decimals` decimal places), deposited by `self.owner` (admin). Used to
+    /// give an inventory-owned vault an initial balance before a synthetic
+    /// venue operator withdraws against it -- `withdraw4` reverts against an
+    /// empty vault, exactly like the underlying OrderBook.
+    pub async fn seed_inventory_vault(
+        &self,
+        inventory: Address,
+        token: Address,
+        vault_id: B256,
+        amount: U256,
+        decimals: u8,
+    ) -> anyhow::Result<()> {
+        // Over-approve for Rain float precision rounding, matching
+        // `deposit_into_raindex_vault`'s orderbook-deposit precedent.
+        IERC20::new(token, &self.provider)
+            .approve(inventory, amount * U256::from(2))
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+
+        let deposit_float = Float::from_fixed_decimal(amount, decimals)
+            .map_err(|err| anyhow::anyhow!("Float conversion: {err:?}"))?
+            .get_inner();
+
+        IRaindexInventory::new(inventory, &self.provider)
+            .deposit4(token, vault_id, deposit_float, vec![])
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+
+        Ok(())
+    }
+}
+
+/// Performs a genuine venue-style settlement against `inventory`, signed by
+/// `operator_provider`'s wallet (an account holding `OPERATOR_ROLE`, distinct
+/// from the bot/order owner): a `deposit4` + `withdraw4` batched into a
+/// single tx via the contract's inherited `Multicall`, so both legs land in
+/// one settlement tx the way a real adapter (Bebop hook, univ4 hook) would --
+/// `enqueue_batch_events` pairs `OperatorDeposit`/`OperatorWithdraw` by
+/// `tx_hash`.
+///
+/// `deposit`/`withdraw` are `(token, vault_id, amount, decimals)`; `amount`
+/// is in raw fixed-decimal units. Returns the settlement tx hash.
+pub async fn inventory_operator_settle<P: Provider>(
+    operator_provider: &P,
+    inventory: Address,
+    deposit: (Address, B256, U256, u8),
+    withdraw: (Address, B256, U256, u8),
+) -> anyhow::Result<B256> {
+    let (deposit_token, deposit_vault_id, deposit_amount, deposit_decimals) = deposit;
+    let (withdraw_token, withdraw_vault_id, withdraw_amount, withdraw_decimals) = withdraw;
+
+    let deposit_float = Float::from_fixed_decimal(deposit_amount, deposit_decimals)
+        .map_err(|err| anyhow::anyhow!("Float conversion: {err:?}"))?
+        .get_inner();
+    let withdraw_float = Float::from_fixed_decimal(withdraw_amount, withdraw_decimals)
+        .map_err(|err| anyhow::anyhow!("Float conversion: {err:?}"))?
+        .get_inner();
+
+    let inventory_instance = IRaindexInventory::new(inventory, operator_provider);
+
+    let deposit_calldata = inventory_instance
+        .deposit4(deposit_token, deposit_vault_id, deposit_float, vec![])
+        .calldata()
+        .to_owned();
+    let withdraw_calldata = inventory_instance
+        .withdraw4(withdraw_token, withdraw_vault_id, withdraw_float, vec![])
+        .calldata()
+        .to_owned();
+
+    let receipt = inventory_instance
+        .multicall(vec![deposit_calldata, withdraw_calldata])
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    anyhow::ensure!(receipt.status(), "inventory multicall settlement reverted");
+
+    Ok(receipt.transaction_hash)
 }
 
 /// Deploys a USDC ERC20 at the given address using `anvil_set_code` with

--- a/tests/e2e/hedging.rs
+++ b/tests/e2e/hedging.rs
@@ -10,6 +10,11 @@
 
 pub(crate) mod assertions;
 
+use alloy::network::EthereumWallet;
+use alloy::primitives::{B256, U256, utils::parse_units};
+use alloy::providers::ProviderBuilder;
+use alloy::providers::ext::AnvilApi as _;
+use alloy::signers::local::PrivateKeySigner;
 use rain_math_float::Float;
 use st0x_execution::alpaca_broker_api::OrderStatus;
 use st0x_float_macro::float;
@@ -17,6 +22,8 @@ use st0x_float_macro::float;
 use st0x_hedge::FailureInjector;
 
 use self::assertions::*;
+use crate::assert::{assert_broker_state, assert_cqrs_state};
+use crate::base_chain::{self, DeployableERC20, IERC20, USDC_BASE};
 use crate::poll::poll_for_all_jobs_done;
 
 #[test_log::test(tokio::test)]
@@ -1569,5 +1576,137 @@ async fn job_failure_halts_bot() -> anyhow::Result<()> {
         "No new OnChainTrade events should be persisted after terminal failure"
     );
 
+    Ok(())
+}
+
+/// An `InventoryTrade` fill (settlement through a shared `RaindexInventory`,
+/// as a real venue adapter like the Bebop hook or univ4 hook would submit)
+/// must hedge exactly like a direct ClearV3/TakeOrderV3 fill.
+///
+/// Deploys `RaindexInventory` on the same Anvil chain, grants `OPERATOR_ROLE`
+/// to a synthetic venue operator distinct from the bot/order owner, funds it
+/// with equity shares, and has it perform a genuine `deposit4` (equity in) +
+/// `withdraw4` (USDC out) settlement batched into one tx via the contract's
+/// inherited `Multicall` -- mirroring how a real adapter settles atomically.
+/// The bot runs in `inventory_mode = "managed"` pointed at this contract, so
+/// the live `OrderFillMonitor` must pick up the `OperatorDeposit`/
+/// `OperatorWithdraw` pair through the real backfill -> pairing -> accountant
+/// -> hedge pipeline (no test-only shortcuts) and place the expected hedge.
+#[test_log::test(tokio::test)]
+async fn e2e_inventory_trade_settlement_hedges() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(150.00);
+    let broker_fill_price = float!(148.50);
+    let equity_amount = float!(4);
+
+    // BuyEquity hedges Sell, which the extended-hours guard treats as a
+    // short unless the broker already reports enough shares -- pre-seed a
+    // broker position, mirroring `multi_asset_sustained_load`'s TSLA leg.
+    let infra = TestInfra::start(
+        vec![(equity_symbol, broker_fill_price)],
+        vec![(equity_symbol, float!(100))],
+    )
+    .await?;
+
+    let (_, equity_vault_token, _) = infra
+        .equity_addresses
+        .iter()
+        .find(|(symbol, ..)| symbol == equity_symbol)
+        .expect("AAPL equity vault must be deployed by TestInfra::start")
+        .clone();
+
+    // Deploy the shared inventory pointed at this chain's OrderBook, with
+    // the same account TestInfra uses as order owner/admin.
+    let inventory = infra.base_chain.deploy_inventory().await?;
+
+    // A synthetic venue operator: a fresh, funded account distinct from the
+    // bot's own order owner, holding OPERATOR_ROLE only.
+    let operator_signer = PrivateKeySigner::random();
+    let operator = operator_signer.address();
+    let operator_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(operator_signer))
+        .connect(&infra.base_chain.endpoint())
+        .await?;
+    let ten_eth: U256 = parse_units("10", 18)?.into();
+    infra
+        .base_chain
+        .provider
+        .anvil_set_balance(operator, ten_eth)
+        .await?;
+
+    infra
+        .base_chain
+        .grant_inventory_operator(inventory, operator)
+        .await?;
+
+    // Seed the inventory's USDC vault (admin-funded) so the operator's
+    // withdraw4(USDC) below has a real balance to draw from.
+    let usdc_vault_id = B256::random();
+    let usdc_amount: U256 = parse_units("600", 6)?.into();
+    infra
+        .base_chain
+        .seed_inventory_vault(inventory, USDC_BASE, usdc_vault_id, usdc_amount, 6)
+        .await?;
+
+    // Fund the operator with equity shares to deposit, and have it approve
+    // the inventory to pull them.
+    let equity_vault_id = B256::random();
+    let equity_amount_raw: U256 = parse_units("4", 18)?.into();
+    DeployableERC20::new(equity_vault_token, &infra.base_chain.provider)
+        .transfer(operator, equity_amount_raw)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    IERC20::new(equity_vault_token, &operator_provider)
+        .approve(inventory, equity_amount_raw * U256::from(2))
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    // Everything above is setup noise the bot must not backfill; only scan
+    // from here on.
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .inventory_mode_override(InventoryMode::Managed { inventory })
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // The real settlement: the pool received equity (deposit) and sent USDC
+    // out (withdraw), i.e. it bought equity onchain, so the bot must hedge
+    // Sell -- both legs batched into one tx via Multicall.
+    base_chain::inventory_operator_settle(
+        &operator_provider,
+        inventory,
+        (equity_vault_token, equity_vault_id, equity_amount_raw, 18),
+        (USDC_BASE, usdc_vault_id, usdc_amount, 6),
+    )
+    .await?;
+
+    poll_for_events(&mut bot, &infra.db_path, "OffchainOrderEvent::Filled", 1).await;
+
+    let expected_positions = [ExpectedPosition::builder()
+        .symbol(equity_symbol)
+        .amount(equity_amount)
+        .direction(TakeDirection::BuyEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(equity_amount)
+        .expected_accumulated_short(float!(0))
+        .expected_net(float!(0))
+        .build()];
+
+    assert_broker_state(&expected_positions, &infra.broker_service);
+    assert_cqrs_state(&expected_positions, 1, &infra.db_path.display().to_string()).await?;
+
+    bot.abort();
     Ok(())
 }

--- a/tests/e2e/hedging/assertions.rs
+++ b/tests/e2e/hedging/assertions.rs
@@ -5,6 +5,7 @@ use sqlx::SqlitePool;
 pub(crate) use std::time::Duration;
 use tokio::task::JoinHandle;
 
+pub(crate) use st0x_config::InventoryMode;
 use st0x_config::{AssetsConfig, BrokerCtx, Ctx};
 pub(crate) use st0x_event_sorcery::Projection;
 use st0x_execution::alpaca_broker_api::{AlpacaBrokerMock, TEST_API_KEY, TEST_API_SECRET};
@@ -42,6 +43,10 @@ pub(crate) fn build_ctx<P: Provider + Clone>(
     /// `broker.base_url()`. Used by chaos tests to route broker calls
     /// through a fault-injecting proxy.
     broker_url_override: Option<url::Url>,
+    /// Rebalancing settlement mode; defaults to `Legacy` (see
+    /// `Ctx::for_test`). Tests exercising a shared `RaindexInventory` pass
+    /// `Managed { inventory }` explicitly.
+    inventory_mode_override: Option<InventoryMode>,
 ) -> anyhow::Result<Ctx> {
     let broker_url = broker_url_override.map_or_else(
         || broker.base_url(),
@@ -72,6 +77,7 @@ pub(crate) fn build_ctx<P: Provider + Clone>(
         .order_owner(chain.owner)
         .assets(assets)
         .maybe_execution_threshold_override(execution_threshold_override)
+        .maybe_inventory_mode(inventory_mode_override)
         .call()
         .map_err(Into::into)
 }


### PR DESCRIPTION
## What

Closes [RAI-1197](https://linear.app/makeitrain/issue/RAI-1197/liquidity-bot-hedge-on-cross-venue-fills-bebop-univ4-trade-events) and [RAI-684](https://linear.app/makeitrain/issue/RAI-684/extend-liquidity-bot-countertrading-to-bebop) (folded in — the venue-agnostic version covers Bebop).

Adds a third fill source to the `st0x.liquidity` fill watcher: settlements routed through the shared **`RaindexInventory`** on behalf of any venue adapter (Bebop hook, univ4 hook, or any future venue holding `OPERATOR_ROLE`) are now hedged alongside direct Raindex clears.

Stacked on [#969](https://app.graphite.com/github/pr/ST0x-Technology/st0x.liquidity/969).

## Why

- One pool, many consumers: Bebop RFQs and univ4 swaps against the same shared vaults are settled by draws on the inventory contract (`OperatorDeposit` + `OperatorWithdraw` per settlement). Before this PR the bot only hedged direct Raindex clears (`ClearV3`/`TakeOrderV3`), so every adapter fill flowed through the shared pool unhedged — a growing directional exposure.
- Venue-agnostic by construction: the vault deltas ARE the trade regardless of which adapter routed the settlement, so watching the single inventory contract covers every future venue for free (supersedes the Bebop-only RAI-684).

## How

- **Event model:** new `RaindexTradeEvent::InventoryTrade` variant carrying the paired `(OperatorDeposit, OperatorWithdraw)`. Direction/price/amount derive through the same `TradeDetails::try_from_io` as the ClearV3 path (USDC side prices, wrapped-equity side drives quantity). `TradeDetails` now carries the resolved `equity_symbol` + `equity_token`, so both parsers stop re-deriving the equity side from a raw `"USDC"` string compare.
- **Backfill:** a third `eth_getLogs` filter (address = `evm_ctx.inventory_address()`, topic0 ∈ `{OperatorDeposit, OperatorWithdraw}`). Deposits are bucketed by `tx_hash`; each withdraw pairs with its same-tx deposit into one `AccountForDexTrade`.
- **Skip the bot's own settlements:** since #969 the bot's rebalancing calls `deposit4`/`withdraw4` on the same inventory, emitting `Operator*` events with `operator == order_owner`. Those are filtered out before pairing (threaded from `BackfillRange::perform`), so routine rebalances don't fire the unpaired-withdraw path or create phantom hedges. A genuinely unpaired withdraw (or a second deposit in one tx) is logged.
- **Parser** (`try_from_inventory_trade`): resolves symbols/decimals, and now matches the ClearV3 sibling exactly — a non-positive price on a non-zero-equity fill now returns `Err(NonPositivePrice)` — recorded in `skipped_fills` rather than silently dropped as `Ok(None)` — and the block timestamp goes through `resolve_block_timestamp` (header fallback) so backfilled fills don't persist null timestamps.
- **Trade accountant:** `AccountantCtx` gains the `inventory` address; `reconstruct_log` selects the emitting contract per event type. Downstream Alpaca hedging is untouched.
- **Rebase note:** #969 turned `EvmCtx.inventory` into an `InventoryMode` enum, so the three read sites here now use `inventory_address()`.

## Testing

- `cargo nextest run -p st0x-hedge --all-features` (incl. e2e): all pass. `cargo clippy --workspace --all-targets --all-features` and `cargo fmt --check`: clean.
- New tests: parser happy-path + zero-equity + non-positive-price + USDC-on-deposit direction-flip; backfill pairing (real pair → one job, unpaired → skipped, bot-operator pair → skipped, interleaved ordering); accountant `InventoryTrade` perform arm; `reconstruct_log` address/round-trip.

## Anything else

- **Prod fill txs to sanity-check against once live:**
  - Bebop: `0xe13a11de734768f08a9c1ef66e8de3bcb9072f8cdabce9f1d819e1ae9909d4b9` (~0.0342 wtCOIN for 5 USDC via BebopRouter)
  - Univ4: `0x9ee8e401a6f12227df1a30a236b60ac83c72b2b1eb610d83cf292ae789eb0805` (0.01 wtCOIN → 2 USDC on the v4 pool)
- **On rollout, rewind the backfill checkpoint** to the inventory deploy block (or run a one-shot backfill) so adapter fills before this deploy get ingested — the persisted checkpoint predates inventory ingestion (noted at the checkpoint site).
- **Attribution vs signal:** the `operator` topic identifies which venue routed a settlement, but the hedge signal is `(token, vaultId, net Δ)` regardless of operator — per-venue metrics are easy to add later.
- Same ops dependency as [#969](https://app.graphite.com/github/pr/ST0x-Technology/st0x.liquidity/969): [RAI-1198](https://linear.app/makeitrain/issue/RAI-1198/redeploy-raindexinventory-owned-by-turnkey-migrate-vaults-regrant) supplies the final inventory address for config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for inventory-settled trades in managed inventory mode by pairing deposit/withdraw settlement legs and processing them through the existing trade pipeline.
  * Enabled inventory-aware on-chain recovery/backfill and added an ABI binding for inventory event decoding.

* **Bug Fixes**
  * Prevent inventory trade events from triggering vault registry discovery.
  * Quarantines/skips ambiguous, reorged, bot-origin, invalid, or non-introspectable inventory settlements; records skipped fills.

* **Documentation / Metrics / Tests**
  * Updated the event-processing specification and expanded metrics for inventory ambiguity/unpaired settlements.
  * Expanded integration and unit test coverage, including managed inventory e2e hedging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->