### PR TITLE
feat: render performance charts with LayerChart

### DIFF
--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -27,6 +27,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-svelte": "^3.13.1",
         "globals": "^16.5.0",
+        "layerchart": "2.0.0-next.48",
         "prettier": "^3.7.4",
         "prettier-plugin-svelte": "^3.4.0",
         "svelte": "^5.45.6",
@@ -42,6 +43,10 @@
     },
   },
   "packages": {
+    "@dagrejs/dagre": ["@dagrejs/dagre@2.0.4", "", { "dependencies": { "@dagrejs/graphlib": "3.0.4" } }, "sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA=="],
+
+    "@dagrejs/graphlib": ["@dagrejs/graphlib@3.0.4", "", {}, "sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
@@ -137,6 +142,14 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@layerstack/svelte-actions": ["@layerstack/svelte-actions@1.0.1-next.18", "", { "dependencies": { "@floating-ui/dom": "^1.7.0", "@layerstack/utils": "2.0.0-next.18", "d3-scale": "^4.0.2" } }, "sha512-gxPzCnJ1c9LTfWtRqLUzefCx+k59ZpxDUQ2XB+LokveZQPe7IDSOwHaBOEMlaGoGrtwc3Ft8dSZq+2WT2o9u/g=="],
+
+    "@layerstack/svelte-state": ["@layerstack/svelte-state@0.1.0-next.23", "", { "dependencies": { "@layerstack/utils": "2.0.0-next.18" } }, "sha512-7O4umv+gXwFfs3/vjzFWYHNXGwYnnjBapWJ5Y+9u99F4eVk6rh4ocNwqkqQNkpMZ5tUJBlRTWjPE1So6+hEzIg=="],
+
+    "@layerstack/tailwind": ["@layerstack/tailwind@2.0.0-next.21", "", { "dependencies": { "@layerstack/utils": "^2.0.0-next.18", "clsx": "^2.1.1", "d3-array": "^3.2.4", "tailwind-merge": "^3.2.0" } }, "sha512-Qgp2EpmEHmjtura8MQzWicR6ztBRSsRvddakFtx9ShrLMz6jWzd6bCMVVRu44Q3ZOrtXmSu4QxjCZWu1ytvuPg=="],
+
+    "@layerstack/utils": ["@layerstack/utils@2.0.0-next.18", "", { "dependencies": { "d3-array": "^3.2.4", "d3-time": "^3.1.0", "d3-time-format": "^4.1.0" } }, "sha512-EYILHpfBRYMMEahajInu9C2AXQom5IcAEdtCeucD3QIl/fdDgRbtzn6/8QW9ewumfyNZetdUvitOksmI1+gZYQ=="],
 
     "@lucide/svelte": ["@lucide/svelte@0.544.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-9f9O6uxng2pLB01sxNySHduJN3HTl5p0HDu4H26VR51vhZfiMzyOMe9Mhof3XAk4l813eTtl+/DYRvGyoRR+yw=="],
 
@@ -240,9 +253,15 @@
 
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
@@ -318,6 +337,8 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
@@ -326,6 +347,58 @@
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-geo-voronoi": ["d3-geo-voronoi@2.1.0", "", { "dependencies": { "d3-array": "3", "d3-delaunay": "6", "d3-geo": "3", "d3-tricontour": "1" } }, "sha512-kqE4yYuOjPbKdBXG0xztCacPwkVSK2REF1opSNrnqqtXJmNcM++UbwQ8SxvwP6IQTj9RvIjjK4qeiVsEfj0Z2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-interpolate-path": ["d3-interpolate-path@2.3.0", "", {}, "sha512-tZYtGXxBmbgHsIc9Wms6LS5u4w6KbP8C09a4/ZYc4KLMYYqub57rRBUgpUr2CIarIrJEpdAWWxWQvofgaMpbKQ=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-tile": ["d3-tile@1.0.0", "", {}, "sha512-79fnTKpPMPDS5xQ0xuS9ir0165NEwwkFpe/DSOmc2Gl9ldYzKKRDWogmTTE8wAJ8NA7PMapNfEcyKhI9Lxdu5Q=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-tricontour": ["d3-tricontour@1.1.0", "", { "dependencies": { "d3-delaunay": "6", "d3-scale": "4" } }, "sha512-G7gHKj89n2owmkGb6WX6ixcnQ0Kf/0wpa9VIh9DGdbHu8wdrlaHU4ir3/bFNERl8N8nn4G7e7qbtBG8N9caihQ=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
@@ -333,6 +406,8 @@
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -402,6 +477,8 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -409,6 +486,8 @@
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -433,6 +512,8 @@
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "known-css-properties": ["known-css-properties@0.37.0", "", {}, "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ=="],
+
+    "layerchart": ["layerchart@2.0.0-next.48", "", { "dependencies": { "@dagrejs/dagre": "^2.0.4", "@layerstack/svelte-actions": "1.0.1-next.18", "@layerstack/svelte-state": "0.1.0-next.23", "@layerstack/tailwind": "2.0.0-next.21", "@layerstack/utils": "2.0.0-next.18", "@types/d3-contour": "^3.0.6", "d3-array": "^3.2.4", "d3-chord": "^3.0.1", "d3-color": "^3.1.0", "d3-contour": "^4.0.2", "d3-delaunay": "^6.0.4", "d3-dsv": "^3.0.1", "d3-force": "^3.0.0", "d3-geo": "^3.1.1", "d3-geo-voronoi": "^2.1.0", "d3-hierarchy": "^3.1.2", "d3-interpolate": "^3.0.1", "d3-interpolate-path": "^2.3.0", "d3-path": "^3.1.0", "d3-quadtree": "^3.0.1", "d3-random": "^3.0.1", "d3-sankey": "^0.12.3", "d3-scale": "^4.0.2", "d3-scale-chromatic": "^3.1.0", "d3-shape": "^3.2.0", "d3-tile": "^1.0.0", "d3-time": "^3.1.0", "memoize": "^10.2.0", "runed": "^0.37.1" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-XoEYBztamA8lMxtF/Jz3aDX0HMk8dI+o4fK9fSl8ecT2Tdx3DQUjtKGtlQAOFdwC/AWifeLmKq5cMTQt9COZPQ=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -471,6 +552,10 @@
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "memoize": ["memoize@10.2.0", "", { "dependencies": { "mimic-function": "^5.0.1" } }, "sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA=="],
+
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -526,11 +611,17 @@
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rollup": ["rollup@4.53.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.53.3", "@rollup/rollup-android-arm64": "4.53.3", "@rollup/rollup-darwin-arm64": "4.53.3", "@rollup/rollup-darwin-x64": "4.53.3", "@rollup/rollup-freebsd-arm64": "4.53.3", "@rollup/rollup-freebsd-x64": "4.53.3", "@rollup/rollup-linux-arm-gnueabihf": "4.53.3", "@rollup/rollup-linux-arm-musleabihf": "4.53.3", "@rollup/rollup-linux-arm64-gnu": "4.53.3", "@rollup/rollup-linux-arm64-musl": "4.53.3", "@rollup/rollup-linux-loong64-gnu": "4.53.3", "@rollup/rollup-linux-ppc64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-musl": "4.53.3", "@rollup/rollup-linux-s390x-gnu": "4.53.3", "@rollup/rollup-linux-x64-gnu": "4.53.3", "@rollup/rollup-linux-x64-musl": "4.53.3", "@rollup/rollup-openharmony-arm64": "4.53.3", "@rollup/rollup-win32-arm64-msvc": "4.53.3", "@rollup/rollup-win32-ia32-msvc": "4.53.3", "@rollup/rollup-win32-x64-gnu": "4.53.3", "@rollup/rollup-win32-x64-msvc": "4.53.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA=="],
 
     "runed": ["runed@0.37.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0", "zod": "^4.1.0" }, "optionalPeers": ["@sveltejs/kit", "zod"] }, "sha512-MeFY73xBW8IueWBm012nNFIGy19WUGPLtknavyUPMpnyt350M47PhGSGrGoSLbidwn+Zlt/O0cp8/OZE3LASWA=="],
 
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
@@ -640,10 +731,18 @@
 
     "bits-ui/runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
 
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "svelte-toolbelt/runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
   }
 }

--- a/dashboard/bun.nix
+++ b/dashboard/bun.nix
@@ -13,6 +13,14 @@
   ...
 }:
 {
+  "@dagrejs/dagre@2.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-2.0.4.tgz";
+    hash = "sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==";
+  };
+  "@dagrejs/graphlib@3.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-3.0.4.tgz";
+    hash = "sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg==";
+  };
   "@emnapi/core@1.7.1" = fetchurl {
     url = "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz";
     hash = "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==";
@@ -216,6 +224,22 @@
   "@jridgewell/trace-mapping@0.3.31" = fetchurl {
     url = "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz";
     hash = "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==";
+  };
+  "@layerstack/svelte-actions@1.0.1-next.18" = fetchurl {
+    url = "https://registry.npmjs.org/@layerstack/svelte-actions/-/svelte-actions-1.0.1-next.18.tgz";
+    hash = "sha512-gxPzCnJ1c9LTfWtRqLUzefCx+k59ZpxDUQ2XB+LokveZQPe7IDSOwHaBOEMlaGoGrtwc3Ft8dSZq+2WT2o9u/g==";
+  };
+  "@layerstack/svelte-state@0.1.0-next.23" = fetchurl {
+    url = "https://registry.npmjs.org/@layerstack/svelte-state/-/svelte-state-0.1.0-next.23.tgz";
+    hash = "sha512-7O4umv+gXwFfs3/vjzFWYHNXGwYnnjBapWJ5Y+9u99F4eVk6rh4ocNwqkqQNkpMZ5tUJBlRTWjPE1So6+hEzIg==";
+  };
+  "@layerstack/tailwind@2.0.0-next.21" = fetchurl {
+    url = "https://registry.npmjs.org/@layerstack/tailwind/-/tailwind-2.0.0-next.21.tgz";
+    hash = "sha512-Qgp2EpmEHmjtura8MQzWicR6ztBRSsRvddakFtx9ShrLMz6jWzd6bCMVVRu44Q3ZOrtXmSu4QxjCZWu1ytvuPg==";
+  };
+  "@layerstack/utils@2.0.0-next.18" = fetchurl {
+    url = "https://registry.npmjs.org/@layerstack/utils/-/utils-2.0.0-next.18.tgz";
+    hash = "sha512-EYILHpfBRYMMEahajInu9C2AXQom5IcAEdtCeucD3QIl/fdDgRbtzn6/8QW9ewumfyNZetdUvitOksmI1+gZYQ==";
   };
   "@lucide/svelte@0.544.0" = fetchurl {
     url = "https://registry.npmjs.org/@lucide/svelte/-/svelte-0.544.0.tgz";
@@ -429,6 +453,14 @@
     url = "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz";
     hash = "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==";
   };
+  "@types/d3-array@3.2.2" = fetchurl {
+    url = "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz";
+    hash = "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==";
+  };
+  "@types/d3-contour@3.0.6" = fetchurl {
+    url = "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz";
+    hash = "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==";
+  };
   "@types/deep-eql@4.0.2" = fetchurl {
     url = "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz";
     hash = "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==";
@@ -436,6 +468,10 @@
   "@types/estree@1.0.8" = fetchurl {
     url = "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz";
     hash = "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==";
+  };
+  "@types/geojson@7946.0.16" = fetchurl {
+    url = "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz";
+    hash = "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==";
   };
   "@types/json-schema@7.0.15" = fetchurl {
     url = "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz";
@@ -589,6 +625,10 @@
     url = "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz";
     hash = "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==";
   };
+  "commander@7.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz";
+    hash = "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==";
+  };
   "concat-map@0.0.1" = fetchurl {
     url = "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz";
     hash = "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==";
@@ -605,6 +645,122 @@
     url = "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz";
     hash = "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==";
   };
+  "d3-array@2.12.1" = fetchurl {
+    url = "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz";
+    hash = "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==";
+  };
+  "d3-array@3.2.4" = fetchurl {
+    url = "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz";
+    hash = "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==";
+  };
+  "d3-chord@3.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz";
+    hash = "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==";
+  };
+  "d3-color@3.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz";
+    hash = "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==";
+  };
+  "d3-contour@4.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz";
+    hash = "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==";
+  };
+  "d3-delaunay@6.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz";
+    hash = "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==";
+  };
+  "d3-dispatch@3.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz";
+    hash = "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==";
+  };
+  "d3-dsv@3.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz";
+    hash = "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==";
+  };
+  "d3-force@3.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz";
+    hash = "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==";
+  };
+  "d3-format@3.1.2" = fetchurl {
+    url = "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz";
+    hash = "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==";
+  };
+  "d3-geo-voronoi@2.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/d3-geo-voronoi/-/d3-geo-voronoi-2.1.0.tgz";
+    hash = "sha512-kqE4yYuOjPbKdBXG0xztCacPwkVSK2REF1opSNrnqqtXJmNcM++UbwQ8SxvwP6IQTj9RvIjjK4qeiVsEfj0Z2Q==";
+  };
+  "d3-geo@3.1.1" = fetchurl {
+    url = "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz";
+    hash = "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==";
+  };
+  "d3-hierarchy@3.1.2" = fetchurl {
+    url = "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz";
+    hash = "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==";
+  };
+  "d3-interpolate-path@2.3.0" = fetchurl {
+    url = "https://registry.npmjs.org/d3-interpolate-path/-/d3-interpolate-path-2.3.0.tgz";
+    hash = "sha512-tZYtGXxBmbgHsIc9Wms6LS5u4w6KbP8C09a4/ZYc4KLMYYqub57rRBUgpUr2CIarIrJEpdAWWxWQvofgaMpbKQ==";
+  };
+  "d3-interpolate@3.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz";
+    hash = "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==";
+  };
+  "d3-path@1.0.9" = fetchurl {
+    url = "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz";
+    hash = "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==";
+  };
+  "d3-path@3.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz";
+    hash = "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==";
+  };
+  "d3-quadtree@3.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz";
+    hash = "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==";
+  };
+  "d3-random@3.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz";
+    hash = "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==";
+  };
+  "d3-sankey@0.12.3" = fetchurl {
+    url = "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz";
+    hash = "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==";
+  };
+  "d3-scale-chromatic@3.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz";
+    hash = "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==";
+  };
+  "d3-scale@4.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz";
+    hash = "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==";
+  };
+  "d3-shape@1.3.7" = fetchurl {
+    url = "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz";
+    hash = "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==";
+  };
+  "d3-shape@3.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz";
+    hash = "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==";
+  };
+  "d3-tile@1.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/d3-tile/-/d3-tile-1.0.0.tgz";
+    hash = "sha512-79fnTKpPMPDS5xQ0xuS9ir0165NEwwkFpe/DSOmc2Gl9ldYzKKRDWogmTTE8wAJ8NA7PMapNfEcyKhI9Lxdu5Q==";
+  };
+  "d3-time-format@4.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz";
+    hash = "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==";
+  };
+  "d3-time@3.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz";
+    hash = "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==";
+  };
+  "d3-timer@3.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz";
+    hash = "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==";
+  };
+  "d3-tricontour@1.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/d3-tricontour/-/d3-tricontour-1.1.0.tgz";
+    hash = "sha512-G7gHKj89n2owmkGb6WX6ixcnQ0Kf/0wpa9VIh9DGdbHu8wdrlaHU4ir3/bFNERl8N8nn4G7e7qbtBG8N9caihQ==";
+  };
   "debug@4.4.3" = fetchurl {
     url = "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz";
     hash = "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==";
@@ -620,6 +776,10 @@
   "deepmerge@4.3.1" = fetchurl {
     url = "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz";
     hash = "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==";
+  };
+  "delaunator@5.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz";
+    hash = "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==";
   };
   "dequal@2.0.3" = fetchurl {
     url = "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz";
@@ -765,6 +925,10 @@
     url = "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz";
     hash = "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==";
   };
+  "iconv-lite@0.6.3" = fetchurl {
+    url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz";
+    hash = "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==";
+  };
   "ignore@5.3.2" = fetchurl {
     url = "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz";
     hash = "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==";
@@ -784,6 +948,14 @@
   "inline-style-parser@0.2.7" = fetchurl {
     url = "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz";
     hash = "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==";
+  };
+  "internmap@1.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz";
+    hash = "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==";
+  };
+  "internmap@2.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz";
+    hash = "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==";
   };
   "is-extglob@2.1.1" = fetchurl {
     url = "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz";
@@ -832,6 +1004,10 @@
   "known-css-properties@0.37.0" = fetchurl {
     url = "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz";
     hash = "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==";
+  };
+  "layerchart@2.0.0-next.48" = fetchurl {
+    url = "https://registry.npmjs.org/layerchart/-/layerchart-2.0.0-next.48.tgz";
+    hash = "sha512-XoEYBztamA8lMxtF/Jz3aDX0HMk8dI+o4fK9fSl8ecT2Tdx3DQUjtKGtlQAOFdwC/AWifeLmKq5cMTQt9COZPQ==";
   };
   "levn@0.4.1" = fetchurl {
     url = "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz";
@@ -908,6 +1084,14 @@
   "magic-string@0.30.21" = fetchurl {
     url = "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz";
     hash = "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==";
+  };
+  "memoize@10.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/memoize/-/memoize-10.2.0.tgz";
+    hash = "sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA==";
+  };
+  "mimic-function@5.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz";
+    hash = "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==";
   };
   "minimatch@3.1.2" = fetchurl {
     url = "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz";
@@ -1021,6 +1205,10 @@
     url = "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz";
     hash = "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==";
   };
+  "robust-predicates@3.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz";
+    hash = "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==";
+  };
   "rollup@4.53.3" = fetchurl {
     url = "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz";
     hash = "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==";
@@ -1033,9 +1221,17 @@
     url = "https://registry.npmjs.org/runed/-/runed-0.37.1.tgz";
     hash = "sha512-MeFY73xBW8IueWBm012nNFIGy19WUGPLtknavyUPMpnyt350M47PhGSGrGoSLbidwn+Zlt/O0cp8/OZE3LASWA==";
   };
