### PR TITLE
test: assert eventual consistency under concurrent trade chaos

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,7 +13,7 @@ slow-timeout = { period = "120s", terminate-after = 3 }
 # E2e tests are slow and prone to hangs — limit threads and allow more time
 # Stream output immediately so progress is visible during long runs
 [[profile.default.overrides]]
-filter = "binary(=e2e) & not test(=full_system::simulate)"
+filter = "binary(=e2e) & not (test(=full_system::simulate) | test(=full_system::full_system_concurrent))"
 test-group = "simulate"
 slow-timeout = { period = "150s", terminate-after = 3 }
 retries = { backoff = "exponential", count = 1, delay = "5s", jitter = true }
@@ -22,7 +22,7 @@ failure-output = "immediate"
 
 # Long-running simulation — effectively infinite timeout, no retries
 [[profile.default.overrides]]
-filter = "test(=full_system::simulate)"
+filter = "test(=full_system::simulate) | test(=full_system::full_system_concurrent)"
 test-group = "simulate"
 slow-timeout = { period = "1y", terminate-after = 100 }
 retries = 0
@@ -34,7 +34,7 @@ failure-output = "immediate"
 
 [profile.ci]
 fail-fast = false
-default-filter = "not test(=full_system::simulate)"
+default-filter = "not test(=full_system::simulate) & not test(=full_system::full_system_concurrent)"
 retries = { backoff = "exponential", count = 2, delay = "1s", jitter = true }
 slow-timeout = { period = "90s", terminate-after = 3 }
 
@@ -43,7 +43,7 @@ filter = "test(compile_fail_tests)"
 slow-timeout = { period = "180s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
-filter = "binary(=e2e) & not test(=full_system::simulate)"
+filter = "binary(=e2e) & not (test(=full_system::simulate) | test(=full_system::full_system_concurrent))"
 test-group = "simulate"
 slow-timeout = { period = "600s", terminate-after = 2 }
 retries = { backoff = "exponential", count = 3, delay = "5s", jitter = true }

--- a/README.md
+++ b/README.md
@@ -272,13 +272,25 @@ nix develop .#ci-backend -c cargo clippy --workspace --all-targets --all-feature
 
 ## Local Simulation
 
-`nix run .#simulate` launches a full local simulation of the market making
-system using [mprocs](https://github.com/pvolok/mprocs) to run the dashboard and
-the bot side-by-side. `nix run .#simulate-failures` starts the same stack, then
+`nix run .#simulate` launches the full-system chaos eventual-consistency e2e
+test (`full_system_concurrent`) with [mprocs](https://github.com/pvolok/mprocs)
+running the dashboard and bot side-by-side. Trades fire in randomized order with
+delayed broker fills; between rounds the test injects chaos (bot restarts, NAV
+bumps, asset add/remove, broker latency) and then asserts hedging, mint, and
+USDC rebalancing still converge. Open `http://localhost:5173` to watch the
+dashboard while it runs. Set `SIMULATE_EXIT_AFTER_CHAOS=1` to exit once
+assertions pass instead of idling for dashboard inspection.
+
+`nix run .#simulate-market` runs the infinite market simulation instead —
+continuous user trades at ~10-second intervals. Use this when you want to
+observe long-running liquidity cycling rather than a single bounded chaos
+scenario.
+
+`nix run .#simulate-failures` starts the same stack as `simulate-market`, then
 creates failed mint and redemption rebalances whose mock Alpaca provider later
 completes and prints the `transfer recheck` commands that recover them.
 
-What it does:
+What `simulate-market` does:
 
 1. Starts a local Anvil blockchain with deployed Raindex orderbook contracts
 2. Deploys mock services: Alpaca broker, tokenization API, CCTP attestation
@@ -294,7 +306,7 @@ equity supply between venues, and bridges USDC via mock CCTP to keep cash
 balanced. If the system works correctly, the vaults never permanently drain —
 the bot cycles liquidity back through hedging and rebalancing.
 
-Open `http://localhost:5173` to watch the dashboard. Press `Ctrl-C` to stop.
+Press `Ctrl-C` to stop.
 
 ## Project Structure
 

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1200,6 +1200,7 @@ impl Ctx {
         execution_threshold_override: Option<ExecutionThreshold>,
         travel_rule: Option<TravelRuleConfig>,
         rest_api: Option<RestApiCtx>,
+        #[builder(default = create_test_issuance_ctx())] issuance: IssuanceStatusCtx,
         redemption_wallet: Option<Address>,
     ) -> Result<Self, CtxError> {
         let execution_threshold = match execution_threshold_override {
@@ -1245,7 +1246,7 @@ impl Ctx {
             assets,
             travel_rule,
             rest_api,
-            issuance: create_test_issuance_ctx(),
+            issuance,
             redemption_wallet,
         })
     }
@@ -1454,6 +1455,16 @@ pub fn create_test_issuance_ctx() -> IssuanceStatusCtx {
         #[allow(clippy::unwrap_used)]
         base_url: Url::parse("http://localhost:8000").unwrap(),
         api_key: IssuanceApiKey(B256::repeat_byte(0xab)),
+    }
+}
+
+/// Issuance status context pointing at an e2e mock server URL.
+#[cfg(any(test, feature = "test-support"))]
+#[must_use]
+pub fn test_issuance_status_ctx(base_url: Url) -> IssuanceStatusCtx {
+    IssuanceStatusCtx {
+        base_url,
+        api_key: create_test_issuance_ctx().api_key,
     }
 }
 
@@ -3333,6 +3344,13 @@ mod tests {
             !rendered.contains(raw_key),
             "the raw api_key leaked into the error output: {rendered}"
         );
+    }
+
+    #[test]
+    fn test_issuance_status_ctx_uses_supplied_base_url() {
+        let base_url = Url::parse("http://127.0.0.1:4242").unwrap();
+        let ctx = test_issuance_status_ctx(base_url.clone());
+        assert_eq!(ctx.base_url, base_url);
     }
 
     #[test]

--- a/flake.nix
+++ b/flake.nix
@@ -339,13 +339,20 @@
                 '';
               };
 
