### PR TITLE
feat: show per-asset inventory config flags

### DIFF
--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -750,6 +750,22 @@ fn parse_and_validate(
         });
     }
 
+    // Extended-hours counter-trading depends on counter-trading itself: the
+    // hedge path gates on `trading` before it ever consults the extended-hours
+    // session (see `check_execution_readiness`), so
+    // `extended_hours_counter_trading = enabled` with `trading = disabled` is a
+    // dead configuration that can never execute. Reject it so the invalid
+    // combination never loads and never reaches the dashboard.
+    for (symbol, equity) in &config.assets.equities.symbols {
+        if equity.extended_hours_counter_trading == OperationMode::Enabled
+            && equity.trading == OperationMode::Disabled
+        {
+            return Err(CtxError::ExtendedHoursWithoutCounterTrading {
+                symbol: symbol.clone(),
+            });
+        }
+    }
+
     let broker = BrokerCtx::from_parts(secrets.broker, config.broker.as_ref())?;
     let telemetry = config.telemetry.map(TelemetryCtx::from);
     let alerts = AlertsCtx::new(config.alerts, secrets.alerts)?;
@@ -1337,6 +1353,13 @@ pub enum CtxError {
          rebalancing is enabled but not configured"
     )]
     MissingEquityVaultId { symbol: Symbol },