+  "rw@1.3.3" = fetchurl {
+    url = "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz";
+    hash = "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==";
+  };
   "sade@1.8.1" = fetchurl {
     url = "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz";
     hash = "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==";
+  };
+  "safer-buffer@2.1.2" = fetchurl {
+    url = "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz";
+    hash = "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==";
   };
   "semver@7.7.3" = fetchurl {
     url = "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz";

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -36,6 +36,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-svelte": "^3.13.1",
     "globals": "^16.5.0",
+    "layerchart": "2.0.0-next.48",
     "prettier": "^3.7.4",
     "prettier-plugin-svelte": "^3.4.0",
     "svelte": "^5.45.6",

--- a/dashboard/src/lib/components/performance-panel.svelte
+++ b/dashboard/src/lib/components/performance-panel.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import { onMount } from 'svelte'
+  import { BarChart, LineChart, type ChartState, type Tooltip } from 'layerchart'
   import * as Card from '$lib/components/ui/card'
+  import * as Chart from '$lib/components/ui/chart'
+  import type { EquityOperationKind } from '$lib/api/EquityOperationKind'
+  import type { EquityStageName } from '$lib/api/EquityStageName'
+  import type { EquityTimings } from '$lib/api/EquityTimings'
   import type { HedgeLatencies } from '$lib/api/HedgeLatencies'
   import type { InfraReport } from '$lib/api/InfraReport'
   import type { RebalanceStageName } from '$lib/api/RebalanceStageName'
@@ -10,31 +15,43 @@
   import type { UsdcBridgeDirection } from '$lib/api/UsdcBridgeDirection'
   import { reactive } from '$lib/frp.svelte'
   import {
+    fetchEquityTimings,
     fetchHedgeLatencies,
     fetchInfraReport,
     fetchRebalanceTimings,
-    fetchReliabilityReport,
+    fetchReliabilityReport
   } from '$lib/performance/api'
   import {
     blockLagCard,
     detectionCard,
     errorsCard,
     exposureCard,
-    openExposureCard,
+    openExposureCard
   } from '$lib/performance/cards'
   import {
-    type WaterfallSegmentName,
+    type EquityBarRow,
+    type RebalanceBarRow,
+    type WaterfallBarRow,
     type WaterfallSort,
-    layoutAttestationTrend,
-    layoutBlockLagTrend,
+    buildEquityRows,
+    buildPercentileSeries,
+    buildRebalanceRows,
+    buildWaterfallRows,
     layoutDependencySparkline,
-    layoutPercentileSeries,
-    layoutRebalanceBars,
-    layoutWaterfall,
+    thinTicks
   } from '$lib/performance/charts'
   import { type SloStatus, formatDurationMs } from '$lib/performance/slo'
 
   const { onOpenLogs }: { onOpenLogs?: (target: string) => void } = $props()
+
+  // Explicit params type for every `Chart.Tooltip` `formatter` snippet below --
+  // layerchart's generic component typing doesn't reliably flow through to
+  // inline snippet destructuring, leaving `item` typed `any` without this.
+  type TooltipFormatterParams = {
+    value: unknown
+    name: string
+    item: Tooltip.TooltipSeries
+  }
 
   const POLL_INTERVAL_MS = 30_000
   const CARD_WINDOW_HOURS = 24
@@ -73,7 +90,7 @@
     try {
       const [latencyReport, reliabilityReport] = await Promise.all([
         fetchHedgeLatencies({ from, to }),
-        fetchReliabilityReport({ from, to }),
+        fetchReliabilityReport({ from, to })
       ])
       if (seq !== cardFetchSeq) return
 
@@ -86,17 +103,15 @@
     } catch (fetchError) {
       if (seq !== cardFetchSeq) return
 
-      error.update(() =>
-        fetchError instanceof Error ? fetchError.message : 'Unknown error',
-      )
+      error.update(() => (fetchError instanceof Error ? fetchError.message : 'Unknown error'))
     }
 
     await infraRefresh
   }
 
-  type RangePreset = '1W' | '1M' | 'YTD' | '1Y' | 'ALL'
+  type RangePreset = '1W' | '2W' | '1M' | 'YTD' | '1Y' | 'ALL'
 
-  const RANGE_PRESETS: RangePreset[] = ['1W', '1M', 'YTD', '1Y', 'ALL']
+  const RANGE_PRESETS: RangePreset[] = ['1W', '2W', '1M', 'YTD', '1Y', 'ALL']
 
   /** Pre-dates the system's first deployment, so ALL covers everything. */
   const ALL_TIME_START = new Date('2025-01-01T00:00:00Z')
@@ -104,6 +119,18 @@
   const rangeStart = (preset: RangePreset, now: Date): Date => {
     if (preset === '1W') {
       return new Date(now.getTime() - 7 * 86_400_000)
+    }
+
+    if (preset === '2W') {
+      // 15, not 14: stays under ReportRange::bucket_width's 31-day daily/
+      // weekly threshold (so this still renders at daily granularity, same
+      // as 1W) with a day of margin over a literal two weeks. Covers
+      // `nix run .#simulate-14d`'s 14-day seeded fixture as long as the
+      // dashboard is viewed within ~12h of the bot starting (the fixture's
+      // oldest sample is a fixed timestamp set once at seed time, so a
+      // longer-running session can eventually age it out of this trailing
+      // window -- see `seed_simulated_hedge_latency_history`).
+      return new Date(now.getTime() - 15 * 86_400_000)
     }
 
     if (preset === '1M') {
@@ -124,6 +151,7 @@
   const chartRange = reactive<RangePreset>('1W')
   const chartLatencies = reactive<HedgeLatencies | null>(null)
   const chartRebalances = reactive<RebalanceTimings | null>(null)
+  const chartEquityTimings = reactive<EquityTimings | null>(null)
   const chartInfra = reactive<InfraReport | null>(null)
   const ingestionTruncated = reactive<boolean>(false)
   const chartError = reactive<string | null>(null)
@@ -137,14 +165,14 @@
     const to = new Date()
     const range = {
       from: rangeStart(chartRange.current, to),
-      to,
+      to
     }
 
     // Ingestion-health telemetry is pruned at the retention window, so clamp
     // the infra query to it and flag when the selected range was truncated --
     // a 1Y view must not be mistaken for "the system has only run 14 days".
     const infraFrom = new Date(
-      Math.max(range.from.getTime(), to.getTime() - INGESTION_RETENTION_MS),
+      Math.max(range.from.getTime(), to.getTime() - INGESTION_RETENTION_MS)
     )
     ingestionTruncated.update(() => infraFrom.getTime() > range.from.getTime())
 
@@ -158,10 +186,20 @@
         // Isolated: latency/rebalance charts stay fresh even if infra is down.
       })
 
+    // Equity timing is the newest endpoint, so keep its failure from blocking
+    // the latency and rebalance chart refresh (same rationale as infra above).
+    const equityRefresh = fetchEquityTimings(range)
+      .then((equityReport) => {
+        if (seq === chartFetchSeq) chartEquityTimings.update(() => equityReport)
+      })
+      .catch(() => {
+        // Isolated: latency/rebalance charts stay fresh even if equity is down.
+      })
+
     try {
       const [latencyReport, rebalanceReport] = await Promise.all([
         fetchHedgeLatencies(range),
-        fetchRebalanceTimings(range),
+        fetchRebalanceTimings(range)
       ])
 
       if (seq !== chartFetchSeq) return
@@ -173,12 +211,11 @@
     } catch (fetchError) {
       if (seq !== chartFetchSeq) return
 
-      chartError.update(() =>
-        fetchError instanceof Error ? fetchError.message : 'Unknown error',
-      )
+      chartError.update(() => (fetchError instanceof Error ? fetchError.message : 'Unknown error'))
     }
 
     await infraRefresh
+    await equityRefresh
   }
 
   const selectRange = (preset: RangePreset) => {
@@ -204,7 +241,7 @@
     exposureCard(latencies.current),
     errorsCard(reliability.current, CARD_WINDOW_HOURS),
     openExposureCard(latencies.current, lastRefreshed.current),
-    blockLagCard(infra.current, lastRefreshed.current),
+    blockLagCard(infra.current, lastRefreshed.current)
   ])
 
   const statusClasses = (status: SloStatus): string => {
@@ -239,36 +276,46 @@
     return 'bg-red-500'
   }
 
-  const WATERFALL_PLOT_WIDTH = 600
   const WATERFALL_MAX_ROWS = 20
+  const WATERFALL_ROW_HEIGHT_PX = 28
 
   const waterfallSort = reactive<WaterfallSort>('slowest')
 
-  const SEGMENT_COLORS: Record<WaterfallSegmentName, string> = {
-    unhedged: '#64748b',
-    submission: '#38bdf8',
-    execution: '#34d399',
-  }
+  const WATERFALL_CHART_CONFIG = {
+    unhedged: {
+      label: 'unhedged (fill -> placed)',
+      color: '#64748b'
+    },
+    submission: {
+      label: 'submission (placed -> accepted)',
+      color: '#38bdf8'
+    },
+    executionOk: {
+      label: 'execution (accepted -> filled)',
+      color: '#34d399'
+    },
+    executionFailed: {
+      label: 'execution (failed)',
+      color: '#f87171'
+    }
+  } satisfies Chart.ChartConfig
 
-  const SEGMENT_LABELS: Record<WaterfallSegmentName, string> = {
-    unhedged: 'unhedged (fill -> placed)',
-    submission: 'submission (placed -> accepted)',
-    execution: 'execution (accepted -> filled)',
-  }
-
-  const segmentColor = (
-    name: WaterfallSegmentName,
-    status: string,
-  ): string => (name === 'execution' && status === 'failed' ? '#f87171' : SEGMENT_COLORS[name])
+  const waterfallSeries = Object.entries(WATERFALL_CHART_CONFIG).map(([key, { label, color }]) => ({
+    key,
+    label,
+    color,
+    value: key
+  }))
 
   const waterfallRows = $derived(
-    layoutWaterfall(chartLatencies.current?.cycles ?? [], {
-      plotWidth: WATERFALL_PLOT_WIDTH,
+    buildWaterfallRows(chartLatencies.current?.cycles ?? [], {
       sort: waterfallSort.current,
       maxRows: WATERFALL_MAX_ROWS,
-      now: chartRefreshedAt.current ?? new Date(),
-    }),
+      now: chartRefreshedAt.current ?? new Date()
+    })
   )
+
+  const waterfallSymbolById = $derived(new Map(waterfallRows.map((row) => [row.id, row.symbol])))
 
   type StageKey = keyof StageLatencies
 
@@ -277,40 +324,61 @@
     { key: 'detection', label: 'Detection' },
     { key: 'decision', label: 'Decision' },
     { key: 'submission', label: 'Submission' },
-    { key: 'execution', label: 'Execution' },
+    { key: 'execution', label: 'Execution' }
   ]
 
-  const SERIES_PLOT_WIDTH = 600
-  const SERIES_PLOT_HEIGHT = 160
-
-  const PERCENTILE_COLORS = {
-    p50Ms: '#34d399',
-    p90Ms: '#fbbf24',
-    p99Ms: '#f87171',
-  } as const
+  const PERCENTILE_CHART_CONFIG = {
+    p50Ms: {
+      label: 'p50',
+      color: '#34d399'
+    },
+    p90Ms: {
+      label: 'p90',
+      color: '#fbbf24'
+    },
+    p99Ms: {
+      label: 'p99',
+      color: '#f87171'
+    }
+  } satisfies Chart.ChartConfig
 
   const selectedStage = reactive<StageKey>('exposureWindow')
 
