### PR TITLE
fix(telemetry): use VictoriaTraces insert path for OTLP spans

### DIFF
--- a/crates/config/src/telemetry.rs
+++ b/crates/config/src/telemetry.rs
@@ -125,7 +125,7 @@ impl TelemetryCtx {
                 .with_http_client(http_client.clone())
                 .with_endpoint(
                     self.traces_endpoint
-                        .join("opentelemetry/v1/traces")?
+                        .join("insert/opentelemetry/v1/traces")?
                         .as_str(),
                 )
                 .with_protocol(opentelemetry_otlp::Protocol::HttpBinary)


### PR DESCRIPTION
## Summary

VictoriaTraces ingests OTLP at `/insert/opentelemetry/v1/traces` — mirroring VictoriaLogs' `/insert/opentelemetry/v1/logs`, which the log exporter already uses. The span exporter posted to `/opentelemetry/v1/traces` instead, which VictoriaTraces rejects:

```
POST http://100.93.167.114:10428/opentelemetry/v1/traces        -> 400
POST http://100.93.167.114:10428/insert/opentelemetry/v1/traces -> 200
```

(verified against the live st0x observability box)

So logs and metrics flow but no trace has ever been ingested. One-line path fix.

## Context — staging telemetry now works end to end except traces

- Metrics: scraping since 2026-07-04 (ACL port 8001 + scrape job via ST0x-Technology/st0x.devops#10); `onchain_events_total`, `position_shares` visible in VictoriaMetrics.
- Logs: flowing (VictoriaLogs was down 9 days on the obs box — the nightly backup script failed mid-run on a missing aws CLI and never restarted the container; fixed operationally, backup script hardened with a restart trap).
- Traces: blocked by this path bug (ACL port 10428 already opened).

## Test plan

- [ ] CI passes
- [ ] Deploy staging from this branch; confirm `st0x-liquidity` appears in VictoriaTraces' Jaeger services endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785763370&installation_id=125569124&pr_number=988&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F988&signature=8fa0fbda2495b9c24e1221773e298c7f2781aaeeaad46f1b1b428addbc417c31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated telemetry trace export routing so traces are sent to the correct endpoint, improving compatibility and reliability of trace delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->