-              # Continuous user-trade driver — the default simulation.
+              # Eventual-consistency chaos test with live dashboard — the default
+              # local simulation entry point.
               simulate = mkSimulation {
                 name = "simulate";
+                testFilter = "full_system_concurrent";
+              };
+
+              # Continuous user-trade driver — infinite market simulation.
+              "simulate-market" = mkSimulation {
+                name = "simulate-market";
                 testFilter = "simulate";
               };
 
-              # Same live dashboard stack as `simulate`, but first creates
+              # Same live dashboard stack as `simulate-market`, but first creates
               # stuck mint and redemption rebalances whose Alpaca mock
               # provider later completes. The backend logs the
               # `transfer recheck` commands needed to recover them.

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -5,12 +5,17 @@
 //!   Validates correctness of the complete hedging -> mint -> USDC bridge
 //!   pipeline. Finishes when all assertions pass.
 //!
+//! - [`full_system_concurrent`]: Chaos eventual-consistency simulation — trades
+//!   fire in randomized order while the harness randomly restarts the bot, bumps
+//!   broker NAV, adds MSFT to config, or removes TSLA from config. Run via
+//!   `nix run .#simulate`.
+//!
 //! - [`simulate`]: Long-running market simulation. Sets up Raindex liquidity
 //!   orders once (buy + sell per symbol, shared vaults) and continuously
 //!   takes them to simulate users buying and selling tokenized equities.
 //!   The bot counter-trades, mints/redeems, and bridges USDC to maintain
 //!   liquidity — if it works correctly, the vaults never drain permanently.
-//!   Run via `nix run .#simulate` (mprocs with dashboard). Ctrl-C to stop.
+//!   Run via `nix run .#simulate-market` (mprocs with dashboard). Ctrl-C to stop.
 //!
 //! - [`simulate_failures`]: Same live simulation, but first creates stuck
 //!   mint and redemption rebalances where the local aggregate failed while
@@ -56,7 +61,7 @@ use crate::base_chain::{self, TakeDirection};
 use crate::cctp::{CctpInfra, CctpOverrides, USDC_ETHEREUM};
 use crate::hedging::assertions::assert_full_hedging_flow;
 use crate::poll::{
-    connect_db, count_events, count_events_of_type, free_port, poll_for_broker_fills,
+    connect_db, count_events, count_events_of_type, free_port_pair, poll_for_broker_fills,
     poll_for_events, poll_for_events_with_timeout, poll_for_ready, spawn_bot_with_event_channel,
 };
 use crate::rebalancing::assertions::TestWallet;
@@ -65,7 +70,7 @@ use crate::test_infra::TestInfra;
 /// Builds a `Ctx` with ALL features enabled: hedging, equity rebalancing,
 /// and USDC rebalancing. This is the superset context for the mega test.
 #[bon::builder]
