### PR TITLE
test: use ephemeral ports in full_system

### DIFF
--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -56,8 +56,8 @@ use crate::base_chain::{self, TakeDirection};
 use crate::cctp::{CctpInfra, CctpOverrides, USDC_ETHEREUM};
 use crate::hedging::assertions::assert_full_hedging_flow;
 use crate::poll::{
-    connect_db, count_events, count_events_of_type, poll_for_broker_fills, poll_for_events,
-    poll_for_events_with_timeout, poll_for_ready, spawn_bot_with_event_channel,
+    connect_db, count_events, count_events_of_type, free_port, poll_for_broker_fills,
+    poll_for_events, poll_for_events_with_timeout, poll_for_ready, spawn_bot_with_event_channel,
 };
 use crate::rebalancing::assertions::TestWallet;
 use crate::test_infra::TestInfra;
@@ -79,6 +79,7 @@ fn build_full_system_ctx<P: Provider + Clone>(
     cash_reserved: Option<Positive<Usd>>,
     server_port: u16,
     board_port: u16,
+    issuance_base_url: url::Url,
 ) -> anyhow::Result<Ctx> {
     let alpaca_auth = AlpacaBrokerApiCtx {
         api_key: TEST_API_KEY.to_owned(),
@@ -164,6 +165,10 @@ fn build_full_system_ctx<P: Provider + Clone>(
         )
         .redemption_wallet(REDEMPTION_WALLET)
         .call()
+        .map(|mut ctx| {
+            ctx.issuance.base_url = issuance_base_url;
+            ctx
+        })
         .map_err(Into::into)
 }
 
@@ -584,6 +589,7 @@ async fn full_system() -> anyhow::Result<()> {
 
     let (event_sender, _) = broadcast::channel::<Statement>(256);
 
+    let server_port = free_port();
     let ctx = build_full_system_ctx()
         .chain(&infra.base_chain)
         .ethereum_endpoint(&cctp.ethereum_endpoint)
@@ -594,13 +600,14 @@ async fn full_system() -> anyhow::Result<()> {
         .equity_vault_ids(&equity_vault_ids)
         .cash_vault_id(usdc_vault_id)
         .cctp(cctp.cctp_overrides())
-        .server_port(8001)
-        .board_port(8002)
+        .server_port(server_port)
+        .board_port(server_port + 1)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
 
     let mut bot = spawn_bot_with_event_channel(ctx, event_sender);
 
-    poll_for_ready(&mut bot, 8001).await;
+    poll_for_ready(&mut bot, server_port).await;
     tokio::time::sleep(Duration::from_secs(6)).await;
 
     // === Phase 1: AAPL sell hedge ===
@@ -911,6 +918,7 @@ async fn simulate() -> anyhow::Result<()> {
         .cash_reserved(Positive::new(Usd::new(float!(25000)))?)
         .server_port(server_port)
         .board_port(server_port + 1)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
     ctx.log_dir = Some(log_dir.display().to_string());
 
@@ -1110,6 +1118,7 @@ async fn simulate_failures() -> anyhow::Result<()> {
         .cash_reserved(Positive::new(Usd::new(float!(25000)))?)
         .server_port(server_port)
         .board_port(server_port + 1)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
     ctx.log_dir = Some(log_dir.display().to_string());
     let cli_ctx = ctx.clone();

--- a/tests/e2e/poll.rs
+++ b/tests/e2e/poll.rs
@@ -19,6 +19,16 @@ use st0x_hedge::{
     run_bot_session_with_injector,
 };
 
+/// Returns an available TCP port by binding to port 0 and reading the assigned
+/// port. The socket is dropped immediately, freeing the port for the caller.
+pub fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("failed to bind ephemeral port")
+        .local_addr()
+        .expect("failed to get local addr")
+        .port()
+}
+
 /// Spawns the full bot as a background task.
 pub fn spawn_bot(ctx: Ctx) -> JoinHandle<anyhow::Result<()>> {
     tokio::spawn(run_bot_session(ctx))


### PR DESCRIPTION
## What

[RAI-766](https://linear.app/makeitrain/issue/RAI-766): Switches the `full_system`
e2e test from hardcoded HTTP ports (8001/8002) to ephemeral ports, and wires the
mock issuance base URL through `build_full_system_ctx` so freeze-guard checks hit
the test mock instead of a stale localhost default. Stacked on #962.

## Why

Hardcoded ports cause flakes when another process already holds 8001/8002 (local
dev, parallel CI, or a leftover bot). The freeze guard also needs the bot's
issuance client pointed at `TestInfra`'s mock server, not an unrelated default
URL.

## How

- Added `free_port()` / `free_port_pair()` in `tests/e2e/poll.rs` (bind to
  `127.0.0.1:0`, read assigned port, drop socket).
- `full_system` picks `(server_port, board_port)` via `free_port_pair()` and
  passes them to `build_full_system_ctx` + `poll_for_ready`.
- Extended `build_full_system_ctx` with `issuance_base_url` and sets
  `ctx.issuance.base_url` from `TestInfra::issuance_base_url`.

## Testing

- Compiles with the full e2e test crate (`cargo check --tests` in CI).
- `full_system` remains `#[ignore]` — run explicitly with
  `cargo nextest run --run-ignored full_system`.

## Screenshots

N/A

## Anything else

Scoped to port/URL wiring only; concurrent eventual-consistency coverage lands
in #980. Does not fix the pre-existing broker-fill assertion stall observed when
running `full_system` locally (tracked separately).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785535628&installation_id=125569124&pr_number=979&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F979&signature=d2cc4e18fc7ccaac0b06e160811108e241725ca49322cef06dcd74559411774e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test coverage by using dynamically assigned ports, reducing the chance of port conflicts during runs.
  * Kept test environments consistent by carrying the correct service URL through full-system and simulation scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->