-  const seriesLayout = $derived(
-    layoutPercentileSeries(chartLatencies.current?.buckets ?? [], selectedStage.current, {
-      plotWidth: SERIES_PLOT_WIDTH,
-      plotHeight: SERIES_PLOT_HEIGHT,
-      maxXLabels: 8,
-    }),
+  const percentileSeriesData = $derived(
+    buildPercentileSeries(chartLatencies.current?.buckets ?? [], selectedStage.current)
   )
 
-  // Each percentile line has one point per sampled time bucket, so the first
-  // line's point count is the number of buckets with samples. A trend needs at
-  // least two; a single bucket would otherwise render as a few floating dots.
-  const seriesBucketCount = $derived(seriesLayout.lines[0]?.points.length ?? 0)
+  // A trend needs at least two sampled buckets; a single bucket would
+  // otherwise render as a few floating points with no line.
+  const percentileSampleCount = $derived(
+    percentileSeriesData.filter((point) => point.p50Ms !== null).length
+  )
+
+  const MAX_PERCENTILE_X_TICKS = 8
+
+  // Explicit tick values, thinned to a fixed cap: see thinTicks' doc comment
+  // for why the default d3 time-scale tick generator can't be trusted here.
+  const percentileXTicks = $derived(thinTicks(percentileSeriesData, MAX_PERCENTILE_X_TICKS))
 
   const rangeButtonClass = (active: boolean): string =>
     `rounded px-2 py-1 text-xs font-medium transition-colors ${active ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground'}`
 
-  const REBALANCE_PLOT_WIDTH = 600
   const REBALANCE_MAX_ROWS = 15
-  const TREND_PLOT_WIDTH = 600
-  const TREND_PLOT_HEIGHT = 80
+  const REBALANCE_ROW_HEIGHT_PX = 28
+
+  const ATTESTATION_CHART_CONFIG = {
+    durationMs: {
+      label: 'Attestation time',
+      color: '#fbbf24'
+    }
+  } satisfies Chart.ChartConfig
+
+  const BLOCK_LAG_CHART_CONFIG = {
+    maxLagBlocks: {
+      label: 'Block lag',
+      color: '#38bdf8'
+    }
+  } satisfies Chart.ChartConfig
 
   const STAGE_COLORS: Record<RebalanceStageName, string> = {
     conversion: '#c084fc',
@@ -318,38 +386,235 @@
     burn: '#fb923c',
     attestation: '#fbbf24',
     mint: '#34d399',
-    deposit: '#818cf8',
+    deposit: '#818cf8'
   }
 
+  const REBALANCE_FAILED_COLOR = '#f87171'
+
+  // Segment order is fixed (conversion -> withdrawal -> burn -> attestation ->
+  // mint -> deposit) and matches AlpacaToBase's chronological pipeline, but
+  // NOT BaseToAlpaca's -- conversion is that direction's last stage (see
+  // src/performance/rebalance.rs), so its bar renders left-to-right out of
+  // real chronological order. A single shared stacked chart can't be
+  // chronological for both directions at once.
+  const REBALANCE_CHART_CONFIG = {
+    conversionOk: {
+      label: 'conversion',
+      color: STAGE_COLORS.conversion
+    },
+    conversionFailed: {
+      label: 'conversion (failed)',
+      color: REBALANCE_FAILED_COLOR
+    },
+    withdrawalOk: {
+      label: 'withdrawal',
+      color: STAGE_COLORS.withdrawal
+    },
+    withdrawalFailed: {
+      label: 'withdrawal (failed)',
+      color: REBALANCE_FAILED_COLOR
+    },
+    burnOk: {
+      label: 'burn',
+      color: STAGE_COLORS.burn
+    },
+    burnFailed: {
+      label: 'burn (failed)',
+      color: REBALANCE_FAILED_COLOR
+    },
+    attestationOk: {
+      label: 'attestation',
+      color: STAGE_COLORS.attestation
+    },
+    attestationFailed: {
+      label: 'attestation (failed)',
+      color: REBALANCE_FAILED_COLOR
+    },
+    mintOk: {
+      label: 'mint',
+      color: STAGE_COLORS.mint
+    },
+    mintFailed: {
+      label: 'mint (failed)',
+      color: REBALANCE_FAILED_COLOR
+    },
+    depositOk: {
+      label: 'deposit',
+      color: STAGE_COLORS.deposit
+    },
+    depositFailed: {
+      label: 'deposit (failed)',
+      color: REBALANCE_FAILED_COLOR
+    },
+    // Elapsed time not accounted for by any measured stage -- covers both an
+    // in-progress operation's still-open stage (no durationMs yet) and a
+    // completed-but-recovered operation whose stages don't fully cover its
+    // measured round-trip. Without this, either case would render as an
+    // invisible or shorter-than-real bar.
+    unmeasuredMs: {
+      label: 'unaccounted elapsed',
+      color: '#64748b'
+    }
+  } satisfies Chart.ChartConfig
+
+  const rebalanceSeries = Object.entries(REBALANCE_CHART_CONFIG).map(([key, { label, color }]) => ({
+    key,
+    label,
+    color,
+    value: key
+  }))
+
   const rebalanceRows = $derived(
-    layoutRebalanceBars(chartRebalances.current?.operations ?? [], {
-      plotWidth: REBALANCE_PLOT_WIDTH,
+    buildRebalanceRows(chartRebalances.current?.operations ?? [], {
       maxRows: REBALANCE_MAX_ROWS,
-      now: chartRefreshedAt.current ?? new Date(),
-    }),
+      now: chartRefreshedAt.current ?? new Date()
+    })
   )
 
-  const attestationTrend = $derived(
-    layoutAttestationTrend(chartRebalances.current?.attestationTrend ?? [], {
-      plotWidth: TREND_PLOT_WIDTH,
-      plotHeight: TREND_PLOT_HEIGHT,
-    }),
+  const attestationChartData = $derived(
+    (chartRebalances.current?.attestationTrend ?? []).map((sample) => ({
+      burnedAt: new Date(sample.burnedAt),
+      durationMs: sample.durationMs
+    }))
+  )
+  const attestationMaxMs = $derived(
+    Math.max(0, ...attestationChartData.map((sample) => sample.durationMs))
   )
 
-  const blockLagTrend = $derived(
-    layoutBlockLagTrend(chartInfra.current?.monitor.blockLag ?? [], {
-      plotWidth: TREND_PLOT_WIDTH,
-      plotHeight: TREND_PLOT_HEIGHT,
-    }),
+  const blockLagChartData = $derived(
+    (chartInfra.current?.monitor.blockLag ?? []).map((point) => ({
+      start: new Date(point.start),
+      maxLagBlocks: point.maxLagBlocks
+    }))
   )
+  const blockLagMax = $derived(Math.max(0, ...blockLagChartData.map((point) => point.maxLagBlocks)))
 
   const DIRECTION_LABELS: Record<UsdcBridgeDirection, string> = {
     alpaca_to_base: 'Alpaca → Base',
-    base_to_alpaca: 'Base → Alpaca',
+    base_to_alpaca: 'Base → Alpaca'
   }
 
   const directionLabel = (direction: UsdcBridgeDirection | null): string =>
     direction === null ? '—' : DIRECTION_LABELS[direction]
+
+  const EQUITY_MAX_ROWS = 15
+  const EQUITY_ROW_HEIGHT_PX = 28
+
+  const EQUITY_STAGE_COLORS: Record<EquityStageName, string> = {
+    mint_acceptance: '#c084fc',
+    mint_receipt: '#38bdf8',
+    mint_wrap: '#fb923c',
+    mint_deposit: '#34d399',
+    redemption_withdraw: '#818cf8',
+    redemption_unwrap: '#f472b6',
+    redemption_send: '#facc15',
+    redemption_detection: '#22d3ee',
+    redemption_completion: '#a3e635'
+  }
+
+  const EQUITY_FAILED_COLOR = '#f87171'
+
+  const EQUITY_CHART_CONFIG = {
+    mintAcceptanceOk: {
+      label: 'mint acceptance',
+      color: EQUITY_STAGE_COLORS.mint_acceptance
+    },
+    mintAcceptanceFailed: {
+      label: 'mint acceptance (failed)',
+      color: EQUITY_FAILED_COLOR
+    },
+    mintReceiptOk: {
+      label: 'mint receipt',
+      color: EQUITY_STAGE_COLORS.mint_receipt
+    },
+    mintReceiptFailed: {
+      label: 'mint receipt (failed)',
+      color: EQUITY_FAILED_COLOR
+    },
+    mintWrapOk: {
+      label: 'mint wrap',
+      color: EQUITY_STAGE_COLORS.mint_wrap
+    },
+    mintWrapFailed: {
+      label: 'mint wrap (failed)',
+      color: EQUITY_FAILED_COLOR
+    },
+    mintDepositOk: {
+      label: 'mint deposit',
+      color: EQUITY_STAGE_COLORS.mint_deposit
+    },
+    mintDepositFailed: {
+      label: 'mint deposit (failed)',
+      color: EQUITY_FAILED_COLOR
+    },
+    redemptionWithdrawOk: {
+      label: 'redemption withdraw',
+      color: EQUITY_STAGE_COLORS.redemption_withdraw
+    },
+    redemptionWithdrawFailed: {
+      label: 'redemption withdraw (failed)',
+      color: EQUITY_FAILED_COLOR
+    },
+    redemptionUnwrapOk: {
+      label: 'redemption unwrap',
+      color: EQUITY_STAGE_COLORS.redemption_unwrap
+    },
+    redemptionUnwrapFailed: {
+      label: 'redemption unwrap (failed)',
+      color: EQUITY_FAILED_COLOR
+    },
+    redemptionSendOk: {
+      label: 'redemption send',
+      color: EQUITY_STAGE_COLORS.redemption_send
+    },
+    redemptionSendFailed: {
+      label: 'redemption send (failed)',
+      color: EQUITY_FAILED_COLOR
+    },
+    redemptionDetectionOk: {
+      label: 'redemption detection',
+      color: EQUITY_STAGE_COLORS.redemption_detection
+    },
+    redemptionDetectionFailed: {
+      label: 'redemption detection (failed)',
+      color: EQUITY_FAILED_COLOR
+    },
+    redemptionCompletionOk: {
+      label: 'redemption completion',
+      color: EQUITY_STAGE_COLORS.redemption_completion
+    },
+    redemptionCompletionFailed: {
+      label: 'redemption completion (failed)',
+      color: EQUITY_FAILED_COLOR
+    },
+    // Same elapsed-remainder rationale as REBALANCE_CHART_CONFIG.unmeasuredMs
+    // -- covers both in-progress and completed-but-recovered operations.
+    unmeasuredMs: {
+      label: 'unaccounted elapsed',
+      color: '#64748b'
+    }
+  } satisfies Chart.ChartConfig
+
+  const equitySeries = Object.entries(EQUITY_CHART_CONFIG).map(([key, { label, color }]) => ({
+    key,
+    label,
+    color,
+    value: key
+  }))
+
+  const equityRows = $derived(
+    buildEquityRows(chartEquityTimings.current?.operations ?? [], {
+      maxRows: EQUITY_MAX_ROWS,
+      now: chartRefreshedAt.current ?? new Date()
+    })
+  )
+
+  const EQUITY_KIND_LABELS: Record<EquityOperationKind, string> = {
+    mint: 'Mint',
+    redeem: 'Redeem'
+  }
+
+  const equityKindLabel = (kind: EquityOperationKind): string => EQUITY_KIND_LABELS[kind]
 </script>
 
 <div class="flex h-full flex-col gap-4 overflow-y-auto">
@@ -434,12 +699,9 @@
         </div>
       </div>
       <div class="flex flex-wrap gap-3 text-xs text-muted-foreground">
-        {#each Object.entries(SEGMENT_LABELS) as [name, label] (name)}
+        {#each Object.entries(WATERFALL_CHART_CONFIG) as [name, { label, color }] (name)}
           <span class="flex items-center gap-1">
-            <span
-              class="inline-block h-2 w-2 rounded-sm"
-              style:background={SEGMENT_COLORS[name as WaterfallSegmentName]}
-            ></span>
+            <span class="inline-block h-2 w-2 rounded-sm" style:background={color}></span>
             {label}
           </span>
         {/each}
@@ -451,40 +713,52 @@
           No hedge cycles in the selected range.
         </p>
       {:else}
-        <div class="flex flex-col gap-1">
-          {#each waterfallRows as row (row.id)}
-            <div class="flex items-center gap-2 text-xs">
-              <span class="w-14 shrink-0 font-medium">{row.symbol}</span>
-              <svg
-                viewBox={`0 0 ${String(WATERFALL_PLOT_WIDTH)} 14`}
-                class="h-3.5 min-w-0 flex-1"
-                preserveAspectRatio="none"
-              >
-                {#each row.segments as segment (segment.name)}
-                  <rect
-                    x={segment.x}
-                    y="2"
-                    width={Math.max(segment.width, segment.ms > 0 ? 1 : 0)}
-                    height="10"
-                    rx="1"
-                    fill={segmentColor(segment.name, row.status)}
-                  >
-                    <title>
-                      {SEGMENT_LABELS[segment.name]}: {formatDurationMs(segment.ms)}
-                    </title>
-                  </rect>
-                {/each}
-              </svg>
-              <span class="w-16 shrink-0 text-right tabular-nums text-muted-foreground">
-                {formatDurationMs(row.totalMs)}
-              </span>
-            </div>
-          {/each}
-        </div>
+        <Chart.Container
+          config={WATERFALL_CHART_CONFIG}
+          class="aspect-auto w-full"
+          style="height: {waterfallRows.length * WATERFALL_ROW_HEIGHT_PX + 40}px"
+        >
+          <BarChart
+            data={waterfallRows}
+            x={Object.keys(WATERFALL_CHART_CONFIG)}
+            y="id"
+            orientation="horizontal"
+            seriesLayout="stack"
+            series={waterfallSeries}
+            padding={{ left: 70 }}
+            props={{
+              xAxis: { format: (value: number) => formatDurationMs(value) },
+              yAxis: { format: (id: string) => waterfallSymbolById.get(id) ?? id }
+            }}
+          >
+            {#snippet tooltip({ context }: { context: ChartState<WaterfallBarRow> })}
+              {@const row = context.tooltip.data as WaterfallBarRow | null}
+              {@const label = row ? (waterfallSymbolById.get(row.id) ?? row.id) : ''}
+              <Chart.Tooltip {label} excludeZero>
+                {#snippet formatter({ value, name, item }: TooltipFormatterParams)}
+                  {#if typeof value === 'number' && value > 0}
+                    <div class="flex w-full flex-1 items-center justify-between gap-2">
+                      <span class="flex items-center gap-1.5 text-muted-foreground">
+                        <span
+                          class="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
+                          style:background={item.color}
+                        ></span>
+                        {name}
+                      </span>
+                      <span class="font-mono font-medium tabular-nums text-foreground">
+                        {formatDurationMs(value)}
+                      </span>
+                    </div>
+                  {/if}
+                {/snippet}
+              </Chart.Tooltip>
+            {/snippet}
+          </BarChart>
+        </Chart.Container>
         {#if (chartLatencies.current?.totalCycles ?? 0) > waterfallRows.length}
           <p class="mt-2 text-xs text-muted-foreground">
-            Showing {waterfallRows.length} of {chartLatencies.current?.totalCycles} cycles
-            in range{waterfallSort.current === 'slowest'
+            Showing {waterfallRows.length} of {chartLatencies.current?.totalCycles} cycles in range{waterfallSort.current ===
+            'slowest'
               ? ' — slowest among the most recent cycles shown, not full-range'
               : ''}.
           </p>
@@ -511,7 +785,7 @@
         </div>
       </div>
       <div class="flex gap-3 text-xs text-muted-foreground">
-        {#each Object.entries(PERCENTILE_COLORS) as [percentile, color] (percentile)}
+        {#each Object.entries(PERCENTILE_CHART_CONFIG) as [percentile, { color }] (percentile)}
           <span class="flex items-center gap-1">
             <span class="inline-block h-0.5 w-3" style:background={color}></span>
             {percentile.replace('Ms', '')}
@@ -520,70 +794,74 @@
       </div>
     </Card.Header>
     <Card.Content>
-      {#if seriesBucketCount === 0}
+      {#if percentileSampleCount === 0}
         <p class="py-6 text-center text-sm text-muted-foreground">
           No samples for this stage in the selected range.
         </p>
-      {:else if seriesBucketCount === 1}
+      {:else if percentileSampleCount === 1}
         <p class="py-6 text-center text-sm text-muted-foreground">
-          Only one time bucket has samples in this range, so there's no trend to
-          plot yet. Widen the range or wait for more data to accumulate.
+          Only one time bucket has samples in this range, so there's no trend to plot yet. Widen the
+          range or wait for more data to accumulate.
         </p>
       {:else}
-        <div class="flex items-start gap-2">
-          <span class="shrink-0 text-xs tabular-nums text-muted-foreground">
-            {formatDurationMs(seriesLayout.maxMs)}
-          </span>
-          <svg
-            viewBox={`0 0 ${String(SERIES_PLOT_WIDTH)} ${String(SERIES_PLOT_HEIGHT + 18)}`}
-            class="min-w-0 flex-1"
+        <Chart.Container config={PERCENTILE_CHART_CONFIG} class="aspect-auto h-40 w-full">
+          <!--
+            xPadding reserves 12px on each side of the x (time) scale's domain --
+            without it the scale maps the first/last sample straight to the plot's
+            literal edges, clipping the endpoint point markers and x-axis labels.
+          -->
+          <LineChart
+            data={percentileSeriesData}
+            x="start"
+            grid={{ x: false, y: true }}
+            series={Object.entries(PERCENTILE_CHART_CONFIG).map(([key, { label, color }]) => ({
+              key,
+              label,
+              color
+            }))}
+            points={true}
+            xPadding={[12, 12]}
+            props={{
+              xAxis: {
+                ticks: percentileXTicks,
+                format: (value: Date) =>
+                  value.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+              },
+              yAxis: { format: (value: number) => formatDurationMs(value) }
+            }}
           >
-            <line
-              x1="0"
-              y1={SERIES_PLOT_HEIGHT}
-              x2={SERIES_PLOT_WIDTH}
-              y2={SERIES_PLOT_HEIGHT}
-              stroke="currentColor"
-              stroke-opacity="0.15"
-            />
-            {#each seriesLayout.lines as line (line.percentile)}
-              <polyline
-                points={line.path}
-                fill="none"
-                stroke={PERCENTILE_COLORS[line.percentile]}
-                stroke-width="1.5"
-              />
-              {#each line.points as point, pointIndex (pointIndex)}
-                <circle
-                  cx={point.x}
-                  cy={point.y}
-                  r="2"
-                  fill={PERCENTILE_COLORS[line.percentile]}
-                />
-              {/each}
-            {/each}
-            {#each seriesLayout.xLabels as xLabel (xLabel.x)}
-              <text
-                x={xLabel.x}
-                y={SERIES_PLOT_HEIGHT + 14}
-                text-anchor="middle"
-                class="fill-muted-foreground"
-                font-size="10"
+            {#snippet tooltip()}
+              <Chart.Tooltip
+                labelFormatter={(value) => (value as Date).toLocaleString()}
+                indicator="line"
               >
-                {xLabel.label}
-              </text>
-            {/each}
-          </svg>
-        </div>
+                {#snippet formatter({ value, name, item }: TooltipFormatterParams)}
+                  {#if typeof value === 'number'}
+                    <div class="flex w-full flex-1 items-center justify-between gap-2">
+                      <span class="flex items-center gap-1.5 text-muted-foreground">
+                        <span
+                          class="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
+                          style:background={item.color}
+                        ></span>
+                        {name}
+                      </span>
+                      <span class="font-mono font-medium tabular-nums text-foreground">
+                        {formatDurationMs(value)}
+                      </span>
+                    </div>
+                  {/if}
+                {/snippet}
+              </Chart.Tooltip>
+            {/snippet}
+          </LineChart>
+        </Chart.Container>
       {/if}
     </Card.Content>
   </Card.Root>
 
   <Card.Root>
     <Card.Header class="pb-2">
-      <Card.Title class="text-sm font-medium">
-        Errors &amp; warnings by module (24h)
-      </Card.Title>
+      <Card.Title class="text-sm font-medium">Errors &amp; warnings by module (24h)</Card.Title>
     </Card.Header>
     <Card.Content>
       {#if reliability.current !== null && reliability.current.logTargets.length === 0}
@@ -633,9 +911,7 @@
 
       {#if reliability.current !== null && reliability.current.failureEvents.length > 0}
         <div class="mt-4 border-t pt-2">
-          <p class="mb-1 text-xs font-medium text-red-400">
-            Lifecycle failures (money-at-risk)
-          </p>
+          <p class="mb-1 text-xs font-medium text-red-400">Lifecycle failures (money-at-risk)</p>
           {#each reliability.current.failureEvents as failure (failure.eventType)}
             <div class="flex items-center gap-2 text-xs">
               <span class="w-72 shrink-0 truncate font-mono">{failure.eventType}</span>
@@ -652,77 +928,211 @@
 
   <Card.Root>
     <Card.Header class="pb-2">
-      <Card.Title class="text-sm font-medium">Rebalance stage breakdown</Card.Title>
+      <Card.Title class="text-sm font-medium">USDC rebalance stage breakdown</Card.Title>
       <div class="flex flex-wrap gap-3 text-xs text-muted-foreground">
         {#each Object.entries(STAGE_COLORS) as [stage, color] (stage)}
           <span class="flex items-center gap-1">
-            <span class="inline-block h-2 w-2 rounded-sm" style:background={color}
-            ></span>
+            <span class="inline-block h-2 w-2 rounded-sm" style:background={color}></span>
             {stage}
           </span>
         {/each}
       </div>
     </Card.Header>
     <Card.Content>
+      {#if (chartRebalances.current?.skippedOperations ?? 0) > 0}
+        <p class="mb-2 text-xs text-amber-400">
+          {chartRebalances.current?.skippedOperations} operations excluded (unparseable timing).
+        </p>
+      {/if}
       {#if rebalanceRows.length === 0}
         <p class="py-6 text-center text-sm text-muted-foreground">
           No rebalance operations in the selected range.
         </p>
       {:else}
-        <div class="flex flex-col gap-1">
-          {#each rebalanceRows as row (row.id)}
-            <div class="flex items-center gap-2 text-xs">
-              <span class="w-28 shrink-0">{directionLabel(row.direction)}</span>
-              <span class="w-20 shrink-0 text-right tabular-nums text-muted-foreground">
-                {row.amount ?? '—'} USDC
-              </span>
-              <svg
-                viewBox={`0 0 ${String(REBALANCE_PLOT_WIDTH)} 14`}
-                class="h-3.5 min-w-0 flex-1"
-                preserveAspectRatio="none"
-              >
-                {#each row.segments as segment, segmentIndex (segmentIndex)}
-                  <rect
-                    x={segment.x}
-                    y="2"
-                    width={Math.max(segment.width, segment.ms > 0 ? 1 : 0)}
-                    height="10"
-                    rx="1"
-                    fill={segment.failed ? '#f87171' : STAGE_COLORS[segment.stage]}
-                  >
-                    <title>{segment.stage}: {formatDurationMs(segment.ms)}</title>
-                  </rect>
-                {/each}
-              </svg>
-              <span class="w-16 shrink-0 text-right tabular-nums text-muted-foreground">
-                {formatDurationMs(row.totalMs)}
-              </span>
-            </div>
-          {/each}
-        </div>
+        <Chart.Container
+          config={REBALANCE_CHART_CONFIG}
+          class="aspect-auto w-full"
+          style="height: {rebalanceRows.length * REBALANCE_ROW_HEIGHT_PX + 40}px"
+        >
+          <BarChart
+            data={rebalanceRows}
+            x={Object.keys(REBALANCE_CHART_CONFIG)}
+            y="id"
+            orientation="horizontal"
+            seriesLayout="stack"
+            series={rebalanceSeries}
+            padding={{ left: 110 }}
+            props={{
+              xAxis: { format: (value: number) => formatDurationMs(value) },
+              yAxis: {
+                format: (id: string) => {
+                  const row = rebalanceRows.find((entry) => entry.id === id)
+                  return row ? directionLabel(row.direction) : id
+                }
+              }
+            }}
+          >
+            {#snippet tooltip({ context }: { context: ChartState<RebalanceBarRow> })}
+              {@const row = context.tooltip.data as RebalanceBarRow | null}
+              {@const label = row
+                ? `${directionLabel(row.direction)} · ${row.amount ?? '—'} USDC · total ${row.totalMs !== null ? formatDurationMs(row.totalMs) : 'unmeasured'}`
+                : ''}
+              <Chart.Tooltip {label} excludeZero>
+                {#snippet formatter({ value, name, item }: TooltipFormatterParams)}
+                  {#if typeof value === 'number' && value > 0}
+                    <div class="flex w-full flex-1 items-center justify-between gap-2">
+                      <span class="flex items-center gap-1.5 text-muted-foreground">
+                        <span
+                          class="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
+                          style:background={item.color}
+                        ></span>
+                        {name}
+                      </span>
+                      <span class="font-mono font-medium tabular-nums text-foreground">
+                        {formatDurationMs(value)}
+                      </span>
+                    </div>
+                  {/if}
+                {/snippet}
+              </Chart.Tooltip>
+            {/snippet}
+          </BarChart>
+        </Chart.Container>
+        {#if (chartRebalances.current?.totalOperations ?? 0) > rebalanceRows.length}
+          <p class="mt-2 text-xs text-muted-foreground">
+            Showing {rebalanceRows.length} of {chartRebalances.current?.totalOperations} operations
+            in range.
+          </p>
+        {/if}
       {/if}
 
-      {#if attestationTrend.points.length > 0}
+      {#if attestationChartData.length > 0}
         <div class="mt-4 border-t pt-2">
           <p class="mb-1 text-xs font-medium text-muted-foreground">
-            CCTP attestation time trend (max {formatDurationMs(attestationTrend.maxMs)})
+            CCTP attestation time trend (max {formatDurationMs(attestationMaxMs)})
           </p>
-          <svg
-            viewBox={`0 0 ${String(TREND_PLOT_WIDTH)} ${String(TREND_PLOT_HEIGHT)}`}
-            class="h-20 w-full"
-            preserveAspectRatio="none"
-          >
-            <polyline
-              points={attestationTrend.path}
-              fill="none"
-              stroke="#fbbf24"
-              stroke-width="1.5"
-            />
-            {#each attestationTrend.points as point, pointIndex (pointIndex)}
-              <circle cx={point.x} cy={point.y} r="2" fill="#fbbf24" />
-            {/each}
-          </svg>
+          <Chart.Container config={ATTESTATION_CHART_CONFIG} class="aspect-auto h-20 w-full">
+            <LineChart
+              data={attestationChartData}
+              x="burnedAt"
+              series={Object.entries(ATTESTATION_CHART_CONFIG).map(([key, { label, color }]) => ({
+                key,
+                label,
+                color
+              }))}
+              points={true}
+              props={{
+                yAxis: { format: (value: number) => formatDurationMs(value) }
+              }}
+            >
+              {#snippet tooltip()}
+                <Chart.Tooltip
+                  labelFormatter={(value) => (value as Date).toLocaleString()}
+                  indicator="line"
+                >
+                  {#snippet formatter({ value, name, item }: TooltipFormatterParams)}
+                    {#if typeof value === 'number'}
+                      <div class="flex w-full flex-1 items-center justify-between gap-2">
+                        <span class="flex items-center gap-1.5 text-muted-foreground">
+                          <span
+                            class="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
+                            style:background={item.color}
+                          ></span>
+                          {name}
+                        </span>
+                        <span class="font-mono font-medium tabular-nums text-foreground">
+                          {formatDurationMs(value)}
+                        </span>
+                      </div>
+                    {/if}
+                  {/snippet}
+                </Chart.Tooltip>
+              {/snippet}
+            </LineChart>
+          </Chart.Container>
         </div>
+      {/if}
+    </Card.Content>
+  </Card.Root>
+
+  <Card.Root>
+    <Card.Header class="pb-2">
+      <Card.Title class="text-sm font-medium">Equity rebalance stage breakdown</Card.Title>
+      <div class="flex flex-wrap gap-3 text-xs text-muted-foreground">
+        {#each Object.entries(EQUITY_STAGE_COLORS) as [stage, color] (stage)}
+          <span class="flex items-center gap-1">
+            <span class="inline-block h-2 w-2 rounded-sm" style:background={color}></span>
+            {stage.replace('_', ' ')}
+          </span>
+        {/each}
+      </div>
+    </Card.Header>
+    <Card.Content>
+      {#if (chartEquityTimings.current?.skippedOperations ?? 0) > 0}
+        <p class="mb-2 text-xs text-amber-400">
+          {chartEquityTimings.current?.skippedOperations} operations excluded (unparseable timing).
+        </p>
+      {/if}
+      {#if equityRows.length === 0}
+        <p class="py-6 text-center text-sm text-muted-foreground">
+          No equity mint/redemption operations in the selected range.
+        </p>
+      {:else}
+        <Chart.Container
+          config={EQUITY_CHART_CONFIG}
+          class="aspect-auto w-full"
+          style="height: {equityRows.length * EQUITY_ROW_HEIGHT_PX + 40}px"
+        >
+          <BarChart
+            data={equityRows}
+            x={Object.keys(EQUITY_CHART_CONFIG)}
+            y="id"
+            orientation="horizontal"
+            seriesLayout="stack"
+            series={equitySeries}
+            padding={{ left: 110 }}
+            props={{
+              xAxis: { format: (value: number) => formatDurationMs(value) },
+              yAxis: {
+                format: (id: string) => {
+                  const row = equityRows.find((entry) => entry.id === id)
+                  return row ? equityKindLabel(row.kind) : id
+                }
+              }
+            }}
+          >
+            {#snippet tooltip({ context }: { context: ChartState<EquityBarRow> })}
+              {@const row = context.tooltip.data as EquityBarRow | null}
+              {@const label = row
+                ? `${equityKindLabel(row.kind)} · ${row.symbol ?? '—'} · total ${row.totalMs !== null ? formatDurationMs(row.totalMs) : 'unmeasured'}`
+                : ''}
+              <Chart.Tooltip {label} excludeZero>
+                {#snippet formatter({ value, name, item }: TooltipFormatterParams)}
+                  {#if typeof value === 'number' && value > 0}
+                    <div class="flex w-full flex-1 items-center justify-between gap-2">
+                      <span class="flex items-center gap-1.5 text-muted-foreground">
+                        <span
+                          class="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
+                          style:background={item.color}
+                        ></span>
+                        {name}
+                      </span>
+                      <span class="font-mono font-medium tabular-nums text-foreground">
+                        {formatDurationMs(value)}
+                      </span>
+                    </div>
+                  {/if}
+                {/snippet}
+              </Chart.Tooltip>
+            {/snippet}
+          </BarChart>
+        </Chart.Container>
+        {#if (chartEquityTimings.current?.totalOperations ?? 0) > equityRows.length}
+          <p class="mt-2 text-xs text-muted-foreground">
+            Showing {equityRows.length} of {chartEquityTimings.current?.totalOperations} operations
+            in range.
+          </p>
+        {/if}
       {/if}
     </Card.Content>
   </Card.Root>
@@ -732,40 +1142,45 @@
       <Card.Title class="text-sm font-medium">Ingestion health</Card.Title>
       {#if ingestionTruncated.current}
         <p class="text-xs text-muted-foreground">
-          Showing the last 14 days · older samples are pruned by the telemetry
-          retention window.
+          Showing the last 14 days · older samples are pruned by the telemetry retention window.
         </p>
       {/if}
     </Card.Header>
     <Card.Content>
-      {#if blockLagTrend.points.length === 0}
+      {#if blockLagChartData.length === 0}
         <p class="py-6 text-center text-sm text-muted-foreground">
           No block-lag samples in the selected range.
         </p>
       {:else}
         <p class="mb-1 text-xs font-medium text-muted-foreground">
-          Worst block lag per bucket (max {blockLagTrend.maxLagBlocks} blocks)
+          Worst block lag per bucket (max {blockLagMax} blocks)
         </p>
-        <svg
-          viewBox={`0 0 ${String(TREND_PLOT_WIDTH)} ${String(TREND_PLOT_HEIGHT)}`}
-          class="h-20 w-full"
-          preserveAspectRatio="none"
-        >
-          <polyline
-            points={blockLagTrend.path}
-            fill="none"
-            stroke="#38bdf8"
-            stroke-width="1.5"
-          />
-          {#each blockLagTrend.points as point, pointIndex (pointIndex)}
-            <circle cx={point.x} cy={point.y} r="2" fill="#38bdf8" />
-          {/each}
-        </svg>
+        <Chart.Container config={BLOCK_LAG_CHART_CONFIG} class="aspect-auto h-20 w-full">
+          <LineChart
+            data={blockLagChartData}
+            x="start"
+            series={Object.entries(BLOCK_LAG_CHART_CONFIG).map(([key, { label, color }]) => ({
+              key,
+              label,
+              color
+            }))}
+            points={true}
+          >
+            {#snippet tooltip()}
+              <Chart.Tooltip
+                labelFormatter={(value) => (value as Date).toLocaleString()}
+                indicator="line"
+              />
+            {/snippet}
+          </LineChart>
+        </Chart.Container>
       {/if}
 
       {#if chartInfra.current}
         {@const poll = chartInfra.current.monitor.poll}
-        <div class="mt-4 flex flex-wrap gap-x-4 gap-y-1 border-t pt-2 text-xs text-muted-foreground">
+        <div
+          class="mt-4 flex flex-wrap gap-x-4 gap-y-1 border-t pt-2 text-xs text-muted-foreground"
+        >
           <span>{poll.cycles} poll cycles</span>
           <span class={poll.errors > 0 ? 'text-red-400' : ''}>
             {poll.errors} errors
@@ -789,8 +1204,8 @@
     <Card.Header class="pb-2">
       <Card.Title class="text-sm font-medium">Dependency health</Card.Title>
       <p class="text-xs text-muted-foreground">
-        Per-operation latency and errors for the RPC provider and broker API.
-        Sparkline bars are per-bucket median latency; red bars contain errors.
+        Per-operation latency and errors for the RPC provider and broker API. Sparkline bars are
+        per-bucket median latency; red bars contain errors.
       </p>
     </Card.Header>
     <Card.Content>

--- a/dashboard/src/lib/components/ui/chart/chart-container.svelte
+++ b/dashboard/src/lib/components/ui/chart/chart-container.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import ChartStyle from "./chart-style.svelte";
+	import { setChartContext, type ChartConfig } from "./chart-utils.js";
+
+	const uid = $props.id();
+
+	let {
+		ref = $bindable(null),
+		id = uid,
+		class: className,
+		children,
+		config,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
+		config: ChartConfig;
+	} = $props();
+
+	const chartId = $derived(`chart-${id || uid.replace(/:/g, "")}`);
+
+	setChartContext({
+		get config() {
+			return config;
+		},
+	});
+</script>
+
+<div
+	bind:this={ref}
+	data-chart={chartId}
+	data-slot="chart"
+	class={cn(
+		"flex aspect-video justify-center overflow-visible text-xs",
+		// Overrides
+		//
+		// Stroke around dots/marks when hovering
+		"[&_.lc-highlight-point]:stroke-transparent",
+		// override the default stroke color of lines
+		"[&_.lc-line]:stroke-border/50",
+
+		// by default, layerchart shows a line intersecting the point when hovering, this hides that
+		"[&_.lc-highlight-line]:stroke-0",
+
+		// by default, when you hover a point on a stacked series chart, it will drop the opacity
+		// of the other series, this overrides that
+		"[&_.lc-area-path]:opacity-100 [&_.lc-highlight-line]:opacity-100 [&_.lc-highlight-point]:opacity-100 [&_.lc-spline-path]:opacity-100 [&_.lc-text]:text-xs [&_.lc-text-svg]:overflow-visible",
+
+		// We don't want the little tick lines between the axis labels and the chart, so we remove
+		// the stroke. The alternative is to manually disable `tickMarks` on the x/y axis of every
+		// chart.
+		"[&_.lc-axis-tick]:stroke-0",
+
+		// We don't want to display the rule on the x/y axis, as there is already going to be
+		// a grid line there and rule ends up overlapping the marks because it is rendered after
+		// the marks
+		"[&_.lc-rule-x-line:not(.lc-grid-x-rule)]:stroke-0 [&_.lc-rule-y-line:not(.lc-grid-y-rule)]:stroke-0",
+		"[&_.lc-grid-x-radial-line]:stroke-border [&_.lc-grid-x-radial-circle]:stroke-border",
+		"[&_.lc-grid-y-radial-line]:stroke-border [&_.lc-grid-y-radial-circle]:stroke-border",
+
+		// Legend adjustments
+		"[&_.lc-legend-swatch-button]:items-center [&_.lc-legend-swatch-button]:gap-1.5",
+		"[&_.lc-legend-swatch-group]:items-center [&_.lc-legend-swatch-group]:gap-4",
+		"[&_.lc-legend-swatch]:size-2.5 [&_.lc-legend-swatch]:rounded-[2px]",
+
+		// Labels
+		"[&_.lc-labels-text:not([fill])]:fill-foreground [&_text]:stroke-transparent",
+
+		// Tick labels on th x/y axes
+		"[&_.lc-axis-tick-label]:fill-muted-foreground [&_.lc-axis-tick-label]:font-normal",
+		"[&_.lc-tooltip-rects-g]:fill-transparent",
+		"[&_.lc-layout-svg-g]:fill-transparent",
+		"[&_.lc-root-container]:w-full",
+		className
+	)}
+	{...restProps}
+>
+	<ChartStyle id={chartId} {config} />
+	{@render children?.()}
+</div>

--- a/dashboard/src/lib/components/ui/chart/chart-style.svelte
+++ b/dashboard/src/lib/components/ui/chart/chart-style.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { THEMES, type ChartConfig } from "./chart-utils.js";
+
+	let { id, config }: { id: string; config: ChartConfig } = $props();
+
+	const colorConfig = $derived(
+		Object.entries(config).filter(([, config]) => config.theme || config.color)
+	);
+
+	const themeContents = $derived.by(() => {
+		if (colorConfig.length === 0) return;
+
+		const themeContents = [];
+		for (const [_theme, prefix] of Object.entries(THEMES)) {
+			let content = `${prefix} [data-chart=${id}] {\n`;
+			const color = colorConfig.map(([key, itemConfig]) => {
+				const theme = _theme as keyof typeof itemConfig.theme;
+				const color = itemConfig.theme ? itemConfig.theme[theme] : itemConfig.color;
+				return color ? `\t--color-${key}: ${color};` : null;
+			});
+
+			content += color.join("\n") + "\n}";
+
+			themeContents.push(content);
+		}
+
+		return themeContents.join("\n");
+	});
+</script>
+
+{#if themeContents}
+	{#key id}
+		<svelte:element this={"style"}>
+			{themeContents}
+		</svelte:element>
+	{/key}
+{/if}

--- a/dashboard/src/lib/components/ui/chart/chart-tooltip.svelte
+++ b/dashboard/src/lib/components/ui/chart/chart-tooltip.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+	/* eslint-disable @typescript-eslint/no-confusing-void-expression -- svelte-eslint-parser
+	   represents `{#if cond}{@render Snippet()}{/if}` as a void expression inside a conditional;
+	   this fires on both conditional TooltipLabel() renders below and isn't fixable without
+	   removing the conditional placement they need. */
+	import { cn, type WithElementRef, type WithoutChildren } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { getPayloadConfigFromPayload, useChart, type TooltipPayload } from "./chart-utils.js";
+	import { getChartContext, Tooltip as TooltipPrimitive } from "layerchart";
+	import type { Snippet } from "svelte";
+
+	const defaultFormatter = (value: unknown, _payload: TooltipPayload[]) => String(value);
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		hideLabel = false,
+		indicator = "dot",
+		hideIndicator = false,
+		labelKey,
+		label,
+		labelFormatter = defaultFormatter,
+		labelClassName,
+		formatter,
+		nameKey,
+		color,
+		excludeZero = false,
+		...restProps
+	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> & {
+		hideLabel?: boolean;
+		label?: string;
+		indicator?: "line" | "dot" | "dashed";
+		nameKey?: string;
+		labelKey?: string;
+		hideIndicator?: boolean;
+		labelClassName?: string;
+		labelFormatter?:
+			| ((value: unknown, payload: TooltipPayload[]) => string | number | Snippet)
+			| null;
+		formatter?: Snippet<
+			[
+				{
+					value: unknown;
+					name: string;
+					item: TooltipPayload;
+					index: number;
+					payload: TooltipPayload[];
+				},
+			]
+		>;
+		// Opt-in: exclude zero-valued series from the tooltip. Only meaningful for stacked
+		// stage-breakdown bar charts (waterfall/rebalance/equity) where every series is always
+		// present per row and 0 means "this stage did not occur", not "no data" -- without this,
+		// every zero-valued stage still renders an empty tooltip row. Must default to false so
+		// single-series LineCharts (block-lag, latency percentiles, CCTP attestation) where 0 is a
+		// legitimate, common value keep rendering their tooltip instead of going blank.
+		excludeZero?: boolean;
+	} = $props();
+
+	const chart = useChart();
+	const chartCtx = getChartContext();
+
+	// Defined-ness matters for item-based charts like Pie/Arc where only the hovered item has
+	// a value.
+	const visibleSeries = $derived(
+		chartCtx.tooltip.series.filter(
+			(s: TooltipPayload) => s.value !== undefined && (!excludeZero || s.value !== 0)
+		)
+	);
+
+	const formattedLabel = $derived.by((): string | number | Snippet | null => {
+		if (hideLabel || visibleSeries.length === 0) return null;
+
+		const item = visibleSeries[0];
+		if (!item) return null;
+
+		const tooltipData: unknown = chartCtx.tooltip.data;
+
+		// Get the x-axis label value from the raw tooltip data (e.g. a Date or month string)
+		const dataLabel: unknown = tooltipData != null ? chartCtx.x(tooltipData) : undefined;
+
+		const key = labelKey ?? item.label;
+		const itemConfig = getPayloadConfigFromPayload(
+			chart.config,
+			item,
+			key,
+			tooltipData as Record<string, unknown> | null
+		);
+
+		let value: unknown;
+		if (!labelKey && typeof label === "string") {
+			value = chart.config[label]?.label ?? label;
+		} else if (labelKey) {
+			value = itemConfig?.label ?? dataLabel;
+		} else {
+			value = dataLabel;
+		}
+
+		if (value === undefined) return null;
+		if (!labelFormatter) return value as string | number;
+		return labelFormatter(value, visibleSeries);
+	});
+
+	const nestLabel = $derived(visibleSeries.length === 1 && indicator !== "dot");
+</script>
+
+{#snippet TooltipLabel()}
+	{#if formattedLabel}
+		<div class={cn("font-medium", labelClassName)}>
+			{#if typeof formattedLabel === "function"}
+				{@render formattedLabel()}
+			{:else}
+				{formattedLabel}
+			{/if}
+		</div>
+	{/if}
+{/snippet}
+
+<TooltipPrimitive.Root variant="none">
+	<div
+		bind:this={ref}
+		class={cn(
+			"border-border/50 bg-background grid min-w-[9rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+			className
+		)}
+		{...restProps}
+	>
+		{#if !nestLabel}
+			{@render TooltipLabel()}
+		{/if}
+		<div class="grid gap-1.5">
+			{#each visibleSeries as item, i (item.key)}
+				{@const key = nameKey || item.key || item.label || "value"}
+				{@const itemConfig = getPayloadConfigFromPayload(
+					chart.config,
+					item,
+					key,
+					chartCtx.tooltip.data as Record<string, unknown> | null
+				)}
+				{@const indicatorColor = color || item.config.color || item.color}
+				<div
+					class={cn(
+						"[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:size-2.5",
+						indicator === "dot" && "items-center"
+					)}
+				>
+					{#if formatter && item.value !== undefined && item.label}
+						{@render formatter({
+							value: item.value,
+							name: item.label,
+							item,
+							index: i,
+							payload: visibleSeries,
+						})}
+					{:else}
+						{#if itemConfig?.icon}
+							<itemConfig.icon />
+						{:else if !hideIndicator}
+							<div
+								style="--color-bg: {indicatorColor}; --color-border: {indicatorColor};"
+								class={cn(
+									"shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+									{
+										"size-2.5": indicator === "dot",
+										"h-full w-1": indicator === "line",
+										"w-0 border-[1.5px] border-dashed bg-transparent":
+											indicator === "dashed",
+										"my-0.5": nestLabel && indicator === "dashed",
+									}
+								)}
+							></div>
+						{/if}
+						<div
+							class={cn(
+								"flex flex-1 shrink-0 justify-between leading-none",
+								nestLabel ? "items-end" : "items-center"
+							)}
+						>
+							<div class="grid gap-1.5">
+								{#if nestLabel}
+									<!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- svelte-eslint-parser represents {@render} inside {#if} as a value-position void call; not fixable without restructuring the snippet -->
+									{@render TooltipLabel()}
+								{/if}
+								<span class="text-muted-foreground">
+									{itemConfig?.label || item.label}
+								</span>
+							</div>
+							{#if item.value !== undefined}
+								<span class="text-foreground font-mono font-medium tabular-nums">
+									{(item.value as number | string).toLocaleString()}
+								</span>
+							{/if}
+						</div>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	</div>
+</TooltipPrimitive.Root>

--- a/dashboard/src/lib/components/ui/chart/chart-utils.ts
+++ b/dashboard/src/lib/components/ui/chart/chart-utils.ts
@@ -1,0 +1,59 @@
+import type { Tooltip } from "layerchart";
+import { getContext, setContext, type Component, type Snippet } from "svelte";
+
+export const THEMES = { light: "", dark: ".dark" } as const;
+
+export type ChartConfig = {
+	[k in string]: {
+		label?: string;
+		icon?: Component;
+	} & (
+		| { color?: string; theme?: never }
+		| { color?: never; theme: Record<keyof typeof THEMES, string> }
+	);
+};
+
+export type ExtractSnippetParams<T> = T extends Snippet<[infer P]> ? P : never;
+
+export type TooltipPayload = Tooltip.TooltipSeries;
+
+// Helper to extract item config from a payload.
+export const getPayloadConfigFromPayload = (
+	config: ChartConfig,
+	payload: TooltipPayload,
+	key: string,
+	data?: Record<string, unknown> | null
+) => {
+	const payloadConfig =
+		"config" in payload && typeof payload.config === "object" ? payload.config : undefined;
+
+	let configLabelKey: string = key;
+
+	if (payload.key === key) {
+		configLabelKey = payload.key;
+	} else if (payload.label === key) {
+		configLabelKey = payload.label;
+	} else if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
+		configLabelKey = payload[key as keyof typeof payload] as string;
+	} else if (
+		payloadConfig !== undefined &&
+		key in payloadConfig &&
+		typeof payloadConfig[key as keyof typeof payloadConfig] === "string"
+	) {
+		configLabelKey = payloadConfig[key as keyof typeof payloadConfig] as string;
+	} else if (data !== null && data !== undefined && key in data && typeof data[key] === "string") {
+		configLabelKey = data[key];
+	}
+
+	return configLabelKey in config ? config[configLabelKey] : config[key];
+};
+
+type ChartContextValue = {
+	config: ChartConfig;
+};
+
+const chartContextKey = Symbol("chart-context");
+
+export const setChartContext = (value: ChartContextValue) => setContext(chartContextKey, value);
+
+export const useChart = () => getContext<ChartContextValue>(chartContextKey);

--- a/dashboard/src/lib/components/ui/chart/index.ts
+++ b/dashboard/src/lib/components/ui/chart/index.ts
@@ -1,0 +1,6 @@
+import ChartContainer from "./chart-container.svelte";
+import ChartTooltip from "./chart-tooltip.svelte";
+
+export { getPayloadConfigFromPayload, type ChartConfig } from "./chart-utils.js";
+
+export { ChartContainer, ChartTooltip, ChartContainer as Container, ChartTooltip as Tooltip };

--- a/dashboard/src/lib/performance/api.ts
+++ b/dashboard/src/lib/performance/api.ts
@@ -1,3 +1,4 @@
+import type { EquityTimings } from '$lib/api/EquityTimings'
 import type { HedgeLatencies } from '$lib/api/HedgeLatencies'
 import type { InfraReport } from '$lib/api/InfraReport'
 import type { RebalanceTimings } from '$lib/api/RebalanceTimings'
@@ -55,6 +56,10 @@ export const fetchHedgeLatencies = async (
 export const fetchRebalanceTimings = async (
   range: PerformanceRange = {},
 ): Promise<RebalanceTimings> => fetchPerformanceJson('/performance/rebalances', range)
+
+export const fetchEquityTimings = async (
+  range: PerformanceRange = {},
+): Promise<EquityTimings> => fetchPerformanceJson('/performance/equity-rebalances', range)
 
 export const fetchReliabilityReport = async (
   range: PerformanceRange = {},

--- a/dashboard/src/lib/performance/charts.test.ts
+++ b/dashboard/src/lib/performance/charts.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
+import type { EquityOperationTiming } from '$lib/api/EquityOperationTiming'
 import type { HedgeCycleReport } from '$lib/api/HedgeCycleReport'
 import type { LatencyBucket } from '$lib/api/LatencyBucket'
-import type { LatencyStats } from '$lib/api/LatencyStats'
 import type { RebalanceOperationTiming } from '$lib/api/RebalanceOperationTiming'
 
 import {
-  layoutAttestationTrend,
-  layoutBlockLagTrend,
+  buildEquityRows,
+  buildPercentileSeries,
+  buildRebalanceRows,
+  buildWaterfallRows,
   layoutDependencySparkline,
-  layoutPercentileSeries,
-  layoutRebalanceBars,
-  layoutWaterfall,
+  thinTicks
 } from './charts'
 
 const cycle = (overrides: Partial<HedgeCycleReport>): HedgeCycleReport => ({
@@ -27,52 +27,54 @@ const cycle = (overrides: Partial<HedgeCycleReport>): HedgeCycleReport => ({
   submissionMs: 2_000,
   executionMs: 8_000,
   exposureWindowMs: 20_000,
-  ...overrides,
+  ...overrides
 })
 
-describe('layoutWaterfall', () => {
-  it('splits a filled cycle into unhedged, submission, and execution segments', () => {
-    const rows = layoutWaterfall([cycle({})], {
-      plotWidth: 100,
+describe('buildWaterfallRows', () => {
+  it('splits a filled cycle into unhedged, submission, and execution fields', () => {
+    const rows = buildWaterfallRows([cycle({})], {
       sort: 'slowest',
       maxRows: 10,
-      now: new Date('2026-06-02T00:00:00Z'),
+      now: new Date('2026-06-02T00:00:00Z')
     })
 
     expect(rows).toHaveLength(1)
     expect(rows[0]?.totalMs).toBe(20_000)
-    expect(rows[0]?.segments.map((segment) => segment.name)).toEqual([
-      'unhedged',
-      'submission',
-      'execution',
-    ])
-    expect(rows[0]?.segments.map((segment) => segment.ms)).toEqual([
-      10_000, 2_000, 8_000,
-    ])
-    // Slowest row spans the full plot width.
-    const lastSegment = rows[0]?.segments.at(-1)
-    expect((lastSegment?.x ?? 0) + (lastSegment?.width ?? 0)).toBeCloseTo(100)
+    expect(rows[0]?.unhedged).toBe(10_000)
+    expect(rows[0]?.submission).toBe(2_000)
+    expect(rows[0]?.executionOk).toBe(8_000)
+    expect(rows[0]?.executionFailed).toBe(0)
+  })
+
+  it('routes a failed cycle execution segment to executionFailed, not executionOk', () => {
+    const rows = buildWaterfallRows([cycle({ status: 'failed' })], {
+      sort: 'slowest',
+      maxRows: 10,
+      now: new Date('2026-06-02T00:00:00Z')
+    })
+
+    expect(rows[0]?.executionOk).toBe(0)
+    expect(rows[0]?.executionFailed).toBe(8_000)
   })
 
   it('sorts slowest first and caps rows', () => {
     const fast = cycle({
       offchainOrderId: 'fast',
-      completedAt: '2026-06-01T00:00:13Z',
+      completedAt: '2026-06-01T00:00:13Z'
     })
     const slow = cycle({
       offchainOrderId: 'slow',
-      completedAt: '2026-06-01T00:01:00Z',
+      completedAt: '2026-06-01T00:01:00Z'
     })
     const mid = cycle({
       offchainOrderId: 'mid',
-      completedAt: '2026-06-01T00:00:30Z',
+      completedAt: '2026-06-01T00:00:30Z'
     })
 
-    const rows = layoutWaterfall([fast, slow, mid], {
-      plotWidth: 100,
+    const rows = buildWaterfallRows([fast, slow, mid], {
       sort: 'slowest',
       maxRows: 2,
-      now: new Date('2026-06-02T00:00:00Z'),
+      now: new Date('2026-06-02T00:00:00Z')
     })
 
     expect(rows.map((row) => row.id)).toEqual(['slow', 'mid'])
@@ -81,18 +83,17 @@ describe('layoutWaterfall', () => {
   it('sorts newest first by placement time', () => {
     const earlier = cycle({
       offchainOrderId: 'earlier',
-      placedAt: '2026-06-01T00:00:10Z',
+      placedAt: '2026-06-01T00:00:10Z'
     })
     const later = cycle({
       offchainOrderId: 'later',
-      placedAt: '2026-06-02T00:00:10Z',
+      placedAt: '2026-06-02T00:00:10Z'
     })
 
-    const rows = layoutWaterfall([earlier, later], {
-      plotWidth: 100,
+    const rows = buildWaterfallRows([earlier, later], {
       sort: 'newest',
       maxRows: 10,
-      now: new Date('2026-06-02T00:00:00Z'),
+      now: new Date('2026-06-02T00:00:00Z')
     })
 
     expect(rows.map((row) => row.id)).toEqual(['later', 'earlier'])
@@ -102,33 +103,34 @@ describe('layoutWaterfall', () => {
     const pending = cycle({
       status: 'pending',
       submittedAt: null,
-      completedAt: null,
+      completedAt: null
     })
 
-    const rows = layoutWaterfall([pending], {
-      plotWidth: 100,
+    const rows = buildWaterfallRows([pending], {
       sort: 'slowest',
       maxRows: 10,
-      now: new Date('2026-06-01T00:01:00Z'),
+      now: new Date('2026-06-01T00:01:00Z')
     })
 
-    expect(rows[0]?.segments.map((segment) => segment.name)).toEqual(['unhedged'])
+    expect(rows[0]?.unhedged).toBe(60_000)
+    expect(rows[0]?.submission).toBe(0)
+    expect(rows[0]?.executionOk).toBe(0)
+    expect(rows[0]?.executionFailed).toBe(0)
     // Earliest fill was at 00:00:00; the exposure is still open at now.
     expect(rows[0]?.totalMs).toBe(60_000)
   })
 
   it('returns an empty array for no cycles', () => {
     expect(
-      layoutWaterfall([], {
-        plotWidth: 100,
+      buildWaterfallRows([], {
         sort: 'slowest',
         maxRows: 10,
-        now: new Date('2026-06-02T00:00:00Z'),
-      }),
+        now: new Date('2026-06-02T00:00:00Z')
+      })
     ).toEqual([])
   })
 
-  it('renders an incomplete cycle as a single unhedged live-exposure segment', () => {
+  it('renders an incomplete cycle as a single unhedged live-exposure field', () => {
     const submitted = cycle({
       status: 'pending',
       // earliestFillBlockTimestamp default '2026-06-01T00:00:00Z'. A cycle with
@@ -136,24 +138,21 @@ describe('layoutWaterfall', () => {
       // window (now - earliest fill) counts as unhedged so it ranks correctly in
       // the slowest sort, regardless of whether it was already submitted.
       submittedAt: '2026-06-01T00:00:15Z',
-      completedAt: null,
+      completedAt: null
     })
 
-    const rows = layoutWaterfall([submitted], {
-      plotWidth: 100,
+    const rows = buildWaterfallRows([submitted], {
       sort: 'slowest',
       maxRows: 10,
-      now: new Date('2026-06-02T00:00:00Z'),
+      now: new Date('2026-06-02T00:00:00Z')
     })
 
-    expect(rows[0]?.segments.map((segment) => segment.name)).toEqual(['unhedged'])
-    expect(rows[0]?.segments[0]?.ms).toBe(86_400_000)
+    expect(rows[0]?.unhedged).toBe(86_400_000)
+    expect(rows[0]?.submission).toBe(0)
   })
 })
 
-const operation = (
-  overrides: Partial<RebalanceOperationTiming>,
-): RebalanceOperationTiming => ({
+const operation = (overrides: Partial<RebalanceOperationTiming>): RebalanceOperationTiming => ({
   operationId: 'op-1',
   direction: 'alpaca_to_base',
   amount: '1000',
@@ -166,51 +165,45 @@ const operation = (
       startedAt: '2026-06-01T00:00:00Z',
       endedAt: '2026-06-01T00:00:30Z',
       durationMs: 30_000,
-      outcome: 'succeeded',
+      outcome: 'succeeded'
     },
     {
       stage: 'attestation',
       startedAt: '2026-06-01T00:01:00Z',
       endedAt: '2026-06-01T00:11:00Z',
       durationMs: 600_000,
-      outcome: 'succeeded',
+      outcome: 'succeeded'
     },
     {
       stage: 'deposit',
       startedAt: '2026-06-01T00:11:30Z',
       endedAt: null,
       durationMs: null,
-      outcome: 'unmeasured',
-    },
+      outcome: 'unmeasured'
+    }
   ],
   totalMs: 730_000,
-  ...overrides,
+  ...overrides
 })
 
 const NOW_REBALANCE = new Date('2026-06-01T00:12:10Z')
 
-describe('layoutRebalanceBars', () => {
-  it('lays out completed stages proportionally and skips open ones', () => {
-    const rows = layoutRebalanceBars([operation({})], {
-      plotWidth: 100,
+describe('buildRebalanceRows', () => {
+  it('shapes completed stages into named fields and skips open ones', () => {
+    const rows = buildRebalanceRows([operation({})], {
       maxRows: 10,
-      now: NOW_REBALANCE,
+      now: NOW_REBALANCE
     })
 
     expect(rows).toHaveLength(1)
     // The DTO's elapsed time wins over the sum of completed stages so an
     // open stage does not understate the operation.
     expect(rows[0]?.totalMs).toBe(730_000)
-    expect(rows[0]?.segments.map((segment) => segment.stage)).toEqual([
-      'withdrawal',
-      'attestation',
-    ])
-    const lastSegment = rows[0]?.segments.at(-1)
-    // Completed stages cover 630s of the 730s elapsed total; the unfilled
-    // remainder represents the still-open deposit stage.
-    expect((lastSegment?.x ?? 0) + (lastSegment?.width ?? 0)).toBeCloseTo(
-      (630_000 / 730_000) * 100,
-    )
+    expect(rows[0]?.withdrawalOk).toBe(30_000)
+    expect(rows[0]?.attestationOk).toBe(600_000)
+    // The still-open deposit stage (durationMs null) contributes nothing.
+    expect(rows[0]?.depositOk).toBe(0)
+    expect(rows[0]?.depositFailed).toBe(0)
   })
 
   it('uses now - startedAt as totalMs for in-progress operations', () => {
@@ -218,7 +211,7 @@ describe('layoutRebalanceBars', () => {
     const startedAt = '2026-06-01T00:00:00Z'
     const now = new Date('2026-06-01T01:00:00Z')
 
-    const rows = layoutRebalanceBars(
+    const rows = buildRebalanceRows(
       [
         operation({
           startedAt,
@@ -231,34 +224,39 @@ describe('layoutRebalanceBars', () => {
               startedAt,
               endedAt: null,
               durationMs: null,
-              outcome: 'unmeasured',
-            },
-          ],
-        }),
+              outcome: 'unmeasured'
+            }
+          ]
+        })
       ],
       {
-        plotWidth: 100,
         maxRows: 10,
-        now,
-      },
+        now
+      }
     )
 
     // Elapsed = now - startedAt = 3600000ms. No completed stages.
     expect(rows[0]?.totalMs).toBe(3_600_000)
-    // The open stage has durationMs null so it is filtered out of segments.
-    expect(rows[0]?.segments).toHaveLength(0)
+    // The open stage has durationMs null so it contributes nothing.
+    expect(rows[0]?.withdrawalOk).toBe(0)
+    expect(rows[0]?.withdrawalFailed).toBe(0)
+    // No completed stage accounts for any of the elapsed time, so the whole
+    // elapsed window must surface as a visible unmeasured remainder rather
+    // than rendering as an invisible zero-length bar.
+    expect(rows[0]?.unmeasuredMs).toBe(3_600_000)
   })
 
-  it('falls back to now - startedAt when totalMs is null and startedAt equals now', () => {
-    // totalMs: null with one closed stage — fallback is now - startedAt.
-    // When now equals startedAt the elapsed basis is zero, so totalMs is 0.
+  it('surfaces only the unaccounted-for remainder as unmeasuredMs when some stages completed', () => {
+    // Operation started at T+0, one 30s stage completed, now is T+3600s.
     const startedAt = '2026-06-01T00:00:00Z'
-    const now = new Date('2026-06-01T00:00:00Z')
+    const now = new Date('2026-06-01T01:00:00Z')
 
-    const rows = layoutRebalanceBars(
+    const rows = buildRebalanceRows(
       [
         operation({
           startedAt,
+          completedAt: null,
+          status: 'in_progress',
           totalMs: null,
           stages: [
             {
@@ -266,41 +264,158 @@ describe('layoutRebalanceBars', () => {
               startedAt,
               endedAt: '2026-06-01T00:00:30Z',
               durationMs: 30_000,
-              outcome: 'succeeded',
+              outcome: 'succeeded'
             },
-          ],
-        }),
+            {
+              stage: 'attestation',
+              startedAt: '2026-06-01T00:00:30Z',
+              endedAt: null,
+              durationMs: null,
+              outcome: 'unmeasured'
+            }
+          ]
+        })
       ],
       {
-        plotWidth: 100,
         maxRows: 10,
-        now,
-      },
+        now
+      }
     )
 
-    // now - startedAt = 0, so totalMs = 0. The clamped result is 0.
-    expect(rows[0]?.totalMs).toBe(0)
+    expect(rows[0]?.totalMs).toBe(3_600_000)
+    expect(rows[0]?.withdrawalOk).toBe(30_000)
+    // 3,600,000 elapsed minus the 30,000ms accounted for by the completed
+    // withdrawal stage -- the still-open attestation stage's real elapsed
+    // time, made visible instead of silently dropped.
+    expect(rows[0]?.unmeasuredMs).toBe(3_570_000)
+  })
+
+  it('surfaces an unmeasuredMs remainder for a completed operation whose stages do not fully account for totalMs', () => {
+    // A completed, provider-recovered operation can have a real totalMs while
+    // one of its stages never got measured -- that elapsed time must still
+    // show up as a remainder, not vanish because status isn't 'in_progress'.
+    const rows = buildRebalanceRows([operation({})], {
+      maxRows: 10,
+      now: NOW_REBALANCE
+    })
+
+    expect(rows[0]?.status).toBe('completed')
+    // 730,000 totalMs minus the 630,000ms accounted for by the withdrawal and
+    // attestation stages -- the still-unmeasured deposit stage's real elapsed
+    // time.
+    expect(rows[0]?.unmeasuredMs).toBe(100_000)
+  })
+
+  it('does not fabricate an unmeasuredMs remainder when totalMs is genuinely unmeasured', () => {
+    const rows = buildRebalanceRows(
+      [
+        operation({
+          status: 'completed',
+          totalMs: null,
+          stages: [
+            {
+              stage: 'withdrawal',
+              startedAt: '2026-06-01T00:00:00Z',
+              endedAt: '2026-06-01T00:00:30Z',
+              durationMs: 30_000,
+              outcome: 'succeeded'
+            }
+          ]
+        })
+      ],
+      {
+        maxRows: 10,
+        now: NOW_REBALANCE
+      }
+    )
+
+    expect(rows[0]?.totalMs).toBeNull()
+    expect(rows[0]?.unmeasuredMs).toBe(0)
+  })
+
+  it('preserves null totalMs for a terminal operator-reconciled operation with a known startedAt', () => {
+    // A completed operation with totalMs: null means the backend deliberately
+    // suppressed the round-trip metric (e.g. OperatorReconciled) -- it must
+    // never be backfilled with now - startedAt, since that would render a
+    // fabricated, ever-growing elapsed time as the "total".
+    const startedAt = '2026-06-01T00:00:00Z'
+    const now = new Date('2026-06-01T00:00:00Z')
+
+    const rows = buildRebalanceRows(
+      [
+        operation({
+          startedAt,
+          status: 'completed',
+          totalMs: null,
+          stages: [
+            {
+              stage: 'withdrawal',
+              startedAt,
+              endedAt: '2026-06-01T00:00:30Z',
+              durationMs: 30_000,
+              outcome: 'succeeded'
+            }
+          ]
+        })
+      ],
+      {
+        maxRows: 10,
+        now
+      }
+    )
+
+    expect(rows[0]?.totalMs).toBeNull()
+  })
+
+  it('preserves null totalMs when startedAt is also null, even mid-stream', () => {
+    // startedAt: null means the read model first observed the operation
+    // mid-stream (no genuine start event). There is no elapsed basis to
+    // compute from, so totalMs must stay null rather than fabricate 0ms --
+    // even when some stages did report measured durations.
+    const rows = buildRebalanceRows(
+      [
+        operation({
+          startedAt: null,
+          status: 'completed',
+          totalMs: null,
+          stages: [
+            {
+              stage: 'withdrawal',
+              startedAt: '2026-06-01T00:00:00Z',
+              endedAt: '2026-06-01T00:00:30Z',
+              durationMs: 30_000,
+              outcome: 'succeeded'
+            }
+          ]
+        })
+      ],
+      {
+        maxRows: 10,
+        now: new Date('2026-06-01T00:01:00Z')
+      }
+    )
+
+    expect(rows[0]?.totalMs).toBeNull()
   })
 
   it('caps rows preserving newest-first input order', () => {
-    const rows = layoutRebalanceBars(
+    const rows = buildRebalanceRows(
       [
         operation({ operationId: 'newest' }),
         operation({ operationId: 'older' }),
-        operation({ operationId: 'oldest' }),
+        operation({ operationId: 'oldest' })
       ],
       {
-        plotWidth: 100,
         maxRows: 2,
-        now: NOW_REBALANCE,
-      },
+        now: NOW_REBALANCE
+      }
     )
 
     expect(rows.map((row) => row.id)).toEqual(['newest', 'older'])
   })
 
-  it('marks a failed stage as a failed segment', () => {
-    const rows = layoutRebalanceBars(
+  it('routes a failed stage to its Failed field, not its Ok field', () => {
+    const rows = buildRebalanceRows(
       [
         operation({
           status: 'failed',
@@ -312,167 +427,399 @@ describe('layoutRebalanceBars', () => {
               startedAt: '2026-06-01T00:00:00Z',
               endedAt: '2026-06-01T00:00:30Z',
               durationMs: 30_000,
-              outcome: 'failed',
-            },
-          ],
-        }),
+              outcome: 'failed'
+            }
+          ]
+        })
       ],
       {
-        plotWidth: 100,
         maxRows: 10,
-        now: NOW_REBALANCE,
-      },
+        now: NOW_REBALANCE
+      }
     )
 
-    expect(rows[0]?.segments[0]?.failed).toBe(true)
+    expect(rows[0]?.burnOk).toBe(0)
+    expect(rows[0]?.burnFailed).toBe(30_000)
   })
 })
 
-describe('layoutAttestationTrend', () => {
-  it('centers a single sample', () => {
-    const layout = layoutAttestationTrend(
-      [
-        {
-          burnedAt: '2026-06-01T00:00:00Z',
-          durationMs: 300_000,
-        },
-      ],
-      {
-        plotWidth: 100,
-        plotHeight: 50,
-      },
-    )
-
-    expect(layout.points[0]?.x).toBeCloseTo(50)
-    // The only sample is also the max, so y = plotHeight - (max/max)*plotHeight = 0.
-    expect(layout.points[0]?.y).toBeCloseTo(0)
-    expect(layout.maxMs).toBe(300_000)
-    expect(layout.path.length).toBeGreaterThan(0)
-  })
-
-  it('scales durations to the slowest sample', () => {
-    const layout = layoutAttestationTrend(
-      [
-        {
-          burnedAt: '2026-06-01T00:00:00Z',
-          durationMs: 300_000,
-        },
-        {
-          burnedAt: '2026-06-02T00:00:00Z',
-          durationMs: 600_000,
-        },
-      ],
-      {
-        plotWidth: 100,
-        plotHeight: 50,
-      },
-    )
-
-    expect(layout.maxMs).toBe(600_000)
-    expect(layout.points[0]?.y).toBeCloseTo(25)
-    expect(layout.points[1]?.y).toBeCloseTo(0)
-    expect(layout.points[1]?.x).toBeCloseTo(100)
-  })
+const equityOperation = (overrides: Partial<EquityOperationTiming>): EquityOperationTiming => ({
+  operationId: 'eq-1',
+  kind: 'mint',
+  symbol: 'AAPL',
+  quantity: '5',
+  startedAt: '2026-06-01T00:00:00Z',
+  completedAt: '2026-06-01T00:01:10Z',
+  status: 'completed',
+  stages: [
+    {
+      stage: 'mint_acceptance',
+      startedAt: '2026-06-01T00:00:00Z',
+      endedAt: '2026-06-01T00:00:10Z',
+      durationMs: 10_000,
+      outcome: 'succeeded'
+    },
+    {
+      stage: 'mint_deposit',
+      startedAt: '2026-06-01T00:01:00Z',
+      endedAt: null,
+      durationMs: null,
+      outcome: 'unmeasured'
+    }
+  ],
+  totalMs: 70_000,
+  ...overrides
 })
 
-describe('layoutBlockLagTrend', () => {
-  it('centers a single bucket', () => {
-    const layout = layoutBlockLagTrend(
-      [
-        {
-          start: '2026-06-01T00:00:00Z',
-          maxLagBlocks: 12,
-        },
-      ],
-      {
-        plotWidth: 100,
-        plotHeight: 50,
-      },
-    )
+const NOW_EQUITY = new Date('2026-06-01T00:01:10Z')
 
-    expect(layout.points[0]?.x).toBeCloseTo(50)
-    expect(layout.maxLagBlocks).toBe(12)
-  })
-
-  it('centers a single zero-lag bucket on the baseline', () => {
-    // The common just-started state: one bucket, perfectly caught up. Hits
-    // the single-bucket centering and the divide-by-zero floor together.
-    const layout = layoutBlockLagTrend(
-      [
-        {
-          start: '2026-06-01T00:00:00Z',
-          maxLagBlocks: 0,
-        },
-      ],
-      {
-        plotWidth: 100,
-        plotHeight: 50,
-      },
-    )
-
-    expect(layout.points[0]?.x).toBeCloseTo(50)
-    expect(layout.points[0]?.y).toBe(50)
-    expect(layout.maxLagBlocks).toBe(0)
-  })
-
-  it('scales lag to the worst bucket', () => {
-    const layout = layoutBlockLagTrend(
-      [
-        {
-          start: '2026-06-01T00:00:00Z',
-          maxLagBlocks: 10,
-        },
-        {
-          start: '2026-06-01T01:00:00Z',
-          maxLagBlocks: 40,
-        },
-      ],
-      {
-        plotWidth: 100,
-        plotHeight: 50,
-      },
-    )
-
-    expect(layout.maxLagBlocks).toBe(40)
-    expect(layout.points[0]?.x).toBeCloseTo(0)
-    expect(layout.points[0]?.y).toBeCloseTo(37.5)
-    expect(layout.points[1]?.y).toBeCloseTo(0)
-    expect(layout.points[1]?.x).toBeCloseTo(100)
-  })
-
-  it('keeps a flat zero-lag series on the baseline without dividing by zero', () => {
-    const layout = layoutBlockLagTrend(
-      [
-        {
-          start: '2026-06-01T00:00:00Z',
-          maxLagBlocks: 0,
-        },
-        {
-          start: '2026-06-01T01:00:00Z',
-          maxLagBlocks: 0,
-        },
-      ],
-      {
-        plotWidth: 100,
-        plotHeight: 50,
-      },
-    )
-
-    // The reported maximum is the true series maximum, not the y-scale's
-    // divide-by-zero floor: a healthy panel must read "max 0 blocks".
-    expect(layout.maxLagBlocks).toBe(0)
-    expect(layout.points.every((point) => point.y === 50)).toBe(true)
-  })
-
-  it('returns an empty layout for no buckets', () => {
-    const layout = layoutBlockLagTrend([], {
-      plotWidth: 100,
-      plotHeight: 50,
+describe('buildEquityRows', () => {
+  it('shapes completed mint stages into named fields and skips open ones', () => {
+    const rows = buildEquityRows([equityOperation({})], {
+      maxRows: 10,
+      now: NOW_EQUITY
     })
 
-    expect(layout.points).toEqual([])
-    expect(layout.path).toBe('')
-    expect(layout.maxLagBlocks).toBe(0)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.totalMs).toBe(70_000)
+    expect(rows[0]?.kind).toBe('mint')
+    expect(rows[0]?.mintAcceptanceOk).toBe(10_000)
+    // The still-open deposit stage (durationMs null) contributes nothing.
+    expect(rows[0]?.mintDepositOk).toBe(0)
+    expect(rows[0]?.mintDepositFailed).toBe(0)
+    // Redemption fields never populate for a mint row.
+    expect(rows[0]?.redemptionWithdrawOk).toBe(0)
+  })
+
+  it('uses now - startedAt as totalMs for in-progress operations', () => {
+    const startedAt = '2026-06-01T00:00:00Z'
+    const now = new Date('2026-06-01T01:00:00Z')
+
+    const rows = buildEquityRows(
+      [
+        equityOperation({
+          startedAt,
+          completedAt: null,
+          status: 'in_progress',
+          totalMs: null,
+          stages: [
+            {
+              stage: 'redemption_withdraw',
+              startedAt,
+              endedAt: null,
+              durationMs: null,
+              outcome: 'unmeasured'
+            }
+          ]
+        })
+      ],
+      {
+        maxRows: 10,
+        now
+      }
+    )
+
+    expect(rows[0]?.totalMs).toBe(3_600_000)
+    expect(rows[0]?.redemptionWithdrawOk).toBe(0)
+    // No completed stage accounts for any of the elapsed time, so the whole
+    // elapsed window must surface as a visible unmeasured remainder rather
+    // than rendering as an invisible zero-length bar.
+    expect(rows[0]?.unmeasuredMs).toBe(3_600_000)
+  })
+
+  it('surfaces only the unaccounted-for remainder as unmeasuredMs when some stages completed', () => {
+    const startedAt = '2026-06-01T00:00:00Z'
+    const now = new Date('2026-06-01T01:00:00Z')
+
+    const rows = buildEquityRows(
+      [
+        equityOperation({
+          startedAt,
+          completedAt: null,
+          status: 'in_progress',
+          totalMs: null,
+          stages: [
+            {
+              stage: 'mint_acceptance',
+              startedAt,
+              endedAt: '2026-06-01T00:00:10Z',
+              durationMs: 10_000,
+              outcome: 'succeeded'
+            },
+            {
+              stage: 'mint_receipt',
+              startedAt: '2026-06-01T00:00:10Z',
+              endedAt: null,
+              durationMs: null,
+              outcome: 'unmeasured'
+            }
+          ]
+        })
+      ],
+      {
+        maxRows: 10,
+        now
+      }
+    )
+
+    expect(rows[0]?.totalMs).toBe(3_600_000)
+    expect(rows[0]?.mintAcceptanceOk).toBe(10_000)
+    // 3,600,000 elapsed minus the 10,000ms accounted for by the completed
+    // mint_acceptance stage -- the still-open mint_receipt stage's real
+    // elapsed time, made visible instead of silently dropped.
+    expect(rows[0]?.unmeasuredMs).toBe(3_590_000)
+  })
+
+  it('surfaces an unmeasuredMs remainder for a completed operation whose stages do not fully account for totalMs', () => {
+    // Same rationale as buildRebalanceRows: a completed, provider-recovered
+    // equity operation can have a real totalMs while one of its stages never
+    // got measured -- that elapsed time must still show up as a remainder.
+    const rows = buildEquityRows([equityOperation({})], {
+      maxRows: 10,
+      now: NOW_EQUITY
+    })
+
+    expect(rows[0]?.status).toBe('completed')
+    // 70,000 totalMs minus the 10,000ms accounted for by mint_acceptance --
+    // the still-unmeasured mint_deposit stage's real elapsed time.
+    expect(rows[0]?.unmeasuredMs).toBe(60_000)
+  })
+
+  it('does not fabricate an unmeasuredMs remainder when totalMs is genuinely unmeasured', () => {
+    const rows = buildEquityRows(
+      [
+        equityOperation({
+          status: 'completed',
+          totalMs: null,
+          stages: [
+            {
+              stage: 'mint_acceptance',
+              startedAt: '2026-06-01T00:00:00Z',
+              endedAt: '2026-06-01T00:00:10Z',
+              durationMs: 10_000,
+              outcome: 'succeeded'
+            }
+          ]
+        })
+      ],
+      {
+        maxRows: 10,
+        now: NOW_EQUITY
+      }
+    )
+
+    expect(rows[0]?.totalMs).toBeNull()
+    expect(rows[0]?.unmeasuredMs).toBe(0)
+  })
+
+  it('preserves null totalMs for a terminal operator-reconciled operation with a known startedAt', () => {
+    // Same rationale as buildRebalanceRows: a completed operation with
+    // totalMs: null is a deliberate backend suppression, never a fallback
+    // candidate.
+    const startedAt = '2026-06-01T00:00:00Z'
+    const now = new Date('2026-06-01T00:00:00Z')
+
+    const rows = buildEquityRows(
+      [
+        equityOperation({
+          startedAt,
+          status: 'completed',
+          totalMs: null,
+          stages: [
+            {
+              stage: 'mint_acceptance',
+              startedAt,
+              endedAt: '2026-06-01T00:00:10Z',
+              durationMs: 10_000,
+              outcome: 'succeeded'
+            }
+          ]
+        })
+      ],
+      {
+        maxRows: 10,
+        now
+      }
+    )
+
+    expect(rows[0]?.totalMs).toBeNull()
+  })
+
+  it('preserves null totalMs when startedAt is also null, even mid-stream', () => {
+    const rows = buildEquityRows(
+      [
+        equityOperation({
+          startedAt: null,
+          status: 'completed',
+          totalMs: null,
+          stages: [
+            {
+              stage: 'mint_acceptance',
+              startedAt: '2026-06-01T00:00:00Z',
+              endedAt: '2026-06-01T00:00:10Z',
+              durationMs: 10_000,
+              outcome: 'succeeded'
+            }
+          ]
+        })
+      ],
+      {
+        maxRows: 10,
+        now: new Date('2026-06-01T00:01:00Z')
+      }
+    )
+
+    expect(rows[0]?.totalMs).toBeNull()
+  })
+
+  it('caps rows preserving newest-first input order', () => {
+    const rows = buildEquityRows(
+      [
+        equityOperation({ operationId: 'newest' }),
+        equityOperation({ operationId: 'older' }),
+        equityOperation({ operationId: 'oldest' })
+      ],
+      {
+        maxRows: 2,
+        now: NOW_EQUITY
+      }
+    )
+
+    expect(rows.map((row) => row.id)).toEqual(['newest', 'older'])
+  })
+
+  it('routes a failed stage to its Failed field, not its Ok field', () => {
+    const rows = buildEquityRows(
+      [
+        equityOperation({
+          kind: 'redeem',
+          status: 'failed',
+          completedAt: null,
+          totalMs: null,
+          stages: [
+            {
+              stage: 'redemption_send',
+              startedAt: '2026-06-01T00:00:00Z',
+              endedAt: '2026-06-01T00:00:30Z',
+              durationMs: 30_000,
+              outcome: 'failed'
+            }
+          ]
+        })
+      ],
+      {
+        maxRows: 10,
+        now: NOW_EQUITY
+      }
+    )
+
+    expect(rows[0]?.redemptionSendOk).toBe(0)
+    expect(rows[0]?.redemptionSendFailed).toBe(30_000)
+  })
+
+  it('returns an empty array for no operations', () => {
+    expect(buildEquityRows([], { maxRows: 10, now: NOW_EQUITY })).toEqual([])
+  })
+})
+
+const latencyBucket = (overrides: Partial<LatencyBucket>): LatencyBucket => ({
+  start: '2026-06-01T00:00:00Z',
+  stages: {
+    detection: null,
+    decision: null,
+    submission: null,
+    execution: null,
+    exposureWindow: null
+  },
+  ...overrides
+})
+
+describe('buildPercentileSeries', () => {
+  it('null-coalesces a bucket with no stats for the selected stage', () => {
+    const series = buildPercentileSeries([latencyBucket({})], 'execution')
+
+    expect(series).toEqual([
+      {
+        start: new Date('2026-06-01T00:00:00Z'),
+        p50Ms: null,
+        p90Ms: null,
+        p99Ms: null
+      }
+    ])
+  })
+
+  it('selects the p50/p90/p99 fields from the requested stage only', () => {
+    const buckets = [
+      latencyBucket({
+        stages: {
+          detection: null,
+          decision: null,
+          submission: null,
+          execution: { p50Ms: 100, p90Ms: 200, p95Ms: 250, p99Ms: 300, maxMs: 400, sampleCount: 5 },
+          exposureWindow: {
+            p50Ms: 900,
+            p90Ms: 910,
+            p95Ms: 920,
+            p99Ms: 930,
+            maxMs: 940,
+            sampleCount: 9
+          }
+        }
+      })
+    ]
+
+    expect(buildPercentileSeries(buckets, 'execution')).toEqual([
+      {
+        start: new Date('2026-06-01T00:00:00Z'),
+        p50Ms: 100,
+        p90Ms: 200,
+        p99Ms: 300
+      }
+    ])
+    expect(buildPercentileSeries(buckets, 'exposureWindow')).toEqual([
+      {
+        start: new Date('2026-06-01T00:00:00Z'),
+        p50Ms: 900,
+        p90Ms: 910,
+        p99Ms: 930
+      }
+    ])
+  })
+
+  it('returns an empty array for no buckets', () => {
+    expect(buildPercentileSeries([], 'execution')).toEqual([])
+  })
+})
+
+describe('thinTicks', () => {
+  const point = (isoDate: string): { start: Date } => ({ start: new Date(isoDate) })
+
+  it('always includes the last point even when it does not fall on a step boundary', () => {
+    // 5 points, maxTicks=2 -> step = ceil(5/2) = 3.
+    // Step-aligned indices: 0, 3. Index 4 (last) is NOT on a step -> must still appear.
+    const points = [
+      point('2026-06-01T00:00:00Z'),
+      point('2026-06-02T00:00:00Z'),
+      point('2026-06-03T00:00:00Z'),
+      point('2026-06-04T00:00:00Z'),
+      point('2026-06-05T00:00:00Z')
+    ]
+
+    const ticks = thinTicks(points, 2)
+
+    // Expect 3 ticks: indices 0, 3, and 4 (last).
+    expect(ticks).toHaveLength(3)
+    expect(ticks.at(-1)).toEqual(new Date('2026-06-05T00:00:00Z'))
+  })
+
+  it('keeps every point when there are fewer points than maxTicks', () => {
+    const points = [point('2026-06-01T00:00:00Z'), point('2026-06-02T00:00:00Z')]
+
+    expect(thinTicks(points, 8)).toEqual(points.map((entry) => entry.start))
+  })
+
+  it('returns an empty array for no points', () => {
+    expect(thinTicks([], 8)).toEqual([])
   })
 })
 
@@ -484,145 +831,28 @@ describe('layoutDependencySparkline', () => {
           start: '2026-06-01T00:00:00Z',
           calls: 10,
           errors: 0,
-          p50Ms: 50,
+          p50Ms: 50
         },
         {
           start: '2026-06-01T01:00:00Z',
           calls: 8,
           errors: 2,
-          p50Ms: 200,
+          p50Ms: 200
         },
         {
           start: '2026-06-01T02:00:00Z',
           calls: 0,
           errors: 0,
-          p50Ms: null,
-        },
+          p50Ms: null
+        }
       ],
-      { plotHeight: 12 },
+      { plotHeight: 12 }
     )
 
     expect(bars).toEqual([
       { height: 3, hasErrors: false },
       { height: 12, hasErrors: true },
-      { height: 0, hasErrors: false },
+      { height: 0, hasErrors: false }
     ])
-  })
-})
-
-const stats = (p50: number, p90: number, p99: number): LatencyStats => ({
-  p50Ms: p50,
-  p90Ms: p90,
-  p95Ms: p90,
-  p99Ms: p99,
-  maxMs: p99,
-  sampleCount: 10,
-})
-
-const bucket = (start: string, detection: LatencyStats | null): LatencyBucket => ({
-  start,
-  stages: {
-    detection,
-    decision: null,
-    submission: null,
-    execution: null,
-    exposureWindow: null,
-  },
-})
-
-describe('layoutPercentileSeries', () => {
-  it('lays out p50/p90/p99 lines scaled to the largest p99', () => {
-    const plotHeight = 50
-    // maxMs = 800 (largest p99 across both buckets)
-    const layout = layoutPercentileSeries(
-      [
-        bucket('2026-06-01T00:00:00Z', stats(100, 200, 400)),
-        bucket('2026-06-02T00:00:00Z', stats(150, 300, 800)),
-      ],
-      'detection',
-      {
-        plotWidth: 100,
-        plotHeight,
-        maxXLabels: 6,
-      },
-    )
-
-    expect(layout.maxMs).toBe(800)
-    expect(layout.lines).toHaveLength(3)
-
-    // y = plotHeight - (ms / maxMs) * plotHeight, maxMs = 800
-    const p99 = layout.lines.find((line) => line.percentile === 'p99Ms')
-    expect(p99?.points[1]?.y).toBeCloseTo(0)
-    expect(p99?.points[0]?.y).toBeCloseTo(25)
-    expect(p99?.points[0]?.x).toBeCloseTo(0)
-    expect(p99?.points[1]?.x).toBeCloseTo(100)
-
-    // bucket 0: p50=100, p90=200; bucket 1: p50=150, p90=300 — all scaled to maxMs=800
-    const p50 = layout.lines.find((line) => line.percentile === 'p50Ms')
-    // bucket 0: y = 50 - (100/800)*50 = 50 - 6.25 = 43.75
-    expect(p50?.points[0]?.y).toBeCloseTo(43.75)
-    // bucket 1: y = 50 - (150/800)*50 = 50 - 9.375 = 40.625
-    expect(p50?.points[1]?.y).toBeCloseTo(40.625)
-
-    const p90 = layout.lines.find((line) => line.percentile === 'p90Ms')
-    // bucket 0: y = 50 - (200/800)*50 = 50 - 12.5 = 37.5
-    expect(p90?.points[0]?.y).toBeCloseTo(37.5)
-    // bucket 1: y = 50 - (300/800)*50 = 50 - 18.75 = 31.25
-    expect(p90?.points[1]?.y).toBeCloseTo(31.25)
-  })
-
-  it('skips buckets where the stage has no samples', () => {
-    const layout = layoutPercentileSeries(
-      [
-        bucket('2026-06-01T00:00:00Z', stats(100, 200, 400)),
-        bucket('2026-06-02T00:00:00Z', null),
-        bucket('2026-06-03T00:00:00Z', stats(100, 200, 400)),
-      ],
-      'detection',
-      {
-        plotWidth: 100,
-        plotHeight: 50,
-        maxXLabels: 6,
-      },
-    )
-
-    expect(layout.lines[0]?.points).toHaveLength(2)
-  })
-
-  it('centers a single bucket', () => {
-    const layout = layoutPercentileSeries(
-      [bucket('2026-06-01T00:00:00Z', stats(100, 200, 400))],
-      'detection',
-      {
-        plotWidth: 100,
-        plotHeight: 50,
-        maxXLabels: 6,
-      },
-    )
-
-    expect(layout.lines[0]?.points[0]?.x).toBeCloseTo(50)
-  })
-
-  it('always includes the last bucket label even when it does not fall on a step boundary', () => {
-    // 5 buckets, maxXLabels=2 -> labelStep = ceil(5/2) = 3
-    // Step-aligned indices: 0, 3. Index 4 (last) is NOT on a step -> must still appear.
-    const buckets = [
-      bucket('2026-06-01T00:00:00Z', stats(100, 200, 400)),
-      bucket('2026-06-02T00:00:00Z', stats(100, 200, 400)),
-      bucket('2026-06-03T00:00:00Z', stats(100, 200, 400)),
-      bucket('2026-06-04T00:00:00Z', stats(100, 200, 400)),
-      bucket('2026-06-05T00:00:00Z', stats(100, 200, 400)),
-    ]
-
-    const layout = layoutPercentileSeries(buckets, 'detection', {
-      plotWidth: 100,
-      plotHeight: 50,
-      maxXLabels: 2,
-    })
-
-    // Expect 3 labels: indices 0, 3, and 4 (last)
-    expect(layout.xLabels).toHaveLength(3)
-    // Last label x should equal the rightmost point (index 4 out of 4 -> x=100)
-    expect(layout.xLabels.at(-1)?.x).toBeCloseTo(100)
   })
 })

--- a/dashboard/src/lib/performance/charts.ts
+++ b/dashboard/src/lib/performance/charts.ts
@@ -1,8 +1,13 @@
-/** Pure SVG layout math for the Performance tab's latency charts. */
+/**
+ * Data-shaping for the Performance tab's charts: the actual layout math
+ * (scales, axes, padding) is handled by LayerChart -- these functions only
+ * reshape backend DTOs into the flat, per-series-field rows the chart
+ * components expect.
+ */
 
-import type { AttestationSample } from '$lib/api/AttestationSample'
-import type { BlockLagPoint } from '$lib/api/BlockLagPoint'
 import type { DependencyBucket } from '$lib/api/DependencyBucket'
+import type { EquityOperationTiming } from '$lib/api/EquityOperationTiming'
+import type { EquityStageName } from '$lib/api/EquityStageName'
 import type { HedgeCycleReport } from '$lib/api/HedgeCycleReport'
 import type { LatencyBucket } from '$lib/api/LatencyBucket'
 import type { RebalanceOperationTiming } from '$lib/api/RebalanceOperationTiming'
@@ -11,36 +16,34 @@ import type { StageLatencies } from '$lib/api/StageLatencies'
 
 export type WaterfallSegmentName = 'unhedged' | 'submission' | 'execution'
 
-export type WaterfallSegment = {
-  name: WaterfallSegmentName
-  ms: number
-  x: number
-  width: number
-}
+export type WaterfallSort = 'slowest' | 'newest'
 
-export type WaterfallRow = {
+export type WaterfallBarRow = {
   id: string
   symbol: string
   status: HedgeCycleReport['status']
   totalMs: number
-  segments: WaterfallSegment[]
+  unhedged: number
+  submission: number
+  // Split into two series (rather than one 'execution' series colored per-row)
+  // so a failed cycle's final segment renders red through the chart's normal
+  // per-series coloring -- each row populates only one of the pair, the other
+  // stays 0, so the stack shows exactly one execution segment per row.
+  executionOk: number
+  executionFailed: number
 }
-
-export type WaterfallSort = 'slowest' | 'newest'
 
 const segmentDurations = (
   cycle: HedgeCycleReport,
-  now: Date,
+  now: Date
 ): { name: WaterfallSegmentName; ms: number }[] => {
   const placedAt = new Date(cycle.placedAt).getTime()
   const earliestFill =
     cycle.earliestFillBlockTimestamp !== null
       ? new Date(cycle.earliestFillBlockTimestamp).getTime()
       : placedAt
-  const submittedAt =
-    cycle.submittedAt !== null ? new Date(cycle.submittedAt).getTime() : null
-  const completedAt =
-    cycle.completedAt !== null ? new Date(cycle.completedAt).getTime() : null
+  const submittedAt = cycle.submittedAt !== null ? new Date(cycle.submittedAt).getTime() : null
+  const completedAt = cycle.completedAt !== null ? new Date(cycle.completedAt).getTime() : null
 
   // A cycle that has not reached a terminal state is live exposure: its
   // whole elapsed time still counts as unhedged, so it ranks where it
@@ -49,26 +52,26 @@ const segmentDurations = (
     return [
       {
         name: 'unhedged',
-        ms: Math.max(0, now.getTime() - earliestFill),
-      },
+        ms: Math.max(0, now.getTime() - earliestFill)
+      }
     ]
   }
 
   const segments: { name: WaterfallSegmentName; ms: number }[] = [
     {
       name: 'unhedged',
-      ms: Math.max(0, placedAt - earliestFill),
-    },
+      ms: Math.max(0, placedAt - earliestFill)
+    }
   ]
 
   if (submittedAt !== null) {
     segments.push({
       name: 'submission',
-      ms: Math.max(0, submittedAt - placedAt),
+      ms: Math.max(0, submittedAt - placedAt)
     })
     segments.push({
       name: 'execution',
-      ms: Math.max(0, completedAt - submittedAt),
+      ms: Math.max(0, completedAt - submittedAt)
     })
   }
 
@@ -76,89 +79,44 @@ const segmentDurations = (
 }
 
 /**
- * Lays out hedge cycles as horizontal stacked bars whose segment widths are
- * proportional to wall-clock time, normalized to the slowest visible cycle.
+ * Shapes hedge cycles into rows for a horizontal stacked bar chart, one
+ * numeric field per segment, sorted and capped to the visible window.
  */
-export const layoutWaterfall = (
+export const buildWaterfallRows = (
   cycles: HedgeCycleReport[],
   options: {
-    plotWidth: number
     sort: WaterfallSort
     maxRows: number
     now: Date
-  },
-): WaterfallRow[] => {
+  }
+): WaterfallBarRow[] => {
   const rows = cycles.map((cycle) => {
     const durations = segmentDurations(cycle, options.now)
     const totalMs = durations.reduce((sum, segment) => sum + segment.ms, 0)
+    const byName: Partial<Record<WaterfallSegmentName, number>> = Object.fromEntries(
+      durations.map((segment) => [segment.name, segment.ms])
+    )
+    const executionMs = byName.execution ?? 0
+    const failed = cycle.status === 'failed'
 
     return {
       id: cycle.offchainOrderId,
       symbol: cycle.symbol,
       status: cycle.status,
-      placedAt: new Date(cycle.placedAt).getTime(),
+      placedAtMs: new Date(cycle.placedAt).getTime(),
       totalMs,
-      durations,
+      unhedged: byName.unhedged ?? 0,
+      submission: byName.submission ?? 0,
+      executionOk: failed ? 0 : executionMs,
+      executionFailed: failed ? executionMs : 0
     }
   })
 
   rows.sort((left, right) =>
-    options.sort === 'slowest'
-      ? right.totalMs - left.totalMs
-      : right.placedAt - left.placedAt,
+    options.sort === 'slowest' ? right.totalMs - left.totalMs : right.placedAtMs - left.placedAtMs
   )
-  const visible = rows.slice(0, options.maxRows)
 
-  const maxTotal = Math.max(1, ...visible.map((row) => row.totalMs))
-
-  return visible.map((row) => {
-    let cursor = 0
-    const segments = row.durations.map((segment) => {
-      const width = (segment.ms / maxTotal) * options.plotWidth
-      const positioned = {
-        ...segment,
-        x: cursor,
-        width,
-      }
-      cursor += width
-      return positioned
-    })
-
-    return {
-      id: row.id,
-      symbol: row.symbol,
-      status: row.status,
-      totalMs: row.totalMs,
-      segments,
-    }
-  })
-}
-
-export type PercentileKey = 'p50Ms' | 'p90Ms' | 'p99Ms'
-
-export type SeriesPoint = {
-  x: number
-  y: number
-}
-
-export type SeriesLine = {
-  percentile: PercentileKey
-  points: SeriesPoint[]
-  path: string
-}
-
-export type SeriesLayout = {
-  lines: SeriesLine[]
-  maxMs: number
-  xLabels: { x: number; label: string }[]
-}
-
-export type RebalanceBarSegment = {
-  stage: RebalanceStageName
-  ms: number
-  x: number
-  width: number
-  failed: boolean
+  return rows.slice(0, options.maxRows).map(({ placedAtMs: _placedAtMs, ...row }) => row)
 }
 
 export type RebalanceBarRow = {
@@ -166,46 +124,100 @@ export type RebalanceBarRow = {
   direction: RebalanceOperationTiming['direction']
   amount: string | null
   status: RebalanceOperationTiming['status']
-  totalMs: number
-  segments: RebalanceBarSegment[]
+  totalMs: number | null
+  // Each stage splits into an Ok/Failed pair (rather than one series colored
+  // per-row) so a failed stage renders red through the chart's normal
+  // per-series coloring -- each row populates only one of a pair, the other
+  // stays 0.
+  conversionOk: number
+  conversionFailed: number
+  withdrawalOk: number
+  withdrawalFailed: number
+  burnOk: number
+  burnFailed: number
+  attestationOk: number
+  attestationFailed: number
+  mintOk: number
+  mintFailed: number
+  depositOk: number
+  depositFailed: number
+  // totalMs minus every measured stage above, for any row with a known
+  // totalMs. The stacked bar otherwise only plots completed-stage time, so a
+  // stuck operation (or a completed-but-recovered operation whose stages
+  // don't fully account for its elapsed time) would render as a
+  // shorter-than-real bar despite real elapsed time -- this makes that
+  // elapsed remainder its own visible segment instead of silently vanishing.
+  unmeasuredMs: number
+}
+
+const stageDurations = (
+  stages: RebalanceOperationTiming['stages'],
+  name: RebalanceStageName
+): { ok: number; failed: number } => {
+  const stage = stages.find((entry) => entry.stage === name && entry.durationMs !== null)
+  if (!stage) return { ok: 0, failed: 0 }
+
+  return stage.outcome === 'failed'
+    ? { ok: 0, failed: stage.durationMs ?? 0 }
+    : { ok: stage.durationMs ?? 0, failed: 0 }
 }
 
 /**
- * Lays out rebalance operations as horizontal stacked bars, one segment per
- * completed stage, normalized to the slowest visible operation. Operations
- * arrive newest-first from the backend and stay in that order.
+ * Shapes rebalance operations into rows for a horizontal stacked bar chart,
+ * one numeric field per stage/outcome. Operations arrive newest-first from
+ * the backend and stay in that order.
  *
  * Pass `now` so that in-progress operations (where the backend has not yet
- * set `totalMs`) are rendered with their true elapsed time instead of just
- * the sum of completed stages.
+ * set `totalMs`) are shaped with their true elapsed time instead of just the
+ * sum of completed stages.
  */
-export const layoutRebalanceBars = (
+export const buildRebalanceRows = (
   operations: RebalanceOperationTiming[],
   options: {
-    plotWidth: number
     maxRows: number
     now: Date
-  },
-): RebalanceBarRow[] => {
-  const rows = operations.slice(0, options.maxRows).map((operation) => {
-    const durations = operation.stages
-      .filter((stage) => stage.durationMs !== null)
-      .map((stage) => ({
-        stage: stage.stage,
-        ms: stage.durationMs ?? 0,
-        failed: stage.outcome === 'failed',
-      }))
-
+  }
+): RebalanceBarRow[] =>
+  operations.slice(0, options.maxRows).map((operation) => {
     // For in-progress operations the backend sets totalMs only on completion,
     // so use wall-clock elapsed since startedAt instead of summing completed
     // stages (which would understate a stuck operation on an open stage).
-    // startedAt is null when the read model first observed the operation
-    // mid-stream (no genuine start event), so there is no elapsed basis.
+    // For any other status, totalMs stays whatever the backend reported --
+    // including null, which means the round-trip is genuinely unmeasured
+    // (unknown startedAt, or a terminal OperatorReconciled operation whose
+    // manual-response window must not pollute latency metrics).
     const totalMs =
-      operation.totalMs ??
-      (operation.startedAt !== null
+      operation.status === 'in_progress' && operation.startedAt !== null
         ? Math.max(0, options.now.getTime() - new Date(operation.startedAt).getTime())
-        : 0)
+        : operation.totalMs
+
+    const conversion = stageDurations(operation.stages, 'conversion')
+    const withdrawal = stageDurations(operation.stages, 'withdrawal')
+    const burn = stageDurations(operation.stages, 'burn')
+    const attestation = stageDurations(operation.stages, 'attestation')
+    const mint = stageDurations(operation.stages, 'mint')
+    const deposit = stageDurations(operation.stages, 'deposit')
+
+    // Any operation with a known totalMs can have a remainder: in-progress
+    // operations from the elapsed-time fallback above, but also completed
+    // operations recovered via a provider-completion path, whose stages don't
+    // fully account for the measured round-trip. totalMs === null means the
+    // round-trip is genuinely unmeasured (unknown startedAt, or a terminal
+    // OperatorReconciled operation), so there is no remainder to attribute.
+    const measuredMs =
+      conversion.ok +
+      conversion.failed +
+      withdrawal.ok +
+      withdrawal.failed +
+      burn.ok +
+      burn.failed +
+      attestation.ok +
+      attestation.failed +
+      mint.ok +
+      mint.failed +
+      deposit.ok +
+      deposit.failed
+    const unmeasuredMs = totalMs !== null ? Math.max(0, totalMs - measuredMs) : 0
 
     return {
       id: operation.operationId,
@@ -213,104 +225,191 @@ export const layoutRebalanceBars = (
       amount: operation.amount,
       status: operation.status,
       totalMs,
-      durations,
+      conversionOk: conversion.ok,
+      conversionFailed: conversion.failed,
+      withdrawalOk: withdrawal.ok,
+      withdrawalFailed: withdrawal.failed,
+      burnOk: burn.ok,
+      burnFailed: burn.failed,
+      attestationOk: attestation.ok,
+      attestationFailed: attestation.failed,
+      mintOk: mint.ok,
+      mintFailed: mint.failed,
+      depositOk: deposit.ok,
+      depositFailed: deposit.failed,
+      unmeasuredMs
     }
   })
 
-  const maxTotal = Math.max(1, ...rows.map((row) => row.totalMs))
+export type EquityBarRow = {
+  id: string
+  kind: EquityOperationTiming['kind']
+  symbol: string | null
+  status: EquityOperationTiming['status']
+  totalMs: number | null
+  // Same Ok/Failed-pair-per-stage rationale as RebalanceBarRow. Mint and
+  // redemption stages are distinct series (never both populated for the same
+  // row, since an operation is one kind or the other) so one combined chart
+  // can show both kinds without the legend implying they share a pipeline.
+  mintAcceptanceOk: number
+  mintAcceptanceFailed: number
+  mintReceiptOk: number
+  mintReceiptFailed: number
+  mintWrapOk: number
+  mintWrapFailed: number
+  mintDepositOk: number
+  mintDepositFailed: number
+  redemptionWithdrawOk: number
+  redemptionWithdrawFailed: number
+  redemptionUnwrapOk: number
+  redemptionUnwrapFailed: number
+  redemptionSendOk: number
+  redemptionSendFailed: number
+  redemptionDetectionOk: number
+  redemptionDetectionFailed: number
+  redemptionCompletionOk: number
+  redemptionCompletionFailed: number
+  // Same elapsed-remainder rationale as {@link RebalanceBarRow.unmeasuredMs}.
+  unmeasuredMs: number
+}
 
-  return rows.map((row) => {
-    let cursor = 0
-    const segments = row.durations.map((segment) => {
-      const width = (segment.ms / maxTotal) * options.plotWidth
-      const positioned = {
-        ...segment,
-        x: cursor,
-        width,
-      }
-      cursor += width
-      return positioned
-    })
+const equityStageDurations = (
+  stages: EquityOperationTiming['stages'],
+  name: EquityStageName
+): { ok: number; failed: number } => {
+  const stage = stages.find((entry) => entry.stage === name && entry.durationMs !== null)
+  if (!stage) return { ok: 0, failed: 0 }
+
+  return stage.outcome === 'failed'
+    ? { ok: 0, failed: stage.durationMs ?? 0 }
+    : { ok: stage.durationMs ?? 0, failed: 0 }
+}
+
+/**
+ * Shapes equity mint/redemption operations into rows for a horizontal
+ * stacked bar chart, one numeric field per stage/outcome. Same shape and
+ * `now`-fallback rationale as {@link buildRebalanceRows}.
+ */
+export const buildEquityRows = (
+  operations: EquityOperationTiming[],
+  options: {
+    maxRows: number
+    now: Date
+  }
+): EquityBarRow[] =>
+  operations.slice(0, options.maxRows).map((operation) => {
+    // Same in-progress-only elapsed-time fallback as buildRebalanceRows --
+    // any other status preserves the backend's totalMs verbatim, including
+    // null for a genuinely unmeasured round-trip.
+    const totalMs =
+      operation.status === 'in_progress' && operation.startedAt !== null
+        ? Math.max(0, options.now.getTime() - new Date(operation.startedAt).getTime())
+        : operation.totalMs
+
+    const mintAcceptance = equityStageDurations(operation.stages, 'mint_acceptance')
+    const mintReceipt = equityStageDurations(operation.stages, 'mint_receipt')
+    const mintWrap = equityStageDurations(operation.stages, 'mint_wrap')
+    const mintDeposit = equityStageDurations(operation.stages, 'mint_deposit')
+    const redemptionWithdraw = equityStageDurations(operation.stages, 'redemption_withdraw')
+    const redemptionUnwrap = equityStageDurations(operation.stages, 'redemption_unwrap')
+    const redemptionSend = equityStageDurations(operation.stages, 'redemption_send')
+    const redemptionDetection = equityStageDurations(operation.stages, 'redemption_detection')
+    const redemptionCompletion = equityStageDurations(operation.stages, 'redemption_completion')
+
+    // Same remainder rationale as buildRebalanceRows.
+    const measuredMs =
+      mintAcceptance.ok +
+      mintAcceptance.failed +
+      mintReceipt.ok +
+      mintReceipt.failed +
+      mintWrap.ok +
+      mintWrap.failed +
+      mintDeposit.ok +
+      mintDeposit.failed +
+      redemptionWithdraw.ok +
+      redemptionWithdraw.failed +
+      redemptionUnwrap.ok +
+      redemptionUnwrap.failed +
+      redemptionSend.ok +
+      redemptionSend.failed +
+      redemptionDetection.ok +
+      redemptionDetection.failed +
+      redemptionCompletion.ok +
+      redemptionCompletion.failed
+    const unmeasuredMs = totalMs !== null ? Math.max(0, totalMs - measuredMs) : 0
 
     return {
-      id: row.id,
-      direction: row.direction,
-      amount: row.amount,
-      status: row.status,
-      totalMs: row.totalMs,
-      segments,
+      id: operation.operationId,
+      kind: operation.kind,
+      symbol: operation.symbol,
+      status: operation.status,
+      totalMs,
+      mintAcceptanceOk: mintAcceptance.ok,
+      mintAcceptanceFailed: mintAcceptance.failed,
+      mintReceiptOk: mintReceipt.ok,
+      mintReceiptFailed: mintReceipt.failed,
+      mintWrapOk: mintWrap.ok,
+      mintWrapFailed: mintWrap.failed,
+      mintDepositOk: mintDeposit.ok,
+      mintDepositFailed: mintDeposit.failed,
+      redemptionWithdrawOk: redemptionWithdraw.ok,
+      redemptionWithdrawFailed: redemptionWithdraw.failed,
+      redemptionUnwrapOk: redemptionUnwrap.ok,
+      redemptionUnwrapFailed: redemptionUnwrap.failed,
+      redemptionSendOk: redemptionSend.ok,
+      redemptionSendFailed: redemptionSend.failed,
+      redemptionDetectionOk: redemptionDetection.ok,
+      redemptionDetectionFailed: redemptionDetection.failed,
+      redemptionCompletionOk: redemptionCompletion.ok,
+      redemptionCompletionFailed: redemptionCompletion.failed,
+      unmeasuredMs
     }
   })
+
+export type PercentileSeriesPoint = {
+  start: Date
+  p50Ms: number | null
+  p90Ms: number | null
+  p99Ms: number | null
 }
 
-export type TrendLayout = {
-  points: SeriesPoint[]
-  path: string
-  maxMs: number
-}
+/**
+ * Shapes latency buckets into one row per bucket for the selected stage, null
+ * -coalescing buckets that have no stats for that stage (the stage was never
+ * reached by any sample in that window). One row per bucket in the full
+ * requested range (not just buckets with samples) is intentional: LineChart's
+ * default `defined` accessor skips null y-values, so this renders true gaps
+ * at the bucket's real time position instead of the line stretching to
+ * connect only the populated buckets.
+ */
+export const buildPercentileSeries = (
+  buckets: LatencyBucket[],
+  stage: keyof StageLatencies
+): PercentileSeriesPoint[] =>
+  buckets.map((bucket) => {
+    const stats = bucket.stages[stage]
+    return {
+      start: new Date(bucket.start),
+      p50Ms: stats?.p50Ms ?? null,
+      p90Ms: stats?.p90Ms ?? null,
+      p99Ms: stats?.p99Ms ?? null
+    }
+  })
 
-/** Lays out attestation durations over time as a single polyline. */
-export const layoutAttestationTrend = (
-  samples: AttestationSample[],
-  options: {
-    plotWidth: number
-    plotHeight: number
-  },
-): TrendLayout => {
-  const maxMs = Math.max(1, ...samples.map((sample) => sample.durationMs))
-  const xDenominator = Math.max(1, samples.length - 1)
-  const points = samples.map((sample, index) => ({
-    x:
-      samples.length <= 1
-        ? options.plotWidth / 2
-        : (index / xDenominator) * options.plotWidth,
-    y: options.plotHeight - (sample.durationMs / maxMs) * options.plotHeight,
-  }))
-
-  return {
-    points,
-    path: points
-      .map((point) => `${point.x.toFixed(1)},${point.y.toFixed(1)}`)
-      .join(' '),
-    maxMs,
-  }
-}
-
-export type BlockLagLayout = {
-  points: SeriesPoint[]
-  path: string
-  maxLagBlocks: number
-}
-
-/** Lays out per-bucket worst block lag over time as a single polyline. */
-export const layoutBlockLagTrend = (
-  buckets: BlockLagPoint[],
-  options: {
-    plotWidth: number
-    plotHeight: number
-  },
-): BlockLagLayout => {
-  const maxLagBlocks = Math.max(0, ...buckets.map((bucket) => bucket.maxLagBlocks))
-  // The y-scale denominator is floored at 1 so an all-zero series divides
-  // safely; the reported maximum stays the true value (0 for a healthy
-  // series), never the scale floor.
-  const scaleMax = Math.max(1, maxLagBlocks)
-  const xDenominator = Math.max(1, buckets.length - 1)
-  const points = buckets.map((bucket, index) => ({
-    x:
-      buckets.length <= 1
-        ? options.plotWidth / 2
-        : (index / xDenominator) * options.plotWidth,
-    y: options.plotHeight - (bucket.maxLagBlocks / scaleMax) * options.plotHeight,
-  }))
-
-  return {
-    points,
-    path: points
-      .map((point) => `${point.x.toFixed(1)},${point.y.toFixed(1)}`)
-      .join(' '),
-    maxLagBlocks,
-  }
+/**
+ * Thins a sequence of x-axis points down to at most `maxTicks` explicit tick
+ * values, keeping every `step`-th point (step = ceil(n / maxTicks)) plus
+ * always the last point. The default d3 time-scale tick generator picks
+ * ticks by "nice" time boundaries (hour/day/etc), not by point count, so a
+ * range with many daily buckets can otherwise emit more ticks than there are
+ * distinct days -- rendering the same calendar-date label twice in a row
+ * once two ticks land on the same day.
+ */
+export const thinTicks = (points: { start: Date }[], maxTicks: number): Date[] => {
+  const step = Math.max(1, Math.ceil(points.length / maxTicks))
+  return points
+    .filter((_, index) => index % step === 0 || index === points.length - 1)
+    .map((point) => point.start)
 }
 
 export type DependencySparkBar = {
@@ -325,83 +424,12 @@ export type DependencySparkBar = {
  */
 export const layoutDependencySparkline = (
   buckets: DependencyBucket[],
-  options: { plotHeight: number },
+  options: { plotHeight: number }
 ): DependencySparkBar[] => {
   const maxP50 = Math.max(1, ...buckets.map((bucket) => bucket.p50Ms ?? 0))
 
   return buckets.map((bucket) => ({
     height: ((bucket.p50Ms ?? 0) / maxP50) * options.plotHeight,
-    hasErrors: bucket.errors > 0,
+    hasErrors: bucket.errors > 0
   }))
-}
-
-const PERCENTILE_KEYS: PercentileKey[] = ['p50Ms', 'p90Ms', 'p99Ms']
-
-/**
- * Lays out one stage's percentiles across time buckets as polyline charts.
- * Buckets where the stage has no samples are skipped, keeping the lines
- * continuous across gaps.
- */
-export const layoutPercentileSeries = (
-  buckets: LatencyBucket[],
-  stage: keyof StageLatencies,
-  options: {
-    plotWidth: number
-    plotHeight: number
-    maxXLabels: number
-  },
-): SeriesLayout => {
-  const sampled = buckets
-    .map((bucket) => ({
-      start: bucket.start,
-      stats: bucket.stages[stage],
-    }))
-    .filter((bucket) => bucket.stats !== null)
-
-  const maxMs = Math.max(1, ...sampled.map((bucket) => bucket.stats?.p99Ms ?? 0))
-  const xDenominator = Math.max(1, sampled.length - 1)
-  const xFor = (index: number): number =>
-    sampled.length <= 1
-      ? options.plotWidth / 2
-      : (index / xDenominator) * options.plotWidth
-  const yFor = (ms: number): number =>
-    options.plotHeight - (ms / maxMs) * options.plotHeight
-
-  const lines = PERCENTILE_KEYS.map((percentile) => {
-    const points = sampled.map((bucket, index) => ({
-      x: xFor(index),
-      y: yFor(bucket.stats?.[percentile] ?? 0),
-    }))
-
-    return {
-      percentile,
-      points,
-      path: points
-        .map((point) => `${point.x.toFixed(1)},${point.y.toFixed(1)}`)
-        .join(' '),
-    }
-  })
-
-  const labelStep = Math.max(1, Math.ceil(sampled.length / options.maxXLabels))
-  const lastIndex = sampled.length - 1
-  const xLabels = sampled
-    .map((bucket, index) => ({
-      x: xFor(index),
-      label: new Date(bucket.start).toLocaleDateString(undefined, {
-        month: 'short',
-        day: 'numeric',
-      }),
-      index,
-    }))
-    .filter(({ index }) => index % labelStep === 0 || index === lastIndex)
-    .map(({ x, label }) => ({
-      x,
-      label,
-    }))
-
-  return {
-    lines,
-    maxMs,
-    xLabels,
-  }
 }

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -178,6 +178,16 @@ const mockApi = () => ({
         return
       }
 
+      if (path === '/performance/equity-rebalances') {
+        mockJson(response, {
+          operations: [],
+          totalOperations: 0,
+          skippedOperations: 0,
+          stageSummary: [],
+        })
+        return
+      }
+
       goNext()
     })
   }


### PR DESCRIPTION
## What

- Migrates the Performance tab latency charts to LayerChart primitives.
- Splits USDC and equity stage timing into separate chart sections.
- Handles isolated points, sparse buckets, empty states, and responsive chart sizing in the dashboard.
- Updates dashboard chart shaping/tests for the denser backend time-series data.

## Why

The previous SVG charting clipped or hid single-point series and made sparse history misleading. Equity timing also needs a separate visual path so users can compare mint/redemption timing without mixing it into USDC rebalance stages.

## How

- Adds `layerchart` dashboard dependencies and reusable chart primitives.
- Converts `performance-panel.svelte` to render the new percentile and stage-duration series.
- Extends `charts.ts` layout helpers and tests for isolated points and sparse buckets.

## Testing

- Added dashboard chart tests for LayerChart data shaping and sparse/isolated point behavior.
- Ran `nix develop -c bash -lc 'cd dashboard && bun run check && bun run test:run'`.
- Previously ran `nix develop -c cargo check -p st0x-hedge --all-features` and pre-commit hooks before submit.

## Anything else

The backend dense-bucket report change now lives in #990 so this chart PR is focused on dashboard rendering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new 2-week performance range option.
  * Expanded performance charts with richer visuals and tooltips across several sections.
  * Added equity rebalance timing data to the performance dashboard.

* **Bug Fixes**
  * Improved refresh error messages to show clearer, user-friendly failures.
  * Adjusted retention handling so health charts stay within available data.
  * Improved chart rendering for edge cases like empty or minimal data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->