-fn build_full_system_ctx<P: Provider + Clone>(
+pub(crate) fn build_full_system_ctx<P: Provider + Clone>(
     chain: &base_chain::BaseChain<P>,
     ethereum_endpoint: &str,
     broker: &AlpacaBrokerMock,
@@ -163,12 +168,9 @@ fn build_full_system_ctx<P: Provider + Clone>(
         .maybe_rest_api(
             rest_api_url.map(|url| st0x_config::RestApiCtx::unauthenticated(url.to_string())),
         )
+        .issuance(st0x_config::test_issuance_status_ctx(issuance_base_url))
         .redemption_wallet(REDEMPTION_WALLET)
         .call()
-        .map(|mut ctx| {
-            ctx.issuance.base_url = issuance_base_url;
-            ctx
-        })
         .map_err(Into::into)
 }
 
@@ -589,7 +591,7 @@ async fn full_system() -> anyhow::Result<()> {
 
     let (event_sender, _) = broadcast::channel::<Statement>(256);
 
-    let server_port = free_port();
+    let (server_port, board_port) = free_port_pair();
     let ctx = build_full_system_ctx()
         .chain(&infra.base_chain)
         .ethereum_endpoint(&cctp.ethereum_endpoint)
@@ -601,7 +603,7 @@ async fn full_system() -> anyhow::Result<()> {
         .cash_vault_id(usdc_vault_id)
         .cctp(cctp.cctp_overrides())
         .server_port(server_port)
-        .board_port(server_port + 1)
+        .board_port(board_port)
         .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
 
@@ -787,6 +789,13 @@ async fn full_system() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Chaos eventual-consistency simulation for `nix run .#simulate`.
+#[tokio::test]
+#[ignore = "long-running system test -- run via nix run .#simulate"]
+async fn full_system_concurrent() -> anyhow::Result<()> {
+    Box::pin(crate::full_system_chaos::run_concurrent_chaos_simulation()).await
+}
+
 /// Long-running simulation: sets up mock infrastructure and Raindex
 /// liquidity orders once, starts the bot, then simulates users buying and
 /// selling indefinitely. Each symbol has a SellEquity order (user buys
@@ -798,14 +807,14 @@ async fn full_system() -> anyhow::Result<()> {
 /// supply, and bridges USDC to keep cash balanced. The Rain vaults stay
 /// funded because the bot continuously cycles liquidity back into them.
 ///
-/// Run via `nix run .#simulate` which pairs this with the dashboard dev
+/// Run via `nix run .#simulate-market` which pairs this with the dashboard dev
 /// server in mprocs so you can observe the system in real time.
 #[tokio::test]
-#[ignore = "infinite simulation -- run via nix run .#simulate"]
+#[ignore = "infinite simulation -- run via nix run .#simulate-market"]
 #[allow(clippy::too_many_lines)]
 async fn simulate() -> anyhow::Result<()> {
     let server_port: u16 = std::env::var("SIMULATE_BOT_PORT")
-        .expect("SIMULATE_BOT_PORT must be set (run via `nix run .#simulate`)")
+        .expect("SIMULATE_BOT_PORT must be set (run via `nix run .#simulate-market`)")
         .parse()
         .expect("SIMULATE_BOT_PORT must be a valid u16 port number");
 

--- a/tests/e2e/full_system_chaos.rs
+++ b/tests/e2e/full_system_chaos.rs
@@ -1,0 +1,672 @@
+//! Chaos helpers for [`super::full_system::full_system_concurrent`].
+//!
+//! Exercises restarts, broker NAV bumps, and config changes that add or remove
+//! assets while trades fire concurrently with staggered submission.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy::primitives::{Address, B256, U256, utils::parse_units};
+use alloy::providers::Provider;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use tokio::sync::Mutex;
+use tokio::sync::broadcast;
+use tokio::task::{JoinHandle, JoinSet};
+use tracing::info;
+
+use rain_math_float::Float;
+use st0x_dto::Statement;
+use st0x_event_sorcery::Projection;
+use st0x_execution::FractionalShares;
+use st0x_execution::Symbol;
+use st0x_execution::alpaca_broker_api::{AlpacaBrokerMock, OrderSide};
+use st0x_float_macro::float;
+use st0x_hedge::Position;
+
+use crate::base_chain::{PreparedOrder, TakeDirection};
+use crate::cctp::{CctpInfra, USDC_ETHEREUM};
+use crate::full_system::build_full_system_ctx;
+use crate::poll::{
+    connect_db, count_events, count_events_of_type, poll_for_broker_fills,
+    poll_for_events_with_timeout, poll_for_ready, simulation_ports, sleep_or_crash,
+    spawn_bot_with_event_channel,
+};
+use crate::test_infra::TestInfra;
+
+const CHAOS_ACTION_COUNT: usize = 5;
+
+/// One mint/rebalance lifecycle per AAPL sell imbalance cycle.
+const EXPECTED_TOKENIZED_EQUITY_MINT_EVENTS: i64 = 5;
+/// Full BaseToAlpaca happy-path lifecycle (see `full_system` phase 4).
+const EXPECTED_USDC_REBALANCE_EVENTS: i64 = 12;
+/// Five core onchain trades plus the deferred MSFT sell after `AddAsset`.
+const EXPECTED_OFFCHAIN_FILLS: i64 = 6;
+
+#[derive(Debug, Clone, Copy)]
+enum ChaosAction {
+    NavBump,
+    Restart,
+    AddAsset,
+    RemoveAsset,
+    BrokerLatency,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CoreTrade {
+    AaplSell,
+    TslaBuy,
+    AaplMint(usize),
+    MsftSell,
+}
+
+struct ChaosConfig {
+    msft_enabled: bool,
+    tsla_removed: bool,
+    /// Set after the core TSLA buy is onchain and its broker hedge has converged.
+    /// `RemoveAsset` must not run before this, or the bot could drop TSLA while
+    /// exposure is still open.
+    tsla_hedge_confirmed: bool,
+}
+
+struct ActiveSymbols<'symbol> {
+    symbols: Vec<&'symbol str>,
+}
+
+impl ActiveSymbols<'_> {
+    fn includes(&self, symbol: &str) -> bool {
+        self.symbols.contains(&symbol)
+    }
+}
+
+struct ChaosBootstrap<P> {
+    infra: Arc<TestInfra<P>>,
+    take_lock: Arc<Mutex<()>>,
+    shared_trades: Arc<SharedTradeOrders>,
+    cctp: CctpInfra,
+    usdc_vault_id: B256,
+    equity_vault_ids: HashMap<String, B256>,
+    deployment_block: u64,
+    server_port: u16,
+    board_port: u16,
+    event_sender: broadcast::Sender<Statement>,
+    aapl_broker_price: Float,
+    tsla_broker_price: Float,
+    msft_broker_price: Float,
+}
+
+struct SharedTradeOrders {
+    aapl_sell: PreparedOrder,
+    tsla_buy: PreparedOrder,
+    aapl_mints: Vec<PreparedOrder>,
+    msft_sell: PreparedOrder,
+}
+
+impl SharedTradeOrders {
+    fn prepared(&self, trade: CoreTrade) -> &PreparedOrder {
+        match trade {
+            CoreTrade::AaplSell => &self.aapl_sell,
+            CoreTrade::TslaBuy => &self.tsla_buy,
+            CoreTrade::AaplMint(index) => self
+                .aapl_mints
+                .get(index)
+                .unwrap_or_else(|| panic!("invalid AAPL mint index {index}")),
+            CoreTrade::MsftSell => &self.msft_sell,
+        }
+    }
+}
+
+struct ChaosSession<'bootstrap, P: Provider + Clone> {
+    bot: JoinHandle<anyhow::Result<()>>,
+    bootstrap: &'bootstrap ChaosBootstrap<P>,
+    chaos_config: ChaosConfig,
+}
+
+pub(crate) async fn run_concurrent_chaos_simulation() -> anyhow::Result<()> {
+    crate::test_infra::init_tracing();
+
+    let bootstrap = Box::pin(bootstrap_chaos_world()).await?;
+    let mut session = start_chaos_session(&bootstrap).await?;
+    let mut nav_baselines = HashMap::from([
+        ("AAPL".to_owned(), bootstrap.aapl_broker_price),
+        ("TSLA".to_owned(), bootstrap.tsla_broker_price),
+        ("MSFT".to_owned(), bootstrap.msft_broker_price),
+    ]);
+
+    let mut rng = StdRng::from_entropy();
+    fire_core_trades_concurrently(&bootstrap, &mut rng).await?;
+    wait_for_tsla_hedge(&mut session, &bootstrap).await?;
+
+    let action_plan = build_chaos_action_plan(&mut rng);
+    run_chaos_rounds(&mut session, &mut nav_baselines, &action_plan, &mut rng).await?;
+    take_msft_after_asset_add(&bootstrap, &session.chaos_config).await?;
+    wait_for_chaos_convergence(&mut session.bot, &bootstrap).await?;
+    assert_final_state(&bootstrap.infra).await?;
+
+    if std::env::var_os("SIMULATE_EXIT_AFTER_CHAOS").is_some() {
+        session.bot.abort();
+        return Ok(());
+    }
+
+    info!("Chaos scenario converged - bot staying up for dashboard observation (Ctrl-C to stop)");
+    idle_for_dashboard(&mut session.bot).await
+}
+
+async fn bootstrap_chaos_world() -> anyhow::Result<ChaosBootstrap<impl Provider + Clone + 'static>>
+{
+    let aapl_broker_price = float!(150.25);
+    let tsla_broker_price = float!(245.00);
+    let msft_broker_price = float!(380.00);
+
+    let infra = TestInfra::start_with_cash(
+        vec![
+            ("AAPL", aapl_broker_price),
+            ("TSLA", tsla_broker_price),
+            ("MSFT", msft_broker_price),
+        ],
+        vec![("TSLA", float!(400))],
+        Some(float!(500_000)),
+        None,
+    )
+    .await?;
+    let cctp = CctpInfra::start(&infra).await?;
+
+    let usdc_amount: U256 = parse_units("300000", 6)?.into();
+    let usdc_vault_id = infra.base_chain.create_usdc_vault(usdc_amount).await?;
+
+    let aapl_sell_prepared = infra
+        .base_chain
+        .setup_order()
+        .symbol("AAPL")
+        .amount(float!(10.75))
+        .price(float!(155.00))
+        .direction(TakeDirection::SellEquity)
+        .usdc_vault_id(usdc_vault_id)
+        .call()
+        .await?;
+
+    let aapl_equity_vault_id = aapl_sell_prepared.output_vault_id;
+
+    let tsla_buy_prepared = infra
+        .base_chain
+        .setup_order()
+        .symbol("TSLA")
+        .amount(float!(5.0))
+        .price(float!(250.00))
+        .direction(TakeDirection::BuyEquity)
+        .usdc_vault_id(usdc_vault_id)
+        .call()
+        .await?;
+
+    let mut mint_prepared_orders = Vec::new();
+    for _ in 0..3 {
+        mint_prepared_orders.push(
+            infra
+                .base_chain
+                .setup_order()
+                .symbol("AAPL")
+                .amount(float!(7.5))
+                .price(float!(150.00))
+                .direction(TakeDirection::SellEquity)
+                .usdc_vault_id(usdc_vault_id)
+                .call()
+                .await?,
+        );
+    }
+
+    let msft_sell_prepared = infra
+        .base_chain
+        .setup_order()
+        .symbol("MSFT")
+        .amount(float!(4.0))
+        .price(float!(390.00))
+        .direction(TakeDirection::SellEquity)
+        .usdc_vault_id(usdc_vault_id)
+        .call()
+        .await?;
+
+    let equity_vault_ids = HashMap::from([
+        ("AAPL".to_owned(), aapl_equity_vault_id),
+        ("TSLA".to_owned(), tsla_buy_prepared.input_vault_id),
+        ("MSFT".to_owned(), msft_sell_prepared.output_vault_id),
+    ]);
+
+    let eth_deposit_provider = alloy::providers::ProviderBuilder::new()
+        .connect(&cctp.ethereum_endpoint)
+        .await?;
+    let _deposit_watcher = infra
+        .broker_service
+        .start_deposit_watcher(eth_deposit_provider, USDC_ETHEREUM, infra.base_chain.owner)
+        .await?;
+
+    let deployment_block = infra.base_chain.provider.get_block_number().await?;
+    let (event_sender, _) = broadcast::channel::<Statement>(256);
+    let (server_port, board_port) = simulation_ports();
+
+    Ok(ChaosBootstrap {
+        infra: Arc::new(infra),
+        take_lock: Arc::new(Mutex::new(())),
+        shared_trades: Arc::new(SharedTradeOrders {
+            aapl_sell: aapl_sell_prepared,
+            tsla_buy: tsla_buy_prepared,
+            aapl_mints: mint_prepared_orders,
+            msft_sell: msft_sell_prepared,
+        }),
+        cctp,
+        usdc_vault_id,
+        equity_vault_ids,
+        deployment_block,
+        server_port,
+        board_port,
+        event_sender,
+        aapl_broker_price,
+        tsla_broker_price,
+        msft_broker_price,
+    })
+}
+
+async fn start_chaos_session<P: Provider + Clone + 'static>(
+    bootstrap: &ChaosBootstrap<P>,
+) -> anyhow::Result<ChaosSession<'_, P>> {
+    let chaos_config = ChaosConfig {
+        msft_enabled: false,
+        tsla_removed: false,
+        tsla_hedge_confirmed: false,
+    };
+    let active_symbols = active_symbols(&chaos_config);
+    let mut bot = spawn_bot_for_symbols(bootstrap, &active_symbols)?;
+
+    poll_for_ready(&mut bot, bootstrap.server_port).await;
+    tokio::time::sleep(Duration::from_secs(6)).await;
+
+    bootstrap
+        .infra
+        .broker_service
+        .set_symbol_fill_delay(Symbol::new("TSLA")?, 3);
+
+    Ok(ChaosSession {
+        bot,
+        bootstrap,
+        chaos_config,
+    })
+}
+
+async fn fire_core_trades_concurrently<P: Provider + Clone + 'static>(
+    bootstrap: &ChaosBootstrap<P>,
+    rng: &mut StdRng,
+) -> anyhow::Result<()> {
+    let mut trades = vec![
+        CoreTrade::AaplSell,
+        CoreTrade::TslaBuy,
+        CoreTrade::AaplMint(0),
+        CoreTrade::AaplMint(1),
+        CoreTrade::AaplMint(2),
+    ];
+    trades.shuffle(rng);
+
+    let delays_ms: Vec<u64> = (0..trades.len()).map(|_| rng.gen_range(0..500)).collect();
+
+    info!(
+        trade_count = trades.len(),
+        "Submitting core trades concurrently with staggered delays",
+    );
+
+    let mut join_set = JoinSet::new();
+    for (trade, delay_ms) in trades.into_iter().zip(delays_ms) {
+        let infra = bootstrap.infra.clone();
+        let take_lock = bootstrap.take_lock.clone();
+        let shared_trades = bootstrap.shared_trades.clone();
+        join_set.spawn(async move {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            let _take_guard = take_lock.lock().await;
+            let prepared = shared_trades.prepared(trade);
+            infra.base_chain.take_prepared_order(prepared).await
+        });
+    }
+
+    while let Some(result) = join_set.join_next().await {
+        result??;
+    }
+
+    Ok(())
+}
+
+async fn wait_for_tsla_hedge<P: Provider + Clone>(
+    session: &mut ChaosSession<'_, P>,
+    bootstrap: &ChaosBootstrap<P>,
+) -> anyhow::Result<()> {
+    poll_for_broker_fills(
+        &mut session.bot,
+        &bootstrap.infra.broker_service,
+        "TSLA",
+        OrderSide::Sell,
+        FractionalShares::new(float!(5)),
+        Duration::from_secs(180),
+    )
+    .await;
+    session.chaos_config.tsla_hedge_confirmed = true;
+    Ok(())
+}
+
+fn build_chaos_action_plan(rng: &mut StdRng) -> Vec<ChaosAction> {
+    let mut plan = vec![
+        ChaosAction::Restart,
+        ChaosAction::AddAsset,
+        ChaosAction::RemoveAsset,
+        ChaosAction::NavBump,
+        ChaosAction::BrokerLatency,
+    ];
+    assert_eq!(plan.len(), CHAOS_ACTION_COUNT);
+    plan.shuffle(rng);
+    plan
+}
+
+async fn run_chaos_rounds<P: Provider + Clone + 'static>(
+    session: &mut ChaosSession<'_, P>,
+    nav_baselines: &mut HashMap<String, Float>,
+    action_plan: &[ChaosAction],
+    rng: &mut StdRng,
+) -> anyhow::Result<()> {
+    info!(
+        rounds = action_plan.len(),
+        "Running chaos rounds with guaranteed action coverage",
+    );
+
+    for action in action_plan {
+        apply_chaos_action(session, nav_baselines, *action, rng).await?;
+    }
+
+    Ok(())
+}
+
+async fn take_msft_after_asset_add<P: Provider + Clone + 'static>(
+    bootstrap: &ChaosBootstrap<P>,
+    chaos_config: &ChaosConfig,
+) -> anyhow::Result<()> {
+    if !chaos_config.msft_enabled {
+        return Ok(());
+    }
+
+    info!("Taking deferred MSFT sell after asset was added to config");
+    let _take_guard = bootstrap.take_lock.lock().await;
+    bootstrap
+        .infra
+        .base_chain
+        .take_prepared_order(bootstrap.shared_trades.prepared(CoreTrade::MsftSell))
+        .await?;
+
+    Ok(())
+}
+
+async fn wait_for_chaos_convergence<P: Provider + Clone>(
+    bot: &mut JoinHandle<anyhow::Result<()>>,
+    bootstrap: &ChaosBootstrap<P>,
+) -> anyhow::Result<()> {
+    poll_for_broker_fills(
+        bot,
+        &bootstrap.infra.broker_service,
+        "AAPL",
+        OrderSide::Buy,
+        FractionalShares::new(float!(33.25)),
+        Duration::from_secs(180),
+    )
+    .await;
+
+    poll_for_broker_fills(
+        bot,
+        &bootstrap.infra.broker_service,
+        "MSFT",
+        OrderSide::Buy,
+        FractionalShares::new(float!(4)),
+        Duration::from_secs(180),
+    )
+    .await;
+
+    poll_for_events_with_timeout(
+        bot,
+        &bootstrap.infra.db_path,
+        "OffchainOrderEvent::Filled",
+        EXPECTED_OFFCHAIN_FILLS,
+        Duration::from_secs(180),
+    )
+    .await;
+
+    poll_for_events_with_timeout(
+        bot,
+        &bootstrap.infra.db_path,
+        "TokenizedEquityMintEvent::DepositedIntoRaindex",
+        1,
+        Duration::from_secs(180),
+    )
+    .await;
+
+    poll_for_events_with_timeout(
+        bot,
+        &bootstrap.infra.db_path,
+        "UsdcRebalanceEvent::ConversionConfirmed",
+        1,
+        Duration::from_secs(180),
+    )
+    .await;
+
+    Ok(())
+}
+
+async fn idle_for_dashboard(bot: &mut JoinHandle<anyhow::Result<()>>) -> anyhow::Result<()> {
+    loop {
+        sleep_or_crash(bot, "dashboard idle").await;
+        tokio::time::sleep(Duration::from_secs(30)).await;
+    }
+}
+
+async fn apply_chaos_action<P: Provider + Clone + 'static>(
+    session: &mut ChaosSession<'_, P>,
+    nav_baselines: &mut HashMap<String, Float>,
+    action: ChaosAction,
+    rng: &mut StdRng,
+) -> anyhow::Result<()> {
+    info!(?action, "Applying chaos action");
+
+    match action {
+        ChaosAction::NavBump => {
+            for symbol in ["AAPL", "TSLA", "MSFT"] {
+                let baseline = *nav_baselines
+                    .get(symbol)
+                    .ok_or_else(|| anyhow::anyhow!("missing NAV baseline for {symbol}"))?;
+                let bumped = bump_symbol_nav(
+                    &session.bootstrap.infra.broker_service,
+                    symbol,
+                    baseline,
+                    rng,
+                )?;
+                nav_baselines.insert(symbol.to_owned(), bumped);
+            }
+        }
+        ChaosAction::Restart => restart_bot(session).await?,
+        ChaosAction::AddAsset => {
+            session.chaos_config.msft_enabled = true;
+            restart_bot(session).await?;
+        }
+        ChaosAction::RemoveAsset => {
+            anyhow::ensure!(
+                session.chaos_config.tsla_hedge_confirmed,
+                "RemoveAsset blocked: TSLA core trade must be taken and hedged before removal",
+            );
+            session.chaos_config.tsla_removed = true;
+            restart_bot(session).await?;
+        }
+        ChaosAction::BrokerLatency => {
+            let delay_polls = rng.gen_range(1..=5);
+            session
+                .bootstrap
+                .infra
+                .broker_service
+                .set_symbol_fill_delay(Symbol::new("TSLA")?, delay_polls);
+            info!(delay_polls, "Adjusted TSLA broker fill latency");
+        }
+    }
+
+    Ok(())
+}
+
+fn bump_symbol_nav(
+    broker: &AlpacaBrokerMock,
+    symbol: &str,
+    baseline: Float,
+    rng: &mut StdRng,
+) -> anyhow::Result<Float> {
+    let bump_factors = [float!(1.06), float!(0.94), float!(1.03), float!(0.97)];
+    let factor = *bump_factors
+        .choose(rng)
+        .expect("bump factors must be non-empty");
+    let bumped =
+        (baseline * factor).map_err(|error| anyhow::anyhow!("NAV bump failed: {error:?}"))?;
+    broker.set_symbol_fill_price(Symbol::new(symbol)?, bumped);
+    info!(%symbol, ?baseline, ?bumped, "Applied broker NAV bump");
+    Ok(bumped)
+}
+
+async fn restart_bot<P: Provider + Clone + 'static>(
+    session: &mut ChaosSession<'_, P>,
+) -> anyhow::Result<()> {
+    let bootstrap = session.bootstrap;
+    info!("Restarting bot against same database (crash-recovery path)");
+    let previous = std::mem::replace(&mut session.bot, tokio::spawn(async { Ok(()) }));
+    previous.abort();
+    let _ = previous.await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    session.bot = spawn_bot_for_symbols(bootstrap, &active_symbols(&session.chaos_config))?;
+    poll_for_ready(&mut session.bot, bootstrap.server_port).await;
+    Ok(())
+}
+
+fn spawn_bot_for_symbols<P: Provider + Clone>(
+    bootstrap: &ChaosBootstrap<P>,
+    active: &ActiveSymbols<'_>,
+) -> anyhow::Result<JoinHandle<anyhow::Result<()>>> {
+    let equity_tokens = equity_tokens_for(&bootstrap.infra, &active.symbols);
+    let active_vault_ids: HashMap<String, B256> = bootstrap
+        .equity_vault_ids
+        .iter()
+        .filter(|(symbol, _)| active.includes(symbol))
+        .map(|(symbol, vault_id)| (symbol.clone(), *vault_id))
+        .collect();
+
+    let ctx = build_full_system_ctx()
+        .chain(&bootstrap.infra.base_chain)
+        .ethereum_endpoint(&bootstrap.cctp.ethereum_endpoint)
+        .broker(&bootstrap.infra.broker_service)
+        .db_path(&bootstrap.infra.db_path)
+        .deployment_block(bootstrap.deployment_block)
+        .equity_tokens(&equity_tokens)
+        .equity_vault_ids(&active_vault_ids)
+        .cash_vault_id(bootstrap.usdc_vault_id)
+        .cctp(bootstrap.cctp.cctp_overrides())
+        .server_port(bootstrap.server_port)
+        .board_port(bootstrap.board_port)
+        .issuance_base_url(bootstrap.infra.issuance_base_url.clone())
+        .call()?;
+
+    Ok(spawn_bot_with_event_channel(
+        ctx,
+        bootstrap.event_sender.clone(),
+    ))
+}
+
+fn active_symbols(chaos_config: &ChaosConfig) -> ActiveSymbols<'static> {
+    let mut symbols = vec!["AAPL"];
+    if !chaos_config.tsla_removed {
+        symbols.push("TSLA");
+    }
+    if chaos_config.msft_enabled {
+        symbols.push("MSFT");
+    }
+    ActiveSymbols { symbols }
+}
+
+fn equity_tokens_for(
+    infra: &TestInfra<impl Provider + Clone>,
+    symbols: &[&str],
+) -> Vec<(String, Address, Address)> {
+    infra
+        .equity_addresses
+        .iter()
+        .filter(|(symbol, _, _)| symbols.contains(&symbol.as_str()))
+        .cloned()
+        .collect()
+}
+
+async fn assert_final_state(infra: &TestInfra<impl Provider + Clone>) -> anyhow::Result<()> {
+    let pool = connect_db(&infra.db_path).await?;
+
+    let aapl_position = Projection::<Position>::sqlite(pool.clone())
+        .load(&Symbol::new("AAPL")?)
+        .await?
+        .expect("AAPL position should exist");
+    assert_eq!(
+        aapl_position.net,
+        FractionalShares::ZERO,
+        "AAPL should be fully hedged (net zero)",
+    );
+    assert_eq!(
+        aapl_position.accumulated_short,
+        FractionalShares::new(float!(33.25)),
+        "AAPL accumulated short should reflect all 4 sell trades",
+    );
+
+    let tsla_position = Projection::<Position>::sqlite(pool.clone())
+        .load(&Symbol::new("TSLA")?)
+        .await?
+        .expect("TSLA position should exist");
+    assert_eq!(
+        tsla_position.net,
+        FractionalShares::ZERO,
+        "TSLA should be fully hedged (net zero) even after config removal",
+    );
+    assert_eq!(
+        tsla_position.accumulated_long,
+        FractionalShares::new(float!(5)),
+        "TSLA accumulated long should reflect buy trade",
+    );
+
+    let msft_position = Projection::<Position>::sqlite(pool.clone())
+        .load(&Symbol::new("MSFT")?)
+        .await?
+        .expect("MSFT position should exist after asset was added");
+    assert_eq!(
+        msft_position.net,
+        FractionalShares::ZERO,
+        "MSFT should be fully hedged (net zero)",
+    );
+    assert_eq!(
+        msft_position.accumulated_short,
+        FractionalShares::new(float!(4)),
+        "MSFT accumulated short should reflect sell trade",
+    );
+
+    let mint_events = count_events(&pool, "TokenizedEquityMint").await?;
+    assert_eq!(
+        mint_events, EXPECTED_TOKENIZED_EQUITY_MINT_EVENTS,
+        "TokenizedEquityMint lifecycle should emit exactly one event per stage",
+    );
+
+    let usdc_events = count_events(&pool, "UsdcRebalance").await?;
+    assert_eq!(
+        usdc_events, EXPECTED_USDC_REBALANCE_EVENTS,
+        "USDC rebalance should emit the full happy-path lifecycle exactly once",
+    );
+
+    let pending_burn_recorded =
+        count_events_of_type(&pool, "UsdcRebalanceEvent::PendingBurnRecorded").await?;
+    assert_eq!(
+        pending_burn_recorded, 1,
+        "USDC rebalance must record PendingBurnRecorded exactly once, got {pending_burn_recorded}",
+    );
+
+    pool.close().await;
+    Ok(())
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -21,6 +21,7 @@ mod chaos_load;
 mod chaos_rpc;
 mod chaos_time;
 mod full_system;
+mod full_system_chaos;
 mod hedging;
 mod poll;
 mod rebalancing;

--- a/tests/e2e/poll.rs
+++ b/tests/e2e/poll.rs
@@ -29,6 +29,35 @@ pub fn free_port() -> u16 {
         .port()
 }
 
+/// Returns two distinct ephemeral ports for the HTTP server and apalis board.
+pub fn free_port_pair() -> (u16, u16) {
+    let server_port = free_port();
+    let mut board_port = free_port();
+    while board_port == server_port {
+        board_port = free_port();
+    }
+    (server_port, board_port)
+}
+
+/// HTTP server and apalis board ports for e2e tests launched via `nix run`.
+///
+/// When `SIMULATE_BOT_PORT` is set (by `nix run .#simulate` / `.#simulate-market`),
+/// uses that port for the server and the next port for the board so the dashboard
+/// can connect. Otherwise picks two free ephemeral ports for plain `cargo nextest`.
+pub fn simulation_ports() -> (u16, u16) {
+    let Ok(port_str) = std::env::var("SIMULATE_BOT_PORT") else {
+        return free_port_pair();
+    };
+
+    let server_port: u16 = port_str
+        .parse()
+        .expect("SIMULATE_BOT_PORT must be a valid u16 port number");
+    let board_port = server_port
+        .checked_add(1)
+        .expect("SIMULATE_BOT_PORT must be < u16::MAX to allocate board port");
+    (server_port, board_port)
+}
+
 /// Spawns the full bot as a background task.
 pub fn spawn_bot(ctx: Ctx) -> JoinHandle<anyhow::Result<()>> {
     tokio::spawn(run_bot_session(ctx))

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -279,7 +279,7 @@ pub(crate) fn build_rebalancing_ctx<P: Provider + Clone>(
         }),
     };
 
