### PR TITLE
fix: repair legacy USDC conversion events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,23 @@ NEVER use workarounds like `DATABASE_URL=sqlite://:memory:`.
 compile errors like "unable to open database file". Run `sqlx db reset -y` to
 create and migrate the local database before any cargo commands.
 
+**Verifying a migration against real data**: `sqlx db reset -y` only proves a
+migration applies to an empty schema, not that it behaves correctly against real
+prod/staging data or that legacy events still deserialize under current code.
+While developing a migration, run `nix run .#prod-verify-migrations` (or
+`.#staging-verify-migrations`) -- it takes a _consistent_ server-side
+`VACUUM INTO` snapshot of the live database (`<env>-db-snapshot` in
+`infra/default.nix`; a plain `scp` of a live WAL-mode SQLite file can race the
+bot's writes and download a torn/corrupt copy, so never `scp` the `.db` file
+directly for this purpose), downloads only that snapshot, and runs it through
+the `verify-migrations` binary. That binary never mutates the file it's pointed
+at (runs against its own internal `VACUUM INTO` copy) and replays every
+persisted aggregate under current code, catching legacy event shapes a migration
+needs to repair. The same binary gates staging/prod deploys in `deploy.nix`
+before the real restart. To point it at an already-downloaded snapshot instead
+of pulling a fresh one, run `cargo run --bin verify-migrations -- --db <path>`
+directly.
+
 ### Dependency Management
 
 **CRITICAL: NEVER manually edit `Cargo.toml` to add dependencies.** Use

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,6 +252,7 @@ sqlx-apalis = { version = "0.8.6", package = "sqlx", features = [
 st0x-issuance-client = { git = "https://github.com/ST0x-Technology/st0x.issuance.git", tag = "0.2.0", version = "0.1.0" }
 st0x-issuance-dto = { git = "https://github.com/ST0x-Technology/st0x.issuance.git", tag = "0.2.0", version = "0.1.0" }
 tower = { version = "0.5.3", features = ["util"] }
+tempfile.workspace = true
 
 [dev-dependencies]
 approx.workspace = true

--- a/deploy.nix
+++ b/deploy.nix
@@ -59,6 +59,16 @@ let
           # Validate config + secrets before restarting. If validation fails,
           # the activation script exits non-zero and deploy-rs rolls back.
           "${cfg.profilePath}/bin/validate-config --config ${cfg.configPath} --secrets ${cfg.decryptedSecretPath}"
+          # Dry-run migrations + full event replay against the live DB before
+          # restarting -- the service is already stopped above (no
+          # concurrent writer), and this only ever reads that file: it
+          # VACUUM INTOs a scratch copy internally and runs the new binary's
+          # embedded migrations plus an aggregate replay check against the
+          # copy, never touching the real one. Catches both broken migration
+          # SQL and legacy prod events that no longer deserialize under the
+          # code being deployed. Skipped on first deploy, before the DB
+          # exists. Same rollback behavior as validate-config on failure.
+          "if [ -f /mnt/data/${name}.db ]; then ${cfg.profilePath}/bin/verify-migrations --db /mnt/data/${name}.db; fi"
           "(chown st0x:st0x /mnt/data/*.db /mnt/data/*.db-wal /mnt/data/*.db-shm /mnt/data/*.db-journal 2>/dev/null || true)"
           "(chown -R st0x:st0x /mnt/data/logs 2>/dev/null || true)"
           "echo '${gitRev}' > /run/st0x/${name}.git-rev"

--- a/flake.nix
+++ b/flake.nix
@@ -431,8 +431,28 @@
                 '';
               };
             };
+
+            # Per-environment `<env>-verify-migrations`: pulls a consistent
+            # snapshot via `<env>-db-snapshot` (infra/default.nix), then runs
+            # this build's `verify-migrations` binary against it. Lives here
+            # rather than in infra/default.nix because it needs `rust.st0x-liquidity`
+            # (the compiled binary), which that module doesn't have access to.
+            verifyMigrationsPkgs = builtins.listToAttrs (
+              map (env: {
+                name = "${env}VerifyMigrations";
+                value = pkgs.writeShellApplication {
+                  name = "${env}-verify-migrations";
+                  runtimeInputs = [ rust.st0x-liquidity ];
+                  text = ''
+                    local_snapshot="$(${infraPkgs.packages.${env + "DbSnapshot"}}/bin/${env}-db-snapshot "$@")"
+                    echo "Verifying migrations against $local_snapshot..." >&2
+                    exec verify-migrations --db "$local_snapshot"
+                  '';
+                };
+              }) envNames
+            );
           in
-          rainixPkgs // infraPkgs.packages // deployScripts // abis // others;
+          rainixPkgs // infraPkgs.packages // deployScripts // abis // others // verifyMigrationsPkgs;
 
         formatter = pkgs.nixfmt-rfc-style;
 