+    #[error(
+        "assets.equities.{symbol}: extended_hours_counter_trading cannot be \
+         enabled when trading is disabled -- extended-hours counter-trades only \
+         run while counter-trading is enabled, so this combination can never \
+         execute"
+    )]
+    ExtendedHoursWithoutCounterTrading { symbol: Symbol },
     #[error("{field} polling interval must be non-zero")]
     ZeroPollingInterval { field: &'static str },
     #[error("server_port and board_port must differ; both set to {port}")]
@@ -1378,6 +1401,9 @@ impl CtxError {
             }
             Self::MissingCashVaultId => "missing cash vault_ids",
             Self::MissingEquityVaultId { .. } => "missing equity vault_ids",
+            Self::ExtendedHoursWithoutCounterTrading { .. } => {
+                "extended hours enabled without counter-trading"
+            }
             Self::ZeroPollingInterval { .. } => "zero polling interval",
             Self::ServerAndBoardPortsMatch { .. } => "server_port and board_port must differ",
             Self::FloatComparison(_) => "float comparison failed",
@@ -4103,7 +4129,7 @@ mod tests {
             [equities.AAPL]
             tokenized_equity = "0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b"
             tokenized_equity_derivative = "0xf4f8c66085910d583c01f3b4e44bf731d4e2c565"
-            trading = "disabled"
+            trading = "enabled"
             rebalancing = "disabled"
             wrapped_equity_recovery = "disabled"
             extended_hours_counter_trading = "enabled"
@@ -4893,6 +4919,80 @@ mod tests {
     #[test]
     fn validate_files_accepts_example_config_and_secrets() {
         Ctx::validate_files(example_config_toml(), example_secrets_toml()).unwrap();
+    }
+
+    #[test]
+    fn validate_files_rejects_extended_hours_without_counter_trading() {
+        let config = toml_file(
+            r#"
+            database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
+            apalis_finished_job_cleanup_interval_secs = 3600
+
+            [assets.equities.AAPL]
+            tokenized_equity = "0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b"
+            tokenized_equity_derivative = "0xf4f8c66085910d583c01f3b4e44bf731d4e2c565"
+            trading = "disabled"
+            rebalancing = "disabled"
+            wrapped_equity_recovery = "disabled"
+            extended_hours_counter_trading = "enabled"
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+            deployment_block = 1
+            required_confirmations = 3
+            ingestion_cutoff = "safe"
+
+            [wallet]
+            kind = "private-key"
+            address = "0x0000000000000000000000000000000000000001"
+        "#,
+        );
+        let secrets = dry_run_secrets_toml();
+
+        let error = Ctx::validate_files(config.path(), secrets.path()).unwrap_err();
+        assert!(
+            matches!(
+                error,
+                CtxError::ExtendedHoursWithoutCounterTrading { ref symbol }
+                    if symbol.to_string() == "AAPL"
+            ),
+            "Expected ExtendedHoursWithoutCounterTrading for AAPL, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn validate_files_accepts_extended_hours_with_counter_trading() {
+        let config = toml_file(
+            r#"
+            database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
+            apalis_finished_job_cleanup_interval_secs = 3600
+
+            [assets.equities.AAPL]
+            tokenized_equity = "0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b"
+            tokenized_equity_derivative = "0xf4f8c66085910d583c01f3b4e44bf731d4e2c565"
+            trading = "enabled"
+            rebalancing = "disabled"
+            wrapped_equity_recovery = "disabled"
+            extended_hours_counter_trading = "enabled"
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+            deployment_block = 1
+            required_confirmations = 3
+            ingestion_cutoff = "safe"
+
+            [wallet]
+            kind = "private-key"
+            address = "0x0000000000000000000000000000000000000001"
+        "#,
+        );
+        let secrets = dry_run_secrets_toml();
+
+        Ctx::validate_files(config.path(), secrets.path()).unwrap();
     }
 
     #[test]

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -52,6 +52,7 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
     CurrentState::export_all_to(out_dir)?;
     Settings::export_all_to(out_dir)?;
     AssetSettings::export_all_to(out_dir)?;
+    CounterTrading::export_all_to(out_dir)?;
     WalletSettings::export_all_to(out_dir)?;
     Trade::export_all_to(out_dir)?;
     Position::export_all_to(out_dir)?;

--- a/crates/dto/src/settings.rs
+++ b/crates/dto/src/settings.rs
@@ -57,7 +57,82 @@ pub struct WalletSettings {
 pub struct AssetSettings {
     #[ts(type = "string")]
     pub symbol: Symbol,
-    pub trading: bool,
+    pub counter_trading: CounterTrading,
     pub rebalancing: bool,
     pub operational_limit: Option<String>,
+}
+
+/// Counter-trading (hedging) configuration for an asset.
+///
+/// Extended-hours counter-trading only makes sense when counter-trading is
+/// enabled: the hedge path gates on counter-trading before it ever consults the
+/// extended-hours session, so extended hours without counter-trading is a dead
+/// configuration that can never execute. Nesting `extended_hours` under
+/// `Enabled` makes that invalid combination unrepresentable on the wire, so the
+/// dashboard can never receive a contradictory pair.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase", tag = "status")]
+pub enum CounterTrading {
+    Disabled,
+    #[serde(rename_all = "camelCase")]
+    Enabled {
+        extended_hours: bool,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use st0x_finance::Symbol;
+
+    use super::{AssetSettings, CounterTrading};
+
+    #[test]
+    fn counter_trading_disabled_serializes_with_status_tag_only() {
+        let value = serde_json::to_value(CounterTrading::Disabled).unwrap();
+        assert_eq!(value, json!({ "status": "disabled" }));
+    }
+
+    #[test]
+    fn counter_trading_enabled_serializes_extended_hours_flag() {
+        let value = serde_json::to_value(CounterTrading::Enabled {
+            extended_hours: true,
+        })
+        .unwrap();
+        assert_eq!(value, json!({ "status": "enabled", "extendedHours": true }));
+    }
+
+    #[test]
+    fn counter_trading_enabled_without_extended_hours_serializes_false_flag() {
+        let value = serde_json::to_value(CounterTrading::Enabled {
+            extended_hours: false,
+        })
+        .unwrap();
+        assert_eq!(
+            value,
+            json!({ "status": "enabled", "extendedHours": false })
+        );
+    }
+
+    #[test]
+    fn asset_settings_nests_counter_trading_under_status() {
+        let settings = AssetSettings {
+            symbol: Symbol::new("AAPL").unwrap(),
+            counter_trading: CounterTrading::Enabled {
+                extended_hours: true,
+            },
+            rebalancing: false,
+            operational_limit: None,
+        };
+
+        let value = serde_json::to_value(&settings).unwrap();
+        assert_eq!(value["symbol"], json!("AAPL"));
+        assert_eq!(
+            value["counterTrading"],
+            json!({ "status": "enabled", "extendedHours": true })
+        );
+        assert_eq!(value["rebalancing"], json!(false));
+        assert_eq!(value["operationalLimit"], json!(null));
+    }
 }

--- a/dashboard/src/lib/components/available-inventory.svelte
+++ b/dashboard/src/lib/components/available-inventory.svelte
@@ -98,6 +98,11 @@
   const formatRatio = (ratio: number): string => `${(ratio * 100).toFixed(1)}%`
 
   type PositionInfo = { net: string; priceUsdc: string | null }
+  type AssetFlags = {
+    counterTrading: boolean
+    rebalancing: boolean
+    extendedHours: boolean
+  }
 
   const positionMap = $derived(
     new Map(
@@ -108,6 +113,28 @@
           priceUsdc: position.last_price_usdc
         } satisfies PositionInfo
       ])
+    )
+  )
+
+  const assetFlagsMap = $derived(
+    new Map(
+      settings?.assets.map((asset) => {
+        const counterTrading = asset.counterTrading
+        const flags: AssetFlags =
+          counterTrading.status === 'enabled'
+            ? {
+                counterTrading: true,
+                rebalancing: asset.rebalancing,
+                extendedHours: counterTrading.extendedHours
+              }
+            : {
+                counterTrading: false,
+                rebalancing: asset.rebalancing,
+                extendedHours: false
+              }
+
+        return [asset.symbol, flags] as const
+      }) ?? []
     )
   )
 
@@ -123,12 +150,10 @@
     exposure: number
     netShares: string
     priceUsdc: string | null
-    trading: boolean
+    // null when the symbol has no settings entry (unconfigured): the status
+    // lights render as unknown rather than falsely showing all-disabled.
+    flags: AssetFlags | null
   }
-
-  const tradingSet = $derived(
-    new Set(settings?.assets.filter((asset) => asset.trading).map((asset) => asset.symbol) ?? [])
-  )
 
   const equityRows = $derived<EquityRow[]>(
     symbols.map((item) => {
@@ -139,6 +164,7 @@
       )
       const stripped = stripPrefix(item.symbol)
       const pos = positionMap.get(stripped)
+      const flags = assetFlagsMap.get(stripped) ?? null
 
       return {
         asset: stripped,
@@ -152,7 +178,7 @@
         exposure: pos?.priceUsdc ? parseFloat(pos.net) * parseFloat(pos.priceUsdc) : 0,
         netShares: pos?.net ?? '0',
         priceUsdc: pos?.priceUsdc ?? null,
-        trading: tradingSet.has(stripped)
+        flags
       }
     })
   )
@@ -208,8 +234,10 @@
     const rows = [...equityRows]
 
     rows.sort((lhs, rhs) => {
-      // Trading-enabled assets always come first
-      if (lhs.trading !== rhs.trading) return lhs.trading ? -1 : 1
+      // Counter-trading assets always come first
+      const lhsActive = lhs.flags?.counterTrading ?? false
+      const rhsActive = rhs.flags?.counterTrading ?? false
+      if (lhsActive !== rhsActive) return lhsActive ? -1 : 1
 
       if (sort.current) {
         const { column, dir } = sort.current
@@ -234,7 +262,35 @@
       ? approxClass(val)
       : 'cursor-help hover:underline hover:decoration-dotted hover:decoration-muted-foreground hover:underline-offset-4'
 
-  const dimClass = (base: string, trading = true): string => (trading ? base : `${base} opacity-40`)
+  const dimClass = (base: string, active = true): string => (active ? base : `${base} opacity-40`)
+
+  type LightState = 'enabled' | 'disabled' | 'unknown'
+
+  // A light reflects only its own flag. When the asset has no settings entry
+  // (unconfigured) the state is unknown -- rendered distinctly, never as a false
+  // "disabled". Counter-trading state does not dim sibling lights: each of CT /
+  // Rebal / Ext stands on its own so an enabled mode never reads as off.
+  const lightState = (flags: AssetFlags | null, key: keyof AssetFlags): LightState =>
+    flags === null ? 'unknown' : flags[key] ? 'enabled' : 'disabled'
+
+  const statusLightClass = (state: LightState): string => {
+    const color =
+      state === 'enabled'
+        ? 'border-green-500/70 bg-green-500 shadow-[0_0_0_3px_rgba(34,197,94,0.12)]'
+        : state === 'disabled'
+          ? 'border-red-500/70 bg-red-500 shadow-[0_0_0_3px_rgba(239,68,68,0.10)]'
+          : 'border-muted-foreground/40 bg-muted-foreground/30'
+
+    return `mx-auto block h-2.5 w-2.5 rounded-full border ${color}`
+  }
+
+  const statusGroupHeadClass = 'px-4 text-center font-normal normal-case tracking-normal'
+  const statusGroupClass =
+    'mx-auto grid w-max grid-cols-[1.25rem_2.5rem_1.25rem] items-center justify-items-center gap-1'
+  const statusCellClass = 'px-4 text-center'
+
+  const statusLabel = (label: string, state: LightState): string =>
+    `${label} ${state === 'unknown' ? 'unconfigured' : state}`
 
   type DeviationStyle = 'normal' | 'high' | 'low'
 
@@ -507,6 +563,22 @@
           </button>
         </Table.Head>
 
+        <Table.Head class={statusGroupHeadClass}>
+          <div class={statusGroupClass}>
+            <span title="Counter-trading / hedging for this asset: green enabled, red disabled, grey not configured."
+              >CT</span
+            >
+
+            <span title="Automatic equity rebalancing for this asset: green enabled, red disabled, grey not configured."
+              >Rebal</span
+            >
+
+            <span title="Extended-hours counter-trading (only active while counter-trading is enabled): green enabled, red disabled, grey not configured."
+              >Ext</span
+            >
+          </div>
+        </Table.Head>
+
         <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'raindex')}>
           <button
             class="{sortBtnClass} text-left"
@@ -593,16 +665,45 @@
     <Table.Body>
       {#each sortedEquities as row, idx (row.asset)}
         {@const dev = ratioDeviation(row.ratio, false)}
+        {@const ctActive = row.flags?.counterTrading ?? false}
+        {@const ctState = lightState(row.flags, 'counterTrading')}
+        {@const rebalState = lightState(row.flags, 'rebalancing')}
+        {@const extState = lightState(row.flags, 'extendedHours')}
         <Table.Row class={idx % 2 === 0 ? 'bg-muted/40' : ''}>
-          <Table.Cell class="font-mono font-medium {row.trading ? '' : 'opacity-40'}"
+          <Table.Cell class="font-mono font-medium {ctActive ? '' : 'opacity-40'}"
             >{row.asset}</Table.Cell
           >
+
+          <Table.Cell class={statusCellClass}>
+            <div class={statusGroupClass}>
+              <span
+                class={statusLightClass(ctState)}
+                role="img"
+                title={statusLabel('Counter-trading', ctState)}
+                aria-label={statusLabel('Counter-trading', ctState)}
+              ></span>
+
+              <span
+                class={statusLightClass(rebalState)}
+                role="img"
+                title={statusLabel('Rebalancing', rebalState)}
+                aria-label={statusLabel('Rebalancing', rebalState)}
+              ></span>
+
+              <span
+                class={statusLightClass(extState)}
+                role="img"
+                title={statusLabel('Extended hours', extState)}
+                aria-label={statusLabel('Extended hours', extState)}
+              ></span>
+            </div>
+          </Table.Cell>
 
           <Table.Cell class="text-left font-mono {inventoryNumberClass}">
             <InventoryHoverValue
               display={row.raindex.display}
               tooltip={equityUsdTooltip(row.raindex.full, row.priceUsdc)}
-              class={dimClass(valueClass(row.raindex), row.trading)}
+              class={dimClass(valueClass(row.raindex), ctActive)}
             />
           </Table.Cell>
 
@@ -610,7 +711,7 @@
             <InventoryHoverValue
               display={row.inflight.display}
               tooltip={equityUsdTooltip(row.inflight.full, row.priceUsdc)}
-              class={dimClass(`${valueClass(row.inflight)} opacity-50`, row.trading)}
+              class={dimClass(`${valueClass(row.inflight)} opacity-50`, ctActive)}
             />
           </Table.Cell>
 
@@ -618,7 +719,7 @@
             <InventoryHoverValue
               display={row.alpaca.display}
               tooltip={equityUsdTooltip(row.alpaca.full, row.priceUsdc)}
-              class={dimClass(valueClass(row.alpaca), row.trading)}
+              class={dimClass(valueClass(row.alpaca), ctActive)}
             />
           </Table.Cell>
 
@@ -626,7 +727,7 @@
             <InventoryHoverValue
               display={row.total.display}
               tooltip={equityUsdTooltip(row.total.full, row.priceUsdc)}
-              class={dimClass(valueClass(row.total), row.trading)}
+              class={dimClass(valueClass(row.total), ctActive)}
             />
           </Table.Cell>
 
@@ -642,7 +743,7 @@
                   style="width: {String(Math.min(row.ratio * 100, 100))}%"
                 ></div>
               </div>
-              <span class="font-mono text-[11px] {row.trading ? '' : 'opacity-40'}"
+              <span class="font-mono text-[11px] {ctActive ? '' : 'opacity-40'}"
                 >{formatRatio(row.ratio)}</span
               >
             </div>
@@ -662,7 +763,7 @@
                 tooltip={positionSharesTooltip(row.netShares)}
                 class={dimClass(
                   `cursor-help hover:underline hover:decoration-dotted hover:decoration-muted-foreground hover:underline-offset-4 ${row.exposure === 0 || isNegligible(row.exposure) ? 'text-muted-foreground' : row.exposure > 0 ? 'text-green-500' : 'text-red-500'}`,
-                  row.trading
+                  ctActive
                 )}
               />
             </div>
@@ -674,7 +775,7 @@
             <InventoryHoverValue
               display={row.unwrapped.display}
               tooltip={equityUsdTooltip(row.unwrapped.full, row.priceUsdc)}
-              class={dimClass(`${valueClass(row.unwrapped)} opacity-50`, row.trading)}
+              class={dimClass(`${valueClass(row.unwrapped)} opacity-50`, ctActive)}
             />
           </Table.Cell>
 
@@ -682,7 +783,7 @@
             <InventoryHoverValue
               display={row.wrapped.display}
               tooltip={equityUsdTooltip(row.wrapped.full, row.priceUsdc)}
-              class={dimClass(`${valueClass(row.wrapped)} opacity-50`, row.trading)}
+              class={dimClass(`${valueClass(row.wrapped)} opacity-50`, ctActive)}
             />
           </Table.Cell>
         </Table.Row>

--- a/dashboard/src/lib/components/inventory-panel.svelte
+++ b/dashboard/src/lib/components/inventory-panel.svelte
@@ -51,6 +51,9 @@
 
   const equityEntries: GlossaryEntry[] = [
     { name: 'Asset', def: 'Equity symbol with the t/wt prefix stripped (e.g. AAPL for tAAPL / wtAAPL). Non-trading assets are dimmed.' },
+    { name: 'CT', def: 'Counter-trading / hedging status for this asset. Green means enabled; red means disabled; grey means not configured.' },
+    { name: 'Rebal', def: 'Automatic equity rebalancing status for this asset. Green means enabled; red means disabled; grey means not configured.' },
+    { name: 'Ext', def: 'Extended-hours counter-trading status for this asset (only active while counter-trading is enabled). Green means enabled; red means disabled; grey means not configured.' },
     { name: 'Raindex', def: 'tSTOCK tokens available in the Raindex vault to settle takers.' },
     { name: 'Inflight', def: 'Shares the books track as in motion between venues (pending mints, redeems, transfers). Part of imbalance math.' },
     { name: 'Alpaca', def: 'Shares held at Alpaca (offchain available).' },

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -189,9 +189,21 @@ pub(crate) fn settings_from_ctx(ctx: &st0x_config::Ctx) -> st0x_dto::Settings {
                     .unwrap_or_else(|_| "?".to_string())
             });
 
+            // Extended hours lives under `Enabled` only. Config validation
+            // rejects `extended_hours_counter_trading = enabled` with
+            // `trading = disabled`, so a disabled asset never carries a live
+            // extended-hours flag -- this maps valid config, it does not
+            // coerce a contradictory pair.
+            let counter_trading = match config.trading {
+                OperationMode::Enabled => st0x_dto::CounterTrading::Enabled {
+                    extended_hours: config.extended_hours_counter_trading == OperationMode::Enabled,
+                },
+                OperationMode::Disabled => st0x_dto::CounterTrading::Disabled,
+            };
+
             st0x_dto::AssetSettings {
                 symbol: symbol.clone(),
-                trading: config.trading == OperationMode::Enabled,
+                counter_trading,
                 rebalancing: config.rebalancing == OperationMode::Enabled,
                 operational_limit: limit,
             }
@@ -297,11 +309,11 @@ mod tests {
     use tokio::net::TcpListener;
     use tokio_tungstenite::connect_async;
 
+    use st0x_config::{EquityAssetConfig, create_test_ctx_with_order_owner};
     use st0x_dto::{Direction, Trade, TradingVenue};
 
     use super::*;
     use crate::inventory::{self, BroadcastingInventory};
-    use st0x_config::create_test_ctx_with_order_owner;
 
     fn dummy_fill(symbol: &str) -> Statement {
         Statement::TradeFill(Trade {
@@ -345,6 +357,78 @@ mod tests {
             recent_transfers: Vec::new(),
             warnings: Vec::new(),
         })
+    }
+
+    #[test]
+    fn settings_from_ctx_includes_asset_operation_flags() {
+        let mut ctx = create_test_ctx_with_order_owner(address!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ));
+        let symbol = st0x_finance::Symbol::new("RKLB").unwrap();
+        ctx.assets.equities.symbols.insert(
+            symbol.clone(),
+            EquityAssetConfig {
+                tokenized_equity: address!("0x1111111111111111111111111111111111111111"),
+                tokenized_equity_derivative: address!("0x2222222222222222222222222222222222222222"),
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                extended_hours_counter_trading: OperationMode::Enabled,
+                operational_limit: None,
+            },
+        );
+
+        let settings = settings_from_ctx(&ctx);
+        let asset = settings
+            .assets
+            .iter()
+            .find(|asset| asset.symbol == symbol)
+            .expect("RKLB settings should be present");
+
+        assert!(matches!(
+            asset.counter_trading,
+            st0x_dto::CounterTrading::Enabled {
+                extended_hours: true
+            }
+        ));
+        assert!(!asset.rebalancing);
+    }
+
+    #[test]
+    fn settings_from_ctx_maps_disabled_trading_to_counter_trading_disabled() {
+        let mut ctx = create_test_ctx_with_order_owner(address!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ));
+        let symbol = st0x_finance::Symbol::new("RKLB").unwrap();
+        ctx.assets.equities.symbols.insert(
+            symbol.clone(),
+            EquityAssetConfig {
+                tokenized_equity: address!("0x1111111111111111111111111111111111111111"),
+                tokenized_equity_derivative: address!("0x2222222222222222222222222222222222222222"),
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Disabled,
+                rebalancing: OperationMode::Enabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                extended_hours_counter_trading: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+
+        let settings = settings_from_ctx(&ctx);
+        let asset = settings
+            .assets
+            .iter()
+            .find(|asset| asset.symbol == symbol)
+            .expect("RKLB settings should be present");
+
+        assert!(matches!(
+            asset.counter_trading,
+            st0x_dto::CounterTrading::Disabled
+        ));
+        assert!(asset.rebalancing);
     }
 
     async fn create_test_state() -> AppState {


### PR DESCRIPTION

## What

- Adds per-asset inventory indicators for counter trading, rebalancing, and extended-hours counter trading.
- Renders the indicators as aligned green/red status lights in the equity inventory table.
- Adds glossary entries for `CT`, `Rebal`, and `Ext`.

## Why

- Operators need to confirm per-asset behavior flags while reviewing inventory state.
- Extended-hours and rebalancing can vary by asset, so a single global dashboard signal is not enough.

## How

- Extends `AssetSettings` with `extended_hours` and populates it in `settings_from_ctx`.
- Builds per-row `AssetFlags` from dashboard settings and keeps disabled counter-trading rows dimmed via the existing `trading` row behavior.
- Uses a shared status-grid class for the header labels and lights so `CT`, `Rebal`, and `Ext` stay aligned while the group remains compact.
- Adds `settings_from_ctx_includes_asset_operation_flags` to cover trading, rebalancing, and extended-hours DTO population.

## Testing

- `nix develop .#ci-backend -c cargo fmt -- --check`
- `nix develop .#ci-backend -c cargo nextest run -p st0x-dto`
- `nix develop .#ci-backend -c cargo nextest run -p st0x-hedge settings_from_ctx_includes_asset_operation_flags`
- `nix develop .#ci-dashboard -c bash -lc 'cd dashboard && bun run lint'`
- `nix develop .#ci-dashboard -c bash -lc 'cd dashboard && bun run check'`
- `nix run .#ci` passed before the final dashboard-only spacing/alignment tweaks; the final UI tweak was re-checked with dashboard lint/check.

## Screenshots

Not captured for the final state.

## Anything else

- Stacked on #976.
- Adds a dashboard settings DTO field; no database migration, secret update, or deployed config change is included.