-    let mut ctx = Ctx::for_test()
+    let ctx = Ctx::for_test()
         .database_url(db_path.display().to_string())
         .rpc_url(chain.endpoint().parse()?)
         .orderbook(chain.orderbook)
@@ -289,9 +289,9 @@ pub(crate) fn build_rebalancing_ctx<P: Provider + Clone>(
         .order_owner(chain.owner)
         .wallet(wallet_ctx)
         .assets(assets)
+        .issuance(st0x_config::test_issuance_status_ctx(issuance_base_url))
         .redemption_wallet(redemption_wallet)
         .call()?;
-    ctx.issuance.base_url = issuance_base_url;
     Ok(ctx)
 }
 

--- a/tests/e2e/test_infra.rs
+++ b/tests/e2e/test_infra.rs
@@ -270,7 +270,9 @@ async fn start_broker_mock(
 async fn start_issuance_mock() -> httpmock::MockServer {
     let server = httpmock::MockServer::start_async().await;
     server.mock(|when, then| {
-        when.method(httpmock::Method::GET);
+        when.method(httpmock::Method::GET)
+            .path_prefix("/tokenized-assets/")
+            .path_suffix("/status");
         then.status(200).json_body(serde_json::json!({
             "underlying": "TEST",
             "status": "enabled",


### PR DESCRIPTION
## What

[RAI-139](https://linear.app/makeitrain/issue/RAI-139): Adds `full_system_concurrent`,
an eventual-consistency variant of the `full_system` e2e test that fires trades in
random order with timing chaos and delayed broker fills. Stacked on #979.

## Why

The sequential `full_system` test proves correctness when phases run in a fixed
order. Production runs concurrent apalis workers, overlapping rebalances, and
broker latency — we need coverage that the system converges to the same final
inventory/position state regardless of processing order.

## How

- New `full_system_concurrent` test (same `#[ignore]` policy as `full_system`).
- Prepares all Raindex orders before bot start (nonce safety), then shuffles and
  executes them with random inter-trade delays.
- Arms TSLA broker fills with a 3-poll delay to simulate offchain latency while
  AAPL/mint paths proceed at full speed.
- Seeds extra TSLA offchain inventory (`400` shares) and broker cash (`500_000`)
  so concurrent mint/redeem/hedge paths have headroom.
- Polls broker fills before event-count assertions so offchain state catches up
  under timing variance.
- Reuses ephemeral ports + issuance URL wiring from #979.

## Testing

- Compiles with the full e2e test crate (`cargo check --tests` in CI).
- `full_system_concurrent` is `#[ignore]` — run explicitly with
  `cargo nextest run --run-ignored full_system_concurrent`.

## Screenshots

N/A

## Anything else

Shares the pre-existing broker-fill assertion stall with `full_system` when run
locally (likely startup USDC rebalance buying-power contention) — not introduced
by this PR. Follow-up to stabilize both ignored tests is tracked separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785535629&installation_id=125569124&pr_number=980&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F980&signature=05229c5cc3c2dbb8ac3d3a889f43ae99ac36fa397ed92c7a97ec51121dc399c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new full-system chaos simulation scenario and a separate market simulation command.
  * Simulation mode now supports both the existing market flow and a concurrent full-system test path.

* **Bug Fixes**
  * Improved simulation/test port handling to avoid port conflicts.
  * Updated test selection so concurrent full-system tests are included/excluded correctly.

* **Documentation**
  * Expanded local simulation docs with clearer commands, behavior, and dashboard guidance.

* **Tests**
  * Added broader end-to-end coverage for chaos, simulation, and issuance status handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->