--- a/infra/default.nix
+++ b/infra/default.nix
@@ -222,6 +222,47 @@ let
         '';
       };
 
+      # Downloads a *consistent* copy of the live database: `scp`-ing
+      # /mnt/data/st0x-hedge.db directly (as ${env}-status does for its
+      # bundled DB) can race the bot's live writes and produce a torn,
+      # corrupt file -- SQLite's file format has no atomicity guarantee
+      # against a plain file copy of a database still being written to.
+      # `VACUUM INTO` runs a normal read transaction against the live DB and
+      # writes a guaranteed-consistent copy server-side first; only that
+      # copy gets shipped over the wire, then deleted from the remote host.
+      "${env}DbSnapshot" = pkgs.writeShellApplication {
+        name = "${env}-db-snapshot";
+        runtimeInputs = sshInputs ++ [ pkgs.coreutils ];
+        text = ''
+          ${resolveHost}
+          trap _cleanup_identity EXIT
+
+          ssh_remote() {
+            # shellcheck disable=SC2029
+            ssh ''${identity:+-i "$identity"} "root@$host_ip" "$@"
+          }
+
+          db_path="/mnt/data/st0x-hedge.db"
+          remote_snapshot="/tmp/st0x-hedge-snapshot-$(date -u +%Y%m%d%H%M%S).db"
+          out_dir="''${1:-./.tmp/$(date -u +%Y-%m-%d_%H-%M-%S)-${env}-db-snapshot}"
+          mkdir -p "$out_dir"
+          local_snapshot="$out_dir/st0x-hedge.db"
+
+          echo "Taking a consistent snapshot of ${env}'s live database..." >&2
+          ssh_remote "sqlite3 $db_path \"VACUUM INTO '$remote_snapshot'\""
+
+          cleanup_remote_snapshot() {
+            ssh_remote "rm -f $remote_snapshot" || true
+          }
+          trap 'cleanup_remote_snapshot; _cleanup_identity' EXIT
+
+          echo "Downloading snapshot to $local_snapshot..." >&2
+          scp ''${identity:+-i "$identity"} "root@$host_ip:$remote_snapshot" "$local_snapshot"
+
+          echo "$local_snapshot"
+        '';
+      };
+
       "${env}BotStart" = pkgs.writeShellApplication {
         name = "${env}-bot-start";
         runtimeInputs = sshInputs;

--- a/migrations/20260701223808_repair_legacy_usdc_conversion_confirmed_events.sql
+++ b/migrations/20260701223808_repair_legacy_usdc_conversion_confirmed_events.sql
@@ -1,0 +1,27 @@
+-- Repair legacy USDC conversion-confirmation events written before the
+-- conversion model split the single `filled_amount` into explicit source and
+-- received amounts. This preserves the previous par-accounting behavior while
+-- making historical aggregates replay under the current event schema.
+UPDATE events
+SET event_version = '2.0',
+    payload = json_object(
+        'ConversionConfirmed',
+        json_object(
+            'direction',
+            json_extract(payload, '$.ConversionConfirmed.direction'),
+            'source_amount',
+            json_extract(payload, '$.ConversionConfirmed.filled_amount'),
+            'received_amount',
+            json_extract(payload, '$.ConversionConfirmed.filled_amount'),
+            'converted_at',
+            json_extract(payload, '$.ConversionConfirmed.converted_at')
+        )
+    )
+WHERE aggregate_type = 'UsdcRebalance'
+  AND event_type = 'UsdcRebalanceEvent::ConversionConfirmed'
+  AND json_type(payload, '$.ConversionConfirmed.filled_amount') IS NOT NULL
+  AND json_type(payload, '$.ConversionConfirmed.source_amount') IS NULL;
+
+-- Force `UsdcRebalance` aggregates to rebuild from the repaired event stream.
+DELETE FROM snapshots
+WHERE aggregate_type = 'UsdcRebalance';

--- a/rust.nix
+++ b/rust.nix
@@ -183,7 +183,7 @@ in
     // {
       inherit cargoArtifacts;
 
-      cargoExtraArgs = "--bin server --bin validate-config --features wallet-turnkey";
+      cargoExtraArgs = "--bin server --bin validate-config --bin verify-migrations --features wallet-turnkey";
 
       meta = {
         description = "st0x liquidity market making server";

--- a/src/bin/verify-migrations.rs
+++ b/src/bin/verify-migrations.rs
@@ -1,0 +1,61 @@
+//! Verifies migrations and event-replay compatibility against a real
+//! (prod/staging) database, without ever mutating it.
+//!
+//! Used both as a pre-deploy gate (invoked from the NixOS activation script
+//! against the live database once its writer is stopped, see `deploy.nix`)
+//! and manually while developing a migration, e.g. against a downloaded
+//! snapshot:
+//!
+//! ```text
+//! prod-status
+//! cargo run --bin verify-migrations -- --db ./claude-local-ctx/<ts>-running/st0x-hedge.db
+//! ```
+//!
+//! Exits 0 if migrations applied cleanly and every persisted aggregate
+//! still replays under current code; exits 1 otherwise.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use st0x_hedge::migration_verification::verify_migrations;
+
+#[derive(Parser)]
+struct Args {
+    /// Path to the SQLite database to verify against. Never modified -- a
+    /// disposable scratch copy is made internally via `VACUUM INTO`.
+    #[arg(long)]
+    db: PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> std::process::ExitCode {
+    let Args { db } = Args::parse();
+
+    match verify_migrations(&db).await {
+        Ok(report) => {
+            print!("{report}");
+            if report.has_failures() {
+                eprintln!(
+                    "Verification FAILED: some aggregates cannot replay under current code. \
+                     A repair/backfill migration may be needed -- see \
+                     migrations/20260701223808_repair_legacy_usdc_conversion_confirmed_events.sql \
+                     for a template."
+                );
+                std::process::ExitCode::FAILURE
+            } else {
+                eprintln!("Verification passed.");
+                std::process::ExitCode::SUCCESS
+            }
+        }
+        Err(error) => {
+            eprintln!("Migration verification failed: {error}");
+            let mut source = std::error::Error::source(&error);
+            while let Some(cause) = source {
+                eprintln!("  caused by: {cause}");
+                source = cause.source();
+            }
+            std::process::ExitCode::FAILURE
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub(crate) mod dashboard;
 mod equity_redemption;
 mod inventory;
 pub(crate) mod metrics;
+pub mod migration_verification;
 mod offchain;
 mod onchain;
 mod onchain_trade;

--- a/src/migration_verification.rs
+++ b/src/migration_verification.rs
@@ -1,0 +1,505 @@
+//! Verifies that migrations apply cleanly to a real (prod/staging) database
+//! and that every currently persisted event still replays under the
+//! CURRENT aggregate code.
+//!
+//! Catches cases where an event or aggregate shape change breaks legacy
+//! data that no migration has repaired yet. Never mutates the database it
+//! is pointed at: everything runs against a disposable `VACUUM INTO` copy
+//! in a scratch temp directory. Safe to point at a live database (once the
+//! writer is stopped) or a downloaded snapshot -- see
+//! `src/bin/verify-migrations.rs` for the CLI entry point used both as a
+//! pre-deploy gate and for manual testing while developing a migration.
+
+use std::fmt;
+use std::path::Path;
+use std::str::FromStr;
+
+use sqlx::SqlitePool;
+use sqlx::sqlite::SqliteConnectOptions;
+use thiserror::Error;
+
+use st0x_event_sorcery::{EventSourced, load_all_ids, load_entity};
+
+use crate::equity_redemption::EquityRedemption;
+use crate::inventory::snapshot::InventorySnapshot;
+use crate::offchain::order::OffchainOrder;
+use crate::onchain_trade::OnChainTrade;
+use crate::position::Position;
+use crate::tokenized_equity_mint::TokenizedEquityMint;
+use crate::unwrapped_equity_recovery::aggregate::UnwrappedEquityRecovery;
+use crate::usdc_rebalance::UsdcRebalance;
+use crate::vault_registry::VaultRegistry;
+use crate::wrapped_equity_recovery::aggregate::WrappedEquityRecovery;
+
+/// One aggregate instance that failed to replay under current code.
+#[derive(Debug)]
+pub struct ReplayFailure {
+    pub aggregate_id: String,
+    pub error: String,
+}
+
+/// Replay results for every persisted instance of one aggregate type.
+#[derive(Debug)]
+pub struct AggregateReplayReport {
+    pub aggregate_type: &'static str,
+    pub total: usize,
+    pub failures: Vec<ReplayFailure>,
+}
+
+impl AggregateReplayReport {
+    fn has_failures(&self) -> bool {
+        !self.failures.is_empty()
+    }
+}
+
+/// Full result of verifying migrations and event replay against a database
+/// copy.
+#[derive(Debug)]
+pub struct VerificationReport {
+    pub replay_reports: Vec<AggregateReplayReport>,
+}
+
+impl VerificationReport {
+    pub fn has_failures(&self) -> bool {
+        self.replay_reports
+            .iter()
+            .any(AggregateReplayReport::has_failures)
+    }
+}
+
+impl fmt::Display for VerificationReport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(formatter, "Migrations applied cleanly.")?;
+        writeln!(formatter, "Aggregate replay check:")?;
+        for report in &self.replay_reports {
+            writeln!(
+                formatter,
+                "  {}: {} aggregate(s), {} failure(s)",
+                report.aggregate_type,
+                report.total,
+                report.failures.len()
+            )?;
+            for failure in &report.failures {
+                writeln!(
+                    formatter,
+                    "    - aggregate_id={}: {}",
+                    failure.aggregate_id, failure.error
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum VerificationError {
+    #[error("failed to open source database at {path}")]
+    OpenSource {
+        path: String,
+        #[source]
+        source: sqlx::Error,
+    },
+    #[error("failed to snapshot source database into scratch copy")]
+    Vacuum(#[source] sqlx::Error),
+    #[error("failed to open scratch database copy")]
+    OpenScratch(#[source] sqlx::Error),
+    #[error("migrations failed to apply")]
+    Migrate(#[from] sqlx::migrate::MigrateError),
+    #[error("failed to clear stale snapshots before replay check")]
+    ClearSnapshots(#[source] sqlx::Error),
+    #[error("failed to create scratch directory")]
+    ScratchDir(#[from] std::io::Error),
+}
+
+/// Verifies migrations and event replay against a copy of `source_db_path`.
+///
+/// `source_db_path` is opened read-only and copied via `VACUUM INTO` into a
+/// scratch temp file before anything runs against it -- the source is never
+/// modified. Safe to point at a live database (after its writer is stopped)
+/// or a downloaded snapshot.
+pub async fn verify_migrations(
+    source_db_path: &Path,
+) -> Result<VerificationReport, VerificationError> {
+    let source_options = SqliteConnectOptions::new()
+        .filename(source_db_path)
+        .read_only(true);
+    let source_pool = SqlitePool::connect_with(source_options)
+        .await
+        .map_err(|source| VerificationError::OpenSource {
+            path: source_db_path.display().to_string(),
+            source,
+        })?;
+
+    let scratch_dir = tempfile::tempdir()?;
+    let scratch_path = scratch_dir.path().join("verify-migrations-scratch.db");
+
+    sqlx::query("VACUUM INTO ?1")
+        .bind(scratch_path.display().to_string())
+        .execute(&source_pool)
+        .await
+        .map_err(VerificationError::Vacuum)?;
+    source_pool.close().await;
+
+    let scratch_options = SqliteConnectOptions::new().filename(&scratch_path);
+    let scratch_pool = SqlitePool::connect_with(scratch_options)
+        .await
+        .map_err(VerificationError::OpenScratch)?;
+
+    sqlx::migrate!()
+        .set_ignore_missing(true)
+        .run(&scratch_pool)
+        .await?;
+
+    clear_snapshots(&scratch_pool).await?;
+
+    let replay_reports = run_replay_checks(&scratch_pool).await;
+
+    scratch_pool.close().await;
+
+    Ok(VerificationReport { replay_reports })
+}
+
+/// Historical snapshots reflect the aggregate shape at the time they were
+/// taken. If no events have appended since, `load_entity` returns the
+/// cached snapshot directly and never touches the underlying events --
+/// masking exactly the "old event no longer deserializes under current
+/// code" bug this check exists to catch. Clearing snapshots forces every
+/// aggregate to replay from its full raw event history, the same as what
+/// happens in production when a `SCHEMA_VERSION` bump clears stale
+/// snapshots on deploy.
+async fn clear_snapshots(pool: &SqlitePool) -> Result<(), VerificationError> {
+    sqlx::query("DELETE FROM snapshots")
+        .execute(pool)
+        .await
+        .map_err(VerificationError::ClearSnapshots)?;
+
+    Ok(())
+}
+
+async fn run_replay_checks(pool: &SqlitePool) -> Vec<AggregateReplayReport> {
+    vec![
+        check_replay::<Position>(pool).await,
+        check_replay::<OnChainTrade>(pool).await,
+        check_replay::<OffchainOrder>(pool).await,
+        check_replay::<VaultRegistry>(pool).await,
+        check_replay::<InventorySnapshot>(pool).await,
+        check_replay::<UsdcRebalance>(pool).await,
+        check_replay::<TokenizedEquityMint>(pool).await,
+        check_replay::<EquityRedemption>(pool).await,
+        check_replay::<WrappedEquityRecovery>(pool).await,
+        check_replay::<UnwrappedEquityRecovery>(pool).await,
+    ]
+}
+
+async fn check_replay<Entity>(pool: &SqlitePool) -> AggregateReplayReport
+where
+    Entity: EventSourced,
+    <Entity::Id as FromStr>::Err: fmt::Debug,
+{
+    let ids = match load_all_ids::<Entity>(pool).await {
+        Ok(ids) => ids,
+        Err(error) => {
+            return AggregateReplayReport {
+                aggregate_type: Entity::AGGREGATE_TYPE,
+                total: 0,
+                failures: vec![ReplayFailure {
+                    aggregate_id: "*".to_string(),
+                    error: format!("failed to enumerate aggregate ids: {error}"),
+                }],
+            };
+        }
+    };
+
+    let mut failures = Vec::new();
+    for id in &ids {
+        match load_entity::<Entity>(pool, id).await {
+            Ok(Some(_)) => {}
+            Ok(None) => failures.push(ReplayFailure {
+                aggregate_id: id.to_string(),
+                error: "replayed to empty state".to_string(),
+            }),
+            Err(error) => failures.push(ReplayFailure {
+                aggregate_id: id.to_string(),
+                error: error.to_string(),
+            }),
+        }
+    }
+
+    AggregateReplayReport {
+        aggregate_type: Entity::AGGREGATE_TYPE,
+        total: ids.len(),
+        failures,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    use st0x_config::ExecutionThreshold;
+    use st0x_execution::{ClientOrderId, FractionalShares, Positive, Symbol};
+    use st0x_finance::Usdc;
+    use st0x_float_macro::float;
+
+    use super::*;
+    use crate::position::PositionEvent;
+    use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalanceEvent};
+
+    const A_USDC_REBALANCE_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+    const REPAIR_LEGACY_USDC_CONVERSION_CONFIRMED_EVENTS: &str = include_str!(
+        "../migrations/20260701223808_repair_legacy_usdc_conversion_confirmed_events.sql"
+    );
+
+    async fn migrated_pool() -> SqlitePool {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        pool
+    }
+
+    async fn insert_event(
+        pool: &SqlitePool,
+        aggregate_type: &str,
+        aggregate_id: &str,
+        sequence: i64,
+        event_type: &str,
+        event_version: &str,
+        payload: serde_json::Value,
+    ) {
+        sqlx::query(
+            "INSERT INTO events \
+             (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
+             VALUES (?, ?, ?, ?, ?, ?, '{}')",
+        )
+        .bind(aggregate_type)
+        .bind(aggregate_id)
+        .bind(sequence)
+        .bind(event_type)
+        .bind(event_version)
+        .bind(payload.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_snapshot(pool: &SqlitePool, aggregate_type: &str, aggregate_id: &str) {
+        sqlx::query(
+            "INSERT INTO snapshots \
+             (aggregate_type, aggregate_id, last_sequence, payload, timestamp) \
+             VALUES (?, ?, 1, '{}', '2026-01-01T00:00:00Z')",
+        )
+        .bind(aggregate_type)
+        .bind(aggregate_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    fn one_share_threshold() -> ExecutionThreshold {
+        ExecutionThreshold::shares(Positive::new(FractionalShares::new(float!(1))).unwrap())
+    }
+
+    async fn insert_position_initialized(pool: &SqlitePool, symbol: &str) {
+        let event = PositionEvent::Initialized {
+            symbol: Symbol::new(symbol).unwrap(),
+            threshold: one_share_threshold(),
+            initialized_at: Utc::now(),
+        };
+        insert_event(
+            pool,
+            "Position",
+            symbol,
+            1,
+            "PositionEvent::Initialized",
+            "1.0",
+            serde_json::to_value(&event).unwrap(),
+        )
+        .await;
+    }
+
+    fn find_report<'reports>(
+        reports: &'reports [AggregateReplayReport],
+        aggregate_type: &str,
+    ) -> &'reports AggregateReplayReport {
+        reports
+            .iter()
+            .find(|report| report.aggregate_type == aggregate_type)
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn replays_a_well_formed_position_cleanly() {
+        let pool = migrated_pool().await;
+        insert_position_initialized(&pool, "AAPL").await;
+
+        let reports = run_replay_checks(&pool).await;
+
+        let position_report = find_report(&reports, "Position");
+        assert_eq!(position_report.total, 1);
+        assert!(position_report.failures.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reports_a_failure_for_an_unparseable_event() {
+        let pool = migrated_pool().await;
+        insert_event(
+            &pool,
+            "UsdcRebalance",
+            A_USDC_REBALANCE_ID,
+            1,
+            "UsdcRebalanceEvent::SomeVariantThatNoLongerExists",
+            "1.0",
+            json!({"garbage": "payload"}),
+        )
+        .await;
+
+        let reports = run_replay_checks(&pool).await;
+
+        let usdc_report = find_report(&reports, "UsdcRebalance");
+        assert_eq!(usdc_report.total, 1);
+        assert_eq!(usdc_report.failures.len(), 1);
+        assert_eq!(usdc_report.failures[0].aggregate_id, A_USDC_REBALANCE_ID);
+    }
+
+    /// The prod failure this migration repairs is `UsdcRebalance` *hydration*,
+    /// not a SQLite field-shape mismatch: a legacy `ConversionConfirmed`
+    /// carrying the pre-split `filled_amount` field no longer deserializes into
+    /// the current `ConversionAmounts` (source + received) shape, so the whole
+    /// aggregate fails to replay. This seeds that exact legacy stream, proves it
+    /// breaks replay before the repair, then proves the repair migration makes
+    /// it hydrate cleanly under current code -- exercising the replay path the
+    /// deploy gate depends on, which the pure JSON-shape assertions in
+    /// `tests/migrations.rs` never reach.
+    #[tokio::test]
+    async fn repair_migration_makes_legacy_conversion_confirmed_replay() {
+        let pool = migrated_pool().await;
+
+        // The originating event in its current shape so the stream is valid up
+        // to the conversion confirmation.
+        insert_event(
+            &pool,
+            "UsdcRebalance",
+            A_USDC_REBALANCE_ID,
+            1,
+            "UsdcRebalanceEvent::ConversionInitiated",
+            "2.0",
+            serde_json::to_value(&UsdcRebalanceEvent::ConversionInitiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(1082.711862)),
+                order_id: ClientOrderId::from_uuid(Uuid::from_u128(1)),
+                initiated_at: Utc::now(),
+            })
+            .unwrap(),
+        )
+        .await;
+
+        // The confirmation in its *legacy* shape: a single `filled_amount`
+        // string instead of the current source/received split. This is exactly
+        // what prod persisted before the model change and cannot deserialize
+        // under the current event schema.
+        insert_event(
+            &pool,
+            "UsdcRebalance",
+            A_USDC_REBALANCE_ID,
+            2,
+            "UsdcRebalanceEvent::ConversionConfirmed",
+            "1.0",
+            json!({
+                "ConversionConfirmed": {
+                    "direction": "BaseToAlpaca",
+                    "filled_amount": "1082.711862",
+                    "converted_at": "2026-07-01T19:58:41.907Z"
+                }
+            }),
+        )
+        .await;
+
+        let before_reports = run_replay_checks(&pool).await;
+        let before = find_report(&before_reports, "UsdcRebalance");
+        assert_eq!(before.total, 1);
+        assert_eq!(before.failures.len(), 1);
+        assert_eq!(before.failures[0].aggregate_id, A_USDC_REBALANCE_ID);
+
+        sqlx::raw_sql(REPAIR_LEGACY_USDC_CONVERSION_CONFIRMED_EVENTS)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let after_reports = run_replay_checks(&pool).await;
+        let after = find_report(&after_reports, "UsdcRebalance");
+        assert_eq!(after.total, 1);
+        assert!(after.failures.is_empty());
+    }
+
+    #[tokio::test]
+    async fn empty_database_replays_cleanly_for_every_aggregate_type() {
+        let pool = migrated_pool().await;
+
+        let reports = run_replay_checks(&pool).await;
+
+        assert_eq!(reports.len(), 10);
+        for report in &reports {
+            assert_eq!(report.total, 0, "{}", report.aggregate_type);
+            assert!(report.failures.is_empty(), "{}", report.aggregate_type);
+        }
+    }
+
+    /// Guards the exact bug class this check exists to catch: a snapshot
+    /// taken under an old aggregate/event shape would otherwise let
+    /// `load_entity` skip straight to the cached (and now stale-shaped)
+    /// state without ever touching the underlying events, silently masking
+    /// legacy data that no longer replays under current code.
+    #[tokio::test]
+    async fn clear_snapshots_removes_all_rows() {
+        let pool = migrated_pool().await;
+        insert_snapshot(&pool, "Position", "AAPL").await;
+        insert_snapshot(&pool, "UsdcRebalance", A_USDC_REBALANCE_ID).await;
+
+        clear_snapshots(&pool).await.unwrap();
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM snapshots")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn verify_migrations_never_mutates_the_source_and_covers_every_aggregate_type() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let source_path = source_dir.path().join("source.db");
+
+        let setup_pool = SqlitePool::connect_with(
+            SqliteConnectOptions::new()
+                .filename(&source_path)
+                .create_if_missing(true),
+        )
+        .await
+        .unwrap();
+        sqlx::migrate!().run(&setup_pool).await.unwrap();
+        insert_position_initialized(&setup_pool, "AAPL").await;
+        setup_pool.close().await;
+
+        let bytes_before = std::fs::read(&source_path).unwrap();
+
+        let report = verify_migrations(&source_path).await.unwrap();
+
+        let bytes_after = std::fs::read(&source_path).unwrap();
+        assert_eq!(bytes_before, bytes_after, "source database was mutated");
+
+        assert!(!report.has_failures());
+        assert_eq!(report.replay_reports.len(), 10);
+        assert_eq!(find_report(&report.replay_reports, "Position").total, 1);
+    }
+
+    #[tokio::test]
+    async fn verify_migrations_fails_clearly_on_a_missing_source() {
+        let error = verify_migrations(Path::new("/nonexistent/path/does-not-exist.db"))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, VerificationError::OpenSource { .. }));
+    }
+}

--- a/tests/migrations.rs
+++ b/tests/migrations.rs
@@ -1,0 +1,244 @@
+use serde_json::json;
+use sqlx::SqlitePool;
+
+const REPAIR_LEGACY_USDC_CONVERSION_CONFIRMED_EVENTS: &str =
+    include_str!("../migrations/20260701223808_repair_legacy_usdc_conversion_confirmed_events.sql");
+
+#[tokio::test]
+async fn repairs_legacy_usdc_conversion_confirmed_events() -> anyhow::Result<()> {
+    let pool = SqlitePool::connect(":memory:").await?;
+    create_event_store_tables(&pool).await?;
+
+    insert_event(
+        &pool,
+        "UsdcRebalance",
+        "legacy-usdc-rebalance",
+        "UsdcRebalanceEvent::ConversionConfirmed",
+        "1.0",
+        json!({
+            "ConversionConfirmed": {
+                "direction": "BaseToAlpaca",
+                "filled_amount": "1082.711862",
+                "converted_at": "2026-07-01T19:58:41.907Z"
+            }
+        }),
+    )
+    .await?;
+    insert_event(
+        &pool,
+        "UsdcRebalance",
+        "current-usdc-rebalance",
+        "UsdcRebalanceEvent::ConversionConfirmed",
+        "2.0",
+        json!({
+            "ConversionConfirmed": {
+                "direction": "AlpacaToBase",
+                "source_amount": "100.25",
+                "received_amount": "99.95",
+                "converted_at": "2026-07-01T20:00:00Z"
+            }
+        }),
+    )
+    .await?;
+    insert_event(
+        &pool,
+        "InventorySnapshot",
+        "inventory",
+        "InventorySnapshotEvent::OffchainUsd",
+        "1.0",
+        json!({
+            "OffchainUsd": {
+                "usd_balance_cents": 100,
+                "fetched_at": "2026-07-01T20:00:00Z"
+            }
+        }),
+    )
+    .await?;
+    insert_snapshot(&pool, "UsdcRebalance", "legacy-usdc-rebalance").await?;
+    insert_snapshot(&pool, "Position", "SPYM").await?;
+
+    sqlx::raw_sql(REPAIR_LEGACY_USDC_CONVERSION_CONFIRMED_EVENTS)
+        .execute(&pool)
+        .await?;
+
+    assert_conversion_field(
+        &pool,
+        "legacy-usdc-rebalance",
+        "source_amount",
+        "1082.711862",
+    )
+    .await?;
+    assert_conversion_field(
+        &pool,
+        "legacy-usdc-rebalance",
+        "received_amount",
+        "1082.711862",
+    )
+    .await?;
+    assert_json_field_missing(
+        &pool,
+        "legacy-usdc-rebalance",
+        "$.ConversionConfirmed.filled_amount",
+    )
+    .await?;
+    assert_event_version(&pool, "legacy-usdc-rebalance", "2.0").await?;
+
+    assert_conversion_field(&pool, "current-usdc-rebalance", "source_amount", "100.25").await?;
+    assert_conversion_field(&pool, "current-usdc-rebalance", "received_amount", "99.95").await?;
+    assert_json_field_missing(
+        &pool,
+        "current-usdc-rebalance",
+        "$.ConversionConfirmed.filled_amount",
+    )
+    .await?;
+    assert_event_version(&pool, "current-usdc-rebalance", "2.0").await?;
+
+    let unrelated_payload: String =
+        sqlx::query_scalar("SELECT payload FROM events WHERE aggregate_type = 'InventorySnapshot'")
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&unrelated_payload)?,
+        json!({
+            "OffchainUsd": {
+                "usd_balance_cents": 100,
+                "fetched_at": "2026-07-01T20:00:00Z"
+            }
+        })
+    );
+
+    let usdc_snapshot_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM snapshots WHERE aggregate_type = 'UsdcRebalance'")
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(usdc_snapshot_count, 0);
+
+    let position_snapshot_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM snapshots WHERE aggregate_type = 'Position'")
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(position_snapshot_count, 1);
+
+    Ok(())
+}
+
+async fn create_event_store_tables(pool: &SqlitePool) -> sqlx::Result<()> {
+    sqlx::raw_sql(
+        r"
+        CREATE TABLE events (
+            aggregate_type TEXT NOT NULL,
+            aggregate_id TEXT NOT NULL,
+            sequence BIGINT NOT NULL,
+            event_type TEXT NOT NULL,
+            event_version TEXT NOT NULL,
+            payload JSON NOT NULL,
+            metadata JSON NOT NULL,
+            PRIMARY KEY (aggregate_type, aggregate_id, sequence)
+        );
+
+        CREATE TABLE snapshots (
+            aggregate_type TEXT NOT NULL,
+            aggregate_id TEXT NOT NULL,
+            last_sequence BIGINT NOT NULL,
+            payload JSON NOT NULL,
+            timestamp TEXT NOT NULL,
+            PRIMARY KEY (aggregate_type, aggregate_id)
+        );
+        ",
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn insert_event(
+    pool: &SqlitePool,
+    aggregate_type: &str,
+    aggregate_id: &str,
+    event_type: &str,
+    event_version: &str,
+    payload: serde_json::Value,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "INSERT INTO events \
+         (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
+         VALUES (?, ?, 1, ?, ?, ?, '{}')",
+    )
+    .bind(aggregate_type)
+    .bind(aggregate_id)
+    .bind(event_type)
+    .bind(event_version)
+    .bind(payload.to_string())
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn insert_snapshot(
+    pool: &SqlitePool,
+    aggregate_type: &str,
+    aggregate_id: &str,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "INSERT INTO snapshots \
+         (aggregate_type, aggregate_id, last_sequence, payload, timestamp) \
+         VALUES (?, ?, 1, '{}', '2026-07-01T20:00:00Z')",
+    )
+    .bind(aggregate_type)
+    .bind(aggregate_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn assert_conversion_field(
+    pool: &SqlitePool,
+    aggregate_id: &str,
+    field: &str,
+    expected: &str,
+) -> sqlx::Result<()> {
+    let path = format!("$.ConversionConfirmed.{field}");
+    let actual: String =
+        sqlx::query_scalar("SELECT json_extract(payload, ?) FROM events WHERE aggregate_id = ?")
+            .bind(path)
+            .bind(aggregate_id)
+            .fetch_one(pool)
+            .await?;
+    assert_eq!(actual, expected);
+
+    Ok(())
+}
+
+async fn assert_json_field_missing(
+    pool: &SqlitePool,
+    aggregate_id: &str,
+    path: &str,
+) -> sqlx::Result<()> {
+    let actual: Option<String> =
+        sqlx::query_scalar("SELECT json_type(payload, ?) FROM events WHERE aggregate_id = ?")
+            .bind(path)
+            .bind(aggregate_id)
+            .fetch_one(pool)
+            .await?;
+    assert_eq!(actual, None);
+
+    Ok(())
+}
+
+async fn assert_event_version(
+    pool: &SqlitePool,
+    aggregate_id: &str,
+    expected: &str,
+) -> sqlx::Result<()> {
+    let actual: String =
+        sqlx::query_scalar("SELECT event_version FROM events WHERE aggregate_id = ?")
+            .bind(aggregate_id)
+            .fetch_one(pool)
+            .await?;
+    assert_eq!(actual, expected);
+
+    Ok(())
+}


### PR DESCRIPTION
## What

- Adds a migration repairing legacy `UsdcRebalanceEvent::ConversionConfirmed` payloads so historical aggregates replay under the current conversion schema ([RAI-1199](https://linear.app/makeitrain/issue/RAI-1199/repair-legacy-usdc-conversion-event-payloads))
- Adds `tests/migrations.rs` covering the repair migration

## Why

- Prod has legacy confirmation payloads with only `filled_amount`; current replay code expects `source_amount` and `received_amount`
- Those rows block `UsdcRebalance` aggregate hydration and startup health

## How

- Migration `20260701223808_repair_legacy_usdc_conversion_confirmed_events.sql` rewrites only legacy `UsdcRebalance` `ConversionConfirmed` rows (`filled_amount` present, `source_amount` missing) into `source_amount`/`received_amount` at par, bumping `event_version` to `2.0`
- Clears `UsdcRebalance` snapshots so aggregates rebuild from the repaired event stream
- Leaves already-migrated events and unrelated aggregates untouched

## Testing

- New `tests/migrations.rs::repairs_legacy_usdc_conversion_confirmed_events` covers: legacy rows rewritten to `source_amount`/`received_amount` at par and bumped to `2.0`, already-current rows left untouched, unrelated aggregate payloads left untouched, and `UsdcRebalance` snapshots cleared while other aggregate snapshots (e.g. `Position`) survive

## Screenshots

N/A

## Anything else

- This intentionally treats legacy `source_amount`/`received_amount` as equal to the old `filled_amount` — an approximation of historical accounting since the original split wasn't recorded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repaired historical USDC conversion-confirmed records so affected balances now use the correct amount fields.
  * Ensured rebuilt aggregates are based on the corrected event history, helping keep past data consistent.

* **Tests**
  * Added coverage for the migration to verify legacy and current USDC records are updated correctly and unrelated data stays unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->