### PR TITLE
feat: track equity rebalance stage timing

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -496,9 +496,16 @@ hedging decisions.
 
 #### Roundtrip and reliability metrics
 
-- **Rebalance stage timing**: per-stage durations of USDC rebalances
+- **USDC rebalance stage timing**: per-stage durations of USDC rebalances
   (withdrawal, CCTP burn -> attestation -> mint, deposit, conversion) derived
-  from `UsdcRebalanceEvent` timestamps, including attestation-time trends.
+  from `UsdcRebalanceEvent` timestamps, including attestation-time trends. Shown
+  on its own dashboard chart, clearly labeled as USDC-specific.
+- **Equity rebalance stage timing**: per-stage durations of equity mints
+  (acceptance, token receipt, wrap, vault deposit) and redemptions (vault
+  withdraw, unwrap, send, detection, completion), derived from
+  `TokenizedEquityMintEvent`/`EquityRedemptionEvent` timestamps and combined
+  into one dashboard chart (mint and redemption rows share the chart, each
+  labeled by kind), separate from the USDC chart above.
 - **Reliability**: error/warning counts by severity, module, and time bucket
   from the structured log store; lifecycle failure events (failed hedges, failed
   rebalance stages, rejections) as an impact-weighted category; job queue health

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -87,6 +87,12 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
     RebalanceStageName::export_all_to(out_dir)?;
     RebalanceStageStats::export_all_to(out_dir)?;
     AttestationSample::export_all_to(out_dir)?;
+    EquityTimings::export_all_to(out_dir)?;
+    EquityOperationKind::export_all_to(out_dir)?;
+    EquityOperationTiming::export_all_to(out_dir)?;
+    EquityStageTiming::export_all_to(out_dir)?;
+    EquityStageName::export_all_to(out_dir)?;
+    EquityStageStats::export_all_to(out_dir)?;
     ReliabilityReport::export_all_to(out_dir)?;
     LogVolumeBucket::export_all_to(out_dir)?;
     CountedLogLevel::export_all_to(out_dir)?;

--- a/crates/dto/src/performance.rs
+++ b/crates/dto/src/performance.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 use ts_rs::TS;
 use uuid::Uuid;
 
-use st0x_finance::{Symbol, Usdc};
+use st0x_finance::{FractionalShares, Symbol, Usdc};
 
 use crate::UsdcBridgeDirection;
 
@@ -227,6 +227,110 @@ pub enum RebalanceStageName {
 #[serde(rename_all = "camelCase")]
 pub struct RebalanceStageStats {
     pub stage: RebalanceStageName,
+    pub stats: LatencyStats,
+}
+
+/// Response of `GET /performance/equity-rebalances`.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct EquityTimings {
+    /// Most recent operations (stage breakdown rows), newest first.
+    pub operations: Vec<EquityOperationTiming>,
+    /// Total operations in range before the `operations` cap was applied.
+    #[ts(type = "number")]
+    pub total_operations: usize,
+    /// Operations dropped because their stored timing JSON failed to
+    /// deserialize. They are excluded from every field above; this count
+    /// surfaces the gap so a malformed read-model row is not silently invisible.
+    #[ts(type = "number")]
+    pub skipped_operations: u32,
+    /// Percentiles per stage across all operations in range.
+    ///
+    /// SPARSE: a stage with no completed (`Succeeded`) samples in range is
+    /// omitted entirely rather than emitted with an empty/zero entry. Consumers
+    /// must look stages up by name and tolerate absence, not index positionally.
+    pub stage_summary: Vec<EquityStageStats>,
+}
+
+/// Whether an equity rebalance operation is minting tokenized equity from
+/// real shares or redeeming tokenized equity back to real shares.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum EquityOperationKind {
+    Mint,
+    Redeem,
+}
+
+/// One equity mint or redemption operation's per-stage timing breakdown.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct EquityOperationTiming {
+    #[ts(type = "string")]
+    pub operation_id: Uuid,
+    pub kind: EquityOperationKind,
+    /// `null` only when the read model first observed the operation
+    /// mid-stream (its genesis event, which alone carries the symbol, was
+    /// never seen) -- mirrors `RebalanceOperationTiming::direction`'s
+    /// optionality for the same reason.
+    #[ts(type = "string | null")]
+    pub symbol: Option<Symbol>,
+    #[ts(type = "string | null")]
+    pub quantity: Option<FractionalShares>,
+    /// Genuine operation start (the first observed event). `null` when the
+    /// read model first observed the operation mid-stream (e.g. after a
+    /// deploy), in which case its start time is unknown and `total_ms` is
+    /// unmeasured.
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub status: RebalanceTimingStatus,
+    pub stages: Vec<EquityStageTiming>,
+    /// Genuine start to terminal success, when both endpoints are known.
+    /// `null` when the operation is unfinished, or when `started_at` is
+    /// unknown (mid-stream first observation), or when completion was an
+    /// out-of-band `OperatorReconciled` (whose manual-response window must
+    /// not pollute round-trip latency metrics).
+    #[ts(type = "number | null")]
+    pub total_ms: Option<i64>,
+}
+
+/// Timing of one stage within an equity mint or redemption operation.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct EquityStageTiming {
+    pub stage: EquityStageName,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: Option<DateTime<Utc>>,
+    #[ts(type = "number | null")]
+    pub duration_ms: Option<i64>,
+    pub outcome: StageOutcome,
+}
+
+/// Stages of the equity mint and redemption pipelines, in flow order.
+///
+/// Prefixed by operation kind (`Mint`/`Redemption`) since, unlike USDC's
+/// stages (shared meaning across both bridge directions), mint and
+/// redemption stages are semantically distinct pipelines combined into one
+/// chart -- the prefix keeps the legend unambiguous about which row kind a
+/// stage applies to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum EquityStageName {
+    MintAcceptance,
+    MintReceipt,
+    MintWrap,
+    MintDeposit,
+    RedemptionWithdraw,
+    RedemptionUnwrap,
+    RedemptionSend,
+    RedemptionDetection,
+    RedemptionCompletion,
+}
+
+/// Percentiles for one equity stage.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct EquityStageStats {
+    pub stage: EquityStageName,
     pub stats: LatencyStats,
 }
 

--- a/migrations/20260703162302_equity_stage_timing_read_model.sql
+++ b/migrations/20260703162302_equity_stage_timing_read_model.sql
@@ -1,0 +1,35 @@
+-- Forward-only read model for the equity mint/redemption stage-timing report.
+--
+-- This table is maintained exclusively by the EquityTimingProjection reactor
+-- from live TokenizedEquityMint and EquityRedemption events. The report read
+-- path (load_equity_timings) queries ONLY this table and never folds the
+-- events table. One row per mint or redemption operation (aggregate id),
+-- mirroring rebalance_stage_timing's schema exactly (see
+-- migrations/20260616221000_rebalance_timing_read_model.sql and
+-- migrations/20260620003813_rebalance_timing_checkpoint.sql for the USDC
+-- precedent this combines into one migration).
+--
+-- `started_at` is stored as RFC3339 TEXT (chrono `to_rfc3339`) so the report
+-- can filter and order operations. This SQL column holds the timestamp of the
+-- FIRST event this reactor observed for the operation (`first_seen_at`) and is
+-- used exclusively for range filtering and ordering -- NOT the genuine
+-- business start. `timing` is the JSON-serialized accumulated operation
+-- timing (kind, symbol, quantity, status, the genuine
+-- `started_at`/`completed_at`, and the ordered stage list with per-stage
+-- durations) that the read path converts into the dashboard DTO. `total_ms`
+-- is derived at read time from the `started_at`/`completed_at` fields
+-- embedded in the `timing` JSON blob, not stored separately.
+--
+-- `last_sequence` is the highest event `sequence` (within its own aggregate
+-- stream) folded into this row by a catch-up/rebuild pass. Startup catch-up
+-- replays only events past it. NULL means "never checkpointed", which
+-- catch-up treats as 0 and replays the full stream once before establishing
+-- a checkpoint.
+CREATE TABLE equity_stage_timing (
+    operation_id TEXT PRIMARY KEY,
+    started_at TEXT NOT NULL,
+    timing TEXT NOT NULL,
+    last_sequence INTEGER
+);
+
+CREATE INDEX idx_equity_stage_timing_started_at ON equity_stage_timing (started_at);

--- a/src/api.rs
+++ b/src/api.rs
@@ -16,13 +16,16 @@ use sqlx::SqlitePool;
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
-use st0x_dto::{HedgeLatencies, InfraReport, RebalanceTimings, ReliabilityReport, TradingVenue};
+use st0x_dto::{
+    EquityTimings, HedgeLatencies, InfraReport, RebalanceTimings, ReliabilityReport, TradingVenue,
+};
 use st0x_execution::FractionalShares;
 use st0x_tokenization::IssuerRequestId;
 
 use crate::AppState;
 use crate::dashboard::transfer_loader::{InvalidTransferKind, TransferKind};
 use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
+use crate::performance::equity_timing::load_equity_timings;
 use crate::performance::infra::{load_dependency_stats, load_monitor_telemetry};
 use crate::performance::rebalance::load_rebalance_timings;
 use crate::performance::reliability::{
@@ -1517,17 +1520,26 @@ struct PerformanceRangeQuery {
     to: Option<DateTime<Utc>>,
 }
 
+/// Widest span accepted by `/performance/*` range queries. Generous for any
+/// real dashboard preset (the widest, "ALL", spans a bit over a year today)
+/// while rejecting a pathological `from`/`to` that would otherwise make
+/// `hedge_latency_report`'s dense bucket generation iterate unboundedly.
+const MAX_PERFORMANCE_RANGE_DAYS: i64 = 3650;
+
+fn parse_report_range(query: &PerformanceRangeQuery) -> Result<ReportRange, StatusCode> {
+    let to = query.to.unwrap_or_else(Utc::now);
+    let from = query.from.unwrap_or(to - chrono::Duration::days(7));
+    if from >= to || to - from > chrono::Duration::days(MAX_PERFORMANCE_RANGE_DAYS) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    Ok(ReportRange { from, to })
+}
+
 async fn performance_latencies(
     State(state): State<AppState>,
     Query(query): Query<PerformanceRangeQuery>,
 ) -> Result<Json<HedgeLatencies>, StatusCode> {
-    let to = query.to.unwrap_or_else(Utc::now);
-    let from = query.from.unwrap_or(to - chrono::Duration::days(7));
-    if from >= to {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-
-    let report_range = ReportRange { from, to };
+    let report_range = parse_report_range(&query)?;
     let performances = load_hedge_performance(&state.pool, &report_range)
         .await
         .inspect_err(|error| error!(%error, "Failed to load hedge performance"))
@@ -1540,15 +1552,25 @@ async fn performance_rebalances(
     State(state): State<AppState>,
     Query(query): Query<PerformanceRangeQuery>,
 ) -> Result<Json<RebalanceTimings>, StatusCode> {
-    let to = query.to.unwrap_or_else(Utc::now);
-    let from = query.from.unwrap_or(to - chrono::Duration::days(7));
-    if from >= to {
-        return Err(StatusCode::BAD_REQUEST);
-    }
+    let range = parse_report_range(&query)?;
 
-    let timings = load_rebalance_timings(&state.pool, &ReportRange { from, to })
+    let timings = load_rebalance_timings(&state.pool, &range)
         .await
         .inspect_err(|error| error!(%error, "Failed to load rebalance timings"))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(timings))
+}
+
+async fn performance_equity_rebalances(
+    State(state): State<AppState>,
+    Query(query): Query<PerformanceRangeQuery>,
+) -> Result<Json<EquityTimings>, StatusCode> {
+    let range = parse_report_range(&query)?;
+
+    let timings = load_equity_timings(&state.pool, &range)
+        .await
+        .inspect_err(|error| error!(%error, "Failed to load equity timings"))
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(timings))
@@ -1558,12 +1580,7 @@ async fn performance_reliability(
     State(state): State<AppState>,
     Query(query): Query<PerformanceRangeQuery>,
 ) -> Result<Json<ReliabilityReport>, StatusCode> {
-    let to = query.to.unwrap_or_else(Utc::now);
-    let from = query.from.unwrap_or(to - chrono::Duration::days(7));
-    if from >= to {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-    let range = ReportRange { from, to };
+    let range = parse_report_range(&query)?;
 
     let (entries, log_entries_truncated) = if let Some(log_dir) = state.ctx.log_dir.as_deref() {
         let log_dir = log_dir.to_owned();
@@ -1571,8 +1588,8 @@ async fn performance_reliability(
             search_lower: None,
             levels: Some(vec!["ERROR".to_string(), "WARN".to_string()]),
             targets: None,
-            since: Some(from),
-            until: Some(to),
+            since: Some(range.from),
+            until: Some(range.to),
         };
         // Log scanning is synchronous file I/O; keep it off the async
         // workers. The cap bounds memory during error storms, slightly
@@ -1620,13 +1637,7 @@ async fn performance_infra(
     State(state): State<AppState>,
     Query(query): Query<PerformanceRangeQuery>,
 ) -> Result<Json<InfraReport>, StatusCode> {
-    let to = query.to.unwrap_or_else(Utc::now);
-    let from = query.from.unwrap_or(to - chrono::Duration::days(7));
-    if from >= to {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-
-    let range = ReportRange { from, to };
+    let range = parse_report_range(&query)?;
     // The two loaders hit independent tables, so run them concurrently rather
     // than paying both round-trips in series.
     let (monitor, dependencies) = tokio::try_join!(
@@ -1655,6 +1666,10 @@ pub(crate) fn routes() -> Router<AppState> {
         .route("/health", get(health))
         .route("/performance/latencies", get(performance_latencies))
         .route("/performance/rebalances", get(performance_rebalances))
+        .route(
+            "/performance/equity-rebalances",
+            get(performance_equity_rebalances),
+        )
         .route("/performance/reliability", get(performance_reliability))
         .route("/performance/infra", get(performance_infra))
         .route("/logs", get(logs))
@@ -1684,6 +1699,7 @@ mod tests {
 
     use st0x_config::{Ctx, RestApiCtx, create_test_ctx_with_order_owner};
     use st0x_event_sorcery::ReactorHarness;
+    use st0x_float_macro::float;
     use st0x_tokenization::{
         MintVerificationError, TokenizerError, issuer_request_id, tokenization_request_id,
     };
@@ -1692,7 +1708,9 @@ mod tests {
     use crate::dashboard;
     use crate::inventory::{self, BroadcastingInventory};
     use crate::offchain::order::{OffchainOrder, OffchainOrderEvent, OffchainOrderId};
+    use crate::performance::equity_timing::EquityTimingProjection;
     use crate::performance::reliability::LifecycleFailureProjection;
+    use crate::tokenized_equity_mint::TokenizedEquityMint;
 
     async fn empty_app_state(ctx: Ctx) -> AppState {
         let (sender, _) = broadcast::channel(16);
@@ -2675,6 +2693,31 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
+    /// A pathological span (e.g. `to` far in the future) must be rejected
+    /// rather than accepted and handed to `hedge_latency_report`, whose
+    /// dense bucket generation would otherwise iterate once per bucket
+    /// across the entire span.
+    #[tokio::test]
+    async fn performance_latencies_rejects_range_wider_than_max_span() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(
+                        "/performance/latencies\
+                         ?from=2000-01-01T00:00:00Z&to=9000-01-01T00:00:00Z",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
     /// Seeds a fill with a non-zero detection latency (seen_at > block_timestamp)
     /// and verifies the value survives reactor write -> SQL load -> report assembly
     /// -> JSON serialization, ending up in `summary.stages.detection.p50Ms`.
@@ -2818,6 +2861,98 @@ mod tests {
         assert_eq!(
             report["operations"][0]["direction"],
             serde_json::json!("base_to_alpaca")
+        );
+    }
+
+    #[tokio::test]
+    async fn performance_equity_rebalances_returns_empty_report_on_fresh_database() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/performance/equity-rebalances")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = body_to_string(response).await;
+        let report: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(report["totalOperations"], serde_json::json!(0));
+        assert_eq!(report["skippedOperations"], serde_json::json!(0));
+        assert_eq!(report["operations"], serde_json::json!([]));
+        assert_eq!(report["stageSummary"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn performance_equity_rebalances_rejects_inverted_range() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(
+                        "/performance/equity-rebalances\
+                         ?from=2026-01-02T00:00:00Z&to=2026-01-01T00:00:00Z",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn performance_equity_rebalances_reports_seeded_operations() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let state = empty_app_state(ctx).await;
+
+        // Drive the real reactor (not a hand-crafted JSON blob) so this test
+        // stays at the public API surface, mirroring
+        // `performance_rebalances_reports_seeded_operations` above. One
+        // `MintRequested` event leaves an open, in-progress mint operation.
+        let harness = ReactorHarness::new(EquityTimingProjection::new(state.pool.clone()));
+        let operation_id = issuer_request_id("equity-rebalances-seed");
+        harness
+            .receive::<TokenizedEquityMint>(
+                operation_id,
+                TokenizedEquityMintEvent::MintRequested {
+                    symbol: st0x_execution::Symbol::new("AAPL").unwrap(),
+                    quantity: float!(5),
+                    wallet: Address::repeat_byte(0x11),
+                    requested_at: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let app = build_app(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/performance/equity-rebalances")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = body_to_string(response).await;
+        let report: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(report["totalOperations"], serde_json::json!(1));
+        assert_eq!(report["operations"][0]["kind"], serde_json::json!("mint"));
+        assert_eq!(
+            report["operations"][0]["status"],
+            serde_json::json!("in_progress")
         );
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,6 +29,7 @@ use st0x_finance::Usdc;
 use st0x_registry::SymbolCache;
 
 use crate::offchain::order::{OffchainOrder, OffchainOrderId, OrderPlacer};
+use crate::performance::equity_timing::EquityTimingProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
 use crate::performance::reliability::LifecycleFailureProjection;
 use crate::position::Position;
@@ -117,6 +118,10 @@ pub enum AggregateView {
     /// Rebalance stage-timing read model (rebalance_stage_timing). Replays every
     /// `UsdcRebalance` event stream through the reactor fold. Supports `--all` only.
     RebalanceTiming,
+    /// Equity mint/redemption stage-timing read model (equity_stage_timing).
+    /// Replays every `TokenizedEquityMint`/`EquityRedemption` event stream
+    /// through the reactor fold. Supports `--all` only.
+    EquityTiming,
     /// Lifecycle-failure read model (lifecycle_failure_event). Replays every
     /// failure across all four subscribed streams through the reactor fold.
     /// Supports `--all` only.
@@ -1675,6 +1680,25 @@ async fn rebuild_view<W: Write>(
                 "Rebuilt rebalance stage-timing read model ({replayed} events replayed)"
             )?;
         }
+        AggregateView::EquityTiming => {
+            if id.is_some() {
+                anyhow::bail!(
+                    "equity-timing rebuild replays the whole read model; pass --all, not --id"
+                );
+            }
+
+            if !all {
+                anyhow::bail!("equity-timing rebuild replays the whole read model; pass --all");
+            }
+
+            let replayed = EquityTimingProjection::new(pool.clone())
+                .rebuild_all()
+                .await?;
+            writeln!(
+                stdout,
+                "Rebuilt equity stage-timing read model ({replayed} events replayed)"
+            )?;
+        }
         AggregateView::LifecycleFailure => {
             if id.is_some() {
                 anyhow::bail!(
@@ -1846,10 +1870,19 @@ mod tests {
     use st0x_config::create_test_issuance_ctx;
     use st0x_config::{AssetsConfig, BrokerCtx, EquitiesConfig, LogLevel, TradingMode};
     use st0x_config::{EvmCtx, IngestionCutoff};
+    use st0x_event_sorcery::StoreBuilder;
+    use st0x_float_macro::float;
+    use st0x_tokenization::IssuerRequestId;
+    use st0x_tokenization::mock::MockTokenizer;
+    use st0x_wrapper::MockWrapper;
 
     use super::*;
     use crate::offchain::order::OffchainOrderEvent;
+    use crate::onchain::mock::MockRaindex;
+    use crate::rebalancing::equity::EquityTransferServices;
     use crate::test_utils::{positive_shares, setup_test_db};
+    use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintCommand};
+    use crate::vault_lookup::MockVaultLookup;
 
     fn create_test_ctx() -> Ctx {
         Ctx {
@@ -2576,6 +2609,111 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "rebalance-timing rebuild replays the whole read model; pass --all, not --id"
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuild_view_equity_timing_requires_all() {
+        let pool = setup_test_db().await;
+        let mut stdout_buffer = Vec::new();
+
+        let error = rebuild_view(
+            &mut stdout_buffer,
+            &pool,
+            AggregateView::EquityTiming,
+            None,
+            false,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "equity-timing rebuild replays the whole read model; pass --all"
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuild_view_equity_timing_rejects_id() {
+        let pool = setup_test_db().await;
+        let mut stdout_buffer = Vec::new();
+
+        let error = rebuild_view(
+            &mut stdout_buffer,
+            &pool,
+            AggregateView::EquityTiming,
+            Some("some-id".to_string()),
+            false,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "equity-timing rebuild replays the whole read model; pass --all, not --id"
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuild_view_equity_timing_rebuilds_from_event_log() {
+        let pool = setup_test_db().await;
+        let operation_id = Uuid::new_v4();
+
+        // Seed a real TokenizedEquityMint event stream by sending the
+        // fixture-only `RequestMintAt` command through the aggregate's own
+        // store -- never a raw `events` INSERT -- so the replay path folds
+        // the exact event shapes/sequence the live system would produce.
+        // The default `MockTokenizer` accepts the request, so this emits
+        // both `MintRequested` and `MintAccepted`.
+        let store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
+            .build(EquityTransferServices {
+                raindex: Arc::new(MockRaindex::new()),
+                vault_lookup: Arc::new(MockVaultLookup::new()),
+                tokenizer: Arc::new(MockTokenizer::new()),
+                wrapper: Arc::new(MockWrapper::new()),
+            })
+            .await
+            .unwrap();
+        store
+            .send(
+                &IssuerRequestId(operation_id),
+                TokenizedEquityMintCommand::RequestMintAt {
+                    issuer_request_id: IssuerRequestId(operation_id),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(5),
+                    wallet: Address::repeat_byte(0x11),
+                    requested_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut stdout_buffer = Vec::new();
+        rebuild_view(
+            &mut stdout_buffer,
+            &pool,
+            AggregateView::EquityTiming,
+            None,
+            true,
+        )
+        .await
+        .unwrap();
+
+        let output = String::from_utf8(stdout_buffer).unwrap();
+        assert!(
+            output.contains("Rebuilt equity stage-timing read model (2 events replayed)"),
+            "unexpected output: {output}"
+        );
+
+        let timing_rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM equity_stage_timing WHERE operation_id = ?")
+                .bind(operation_id.to_string())
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            timing_rows, 1,
+            "the rebuild folded the seeded mint events into a single operation row"
         );
     }
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -80,6 +80,7 @@ use crate::onchain::backfill::BackfillJobQueue;
 use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vaults_from_clear};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeError, OnChainTradeId};
 use crate::performance::HedgeLatencyProjection;
+use crate::performance::equity_timing::EquityTimingProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
 use crate::performance::reliability::LifecycleFailureProjection;
 use crate::position::{Position, PositionCommand, PositionError, PositionEvent, TradeId};
@@ -1405,20 +1406,16 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         let broadcaster = Arc::new(Broadcaster::new(deps.event_sender, deps.pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(deps.pool.clone()));
         let rebalance_timing = Arc::new(RebalanceTimingProjection::new(deps.pool.clone()));
+        let equity_timing = Arc::new(EquityTimingProjection::new(deps.pool.clone()));
         let lifecycle_failure = Arc::new(LifecycleFailureProjection::new(deps.pool.clone()));
-        // Catch the rebalance stage-timing read model up to the event log before
-        // the reactor goes live, so a restart replays whatever the forward-only
-        // live path missed in the previous run. Reads only the un-folded tail
-        // past each operation's checkpoint, so this does not re-fold history.
-        let rebalance_timing_replayed = rebalance_timing.catch_up().await?;
-        info!(target: "rebalance", replayed = rebalance_timing_replayed,
-            "Rebalance stage-timing read model caught up to the event log at startup");
+        catch_up_stage_timing_projections(&rebalance_timing, &equity_timing).await?;
 
         let manifest = QueryManifest::new(
             rebalancing_service.clone(),
             broadcaster,
             hedge_latency,
             rebalance_timing,
+            equity_timing,
             lifecycle_failure,
         );
 
@@ -1584,6 +1581,26 @@ async fn catch_up_lifecycle_failures(pool: &SqlitePool) -> anyhow::Result<()> {
         replayed,
         "Lifecycle-failure read model caught up to the event log at startup"
     );
+
+    Ok(())
+}
+
+/// Catches the USDC rebalance and equity mint/redemption stage-timing read
+/// models up to the event log before their reactors go live, so a restart
+/// replays whatever the forward-only live path missed in the previous run.
+/// Each reads only its un-folded tail past its own operations' checkpoints,
+/// so this does not re-fold history.
+async fn catch_up_stage_timing_projections(
+    rebalance_timing: &RebalanceTimingProjection,
+    equity_timing: &EquityTimingProjection,
+) -> anyhow::Result<()> {
+    let rebalance_timing_replayed = rebalance_timing.catch_up().await?;
+    info!(target: "rebalance", replayed = rebalance_timing_replayed,
+        "Rebalance stage-timing read model caught up to the event log at startup");
+
+    let equity_timing_replayed = equity_timing.catch_up().await?;
+    info!(target: "equity", replayed = equity_timing_replayed,
+        "Equity stage-timing read model caught up to the event log at startup");
 
     Ok(())
 }

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -22,6 +22,7 @@ use crate::dashboard::Broadcaster;
 use crate::equity_redemption::EquityRedemption;
 use crate::inventory::InventorySnapshot;
 use crate::performance::HedgeLatencyProjection;
+use crate::performance::equity_timing::EquityTimingProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
 use crate::performance::reliability::LifecycleFailureProjection;
 use crate::position::Position;
@@ -39,6 +40,7 @@ pub(super) struct QueryManifest {
     broadcaster: Arc<Broadcaster>,
     hedge_latency: Arc<HedgeLatencyProjection>,
     rebalance_timing: Arc<RebalanceTimingProjection>,
+    equity_timing: Arc<EquityTimingProjection>,
     lifecycle_failure: Arc<LifecycleFailureProjection>,
 }
 
@@ -62,6 +64,7 @@ impl QueryManifest {
         broadcaster: Arc<Broadcaster>,
         hedge_latency: Arc<HedgeLatencyProjection>,
         rebalance_timing: Arc<RebalanceTimingProjection>,
+        equity_timing: Arc<EquityTimingProjection>,
         lifecycle_failure: Arc<LifecycleFailureProjection>,
     ) -> Self {
         Self {
@@ -69,6 +72,7 @@ impl QueryManifest {
             broadcaster,
             hedge_latency,
             rebalance_timing,
+            equity_timing,
             lifecycle_failure,
         }
     }
@@ -88,6 +92,7 @@ impl QueryManifest {
             broadcaster,
             hedge_latency,
             rebalance_timing,
+            equity_timing,
             lifecycle_failure,
         } = self;
 
@@ -101,6 +106,7 @@ impl QueryManifest {
         let mint = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
             .with(rebalancing_service.clone())
             .with(broadcaster.clone())
+            .with(equity_timing.clone())
             .with(lifecycle_failure.clone())
             .build(services.clone())
             .await?;
@@ -108,6 +114,7 @@ impl QueryManifest {
         let redemption = StoreBuilder::<EquityRedemption>::new(pool.clone())
             .with(rebalancing_service.clone())
             .with(broadcaster.clone())
+            .with(equity_timing)
             .with(lifecycle_failure.clone())
             .build(services)
             .await?;
@@ -213,12 +220,14 @@ mod tests {
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
         let rebalance_timing = Arc::new(RebalanceTimingProjection::new(pool.clone()));
+        let equity_timing = Arc::new(EquityTimingProjection::new(pool.clone()));
         let lifecycle_failure = Arc::new(LifecycleFailureProjection::new(pool.clone()));
         let manifest = QueryManifest::new(
             rebalancing_service,
             broadcaster,
             hedge_latency,
             rebalance_timing,
+            equity_timing,
             lifecycle_failure,
         );
 
@@ -271,12 +280,14 @@ mod tests {
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
         let rebalance_timing = Arc::new(RebalanceTimingProjection::new(pool.clone()));
+        let equity_timing = Arc::new(EquityTimingProjection::new(pool.clone()));
         let lifecycle_failure = Arc::new(LifecycleFailureProjection::new(pool.clone()));
         let manifest = QueryManifest::new(
             rebalancing_service,
             broadcaster,
             hedge_latency,
             rebalance_timing,
+            equity_timing,
             lifecycle_failure,
         );
         let services = EquityTransferServices {
@@ -388,12 +399,14 @@ mod tests {
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
         let rebalance_timing = Arc::new(RebalanceTimingProjection::new(pool.clone()));
+        let equity_timing = Arc::new(EquityTimingProjection::new(pool.clone()));
         let lifecycle_failure = Arc::new(LifecycleFailureProjection::new(pool.clone()));
         let manifest = QueryManifest::new(
             rebalancing_service.clone(),
             broadcaster,
             hedge_latency,
             rebalance_timing,
+            equity_timing,
             lifecycle_failure,
         );
         let services = EquityTransferServices {

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -259,24 +259,70 @@ pub(crate) enum EquityRedemptionCommand {
         token: Address,
         amount: U256,
     },
+    /// Test/fixture-only: identical to `Redeem` but takes `pending_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    RedeemAt {
+        symbol: Symbol,
+        quantity: Float,
+        token: Address,
+        amount: U256,
+        pending_at: DateTime<Utc>,
+    },
     /// Waits for a previously submitted withdrawal to confirm.
     /// Emits WithdrawnFromRaindex.
     ConfirmWithdraw,
+    /// Test/fixture-only: identical to `ConfirmWithdraw` but takes
+    /// `withdrawn_at` explicitly instead of stamping `Utc::now()`, so
+    /// fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    ConfirmWithdrawAt { withdrawn_at: DateTime<Utc> },
     /// Submits ERC-4626 unwrap tx and emits UnwrapSubmitted.
     UnwrapTokens,
+    /// Test/fixture-only: identical to `UnwrapTokens` but takes `pending_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    UnwrapTokensAt { pending_at: DateTime<Utc> },
     /// Waits for a previously submitted unwrap to confirm.
     /// Emits TokensUnwrapped.
     ConfirmUnwrap,
+    /// Test/fixture-only: identical to `ConfirmUnwrap` but takes
+    /// `unwrapped_at` explicitly instead of stamping `Utc::now()`, so
+    /// fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    ConfirmUnwrapAt { unwrapped_at: DateTime<Utc> },
     /// Send unwrapped tokens to Alpaca's redemption wallet.
     SendTokens,
+    /// Test/fixture-only: identical to `SendTokens` but takes `sent_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history. Only the success (`TokensSent`) path
+    /// honours the timestamp; the failure (`TransferFailed`) path keeps
+    /// `Utc::now()` since the fixture never drives it.
+    #[cfg(any(test, feature = "test-support"))]
+    SendTokensAt { sent_at: DateTime<Utc> },
     /// Alpaca detected the token transfer.
     Detect {
         tokenization_request_id: TokenizationRequestId,
+    },
+    /// Test/fixture-only: identical to `Detect` but takes `detected_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    DetectAt {
+        tokenization_request_id: TokenizationRequestId,
+        detected_at: DateTime<Utc>,
     },
     /// Detection polling failed or timed out.
     FailDetection { failure: DetectionFailure },
     /// Redemption completed successfully.
     Complete,
+    /// Test/fixture-only: identical to `Complete` but takes `completed_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    CompleteAt { completed_at: DateTime<Utc> },
     /// Alpaca rejected the redemption.
     RejectRedemption { reason: String },
     /// Recover provider completion after the aggregate had failed.
@@ -289,12 +335,27 @@ pub(crate) enum EquityRedemptionCommand {
     /// Performs the actual vault withdrawal (side-effectful).
     /// Valid from `VaultWithdrawPending`.
     SubmitWithdraw,
+    /// Test/fixture-only: identical to `SubmitWithdraw` but takes
+    /// `submitted_at` explicitly instead of stamping `Utc::now()`, so
+    /// fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    SubmitWithdrawAt { submitted_at: DateTime<Utc> },
     /// Performs the actual ERC-4626 unwrap (side-effectful).
     /// Valid from `UnwrapPending`.
     SubmitUnwrap,
+    /// Test/fixture-only: identical to `SubmitUnwrap` but takes
+    /// `submitted_at` explicitly instead of stamping `Utc::now()`, so
+    /// fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    SubmitUnwrapAt { submitted_at: DateTime<Utc> },
     /// Prepares sending tokens (pure, no side effects).
     /// Valid from `TokensUnwrapped`.
     PrepareSend,
+    /// Test/fixture-only: identical to `PrepareSend` but takes `pending_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    PrepareSendAt { pending_at: DateTime<Utc> },
     /// Reconcile a redemption stranded in the terminal `Failed` state to the
     /// terminal `Reconciled` state. The residual equity was handled out-of-band
     /// (e.g. via wrap-equity/vault-deposit), so this is a bookkeeping resolution
@@ -1750,6 +1811,20 @@ impl EventSourced for EquityRedemption {
                 wrapped_amount: amount,
                 pending_at: Utc::now(),
             }]),
+            #[cfg(any(test, feature = "test-support"))]
+            RedeemAt {
+                symbol,
+                quantity,
+                token,
+                amount,
+                pending_at,
+            } => Ok(vec![VaultWithdrawPending {
+                symbol,
+                quantity,
+                token,
+                wrapped_amount: amount,
+                pending_at,
+            }]),
             SubmitWithdraw
             | SubmitUnwrap
             | PrepareSend
@@ -1764,6 +1839,24 @@ impl EventSourced for EquityRedemption {
             | RecoverProviderCompletion { .. }
             | Reconcile { .. }
             | FailTransfer { .. } => Err(EquityRedemptionError::NotStarted),
+            #[cfg(any(test, feature = "test-support"))]
+            SubmitWithdrawAt { .. } => Err(EquityRedemptionError::NotStarted),
+            #[cfg(any(test, feature = "test-support"))]
+            SubmitUnwrapAt { .. } => Err(EquityRedemptionError::NotStarted),
+            #[cfg(any(test, feature = "test-support"))]
+            PrepareSendAt { .. } => Err(EquityRedemptionError::NotStarted),
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmWithdrawAt { .. } => Err(EquityRedemptionError::NotStarted),
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmUnwrapAt { .. } => Err(EquityRedemptionError::NotStarted),
+            #[cfg(any(test, feature = "test-support"))]
+            UnwrapTokensAt { .. } => Err(EquityRedemptionError::NotStarted),
+            #[cfg(any(test, feature = "test-support"))]
+            SendTokensAt { .. } => Err(EquityRedemptionError::NotStarted),
+            #[cfg(any(test, feature = "test-support"))]
+            DetectAt { .. } => Err(EquityRedemptionError::NotStarted),
+            #[cfg(any(test, feature = "test-support"))]
+            CompleteAt { .. } => Err(EquityRedemptionError::NotStarted),
         }
     }
 
@@ -1782,311 +1875,62 @@ impl EventSourced for EquityRedemption {
                 Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::AlreadyStarted),
             },
-
-            SubmitWithdraw => match self {
-                Self::VaultWithdrawPending {
-                    symbol,
-                    quantity,
-                    token,
-                    wrapped_amount,
-                    ..
-                } => {
-                    let vault_id = match services.vault_lookup.vault_id_for_token(*token).await {
-                        Ok(id) => id,
-                        Err(error) => {
-                            warn!(target: "rebalance", %error, %token, "Vault lookup failed");
-                            return Err(EquityRedemptionError::RaindexVaultNotFound(*token));
-                        }
-                    };
-
-                    info!(target: "rebalance", ?vault_id, %token, %wrapped_amount, "Submitting Raindex vault withdrawal");
-
-                    let tx_hash = match services
-                        .raindex
-                        .submit_withdraw(
-                            *token,
-                            vault_id,
-                            *wrapped_amount,
-                            TOKENIZED_EQUITY_DECIMALS,
-                        )
-                        .await
-                    {
-                        Ok(tx) => tx,
-                        Err(error) => {
-                            warn!(target: "rebalance", %error, %token, %wrapped_amount, "Raindex vault withdrawal submission failed");
-                            return Err(EquityRedemptionError::RaindexWithdrawFailed {
-                                token: *token,
-                                amount: *wrapped_amount,
-                                error_message: error.to_string(),
-                            });
-                        }
-                    };
-
-                    Ok(vec![VaultWithdrawSubmitted {
-                        symbol: symbol.clone(),
-                        quantity: *quantity,
-                        token: *token,
-                        wrapped_amount: *wrapped_amount,
-                        tx_hash,
-                        submitted_at: Utc::now(),
-                    }])
-                }
+            #[cfg(any(test, feature = "test-support"))]
+            RedeemAt { .. } => match self {
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
                 Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::AlreadyStarted),
             },
 
-            ConfirmWithdraw => match self {
-                Self::VaultWithdrawSubmitted {
-                    symbol,
-                    quantity,
-                    token,
-                    wrapped_amount,
-                    tx_hash,
-                    ..
-                } => {
-                    let receipt = services
-                        .raindex
-                        .confirm_tx_receipt(*tx_hash)
-                        .await
-                        .map_err(|error| EquityRedemptionError::RaindexWithdrawFailed {
-                            token: *token,
-                            amount: *wrapped_amount,
-                            error_message: error.to_string(),
-                        })?;
-                    let raindex_withdraw_block = receipt
-                        .block_number
-                        .ok_or(EquityRedemptionError::MissingWithdrawBlock { tx_hash: *tx_hash })?;
-                    let recipient = services.wrapper.owner();
-                    let actual_wrapped_amount =
-                        actual_withdrawn_amount_from_receipt(&receipt, *token, recipient)?;
-                    Ok(vec![WithdrawnFromRaindex {
-                        symbol: symbol.clone(),
-                        quantity: *quantity,
-                        token: *token,
-                        wrapped_amount: *wrapped_amount,
-                        actual_wrapped_amount: Some(actual_wrapped_amount),
-                        raindex_withdraw_tx: *tx_hash,
-                        raindex_withdraw_block: Some(raindex_withdraw_block),
-                        withdrawn_at: Utc::now(),
-                    }])
-                }
-                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
-                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
-                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
-                _ => Err(EquityRedemptionError::AlreadyStarted),
-            },
+            SubmitWithdraw => self.transition_submit_withdraw(services, None).await,
+            #[cfg(any(test, feature = "test-support"))]
+            SubmitWithdrawAt { submitted_at } => {
+                self.transition_submit_withdraw(services, Some(submitted_at))
+                    .await
+            }
 
-            UnwrapTokens => match self {
-                Self::WithdrawnFromRaindex { .. } => Ok(vec![UnwrapPending {
-                    pending_at: Utc::now(),
-                }]),
-                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
-                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
-                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
-                _ => Err(EquityRedemptionError::CannotUnwrapAlreadyStarted),
-            },
+            ConfirmWithdraw => self.transition_confirm_withdraw(services, None).await,
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmWithdrawAt { withdrawn_at } => {
+                self.transition_confirm_withdraw(services, Some(withdrawn_at))
+                    .await
+            }
 
-            SubmitUnwrap => match self {
-                Self::UnwrapPending {
-                    token,
-                    wrapped_amount,
-                    raindex_withdraw_block,
-                    ..
-                } => {
-                    // Wait for the RPC node to catch up to the block where the
-                    // Raindex withdrawal tx confirmed before submitting the unwrap.
-                    // Without this, a load-balanced backend that hasn't indexed
-                    // the withdrawal may simulate the unwrap against a stale
-                    // wrapped-token balance. `raindex_withdraw_block` is None for
-                    // pre-fix aggregates; skip the wait for backward-compatibility.
-                    if let Some(block) = raindex_withdraw_block {
-                        services
-                            .wrapper
-                            .wait_for_block(*block)
-                            .await
-                            .map_err(|error| node_sync_failed(*block, &error))?;
-                    }
-                    let owner = services.wrapper.owner();
-                    let unwrap_tx_hash = services
-                        .wrapper
-                        .submit_unwrap(*token, *wrapped_amount, owner, owner)
-                        .await
-                        .inspect_err(|error| {
-                            warn!(target: "rebalance", %error, %token, "Token unwrap submission failed");
-                        })
-                        .map_err(|error| EquityRedemptionError::UnwrapFailed {
-                            token: *token,
-                            wrapped_amount: *wrapped_amount,
-                            error_message: error.to_string(),
-                        })?;
+            UnwrapTokens => self.transition_unwrap_tokens(Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            UnwrapTokensAt { pending_at } => self.transition_unwrap_tokens(pending_at),
 
-                    Ok(vec![UnwrapSubmitted {
-                        unwrap_tx_hash,
-                        submitted_at: Utc::now(),
-                    }])
-                }
-                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
-                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
-                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
-                _ => Err(EquityRedemptionError::CannotUnwrapAlreadyStarted),
-            },
+            SubmitUnwrap => self.transition_submit_unwrap(services, None).await,
+            #[cfg(any(test, feature = "test-support"))]
+            SubmitUnwrapAt { submitted_at } => {
+                self.transition_submit_unwrap(services, Some(submitted_at))
+                    .await
+            }
 
-            ConfirmUnwrap => match self {
-                Self::UnwrapSubmitted {
-                    symbol,
-                    token,
-                    wrapped_amount,
-                    unwrap_tx_hash,
-                    ..
-                } => {
-                    let underlying_token = services
-                        .wrapper
-                        .lookup_underlying(symbol)
-                        .inspect_err(|error| {
-                            warn!(target: "rebalance", %error, %symbol, "Underlying token lookup failed");
-                        })
-                        .map_err(|error| EquityRedemptionError::UnderlyingLookupFailed {
-                            symbol: symbol.clone(),
-                            error_message: error.to_string(),
-                        })?;
+            ConfirmUnwrap => self.transition_confirm_unwrap(services, None).await,
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmUnwrapAt { unwrapped_at } => {
+                self.transition_confirm_unwrap(services, Some(unwrapped_at))
+                    .await
+            }
 
-                    let unwrap_confirmation = services
-                        .wrapper
-                        .confirm_unwrap(*token, *unwrap_tx_hash)
-                        .await
-                        .inspect_err(|error| {
-                            warn!(target: "rebalance", %error, %token, "Token unwrap confirmation failed");
-                        })
-                        .map_err(|error| EquityRedemptionError::UnwrapFailed {
-                            token: *token,
-                            wrapped_amount: *wrapped_amount,
-                            error_message: error.to_string(),
-                        })?;
-                    let unwrapped_amount = unwrap_confirmation.assets;
-                    let unwrap_block = unwrap_confirmation.block;
-                    let quantity =
-                        Float::from_fixed_decimal(unwrapped_amount, TOKENIZED_EQUITY_DECIMALS)
-                            .map_err(|error| {
-                                EquityRedemptionError::RaindexWithdrawQuantityConversionFailed {
-                                    tx_hash: *unwrap_tx_hash,
-                                    amount: unwrapped_amount,
-                                    error_message: error.to_string(),
-                                }
-                            })?;
+            PrepareSend => self.transition_prepare_send(Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            PrepareSendAt { pending_at } => self.transition_prepare_send(pending_at),
 
-                    Ok(vec![TokensUnwrapped {
-                        quantity: Some(quantity),
-                        underlying_token,
-                        unwrap_tx_hash: *unwrap_tx_hash,
-                        unwrapped_amount,
-                        unwrap_block: Some(unwrap_block),
-                        unwrapped_at: Utc::now(),
-                    }])
-                }
-                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
-                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
-                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
-                _ => Err(EquityRedemptionError::CannotUnwrapAlreadyStarted),
-            },
-
-            PrepareSend => match self {
-                Self::TokensUnwrapped { .. } => Ok(vec![SendPending {
-                    pending_at: Utc::now(),
-                }]),
-                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
-                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
-                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
-                _ => Err(EquityRedemptionError::TokensNotUnwrapped),
-            },
-
-            SendTokens => match self {
-                Self::SendPending {
-                    symbol,
-                    underlying_token,
-                    unwrapped_amount,
-                    unwrap_block,
-                    ..
-                } => {
-                    let token = *underlying_token;
-                    let amount = *unwrapped_amount;
-
-                    let Some(redemption_wallet) =
-                        Tokenizer::redemption_wallet(services.tokenizer.as_ref())
-                    else {
-                        warn!(target: "rebalance", %symbol, "Redemption wallet not configured");
-                        return Ok(vec![TransferFailed {
-                            tx_hash: None,
-                            reason: None,
-                            failed_at: Utc::now(),
-                        }]);
-                    };
-
-                    // Wait for the RPC node to catch up to the block where the
-                    // unwrap tx confirmed before sending the transfer. Without
-                    // this, a load-balanced backend that hasn't indexed the
-                    // unwrap block yet sees the wallet balance as zero and the
-                    // send_for_redemption call reverts with
-                    // ERC20InsufficientBalance. The wait runs on the tokenizer's
-                    // provider -- the same one that performs the transfer -- so
-                    // a caught-up wrapper provider can't mask a lagging
-                    // tokenizer provider. `unwrap_block` is None for aggregates
-                    // persisted before this field was added; in that case the
-                    // wait is skipped for backward-compatibility.
-                    if let Some(block) = unwrap_block {
-                        services
-                            .tokenizer
-                            .wait_for_block(*block)
-                            .await
-                            .map_err(|error| node_sync_failed_from_evm(*block, &error))?;
-                    }
-
-                    info!(target: "rebalance", %token, %amount, "Sending unwrapped tokens for redemption");
-
-                    match Tokenizer::send_for_redemption(services.tokenizer.as_ref(), token, amount)
-                        .await
-                    {
-                        Ok(redemption_tx) => Ok(vec![TokensSent {
-                            redemption_wallet,
-                            redemption_tx,
-                            sent_at: Utc::now(),
-                        }]),
-                        Err(error) => {
-                            warn!(target: "rebalance", %error, %token, %amount, "Send for redemption failed");
-                            Ok(vec![TransferFailed {
-                                tx_hash: None,
-                                reason: None,
-                                failed_at: Utc::now(),
-                            }])
-                        }
-                    }
-                }
-                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
-                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
-                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
-                _ => Err(EquityRedemptionError::TokensNotUnwrapped),
-            },
+            SendTokens => self.transition_send_tokens(services, None).await,
+            #[cfg(any(test, feature = "test-support"))]
+            SendTokensAt { sent_at } => self.transition_send_tokens(services, Some(sent_at)).await,
 
             Detect {
                 tokenization_request_id,
-            } => match self {
-                Self::TokensSent { .. } => Ok(vec![Detected {
-                    tokenization_request_id,
-                    detected_at: Utc::now(),
-                }]),
-                Self::VaultWithdrawPending { .. }
-                | Self::VaultWithdrawSubmitted { .. }
-                | Self::WithdrawnFromRaindex { .. }
-                | Self::UnwrapPending { .. }
-                | Self::UnwrapSubmitted { .. }
-                | Self::TokensUnwrapped { .. }
-                | Self::SendPending { .. } => Err(EquityRedemptionError::TokensNotSent),
-                Self::Pending { .. } => Err(EquityRedemptionError::AlreadyDetected),
-                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
-                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
-                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
-            },
+            } => self.transition_detect(tokenization_request_id, Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            DetectAt {
+                tokenization_request_id,
+                detected_at,
+            } => self.transition_detect(tokenization_request_id, detected_at),
 
             FailDetection { failure } => match self {
                 Self::TokensSent { symbol, .. } => {
@@ -2113,22 +1957,9 @@ impl EventSourced for EquityRedemption {
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
             },
 
-            Complete => match self {
-                Self::VaultWithdrawPending { .. }
-                | Self::VaultWithdrawSubmitted { .. }
-                | Self::WithdrawnFromRaindex { .. }
-                | Self::UnwrapPending { .. }
-                | Self::UnwrapSubmitted { .. }
-                | Self::TokensUnwrapped { .. }
-                | Self::SendPending { .. }
-                | Self::TokensSent { .. } => Err(EquityRedemptionError::NotPending),
-                Self::Pending { .. } => Ok(vec![Completed {
-                    completed_at: Utc::now(),
-                }]),
-                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
-                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
-                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
-            },
+            Complete => self.transition_complete(Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            CompleteAt { completed_at } => self.transition_complete(completed_at),
 
             RejectRedemption { reason } => match self {
                 Self::VaultWithdrawPending { .. }
@@ -2214,6 +2045,398 @@ impl EventSourced for EquityRedemption {
                 Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::NotFailed),
             },
+        }
+    }
+}
+
+impl EquityRedemption {
+    /// Shared body for `SubmitWithdraw`/`SubmitWithdrawAt`.
+    async fn transition_submit_withdraw(
+        &self,
+        services: &EquityTransferServices,
+        override_at: Option<DateTime<Utc>>,
+    ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
+        use EquityRedemptionEvent::*;
+
+        match self {
+            Self::VaultWithdrawPending {
+                symbol,
+                quantity,
+                token,
+                wrapped_amount,
+                ..
+            } => {
+                let vault_id = match services.vault_lookup.vault_id_for_token(*token).await {
+                    Ok(id) => id,
+                    Err(error) => {
+                        warn!(target: "rebalance", %error, %token, "Vault lookup failed");
+                        return Err(EquityRedemptionError::RaindexVaultNotFound(*token));
+                    }
+                };
+
+                info!(target: "rebalance", ?vault_id, %token, %wrapped_amount, "Submitting Raindex vault withdrawal");
+
+                let tx_hash = match services
+                    .raindex
+                    .submit_withdraw(*token, vault_id, *wrapped_amount, TOKENIZED_EQUITY_DECIMALS)
+                    .await
+                {
+                    Ok(tx) => tx,
+                    Err(error) => {
+                        warn!(target: "rebalance", %error, %token, %wrapped_amount, "Raindex vault withdrawal submission failed");
+                        return Err(EquityRedemptionError::RaindexWithdrawFailed {
+                            token: *token,
+                            amount: *wrapped_amount,
+                            error_message: error.to_string(),
+                        });
+                    }
+                };
+
+                Ok(vec![VaultWithdrawSubmitted {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    token: *token,
+                    wrapped_amount: *wrapped_amount,
+                    tx_hash,
+                    submitted_at: override_at.unwrap_or_else(Utc::now),
+                }])
+            }
+            Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+            Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
+            _ => Err(EquityRedemptionError::AlreadyStarted),
+        }
+    }
+
+    /// Shared body for `ConfirmWithdraw`/`ConfirmWithdrawAt`.
+    async fn transition_confirm_withdraw(
+        &self,
+        services: &EquityTransferServices,
+        override_at: Option<DateTime<Utc>>,
+    ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
+        use EquityRedemptionEvent::*;
+
+        match self {
+            Self::VaultWithdrawSubmitted {
+                symbol,
+                quantity,
+                token,
+                wrapped_amount,
+                tx_hash,
+                ..
+            } => {
+                let receipt = services
+                    .raindex
+                    .confirm_tx_receipt(*tx_hash)
+                    .await
+                    .map_err(|error| EquityRedemptionError::RaindexWithdrawFailed {
+                        token: *token,
+                        amount: *wrapped_amount,
+                        error_message: error.to_string(),
+                    })?;
+                let raindex_withdraw_block = receipt
+                    .block_number
+                    .ok_or(EquityRedemptionError::MissingWithdrawBlock { tx_hash: *tx_hash })?;
+                let recipient = services.wrapper.owner();
+                let actual_wrapped_amount =
+                    actual_withdrawn_amount_from_receipt(&receipt, *token, recipient)?;
+                Ok(vec![WithdrawnFromRaindex {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    token: *token,
+                    wrapped_amount: *wrapped_amount,
+                    actual_wrapped_amount: Some(actual_wrapped_amount),
+                    raindex_withdraw_tx: *tx_hash,
+                    raindex_withdraw_block: Some(raindex_withdraw_block),
+                    withdrawn_at: override_at.unwrap_or_else(Utc::now),
+                }])
+            }
+            Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+            Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
+            _ => Err(EquityRedemptionError::AlreadyStarted),
+        }
+    }
+
+    /// Shared body for `UnwrapTokens`/`UnwrapTokensAt`.
+    fn transition_unwrap_tokens(
+        &self,
+        pending_at: DateTime<Utc>,
+    ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
+        use EquityRedemptionEvent::*;
+
+        match self {
+            Self::WithdrawnFromRaindex { .. } => Ok(vec![UnwrapPending { pending_at }]),
+            Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+            Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
+            _ => Err(EquityRedemptionError::CannotUnwrapAlreadyStarted),
+        }
+    }
+
+    /// Shared body for `SubmitUnwrap`/`SubmitUnwrapAt`.
+    async fn transition_submit_unwrap(
+        &self,
+        services: &EquityTransferServices,
+        override_at: Option<DateTime<Utc>>,
+    ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
+        use EquityRedemptionEvent::*;
+
+        match self {
+            Self::UnwrapPending {
+                token,
+                wrapped_amount,
+                raindex_withdraw_block,
+                ..
+            } => {
+                // Wait for the RPC node to catch up to the block where the
+                // Raindex withdrawal tx confirmed before submitting the unwrap.
+                // Without this, a load-balanced backend that hasn't indexed
+                // the withdrawal may simulate the unwrap against a stale
+                // wrapped-token balance. `raindex_withdraw_block` is None for
+                // pre-fix aggregates; skip the wait for backward-compatibility.
+                if let Some(block) = raindex_withdraw_block {
+                    services
+                        .wrapper
+                        .wait_for_block(*block)
+                        .await
+                        .map_err(|error| node_sync_failed(*block, &error))?;
+                }
+                let owner = services.wrapper.owner();
+                let unwrap_tx_hash = services
+                    .wrapper
+                    .submit_unwrap(*token, *wrapped_amount, owner, owner)
+                    .await
+                    .inspect_err(|error| {
+                        warn!(target: "rebalance", %error, %token, "Token unwrap submission failed");
+                    })
+                    .map_err(|error| EquityRedemptionError::UnwrapFailed {
+                        token: *token,
+                        wrapped_amount: *wrapped_amount,
+                        error_message: error.to_string(),
+                    })?;
+
+                Ok(vec![UnwrapSubmitted {
+                    unwrap_tx_hash,
+                    submitted_at: override_at.unwrap_or_else(Utc::now),
+                }])
+            }
+            Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+            Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
+            _ => Err(EquityRedemptionError::CannotUnwrapAlreadyStarted),
+        }
+    }
+
+    /// Shared body for `ConfirmUnwrap`/`ConfirmUnwrapAt`.
+    async fn transition_confirm_unwrap(
+        &self,
+        services: &EquityTransferServices,
+        override_at: Option<DateTime<Utc>>,
+    ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
+        use EquityRedemptionEvent::*;
+
+        match self {
+            Self::UnwrapSubmitted {
+                symbol,
+                token,
+                wrapped_amount,
+                unwrap_tx_hash,
+                ..
+            } => {
+                let underlying_token = services
+                    .wrapper
+                    .lookup_underlying(symbol)
+                    .inspect_err(|error| {
+                        warn!(target: "rebalance", %error, %symbol, "Underlying token lookup failed");
+                    })
+                    .map_err(|error| EquityRedemptionError::UnderlyingLookupFailed {
+                        symbol: symbol.clone(),
+                        error_message: error.to_string(),
+                    })?;
+
+                let unwrap_confirmation = services
+                    .wrapper
+                    .confirm_unwrap(*token, *unwrap_tx_hash)
+                    .await
+                    .inspect_err(|error| {
+                        warn!(target: "rebalance", %error, %token, "Token unwrap confirmation failed");
+                    })
+                    .map_err(|error| EquityRedemptionError::UnwrapFailed {
+                        token: *token,
+                        wrapped_amount: *wrapped_amount,
+                        error_message: error.to_string(),
+                    })?;
+                let unwrapped_amount = unwrap_confirmation.assets;
+                let unwrap_block = unwrap_confirmation.block;
+                let quantity =
+                    Float::from_fixed_decimal(unwrapped_amount, TOKENIZED_EQUITY_DECIMALS)
+                        .map_err(|error| {
+                            EquityRedemptionError::RaindexWithdrawQuantityConversionFailed {
+                                tx_hash: *unwrap_tx_hash,
+                                amount: unwrapped_amount,
+                                error_message: error.to_string(),
+                            }
+                        })?;
+
+                Ok(vec![TokensUnwrapped {
+                    quantity: Some(quantity),
+                    underlying_token,
+                    unwrap_tx_hash: *unwrap_tx_hash,
+                    unwrapped_amount,
+                    unwrap_block: Some(unwrap_block),
+                    unwrapped_at: override_at.unwrap_or_else(Utc::now),
+                }])
+            }
+            Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+            Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
+            _ => Err(EquityRedemptionError::CannotUnwrapAlreadyStarted),
+        }
+    }
+
+    /// Shared body for `PrepareSend`/`PrepareSendAt`.
+    fn transition_prepare_send(
+        &self,
+        pending_at: DateTime<Utc>,
+    ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
+        use EquityRedemptionEvent::*;
+
+        match self {
+            Self::TokensUnwrapped { .. } => Ok(vec![SendPending { pending_at }]),
+            Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+            Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
+            _ => Err(EquityRedemptionError::TokensNotUnwrapped),
+        }
+    }
+
+    /// Shared body for `SendTokens`/`SendTokensAt`: only `sent_at` (the
+    /// success path's timestamp) is parameterized -- the `TransferFailed`
+    /// failure path keeps `Utc::now()` since fixture seeding only ever
+    /// drives the happy path.
+    async fn transition_send_tokens(
+        &self,
+        services: &EquityTransferServices,
+        override_at: Option<DateTime<Utc>>,
+    ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
+        use EquityRedemptionEvent::*;
+
+        match self {
+            Self::SendPending {
+                symbol,
+                underlying_token,
+                unwrapped_amount,
+                unwrap_block,
+                ..
+            } => {
+                let token = *underlying_token;
+                let amount = *unwrapped_amount;
+
+                let Some(redemption_wallet) =
+                    Tokenizer::redemption_wallet(services.tokenizer.as_ref())
+                else {
+                    warn!(target: "rebalance", %symbol, "Redemption wallet not configured");
+                    return Ok(vec![TransferFailed {
+                        tx_hash: None,
+                        reason: None,
+                        failed_at: Utc::now(),
+                    }]);
+                };
+
+                // Wait for the RPC node to catch up to the block where the
+                // unwrap tx confirmed before sending the transfer. Without
+                // this, a load-balanced backend that hasn't indexed the
+                // unwrap block yet sees the wallet balance as zero and the
+                // send_for_redemption call reverts with
+                // ERC20InsufficientBalance. The wait runs on the tokenizer's
+                // provider -- the same one that performs the transfer -- so
+                // a caught-up wrapper provider can't mask a lagging
+                // tokenizer provider. `unwrap_block` is None for aggregates
+                // persisted before this field was added; in that case the
+                // wait is skipped for backward-compatibility.
+                if let Some(block) = unwrap_block {
+                    services
+                        .tokenizer
+                        .wait_for_block(*block)
+                        .await
+                        .map_err(|error| node_sync_failed_from_evm(*block, &error))?;
+                }
+
+                info!(target: "rebalance", %token, %amount, "Sending unwrapped tokens for redemption");
+
+                match Tokenizer::send_for_redemption(services.tokenizer.as_ref(), token, amount)
+                    .await
+                {
+                    Ok(redemption_tx) => Ok(vec![TokensSent {
+                        redemption_wallet,
+                        redemption_tx,
+                        sent_at: override_at.unwrap_or_else(Utc::now),
+                    }]),
+                    Err(error) => {
+                        warn!(target: "rebalance", %error, %token, %amount, "Send for redemption failed");
+                        Ok(vec![TransferFailed {
+                            tx_hash: None,
+                            reason: None,
+                            failed_at: Utc::now(),
+                        }])
+                    }
+                }
+            }
+            Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+            Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
+            _ => Err(EquityRedemptionError::TokensNotUnwrapped),
+        }
+    }
+
+    /// Shared body for `Detect`/`DetectAt`.
+    fn transition_detect(
+        &self,
+        tokenization_request_id: TokenizationRequestId,
+        detected_at: DateTime<Utc>,
+    ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
+        use EquityRedemptionEvent::*;
+
+        match self {
+            Self::TokensSent { .. } => Ok(vec![Detected {
+                tokenization_request_id,
+                detected_at,
+            }]),
+            Self::VaultWithdrawPending { .. }
+            | Self::VaultWithdrawSubmitted { .. }
+            | Self::WithdrawnFromRaindex { .. }
+            | Self::UnwrapPending { .. }
+            | Self::UnwrapSubmitted { .. }
+            | Self::TokensUnwrapped { .. }
+            | Self::SendPending { .. } => Err(EquityRedemptionError::TokensNotSent),
+            Self::Pending { .. } => Err(EquityRedemptionError::AlreadyDetected),
+            Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
+            Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+        }
+    }
+
+    /// Shared body for `Complete`/`CompleteAt`.
+    fn transition_complete(
+        &self,
+        completed_at: DateTime<Utc>,
+    ) -> Result<Vec<EquityRedemptionEvent>, EquityRedemptionError> {
+        use EquityRedemptionEvent::*;
+
+        match self {
+            Self::VaultWithdrawPending { .. }
+            | Self::VaultWithdrawSubmitted { .. }
+            | Self::WithdrawnFromRaindex { .. }
+            | Self::UnwrapPending { .. }
+            | Self::UnwrapSubmitted { .. }
+            | Self::TokensUnwrapped { .. }
+            | Self::SendPending { .. }
+            | Self::TokensSent { .. } => Err(EquityRedemptionError::NotPending),
+            Self::Pending { .. } => Ok(vec![Completed { completed_at }]),
+            Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+            Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
         }
     }
 }
@@ -2670,6 +2893,16 @@ mod tests {
         }
     }
 
+    fn vault_withdraw_pending_event() -> EquityRedemptionEvent {
+        EquityRedemptionEvent::VaultWithdrawPending {
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: float!(50.25),
+            token: Address::random(),
+            wrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
+            pending_at: Utc::now(),
+        }
+    }
+
     fn withdrawn_from_raindex_event() -> EquityRedemptionEvent {
         EquityRedemptionEvent::WithdrawnFromRaindex {
             symbol: Symbol::new("AAPL").unwrap(),
@@ -2842,6 +3075,295 @@ mod tests {
 
         let entity = store.load(&id).await.unwrap().unwrap();
         assert!(matches!(entity, EquityRedemption::Completed { .. }));
+    }
+
+    /// Covers the fixture-only `*At` siblings of the async transitions that
+    /// take an explicit timestamp instead of `Utc::now()`: each must thread
+    /// the caller-supplied timestamp through to the emitted event's field
+    /// rather than silently falling back to the current time.
+    #[tokio::test]
+    async fn submit_withdraw_at_uses_supplied_timestamp() {
+        let submitted_at = Utc::now() - chrono::Duration::hours(3);
+
+        let events = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![vault_withdraw_pending_event()])
+            .when(EquityRedemptionCommand::SubmitWithdrawAt { submitted_at })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let EquityRedemptionEvent::VaultWithdrawSubmitted {
+            submitted_at: event_submitted_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected VaultWithdrawSubmitted, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_submitted_at, submitted_at);
+    }
+
+    #[tokio::test]
+    async fn confirm_withdraw_at_uses_supplied_timestamp() {
+        let withdrawn_at = Utc::now() - chrono::Duration::hours(2);
+
+        let store = TestStore::<EquityRedemption>::new(mock_services());
+        let id = redemption_aggregate_id("confirm-withdraw-at");
+
+        store
+            .send(
+                &id,
+                EquityRedemptionCommand::Redeem {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(50.25),
+                    token: Address::random(),
+                    amount: U256::from(50_250_000_000_000_000_000_u128),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmWithdrawAt { withdrawn_at },
+            )
+            .await
+            .unwrap();
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        let EquityRedemption::WithdrawnFromRaindex {
+            withdrawn_at: stored_withdrawn_at,
+            ..
+        } = entity
+        else {
+            panic!("Expected WithdrawnFromRaindex state, got: {entity:?}");
+        };
+        assert_eq!(stored_withdrawn_at, withdrawn_at);
+    }
+
+    #[tokio::test]
+    async fn submit_unwrap_at_uses_supplied_timestamp() {
+        let submitted_at = Utc::now() - chrono::Duration::hours(1);
+
+        let events = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![withdrawn_from_raindex_event(), unwrap_pending_event()])
+            .when(EquityRedemptionCommand::SubmitUnwrapAt { submitted_at })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let EquityRedemptionEvent::UnwrapSubmitted {
+            submitted_at: event_submitted_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected UnwrapSubmitted, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_submitted_at, submitted_at);
+    }
+
+    #[tokio::test]
+    async fn confirm_unwrap_at_uses_supplied_timestamp() {
+        let unwrapped_at = Utc::now() - chrono::Duration::minutes(30);
+
+        let store = TestStore::<EquityRedemption>::new(mock_services());
+        let id = redemption_aggregate_id("confirm-unwrap-at");
+
+        store
+            .send(
+                &id,
+                EquityRedemptionCommand::Redeem {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(50.25),
+                    token: Address::random(),
+                    amount: U256::from(50_250_000_000_000_000_000_u128),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .await
+            .unwrap();
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .await
+            .unwrap();
+        store
+            .send(&id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+        store
+            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmUnwrapAt { unwrapped_at },
+            )
+            .await
+            .unwrap();
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        let EquityRedemption::TokensUnwrapped {
+            unwrapped_at: stored_unwrapped_at,
+            ..
+        } = entity
+        else {
+            panic!("Expected TokensUnwrapped state, got: {entity:?}");
+        };
+        assert_eq!(stored_unwrapped_at, unwrapped_at);
+    }
+
+    #[tokio::test]
+    async fn send_tokens_at_uses_supplied_timestamp() {
+        let sent_at = Utc::now() - chrono::Duration::minutes(15);
+
+        let events = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![
+                withdrawn_from_raindex_event(),
+                tokens_unwrapped_event(),
+                EquityRedemptionEvent::SendPending {
+                    pending_at: Utc::now(),
+                },
+            ])
+            .when(EquityRedemptionCommand::SendTokensAt { sent_at })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let EquityRedemptionEvent::TokensSent {
+            sent_at: event_sent_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected TokensSent, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_sent_at, sent_at);
+    }
+
+    #[tokio::test]
+    async fn redeem_at_uses_supplied_timestamp() {
+        let pending_at = Utc::now() - chrono::Duration::hours(4);
+
+        let events = TestHarness::<EquityRedemption>::with(mock_services())
+            .given_no_previous_events()
+            .when(EquityRedemptionCommand::RedeemAt {
+                symbol: Symbol::new("AAPL").unwrap(),
+                quantity: float!(50.25),
+                token: Address::random(),
+                amount: U256::from(50_250_000_000_000_000_000_u128),
+                pending_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let EquityRedemptionEvent::VaultWithdrawPending {
+            pending_at: event_pending_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected VaultWithdrawPending, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_pending_at, pending_at);
+    }
+
+    #[tokio::test]
+    async fn unwrap_tokens_at_uses_supplied_timestamp() {
+        let pending_at = Utc::now() - chrono::Duration::hours(3);
+
+        let events = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![withdrawn_from_raindex_event()])
+            .when(EquityRedemptionCommand::UnwrapTokensAt { pending_at })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let EquityRedemptionEvent::UnwrapPending {
+            pending_at: event_pending_at,
+        } = &events[0]
+        else {
+            panic!("Expected UnwrapPending, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_pending_at, pending_at);
+    }
+
+    #[tokio::test]
+    async fn prepare_send_at_uses_supplied_timestamp() {
+        let pending_at = Utc::now() - chrono::Duration::hours(2);
+
+        let events = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![
+                withdrawn_from_raindex_event(),
+                tokens_unwrapped_event(),
+            ])
+            .when(EquityRedemptionCommand::PrepareSendAt { pending_at })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let EquityRedemptionEvent::SendPending {
+            pending_at: event_pending_at,
+        } = &events[0]
+        else {
+            panic!("Expected SendPending, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_pending_at, pending_at);
+    }
+
+    #[tokio::test]
+    async fn detect_at_uses_supplied_timestamp() {
+        let detected_at = Utc::now() - chrono::Duration::hours(1);
+
+        let events = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
+            .when(EquityRedemptionCommand::DetectAt {
+                tokenization_request_id: tokenization_request_id("REQ789"),
+                detected_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let EquityRedemptionEvent::Detected {
+            detected_at: event_detected_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected Detected, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_detected_at, detected_at);
+    }
+
+    #[tokio::test]
+    async fn complete_at_uses_supplied_timestamp() {
+        let completed_at = Utc::now() - chrono::Duration::minutes(45);
+
+        let events = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![
+                withdrawn_from_raindex_event(),
+                tokens_sent_event(),
+                detected_event(),
+            ])
+            .when(EquityRedemptionCommand::CompleteAt { completed_at })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let EquityRedemptionEvent::Completed {
+            completed_at: event_completed_at,
+        } = &events[0]
+        else {
+            panic!("Expected Completed, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_completed_at, completed_at);
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,13 @@ pub fn check_positions_job_type() -> &'static str {
 #[cfg(any(test, feature = "test-support"))]
 pub use conductor::job::{FailureInjector, JobKind};
 #[cfg(any(test, feature = "test-support"))]
+pub use performance::seed_simulated_hedge_latency_history;
+#[cfg(any(test, feature = "test-support"))]
+pub use performance::simulated_transfers::{
+    seed_simulated_equity_redemption_history, seed_simulated_mint_history,
+    seed_simulated_usdc_rebalance_history,
+};
+#[cfg(any(test, feature = "test-support"))]
 pub use st0x_config::ExecutionThreshold;
 #[cfg(any(test, feature = "test-support"))]
 pub use st0x_config::TradingMode;

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -364,6 +364,7 @@ fn placed_event(
     executor: SupportedExecutor,
     client_order_id: &ClientOrderId,
     kind: &CounterTradeOrderKind,
+    placed_at: DateTime<Utc>,
 ) -> OffchainOrderEvent {
     let requested_market_session = kind.market_session();
     let limit_price = match kind {
@@ -376,7 +377,7 @@ fn placed_event(
         shares,
         direction,
         executor,
-        placed_at: Utc::now(),
+        placed_at,
         is_extended_hours: requested_market_session == MarketSession::Extended,
         limit_price,
         client_order_id: Some(client_order_id.clone()),
@@ -784,6 +785,26 @@ impl EventSourced for OffchainOrder {
                 executor,
                 &client_order_id,
                 &kind,
+                Utc::now(),
+            )]),
+
+            #[cfg(any(test, feature = "test-support"))]
+            PlaceAt {
+                symbol,
+                shares,
+                direction,
+                executor,
+                client_order_id,
+                kind,
+                placed_at,
+            } => Ok(vec![placed_event(
+                symbol,
+                shares,
+                direction,
+                executor,
+                &client_order_id,
+                &kind,
+                placed_at,
             )]),
 
             _ => Err(OffchainOrderError::NotPlaced),
@@ -810,6 +831,17 @@ impl EventSourced for OffchainOrder {
                 shares: _,
                 client_order_id: _,
                 kind: _,
+            } => validate_place_replay(self, &symbol, direction, executor),
+
+            #[cfg(any(test, feature = "test-support"))]
+            OffchainOrderCommand::PlaceAt {
+                symbol,
+                direction,
+                executor,
+                shares: _,
+                client_order_id: _,
+                kind: _,
+                placed_at: _,
             } => validate_place_replay(self, &symbol, direction, executor),
 
             OffchainOrderCommand::CancelOrder { reason } => {
@@ -2230,6 +2262,19 @@ pub enum OffchainOrderCommand {
         client_order_id: ClientOrderId,
         kind: CounterTradeOrderKind,
     },
+    /// Test/fixture-only: identical to `Place` but takes `placed_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    PlaceAt {
+        symbol: Symbol,
+        shares: Positive<FractionalShares>,
+        direction: Direction,
+        executor: SupportedExecutor,
+        client_order_id: ClientOrderId,
+        kind: CounterTradeOrderKind,
+        placed_at: DateTime<Utc>,
+    },
     /// Request broker cancellation for a submitted order and persist the
     /// in-flight cancellation state. The order becomes terminal only after the
     /// broker later reports `Cancelled`.
@@ -2401,6 +2446,13 @@ impl FromStr for OffchainOrderId {
 impl OffchainOrderId {
     pub(crate) fn new() -> Self {
         Self(Uuid::new_v4())
+    }
+
+    /// Wraps a caller-supplied UUID, for deterministic identifiers (e.g.
+    /// fixture seeding) where [`Self::new`]'s randomness isn't wanted.
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn from_uuid(id: Uuid) -> Self {
+        Self(id)
     }
 
     /// Exposes the wrapped UUID so callers can derive other identifiers
@@ -3306,6 +3358,42 @@ mod tests {
             store.load(&id).await.unwrap().unwrap(),
             "re-placing a terminal order stays a no-op"
         );
+    }
+
+    /// Covers the fixture-only `PlaceAt` sibling of `Place`: it must thread
+    /// the caller-supplied `placed_at` through to the emitted event's field
+    /// rather than silently falling back to `Utc::now()`.
+    #[tokio::test]
+    async fn place_at_uses_supplied_timestamp() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let id = OffchainOrderId::new();
+        let placed_at = Utc::now() - chrono::Duration::hours(2);
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::PlaceAt {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
+                    direction: Direction::Buy,
+                    executor: SupportedExecutor::DryRun,
+                    client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                    kind: CounterTradeOrderKind::Market,
+                    placed_at,
+                },
+            )
+            .await
+            .unwrap();
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        let OffchainOrder::Pending {
+            placed_at: stored_placed_at,
+            ..
+        } = entity
+        else {
+            panic!("Expected Pending state, got: {entity:?}");
+        };
+        assert_eq!(stored_placed_at, placed_at);
     }
 
     #[tokio::test]

--- a/src/onchain_trade.rs
+++ b/src/onchain_trade.rs
@@ -178,6 +178,25 @@ impl EventSourced for OnChainTrade {
                 filled_at: Utc::now(),
             }]),
 
+            #[cfg(any(test, feature = "test-support"))]
+            WitnessAt {
+                symbol,
+                amount,
+                direction,
+                price_usdc,
+                block_number,
+                block_timestamp,
+                filled_at,
+            } => Ok(vec![Filled {
+                symbol,
+                amount,
+                direction,
+                price_usdc,
+                block_number,
+                block_timestamp,
+                filled_at,
+            }]),
+
             Enrich { .. } | Acknowledge => Err(OnChainTradeError::NotFilled),
         }
     }
@@ -191,6 +210,9 @@ impl EventSourced for OnChainTrade {
         use OnChainTradeEvent::*;
         match command {
             Witness { .. } => Err(OnChainTradeError::AlreadyFilled),
+
+            #[cfg(any(test, feature = "test-support"))]
+            WitnessAt { .. } => Err(OnChainTradeError::AlreadyFilled),
 
             Enrich {
                 gas_used,
@@ -288,6 +310,27 @@ pub(crate) enum OnChainTradeCommand {
         price_usdc: Float,
         block_number: u64,
         block_timestamp: DateTime<Utc>,
+    },
+    /// Test/fixture-only: identical to `Witness` but takes `filled_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    WitnessAt {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        amount: Float,
+        direction: Direction,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        price_usdc: Float,
+        block_number: u64,
+        block_timestamp: DateTime<Utc>,
+        filled_at: DateTime<Utc>,
     },
     Enrich {
         gas_used: u64,
@@ -448,6 +491,40 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         assert!(matches!(events[0], OnChainTradeEvent::Filled { .. }));
+    }
+
+    /// Covers the fixture-only `WitnessAt` sibling of `Witness`: it must
+    /// thread the caller-supplied `filled_at` through to the emitted event's
+    /// field rather than silently falling back to `Utc::now()`.
+    #[tokio::test]
+    async fn witness_at_uses_supplied_timestamp() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let block_timestamp = Utc::now();
+        let filled_at = block_timestamp - chrono::Duration::hours(4);
+
+        let events = TestHarness::<OnChainTrade>::with(())
+            .given_no_previous_events()
+            .when(OnChainTradeCommand::WitnessAt {
+                symbol: symbol.clone(),
+                amount: float!(10.5),
+                direction: Direction::Buy,
+                price_usdc: float!(150.25),
+                block_number: 12345,
+                block_timestamp,
+                filled_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let OnChainTradeEvent::Filled {
+            filled_at: event_filled_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected Filled, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_filled_at, filled_at);
     }
 
     #[tokio::test]

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -29,17 +29,53 @@
 //! events and a read side ([`report`]) that loads and assembles the report. The
 //! attribution recompute they share lives here as [`uncovered_fills`].
 
+#[cfg(any(test, feature = "test-support"))]
+use alloy::primitives::TxHash;
+#[cfg(any(test, feature = "test-support"))]
+use async_trait::async_trait;
+#[cfg(any(test, feature = "test-support"))]
+use chrono::Duration;
 use chrono::{DateTime, Utc};
+#[cfg(any(test, feature = "test-support"))]
+use rain_math_float::Float;
 use sqlx::SqlitePool;
+#[cfg(any(test, feature = "test-support"))]
+use std::sync::Arc;
 use tracing::warn;
 
+#[cfg(any(test, feature = "test-support"))]
+use st0x_config::ExecutionThreshold;
+#[cfg(any(test, feature = "test-support"))]
+use st0x_event_sorcery::StoreBuilder;
 use st0x_execution::Symbol;
+#[cfg(any(test, feature = "test-support"))]
+use st0x_execution::{
+    CancellationOutcome, ClientOrderId, Direction, ExecutorOrderId, FractionalShares, LimitOrder,
+    MarketOrder, MarketSession, Positive, SupportedExecutor,
+};
+#[cfg(any(test, feature = "test-support"))]
+use st0x_finance::Usd;
+#[cfg(any(test, feature = "test-support"))]
+use st0x_float_macro::float;
 
+#[cfg(any(test, feature = "test-support"))]
+use crate::offchain::order::{
+    CounterTradeOrderKind, OffchainOrder, OffchainOrderCommand, OffchainOrderId,
+    OrderPlacementResult, OrderPlacer,
+};
+#[cfg(any(test, feature = "test-support"))]
+use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
+#[cfg(any(test, feature = "test-support"))]
+use crate::position::{Position, PositionCommand, TradeId};
+
+pub(crate) mod equity_timing;
 pub(crate) mod infra;
 pub(crate) mod projection;
 pub(crate) mod rebalance;
 pub(crate) mod reliability;
 pub(crate) mod report;
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) mod simulated_transfers;
 
 // Re-exported for external callers (`crate::api`, `crate::conductor`) so the
 // split is transparent at the `crate::performance::NAME` path.
@@ -47,6 +83,263 @@ pub(crate) use projection::HedgeLatencyProjection;
 pub(crate) use report::{
     PerformanceError, ReportRange, hedge_latency_report, load_hedge_performance,
 };
+
+/// Minimal [`OrderPlacer`] for [`seed_simulated_hedge_latency_history`]'s
+/// temporary `Store<OffchainOrder>`. The fixture drives the aggregate
+/// directly via `Store::send` (never through
+/// `crate::offchain::order::place_offchain_order_at_broker`), so none of
+/// these methods are ever actually invoked -- they exist only to satisfy
+/// `OffchainOrder::Services`.
+#[cfg(any(test, feature = "test-support"))]
+struct FixtureOrderPlacer;
+
+#[cfg(any(test, feature = "test-support"))]
+#[async_trait]
+impl OrderPlacer for FixtureOrderPlacer {
+    async fn place_market_order(
+        &self,
+        _order: MarketOrder,
+    ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
+        Err("FixtureOrderPlacer never places live orders".into())
+    }
+
+    async fn place_limit_order(
+        &self,
+        _order: LimitOrder,
+    ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>> {
+        Err("FixtureOrderPlacer never places live orders".into())
+    }
+
+    async fn cancel_order(
+        &self,
+        _executor_order_id: &ExecutorOrderId,
+    ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+        Err("FixtureOrderPlacer never cancels orders".into())
+    }
+}
+
+/// Seeds deterministic hedge history for local dashboard simulation.
+///
+/// Drives real `Position`/`OffchainOrder`/`OnChainTrade` commands through
+/// temporary CQRS stores -- the same reactor (`HedgeLatencyProjection`) that
+/// builds the Performance tab's read model in production builds it here, and
+/// the raw `events` table it persists to also feeds Trade History
+/// (`dashboard/trade_loader.rs`) and PnL (`dashboard/src/lib/pnl/sql-source.ts`)
+/// directly, so all three tabs populate from one seeding pass.
+///
+/// Uses dedicated fixture symbols (`AAPL.SIM`/`TSLA.SIM`), never the live
+/// simulation's real `AAPL`/`TSLA`: replaying fabricated fills into the same
+/// `Position` aggregate the live simulation trades against would corrupt its
+/// net position and pending-order state.
+///
+/// The temporary stores are wired ONLY with `HedgeLatencyProjection` --
+/// explicitly not `RebalancingService`/`Broadcaster`/`LifecycleFailureProjection`
+/// -- so seeding never triggers real mint/redeem/USDC side effects. Callers
+/// MUST run this before the bot's own `Store<Position>` (which IS wired with
+/// `RebalancingService`) starts, so the two never coexist against the same
+/// symbols.
+///
+/// The dashboard's default "1W" view shows the most recent week of this
+/// seed at daily granularity immediately; the "2W" preset shows the full 14
+/// days (also at daily granularity -- `ReportRange::bucket_width` only steps
+/// to weekly past 31 days, and "2W" stays under that). Presets past "2W"
+/// (1M+) switch to coarser buckets whose newest bucket can be wide enough to
+/// catch both the freshest synthetic day and live samples, re-mixing them
+/// the same way the buffer below prevents for "1W"/"2W" -- an accepted
+/// trade-off, not an oversight: sizing the buffer for the widest preset
+/// would push all synthetic data outside the "1W" window instead, defeating
+/// this fixture's purpose (trends visible immediately in the default view).
+///
+/// Single-run-only: unlike the old raw-`INSERT OR IGNORE` version, real
+/// aggregate commands are not transparently re-run-safe -- a second call
+/// against the same pool hits `PositionError::DuplicateTrade` /
+/// `OnChainTradeError::AlreadyFilled` and aborts. The only caller
+/// (`simulate()` in `tests/e2e/full_system.rs`) always seeds a freshly
+/// created database file, so this is never exercised in practice.
+#[cfg(any(test, feature = "test-support"))]
+pub async fn seed_simulated_hedge_latency_history(
+    pool: &SqlitePool,
+    now: DateTime<Utc>,
+    days: u32,
+) -> anyhow::Result<()> {
+    const SAMPLES_PER_DAY: u32 = 12;
+
+    sqlx::migrate!().set_ignore_missing(true).run(pool).await?;
+
+    let (position, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
+        .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
+        .build(())
+        .await?;
+
+    let order_placer: Arc<dyn OrderPlacer> = Arc::new(FixtureOrderPlacer);
+    let (offchain_order, _offchain_order_projection) =
+        StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
+            .build(order_placer)
+            .await?;
+
+    let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+        .build(())
+        .await?;
+
+    // The dashboard's rolling window queries with `to = now()`, which keeps
+    // advancing while the simulation runs. Without this buffer the newest
+    // synthetic day would land inside the live tail bucket (`[to-24h, to]`)
+    // alongside real simulated trades, whose near-instant hedge-cycle
+    // latency drags that bucket's percentiles toward zero even though every
+    // other bucket holds only the deliberately slow synthetic samples.
+    let range_start = now - Duration::days(i64::from(days)) - Duration::days(1);
+    let aapl = Symbol::new("AAPL.SIM")?;
+    let tsla = Symbol::new("TSLA.SIM")?;
+    let threshold = ExecutionThreshold::whole_share();
+    let amount = Positive::new(FractionalShares::new(float!(1)))?;
+
+    for day in 0..days {
+        for sample in 0..SAMPLES_PER_DAY {
+            let symbol = if sample % 2 == 0 { &aapl } else { &tsla };
+            let sample_start = range_start
+                + Duration::days(i64::from(day))
+                + Duration::hours(12)
+                + Duration::minutes(i64::from(sample) * 4);
+            // Kept modest (total exposure window ~1-3s) rather than the
+            // multi-second range an earlier version used: the live
+            // simulation's own dry-run cycles resolve near-instantly, and a
+            // huge synthetic/live scale mismatch made the percentile chart's
+            // transition from seeded history into live data look like a
+            // cliff dropping from ~16s to 0.
+            let latency_ms = i64::from(day) * 15 + i64::from(sample) * 25;
+            let block_timestamp = sample_start;
+            let seen_at = block_timestamp + Duration::milliseconds(300 + latency_ms);
+            let placed_at = seen_at + Duration::milliseconds(150 + latency_ms);
+            let submitted_at = placed_at + Duration::milliseconds(200 + latency_ms);
+            let filled_at = submitted_at + Duration::milliseconds(400 + latency_ms);
+
+            let fill_uuid = simulated_latency_uuid("fill", day, sample);
+            let order_id = OffchainOrderId::from_uuid(simulated_latency_uuid("order", day, sample));
+            let tx_hash = TxHash::left_padding_from(fill_uuid.as_bytes());
+            let log_index = u64::from(sample);
+            let block_number = 1_000_000_u64 + u64::from(day) * 100 + u64::from(sample);
+
+            // Illustrative onchain/hedge spread + small per-day drift, not
+            // from any real feed, so PnL shows a realistic-looking curve
+            // instead of netting to flat zero every cycle.
+            let base_price = if symbol == &aapl { 150.0 } else { 245.0 };
+            let drift = f64::from(day) * 0.15;
+            let onchain_price = Float::parse(format!("{:.4}", base_price + drift))?;
+            let offchain_price =
+                Usd::new(Float::parse(format!("{:.4}", base_price + drift + 0.08))?);
+
+            onchain_trade
+                .send(
+                    &OnChainTradeId { tx_hash, log_index },
+                    OnChainTradeCommand::WitnessAt {
+                        symbol: symbol.clone(),
+                        amount: amount.inner().inner(),
+                        direction: Direction::Buy,
+                        price_usdc: onchain_price,
+                        block_number,
+                        block_timestamp,
+                        filled_at: seen_at,
+                    },
+                )
+                .await?;
+
+            position
+                .send(
+                    symbol,
+                    PositionCommand::AcknowledgeOnChainFillAt {
+                        symbol: symbol.clone(),
+                        threshold,
+                        trade_id: TradeId { tx_hash, log_index },
+                        amount: amount.inner(),
+                        direction: Direction::Buy,
+                        price_usdc: onchain_price,
+                        block_timestamp,
+                        seen_at,
+                    },
+                )
+                .await?;
+
+            position
+                .send(
+                    symbol,
+                    PositionCommand::PlaceOffChainOrderAt {
+                        offchain_order_id: order_id,
+                        shares: amount,
+                        direction: Direction::Sell,
+                        executor: SupportedExecutor::DryRun,
+                        threshold,
+                        placed_at,
+                    },
+                )
+                .await?;
+
+            let client_order_id = ClientOrderId::from_uuid(order_id.as_uuid());
+            offchain_order
+                .send(
+                    &order_id,
+                    OffchainOrderCommand::PlaceAt {
+                        symbol: symbol.clone(),
+                        shares: amount,
+                        direction: Direction::Sell,
+                        executor: SupportedExecutor::DryRun,
+                        client_order_id,
+                        kind: CounterTradeOrderKind::Market,
+                        placed_at,
+                    },
+                )
+                .await?;
+
+            let executor_order_id = ExecutorOrderId::new(&format!("sim-{order_id}"));
+            offchain_order
+                .send(
+                    &order_id,
+                    OffchainOrderCommand::MarkAccepted {
+                        executor_order_id: executor_order_id.clone(),
+                        placed_shares: amount,
+                        submitted_at,
+                        market_session: MarketSession::Regular,
+                        limit_price: None,
+                    },
+                )
+                .await?;
+
+            offchain_order
+                .send(
+                    &order_id,
+                    OffchainOrderCommand::CompleteFill {
+                        price: offchain_price,
+                        filled_at,
+                    },
+                )
+                .await?;
+
+            position
+                .send(
+                    symbol,
+                    PositionCommand::CompleteOffChainOrder {
+                        offchain_order_id: order_id,
+                        shares_filled: amount,
+                        direction: Direction::Sell,
+                        executor_order_id,
+                        price: offchain_price,
+                        broker_timestamp: filled_at,
+                    },
+                )
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn simulated_latency_uuid(kind: &str, day: u32, sample: u32) -> uuid::Uuid {
+    uuid::Uuid::new_v5(
+        &uuid::Uuid::NAMESPACE_OID,
+        format!("st0x-simulated-hedge-latency:{kind}:{day}:{sample}").as_bytes(),
+    )
+}
 
 // Shared with the sibling `rebalance`/`reliability` submodules via `super::`,
 // matching the visibility these items had before the split. `latency_stats`
@@ -317,5 +610,93 @@ pub(super) mod test_helpers {
         load_hedge_performance(&pool, &ReportRange::all_time())
             .await
             .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod simulated_history_tests {
+    use chrono::TimeZone;
+
+    use super::report::{ReportRange, hedge_latency_report, load_hedge_performance};
+    use super::*;
+    use crate::test_utils::setup_test_db;
+
+    #[tokio::test]
+    async fn simulated_hedge_latency_history_populates_daily_percentile_buckets() {
+        let pool = setup_test_db().await;
+        let now = Utc.with_ymd_and_hms(2026, 7, 1, 18, 0, 0).unwrap();
+        let days = 14;
+
+        seed_simulated_hedge_latency_history(&pool, now, days)
+            .await
+            .unwrap();
+
+        // Seeding leaves the most recent day empty (see the buffer comment on
+        // `seed_simulated_hedge_latency_history`), so a range ending "today"
+        // must be shifted back a day to see all `days` fully-populated
+        // buckets.
+        let range = ReportRange {
+            from: now - Duration::days(i64::from(days)) - Duration::days(1),
+            to: now - Duration::days(1),
+        };
+        let performances = load_hedge_performance(&pool, &range).await.unwrap();
+        let report = hedge_latency_report(&performances, &range);
+
+        assert_eq!(report.summary.fill_count, 168);
+        assert_eq!(report.total_cycles, 168);
+        assert_eq!(report.cycles.len(), 100);
+        // Buckets are dense across the full range (see `hedge_latency_report`):
+        // a `from`/`to` span of exactly 14 days at daily granularity produces
+        // 15 boundaries (indices 0..=14), the last of which is the range's
+        // closing instant itself with no seeded sample in it.
+        assert_eq!(report.buckets.len(), 15);
+        assert!(report.open_exposures.is_empty());
+        assert!(
+            report.buckets[..14]
+                .iter()
+                .all(|bucket| bucket.stages.exposure_window.is_some()),
+            "every seeded day must produce exposure-window percentile samples",
+        );
+        assert!(
+            report.buckets[14].stages.exposure_window.is_none(),
+            "the dense range's trailing boundary bucket has no seeded sample in it",
+        );
+
+        let first = report.buckets[0].stages.exposure_window.as_ref().unwrap();
+        let last = report.buckets[13].stages.exposure_window.as_ref().unwrap();
+
+        assert!(first.p50_ms < first.p90_ms);
+        assert!(first.p90_ms < first.p99_ms);
+        assert!(last.p50_ms > first.p50_ms);
+    }
+
+    /// Regression test for a bug where the dashboard's percentile chart
+    /// showed p50 crashing to near-zero on its most recent data point: the
+    /// fixture's newest synthetic day landed in the same rolling 24h bucket
+    /// the live dashboard queries with `to = now()`, mixing deliberately
+    /// slow synthetic samples with real (near-instant, in a local
+    /// simulation) trade latency in one bucket.
+    #[tokio::test]
+    async fn simulated_hedge_latency_history_leaves_the_live_tail_bucket_empty() {
+        let pool = setup_test_db().await;
+        let now = Utc.with_ymd_and_hms(2026, 7, 1, 18, 0, 0).unwrap();
+
+        seed_simulated_hedge_latency_history(&pool, now, 14)
+            .await
+            .unwrap();
+
+        let live_tail_range = ReportRange {
+            from: now - Duration::days(1),
+            to: now,
+        };
+        let performances = load_hedge_performance(&pool, &live_tail_range)
+            .await
+            .unwrap();
+        let report = hedge_latency_report(&performances, &live_tail_range);
+
+        assert_eq!(
+            report.summary.fill_count, 0,
+            "no seeded samples should fall within the last 24h before `now`",
+        );
     }
 }

--- a/src/performance/equity_timing/mint.rs
+++ b/src/performance/equity_timing/mint.rs
@@ -1,0 +1,820 @@
+//! Mint pipeline stage folding for the equity stage-timing read model.
+//!
+//! Holds [`StoredOperation::apply_mint`] and [`mint_observed_at`]; the shared
+//! read-model machinery, stored types, and stage helpers live in the parent
+//! [`super`] module.
+
+use chrono::{DateTime, Utc};
+
+use st0x_finance::FractionalShares;
+
+use super::{StoredOperation, StoredStageName, StoredStageOutcome, StoredStatus};
+use crate::tokenized_equity_mint::TokenizedEquityMintEvent;
+
+impl StoredOperation {
+    /// Apply one mint event to the accumulated state.
+    ///
+    /// Idempotent under redelivery: every stage open goes through
+    /// [`Self::open_once`] and every close/record-unmeasured arm is a no-op
+    /// when the target run is already in its terminal shape, so replaying a
+    /// fully-applied event sequence yields the same stage list and
+    /// durations.
+    pub(super) fn apply_mint(&mut self, event: &TokenizedEquityMintEvent) {
+        use StoredStageName::*;
+        use TokenizedEquityMintEvent::*;
+
+        match event {
+            MintRequested {
+                symbol,
+                quantity,
+                requested_at,
+                ..
+            } => {
+                self.symbol.get_or_insert_with(|| symbol.clone());
+                self.quantity
+                    .get_or_insert_with(|| FractionalShares::new(*quantity));
+                // `MintRequested` is always the genuine genesis event -- it
+                // is the aggregate's own `initialize()` command, so unlike
+                // USDC's direction-gated seeding, no gating is needed here.
+                self.started_at.get_or_insert(*requested_at);
+                self.open_once(MintAcceptance, *requested_at);
+            }
+            // A mid-stream-first operation (genesis `MintRequested` never
+            // seen) has no open `MintAcceptance` run, so record it as
+            // unmeasured rather than silently dropping it.
+            MintAccepted { accepted_at, .. } => {
+                self.close_or_record_unmeasured(
+                    MintAcceptance,
+                    *accepted_at,
+                    StoredStageOutcome::Succeeded,
+                );
+                self.open_once(MintReceipt, *accepted_at);
+            }
+            // Terminal failures: whichever stage is currently open (varies by
+            // which of these fired -- pre-acceptance or vault-deposit) is
+            // closed as failed and the operation ends. If this is the
+            // operation's mid-stream-first event (deploy/restart backfill,
+            // `self.stages` empty), `close_open_stages` has nothing to close,
+            // so derive and fail the stage the event implies instead --
+            // otherwise the operation would go `Failed` with zero stage
+            // entries. `MintRejected` fires only from `MintRequested` (see
+            // `TokenizedEquityMintCommand::RequestMint`'s immediate-rejection
+            // doc), and `RaindexDepositFailed`'s two source states
+            // (`TokensWrapped`/`VaultDepositSubmitted`) both map to the SAME
+            // stage (`MintDeposit`, see its own `evolve` arm), so the
+            // ambiguity there is harmless and the derivation below is a fixed
+            // mapping, not a pipeline-position guess. `MintAcceptanceFailed`
+            // is NOT a fixed mapping -- see its own arm below.
+            MintRejected {
+                rejected_at: at, ..
+            }
+            | RaindexDepositFailed { failed_at: at, .. } => {
+                let had_open_stage = self.stages.iter().any(|run| run.ended_at.is_none());
+                self.close_open_stages(*at, StoredStageOutcome::Failed);
+                if !had_open_stage && self.status != StoredStatus::Failed {
+                    let derived_stage = match event {
+                        MintRejected { .. } => Some(MintAcceptance),
+                        RaindexDepositFailed { .. } => Some(MintDeposit),
+                        _ => None,
+                    };
+                    if let Some(stage) = derived_stage {
+                        self.fail_unopened_stage(stage, *at);
+                    }
+                }
+                self.status = StoredStatus::Failed;
+            }
+            // `MintAcceptanceFailed` fires from EITHER `MintRequested`
+            // (pre-acceptance operator force-fail: `MintAcceptance` itself
+            // failed, still open) OR `MintAccepted` (post-acceptance:
+            // `MintAcceptance` already succeeded and `MintReceipt` -- never
+            // opened, since `TokensReceived` never fired -- is what failed).
+            // See `TokenizedEquityMintCommand::FailAcceptance`'s doc. Unlike
+            // the fixed mapping above, these two source states map to TWO
+            // DIFFERENT stages, so when this is the mid-stream-first event
+            // (`self.stages` empty, no open stage to close), the bare event
+            // payload cannot say which of the two actually happened -- the
+            // same fundamental ambiguity as redemption's `TransferFailed`
+            // (see `next_missing_redemption_stage`'s doc, an accepted, known
+            // limitation). Default to `MintAcceptance`, the earlier of the
+            // two, as a best-effort guess rather than silently dropping the
+            // stage.
+            MintAcceptanceFailed { failed_at: at, .. } => {
+                let had_open_stage = self.stages.iter().any(|run| run.ended_at.is_none());
+                self.close_open_stages(*at, StoredStageOutcome::Failed);
+                if !had_open_stage && self.status != StoredStatus::Failed {
+                    self.fail_unopened_stage(MintAcceptance, *at);
+                }
+                self.status = StoredStatus::Failed;
+            }
+            // Also carries symbol/quantity, unlike the other terminal
+            // failures above: hydrate them so an operation first observed
+            // here (mid-stream) is not left with `symbol: None,
+            // quantity: None`, mirroring redemption's `WithdrawnFromRaindex`
+            // handling. Same mid-stream-first derivation as above: fires only
+            // from `TokensReceived`, so it always implies `MintWrap`.
+            WrappingFailed {
+                symbol,
+                quantity,
+                failed_at,
+                ..
+            } => {
+                self.symbol.get_or_insert_with(|| symbol.clone());
+                self.quantity
+                    .get_or_insert_with(|| FractionalShares::new(*quantity));
+                let had_open_stage = self.stages.iter().any(|run| run.ended_at.is_none());
+                self.close_open_stages(*failed_at, StoredStageOutcome::Failed);
+                if !had_open_stage && self.status != StoredStatus::Failed {
+                    self.fail_unopened_stage(MintWrap, *failed_at);
+                }
+                self.status = StoredStatus::Failed;
+            }
+            // Mid-stream-first case as above: no open `MintReceipt` run when
+            // `MintAccepted` was never seen.
+            TokensReceived { received_at, .. } => {
+                self.close_or_record_unmeasured(
+                    MintReceipt,
+                    *received_at,
+                    StoredStageOutcome::Succeeded,
+                );
+                self.open_once(MintWrap, *received_at);
+            }
+            // Pure markers within their already-open stage.
+            WrapSubmitted { .. } | VaultDepositSubmitted { .. } => {}
+            // Mid-stream-first case as above: no open `MintWrap` run when
+            // `TokensReceived` was never seen.
+            TokensWrapped { wrapped_at, .. } => {
+                self.close_or_record_unmeasured(
+                    MintWrap,
+                    *wrapped_at,
+                    StoredStageOutcome::Succeeded,
+                );
+                self.open_once(MintDeposit, *wrapped_at);
+            }
+            // Mid-stream-first case as above: no open `MintDeposit` run when
+            // `TokensWrapped` was never seen.
+            DepositedIntoRaindex { deposited_at, .. } => {
+                self.close_or_record_unmeasured(
+                    MintDeposit,
+                    *deposited_at,
+                    StoredStageOutcome::Succeeded,
+                );
+                self.status = StoredStatus::Completed;
+                self.completed_at = Some(*deposited_at);
+            }
+            ProviderCompletionRecovered { recovered_at, .. } => {
+                // Mirrors USDC's `BridgingCompletionRecovered` (see
+                // `rebalance::StoredOperation`'s fold): this recovers a mint
+                // that failed at acceptance (tokens never received --
+                // `recover_mint` refuses to dispatch this event otherwise), so
+                // the aggregate lands in `TokensReceived`, the SAME
+                // non-terminal state the normal `TokensReceived` event
+                // produces -- not the terminal `DepositedIntoRaindex`. Real
+                // wrap/deposit work still follows via `resume_mint`, so the
+                // operation stays `InProgress` (no `completed_at`) and only
+                // token receipt (not the deposit) is what was recovered. Adds
+                // an Unmeasured `MintReceipt` run (its true duration is
+                // unknown, discovered after the fact) and opens `MintWrap` so
+                // the subsequent genuine `TokensWrapped` event has a run to
+                // close -- matching what the normal `TokensReceived` arm
+                // does. Recovery is also valid when the failure was
+                // POST-acceptance (`MintAcceptanceFailed`), where
+                // `MintReceipt` already closed `Failed` via that arm's own
+                // `close_open_stages` call. But `MintAcceptanceFailed` can
+                // ALSO fire PRE-acceptance (operator force-fail straight from
+                // `MintRequested`), and `MintRejected` always fires
+                // pre-acceptance -- both close `MintAcceptance` (not
+                // `MintReceipt`) `Failed` instead. Scrub EVERY Failed-outcome
+                // run back to Unmeasured (mirroring the redemption arm's
+                // identical loop below) so no prior-failure shape leaves a
+                // stage permanently `Failed` on a mint that later completes.
+                //
+                // Deliberately no `close_open_stages` call here (unlike the
+                // terminal-failure arms above): by the time this event fires,
+                // `MintRejected`/`MintAcceptanceFailed` has already closed
+                // whatever was open via its own `close_open_stages`, so there
+                // is nothing legitimately left open to close on a fresh fold.
+                // On full-stream redelivery (a restart's `catch_up` re-folding
+                // this event onto already-live-folded state), calling it here
+                // would instead force-close the `MintWrap` run this exact
+                // event opened during its OWN prior application (same
+                // `started_at == recovered_at`), fabricating a spurious
+                // `duration_ms: Some(0)` success and permanently losing the
+                // real wrap timing (`open_once`/`record_unmeasured` below both
+                // no-op once a run already exists).
+                for run in self
+                    .stages
+                    .iter_mut()
+                    .filter(|run| run.outcome == StoredStageOutcome::Failed)
+                {
+                    run.outcome = StoredStageOutcome::Unmeasured;
+                    run.duration_ms = None;
+                }
+                // Still needed for the pre-acceptance `MintRejected` case:
+                // `MintReceipt` never opened at all there, so the loop above
+                // has nothing to scrub for it -- `recover_receipt_stage`'s
+                // `None` branch adds a fresh Unmeasured entry instead. In the
+                // POST-acceptance case the loop above already flipped
+                // `MintReceipt` to Unmeasured, so this call is a harmless
+                // no-op re-set of the same outcome.
+                self.recover_receipt_stage(MintReceipt, *recovered_at);
+                self.open_once(MintWrap, *recovered_at);
+                self.status = StoredStatus::InProgress;
+            }
+            OperatorReconciled { reconciled_at, .. } => {
+                // Reconcile is valid only from the terminal `Failed` state
+                // (see `TokenizedEquityMintCommand::Reconcile`), so the
+                // failed stage is already closed -- no stage manipulation
+                // needed here, matching USDC's `OperatorReconciled` handling
+                // exactly.
+                self.status = StoredStatus::Completed;
+                self.completed_at = Some(*reconciled_at);
+                self.operator_reconciled = true;
+            }
+        }
+    }
+}
+
+/// The timestamp at which the read model observed `event`, used to anchor a
+/// freshly-seen mint operation's `first_seen_at` (the SQL window/sort key).
+///
+/// For `OperatorReconciled` this is `reconciled_at` -- when the reconciliation
+/// actually happened -- NOT the original `requested_at` (which may be weeks
+/// old). A recently-reconciled old operation must fall inside recent query
+/// windows; anchoring it to the stale `requested_at` would hide exactly the
+/// out-of-band recoveries operators want to see after a restart.
+pub(super) fn mint_observed_at(event: &TokenizedEquityMintEvent) -> DateTime<Utc> {
+    use TokenizedEquityMintEvent::*;
+
+    // Every variant carries exactly one meaningful timestamp; combined into
+    // one arm (rebinding each variant's differently-named field to `at`)
+    // rather than 13 separate `Variant { field, .. } => *field` arms, whose
+    // bodies are identical once the binding name is normalized.
+    match event {
+        MintRequested {
+            requested_at: at, ..
+        }
+        | MintRejected {
+            rejected_at: at, ..
+        }
+        | MintAccepted {
+            accepted_at: at, ..
+        }
+        | MintAcceptanceFailed { failed_at: at, .. }
+        | TokensReceived {
+            received_at: at, ..
+        }
+        | WrapSubmitted {
+            submitted_at: at, ..
+        }
+        | TokensWrapped { wrapped_at: at, .. }
+        | WrappingFailed { failed_at: at, .. }
+        | VaultDepositSubmitted {
+            submitted_at: at, ..
+        }
+        | DepositedIntoRaindex {
+            deposited_at: at, ..
+        }
+        | RaindexDepositFailed { failed_at: at, .. }
+        | ProviderCompletionRecovered {
+            recovered_at: at, ..
+        }
+        | OperatorReconciled {
+            reconciled_at: at, ..
+        } => *at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{Address, TxHash, U256};
+    use uuid::Uuid;
+
+    use st0x_dto::{EquityOperationKind, EquityStageName, RebalanceTimingStatus, StageOutcome};
+    use st0x_float_macro::float;
+    use st0x_tokenization::{TokenizationRequestId, issuer_request_id};
+
+    use super::super::StoredKind;
+    use super::super::tests::{fold_mint, mint_happy_path, stage, symbol, timestamp};
+    use super::*;
+
+    #[test]
+    fn mint_happy_path_completes_all_four_stages() {
+        let operation = fold_mint(&mint_happy_path());
+
+        assert_eq!(operation.kind, EquityOperationKind::Mint);
+        assert_eq!(operation.symbol.as_ref(), Some(&symbol()));
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.started_at, Some(timestamp(0)));
+        assert_eq!(operation.completed_at, Some(timestamp(70)));
+        assert_eq!(operation.total_ms, Some(70_000));
+
+        for name in [
+            EquityStageName::MintAcceptance,
+            EquityStageName::MintReceipt,
+            EquityStageName::MintWrap,
+            EquityStageName::MintDeposit,
+        ] {
+            assert_eq!(
+                stage(&operation, name).outcome,
+                StageOutcome::Succeeded,
+                "{name:?} did not succeed"
+            );
+        }
+    }
+
+    #[test]
+    fn mint_rejected_closes_acceptance_as_failed() {
+        let events = vec![
+            TokenizedEquityMintEvent::MintRequested {
+                symbol: symbol(),
+                quantity: float!(5),
+                wallet: Address::repeat_byte(0x11),
+                requested_at: timestamp(0),
+            },
+            TokenizedEquityMintEvent::MintRejected {
+                reason: "rejected by provider".to_string(),
+                rejected_at: timestamp(5),
+            },
+        ];
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::MintAcceptance).outcome,
+            StageOutcome::Failed
+        );
+        assert_eq!(operation.total_ms, None);
+    }
+
+    #[test]
+    fn mint_acceptance_failed_after_acceptance_closes_receipt_as_failed() {
+        let events = vec![
+            TokenizedEquityMintEvent::MintRequested {
+                symbol: symbol(),
+                quantity: float!(5),
+                wallet: Address::repeat_byte(0x11),
+                requested_at: timestamp(0),
+            },
+            TokenizedEquityMintEvent::MintAccepted {
+                issuer_request_id: issuer_request_id("op"),
+                tokenization_request_id: TokenizationRequestId::try_new("tok-1").unwrap(),
+                accepted_at: timestamp(10),
+            },
+            TokenizedEquityMintEvent::MintAcceptanceFailed {
+                reason: "poll timeout".to_string(),
+                failed_at: timestamp(20),
+            },
+        ];
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::MintAcceptance).outcome,
+            StageOutcome::Succeeded
+        );
+        assert_eq!(
+            stage(&operation, EquityStageName::MintReceipt).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn mint_wrapping_failed_closes_wrap_as_failed() {
+        let mut events = mint_happy_path()[..3].to_vec();
+        events.push(TokenizedEquityMintEvent::WrappingFailed {
+            symbol: symbol(),
+            quantity: float!(5),
+            reason: Some("ERC-4626 wrapping failed".to_string()),
+            failed_at: timestamp(40),
+        });
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::MintWrap).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn mint_raindex_deposit_failed_closes_deposit_as_failed() {
+        let mut events = mint_happy_path()[..5].to_vec();
+        events.push(TokenizedEquityMintEvent::RaindexDepositFailed {
+            reason: "revert".to_string(),
+            failed_at: timestamp(60),
+        });
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::MintDeposit).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn mint_provider_completion_recovered_stays_in_progress_with_unmeasured_receipt() {
+        // Recovery only ever fires for a mint that failed before tokens were
+        // received (`recover_mint`'s `context.received_tokens` guard) -- here
+        // `MintRejected` fires straight from `MintRequested`, before
+        // `MintReceipt` ever opens, so `record_unmeasured` adds a fresh
+        // Unmeasured entry for it. The aggregate lands in `TokensReceived`
+        // (the same non-terminal state the normal `TokensReceived` event
+        // produces), not the terminal `DepositedIntoRaindex`, so the
+        // operation must stay `InProgress` with no `completed_at` -- the real
+        // wrap/deposit work still has to happen.
+        let mut events = mint_happy_path()[..1].to_vec();
+        events.push(TokenizedEquityMintEvent::MintRejected {
+            reason: "rejected by provider".to_string(),
+            rejected_at: timestamp(5),
+        });
+        events.push(TokenizedEquityMintEvent::ProviderCompletionRecovered {
+            issuer_request_id: issuer_request_id("op"),
+            wallet: Address::repeat_byte(0x11),
+            tokenization_request_id: TokenizationRequestId::try_new("tok-1").unwrap(),
+            tx_hash: TxHash::random(),
+            shares_minted: U256::from(5_000_000_000_000_000_000_u128),
+            fees: None,
+            recovered_at: timestamp(200),
+        });
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::InProgress);
+        assert_eq!(operation.completed_at, None);
+        let receipt = stage(&operation, EquityStageName::MintReceipt);
+        assert_eq!(receipt.outcome, StageOutcome::Unmeasured);
+        assert_eq!(receipt.duration_ms, None);
+        // `MintWrap` must already be open so the subsequent genuine
+        // `TokensWrapped` event has a run to close.
+        let wrap = stage(&operation, EquityStageName::MintWrap);
+        assert_eq!(wrap.outcome, StageOutcome::Unmeasured);
+        assert_eq!(wrap.ended_at, None);
+    }
+
+    #[test]
+    fn mint_provider_completion_recovered_then_real_wrap_deposit_are_measured() {
+        // The realistic post-recovery path: `resume_mint` drives genuine
+        // wrap/deposit transactions after recovery. Both stages must end up
+        // `Succeeded` with real measured durations, not missing (MintWrap
+        // never opened) or stuck `Unmeasured` (MintDeposit's real close
+        // silently discarded because an earlier bogus entry already closed
+        // it) -- the corruption this fix prevents.
+        let mut events = mint_happy_path()[..1].to_vec();
+        events.push(TokenizedEquityMintEvent::MintRejected {
+            reason: "rejected by provider".to_string(),
+            rejected_at: timestamp(5),
+        });
+        events.push(TokenizedEquityMintEvent::ProviderCompletionRecovered {
+            issuer_request_id: issuer_request_id("op"),
+            wallet: Address::repeat_byte(0x11),
+            tokenization_request_id: TokenizationRequestId::try_new("tok-1").unwrap(),
+            tx_hash: TxHash::random(),
+            shares_minted: U256::from(5_000_000_000_000_000_000_u128),
+            fees: None,
+            recovered_at: timestamp(200),
+        });
+        events.push(TokenizedEquityMintEvent::WrapSubmitted {
+            wrap_tx_hash: TxHash::random(),
+            submitted_at: timestamp(205),
+        });
+        events.push(TokenizedEquityMintEvent::TokensWrapped {
+            wrap_tx_hash: TxHash::random(),
+            wrapped_shares: U256::from(5_000_000_000_000_000_000_u128),
+            wrapped_at: timestamp(220),
+            wrap_block: Some(1),
+        });
+        events.push(TokenizedEquityMintEvent::VaultDepositSubmitted {
+            vault_deposit_tx_hash: TxHash::random(),
+            submitted_at: timestamp(225),
+        });
+        events.push(TokenizedEquityMintEvent::DepositedIntoRaindex {
+            vault_deposit_tx_hash: TxHash::random(),
+            deposited_at: timestamp(240),
+        });
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.completed_at, Some(timestamp(240)));
+        let wrap = stage(&operation, EquityStageName::MintWrap);
+        assert_eq!(wrap.outcome, StageOutcome::Succeeded);
+        assert_eq!(wrap.duration_ms, Some(20_000));
+        let deposit = stage(&operation, EquityStageName::MintDeposit);
+        assert_eq!(deposit.outcome, StageOutcome::Succeeded);
+        assert_eq!(deposit.duration_ms, Some(20_000));
+    }
+
+    #[test]
+    fn redelivering_provider_completion_recovered_does_not_force_close_the_mint_wrap_it_opened() {
+        // Regression test: like
+        // `redelivering_transfer_failed_after_withdraw_does_not_fabricate_extra_failed_stages`,
+        // a restart's `catch_up` re-folds an operation's entire event stream
+        // from scratch on top of the already-live-folded stored row. If the
+        // real wrap/deposit work (driven by `resume_mint`) has not completed
+        // by the time of the restart, `MintWrap` is still open when the
+        // redelivered `ProviderCompletionRecovered` event is re-applied.
+        // Before this fix, `close_open_stages` in that arm would find the
+        // `MintWrap` run this exact event opened during its OWN prior
+        // application (`started_at == recovered_at`) and force-close it
+        // `Succeeded` with a fabricated `duration_ms: Some(0)`, permanently
+        // discarding the real wrap timing.
+        let mut events = mint_happy_path()[..1].to_vec();
+        events.push(TokenizedEquityMintEvent::MintAcceptanceFailed {
+            reason: "provider rejected".to_string(),
+            failed_at: timestamp(5),
+        });
+        events.push(TokenizedEquityMintEvent::ProviderCompletionRecovered {
+            issuer_request_id: issuer_request_id("op"),
+            wallet: Address::repeat_byte(0x11),
+            tokenization_request_id: TokenizationRequestId::try_new("tok-1").unwrap(),
+            tx_hash: TxHash::random(),
+            shares_minted: U256::from(5_000_000_000_000_000_000_u128),
+            fees: None,
+            recovered_at: timestamp(200),
+        });
+
+        let mut operation = StoredOperation::new(
+            Uuid::new_v4(),
+            StoredKind::Mint,
+            mint_observed_at(&events[0]),
+        );
+        for event in &events {
+            operation.apply_mint(event);
+        }
+        // Simulates the restart: `catch_up` re-folds the whole stream onto
+        // the already-live-folded state above (the real wrap/deposit has not
+        // happened yet, so `MintWrap` is still open).
+        for event in &events {
+            operation.apply_mint(event);
+        }
+        let redelivered = operation.into_dto();
+
+        assert_eq!(redelivered.status, RebalanceTimingStatus::InProgress);
+        let wrap = stage(&redelivered, EquityStageName::MintWrap);
+        assert_eq!(wrap.outcome, StageOutcome::Unmeasured);
+        assert_eq!(wrap.ended_at, None);
+        assert_eq!(wrap.duration_ms, None);
+    }
+
+    #[test]
+    fn mint_provider_completion_recovered_after_acceptance_failure_marks_receipt_unmeasured() {
+        // Unlike the pre-acceptance `MintRejected` case above, `MintAccepted`
+        // opens `MintReceipt` and `MintAcceptanceFailed` closes it `Failed`
+        // via `close_open_stages` before recovery fires. Recovery must flip
+        // that stale `Failed` outcome to `Unmeasured` rather than leaving the
+        // recovered mint's receipt stage marked failed forever.
+        let mut events = mint_happy_path()[..2].to_vec();
+        events.push(TokenizedEquityMintEvent::MintAcceptanceFailed {
+            reason: "provider poll failed".to_string(),
+            failed_at: timestamp(15),
+        });
+        events.push(TokenizedEquityMintEvent::ProviderCompletionRecovered {
+            issuer_request_id: issuer_request_id("op"),
+            wallet: Address::repeat_byte(0x11),
+            tokenization_request_id: TokenizationRequestId::try_new("tok-1").unwrap(),
+            tx_hash: TxHash::random(),
+            shares_minted: U256::from(5_000_000_000_000_000_000_u128),
+            fees: None,
+            recovered_at: timestamp(200),
+        });
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::InProgress);
+        assert_eq!(operation.completed_at, None);
+        let receipt = stage(&operation, EquityStageName::MintReceipt);
+        assert_eq!(receipt.outcome, StageOutcome::Unmeasured);
+        assert_eq!(receipt.duration_ms, None);
+        let wrap = stage(&operation, EquityStageName::MintWrap);
+        assert_eq!(wrap.outcome, StageOutcome::Unmeasured);
+        assert_eq!(wrap.ended_at, None);
+    }
+
+    #[test]
+    fn mint_provider_completion_recovered_after_pre_acceptance_rejection_unmeasures_acceptance() {
+        // `MintRejected` fires straight from `MintRequested`, closing
+        // `MintAcceptance` (not `MintReceipt`, which never opened) `Failed`
+        // via `close_open_stages`. Before this fix, `ProviderCompletionRecovered`
+        // only scrubbed `MintReceipt`, so `MintAcceptance` stayed permanently
+        // `Failed` even once the operation goes on to genuinely `Complete`
+        // via real wrap/deposit work. Recovery must scrub every Failed-outcome
+        // stage, matching how the redemption `ProviderCompletionRecovered` arm
+        // already handles this.
+        let mut events = mint_happy_path()[..1].to_vec();
+        events.push(TokenizedEquityMintEvent::MintRejected {
+            reason: "rejected by provider".to_string(),
+            rejected_at: timestamp(5),
+        });
+        events.push(TokenizedEquityMintEvent::ProviderCompletionRecovered {
+            issuer_request_id: issuer_request_id("op"),
+            wallet: Address::repeat_byte(0x11),
+            tokenization_request_id: TokenizationRequestId::try_new("tok-1").unwrap(),
+            tx_hash: TxHash::random(),
+            shares_minted: U256::from(5_000_000_000_000_000_000_u128),
+            fees: None,
+            recovered_at: timestamp(200),
+        });
+        events.push(TokenizedEquityMintEvent::WrapSubmitted {
+            wrap_tx_hash: TxHash::random(),
+            submitted_at: timestamp(205),
+        });
+        events.push(TokenizedEquityMintEvent::TokensWrapped {
+            wrap_tx_hash: TxHash::random(),
+            wrapped_shares: U256::from(5_000_000_000_000_000_000_u128),
+            wrapped_at: timestamp(220),
+            wrap_block: Some(1),
+        });
+        events.push(TokenizedEquityMintEvent::VaultDepositSubmitted {
+            vault_deposit_tx_hash: TxHash::random(),
+            submitted_at: timestamp(225),
+        });
+        events.push(TokenizedEquityMintEvent::DepositedIntoRaindex {
+            vault_deposit_tx_hash: TxHash::random(),
+            deposited_at: timestamp(240),
+        });
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        let acceptance = stage(&operation, EquityStageName::MintAcceptance);
+        assert_eq!(acceptance.outcome, StageOutcome::Unmeasured);
+        assert_eq!(acceptance.duration_ms, None);
+    }
+
+    #[test]
+    fn mint_operator_reconciled_completes_without_touching_stages() {
+        let mut events = mint_happy_path()[..1].to_vec();
+        events.push(TokenizedEquityMintEvent::MintRejected {
+            reason: "rejected".to_string(),
+            rejected_at: timestamp(5),
+        });
+        events.push(TokenizedEquityMintEvent::OperatorReconciled {
+            reason: "funds recovered manually".to_string(),
+            reconciled_at: timestamp(300),
+        });
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.completed_at, Some(timestamp(300)));
+        // Round-trip latency must exclude the operator-response window.
+        assert_eq!(operation.total_ms, None);
+        assert_eq!(
+            stage(&operation, EquityStageName::MintAcceptance).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn mint_first_observed_at_mint_accepted_records_acceptance_unmeasured() {
+        // Deploy/restart backfill case: the read model first observes this
+        // operation at `MintAccepted` because the genesis `MintRequested`
+        // predates the projection's window (or was otherwise never seen).
+        // `MintAcceptance` must be recorded as an Unmeasured stage rather than
+        // silently dropped, and the rest of the happy path still folds
+        // normally on top of it.
+        let events = mint_happy_path()[1..].to_vec();
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        let acceptance = stage(&operation, EquityStageName::MintAcceptance);
+        assert_eq!(acceptance.outcome, StageOutcome::Unmeasured);
+        assert_eq!(acceptance.duration_ms, None);
+        assert_eq!(
+            stage(&operation, EquityStageName::MintReceipt).outcome,
+            StageOutcome::Succeeded
+        );
+    }
+
+    #[test]
+    fn mint_first_observed_at_tokens_received_records_receipt_unmeasured() {
+        // Same mid-stream-first case, one stage later: `MintAccepted` was
+        // never seen either.
+        let events = mint_happy_path()[2..].to_vec();
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        let receipt = stage(&operation, EquityStageName::MintReceipt);
+        assert_eq!(receipt.outcome, StageOutcome::Unmeasured);
+        assert_eq!(receipt.duration_ms, None);
+        assert_eq!(
+            stage(&operation, EquityStageName::MintWrap).outcome,
+            StageOutcome::Succeeded
+        );
+    }
+
+    #[test]
+    fn mint_first_observed_at_tokens_wrapped_records_wrap_unmeasured() {
+        let events = mint_happy_path()[4..].to_vec();
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        let wrap = stage(&operation, EquityStageName::MintWrap);
+        assert_eq!(wrap.outcome, StageOutcome::Unmeasured);
+        assert_eq!(wrap.duration_ms, None);
+        assert_eq!(
+            stage(&operation, EquityStageName::MintDeposit).outcome,
+            StageOutcome::Succeeded
+        );
+    }
+
+    #[test]
+    fn mint_first_observed_at_deposited_into_raindex_records_deposit_unmeasured() {
+        let events = mint_happy_path()[6..].to_vec();
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        let deposit = stage(&operation, EquityStageName::MintDeposit);
+        assert_eq!(deposit.outcome, StageOutcome::Unmeasured);
+        assert_eq!(deposit.duration_ms, None);
+    }
+
+    #[test]
+    fn mint_first_observed_at_wrapping_failed_hydrates_symbol_and_quantity() {
+        // `WrappingFailed` carries `symbol`/`quantity` unlike the other
+        // terminal mint failures, so an operation first observed here (the
+        // genesis `MintRequested` never seen) must still hydrate them instead
+        // of leaving `symbol: None, quantity: None`. It must also derive and
+        // fail `MintWrap` (the stage it implies) rather than leaving the
+        // operation `Failed` with an empty stage list -- `close_open_stages`
+        // alone has nothing open to close since `self.stages` starts empty.
+        let events = vec![TokenizedEquityMintEvent::WrappingFailed {
+            symbol: symbol(),
+            quantity: float!(5),
+            reason: Some("ERC-4626 wrapping failed".to_string()),
+            failed_at: timestamp(40),
+        }];
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.symbol, Some(symbol()));
+        assert_eq!(operation.quantity, Some(FractionalShares::new(float!(5))));
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::MintWrap).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn mint_first_observed_at_raindex_deposit_failed_derives_failed_deposit_stage() {
+        // Same mid-stream-first gap as `WrappingFailed` above, one stage
+        // later: `RaindexDepositFailed` fires only from `TokensWrapped`, so a
+        // first observation here (no earlier stage ever seen) must derive
+        // and fail `MintDeposit` instead of leaving the operation `Failed`
+        // with zero stage entries.
+        let events = vec![TokenizedEquityMintEvent::RaindexDepositFailed {
+            reason: "revert".to_string(),
+            failed_at: timestamp(60),
+        }];
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::MintDeposit).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn mint_first_observed_at_mint_rejected_derives_failed_acceptance_stage() {
+        // `MintRejected` fires only from `MintRequested`, so a mid-stream-first
+        // observation of it alone (no earlier stage ever seen) unambiguously
+        // means `MintAcceptance` is what failed -- must derive and fail it
+        // instead of leaving the operation `Failed` with zero stage entries.
+        let events = vec![TokenizedEquityMintEvent::MintRejected {
+            reason: "rejected by provider".to_string(),
+            rejected_at: timestamp(5),
+        }];
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::MintAcceptance).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn mint_first_observed_at_mint_acceptance_failed_defaults_to_acceptance_stage() {
+        // Regression-lock, not a behavior fix: `MintAcceptanceFailed` is valid
+        // from either `MintRequested` (pre-acceptance) or `MintAccepted`
+        // (post-acceptance), which map to two DIFFERENT stages
+        // (`MintAcceptance` vs `MintReceipt`). When it is the
+        // mid-stream-first event (no stage ever observed, `self.stages`
+        // empty), the bare event payload cannot say which of the two the
+        // pipeline actually reached, so the best-effort default is
+        // `MintAcceptance`, the earlier of the two -- even though the true
+        // prior state may have been `MintAccepted` (acceptance actually
+        // succeeded). This is a known, accepted limitation mirroring
+        // redemption's `TransferFailed`; this test locks in the CURRENT
+        // best-effort behavior so a future change to it is deliberate, not an
+        // accidental regression.
+        let events = vec![TokenizedEquityMintEvent::MintAcceptanceFailed {
+            reason: "poll timeout".to_string(),
+            failed_at: timestamp(20),
+        }];
+        let operation = fold_mint(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::MintAcceptance).outcome,
+            StageOutcome::Failed
+        );
+    }
+}

--- a/src/performance/equity_timing/mod.rs
+++ b/src/performance/equity_timing/mod.rs
@@ -1,0 +1,1817 @@
+//! Equity mint/redemption stage timing read model maintained forward-only by
+//! a reactor.
+//!
+//! [`EquityTimingProjection`] subscribes to the `TokenizedEquityMint` and
+//! `EquityRedemption` event streams and maintains the `equity_stage_timing`
+//! table: one row per operation holding the accumulated per-stage breakdown
+//! (mint: acceptance -> receipt -> wrap -> deposit; redemption: withdraw ->
+//! unwrap -> send -> detection -> completion). The report read path
+//! ([`load_equity_timings`]) queries ONLY that table and never folds the
+//! `events` table.
+//!
+//! Structured identically to [`super::rebalance::RebalanceTimingProjection`]
+//! (its module doc explains the checkpointed catch-up / rebuildable-projection
+//! design in full; not repeated here), but subscribes to TWO aggregate types
+//! via one [`deps!`] call -- mirroring
+//! [`super::reliability::LifecycleFailureProjection`], which already
+//! subscribes to four. `operation_id` (a `Uuid`) is unique across mint and
+//! redemption aggregates (independently generated), so both operation kinds
+//! share one read-model table keyed by `operation_id` alone, exactly like
+//! [`super::rebalance`]'s single-aggregate table -- no composite
+//! `(aggregate_type, aggregate_id)` key is needed the way
+//! `LifecycleFailureProjection`'s checkpoint table uses one.
+
+mod mint;
+mod redemption;
+
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{Sqlite, SqlitePool, Transaction};
+use thiserror::Error;
+use tracing::warn;
+use uuid::Uuid;
+
+use st0x_dto::{
+    EquityOperationKind, EquityOperationTiming, EquityStageName, EquityStageStats,
+    EquityStageTiming, RebalanceTimingStatus, StageOutcome,
+};
+use st0x_event_sorcery::{EntityList, EventSourced, Reactor, deps};
+use st0x_execution::Symbol;
+use st0x_finance::FractionalShares;
+use st0x_tokenization::IssuerRequestId;
+
+use super::{PerformanceError, ReportRange, latency_stats};
+use crate::equity_redemption::{EquityRedemption, EquityRedemptionEvent, RedemptionAggregateId};
+use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintEvent};
+use mint::mint_observed_at;
+use redemption::redemption_observed_at;
+
+/// Stage-breakdown rows returned per report; the full operation count is
+/// still reported via `total_operations`. Matches
+/// `rebalance::MAX_OPERATION_REPORTS`.
+const MAX_OPERATION_REPORTS: usize = 100;
+
+/// Load equity mint/redemption stage timings for operations started within
+/// `range`.
+///
+/// Reads ONLY the reactor-maintained `equity_stage_timing` table. Rows whose
+/// stored timing is undeserializable are skipped with a warning rather than
+/// failing the whole report.
+pub(crate) async fn load_equity_timings(
+    pool: &SqlitePool,
+    range: &ReportRange,
+) -> Result<EquityTimings, PerformanceError> {
+    let from = range.from.to_rfc3339();
+    let to = range.to.to_rfc3339();
+
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        "SELECT operation_id, timing FROM equity_stage_timing \
+         WHERE started_at >= ? AND started_at <= ?",
+    )
+    .bind(&from)
+    .bind(&to)
+    .fetch_all(pool)
+    .await?;
+
+    let mut skipped_operations: u32 = 0;
+    let operations = rows
+        .into_iter()
+        .filter_map(|(operation_id, timing)| {
+            match serde_json::from_str::<StoredOperation>(&timing) {
+                Ok(stored) => Some(stored),
+                Err(error) => {
+                    warn!(%operation_id, %error, "Skipping undeserializable equity timing row");
+                    skipped_operations = skipped_operations.saturating_add(1);
+                    None
+                }
+            }
+        })
+        .map(WindowedOperation::from_stored)
+        .collect();
+
+    Ok(equity_timing_report(operations, range, skipped_operations))
+}
+
+// Re-exported so callers (`src/api.rs`) don't need a separate `st0x_dto`
+// import purely to name this endpoint's response type.
+pub(crate) use st0x_dto::EquityTimings;
+
+/// A report operation paired with its observation time (`first_seen_at`), the
+/// timestamp the SQL window/sort key uses. Mid-stream-first operations have a
+/// `None` genuine `started_at` but always carry a `first_seen_at`, so windowing
+/// and ordering by it keeps them visible instead of sorting them to the tail
+/// and dropping them first on truncation.
+struct WindowedOperation {
+    first_seen_at: DateTime<Utc>,
+    operation: EquityOperationTiming,
+}
+
+impl WindowedOperation {
+    fn from_stored(stored: StoredOperation) -> Self {
+        Self {
+            first_seen_at: stored.first_seen_at,
+            operation: stored.into_dto(),
+        }
+    }
+}
+
+/// Assemble the dashboard report from windowed operations.
+///
+/// `skipped_operations` is the count of read-model rows that failed to
+/// deserialize upstream; it is surfaced verbatim so a malformed row is visible.
+fn equity_timing_report(
+    operations: Vec<WindowedOperation>,
+    range: &ReportRange,
+    skipped_operations: u32,
+) -> EquityTimings {
+    // Window by observation time (`first_seen_at`), not the genuine
+    // `started_at`: an operation first observed mid-stream has no known
+    // start but a valid observation time, so filtering by `first_seen_at`
+    // keeps it in range instead of dropping it on a `None` start.
+    let mut operations: Vec<WindowedOperation> = operations
+        .into_iter()
+        .filter(|windowed| range.contains(windowed.first_seen_at))
+        .collect();
+
+    let stage_summary = stage_summary(&operations);
+
+    // Order by observation time (`first_seen_at`), not the genuine
+    // `started_at`: a mid-stream-first operation has no genuine start but
+    // must still keep its recency-ranked slot, otherwise it would sort to
+    // the tail and be the first dropped when the row cap fires.
+    operations.sort_unstable_by_key(|windowed| std::cmp::Reverse(windowed.first_seen_at));
+    let total_operations = operations.len();
+    operations.truncate(MAX_OPERATION_REPORTS);
+
+    EquityTimings {
+        operations: operations
+            .into_iter()
+            .map(|windowed| windowed.operation)
+            .collect(),
+        total_operations,
+        skipped_operations,
+        stage_summary,
+    }
+}
+
+/// Percentiles per stage over `Succeeded` stage runs only.
+///
+/// Returns a SPARSE list: a stage with no successful samples is omitted, not
+/// emitted with a zero entry. Only `Succeeded` runs carry a duration
+/// meaningful for percentiles -- `Failed` and `Unmeasured` runs are excluded.
+fn stage_summary(operations: &[WindowedOperation]) -> Vec<EquityStageStats> {
+    use EquityStageName::*;
+
+    [
+        MintAcceptance,
+        MintReceipt,
+        MintWrap,
+        MintDeposit,
+        RedemptionWithdraw,
+        RedemptionUnwrap,
+        RedemptionSend,
+        RedemptionDetection,
+        RedemptionCompletion,
+    ]
+    .into_iter()
+    .filter_map(|name| {
+        let mut samples: Vec<i64> = operations
+            .iter()
+            .flat_map(|windowed| &windowed.operation.stages)
+            .filter(|stage| stage.stage == name && stage.outcome == StageOutcome::Succeeded)
+            .filter_map(|stage| stage.duration_ms)
+            .collect();
+        Some(EquityStageStats {
+            stage: name,
+            stats: latency_stats(&mut samples)?,
+        })
+    })
+    .collect()
+}
+
+/// Reactor maintaining the equity mint/redemption stage-timing read model
+/// from live events.
+pub(crate) struct EquityTimingProjection {
+    pool: SqlitePool,
+}
+
+deps!(
+    EquityTimingProjection,
+    [TokenizedEquityMint, EquityRedemption]
+);
+
+impl EquityTimingProjection {
+    pub(crate) fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    async fn load_operation_tx(
+        tx: &mut Transaction<'_, Sqlite>,
+        operation_id: Uuid,
+    ) -> Result<Option<StoredOperation>, ProjectionError> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT timing FROM equity_stage_timing WHERE operation_id = ?")
+                .bind(operation_id.to_string())
+                .fetch_optional(&mut **tx)
+                .await?;
+
+        row.map(|(timing,)| serde_json::from_str::<StoredOperation>(&timing))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    async fn save_operation_tx(
+        tx: &mut Transaction<'_, Sqlite>,
+        operation: &StoredOperation,
+        checkpoint: Option<i64>,
+    ) -> Result<(), ProjectionError> {
+        let timing = serde_json::to_string(operation)?;
+        sqlx::query(
+            "INSERT INTO equity_stage_timing (operation_id, started_at, timing, last_sequence) \
+             VALUES (?, ?, ?, ?) \
+             ON CONFLICT(operation_id) DO UPDATE SET \
+             started_at = excluded.started_at, timing = excluded.timing, \
+             last_sequence = COALESCE(excluded.last_sequence, equity_stage_timing.last_sequence)",
+        )
+        .bind(operation.operation_id.to_string())
+        // The `started_at` column orders and windows rows, so it tracks the
+        // first OBSERVED event even when the genuine start is still unknown
+        // (`StoredOperation::started_at` is `None`); without this a
+        // mid-stream operation would have no sort/filter key.
+        .bind(operation.first_seen_at.to_rfc3339())
+        .bind(timing)
+        // The event sequence just folded in -- set by replay/catch-up so a
+        // later catch-up skips it. The live reactor has no access to the
+        // sequence and passes `None`, so `COALESCE` leaves the prior
+        // checkpoint untouched.
+        .bind(checkpoint)
+        .execute(&mut **tx)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn on_mint_event(
+        &self,
+        id: IssuerRequestId,
+        event: TokenizedEquityMintEvent,
+    ) -> Result<(), ProjectionError> {
+        let IssuerRequestId(operation_id) = id;
+
+        // Load, apply, and save in one transaction so a save failure cannot
+        // drop the event after a partial in-memory apply.
+        let mut tx = self.pool.begin().await?;
+
+        let mut operation = Self::load_operation_tx(&mut tx, operation_id)
+            .await?
+            .unwrap_or_else(|| {
+                StoredOperation::new(operation_id, StoredKind::Mint, mint_observed_at(&event))
+            });
+        operation.apply_mint(&event);
+        Self::save_operation_tx(&mut tx, &operation, None).await?;
+
+        tx.commit().await?;
+
+        Ok(())
+    }
+
+    async fn on_redemption_event(
+        &self,
+        id: RedemptionAggregateId,
+        event: EquityRedemptionEvent,
+    ) -> Result<(), ProjectionError> {
+        let RedemptionAggregateId(operation_id) = id;
+
+        let mut tx = self.pool.begin().await?;
+
+        let mut operation = Self::load_operation_tx(&mut tx, operation_id)
+            .await?
+            .unwrap_or_else(|| {
+                StoredOperation::new(
+                    operation_id,
+                    StoredKind::Redeem,
+                    redemption_observed_at(&event),
+                )
+            });
+        // The live reactor has no access to the event's sequence (see
+        // `on_mint_event`'s `checkpoint: None`), so it can never legitimately
+        // observe a legacy genesis event (see `apply_redemption`'s
+        // `VaultWithdrawSubmitted`/`WithdrawnFromRaindex` arms) -- the
+        // aggregate command that emits one directly no longer exists, so
+        // `None` safely falls back to the mid-stream-first path there.
+        operation.apply_redemption(&event, None);
+        Self::save_operation_tx(&mut tx, &operation, None).await?;
+
+        tx.commit().await?;
+
+        Ok(())
+    }
+
+    /// Catches the read model up to the event log, then returns events replayed.
+    ///
+    /// See `RebalanceTimingProjection::catch_up`'s doc for the full rationale
+    /// (identical here): run at startup, before the live reactor begins
+    /// consuming events.
+    pub(crate) async fn catch_up(&self) -> Result<u64, ProjectionError> {
+        let mut tx = self.pool.begin().await?;
+
+        let replayed = Self::replay_pending(&mut tx).await?;
+
+        tx.commit().await?;
+
+        Ok(replayed)
+    }
+
+    /// Rebuilds the entire `equity_stage_timing` table from the event log.
+    ///
+    /// See `RebalanceTimingProjection::rebuild_all`'s doc for the full
+    /// rationale (identical here).
+    pub(crate) async fn rebuild_all(&self) -> Result<u64, ProjectionError> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("DELETE FROM equity_stage_timing")
+            .execute(&mut *tx)
+            .await?;
+        let replayed = Self::replay_pending(&mut tx).await?;
+
+        tx.commit().await?;
+
+        Ok(replayed)
+    }
+
+    /// Folds every `TokenizedEquityMint`/`EquityRedemption` event past its
+    /// operation's checkpoint into the read model, advancing each operation's
+    /// `last_sequence` as it goes.
+    ///
+    /// Mirrors `RebalanceTimingProjection::replay_pending` exactly (see its
+    /// doc for the full poison-row/order-independence rationale), extended
+    /// to two aggregate types the same way
+    /// `LifecycleFailureProjection::replay_pending` folds four: the query
+    /// binds both `AGGREGATE_TYPE` constants via `IN (?, ?)`, and the loop
+    /// dispatches which event type to deserialize based on the returned
+    /// `aggregate_type` column.
+    async fn replay_pending(tx: &mut Transaction<'_, Sqlite>) -> Result<u64, ProjectionError> {
+        let pending: Vec<(String, String, i64, String)> = sqlx::query_as(
+            "SELECT event.aggregate_type, event.aggregate_id, event.sequence, event.payload \
+             FROM events event \
+             LEFT JOIN equity_stage_timing timing \
+               ON timing.operation_id = event.aggregate_id \
+             WHERE event.aggregate_type IN (?, ?) \
+               AND event.sequence > COALESCE(timing.last_sequence, 0) \
+             ORDER BY event.aggregate_id, event.sequence ASC",
+        )
+        .bind(TokenizedEquityMint::AGGREGATE_TYPE)
+        .bind(EquityRedemption::AGGREGATE_TYPE)
+        .fetch_all(&mut **tx)
+        .await?;
+
+        let mut replayed: u64 = 0;
+        // Streams that hit a poison row this pass. Events arrive ordered by
+        // (aggregate_id, sequence), so once a stream is poisoned every later
+        // event of it must be left unfolded: folding them would advance the
+        // checkpoint past the poison (burying it) and fold onto an
+        // indeterminate state (the skipped event's effect is missing).
+        let mut poisoned_aggregates = HashSet::<String>::new();
+        for (aggregate_type, aggregate_id, sequence, payload) in pending {
+            // Already poisoned earlier in this pass; the skip was logged then.
+            if poisoned_aggregates.contains(&aggregate_id) {
+                continue;
+            }
+
+            let operation_id: Uuid = match aggregate_id.parse() {
+                Ok(operation_id) => operation_id,
+                Err(error) => {
+                    warn!(
+                        %aggregate_id,
+                        %error,
+                        "Skipping equity timing event with an unparseable aggregate id"
+                    );
+                    poisoned_aggregates.insert(aggregate_id);
+                    continue;
+                }
+            };
+
+            let fold_result = if aggregate_type == TokenizedEquityMint::AGGREGATE_TYPE {
+                Self::replay_mint_event(tx, operation_id, sequence, &payload).await
+            } else if aggregate_type == EquityRedemption::AGGREGATE_TYPE {
+                Self::replay_redemption_event(tx, operation_id, sequence, &payload).await
+            } else {
+                // Unreachable given the query's `IN` filter, but handled
+                // exhaustively rather than assumed away.
+                warn!(%aggregate_type, "equity timing replay saw an unsubscribed aggregate type; ignoring");
+                Ok(false)
+            };
+
+            match fold_result {
+                Ok(true) => replayed += 1,
+                Ok(false) => {}
+                Err(ReplayError::Poison) => {
+                    poisoned_aggregates.insert(aggregate_id);
+                }
+                Err(ReplayError::Database(error)) => return Err(error.into()),
+            }
+        }
+
+        Ok(replayed)
+    }
+
+    /// Deserializes and folds one mint event during replay. Returns `Ok(true)`
+    /// on success, `Err(ReplayError::Poison)` for an unparseable payload or
+    /// corrupt stored row (logged here), or `Err(ReplayError::Database(_))`
+    /// for an infrastructure failure that must abort the whole pass.
+    async fn replay_mint_event(
+        tx: &mut Transaction<'_, Sqlite>,
+        operation_id: Uuid,
+        sequence: i64,
+        payload: &str,
+    ) -> Result<bool, ReplayError> {
+        let event: TokenizedEquityMintEvent = match serde_json::from_str(payload) {
+            Ok(event) => event,
+            Err(error) => {
+                warn!(
+                    %operation_id,
+                    sequence,
+                    %error,
+                    "Skipping unparseable mint event payload"
+                );
+                return Err(ReplayError::Poison);
+            }
+        };
+
+        let mut operation = match Self::load_operation_tx(tx, operation_id).await {
+            Ok(Some(operation)) => operation,
+            Ok(None) => {
+                StoredOperation::new(operation_id, StoredKind::Mint, mint_observed_at(&event))
+            }
+            Err(ProjectionError::State(error)) => {
+                warn!(
+                    %operation_id,
+                    sequence,
+                    %error,
+                    "Skipping mint event: corrupt stored timing row (repair with view rebuild --all)"
+                );
+                return Err(ReplayError::Poison);
+            }
+            Err(ProjectionError::Database(error)) => return Err(ReplayError::Database(error)),
+        };
+        operation.apply_mint(&event);
+        match Self::save_operation_tx(tx, &operation, Some(sequence)).await {
+            Ok(()) => {}
+            Err(ProjectionError::Database(error)) => return Err(ReplayError::Database(error)),
+            Err(ProjectionError::State(error)) => {
+                warn!(
+                    %operation_id,
+                    sequence,
+                    %error,
+                    "Skipping mint event: failed to serialize stored timing row"
+                );
+                return Err(ReplayError::Poison);
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Redemption counterpart to [`Self::replay_mint_event`]; same contract.
+    async fn replay_redemption_event(
+        tx: &mut Transaction<'_, Sqlite>,
+        operation_id: Uuid,
+        sequence: i64,
+        payload: &str,
+    ) -> Result<bool, ReplayError> {
+        let event: EquityRedemptionEvent = match serde_json::from_str(payload) {
+            Ok(event) => event,
+            Err(error) => {
+                warn!(
+                    %operation_id,
+                    sequence,
+                    %error,
+                    "Skipping unparseable redemption event payload"
+                );
+                return Err(ReplayError::Poison);
+            }
+        };
+
+        let mut operation = match Self::load_operation_tx(tx, operation_id).await {
+            Ok(Some(operation)) => operation,
+            Ok(None) => StoredOperation::new(
+                operation_id,
+                StoredKind::Redeem,
+                redemption_observed_at(&event),
+            ),
+            Err(ProjectionError::State(error)) => {
+                warn!(
+                    %operation_id,
+                    sequence,
+                    %error,
+                    "Skipping redemption event: corrupt stored timing row (repair with view rebuild --all)"
+                );
+                return Err(ReplayError::Poison);
+            }
+            Err(ProjectionError::Database(error)) => return Err(ReplayError::Database(error)),
+        };
+        operation.apply_redemption(&event, Some(sequence));
+        match Self::save_operation_tx(tx, &operation, Some(sequence)).await {
+            Ok(()) => {}
+            Err(ProjectionError::Database(error)) => return Err(ReplayError::Database(error)),
+            Err(ProjectionError::State(error)) => {
+                warn!(
+                    %operation_id,
+                    sequence,
+                    %error,
+                    "Skipping redemption event: failed to serialize stored timing row"
+                );
+                return Err(ReplayError::Poison);
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+/// Outcome of folding one event during replay, distinct from [`ProjectionError`]
+/// so a poison row (bad payload / corrupt stored state) can be handled by the
+/// caller (skip + continue) while a database error still propagates and
+/// aborts the transaction.
+enum ReplayError {
+    Poison,
+    Database(sqlx::Error),
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ProjectionError {
+    #[error("equity stage-timing read-model write failed")]
+    Database(#[from] sqlx::Error),
+    #[error("equity operation timing (de)serialization failed")]
+    State(#[from] serde_json::Error),
+}
+
+#[async_trait]
+impl Reactor for EquityTimingProjection {
+    type Error = ProjectionError;
+
+    async fn react(
+        &self,
+        event: <Self::Dependencies as EntityList>::Event,
+    ) -> Result<(), Self::Error> {
+        event
+            .on(|id, event| async move { self.on_mint_event(id, event).await })
+            .on(|id, event| async move { self.on_redemption_event(id, event).await })
+            .exhaustive()
+            .await
+    }
+}
+
+/// Accumulated per-operation timing state, persisted as JSON.
+///
+/// Mirrors the dashboard [`EquityOperationTiming`] DTO but with serde-friendly
+/// domain types so the reactor can load, apply one event, and upsert. Shared
+/// by both mint and redemption operations (distinguished by `kind`) since
+/// `operation_id` is unique across both.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredOperation {
+    operation_id: Uuid,
+    kind: StoredKind,
+    /// `None` only when the read model first observed the operation
+    /// mid-stream (its genesis event, which alone carries the symbol/quantity,
+    /// was never seen) -- mirrors `rebalance::StoredOperation::direction`'s
+    /// optionality for the same reason.
+    symbol: Option<Symbol>,
+    quantity: Option<FractionalShares>,
+    /// Timestamp of the FIRST event this read model observed for the
+    /// operation. Always set, even when the genuine start was missed. It
+    /// backs the `started_at` SQL column so every row has a stable
+    /// sort/window key.
+    first_seen_at: DateTime<Utc>,
+    /// Genuine operation start, seeded ONLY by the operation's genesis event
+    /// (`MintRequested` for mint, `VaultWithdrawPending` for redemption --
+    /// both are the aggregate's own `initialize()` event, so this is always
+    /// the true first phase, unlike USDC's direction-gated seeding). Stays
+    /// `None` when the operation was first observed mid-stream.
+    started_at: Option<DateTime<Utc>>,
+    completed_at: Option<DateTime<Utc>>,
+    status: StoredStatus,
+    /// Set when an `OperatorReconciled` resolved the operation out-of-band.
+    /// Its `completed_at` is the manual reconciliation time, so the
+    /// round-trip `total_ms` is suppressed to keep the operator-response
+    /// window out of latency metrics. The operation still reports as
+    /// `Completed`.
+    operator_reconciled: bool,
+    stages: Vec<StoredStage>,
+}
+
+/// Which pipeline an operation belongs to, mirroring [`EquityOperationKind`]
+/// with serde support.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum StoredKind {
+    Mint,
+    Redeem,
+}
+
+/// Operation status, mirroring [`RebalanceTimingStatus`] with serde support.
+/// Reused across both `rebalance` and `equity_timing` read models (both DTOs
+/// share `RebalanceTimingStatus`), but each module keeps its own serde
+/// stand-in since the DTO enum derives `Serialize` + `TS` but not
+/// `Deserialize` (the persisted JSON must round-trip through the read model).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum StoredStatus {
+    InProgress,
+    Completed,
+    Failed,
+}
+
+/// One stage run, mirroring [`EquityStageTiming`] with serde support.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredStage {
+    stage: StoredStageName,
+    started_at: DateTime<Utc>,
+    ended_at: Option<DateTime<Utc>>,
+    duration_ms: Option<i64>,
+    outcome: StoredStageOutcome,
+}
+
+/// Outcome of a stage run, mirroring [`StageOutcome`] with serde support.
+/// `InProgress` is read-model-internal: a stage that has opened but not
+/// closed has no DTO outcome yet, surfacing as `Unmeasured`.
+///
+/// `Placeholder` is also read-model-internal, distinct from `Unmeasured`: it
+/// positively marks a run [`StoredOperation::push_closed_stage`] created
+/// because a stage-closing event arrived with no open run for it (see
+/// [`StoredOperation::record_unmeasured`]) -- a shape
+/// [`StoredOperation::upgrade_placeholder_start`] can safely recognize and
+/// backfill with the real start time once it arrives (typically via
+/// catch-up's full-stream replay). A run the recovery scrub loops (mint/
+/// redemption `ProviderCompletionRecovered`, `recover_receipt_stage`'s
+/// already-closed-run branch) flip back from `Failed` is deliberately left as
+/// plain `Unmeasured`, NOT `Placeholder`: that run's `started_at`/`ended_at`
+/// came from a genuine (if now-superseded) open/close pair, so it must never
+/// be mistaken for an upgradeable placeholder even if it happens to share the
+/// same `started_at == ended_at` shape (e.g. a stage opened and failed at the
+/// exact same timestamp). Both variants surface as `StageOutcome::Unmeasured`
+/// on the dashboard -- the distinction is purely internal bookkeeping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum StoredStageOutcome {
+    InProgress,
+    Succeeded,
+    Failed,
+    Unmeasured,
+    Placeholder,
+}
+
+/// Stage identity, mirroring [`EquityStageName`] with serde support.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum StoredStageName {
+    MintAcceptance,
+    MintReceipt,
+    MintWrap,
+    MintDeposit,
+    RedemptionWithdraw,
+    RedemptionUnwrap,
+    RedemptionSend,
+    RedemptionDetection,
+    RedemptionCompletion,
+}
+
+impl StoredOperation {
+    fn new(operation_id: Uuid, kind: StoredKind, first_seen_at: DateTime<Utc>) -> Self {
+        Self {
+            operation_id,
+            kind,
+            symbol: None,
+            quantity: None,
+            first_seen_at,
+            started_at: None,
+            completed_at: None,
+            status: StoredStatus::InProgress,
+            operator_reconciled: false,
+            stages: Vec::new(),
+        }
+    }
+
+    /// Open `stage` only if no run for it exists yet. Each pipeline stage
+    /// runs at most once per operation, so this guards a redelivered start
+    /// event (whose run is already open or already closed) from resetting
+    /// the clock or pushing a duplicate run.
+    ///
+    /// An existing `Placeholder` run (see [`Self::upgrade_placeholder_start`])
+    /// is the one exception: it is recoverable, not "already handled", so it
+    /// is upgraded in place with the real start time instead of being left
+    /// untouched.
+    fn open_once(&mut self, stage: StoredStageName, at: DateTime<Utc>) {
+        if self.upgrade_placeholder_start(stage, at) {
+            return;
+        }
+
+        if self.has_run(stage) {
+            return;
+        }
+
+        self.stages.push(StoredStage {
+            stage,
+            started_at: at,
+            ended_at: None,
+            duration_ms: None,
+            outcome: StoredStageOutcome::InProgress,
+        });
+    }
+
+    /// Recovers a `Placeholder` run for `stage` (pushed by
+    /// [`Self::record_unmeasured`] when a stage-closing event arrived with no
+    /// open run for it -- e.g. because the live reactor's fold of the real
+    /// start event failed and the event-sorcery reactor-bridge logged and
+    /// continued past it) by backfilling its `started_at` with the real
+    /// start time now arriving (typically via catch-up's full-stream
+    /// replay) and recomputing `duration_ms`/`outcome` from it.
+    ///
+    /// A placeholder is identified by its dedicated `StoredStageOutcome`
+    /// variant, NOT by shape (`started_at == ended_at` with
+    /// `duration_ms: None`): a genuinely-measured run never has that shape,
+    /// but a run the recovery scrub loops rescrub from `Failed` back to plain
+    /// `Unmeasured` (e.g. [`Self::recover_receipt_stage`]'s
+    /// already-closed-run branch) CAN coincidentally share it, if the stage's
+    /// open and its terminal-failure close carried the exact same timestamp.
+    /// Matching on shape would then wrongly upgrade that scrubbed run on
+    /// redelivery instead of leaving it `Unmeasured`, breaking fold
+    /// idempotency -- so this matches the positive `Placeholder` marker
+    /// instead, which the scrub loops never produce. Returns `true` if a
+    /// placeholder was found and upgraded, so [`Self::open_once`] knows not
+    /// to push a fresh run.
+    fn upgrade_placeholder_start(
+        &mut self,
+        stage: StoredStageName,
+        real_started_at: DateTime<Utc>,
+    ) -> bool {
+        let Some(run) = self
+            .stages
+            .iter_mut()
+            .find(|run| run.stage == stage && run.outcome == StoredStageOutcome::Placeholder)
+        else {
+            return false;
+        };
+
+        run.started_at = real_started_at;
+        if let Some(ended_at) = run.ended_at {
+            run.duration_ms = Some((ended_at - real_started_at).num_milliseconds().max(0));
+            run.outcome = StoredStageOutcome::Succeeded;
+        }
+
+        true
+    }
+
+    fn close(&mut self, stage: StoredStageName, at: DateTime<Utc>, outcome: StoredStageOutcome) {
+        let Some(index) = self.open_run_index(stage) else {
+            // No OPEN run to close. Either a genuine end-without-start, or a
+            // redelivered end event whose run already closed -- both are
+            // no-ops here. The already-closed run keeps its recorded
+            // duration, so redelivery is idempotent. Only warn when no run
+            // for the stage exists at all (the true end-without-start case).
+            if !self.has_run(stage) {
+                warn!(
+                    operation_id = %self.operation_id,
+                    ?stage,
+                    "Stage end event without a matching start; skipping stage timing"
+                );
+            }
+
+            return;
+        };
+        let run = &mut self.stages[index];
+        run.ended_at = Some(at);
+        // Clamped like the USDC rebalance fold: clock skew between event
+        // sources must not push negative durations into percentiles.
+        run.duration_ms = Some((at - run.started_at).num_milliseconds().max(0));
+        run.outcome = outcome;
+    }
+
+    /// Close every stage open as of `at`, e.g. an operator force-fail or a
+    /// provider-completion recovery with no per-stage end marker. A no-op
+    /// when no stage is open, so a redelivered terminal event does not
+    /// re-close already-closed runs.
+    ///
+    /// Only stages whose run started at or before `at` are closed -- see
+    /// `rebalance::StoredOperation::close_open_stages`'s doc for the full
+    /// order-independence rationale (identical here).
+    fn close_open_stages(&mut self, at: DateTime<Utc>, outcome: StoredStageOutcome) {
+        for run in self
+            .stages
+            .iter_mut()
+            .filter(|run| run.ended_at.is_none() && run.started_at <= at)
+        {
+            run.ended_at = Some(at);
+            run.duration_ms = Some((at - run.started_at).num_milliseconds().max(0));
+            run.outcome = outcome;
+        }
+    }
+
+    /// Push a stage run that never had a genuine open/close pair (its
+    /// `started_at`/`ended_at` are both `at`, `duration_ms` is unmeasurable).
+    /// A no-op when any run for the stage already exists, so a redelivered
+    /// event does not push a duplicate. Shared by [`Self::record_unmeasured`]
+    /// and [`Self::fail_unopened_stage`], which differ only in `outcome`.
+    fn push_closed_stage(
+        &mut self,
+        stage: StoredStageName,
+        at: DateTime<Utc>,
+        outcome: StoredStageOutcome,
+    ) {
+        if self.has_run(stage) {
+            return;
+        }
+
+        self.stages.push(StoredStage {
+            stage,
+            started_at: at,
+            ended_at: Some(at),
+            duration_ms: None,
+            outcome,
+        });
+    }
+
+    /// Record a stage that demonstrably happened but whose duration cannot be
+    /// measured from the stream; excluded from percentile summaries.
+    ///
+    /// Pushed with the `Placeholder` outcome (not plain `Unmeasured`) so
+    /// [`Self::upgrade_placeholder_start`] can positively identify it as
+    /// recoverable if the stage's real start event arrives later (typically
+    /// via catch-up's full-stream replay) -- see that method's doc for why
+    /// shape alone cannot make this distinction.
+    fn record_unmeasured(&mut self, stage: StoredStageName, at: DateTime<Utc>) {
+        self.push_closed_stage(stage, at, StoredStageOutcome::Placeholder);
+    }
+
+    /// Close `stage` if a run is open for it, else record it as
+    /// [`Self::record_unmeasured`]. Every stage-closing event in the pipeline
+    /// can plausibly be the projection's first-ever observation of an
+    /// operation (deploy/restart backfill, or a missed live-reactor
+    /// interval): without this guard, `close` would find no open run and
+    /// silently drop the stage entirely instead of recording that it
+    /// demonstrably happened.
+    fn close_or_record_unmeasured(
+        &mut self,
+        stage: StoredStageName,
+        at: DateTime<Utc>,
+        outcome: StoredStageOutcome,
+    ) {
+        if self.open_run_index(stage).is_some() {
+            self.close(stage, at, outcome);
+        } else {
+            self.record_unmeasured(stage, at);
+        }
+    }
+
+    /// Record a stage that never opened as failed, e.g. a terminal transfer
+    /// failure arriving between two stages: the prior stage already closed
+    /// successfully, but the next stage's start event never fired.
+    fn fail_unopened_stage(&mut self, stage: StoredStageName, at: DateTime<Utc>) {
+        self.push_closed_stage(stage, at, StoredStageOutcome::Failed);
+    }
+
+    /// Recover `stage` as `Unmeasured`, e.g. mint's `ProviderCompletionRecovered`.
+    /// Handles both shapes recovery can find the stage in: no run yet (the
+    /// failure predated the stage opening, e.g. `MintRejected`) falls back to
+    /// [`Self::record_unmeasured`]; an already-closed run (the failure closed
+    /// it `Failed`, e.g. `MintAcceptanceFailed`) has its outcome flipped to
+    /// `Unmeasured` instead of staying permanently `Failed`, since recovery
+    /// proves the stage actually succeeded even though its true duration is
+    /// now unknown.
+    fn recover_receipt_stage(&mut self, stage: StoredStageName, at: DateTime<Utc>) {
+        match self.stages.iter_mut().find(|run| run.stage == stage) {
+            Some(run) => {
+                run.outcome = StoredStageOutcome::Unmeasured;
+                run.duration_ms = None;
+            }
+            None => self.record_unmeasured(stage, at),
+        }
+    }
+
+    fn open_run_index(&self, stage: StoredStageName) -> Option<usize> {
+        self.stages
+            .iter()
+            .rposition(|run| run.stage == stage && run.ended_at.is_none())
+    }
+
+    fn has_run(&self, stage: StoredStageName) -> bool {
+        self.stages.iter().any(|run| run.stage == stage)
+    }
+
+    /// Convert the accumulated state into the dashboard DTO.
+    fn into_dto(self) -> EquityOperationTiming {
+        // Round-trip latency requires a genuine start and a completion; an
+        // out-of-band operator reconciliation is excluded so the manual
+        // response window never pollutes the metric.
+        let total_ms = match (self.started_at, self.completed_at, self.operator_reconciled) {
+            (Some(started_at), Some(completed_at), false) => {
+                Some((completed_at - started_at).num_milliseconds().max(0))
+            }
+            _ => None,
+        };
+
+        EquityOperationTiming {
+            operation_id: self.operation_id,
+            kind: self.kind.into(),
+            symbol: self.symbol,
+            quantity: self.quantity,
+            started_at: self.started_at,
+            completed_at: self.completed_at,
+            status: self.status.into(),
+            stages: self.stages.into_iter().map(StoredStage::into_dto).collect(),
+            total_ms,
+        }
+    }
+}
+
+impl StoredStage {
+    fn into_dto(self) -> EquityStageTiming {
+        EquityStageTiming {
+            stage: self.stage.into(),
+            started_at: self.started_at,
+            ended_at: self.ended_at,
+            duration_ms: self.duration_ms,
+            outcome: self.outcome.into(),
+        }
+    }
+}
+
+impl From<StoredKind> for EquityOperationKind {
+    fn from(kind: StoredKind) -> Self {
+        match kind {
+            StoredKind::Mint => Self::Mint,
+            StoredKind::Redeem => Self::Redeem,
+        }
+    }
+}
+
+impl From<StoredStageOutcome> for StageOutcome {
+    fn from(outcome: StoredStageOutcome) -> Self {
+        match outcome {
+            // An open stage has no terminal DTO outcome yet, and a
+            // `Placeholder` (see its own doc) is internal recoverable
+            // bookkeeping with no genuine duration -- both surface as
+            // unmeasured so they are excluded from percentiles like any
+            // other duration-less run.
+            StoredStageOutcome::InProgress
+            | StoredStageOutcome::Unmeasured
+            | StoredStageOutcome::Placeholder => Self::Unmeasured,
+            StoredStageOutcome::Succeeded => Self::Succeeded,
+            StoredStageOutcome::Failed => Self::Failed,
+        }
+    }
+}
+
+impl From<StoredStatus> for RebalanceTimingStatus {
+    fn from(status: StoredStatus) -> Self {
+        match status {
+            StoredStatus::InProgress => Self::InProgress,
+            StoredStatus::Completed => Self::Completed,
+            StoredStatus::Failed => Self::Failed,
+        }
+    }
+}
+
+impl From<StoredStageName> for EquityStageName {
+    fn from(stage: StoredStageName) -> Self {
+        match stage {
+            StoredStageName::MintAcceptance => Self::MintAcceptance,
+            StoredStageName::MintReceipt => Self::MintReceipt,
+            StoredStageName::MintWrap => Self::MintWrap,
+            StoredStageName::MintDeposit => Self::MintDeposit,
+            StoredStageName::RedemptionWithdraw => Self::RedemptionWithdraw,
+            StoredStageName::RedemptionUnwrap => Self::RedemptionUnwrap,
+            StoredStageName::RedemptionSend => Self::RedemptionSend,
+            StoredStageName::RedemptionDetection => Self::RedemptionDetection,
+            StoredStageName::RedemptionCompletion => Self::RedemptionCompletion,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{Address, TxHash, U256};
+    use chrono::TimeZone;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    use st0x_dto::EquityOperationKind;
+    use st0x_event_sorcery::{ReactorHarness, StoreBuilder};
+    use st0x_float_macro::float;
+    use st0x_tokenization::{TokenizationRequestId, issuer_request_id};
+
+    use super::*;
+    use crate::equity_redemption::redemption_aggregate_id;
+    use crate::test_utils::setup_test_db;
+    use crate::tokenized_equity_mint::TokenizedEquityMintCommand;
+
+    pub(super) fn timestamp(seconds: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(1_750_000_000 + seconds, 0).unwrap()
+    }
+
+    pub(super) fn range() -> ReportRange {
+        ReportRange {
+            from: timestamp(0),
+            to: timestamp(1_000_000),
+        }
+    }
+
+    pub(super) fn symbol() -> Symbol {
+        Symbol::new("AAPL").unwrap()
+    }
+
+    pub(super) fn stage(
+        operation: &EquityOperationTiming,
+        name: EquityStageName,
+    ) -> &EquityStageTiming {
+        operation
+            .stages
+            .iter()
+            .find(|stage| stage.stage == name)
+            .unwrap()
+    }
+
+    pub(super) fn mint_happy_path() -> Vec<TokenizedEquityMintEvent> {
+        vec![
+            TokenizedEquityMintEvent::MintRequested {
+                symbol: symbol(),
+                quantity: float!(5),
+                wallet: Address::repeat_byte(0x11),
+                requested_at: timestamp(0),
+            },
+            TokenizedEquityMintEvent::MintAccepted {
+                issuer_request_id: issuer_request_id("op"),
+                tokenization_request_id: TokenizationRequestId::try_new("tok-1").unwrap(),
+                accepted_at: timestamp(10),
+            },
+            TokenizedEquityMintEvent::TokensReceived {
+                tx_hash: TxHash::random(),
+                shares_minted: U256::from(5_000_000_000_000_000_000_u128),
+                fees: None,
+                received_at: timestamp(30),
+            },
+            TokenizedEquityMintEvent::WrapSubmitted {
+                wrap_tx_hash: TxHash::random(),
+                submitted_at: timestamp(35),
+            },
+            TokenizedEquityMintEvent::TokensWrapped {
+                wrap_tx_hash: TxHash::random(),
+                wrapped_shares: U256::from(5_000_000_000_000_000_000_u128),
+                wrapped_at: timestamp(50),
+                wrap_block: Some(1),
+            },
+            TokenizedEquityMintEvent::VaultDepositSubmitted {
+                vault_deposit_tx_hash: TxHash::random(),
+                submitted_at: timestamp(55),
+            },
+            TokenizedEquityMintEvent::DepositedIntoRaindex {
+                vault_deposit_tx_hash: TxHash::random(),
+                deposited_at: timestamp(70),
+            },
+        ]
+    }
+
+    pub(super) fn redemption_happy_path() -> Vec<EquityRedemptionEvent> {
+        vec![
+            EquityRedemptionEvent::VaultWithdrawPending {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                pending_at: timestamp(0),
+            },
+            EquityRedemptionEvent::VaultWithdrawSubmitted {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                tx_hash: TxHash::random(),
+                submitted_at: timestamp(5),
+            },
+            EquityRedemptionEvent::WithdrawnFromRaindex {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                actual_wrapped_amount: Some(U256::from(5_000_000_000_000_000_000_u128)),
+                raindex_withdraw_tx: TxHash::random(),
+                raindex_withdraw_block: Some(1),
+                withdrawn_at: timestamp(20),
+            },
+            EquityRedemptionEvent::UnwrapPending {
+                pending_at: timestamp(25),
+            },
+            EquityRedemptionEvent::UnwrapSubmitted {
+                unwrap_tx_hash: TxHash::random(),
+                submitted_at: timestamp(30),
+            },
+            EquityRedemptionEvent::TokensUnwrapped {
+                quantity: Some(float!(5)),
+                underlying_token: Address::repeat_byte(0x33),
+                unwrap_tx_hash: TxHash::random(),
+                unwrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                unwrap_block: Some(2),
+                unwrapped_at: timestamp(45),
+            },
+            EquityRedemptionEvent::SendPending {
+                pending_at: timestamp(50),
+            },
+            EquityRedemptionEvent::TokensSent {
+                redemption_wallet: Address::repeat_byte(0x44),
+                redemption_tx: TxHash::random(),
+                sent_at: timestamp(60),
+            },
+            EquityRedemptionEvent::Detected {
+                tokenization_request_id: TokenizationRequestId::try_new("tok-2").unwrap(),
+                detected_at: timestamp(90),
+            },
+            EquityRedemptionEvent::Completed {
+                completed_at: timestamp(100),
+            },
+        ]
+    }
+
+    pub(super) fn fold_mint(events: &[TokenizedEquityMintEvent]) -> EquityOperationTiming {
+        let mut operation = StoredOperation::new(
+            Uuid::new_v4(),
+            StoredKind::Mint,
+            mint_observed_at(&events[0]),
+        );
+        for event in events {
+            operation.apply_mint(event);
+        }
+        operation.into_dto()
+    }
+
+    /// Folds redemption events the way the live reactor does: no known
+    /// sequence. Most fixtures slice `redemption_happy_path()` from the
+    /// middle to simulate a mid-stream first observation, so this must NOT
+    /// derive a sequence from the slice's own position (that would wrongly
+    /// look like a legacy genesis to `apply_redemption`) -- use
+    /// [`fold_redemption_from_genesis`] for fixtures that are genuinely a
+    /// full stream starting at the aggregate's real sequence 1.
+    pub(super) fn fold_redemption(events: &[EquityRedemptionEvent]) -> EquityOperationTiming {
+        let mut operation = StoredOperation::new(
+            Uuid::new_v4(),
+            StoredKind::Redeem,
+            redemption_observed_at(&events[0]),
+        );
+        for event in events {
+            operation.apply_redemption(event, None);
+        }
+        operation.into_dto()
+    }
+
+    /// Folds a full redemption stream with the real 1-based sequence threaded
+    /// through, mirroring what `replay_redemption_event` does on catch-up.
+    /// Only valid when `events[0]` is genuinely the aggregate's sequence-1
+    /// event (never a slice starting mid-stream).
+    pub(super) fn fold_redemption_from_genesis(
+        events: &[EquityRedemptionEvent],
+    ) -> EquityOperationTiming {
+        let mut operation = StoredOperation::new(
+            Uuid::new_v4(),
+            StoredKind::Redeem,
+            redemption_observed_at(&events[0]),
+        );
+        for (index, event) in events.iter().enumerate() {
+            let sequence = i64::try_from(index + 1).unwrap();
+            operation.apply_redemption(event, Some(sequence));
+        }
+        operation.into_dto()
+    }
+
+    #[tokio::test]
+    async fn reactor_round_trip_mint_matches_direct_fold() {
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(EquityTimingProjection::new(pool.clone()));
+        let operation_id = issuer_request_id("reactor-mint");
+
+        for event in mint_happy_path() {
+            harness
+                .receive::<TokenizedEquityMint>(operation_id.clone(), event)
+                .await
+                .unwrap();
+        }
+
+        let report = load_equity_timings(&pool, &range()).await.unwrap();
+        assert_eq!(report.operations.len(), 1);
+        let operation = &report.operations[0];
+        assert_eq!(operation.kind, EquityOperationKind::Mint);
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.total_ms, Some(70_000));
+    }
+
+    #[tokio::test]
+    async fn reactor_round_trip_redemption_matches_direct_fold() {
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(EquityTimingProjection::new(pool.clone()));
+        let operation_id = redemption_aggregate_id("reactor-redemption");
+
+        for event in redemption_happy_path() {
+            harness
+                .receive::<EquityRedemption>(operation_id.clone(), event)
+                .await
+                .unwrap();
+        }
+
+        let report = load_equity_timings(&pool, &range()).await.unwrap();
+        assert_eq!(report.operations.len(), 1);
+        let operation = &report.operations[0];
+        assert_eq!(operation.kind, EquityOperationKind::Redeem);
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.total_ms, Some(100_000));
+    }
+
+    #[tokio::test]
+    async fn catch_up_replays_events_the_live_reactor_never_saw() {
+        let pool = setup_test_db().await;
+
+        // Seed events directly through a store with NO projection attached,
+        // simulating history that accumulated before this projection existed.
+        // `RequestMint`'s `initialize()` calls `services.tokenizer.request_mint`,
+        // so the panicking stub's tokenizer is swapped for a working mock --
+        // mirrors `simulated_transfers.rs`'s `FixtureTokenizer` wiring pattern.
+        let mut services = crate::rebalancing::equity::EquityTransferServices::panicking();
+        services.tokenizer = Arc::new(st0x_tokenization::mock::MockTokenizer::new());
+        let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
+            .build(services)
+            .await
+            .unwrap();
+        let operation_id = issuer_request_id("catch-up-mint");
+        mint_store
+            .send(
+                &operation_id,
+                TokenizedEquityMintCommand::RequestMintAt {
+                    issuer_request_id: operation_id.clone(),
+                    symbol: symbol(),
+                    quantity: float!(5),
+                    wallet: Address::repeat_byte(0x11),
+                    requested_at: timestamp(0),
+                },
+            )
+            .await
+            .unwrap();
+
+        let projection = EquityTimingProjection::new(pool.clone());
+        let replayed = projection.catch_up().await.unwrap();
+        // `RequestMintAt` against a mock tokenizer that returns `Pending` (not
+        // `Rejected`) persists both `MintRequested` and `MintAccepted`.
+        assert_eq!(
+            replayed, 2,
+            "catch_up must replay exactly the two pre-existing events"
+        );
+
+        let report = load_equity_timings(&pool, &range()).await.unwrap();
+        assert_eq!(report.operations.len(), 1);
+        assert_eq!(report.operations[0].kind, EquityOperationKind::Mint);
+        assert_eq!(
+            report.operations[0].status,
+            RebalanceTimingStatus::InProgress
+        );
+
+        // A second catch_up must be a no-op (nothing new past the checkpoint).
+        let replayed_again = projection.catch_up().await.unwrap();
+        assert_eq!(replayed_again, 0);
+    }
+
+    /// Inserts a raw event row straight into the event store -- the only way
+    /// to stage a poison row (malformed payload or aggregate id) that no
+    /// domain command can produce. Also used to seed valid streams for
+    /// catch-up tests without going through a real command store: replay
+    /// only deserializes the JSON payload and never re-validates aggregate
+    /// state transitions, so a raw insert is indistinguishable from one
+    /// produced by a real command.
+    async fn insert_raw_equity_event(
+        pool: &SqlitePool,
+        aggregate_type: &str,
+        aggregate_id: &str,
+        sequence: i64,
+        payload: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO events \
+             (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, \
+              metadata) \
+             VALUES (?, ?, ?, 'test-event', '1', ?, '{}')",
+        )
+        .bind(aggregate_type)
+        .bind(aggregate_id)
+        .bind(sequence)
+        .bind(payload)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// Snapshots the full `equity_stage_timing` table so poison-row handling
+    /// can be asserted row-for-row, mirroring
+    /// `rebalance::tests::fetch_timing_rows`.
+    async fn fetch_equity_timing_rows(pool: &SqlitePool) -> Vec<(String, String, String)> {
+        sqlx::query_as(
+            "SELECT operation_id, started_at, timing FROM equity_stage_timing \
+             ORDER BY operation_id",
+        )
+        .fetch_all(pool)
+        .await
+        .unwrap()
+    }
+
+    /// Reads an operation's persisted replay checkpoint (`NULL` -> `None`),
+    /// mirroring `rebalance::tests::fetch_last_sequence`.
+    async fn fetch_equity_last_sequence(pool: &SqlitePool, operation_id: &str) -> Option<i64> {
+        let row: Option<(Option<i64>,)> =
+            sqlx::query_as("SELECT last_sequence FROM equity_stage_timing WHERE operation_id = ?")
+                .bind(operation_id)
+                .fetch_optional(pool)
+                .await
+                .unwrap();
+
+        row.and_then(|(last_sequence,)| last_sequence)
+    }
+
+    /// A poison row -- an unparseable aggregate id, an unparseable event
+    /// payload, or a corrupt stored timing row -- must NOT abort catch_up
+    /// (and so must not brick startup): the bad rows are skipped with a
+    /// warning, valid streams still fold, and the returned count reflects
+    /// only folded events. Ports `rebalance`'s
+    /// `catch_up_skips_poison_rows_and_folds_the_rest`.
+    #[tokio::test]
+    async fn catch_up_skips_poison_rows_and_folds_the_rest() {
+        let pool = setup_test_db().await;
+
+        // A valid redemption stream that must still fold despite the poison
+        // rows around it.
+        let valid_id = Uuid::new_v4();
+        insert_raw_equity_event(
+            &pool,
+            EquityRedemption::AGGREGATE_TYPE,
+            &valid_id.to_string(),
+            1,
+            &serde_json::to_string(&EquityRedemptionEvent::VaultWithdrawPending {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                pending_at: timestamp(0),
+            })
+            .unwrap(),
+        )
+        .await;
+        insert_raw_equity_event(
+            &pool,
+            EquityRedemption::AGGREGATE_TYPE,
+            &valid_id.to_string(),
+            2,
+            &serde_json::to_string(&EquityRedemptionEvent::WithdrawnFromRaindex {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                actual_wrapped_amount: Some(U256::from(5_000_000_000_000_000_000_u128)),
+                raindex_withdraw_tx: TxHash::random(),
+                raindex_withdraw_block: Some(1),
+                withdrawn_at: timestamp(20),
+            })
+            .unwrap(),
+        )
+        .await;
+
+        // A stream whose stored timing row is corrupt JSON: catch_up must
+        // skip it (recoverable via rebuild_all) rather than bricking startup.
+        let corrupt_row_id = Uuid::new_v4();
+        insert_raw_equity_event(
+            &pool,
+            EquityRedemption::AGGREGATE_TYPE,
+            &corrupt_row_id.to_string(),
+            1,
+            &serde_json::to_string(&EquityRedemptionEvent::VaultWithdrawPending {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                pending_at: timestamp(0),
+            })
+            .unwrap(),
+        )
+        .await;
+        sqlx::query(
+            "INSERT INTO equity_stage_timing (operation_id, started_at, timing) \
+             VALUES (?, ?, ?)",
+        )
+        .bind(corrupt_row_id.to_string())
+        .bind(timestamp(0).to_rfc3339())
+        .bind("not-valid-json")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // A raw event row with an unparseable payload, and one with an
+        // unparseable aggregate id.
+        insert_raw_equity_event(
+            &pool,
+            EquityRedemption::AGGREGATE_TYPE,
+            &Uuid::new_v4().to_string(),
+            1,
+            "not-valid-json",
+        )
+        .await;
+        insert_raw_equity_event(
+            &pool,
+            EquityRedemption::AGGREGATE_TYPE,
+            "not-a-uuid",
+            1,
+            "not-valid-json",
+        )
+        .await;
+
+        // None of the poison rows abort catch_up; only the valid stream folds.
+        let replayed = EquityTimingProjection::new(pool.clone())
+            .catch_up()
+            .await
+            .unwrap();
+        assert_eq!(
+            replayed, 2,
+            "only the two events of the valid stream fold; every poison row is skipped"
+        );
+
+        let rows = fetch_equity_timing_rows(&pool).await;
+        assert_eq!(
+            rows.len(),
+            2,
+            "the valid fold and the untouched corrupt row remain; no poison-event rows are created"
+        );
+
+        let valid = valid_id.to_string();
+        assert!(
+            rows.iter()
+                .any(|(operation_id, _, _)| operation_id == &valid),
+            "the valid stream folded into a row"
+        );
+
+        // The corrupt row is left exactly as staged -- catch_up skipped it
+        // rather than overwriting or repairing it.
+        let corrupt = corrupt_row_id.to_string();
+        let corrupt_row = rows
+            .iter()
+            .find(|(operation_id, _, _)| operation_id == &corrupt)
+            .expect("the corrupt row remains in place");
+        assert_eq!(
+            corrupt_row.2, "not-valid-json",
+            "catch_up does not touch the corrupt stored row"
+        );
+
+        // The valid stream is checkpointed; the skipped corrupt row is not
+        // (so it stays visible and re-scanned until a rebuild repairs it).
+        assert_eq!(
+            fetch_equity_last_sequence(&pool, &valid).await,
+            Some(2),
+            "the valid stream advances its checkpoint"
+        );
+        assert_eq!(
+            fetch_equity_last_sequence(&pool, &corrupt).await,
+            None,
+            "the skipped corrupt row is never checkpointed"
+        );
+
+        // A second catch-up converges: the valid stream is past its
+        // checkpoint and the poison rows are re-skipped, so nothing new
+        // folds.
+        let second = EquityTimingProjection::new(pool.clone())
+            .catch_up()
+            .await
+            .unwrap();
+        assert_eq!(
+            second, 0,
+            "the valid stream is caught up and every poison row is re-skipped"
+        );
+    }
+
+    /// A poison event in the MIDDLE of a stream must not let later valid
+    /// events advance the checkpoint past it: that would bury the poison
+    /// (the `sequence > last_sequence` filter would stop re-scanning it) and
+    /// fold the tail onto the indeterminate state left by the skipped event.
+    /// Ports `rebalance`'s
+    /// `catch_up_holds_checkpoint_behind_a_mid_stream_poison_event`.
+    #[tokio::test]
+    async fn catch_up_holds_checkpoint_behind_a_mid_stream_poison_event() {
+        let pool = setup_test_db().await;
+
+        let operation_id = Uuid::new_v4();
+        insert_raw_equity_event(
+            &pool,
+            EquityRedemption::AGGREGATE_TYPE,
+            &operation_id.to_string(),
+            1,
+            &serde_json::to_string(&EquityRedemptionEvent::VaultWithdrawPending {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                pending_at: timestamp(0),
+            })
+            .unwrap(),
+        )
+        .await;
+        insert_raw_equity_event(
+            &pool,
+            EquityRedemption::AGGREGATE_TYPE,
+            &operation_id.to_string(),
+            2,
+            &serde_json::to_string(&EquityRedemptionEvent::VaultWithdrawSubmitted {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                tx_hash: TxHash::random(),
+                submitted_at: timestamp(5),
+            })
+            .unwrap(),
+        )
+        .await;
+        insert_raw_equity_event(
+            &pool,
+            EquityRedemption::AGGREGATE_TYPE,
+            &operation_id.to_string(),
+            3,
+            &serde_json::to_string(&EquityRedemptionEvent::WithdrawnFromRaindex {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                actual_wrapped_amount: Some(U256::from(5_000_000_000_000_000_000_u128)),
+                raindex_withdraw_tx: TxHash::random(),
+                raindex_withdraw_block: Some(1),
+                withdrawn_at: timestamp(20),
+            })
+            .unwrap(),
+        )
+        .await;
+
+        // Corrupt the middle event into a poison payload: now valid(1),
+        // poison(2), valid(3) within the one stream.
+        sqlx::query(
+            "UPDATE events SET payload = 'not-valid-json' \
+             WHERE aggregate_type = ? AND aggregate_id = ? AND sequence = 2",
+        )
+        .bind(EquityRedemption::AGGREGATE_TYPE)
+        .bind(operation_id.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let replayed = EquityTimingProjection::new(pool.clone())
+            .catch_up()
+            .await
+            .unwrap();
+        assert_eq!(
+            replayed, 1,
+            "only seq 1 folds; the poison at seq 2 stops the stream, so seq 3 is left unfolded"
+        );
+
+        // The checkpoint holds at the last good sequence before the poison,
+        // not seq 3 -- otherwise the poison at seq 2 would be buried from
+        // re-scans.
+        assert_eq!(
+            fetch_equity_last_sequence(&pool, &operation_id.to_string()).await,
+            Some(1),
+            "the checkpoint stays at seq 1 so the poison at seq 2 stays visible"
+        );
+
+        // A second catch-up re-scans from seq 2, re-skips the poison, and
+        // folds nothing new: seq 3 stays blocked behind the poison until a
+        // rebuild.
+        let second = EquityTimingProjection::new(pool.clone())
+            .catch_up()
+            .await
+            .unwrap();
+        assert_eq!(
+            second, 0,
+            "the poison keeps blocking the tail; nothing new folds"
+        );
+    }
+
+    /// A malformed `timing` JSON row that survives the SQL window must be
+    /// skipped from `operations` but surfaced via `skipped_operations`
+    /// rather than vanishing silently. Ports `rebalance`'s
+    /// `load_rebalance_timings_counts_skipped_undeserializable_rows`.
+    #[tokio::test]
+    async fn load_equity_timings_counts_skipped_undeserializable_rows() {
+        let pool = setup_test_db().await;
+
+        // Seed one well-formed mint operation through the reactor so the
+        // report is not empty, proving the malformed row is dropped while
+        // the good row remains.
+        let harness = ReactorHarness::new(EquityTimingProjection::new(pool.clone()));
+        let good_id = issuer_request_id("good-mint");
+        for event in mint_happy_path() {
+            harness
+                .receive::<TokenizedEquityMint>(good_id.clone(), event)
+                .await
+                .unwrap();
+        }
+
+        // Insert a row with a valid in-window `started_at` but unparseable
+        // timing.
+        sqlx::query(
+            "INSERT INTO equity_stage_timing (operation_id, started_at, timing) \
+             VALUES (?, ?, ?)",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(timestamp(5).to_rfc3339())
+        .bind("not-valid-json")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let report = load_equity_timings(&pool, &range()).await.unwrap();
+
+        assert_eq!(report.skipped_operations, 1);
+        // Only the well-formed operation survives; the malformed row is
+        // absent.
+        assert_eq!(report.total_operations, 1);
+        assert_eq!(report.operations.len(), 1);
+        assert_eq!(report.operations[0].kind, EquityOperationKind::Mint);
+    }
+
+    /// The `aggregate_type` dispatch (mint vs redemption) has no
+    /// single-aggregate-type analogue in `rebalance`'s catch-up -- this seeds
+    /// one stream of each kind with no projection attached and asserts one
+    /// `catch_up` call folds both, each into its own operation with the
+    /// correct kind and an independently-tracked checkpoint.
+    #[tokio::test]
+    async fn catch_up_replays_both_mint_and_redemption_streams_independently() {
+        let pool = setup_test_db().await;
+
+        let mint_id = Uuid::new_v4();
+        insert_raw_equity_event(
+            &pool,
+            TokenizedEquityMint::AGGREGATE_TYPE,
+            &mint_id.to_string(),
+            1,
+            &serde_json::to_string(&TokenizedEquityMintEvent::MintRequested {
+                symbol: symbol(),
+                quantity: float!(5),
+                wallet: Address::repeat_byte(0x11),
+                requested_at: timestamp(0),
+            })
+            .unwrap(),
+        )
+        .await;
+
+        let redemption_id = Uuid::new_v4();
+        insert_raw_equity_event(
+            &pool,
+            EquityRedemption::AGGREGATE_TYPE,
+            &redemption_id.to_string(),
+            1,
+            &serde_json::to_string(&EquityRedemptionEvent::VaultWithdrawPending {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                pending_at: timestamp(0),
+            })
+            .unwrap(),
+        )
+        .await;
+
+        let replayed = EquityTimingProjection::new(pool.clone())
+            .catch_up()
+            .await
+            .unwrap();
+        assert_eq!(
+            replayed, 2,
+            "one event from each aggregate type folds in a single catch_up pass"
+        );
+
+        let report = load_equity_timings(&pool, &range()).await.unwrap();
+        assert_eq!(report.operations.len(), 2);
+
+        let mint_operation = report
+            .operations
+            .iter()
+            .find(|operation| operation.operation_id == mint_id)
+            .expect("the mint stream folded into its own operation");
+        assert_eq!(mint_operation.kind, EquityOperationKind::Mint);
+
+        let redemption_operation = report
+            .operations
+            .iter()
+            .find(|operation| operation.operation_id == redemption_id)
+            .expect("the redemption stream folded into its own operation");
+        assert_eq!(redemption_operation.kind, EquityOperationKind::Redeem);
+
+        // Each stream's checkpoint is tracked independently.
+        assert_eq!(
+            fetch_equity_last_sequence(&pool, &mint_id.to_string()).await,
+            Some(1)
+        );
+        assert_eq!(
+            fetch_equity_last_sequence(&pool, &redemption_id.to_string()).await,
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn stage_summary_is_sparse_and_only_counts_succeeded_runs() {
+        let mint = fold_mint(&mint_happy_path());
+        let report = equity_timing_report(
+            vec![WindowedOperation {
+                first_seen_at: mint.started_at.unwrap(),
+                operation: mint,
+            }],
+            &range(),
+            0,
+        );
+
+        // Only the four mint stages have succeeded samples; no redemption
+        // stage should appear.
+        let names: Vec<EquityStageName> = report.stage_summary.iter().map(|s| s.stage).collect();
+        assert!(names.contains(&EquityStageName::MintAcceptance));
+        assert!(!names.contains(&EquityStageName::RedemptionWithdraw));
+    }
+
+    #[test]
+    fn report_excludes_operations_outside_range() {
+        // Mirrors `rebalance::tests::report_excludes_operations_outside_range`:
+        // `equity_timing_report`'s own `first_seen_at` windowing is a pure-
+        // function-level filter, independent of `load_equity_timings`'s SQL
+        // `WHERE` clause -- exercise it directly so a regression (e.g. an
+        // inverted condition) is caught even outside the DB-backed path.
+        let mint = fold_mint(&mint_happy_path());
+        let narrow = ReportRange {
+            from: timestamp(100_000),
+            to: timestamp(200_000),
+        };
+
+        let report = equity_timing_report(
+            vec![WindowedOperation {
+                first_seen_at: mint.started_at.unwrap(),
+                operation: mint,
+            }],
+            &narrow,
+            0,
+        );
+
+        assert_eq!(report.total_operations, 0);
+        assert!(report.operations.is_empty());
+        assert!(report.stage_summary.is_empty());
+    }
+
+    #[test]
+    fn mint_stage_duration_clamps_negative_clock_skew_to_zero() {
+        // Mirrors `rebalance::tests::negative_stage_durations_clamp_to_zero`:
+        // the close-out event's timestamp arrives before the stage-open
+        // event's timestamp (clock skew between event sources), so the naive
+        // `ended_at - started_at` would be negative. `close`'s `.max(0)` clamp
+        // must keep it from leaking a negative sample into percentiles.
+        let events = [
+            TokenizedEquityMintEvent::MintRequested {
+                symbol: symbol(),
+                quantity: float!(5),
+                wallet: Address::repeat_byte(0x11),
+                requested_at: timestamp(10),
+            },
+            TokenizedEquityMintEvent::MintAccepted {
+                issuer_request_id: issuer_request_id("op"),
+                tokenization_request_id: TokenizationRequestId::try_new("tok-1").unwrap(),
+                accepted_at: timestamp(0),
+            },
+        ];
+        let operation = fold_mint(&events);
+
+        let acceptance = stage(&operation, EquityStageName::MintAcceptance);
+        assert_eq!(acceptance.outcome, StageOutcome::Succeeded);
+        assert_eq!(acceptance.duration_ms, Some(0));
+    }
+
+    #[test]
+    fn redemption_stage_duration_clamps_negative_clock_skew_to_zero() {
+        // Redemption counterpart, exercising `close`'s identical clamp via a
+        // stage-close event timestamped before the stage-open event.
+        let events = [
+            EquityRedemptionEvent::VaultWithdrawPending {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                pending_at: timestamp(10),
+            },
+            EquityRedemptionEvent::WithdrawnFromRaindex {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                actual_wrapped_amount: Some(U256::from(5_000_000_000_000_000_000_u128)),
+                raindex_withdraw_tx: TxHash::random(),
+                raindex_withdraw_block: Some(1),
+                withdrawn_at: timestamp(0),
+            },
+        ];
+        let operation = fold_redemption(&events);
+
+        let withdraw = stage(&operation, EquityStageName::RedemptionWithdraw);
+        assert_eq!(withdraw.outcome, StageOutcome::Succeeded);
+        assert_eq!(withdraw.duration_ms, Some(0));
+    }
+}

--- a/src/performance/equity_timing/redemption.rs
+++ b/src/performance/equity_timing/redemption.rs
@@ -1,0 +1,856 @@
+//! Redemption pipeline stage folding for the equity stage-timing read model.
+//!
+//! Holds [`StoredOperation::apply_redemption`] and [`redemption_observed_at`];
+//! the shared read-model machinery, stored types, and stage helpers live in
+//! the parent [`super`] module.
+
+use chrono::{DateTime, Utc};
+
+use st0x_finance::FractionalShares;
+
+use super::{StoredOperation, StoredStageName, StoredStageOutcome, StoredStatus};
+use crate::equity_redemption::EquityRedemptionEvent;
+
+impl StoredOperation {
+    /// Apply one redemption event to the accumulated state. Same idempotency
+    /// contract as [`Self::apply_mint`].
+    ///
+    /// `sequence` is the event's stream position when known (only replay
+    /// threads it; the live reactor always passes `None`, see call site).
+    /// Used to distinguish a true legacy-genesis event (`sequence == Some(1)`,
+    /// see `VaultWithdrawSubmitted`/`WithdrawnFromRaindex` below) from a
+    /// genuinely mid-stream first observation, which must NOT be mistaken for
+    /// one -- only the aggregate's actual first event can seed a known start.
+    pub(super) fn apply_redemption(
+        &mut self,
+        event: &EquityRedemptionEvent,
+        sequence: Option<i64>,
+    ) {
+        use EquityRedemptionEvent::*;
+        use StoredStageName::*;
+
+        match event {
+            VaultWithdrawPending {
+                symbol,
+                quantity,
+                pending_at,
+                ..
+            } => {
+                self.symbol.get_or_insert_with(|| symbol.clone());
+                self.quantity
+                    .get_or_insert_with(|| FractionalShares::new(*quantity));
+                // `VaultWithdrawPending` is always the genuine genesis event
+                // (the aggregate's own `initialize()` command).
+                self.started_at.get_or_insert(*pending_at);
+                self.open_once(RedemptionWithdraw, *pending_at);
+            }
+            // Also carries symbol/quantity: hydrate them so an operation
+            // first observed mid-stream (deploy/restart backfill) is not
+            // left with `symbol: None, quantity: None` when the genesis
+            // `VaultWithdrawPending` was never seen.
+            VaultWithdrawSubmitted {
+                symbol,
+                quantity,
+                submitted_at,
+                ..
+            } => {
+                self.symbol.get_or_insert_with(|| symbol.clone());
+                self.quantity
+                    .get_or_insert_with(|| FractionalShares::new(*quantity));
+                // Legacy genesis (see `EquityRedemption::originate`'s own
+                // "old aggregates start with VaultWithdrawSubmitted" comment):
+                // `submitted_at` IS the genuine start, not a mid-stream
+                // observation, so seed both the operation start and the
+                // withdraw stage's open run from it.
+                if sequence == Some(1) {
+                    self.started_at.get_or_insert(*submitted_at);
+                    self.open_once(RedemptionWithdraw, *submitted_at);
+                }
+            }
+            // `UnwrapSubmitted` can fire directly from `WithdrawnFromRaindex`
+            // (see `EquityRedemption::evolve`'s `UnwrapSubmitted` arm, which
+            // accepts both `WithdrawnFromRaindex` and `UnwrapPending` as
+            // valid predecessors) -- a legacy/pre-split code path where
+            // `UnwrapPending` never fires at all, so the genuine
+            // `submitted_at -> unwrapped_at` interval would otherwise be lost
+            // as Unmeasured. `open_once` no-ops when `UnwrapPending` already
+            // opened the stage, so this is safe for the normal path too.
+            UnwrapSubmitted { submitted_at, .. } => {
+                self.open_once(RedemptionUnwrap, *submitted_at);
+            }
+            WithdrawnFromRaindex {
+                symbol,
+                quantity,
+                withdrawn_at,
+                ..
+            } => {
+                self.symbol.get_or_insert_with(|| symbol.clone());
+                self.quantity
+                    .get_or_insert_with(|| FractionalShares::new(*quantity));
+                // Legacy genesis (see `EquityRedemption::originate`'s own
+                // "old aggregates start with WithdrawnFromRaindex" comment):
+                // `withdrawn_at` IS the genuine start (the withdraw already
+                // happened by the time this stream begins), not a mid-stream
+                // observation -- seed the operation start from it so
+                // `total_ms` is measurable even though the withdraw stage
+                // itself stays unmeasured below (no earlier event gives it a
+                // duration).
+                if sequence == Some(1) {
+                    self.started_at.get_or_insert(*withdrawn_at);
+                }
+                // Mirrors USDC's `BridgingInitiated` handling (see
+                // `rebalance::StoredOperation`'s fold): an operation first
+                // observed here (mid-stream, `RedemptionWithdraw` never
+                // opened) has no measurable withdraw duration, so record it
+                // as unmeasured instead of silently dropping the stage.
+                self.close_or_record_unmeasured(
+                    RedemptionWithdraw,
+                    *withdrawn_at,
+                    StoredStageOutcome::Succeeded,
+                );
+            }
+            UnwrapPending { pending_at } => {
+                self.open_once(RedemptionUnwrap, *pending_at);
+            }
+            // Mid-stream-first case as above: no open `RedemptionUnwrap` run
+            // when `WithdrawnFromRaindex`/`UnwrapPending` was never seen.
+            TokensUnwrapped { unwrapped_at, .. } => {
+                self.close_or_record_unmeasured(
+                    RedemptionUnwrap,
+                    *unwrapped_at,
+                    StoredStageOutcome::Succeeded,
+                );
+            }
+            SendPending { pending_at } => {
+                self.open_once(RedemptionSend, *pending_at);
+            }
+            // Terminal failures: whichever stage is currently open (varies by
+            // which of these fired) is closed as failed and the operation
+            // ends. `TransferFailed` is emitted either by `SendTokens` (from
+            // `SendPending`) or the operator `FailTransfer` command (from
+            // `WithdrawnFromRaindex`/`TokensUnwrapped`/etc.); every source
+            // state evolves to the terminal `Failed` state (see
+            // `EquityRedemptionEvent::evolve`'s `TransferFailed` arm).
+            // `DetectionFailed`, despite its doc comment's "keep inflight"
+            // framing (which describes staying in the terminal `Failed`
+            // state until an operator resolves it, not staying
+            // non-terminal), also evolves straight to `Self::Failed`.
+            TransferFailed { failed_at: at, .. }
+            | DetectionFailed { failed_at: at, .. }
+            | RedemptionRejected {
+                rejected_at: at, ..
+            } => {
+                // `FailTransfer` (unlike `FailDetection`/`RejectRedemption`,
+                // each valid from exactly one state with a stage already
+                // open) is also valid from `WithdrawnFromRaindex` and
+                // `TokensUnwrapped` -- states reached right after a stage
+                // closes and before the next stage's start event arrives. In
+                // those cases `close_open_stages` below has nothing open to
+                // fail, and the operation would otherwise go `Failed` with no
+                // failed stage in the breakdown. Derive and fail the stage
+                // the pipeline stopped at instead.
+                // Guarded on `self.status` too, not just `had_open_stage`:
+                // once this arm has derived and failed a stage, every stage
+                // has `ended_at: Some(_)`, so `had_open_stage` alone would be
+                // `false` again on redelivery of the exact same event and
+                // `next_missing_redemption_stage` would then derive the NEXT
+                // stage in pipeline order (since the previously-derived one
+                // now `has_run`), fabricating a second bogus Failed entry.
+                // The operation is already terminal once `status` is
+                // `Failed`, so redelivery must be a pure no-op here.
+                let had_open_stage = self.stages.iter().any(|run| run.ended_at.is_none());
+                self.close_open_stages(*at, StoredStageOutcome::Failed);
+                if !had_open_stage && self.status != StoredStatus::Failed {
+                    // `DetectionFailed`/`RedemptionRejected` are each valid
+                    // from exactly one state (`TokensSent`/`Pending`
+                    // respectively -- see `EquityRedemptionEvent::evolve`),
+                    // so a mid-stream-first observation (no stage ever seen,
+                    // `stages` empty) always means the pipeline reached
+                    // `RedemptionDetection`/`RedemptionCompletion`. Deriving
+                    // via `next_missing_redemption_stage` there would wrongly
+                    // answer `RedemptionWithdraw` (the earliest stage with no
+                    // run at all), since that helper only knows pipeline
+                    // position, not which event fired. `TransferFailed` alone
+                    // is valid from multiple states, so it still needs the
+                    // derived lookup.
+                    // `TransferFailed` alone (unlike `DetectionFailed`/
+                    // `RedemptionRejected` above) is valid from either
+                    // `WithdrawnFromRaindex` or `TokensUnwrapped`, and its
+                    // payload carries nothing that says which. When it is
+                    // ALSO the mid-stream-first event (`stages` empty, this
+                    // branch), `next_missing_redemption_stage` always answers
+                    // the earliest stage, `RedemptionWithdraw` -- a
+                    // best-effort guess that is wrong whenever the true prior
+                    // state was `TokensUnwrapped` (withdraw AND unwrap both
+                    // actually succeeded). This is an accepted, inherent
+                    // limitation: no event payload can disambiguate it, so it
+                    // is deliberately not "fixed" by guessing further.
+                    let derived_stage = match event {
+                        DetectionFailed { .. } => Some(RedemptionDetection),
+                        RedemptionRejected { .. } => Some(RedemptionCompletion),
+                        _ => self.next_missing_redemption_stage(),
+                    };
+                    if let Some(stage) = derived_stage {
+                        self.fail_unopened_stage(stage, *at);
+                    }
+                }
+                self.status = StoredStatus::Failed;
+            }
+            // Mid-stream-first case as above: no open `RedemptionSend` run
+            // when `SendPending` was never seen.
+            TokensSent { sent_at, .. } => {
+                self.close_or_record_unmeasured(
+                    RedemptionSend,
+                    *sent_at,
+                    StoredStageOutcome::Succeeded,
+                );
+                self.open_once(RedemptionDetection, *sent_at);
+            }
+            // Mid-stream-first case as above: no open `RedemptionDetection`
+            // run when `TokensSent` was never seen.
+            Detected { detected_at, .. } => {
+                self.close_or_record_unmeasured(
+                    RedemptionDetection,
+                    *detected_at,
+                    StoredStageOutcome::Succeeded,
+                );
+                self.open_once(RedemptionCompletion, *detected_at);
+            }
+            // Mid-stream-first case as above: no open `RedemptionCompletion`
+            // run when `Detected` was never seen.
+            Completed { completed_at } => {
+                self.close_or_record_unmeasured(
+                    RedemptionCompletion,
+                    *completed_at,
+                    StoredStageOutcome::Succeeded,
+                );
+                self.status = StoredStatus::Completed;
+                self.completed_at = Some(*completed_at);
+            }
+            // `RecoverProviderCompletion` is valid from `Failed{redemption_tx:
+            // Some(_), ..}`, reached via two distinct prior failures: (1)
+            // `DetectionFailed` from `TokensSent`, which closes the
+            // already-open `RedemptionDetection` stage `Failed` (via
+            // `close_open_stages` above) while `RedemptionCompletion` was
+            // never opened; or (2) `RedemptionRejected` from `Pending` (i.e.
+            // *after* `Detected` already opened `RedemptionCompletion`), which
+            // closes `RedemptionCompletion` itself `Failed`. Either way,
+            // recovery proves the operation actually completed, so flip
+            // whichever stage a prior failure left `Failed` back to
+            // `Unmeasured` first -- mirroring `recover_receipt_stage`'s
+            // already-closed-run handling -- otherwise that stage would stay
+            // permanently `Failed` on a `Completed` operation.
+            ProviderCompletionRecovered { recovered_at, .. } => {
+                self.close_open_stages(*recovered_at, StoredStageOutcome::Succeeded);
+                for run in self
+                    .stages
+                    .iter_mut()
+                    .filter(|run| run.outcome == StoredStageOutcome::Failed)
+                {
+                    run.outcome = StoredStageOutcome::Unmeasured;
+                    run.duration_ms = None;
+                }
+                self.record_unmeasured(RedemptionCompletion, *recovered_at);
+                self.status = StoredStatus::Completed;
+                self.completed_at = Some(*recovered_at);
+            }
+            OperatorReconciled { reconciled_at, .. } => {
+                // Reconcile is valid only from the terminal `Failed` state
+                // (see `EquityRedemptionCommand::Reconcile`), so the failed
+                // stage is already closed -- no stage manipulation needed
+                // here, matching USDC's `OperatorReconciled` handling
+                // exactly.
+                self.status = StoredStatus::Completed;
+                self.completed_at = Some(*reconciled_at);
+                self.operator_reconciled = true;
+            }
+        }
+    }
+
+    /// The earliest redemption stage (in pipeline order) that has no run yet,
+    /// used by `apply_redemption`'s `TransferFailed` arm to derive where the
+    /// pipeline stopped when the failure arrives with no stage open.
+    fn next_missing_redemption_stage(&self) -> Option<StoredStageName> {
+        use StoredStageName::*;
+
+        [
+            RedemptionWithdraw,
+            RedemptionUnwrap,
+            RedemptionSend,
+            RedemptionDetection,
+            RedemptionCompletion,
+        ]
+        .into_iter()
+        .find(|stage| !self.has_run(*stage))
+    }
+}
+
+/// Redemption counterpart to [`super::mint::mint_observed_at`]; same rationale.
+pub(super) fn redemption_observed_at(event: &EquityRedemptionEvent) -> DateTime<Utc> {
+    use EquityRedemptionEvent::*;
+
+    // Same combined-arm rationale as `mint_observed_at`.
+    match event {
+        VaultWithdrawPending { pending_at: at, .. }
+        | VaultWithdrawSubmitted {
+            submitted_at: at, ..
+        }
+        | WithdrawnFromRaindex {
+            withdrawn_at: at, ..
+        }
+        | UnwrapPending { pending_at: at }
+        | UnwrapSubmitted {
+            submitted_at: at, ..
+        }
+        | TokensUnwrapped {
+            unwrapped_at: at, ..
+        }
+        | SendPending { pending_at: at }
+        | TransferFailed { failed_at: at, .. }
+        | TokensSent { sent_at: at, .. }
+        | DetectionFailed { failed_at: at, .. }
+        | Detected {
+            detected_at: at, ..
+        }
+        | RedemptionRejected {
+            rejected_at: at, ..
+        }
+        | Completed { completed_at: at }
+        | ProviderCompletionRecovered {
+            recovered_at: at, ..
+        }
+        | OperatorReconciled {
+            reconciled_at: at, ..
+        } => *at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{Address, TxHash, U256};
+    use uuid::Uuid;
+
+    use st0x_dto::{EquityOperationKind, EquityStageName, RebalanceTimingStatus, StageOutcome};
+    use st0x_float_macro::float;
+    use st0x_tokenization::TokenizationRequestId;
+
+    use super::super::StoredKind;
+    use super::super::tests::{
+        fold_redemption, fold_redemption_from_genesis, redemption_happy_path, stage, symbol,
+        timestamp,
+    };
+    use super::*;
+    use crate::equity_redemption::DetectionFailure;
+
+    #[test]
+    fn redemption_happy_path_completes_all_five_stages() {
+        let operation = fold_redemption(&redemption_happy_path());
+
+        assert_eq!(operation.kind, EquityOperationKind::Redeem);
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.started_at, Some(timestamp(0)));
+        assert_eq!(operation.completed_at, Some(timestamp(100)));
+        assert_eq!(operation.total_ms, Some(100_000));
+
+        for name in [
+            EquityStageName::RedemptionWithdraw,
+            EquityStageName::RedemptionUnwrap,
+            EquityStageName::RedemptionSend,
+            EquityStageName::RedemptionDetection,
+            EquityStageName::RedemptionCompletion,
+        ] {
+            assert_eq!(
+                stage(&operation, name).outcome,
+                StageOutcome::Succeeded,
+                "{name:?} did not succeed"
+            );
+        }
+    }
+
+    #[test]
+    fn redemption_first_observed_at_withdrawn_from_raindex_hydrates_symbol_and_quantity() {
+        // Deploy/restart backfill case: the read model first observes this
+        // operation at `WithdrawnFromRaindex` because the genesis
+        // `VaultWithdrawPending` predates the projection's `started_at`
+        // window (or was otherwise never seen). `WithdrawnFromRaindex` still
+        // carries `symbol`/`quantity`, so those fields -- and an Unmeasured
+        // `RedemptionWithdraw` stage recording that the withdraw demonstrably
+        // happened -- must be populated rather than left `None`/missing.
+        let events = redemption_happy_path()[2..].to_vec();
+        let operation = fold_redemption(&events);
+
+        assert_eq!(operation.symbol, Some(symbol()));
+        assert_eq!(operation.quantity, Some(FractionalShares::new(float!(5))));
+        let withdraw = stage(&operation, EquityStageName::RedemptionWithdraw);
+        assert_eq!(withdraw.outcome, StageOutcome::Unmeasured);
+        assert_eq!(withdraw.duration_ms, None);
+    }
+
+    #[test]
+    fn redemption_legacy_genesis_at_withdrawn_from_raindex_seeds_known_start() {
+        // Distinct from the mid-stream-first case above: `EquityRedemption`
+        // supports OLD aggregates that genuinely start their event stream at
+        // `WithdrawnFromRaindex` (see its `originate` doc comment), so
+        // `withdrawn_at` IS the real start, not an unknown one -- `started_at`
+        // and `total_ms` must be populated, not left `None`.
+        let events = redemption_happy_path()[2..].to_vec();
+        let operation = fold_redemption_from_genesis(&events);
+
+        assert_eq!(operation.started_at, Some(timestamp(20)));
+        assert_eq!(operation.completed_at, Some(timestamp(100)));
+        assert_eq!(operation.total_ms, Some(80_000));
+        // The withdraw stage's own duration is still unmeasurable (no earlier
+        // event gives it a start distinct from `withdrawn_at`), only the
+        // operation-level start becomes known.
+        let withdraw = stage(&operation, EquityStageName::RedemptionWithdraw);
+        assert_eq!(withdraw.outcome, StageOutcome::Unmeasured);
+        assert_eq!(withdraw.duration_ms, None);
+    }
+
+    #[test]
+    fn redemption_legacy_genesis_at_vault_withdraw_submitted_seeds_known_start_and_stage() {
+        // Same legacy support, one event earlier: `EquityRedemption` also
+        // supports old aggregates starting at `VaultWithdrawSubmitted` (see
+        // its `originate` doc comment). Unlike `WithdrawnFromRaindex`
+        // genesis, `RedemptionWithdraw`'s full duration IS measurable here
+        // (`submitted_at` -> the later `WithdrawnFromRaindex`).
+        let events = redemption_happy_path()[1..].to_vec();
+        let operation = fold_redemption_from_genesis(&events);
+
+        assert_eq!(operation.started_at, Some(timestamp(5)));
+        assert_eq!(operation.completed_at, Some(timestamp(100)));
+        assert_eq!(operation.total_ms, Some(95_000));
+        let withdraw = stage(&operation, EquityStageName::RedemptionWithdraw);
+        assert_eq!(withdraw.outcome, StageOutcome::Succeeded);
+        assert_eq!(withdraw.duration_ms, Some(15_000));
+    }
+
+    #[test]
+    fn redemption_first_observed_at_tokens_unwrapped_records_unwrap_unmeasured() {
+        // Same mid-stream-first case, one stage later: `WithdrawnFromRaindex`
+        // was never seen either.
+        let events = redemption_happy_path()[5..].to_vec();
+        let operation = fold_redemption(&events);
+
+        let unwrap = stage(&operation, EquityStageName::RedemptionUnwrap);
+        assert_eq!(unwrap.outcome, StageOutcome::Unmeasured);
+        assert_eq!(unwrap.duration_ms, None);
+        assert_eq!(
+            stage(&operation, EquityStageName::RedemptionSend).outcome,
+            StageOutcome::Succeeded
+        );
+    }
+
+    #[test]
+    fn redemption_unwrap_submitted_without_unwrap_pending_still_measures_unwrap_duration() {
+        // Legacy/pre-split path: `EquityRedemption::evolve`'s `UnwrapSubmitted`
+        // arm accepts `WithdrawnFromRaindex` as a valid predecessor (not only
+        // `UnwrapPending`), so some real streams never emit `UnwrapPending` at
+        // all. Before this fix `UnwrapSubmitted` was a pure no-op marker, so
+        // `RedemptionUnwrap` never opened and `TokensUnwrapped` recorded it as
+        // Unmeasured even though `submitted_at -> unwrapped_at` is a genuine,
+        // measurable interval.
+        let events = vec![
+            EquityRedemptionEvent::WithdrawnFromRaindex {
+                symbol: symbol(),
+                quantity: float!(5),
+                token: Address::repeat_byte(0x22),
+                wrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                actual_wrapped_amount: Some(U256::from(5_000_000_000_000_000_000_u128)),
+                raindex_withdraw_tx: TxHash::random(),
+                raindex_withdraw_block: Some(1),
+                withdrawn_at: timestamp(20),
+            },
+            EquityRedemptionEvent::UnwrapSubmitted {
+                unwrap_tx_hash: TxHash::random(),
+                submitted_at: timestamp(25),
+            },
+            EquityRedemptionEvent::TokensUnwrapped {
+                quantity: Some(float!(5)),
+                underlying_token: Address::repeat_byte(0x33),
+                unwrap_tx_hash: TxHash::random(),
+                unwrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                unwrap_block: Some(2),
+                unwrapped_at: timestamp(45),
+            },
+        ];
+        let operation = fold_redemption(&events);
+
+        let unwrap = stage(&operation, EquityStageName::RedemptionUnwrap);
+        assert_eq!(unwrap.outcome, StageOutcome::Succeeded);
+        assert_eq!(unwrap.duration_ms, Some(20_000));
+    }
+
+    #[test]
+    fn catch_up_upgrades_unmeasured_placeholder_to_measured_duration() {
+        // Simulates the gap `open_once`'s placeholder-upgrade fix targets:
+        // the live reactor missed folding `UnwrapPending` (the event-sorcery
+        // reactor-bridge logs and continues past a single reactor error), so
+        // `TokensUnwrapped` arrives with no open `RedemptionUnwrap` run and
+        // is recorded as an Unmeasured placeholder. A later restart's
+        // `catch_up` replays the ENTIRE stream, so the real `UnwrapPending`
+        // now arrives too, after the placeholder already exists. `open_once`
+        // must recognize the placeholder as recoverable and backfill the
+        // real duration instead of leaving the stage stuck Unmeasured
+        // forever (once catch-up advances the checkpoint, this is the only
+        // chance to repair it).
+        let events = vec![
+            EquityRedemptionEvent::TokensUnwrapped {
+                quantity: Some(float!(5)),
+                underlying_token: Address::repeat_byte(0x33),
+                unwrap_tx_hash: TxHash::random(),
+                unwrapped_amount: U256::from(5_000_000_000_000_000_000_u128),
+                unwrap_block: Some(2),
+                unwrapped_at: timestamp(45),
+            },
+            EquityRedemptionEvent::UnwrapPending {
+                pending_at: timestamp(25),
+            },
+        ];
+        let operation = fold_redemption(&events);
+
+        let unwrap = stage(&operation, EquityStageName::RedemptionUnwrap);
+        assert_eq!(unwrap.outcome, StageOutcome::Succeeded);
+        assert_eq!(unwrap.started_at, timestamp(25));
+        assert_eq!(unwrap.duration_ms, Some(20_000));
+    }
+
+    #[test]
+    fn redemption_first_observed_at_tokens_sent_records_send_unmeasured() {
+        let events = redemption_happy_path()[7..].to_vec();
+        let operation = fold_redemption(&events);
+
+        let send = stage(&operation, EquityStageName::RedemptionSend);
+        assert_eq!(send.outcome, StageOutcome::Unmeasured);
+        assert_eq!(send.duration_ms, None);
+        assert_eq!(
+            stage(&operation, EquityStageName::RedemptionDetection).outcome,
+            StageOutcome::Succeeded
+        );
+    }
+
+    #[test]
+    fn redemption_first_observed_at_detected_records_detection_unmeasured() {
+        let events = redemption_happy_path()[8..].to_vec();
+        let operation = fold_redemption(&events);
+
+        let detection = stage(&operation, EquityStageName::RedemptionDetection);
+        assert_eq!(detection.outcome, StageOutcome::Unmeasured);
+        assert_eq!(detection.duration_ms, None);
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+    }
+
+    #[test]
+    fn redemption_transfer_failed_closes_send_as_failed() {
+        let mut events = redemption_happy_path()[..7].to_vec();
+        events.push(EquityRedemptionEvent::TransferFailed {
+            tx_hash: None,
+            reason: None,
+            failed_at: timestamp(55),
+        });
+        let operation = fold_redemption(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::RedemptionSend).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn redemption_transfer_failed_first_observed_defaults_to_withdraw_stage() {
+        // Regression-lock, not a behavior fix: `TransferFailed` is valid from
+        // either `WithdrawnFromRaindex` or `TokensUnwrapped` (see the shared
+        // failure arm's doc), so when it is the mid-stream-first event (no
+        // stage ever observed, `self.stages` empty) the bare event payload
+        // cannot say which of the two the pipeline actually reached --
+        // `next_missing_redemption_stage` always answers the earliest stage,
+        // `RedemptionWithdraw`, even though the true prior state may have
+        // been `TokensUnwrapped` (withdraw AND unwrap both actually
+        // succeeded). This is a known, accepted limitation documented at the
+        // call site; this test locks in the CURRENT best-effort behavior so
+        // a future change to it is deliberate, not an accidental regression.
+        let events = vec![EquityRedemptionEvent::TransferFailed {
+            tx_hash: None,
+            reason: None,
+            failed_at: timestamp(55),
+        }];
+        let operation = fold_redemption(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::RedemptionWithdraw).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn redemption_transfer_failed_after_withdraw_derives_failed_unwrap_stage() {
+        // `FailTransfer` is valid from `WithdrawnFromRaindex`, reached right
+        // after `RedemptionWithdraw` closes and before `RedemptionUnwrap`
+        // ever opens -- `close_open_stages` alone has nothing open to fail
+        // here, so without the derived-stage fix the operation would go
+        // `Failed` with every recorded stage showing `Succeeded`.
+        let mut events = redemption_happy_path()[..3].to_vec();
+        events.push(EquityRedemptionEvent::TransferFailed {
+            tx_hash: None,
+            reason: None,
+            failed_at: timestamp(22),
+        });
+        let operation = fold_redemption(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::RedemptionWithdraw).outcome,
+            StageOutcome::Succeeded
+        );
+        assert_eq!(
+            stage(&operation, EquityStageName::RedemptionUnwrap).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn redelivering_transfer_failed_after_withdraw_does_not_fabricate_extra_failed_stages() {
+        // Regression test: `catch_up` refolds an operation's entire event
+        // stream from scratch on top of the already-fully-folded stored row
+        // on every server restart (see `rebalance.rs`'s
+        // `redelivering_full_event_sequence_is_idempotent`, the precedent
+        // this mirrors). Reapplying the exact same gap-triggering sequence
+        // must not derive a second bogus Failed stage on top of the one the
+        // first application already derived.
+        let mut events = redemption_happy_path()[..3].to_vec();
+        events.push(EquityRedemptionEvent::TransferFailed {
+            tx_hash: None,
+            reason: None,
+            failed_at: timestamp(22),
+        });
+
+        let mut operation = StoredOperation::new(
+            Uuid::new_v4(),
+            StoredKind::Redeem,
+            redemption_observed_at(&events[0]),
+        );
+        for event in &events {
+            operation.apply_redemption(event, None);
+        }
+        let once = operation.clone().into_dto();
+
+        for event in &events {
+            operation.apply_redemption(event, None);
+        }
+        let twice = operation.into_dto();
+
+        assert_eq!(once.stages.len(), twice.stages.len());
+        for (single, redelivered) in once.stages.iter().zip(twice.stages.iter()) {
+            assert_eq!(single.stage, redelivered.stage);
+            assert_eq!(single.outcome, redelivered.outcome);
+        }
+    }
+
+    #[test]
+    fn redemption_transfer_failed_after_unwrap_derives_failed_send_stage() {
+        // Same gap as `WithdrawnFromRaindex`, one stage later:
+        // `RedemptionUnwrap` has already closed and `RedemptionSend` never
+        // opened.
+        let mut events = redemption_happy_path()[..6].to_vec();
+        events.push(EquityRedemptionEvent::TransferFailed {
+            tx_hash: None,
+            reason: None,
+            failed_at: timestamp(47),
+        });
+        let operation = fold_redemption(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::RedemptionUnwrap).outcome,
+            StageOutcome::Succeeded
+        );
+        assert_eq!(
+            stage(&operation, EquityStageName::RedemptionSend).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn redemption_detection_failed_closes_detection_as_failed() {
+        let mut events = redemption_happy_path()[..8].to_vec();
+        events.push(EquityRedemptionEvent::DetectionFailed {
+            failure: DetectionFailure::Timeout,
+            failed_at: timestamp(80),
+        });
+        let operation = fold_redemption(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::RedemptionDetection).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn redemption_detection_failed_first_observed_derives_detection_not_withdraw() {
+        // Mid-stream-first observation (see `redemption_first_observed_at_*`
+        // above): the projection's stream begins directly at
+        // `DetectionFailed`, with no earlier stage ever recorded. Because
+        // `DetectionFailed` is only ever valid from `TokensSent` (see
+        // `EquityRedemptionCommand::FailDetection`), the derived-failed stage
+        // must be `RedemptionDetection` -- not `next_missing_redemption_stage`'s
+        // pipeline-position answer of `RedemptionWithdraw`, which would be
+        // wrong here since no stage has run at all yet.
+        let events = vec![EquityRedemptionEvent::DetectionFailed {
+            failure: DetectionFailure::Timeout,
+            failed_at: timestamp(80),
+        }];
+        let operation = fold_redemption(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::RedemptionDetection).outcome,
+            StageOutcome::Failed
+        );
+        assert!(
+            operation
+                .stages
+                .iter()
+                .all(|entry| entry.stage != EquityStageName::RedemptionWithdraw),
+            "must not fabricate a Failed RedemptionWithdraw stage that never ran"
+        );
+    }
+
+    #[test]
+    fn redemption_rejected_closes_open_stage_as_failed() {
+        let mut events = redemption_happy_path()[..2].to_vec();
+        events.push(EquityRedemptionEvent::RedemptionRejected {
+            reason: "rejected".to_string(),
+            rejected_at: timestamp(10),
+        });
+        let operation = fold_redemption(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(
+            stage(&operation, EquityStageName::RedemptionWithdraw).outcome,
+            StageOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn redemption_provider_completion_recovered_marks_completion_unmeasured() {
+        let mut events = redemption_happy_path()[..8].to_vec();
+        events.push(EquityRedemptionEvent::DetectionFailed {
+            failure: DetectionFailure::Timeout,
+            failed_at: timestamp(80),
+        });
+        events.push(EquityRedemptionEvent::ProviderCompletionRecovered {
+            tokenization_request_id: TokenizationRequestId::try_new("tok-2").unwrap(),
+            recovered_at: timestamp(400),
+        });
+        let operation = fold_redemption(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.completed_at, Some(timestamp(400)));
+        let completion = stage(&operation, EquityStageName::RedemptionCompletion);
+        assert_eq!(completion.outcome, StageOutcome::Unmeasured);
+        assert_eq!(completion.duration_ms, None);
+        // `RedemptionDetection` was closed `Failed` by `DetectionFailed`
+        // before `RedemptionCompletion` ever opened; recovery must flip it
+        // back to `Unmeasured` too, not leave it permanently `Failed` on a
+        // `Completed` operation.
+        let detection = stage(&operation, EquityStageName::RedemptionDetection);
+        assert_eq!(detection.outcome, StageOutcome::Unmeasured);
+        assert_eq!(detection.duration_ms, None);
+    }
+
+    #[test]
+    fn redemption_provider_completion_recovered_after_rejection_marks_completion_unmeasured() {
+        // Unlike the `DetectionFailed` case above, `RedemptionRejected` fires
+        // from `Pending` -- reached *after* `Detected` already opened
+        // `RedemptionCompletion` -- so the shared failure arm closes
+        // `RedemptionCompletion` itself `Failed` before recovery fires.
+        // Recovery must flip that stale `Failed` outcome to `Unmeasured`
+        // rather than leaving a `Completed` operation with a permanently
+        // `Failed` `RedemptionCompletion` stage.
+        let mut events = redemption_happy_path()[..9].to_vec();
+        events.push(EquityRedemptionEvent::RedemptionRejected {
+            reason: "rejected by operator".to_string(),
+            rejected_at: timestamp(95),
+        });
+        events.push(EquityRedemptionEvent::ProviderCompletionRecovered {
+            tokenization_request_id: TokenizationRequestId::try_new("tok-2").unwrap(),
+            recovered_at: timestamp(400),
+        });
+        let operation = fold_redemption(&events);
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.completed_at, Some(timestamp(400)));
+        let completion = stage(&operation, EquityStageName::RedemptionCompletion);
+        assert_eq!(completion.outcome, StageOutcome::Unmeasured);
+        assert_eq!(completion.duration_ms, None);
+        assert_eq!(
+            stage(&operation, EquityStageName::RedemptionDetection).outcome,
+            StageOutcome::Succeeded,
+            "detection succeeded before rejection; recovery must not touch it"
+        );
+    }
+
+    #[test]
+    fn redelivering_after_same_timestamp_open_and_fail_does_not_wrongly_upgrade_scrubbed_stage() {
+        // Regression test for a shape-vs-marker bug: `DetectionFailed` fires
+        // at the EXACT same timestamp as the `TokensSent` event that opened
+        // `RedemptionDetection` (a stage's open and its terminal-failure
+        // close can genuinely carry identical timestamps), so the closed
+        // `RedemptionDetection` run ends up with `started_at == ended_at`.
+        // `ProviderCompletionRecovered` then scrubs it from `Failed` back to
+        // plain `Unmeasured` (NOT `Placeholder`) without touching
+        // `started_at`/`ended_at`, leaving it with the EXACT same shape a
+        // real upgradeable placeholder has. On a full-stream redelivery
+        // (`catch_up` re-folding the whole stream, simulated here by
+        // re-applying every event), the original `TokensSent` event re-fires
+        // and calls `open_once(RedemptionDetection, ..)`. Before this fix,
+        // `upgrade_placeholder_start` matched by shape alone and would
+        // wrongly flip this scrubbed run to `Succeeded` with a fabricated
+        // `duration_ms: Some(0)`, diverging from the single-pass fold (which
+        // leaves it `Unmeasured`) and breaking redelivery idempotency.
+        //
+        // Unlike an equivalent mint-side scenario, `RedemptionCompletion`'s
+        // recovery path (`record_unmeasured`, a fresh stage push) never
+        // touches `RedemptionDetection` again, so nothing here masks the bug
+        // the way mint's `recover_receipt_stage` (which unconditionally
+        // re-flips its target stage to `Unmeasured` on every replay) would.
+        let events = vec![
+            EquityRedemptionEvent::TokensSent {
+                redemption_wallet: Address::repeat_byte(0x44),
+                redemption_tx: TxHash::random(),
+                sent_at: timestamp(60),
+            },
+            EquityRedemptionEvent::DetectionFailed {
+                failure: DetectionFailure::Timeout,
+                failed_at: timestamp(60),
+            },
+            EquityRedemptionEvent::ProviderCompletionRecovered {
+                tokenization_request_id: TokenizationRequestId::try_new("tok-2").unwrap(),
+                recovered_at: timestamp(400),
+            },
+        ];
+
+        let mut operation = StoredOperation::new(
+            Uuid::new_v4(),
+            StoredKind::Redeem,
+            redemption_observed_at(&events[0]),
+        );
+        for event in &events {
+            operation.apply_redemption(event, None);
+        }
+        // Simulates the restart: `catch_up` re-folds the whole stream onto
+        // the already-live-folded state above.
+        for event in &events {
+            operation.apply_redemption(event, None);
+        }
+        let redelivered = operation.into_dto();
+
+        let detection = stage(&redelivered, EquityStageName::RedemptionDetection);
+        assert_eq!(detection.outcome, StageOutcome::Unmeasured);
+        assert_eq!(detection.started_at, timestamp(60));
+        assert_eq!(detection.duration_ms, None);
+    }
+}

--- a/src/performance/report.rs
+++ b/src/performance/report.rs
@@ -527,11 +527,22 @@ pub(crate) fn hedge_latency_report(
     let total_cycles = cycles.len();
     cycles.truncate(MAX_CYCLE_REPORTS);
 
-    let buckets = bucket_samples
-        .into_iter()
-        .map(|(index, samples)| LatencyBucket {
+    // Dense across the FULL requested range, not just the indices that
+    // happen to have samples: a sparse (samples-only) bucket list loses all
+    // positional information about how far apart populated buckets really
+    // are, so the dashboard chart can't tell a burst of data 2 buckets wide
+    // from one 200 buckets wide -- both would render identically, stretched
+    // to fill the whole plot. Filling gaps with empty (all-None) stats lets
+    // the frontend position every sampled point at its true index in the
+    // requested range.
+    let last_index = bucket_index(range.to);
+    let buckets = (0..=last_index)
+        .map(|index| LatencyBucket {
             start: range.from + Duration::seconds(width.num_seconds() * index),
-            stages: samples.into_stage_latencies(),
+            stages: bucket_samples
+                .remove(&index)
+                .unwrap_or_default()
+                .into_stage_latencies(),
         })
         .collect();
 
@@ -1205,6 +1216,11 @@ mod tests {
         );
     }
 
+    /// Buckets are dense across the FULL requested range, not just the
+    /// indices with samples: a range's empty buckets carry positional
+    /// information the dashboard chart needs (a burst of activity should
+    /// render at its true position within the range, not stretch to fill
+    /// the whole plot -- see `layoutPercentileSeries` on the frontend).
     #[tokio::test]
     async fn report_buckets_fills_by_day() {
         let day = 86_400;
@@ -1216,17 +1232,23 @@ mod tests {
 
         let report = hedge_latency_report(&performances, &report_range(0, 10 * day));
 
-        assert_eq!(report.buckets.len(), 2);
+        // 10-day range at daily granularity -> 11 buckets (indices 0..=10).
+        assert_eq!(report.buckets.len(), 11);
         assert_eq!(report.buckets[0].start, timestamp(0));
-        assert_eq!(report.buckets[1].start, timestamp(3 * day));
+        assert_eq!(report.buckets[3].start, timestamp(3 * day));
         assert_eq!(
             report.buckets[0].stages.detection.as_ref().unwrap().p50_ms,
             2_000
         );
         assert_eq!(
-            report.buckets[1].stages.detection.as_ref().unwrap().p50_ms,
+            report.buckets[3].stages.detection.as_ref().unwrap().p50_ms,
             4_000
         );
+        // The gap between the two fills is real empty buckets, not skipped
+        // indices -- proving the dense range, not just the populated ends.
+        assert!(report.buckets[1].stages.detection.is_none());
+        assert!(report.buckets[2].stages.detection.is_none());
+        assert!(report.buckets[10].stages.detection.is_none());
     }
 
     #[tokio::test]
@@ -1240,9 +1262,11 @@ mod tests {
 
         let report = hedge_latency_report(&performances, &report_range(0, 60 * day));
 
-        assert_eq!(report.buckets.len(), 2);
+        // 60-day range at weekly granularity -> 9 buckets (indices 0..=8).
+        assert_eq!(report.buckets.len(), 9);
         assert_eq!(report.buckets[0].start, timestamp(0));
         assert_eq!(report.buckets[1].start, timestamp(7 * day));
+        assert!(report.buckets[8].stages.detection.is_none());
     }
 
     #[tokio::test]
@@ -1256,9 +1280,12 @@ mod tests {
 
         let report = hedge_latency_report(&performances, &report_range(0, 300 * day));
 
-        assert_eq!(report.buckets.len(), 2);
+        // 300-day range at monthly (30-day) granularity -> 11 buckets
+        // (indices 0..=10).
+        assert_eq!(report.buckets.len(), 11);
         assert_eq!(report.buckets[0].start, timestamp(0));
         assert_eq!(report.buckets[1].start, timestamp(30 * day));
+        assert!(report.buckets[10].stages.detection.is_none());
     }
 
     /// A range whose endpoints are EXACTLY 31 days apart spans 32 inclusive
@@ -1363,7 +1390,12 @@ mod tests {
         assert_eq!(report.summary.fill_count, 0);
         assert_eq!(report.total_cycles, 0);
         assert_eq!(report.summary.stages.detection, None);
-        assert_eq!(report.buckets.len(), 0);
+        // The range still produces its one (hourly, for a 1000s span) dense
+        // bucket -- empty of samples, not absent -- so the dashboard chart
+        // has positional context for the requested window even with zero
+        // activity in it.
+        assert_eq!(report.buckets.len(), 1);
+        assert_eq!(report.buckets[0].stages.detection, None);
         assert_eq!(report.cycles.len(), 0);
         assert_eq!(report.open_exposures.len(), 0);
     }

--- a/src/performance/simulated_transfers.rs
+++ b/src/performance/simulated_transfers.rs
@@ -1,0 +1,1335 @@
+//! Seeds simulated cross-venue transfer history (USDC rebalances, equity
+//! mints, and equity redemptions) for local dashboard simulation, mirroring
+//! `super::seed_simulated_hedge_latency_history`'s approach: real CQRS
+//! commands through a temporary store instead of raw inserts.
+//!
+//! The Transfers panel (`dashboard/transfer_loader.rs`) replays straight from
+//! the `events` table via `load_entity`/`load_all_ids`, so the bare `events`
+//! rows these commands persist are all it needs -- no reactor required.
+//! The mint/redemption stores are still wired with `EquityTimingProjection`
+//! (mirroring how the USDC store is wired with `RebalanceTimingProjection`
+//! below) so the Performance tab's "Equity rebalance stage breakdown" chart
+//! also gets historical data, not just the Transfers panel.
+//!
+//! Single-run-only, same caveat as the hedge-latency fixture: a second call
+//! against the same pool hits each aggregate's own already-initialized guard
+//! (`UsdcRebalanceError::AlreadyInitiated` /
+//! `TokenizedEquityMintError::AlreadyInProgress` /
+//! `EquityRedemptionError::AlreadyStarted`). The only caller (`simulate()` in
+//! `tests/e2e/full_system.rs`) always seeds a freshly created database file.
+
+use alloy::consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
+use alloy::primitives::{Address, B256, Bloom, Log as PrimitiveLog, TxHash, U256};
+use alloy::rpc::types::{Log, TransactionReceipt};
+use alloy::sol_types::SolEvent;
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use rain_math_float::Float;
+use sqlx::SqlitePool;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use st0x_event_sorcery::{Store, StoreBuilder};
+use st0x_evm::IERC20;
+use st0x_execution::{AlpacaTransferId, ClientOrderId, FractionalShares, Symbol};
+use st0x_finance::Usdc;
+use st0x_raindex::{Raindex, RaindexError, RaindexVaultId};
+use st0x_tokenization::{
+    AlpacaTokenizationError, IssuerRequestId, TokenizationRequest, TokenizationRequestId,
+    TokenizationRequestStatus, TokenizationRequestType, Tokenizer, TokenizerError,
+    tokenization_request_id,
+};
+use st0x_wrapper::{
+    UnderlyingPerWrapped, UnwrapConfirmation, WrapConfirmation, Wrapper, WrapperError,
+};
+
+use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
+use crate::performance::equity_timing::EquityTimingProjection;
+use crate::performance::rebalance::RebalanceTimingProjection;
+use crate::rebalancing::equity::EquityTransferServices;
+use crate::tokenized_equity_mint::{
+    TOKENIZED_EQUITY_DECIMALS, TokenizedEquityMint, TokenizedEquityMintCommand,
+};
+use crate::usdc_rebalance::{
+    ConversionAmounts, RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand,
+    UsdcRebalanceId,
+};
+use crate::vault_lookup::{VaultLookup, VaultLookupError};
+
+/// Minimal [`Tokenizer`] shared by [`seed_simulated_mint_history`]'s and
+/// [`seed_simulated_equity_redemption_history`]'s temporary stores.
+///
+/// The mint fixture drives only the mint happy path (`RequestMintAt` ->
+/// `PollAt` -> `WrapTokensAt` -> `DepositToVaultAt`), which calls exactly
+/// `request_mint`/`poll_mint_until_complete`. The redemption fixture drives
+/// only `wait_for_block`/`redemption_wallet`/`send_for_redemption` (its
+/// `Detect`/`Complete` steps are pure state transitions with no service
+/// call). Every other `Tokenizer` method is unreachable from either path.
+///
+/// Stateful rather than static (unlike `st0x_tokenization::mock::MockTokenizer`)
+/// because `poll_mint_until_complete` must echo back the SAME symbol
+/// `request_mint` was called with -- the mint aggregate validates
+/// `token_symbol == format!("t{symbol}")`, and this fixture cycles through
+/// multiple symbols in one run.
+struct FixtureTokenizer {
+    pending: Mutex<HashMap<TokenizationRequestId, (Symbol, TxHash)>>,
+    redemption_wallet: Address,
+    /// Feeds `send_for_redemption`'s synthetic tx hash through
+    /// `simulated_transfer_uuid`, keeping it deterministic across runs like
+    /// every other id in this module.
+    day: u32,
+}
+
+impl FixtureTokenizer {
+    fn new(redemption_wallet: Address, day: u32) -> Self {
+        Self {
+            pending: Mutex::new(HashMap::new()),
+            redemption_wallet,
+            day,
+        }
+    }
+}
+
+#[async_trait]
+impl Tokenizer for FixtureTokenizer {
+    async fn request_mint(
+        &self,
+        symbol: Symbol,
+        quantity: FractionalShares,
+        wallet: Address,
+        issuer_request_id: IssuerRequestId,
+    ) -> Result<TokenizationRequest, TokenizerError> {
+        let id = tokenization_request_id(&format!("sim-mint-{issuer_request_id}"));
+        // Derived from the 16-byte `IssuerRequestId` uuid, not the (longer)
+        // `TokenizationRequestId` string: `TxHash::left_padding_from` panics
+        // above 32 input bytes, and the request-id string exceeds that.
+        let tx_hash = TxHash::left_padding_from(issuer_request_id.0.as_bytes());
+        self.pending
+            .lock()
+            .await
+            .insert(id.clone(), (symbol.clone(), tx_hash));
+
+        Ok(TokenizationRequest {
+            id,
+            r#type: Some(TokenizationRequestType::Mint),
+            status: TokenizationRequestStatus::Pending,
+            underlying_symbol: symbol,
+            token_symbol: None,
+            quantity,
+            wallet: Some(wallet),
+            issuer_request_id: Some(issuer_request_id),
+            tx_hash: None,
+            fees: None,
+            created_at: Utc::now(),
+        })
+    }
+
+    async fn poll_mint_until_complete(
+        &self,
+        id: &TokenizationRequestId,
+    ) -> Result<TokenizationRequest, TokenizerError> {
+        let (symbol, tx_hash) = self.pending.lock().await.get(id).cloned().ok_or_else(|| {
+            TokenizerError::Alpaca(AlpacaTokenizationError::RequestNotFound { id: id.clone() })
+        })?;
+
+        Ok(TokenizationRequest {
+            id: id.clone(),
+            r#type: Some(TokenizationRequestType::Mint),
+            status: TokenizationRequestStatus::Completed,
+            token_symbol: Some(format!("t{symbol}")),
+            underlying_symbol: symbol,
+            quantity: FractionalShares::ZERO,
+            wallet: None,
+            issuer_request_id: None,
+            tx_hash: Some(tx_hash),
+            fees: None,
+            created_at: Utc::now(),
+        })
+    }
+
+    async fn get_request(
+        &self,
+        _id: &TokenizationRequestId,
+    ) -> Result<TokenizationRequest, TokenizerError> {
+        unimplemented!("FixtureTokenizer: mint fixture never calls get_request")
+    }
+
+    fn redemption_wallet(&self) -> Option<Address> {
+        Some(self.redemption_wallet)
+    }
+
+    async fn wait_for_block(&self, _block: u64) -> Result<(), st0x_evm::EvmError> {
+        Ok(())
+    }
+
+    async fn send_for_redemption(
+        &self,
+        _token: Address,
+        _amount: U256,
+    ) -> Result<TxHash, TokenizerError> {
+        Ok(TxHash::left_padding_from(
+            simulated_transfer_uuid("redeem-send-tx", self.day).as_bytes(),
+        ))
+    }
+
+    async fn poll_for_redemption(
+        &self,
+        _tx_hash: &TxHash,
+    ) -> Result<TokenizationRequest, TokenizerError> {
+        unimplemented!("FixtureTokenizer: mint fixture never calls poll_for_redemption")
+    }
+
+    async fn find_redemption_by_tx(
+        &self,
+        _tx_hash: &TxHash,
+    ) -> Result<Option<TokenizationRequest>, TokenizerError> {
+        unimplemented!("FixtureTokenizer: mint fixture never calls find_redemption_by_tx")
+    }
+
+    async fn poll_redemption_until_complete(
+        &self,
+        _id: &TokenizationRequestId,
+    ) -> Result<TokenizationRequest, TokenizerError> {
+        unimplemented!("FixtureTokenizer: mint fixture never calls poll_redemption_until_complete")
+    }
+
+    async fn verify_mint_tx(
+        &self,
+        _tx_hash: TxHash,
+        _token_address: Address,
+        _wallet: Address,
+        _expected_amount: U256,
+    ) -> Result<(), st0x_tokenization::MintVerificationError> {
+        unimplemented!("FixtureTokenizer: mint fixture never calls verify_mint_tx")
+    }
+
+    async fn list_pending_requests(&self) -> Result<Vec<TokenizationRequest>, TokenizerError> {
+        unimplemented!("FixtureTokenizer: mint fixture never calls list_pending_requests")
+    }
+}
+
+/// Deterministic UUID for this module's fixtures, namespaced separately from
+/// `super::simulated_latency_uuid` so the two fixtures' synthetic ids never
+/// collide even where they happen to share a `kind`/`day` pair.
+fn simulated_transfer_uuid(kind: &str, day: u32) -> uuid::Uuid {
+    uuid::Uuid::new_v5(
+        &uuid::Uuid::NAMESPACE_OID,
+        format!("st0x-simulated-transfer-history:{kind}:{day}").as_bytes(),
+    )
+}
+
+fn usdc(value: f64) -> anyhow::Result<Usdc> {
+    Ok(Usdc::new(Float::parse(format!("{value:.2}"))?))
+}
+
+/// Seeds deterministic equity-mint history for local dashboard simulation.
+///
+/// Drives the `TokenizedEquityMint` aggregate's happy path
+/// (`RequestMintAt` -> `PollAt` -> `WrapTokensAt` -> `DepositToVaultAt`)
+/// through a temporary store, one mint per day alternating between the same
+/// dedicated fixture symbols (`AAPL.SIM`/`TSLA.SIM`) used by
+/// [`super::seed_simulated_hedge_latency_history`].
+pub async fn seed_simulated_mint_history(
+    pool: &SqlitePool,
+    now: DateTime<Utc>,
+    days: u32,
+) -> anyhow::Result<()> {
+    sqlx::migrate!().set_ignore_missing(true).run(pool).await?;
+
+    let mut services = EquityTransferServices::panicking();
+    // Mint's happy path never calls `redemption_wallet`/`send_for_redemption`;
+    // the address and day are meaningful only to
+    // `seed_simulated_equity_redemption_history`'s use of this same fixture.
+    services.tokenizer = Arc::new(FixtureTokenizer::new(Address::ZERO, 0));
+
+    let mint = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
+        .with(Arc::new(EquityTimingProjection::new(pool.clone())))
+        .build(services)
+        .await?;
+
+    let range_start = now - Duration::days(i64::from(days)) - Duration::days(1);
+    let aapl = Symbol::new("AAPL.SIM")?;
+    let tsla = Symbol::new("TSLA.SIM")?;
+    let wallet = Address::repeat_byte(0x5A);
+
+    for day in 0..days {
+        let symbol = if day % 2 == 0 { &aapl } else { &tsla };
+        let requested_at = range_start + Duration::days(i64::from(day)) + Duration::hours(9);
+        let received_at = requested_at + Duration::minutes(2) + Duration::seconds(30);
+        let wrapped_at = received_at + Duration::seconds(45);
+        let deposited_at = wrapped_at + Duration::seconds(30);
+
+        let issuer_request_id = IssuerRequestId(simulated_transfer_uuid("mint", day));
+        let quantity = Float::parse("5".to_string())?;
+
+        mint.send(
+            &issuer_request_id,
+            TokenizedEquityMintCommand::RequestMintAt {
+                issuer_request_id: issuer_request_id.clone(),
+                symbol: symbol.clone(),
+                quantity,
+                wallet,
+                requested_at,
+            },
+        )
+        .await?;
+
+        mint.send(
+            &issuer_request_id,
+            TokenizedEquityMintCommand::PollAt { received_at },
+        )
+        .await?;
+
+        let wrap_tx_hash =
+            TxHash::left_padding_from(simulated_transfer_uuid("mint-wrap", day).as_bytes());
+        let wrapped_shares = quantity.to_fixed_decimal(TOKENIZED_EQUITY_DECIMALS)?;
+        let wrap_block = 2_000_000_u64 + u64::from(day) * 10;
+
+        mint.send(
+            &issuer_request_id,
+            TokenizedEquityMintCommand::WrapTokensAt {
+                wrap_tx_hash,
+                wrapped_shares,
+                wrap_block,
+                wrapped_at,
+            },
+        )
+        .await?;
+
+        let vault_deposit_tx_hash =
+            TxHash::left_padding_from(simulated_transfer_uuid("mint-deposit", day).as_bytes());
+
+        mint.send(
+            &issuer_request_id,
+            TokenizedEquityMintCommand::DepositToVaultAt {
+                vault_deposit_tx_hash,
+                deposited_at,
+            },
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+/// Seeds deterministic USDC-rebalance (Alpaca<->Base) history for local
+/// dashboard simulation.
+///
+/// Drives the `UsdcRebalance` aggregate (whose `Services = ()`, so no
+/// fixture service implementations are needed -- none of its commands call
+/// out to an external service) through the full per-direction command
+/// sequence, alternating direction by day. Wired with
+/// `RebalanceTimingProjection` (the equity-mint/redemption fixtures wire
+/// `EquityTimingProjection` for the same reason) so the Performance tab's
+/// "Rebalance stage breakdown" chart, not just the dashboard's Transfers
+/// panel, gets historical data too.
+pub async fn seed_simulated_usdc_rebalance_history(
+    pool: &SqlitePool,
+    now: DateTime<Utc>,
+    days: u32,
+) -> anyhow::Result<()> {
+    sqlx::migrate!().set_ignore_missing(true).run(pool).await?;
+
+    // `UsdcRebalance::Materialized = Nil`, so `build()` returns `Arc<Store<_>>`
+    // alone regardless of `.with()` reactor count (unlike `Position`'s
+    // `Materialized = Table`, which returns a `(Store, Projection)` pair) --
+    // the reactor is wired into the store's dispatch either way.
+    let rebalance = StoreBuilder::<UsdcRebalance>::new(pool.clone())
+        .with(Arc::new(RebalanceTimingProjection::new(pool.clone())))
+        .build(())
+        .await?;
+
+    let range_start = now - Duration::days(i64::from(days)) - Duration::days(1);
+
+    for day in 0..days {
+        let id = UsdcRebalanceId(simulated_transfer_uuid("usdc-rebalance", day));
+        let base_time = range_start + Duration::days(i64::from(day)) + Duration::hours(15);
+
+        if day % 2 == 0 {
+            seed_alpaca_to_base(&rebalance, id, day, base_time).await?;
+        } else {
+            seed_base_to_alpaca(&rebalance, id, day, base_time).await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Drives one full AlpacaToBase cycle: pre-withdrawal USD->USDC conversion,
+/// Alpaca withdrawal, CCTP bridge, onchain deposit. Terminal at
+/// `DepositConfirmed` (`AlpacaToBase` completes there; see
+/// `UsdcRebalance::to_dto`).
+async fn seed_alpaca_to_base(
+    store: &Store<UsdcRebalance>,
+    id: UsdcRebalanceId,
+    day: u32,
+    base_time: DateTime<Utc>,
+) -> anyhow::Result<()> {
+    let requested_value = f64::from(day).mul_add(50.0, 5_000.0);
+    let received_value = requested_value * 0.998;
+    let bridged_value = received_value - 1.0;
+
+    let requested = usdc(requested_value)?;
+    let received = usdc(received_value)?;
+    let bridged = usdc(bridged_value)?;
+    let fee = usdc(1.0)?;
+
+    let order_id = ClientOrderId::from_uuid(simulated_transfer_uuid("usdc-a2b-convert", day));
+    let t0 = base_time;
+    let t1 = t0 + Duration::seconds(20);
+    let t2 = t1 + Duration::seconds(5);
+    let t3 = t2 + Duration::minutes(3);
+    let t4 = t3 + Duration::seconds(30);
+    let t5 = t4 + Duration::seconds(10);
+    let t6 = t5 + Duration::seconds(15);
+    let t7 = t6 + Duration::minutes(2);
+    let t8 = t7 + Duration::seconds(45);
+    let t9 = t8 + Duration::seconds(20);
+    let t10 = t9 + Duration::minutes(1);
+    let from_block = 3_000_000_u64 + u64::from(day) * 10;
+
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversionAt {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: requested,
+                order_id,
+                initiated_at: t0,
+            },
+        )
+        .await?;
+
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversionAt {
+                conversion: ConversionAmounts::new(requested, received),
+                converted_at: t1,
+            },
+        )
+        .await?;
+
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::BeginWithdrawalAt {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: received,
+                from_block,
+                submitting_at: t2,
+            },
+        )
+        .await?;
+
+    let withdrawal_ref =
+        AlpacaTransferId::from(simulated_transfer_uuid("usdc-a2b-withdraw-ref", day));
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::InitiateAt {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: received,
+                withdrawal: TransferRef::AlpacaId(withdrawal_ref),
+                initiated_at: t3,
+            },
+        )
+        .await?;
+
+    let withdrawal_tx =
+        TxHash::left_padding_from(simulated_transfer_uuid("usdc-a2b-withdraw-tx", day).as_bytes());
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::ConfirmWithdrawalAt {
+                withdrawal_tx: Some(withdrawal_tx),
+                confirmed_at: t4,
+            },
+        )
+        .await?;
+
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::BeginBridgingAt {
+                from_block: from_block + 5,
+                burn_amount: Some(received),
+                submitting_at: t5,
+            },
+        )
+        .await?;
+
+    let burn_tx =
+        TxHash::left_padding_from(simulated_transfer_uuid("usdc-a2b-burn", day).as_bytes());
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::InitiateBridgingAt {
+                burn_tx,
+                burned_at: t6,
+            },
+        )
+        .await?;
+
+    let attestation = simulated_transfer_uuid("usdc-a2b-attestation", day)
+        .into_bytes()
+        .to_vec();
+    let cctp_nonce =
+        B256::left_padding_from(simulated_transfer_uuid("usdc-a2b-nonce", day).as_bytes());
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::ReceiveAttestationAt {
+                attestation: attestation.clone(),
+                cctp_nonce,
+                message: attestation,
+                mint_scan_from_block: from_block + 20,
+                attested_at: t7,
+            },
+        )
+        .await?;
+
+    let mint_tx =
+        TxHash::left_padding_from(simulated_transfer_uuid("usdc-a2b-mint", day).as_bytes());
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::ConfirmBridgingAt {
+                mint_tx,
+                amount_received: bridged,
+                fee_collected: fee,
+                minted_at: t8,
+            },
+        )
+        .await?;
+
+    let deposit_tx =
+        TxHash::left_padding_from(simulated_transfer_uuid("usdc-a2b-deposit", day).as_bytes());
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::InitiateDepositAt {
+                deposit: TransferRef::OnchainTx(deposit_tx),
+                deposit_initiated_at: t9,
+            },
+        )
+        .await?;
+
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::ConfirmDepositAt {
+                deposit_confirmed_at: t10,
+            },
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// Drives one full BaseToAlpaca cycle: onchain withdrawal, CCTP bridge,
+/// Alpaca deposit, post-deposit USDC->USD conversion. Terminal at
+/// `ConversionComplete` (see `UsdcRebalance::to_dto`).
+async fn seed_base_to_alpaca(
+    store: &Store<UsdcRebalance>,
+    id: UsdcRebalanceId,
+    day: u32,
+    base_time: DateTime<Utc>,
+) -> anyhow::Result<()> {
+    let withdraw_value = f64::from(day).mul_add(50.0, 5_000.0);
+    let bridged_value = withdraw_value - 1.0;
+    let final_value = bridged_value * 0.998;
+
+    let withdraw_amount = usdc(withdraw_value)?;
+    let bridged_amount = usdc(bridged_value)?;
+    let fee = usdc(1.0)?;
+    let final_amount = usdc(final_value)?;
+
+    let t0 = base_time;
+    let t1 = t0 + Duration::seconds(30);
+    let t2 = t1 + Duration::minutes(2);
+    let t3 = t2 + Duration::seconds(10);
+    let t4 = t3 + Duration::seconds(15);
+    let t5 = t4 + Duration::minutes(2);
+    let t6 = t5 + Duration::seconds(45);
+    let t7 = t6 + Duration::seconds(20);
+    let t8 = t7 + Duration::minutes(1);
+    let t9 = t8 + Duration::seconds(20);
+    let t10 = t9 + Duration::seconds(15);
+    let from_block = 3_500_000_u64 + u64::from(day) * 10;
+
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::BeginWithdrawalAt {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: withdraw_amount,
+                from_block,
+                submitting_at: t0,
+            },
+        )
+        .await?;
+
+    let withdrawal_tx =
+        TxHash::left_padding_from(simulated_transfer_uuid("usdc-b2a-withdraw-tx", day).as_bytes());
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::InitiateAt {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: withdraw_amount,
+                withdrawal: TransferRef::OnchainTx(withdrawal_tx),
+                initiated_at: t1,
+            },
+        )
+        .await?;
+
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::ConfirmWithdrawalAt {
+                withdrawal_tx: None,
+                confirmed_at: t2,
+            },
+        )
+        .await?;
+
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::BeginBridgingAt {
+                from_block: from_block + 5,
+                burn_amount: Some(withdraw_amount),
+                submitting_at: t3,
+            },
+        )
+        .await?;
+
+    let burn_tx =
+        TxHash::left_padding_from(simulated_transfer_uuid("usdc-b2a-burn", day).as_bytes());
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::InitiateBridgingAt {
+                burn_tx,
+                burned_at: t4,
+            },
+        )
+        .await?;
+
+    let attestation = simulated_transfer_uuid("usdc-b2a-attestation", day)
+        .into_bytes()
+        .to_vec();
+    let cctp_nonce =
+        B256::left_padding_from(simulated_transfer_uuid("usdc-b2a-nonce", day).as_bytes());
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::ReceiveAttestationAt {
+                attestation: attestation.clone(),
+                cctp_nonce,
+                message: attestation,
+                mint_scan_from_block: from_block + 20,
+                attested_at: t5,
+            },
+        )
+        .await?;
+
+    let mint_tx =
+        TxHash::left_padding_from(simulated_transfer_uuid("usdc-b2a-mint", day).as_bytes());
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::ConfirmBridgingAt {
+                mint_tx,
+                amount_received: bridged_amount,
+                fee_collected: fee,
+                minted_at: t6,
+            },
+        )
+        .await?;
+
+    let deposit_ref = AlpacaTransferId::from(simulated_transfer_uuid("usdc-b2a-deposit-ref", day));
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::InitiateDepositAt {
+                deposit: TransferRef::AlpacaId(deposit_ref),
+                deposit_initiated_at: t7,
+            },
+        )
+        .await?;
+
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::ConfirmDepositAt {
+                deposit_confirmed_at: t8,
+            },
+        )
+        .await?;
+
+    let post_deposit_order_id =
+        ClientOrderId::from_uuid(simulated_transfer_uuid("usdc-b2a-post-convert", day));
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::InitiatePostDepositConversionAt {
+                order_id: post_deposit_order_id,
+                amount: bridged_amount,
+                initiated_at: t9,
+            },
+        )
+        .await?;
+
+    store
+        .send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversionAt {
+                conversion: ConversionAmounts::new(bridged_amount, final_amount),
+                converted_at: t10,
+            },
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// Builds a synthetic, always-`status: true` transaction receipt whose logs
+/// are exactly `logs`. Mirrors `src/onchain/mock.rs`'s `successful_receipt`
+/// (that copy is `#[cfg(test)]`-only, so unusable from a `test-support` e2e
+/// build; this is its `test-support`-gated counterpart).
+fn successful_receipt(tx_hash: TxHash, block_number: u64, logs: Vec<Log>) -> TransactionReceipt {
+    TransactionReceipt {
+        inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom {
+            receipt: Receipt {
+                status: true.into(),
+                cumulative_gas_used: 0,
+                logs,
+            },
+            logs_bloom: Bloom::default(),
+        }),
+        transaction_hash: tx_hash,
+        transaction_index: Some(0),
+        block_hash: None,
+        block_number: Some(block_number),
+        gas_used: 21_000,
+        effective_gas_price: 1,
+        blob_gas_used: None,
+        blob_gas_price: None,
+        from: Address::ZERO,
+        to: Some(Address::ZERO),
+        contract_address: None,
+    }
+}
+
+/// Builds a decodable ERC20 `Transfer` log, mirroring `src/onchain/mock.rs`'s
+/// `transfer_log` (see `successful_receipt` above for why this can't just
+/// reuse that `#[cfg(test)]`-only copy).
+fn transfer_log(token: Address, to: Address, amount: U256) -> Log {
+    let event = IERC20::Transfer {
+        from: Address::ZERO,
+        to,
+        value: amount,
+    };
+    let inner = PrimitiveLog {
+        address: token,
+        data: event.encode_log_data(),
+    };
+
+    Log {
+        inner,
+        transaction_hash: None,
+        transaction_index: None,
+        block_hash: None,
+        block_number: None,
+        block_timestamp: None,
+        log_index: None,
+        removed: false,
+    }
+}
+
+/// Minimal [`Raindex`] for one [`seed_simulated_equity_redemption_history`]
+/// cycle. Scoped to a single redemption (a fresh instance per day, not
+/// shared across the seeding loop), so `submit_withdraw`'s single-slot
+/// `pending_withdraw` is always populated by the time `confirm_tx_receipt`
+/// reads it -- the redemption fixture always calls them in that order.
+/// `withdraw`/`submit_deposit` are unreachable from `EquityRedemption`'s
+/// happy path (it only ever calls `submit_withdraw`/`confirm_tx_receipt`).
+struct FixtureRaindex {
+    /// Recipient the synthetic withdrawal's `Transfer` log credits -- must
+    /// match `FixtureWrapper::owner()`, since `ConfirmWithdraw`'s handler
+    /// reads `services.wrapper.owner()` as the expected recipient.
+    recipient: Address,
+    block_number: u64,
+    pending_withdraw: Mutex<Option<(Address, U256)>>,
+    /// Feeds `submit_withdraw`'s synthetic tx hash through
+    /// `simulated_transfer_uuid`, keeping it deterministic across runs like
+    /// every other id in this module.
+    day: u32,
+}
+
+impl FixtureRaindex {
+    fn new(recipient: Address, block_number: u64, day: u32) -> Self {
+        Self {
+            recipient,
+            block_number,
+            pending_withdraw: Mutex::new(None),
+            day,
+        }
+    }
+}
+
+#[async_trait]
+impl Raindex for FixtureRaindex {
+    async fn withdraw(
+        &self,
+        _token: Address,
+        _vault_id: RaindexVaultId,
+        _target_amount: U256,
+        _decimals: u8,
+    ) -> Result<TxHash, RaindexError> {
+        unimplemented!("FixtureRaindex: redemption fixture never calls withdraw")
+    }
+
+    async fn submit_deposit(
+        &self,
+        _token: Address,
+        _vault_id: RaindexVaultId,
+        _amount: U256,
+        _decimals: u8,
+    ) -> Result<TxHash, RaindexError> {
+        unimplemented!("FixtureRaindex: redemption fixture never calls submit_deposit")
+    }
+
+    async fn submit_withdraw(
+        &self,
+        token: Address,
+        _vault_id: RaindexVaultId,
+        target_amount: U256,
+        _decimals: u8,
+    ) -> Result<TxHash, RaindexError> {
+        *self.pending_withdraw.lock().await = Some((token, target_amount));
+        Ok(TxHash::left_padding_from(
+            simulated_transfer_uuid("redeem-withdraw-tx", self.day).as_bytes(),
+        ))
+    }
+
+    async fn confirm_tx_receipt(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<TransactionReceipt, RaindexError> {
+        let (token, amount) = self
+            .pending_withdraw
+            .lock()
+            .await
+            .ok_or(RaindexError::ScanInconclusive { from_block: 0 })?;
+
+        Ok(successful_receipt(
+            tx_hash,
+            self.block_number,
+            vec![transfer_log(token, self.recipient, amount)],
+        ))
+    }
+}
+
+/// Minimal [`VaultLookup`] for one redemption cycle: resolves every token to
+/// the same fixed vault id. `vault_token_for_symbol` is unreachable from
+/// `EquityRedemption`'s happy path.
+struct FixtureVaultLookup {
+    vault_id: RaindexVaultId,
+}
+
+impl FixtureVaultLookup {
+    fn new(vault_id: RaindexVaultId) -> Self {
+        Self { vault_id }
+    }
+}
+
+#[async_trait]
+impl VaultLookup for FixtureVaultLookup {
+    async fn vault_id_for_token(
+        &self,
+        _token: Address,
+    ) -> Result<RaindexVaultId, VaultLookupError> {
+        Ok(self.vault_id)
+    }
+
+    async fn vault_token_for_symbol(&self, _symbol: &Symbol) -> Result<Address, VaultLookupError> {
+        unimplemented!("FixtureVaultLookup: redemption fixture never calls vault_token_for_symbol")
+    }
+}
+
+/// Minimal [`Wrapper`] for one [`seed_simulated_equity_redemption_history`]
+/// cycle. Scoped to a single redemption, same reasoning as [`FixtureRaindex`]:
+/// `submit_unwrap`'s single-slot `pending_unwrap` is always populated by the
+/// time `confirm_unwrap` reads it. 1:1 unwrap ratio, matching
+/// `st0x_wrapper::mock::MockWrapper`'s convention. Every method beyond
+/// `owner`/`lookup_underlying`/`submit_unwrap`/`confirm_unwrap`/
+/// `wait_for_block` is unreachable from `EquityRedemption`'s happy path.
+struct FixtureWrapper {
+    owner: Address,
+    underlying_token: Address,
+    unwrap_block: u64,
+    pending_unwrap: Mutex<Option<U256>>,
+    /// Feeds `submit_unwrap`'s synthetic tx hash through
+    /// `simulated_transfer_uuid`, keeping it deterministic across runs like
+    /// every other id in this module.
+    day: u32,
+}
+
+impl FixtureWrapper {
+    fn new(owner: Address, underlying_token: Address, unwrap_block: u64, day: u32) -> Self {
+        Self {
+            owner,
+            underlying_token,
+            unwrap_block,
+            pending_unwrap: Mutex::new(None),
+            day,
+        }
+    }
+}
+
+#[async_trait]
+impl Wrapper for FixtureWrapper {
+    async fn get_ratio_for_symbol(
+        &self,
+        _symbol: &Symbol,
+    ) -> Result<UnderlyingPerWrapped, WrapperError> {
+        unimplemented!("FixtureWrapper: redemption fixture never calls get_ratio_for_symbol")
+    }
+
+    fn lookup_underlying(&self, _symbol: &Symbol) -> Result<Address, WrapperError> {
+        Ok(self.underlying_token)
+    }
+
+    fn lookup_derivative(&self, _symbol: &Symbol) -> Result<Address, WrapperError> {
+        unimplemented!("FixtureWrapper: redemption fixture never calls lookup_derivative")
+    }
+
+    async fn to_wrapped(
+        &self,
+        _wrapped_token: Address,
+        _underlying_amount: U256,
+        _receiver: Address,
+    ) -> Result<(TxHash, U256), WrapperError> {
+        unimplemented!("FixtureWrapper: redemption fixture never calls to_wrapped")
+    }
+
+    async fn to_underlying(
+        &self,
+        _wrapped_token: Address,
+        _wrapped_amount: U256,
+        _receiver: Address,
+        _owner: Address,
+    ) -> Result<(TxHash, U256), WrapperError> {
+        unimplemented!("FixtureWrapper: redemption fixture never calls to_underlying")
+    }
+
+    async fn donate(
+        &self,
+        _wrapped_token: Address,
+        _underlying_amount: U256,
+    ) -> Result<TxHash, WrapperError> {
+        unimplemented!("FixtureWrapper: redemption fixture never calls donate")
+    }
+
+    async fn submit_wrap(
+        &self,
+        _wrapped_token: Address,
+        _underlying_amount: U256,
+        _receiver: Address,
+    ) -> Result<TxHash, WrapperError> {
+        unimplemented!("FixtureWrapper: redemption fixture never calls submit_wrap")
+    }
+
+    async fn confirm_wrap(
+        &self,
+        _wrapped_token: Address,
+        _tx_hash: TxHash,
+    ) -> Result<WrapConfirmation, WrapperError> {
+        unimplemented!("FixtureWrapper: redemption fixture never calls confirm_wrap")
+    }
+
+    async fn submit_unwrap(
+        &self,
+        _wrapped_token: Address,
+        wrapped_amount: U256,
+        _receiver: Address,
+        _owner: Address,
+    ) -> Result<TxHash, WrapperError> {
+        *self.pending_unwrap.lock().await = Some(wrapped_amount);
+        Ok(TxHash::left_padding_from(
+            simulated_transfer_uuid("redeem-unwrap-tx", self.day).as_bytes(),
+        ))
+    }
+
+    async fn confirm_unwrap(
+        &self,
+        _wrapped_token: Address,
+        _tx_hash: TxHash,
+    ) -> Result<UnwrapConfirmation, WrapperError> {
+        let assets = self
+            .pending_unwrap
+            .lock()
+            .await
+            .ok_or(WrapperError::MissingWithdrawEvent)?;
+
+        Ok(UnwrapConfirmation {
+            assets,
+            block: self.unwrap_block,
+        })
+    }
+
+    async fn wait_for_block(&self, _block: u64) -> Result<(), WrapperError> {
+        Ok(())
+    }
+
+    fn owner(&self) -> Address {
+        self.owner
+    }
+}
+
+/// Seeds deterministic equity-redemption history for local dashboard
+/// simulation.
+///
+/// Drives the `EquityRedemption` aggregate's happy path (`RedeemAt` ->
+/// `SubmitWithdrawAt` -> `ConfirmWithdrawAt` -> `UnwrapTokensAt` ->
+/// `SubmitUnwrapAt` -> `ConfirmUnwrapAt` -> `PrepareSendAt` ->
+/// `SendTokensAt` -> `DetectAt` -> `CompleteAt`), one redemption per day
+/// alternating between the same dedicated fixture symbols
+/// (`AAPL.SIM`/`TSLA.SIM`) used by [`super::seed_simulated_hedge_latency_history`].
+///
+/// Unlike the mint/USDC fixtures, `EquityRedemption`'s service-calling
+/// commands (`SubmitWithdraw`/`ConfirmWithdraw`/`SubmitUnwrap`/
+/// `ConfirmUnwrap`/`SendTokens`) drive the side effect FROM WITHIN
+/// `transition()` itself (mint's analogous commands take the service
+/// result as command input instead), so a fresh, single-cycle-scoped
+/// [`FixtureRaindex`]/[`FixtureVaultLookup`]/[`FixtureWrapper`] triple is
+/// built for every redemption.
+pub async fn seed_simulated_equity_redemption_history(
+    pool: &SqlitePool,
+    now: DateTime<Utc>,
+    days: u32,
+) -> anyhow::Result<()> {
+    sqlx::migrate!().set_ignore_missing(true).run(pool).await?;
+
+    let range_start = now - Duration::days(i64::from(days)) - Duration::days(1);
+    let aapl = Symbol::new("AAPL.SIM")?;
+    let tsla = Symbol::new("TSLA.SIM")?;
+    let owner = Address::repeat_byte(0x5A);
+    let redemption_wallet = Address::repeat_byte(0xA1);
+
+    for day in 0..days {
+        let symbol = if day % 2 == 0 { &aapl } else { &tsla };
+        let token =
+            Address::left_padding_from(simulated_transfer_uuid("redeem-token", day).as_bytes());
+        let underlying_token = Address::left_padding_from(
+            simulated_transfer_uuid("redeem-underlying", day).as_bytes(),
+        );
+        let vault_id = RaindexVaultId(B256::left_padding_from(
+            simulated_transfer_uuid("redeem-vault", day).as_bytes(),
+        ));
+        let withdraw_block = 4_000_000_u64 + u64::from(day) * 10;
+        let unwrap_block = withdraw_block + 5;
+
+        let services = EquityTransferServices {
+            raindex: Arc::new(FixtureRaindex::new(owner, withdraw_block, day)),
+            vault_lookup: Arc::new(FixtureVaultLookup::new(vault_id)),
+            tokenizer: Arc::new(FixtureTokenizer::new(redemption_wallet, day)),
+            wrapper: Arc::new(FixtureWrapper::new(
+                owner,
+                underlying_token,
+                unwrap_block,
+                day,
+            )),
+        };
+
+        let redemption = StoreBuilder::<EquityRedemption>::new(pool.clone())
+            .with(Arc::new(EquityTimingProjection::new(pool.clone())))
+            .build(services)
+            .await?;
+
+        let id = RedemptionAggregateId(simulated_transfer_uuid("redemption", day));
+        let quantity = Float::parse("5".to_string())?;
+        let wrapped_amount = quantity.to_fixed_decimal(TOKENIZED_EQUITY_DECIMALS)?;
+
+        let pending_at = range_start + Duration::days(i64::from(day)) + Duration::hours(11);
+        let submitted_at = pending_at + Duration::seconds(20);
+        let withdrawn_at = submitted_at + Duration::seconds(30);
+        let unwrap_pending_at = withdrawn_at + Duration::seconds(10);
+        let unwrap_submitted_at = unwrap_pending_at + Duration::seconds(15);
+        let unwrapped_at = unwrap_submitted_at + Duration::seconds(25);
+        let send_pending_at = unwrapped_at + Duration::seconds(10);
+        let sent_at = send_pending_at + Duration::seconds(20);
+        let detected_at = sent_at + Duration::minutes(2);
+        let completed_at = detected_at + Duration::seconds(30);
+
+        redemption
+            .send(
+                &id,
+                EquityRedemptionCommand::RedeemAt {
+                    symbol: symbol.clone(),
+                    quantity,
+                    token,
+                    amount: wrapped_amount,
+                    pending_at,
+                },
+            )
+            .await?;
+
+        redemption
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitWithdrawAt { submitted_at },
+            )
+            .await?;
+
+        redemption
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmWithdrawAt { withdrawn_at },
+            )
+            .await?;
+
+        redemption
+            .send(
+                &id,
+                EquityRedemptionCommand::UnwrapTokensAt {
+                    pending_at: unwrap_pending_at,
+                },
+            )
+            .await?;
+
+        redemption
+            .send(
+                &id,
+                EquityRedemptionCommand::SubmitUnwrapAt {
+                    submitted_at: unwrap_submitted_at,
+                },
+            )
+            .await?;
+
+        redemption
+            .send(
+                &id,
+                EquityRedemptionCommand::ConfirmUnwrapAt { unwrapped_at },
+            )
+            .await?;
+
+        redemption
+            .send(
+                &id,
+                EquityRedemptionCommand::PrepareSendAt {
+                    pending_at: send_pending_at,
+                },
+            )
+            .await?;
+
+        redemption
+            .send(&id, EquityRedemptionCommand::SendTokensAt { sent_at })
+            .await?;
+
+        redemption
+            .send(
+                &id,
+                EquityRedemptionCommand::DetectAt {
+                    tokenization_request_id: tokenization_request_id(&format!("sim-redeem-{id}")),
+                    detected_at,
+                },
+            )
+            .await?;
+
+        redemption
+            .send(&id, EquityRedemptionCommand::CompleteAt { completed_at })
+            .await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use st0x_dto::EquityOperationKind;
+    use st0x_event_sorcery::load_entity;
+
+    use super::*;
+    use crate::performance::ReportRange;
+    use crate::performance::equity_timing::load_equity_timings;
+    use crate::performance::rebalance::load_rebalance_timings;
+    use crate::test_utils::setup_test_db;
+
+    #[tokio::test]
+    async fn mint_history_reaches_deposited_into_raindex_for_every_seeded_day() {
+        let pool = setup_test_db().await;
+        let now = Utc.with_ymd_and_hms(2026, 7, 1, 18, 0, 0).unwrap();
+        let days = 6;
+
+        seed_simulated_mint_history(&pool, now, days).await.unwrap();
+
+        for day in 0..days {
+            let issuer_request_id = IssuerRequestId(simulated_transfer_uuid("mint", day));
+            let mint = load_entity::<TokenizedEquityMint>(&pool, &issuer_request_id)
+                .await
+                .unwrap()
+                .unwrap_or_else(|| panic!("mint aggregate for day {day} was never initialized"));
+
+            assert!(
+                matches!(mint, TokenizedEquityMint::DepositedIntoRaindex { .. }),
+                "day {day} mint did not reach DepositedIntoRaindex: {mint:?}",
+            );
+        }
+
+        let timings = load_equity_timings(&pool, &ReportRange::all_time())
+            .await
+            .unwrap();
+        assert_eq!(timings.total_operations, days as usize);
+        assert_eq!(timings.skipped_operations, 0);
+        assert!(
+            timings
+                .operations
+                .iter()
+                .all(|operation| operation.kind == EquityOperationKind::Mint),
+            "expected every seeded operation to be a mint: {:?}",
+            timings.operations,
+        );
+
+        // Each seeded day's `RequestMintAt` backdates `requested_at` (which
+        // becomes `started_at`) by one additional day. If any `*At` handler
+        // silently fell back to `Utc::now()` instead of threading the
+        // supplied timestamp, every operation would collapse onto
+        // near-identical `started_at` values instead of spanning the full
+        // seeded range.
+        let mut started_ats: Vec<DateTime<Utc>> = timings
+            .operations
+            .iter()
+            .map(|operation| {
+                operation
+                    .started_at
+                    .unwrap_or_else(|| panic!("mint operation missing started_at: {operation:?}"))
+            })
+            .collect();
+        started_ats.sort_unstable();
+        let earliest = *started_ats.first().unwrap();
+        let latest = *started_ats.last().unwrap();
+        assert_eq!(
+            latest - earliest,
+            Duration::days(i64::from(days - 1)),
+            "seeded mint started_at values should span one day per seeded day",
+        );
+    }
+
+    #[tokio::test]
+    async fn usdc_rebalance_history_reaches_the_correct_terminal_per_direction() {
+        let pool = setup_test_db().await;
+        let now = Utc.with_ymd_and_hms(2026, 7, 1, 18, 0, 0).unwrap();
+        let days = 6;
+
+        seed_simulated_usdc_rebalance_history(&pool, now, days)
+            .await
+            .unwrap();
+
+        for day in 0..days {
+            let id = UsdcRebalanceId(simulated_transfer_uuid("usdc-rebalance", day));
+            let rebalance = load_entity::<UsdcRebalance>(&pool, &id)
+                .await
+                .unwrap()
+                .unwrap_or_else(|| panic!("usdc rebalance for day {day} was never initialized"));
+
+            if day % 2 == 0 {
+                assert!(
+                    matches!(
+                        rebalance,
+                        UsdcRebalance::DepositConfirmed {
+                            direction: RebalanceDirection::AlpacaToBase,
+                            ..
+                        }
+                    ),
+                    "day {day} (AlpacaToBase) did not reach DepositConfirmed: {rebalance:?}",
+                );
+            } else {
+                assert!(
+                    matches!(
+                        rebalance,
+                        UsdcRebalance::ConversionComplete {
+                            direction: RebalanceDirection::BaseToAlpaca,
+                            ..
+                        }
+                    ),
+                    "day {day} (BaseToAlpaca) did not reach ConversionComplete: {rebalance:?}",
+                );
+            }
+        }
+
+        let timings = load_rebalance_timings(&pool, &ReportRange::all_time())
+            .await
+            .unwrap();
+        assert_eq!(timings.total_operations, days as usize);
+        assert_eq!(timings.skipped_operations, 0);
+
+        // Each seeded day's first `*At` command (`InitiateConversionAt` for
+        // AlpacaToBase, `BeginWithdrawalAt` for BaseToAlpaca) backdates
+        // `started_at` by one additional day. If any of the 12 `*At` handlers
+        // silently fell back to `Utc::now()` instead of threading the
+        // supplied timestamp, every operation would collapse onto
+        // near-identical `started_at` values instead of spanning the full
+        // seeded range.
+        let mut started_ats: Vec<DateTime<Utc>> = timings
+            .operations
+            .iter()
+            .map(|operation| {
+                operation.started_at.unwrap_or_else(|| {
+                    panic!("rebalance operation missing started_at: {operation:?}")
+                })
+            })
+            .collect();
+        started_ats.sort_unstable();
+        let earliest = *started_ats.first().unwrap();
+        let latest = *started_ats.last().unwrap();
+        assert_eq!(
+            latest - earliest,
+            Duration::days(i64::from(days - 1)),
+            "seeded rebalance started_at values should span one day per seeded day",
+        );
+    }
+
+    #[tokio::test]
+    async fn equity_redemption_history_reaches_completed_for_every_seeded_day() {
+        let pool = setup_test_db().await;
+        let now = Utc.with_ymd_and_hms(2026, 7, 1, 18, 0, 0).unwrap();
+        let days = 6;
+
+        seed_simulated_equity_redemption_history(&pool, now, days)
+            .await
+            .unwrap();
+
+        for day in 0..days {
+            let id = RedemptionAggregateId(simulated_transfer_uuid("redemption", day));
+            let redemption = load_entity::<EquityRedemption>(&pool, &id)
+                .await
+                .unwrap()
+                .unwrap_or_else(|| panic!("redemption for day {day} was never initialized"));
+
+            assert!(
+                matches!(redemption, EquityRedemption::Completed { .. }),
+                "day {day} redemption did not reach Completed: {redemption:?}",
+            );
+        }
+
+        let timings = load_equity_timings(&pool, &ReportRange::all_time())
+            .await
+            .unwrap();
+        assert_eq!(timings.total_operations, days as usize);
+        assert_eq!(timings.skipped_operations, 0);
+        assert!(
+            timings
+                .operations
+                .iter()
+                .all(|operation| operation.kind == EquityOperationKind::Redeem),
+            "expected every seeded operation to be a redemption: {:?}",
+            timings.operations,
+        );
+    }
+}

--- a/src/position.rs
+++ b/src/position.rs
@@ -392,28 +392,37 @@ impl EventSourced for Position {
                 direction,
                 price_usdc,
                 block_timestamp,
-            } => {
-                let now = Utc::now();
-                Ok(vec![
-                    PositionEvent::Initialized {
-                        symbol,
-                        threshold,
-                        initialized_at: now,
-                    },
-                    PositionEvent::OnChainOrderFilled {
-                        trade_id: trade_id.clone(),
-                        amount,
-                        direction,
-                        price_usdc,
-                        block_timestamp,
-                        seen_at: now,
-                    },
-                    PositionEvent::OnChainFillApplied {
-                        trade_id,
-                        applied_at: now,
-                    },
-                ])
-            }
+            } => Ok(Self::acknowledge_on_chain_fill_init_events(
+                symbol,
+                threshold,
+                trade_id,
+                amount,
+                direction,
+                price_usdc,
+                block_timestamp,
+                Utc::now(),
+            )),
+
+            #[cfg(any(test, feature = "test-support"))]
+            AcknowledgeOnChainFillAt {
+                symbol,
+                threshold,
+                trade_id,
+                amount,
+                direction,
+                price_usdc,
+                block_timestamp,
+                seen_at,
+            } => Ok(Self::acknowledge_on_chain_fill_init_events(
+                symbol,
+                threshold,
+                trade_id,
+                amount,
+                direction,
+                price_usdc,
+                block_timestamp,
+                seen_at,
+            )),
 
             // Pruning a fill the position never applied is a no-op; never
             // initialize the aggregate just to settle an absent trade.
@@ -478,34 +487,32 @@ impl EventSourced for Position {
                 price_usdc,
                 block_timestamp,
                 ..
-            } => {
-                // Dual guard (ADR 0010): the retained slot bridges a fill
-                // applied under pre-set code and left unmarked at the
-                // deploy restart; the set rejects an out-of-order /
-                // cross-process re-drive the single slot cannot, because a
-                // newer fill displaces the slot but never the set entry.
-                if self.last_acknowledged_trade_id.as_ref() == Some(&trade_id)
-                    || self.pending_acknowledged_trade_ids.contains(&trade_id)
-                {
-                    return Err(PositionError::DuplicateTrade { trade_id });
-                }
+            } => self.acknowledge_on_chain_fill_transition_events(
+                trade_id,
+                amount,
+                direction,
+                price_usdc,
+                block_timestamp,
+                Utc::now(),
+            ),
 
-                let now = Utc::now();
-                Ok(vec![
-                    PositionEvent::OnChainOrderFilled {
-                        trade_id: trade_id.clone(),
-                        amount,
-                        direction,
-                        price_usdc,
-                        block_timestamp,
-                        seen_at: now,
-                    },
-                    PositionEvent::OnChainFillApplied {
-                        trade_id,
-                        applied_at: now,
-                    },
-                ])
-            }
+            #[cfg(any(test, feature = "test-support"))]
+            AcknowledgeOnChainFillAt {
+                trade_id,
+                amount,
+                direction,
+                price_usdc,
+                block_timestamp,
+                seen_at,
+                ..
+            } => self.acknowledge_on_chain_fill_transition_events(
+                trade_id,
+                amount,
+                direction,
+                price_usdc,
+                block_timestamp,
+                seen_at,
+            ),
 
             SettleOnChainFill { trade_id } => {
                 if self.pending_acknowledged_trade_ids.contains(&trade_id) {
@@ -524,36 +531,29 @@ impl EventSourced for Position {
                 direction,
                 executor,
                 ..
-            } => {
-                if let Some(pending) = self.pending_offchain_order_id {
-                    return Err(PositionError::PendingExecution {
-                        offchain_order_id: pending,
-                    });
-                }
+            } => self.place_offchain_order_events(
+                offchain_order_id,
+                shares,
+                direction,
+                executor,
+                Utc::now(),
+            ),
 
-                let trigger_reason = self
-                    .create_trigger_reason(&self.threshold)?
-                    .ok_or(PositionError::ThresholdNotMet {
-                        net_position: self.net,
-                        threshold: self.threshold,
-                    })
-                    .inspect_err(|error| {
-                        warn!(
-                            target: "hedge",
-                            %offchain_order_id, symbol = %self.symbol,
-                            "Order placement rejected: {error}",
-                        );
-                    })?;
-
-                Ok(vec![PositionEvent::OffChainOrderPlaced {
-                    offchain_order_id,
-                    shares,
-                    direction,
-                    executor,
-                    trigger_reason,
-                    placed_at: Utc::now(),
-                }])
-            }
+            #[cfg(any(test, feature = "test-support"))]
+            PlaceOffChainOrderAt {
+                offchain_order_id,
+                shares,
+                direction,
+                executor,
+                placed_at,
+                ..
+            } => self.place_offchain_order_events(
+                offchain_order_id,
+                shares,
+                direction,
+                executor,
+                placed_at,
+            ),
 
             CompleteOffChainOrder {
                 offchain_order_id,
@@ -664,6 +664,111 @@ impl EventSourced for Position {
 }
 
 impl Position {
+    fn acknowledge_on_chain_fill_init_events(
+        symbol: Symbol,
+        threshold: ExecutionThreshold,
+        trade_id: TradeId,
+        amount: FractionalShares,
+        direction: Direction,
+        price_usdc: Float,
+        block_timestamp: DateTime<Utc>,
+        seen_at: DateTime<Utc>,
+    ) -> Vec<PositionEvent> {
+        vec![
+            PositionEvent::Initialized {
+                symbol,
+                threshold,
+                initialized_at: seen_at,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: trade_id.clone(),
+                amount,
+                direction,
+                price_usdc,
+                block_timestamp,
+                seen_at,
+            },
+            PositionEvent::OnChainFillApplied {
+                trade_id,
+                applied_at: seen_at,
+            },
+        ]
+    }
+
+    fn acknowledge_on_chain_fill_transition_events(
+        &self,
+        trade_id: TradeId,
+        amount: FractionalShares,
+        direction: Direction,
+        price_usdc: Float,
+        block_timestamp: DateTime<Utc>,
+        seen_at: DateTime<Utc>,
+    ) -> Result<Vec<PositionEvent>, PositionError> {
+        // Dual guard (ADR 0010): the retained slot bridges a fill applied
+        // under pre-set code and left unmarked at the deploy restart; the
+        // set rejects an out-of-order / cross-process re-drive the single
+        // slot cannot, because a newer fill displaces the slot but never
+        // the set entry.
+        if self.last_acknowledged_trade_id.as_ref() == Some(&trade_id)
+            || self.pending_acknowledged_trade_ids.contains(&trade_id)
+        {
+            return Err(PositionError::DuplicateTrade { trade_id });
+        }
+
+        Ok(vec![
+            PositionEvent::OnChainOrderFilled {
+                trade_id: trade_id.clone(),
+                amount,
+                direction,
+                price_usdc,
+                block_timestamp,
+                seen_at,
+            },
+            PositionEvent::OnChainFillApplied {
+                trade_id,
+                applied_at: seen_at,
+            },
+        ])
+    }
+
+    fn place_offchain_order_events(
+        &self,
+        offchain_order_id: OffchainOrderId,
+        shares: Positive<FractionalShares>,
+        direction: Direction,
+        executor: SupportedExecutor,
+        placed_at: DateTime<Utc>,
+    ) -> Result<Vec<PositionEvent>, PositionError> {
+        if let Some(pending) = self.pending_offchain_order_id {
+            return Err(PositionError::PendingExecution {
+                offchain_order_id: pending,
+            });
+        }
+
+        let trigger_reason = self
+            .create_trigger_reason(&self.threshold)?
+            .ok_or(PositionError::ThresholdNotMet {
+                net_position: self.net,
+                threshold: self.threshold,
+            })
+            .inspect_err(|error| {
+                warn!(
+                    target: "hedge",
+                    %offchain_order_id, symbol = %self.symbol,
+                    "Order placement rejected: {error}",
+                );
+            })?;
+
+        Ok(vec![PositionEvent::OffChainOrderPlaced {
+            offchain_order_id,
+            shares,
+            direction,
+            executor,
+            trigger_reason,
+            placed_at,
+        }])
+    }
+
     fn create_trigger_reason(
         &self,
         threshold: &ExecutionThreshold,
@@ -919,6 +1024,21 @@ pub enum PositionCommand {
         price_usdc: Float,
         block_timestamp: DateTime<Utc>,
     },
+    /// Test/fixture-only: identical to `AcknowledgeOnChainFill` but takes
+    /// `seen_at` explicitly instead of stamping `Utc::now()`, so fixture
+    /// seeding (e.g. `nix run .#simulate-14d`) can backdate synthetic
+    /// history to build a realistic-looking trend.
+    #[cfg(any(test, feature = "test-support"))]
+    AcknowledgeOnChainFillAt {
+        symbol: Symbol,
+        threshold: ExecutionThreshold,
+        trade_id: TradeId,
+        amount: FractionalShares,
+        direction: Direction,
+        price_usdc: Float,
+        block_timestamp: DateTime<Utc>,
+        seen_at: DateTime<Utc>,
+    },
     /// Prunes `trade_id` from the pending-acknowledgement set after its
     /// `OnChainTrade` marker is durable (ADR 0010). A no-op (emits no
     /// events) when the trade is not in the set, so a re-driven prune is
@@ -932,6 +1052,18 @@ pub enum PositionCommand {
         direction: Direction,
         executor: SupportedExecutor,
         threshold: ExecutionThreshold,
+    },
+    /// Test/fixture-only: identical to `PlaceOffChainOrder` but takes
+    /// `placed_at` explicitly instead of stamping `Utc::now()`, so fixture
+    /// seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    PlaceOffChainOrderAt {
+        offchain_order_id: OffchainOrderId,
+        shares: Positive<FractionalShares>,
+        direction: Direction,
+        executor: SupportedExecutor,
+        threshold: ExecutionThreshold,
+        placed_at: DateTime<Utc>,
     },
     CompleteOffChainOrder {
         offchain_order_id: OffchainOrderId,
@@ -1381,6 +1513,27 @@ impl std::fmt::Debug for PositionCommand {
                 .field("price_usdc", &DebugFloat(price_usdc))
                 .field("block_timestamp", block_timestamp)
                 .finish(),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::AcknowledgeOnChainFillAt {
+                symbol,
+                threshold,
+                trade_id,
+                amount,
+                direction,
+                price_usdc,
+                block_timestamp,
+                seen_at,
+            } => f
+                .debug_struct("AcknowledgeOnChainFillAt")
+                .field("symbol", symbol)
+                .field("threshold", threshold)
+                .field("trade_id", trade_id)
+                .field("amount", amount)
+                .field("direction", direction)
+                .field("price_usdc", &DebugFloat(price_usdc))
+                .field("block_timestamp", block_timestamp)
+                .field("seen_at", seen_at)
+                .finish(),
             Self::SettleOnChainFill { trade_id } => f
                 .debug_struct("SettleOnChainFill")
                 .field("trade_id", trade_id)
@@ -1398,6 +1551,23 @@ impl std::fmt::Debug for PositionCommand {
                 .field("direction", direction)
                 .field("executor", executor)
                 .field("threshold", threshold)
+                .finish(),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::PlaceOffChainOrderAt {
+                offchain_order_id,
+                shares,
+                direction,
+                executor,
+                threshold,
+                placed_at,
+            } => f
+                .debug_struct("PlaceOffChainOrderAt")
+                .field("offchain_order_id", offchain_order_id)
+                .field("shares", shares)
+                .field("direction", direction)
+                .field("executor", executor)
+                .field("threshold", threshold)
+                .field("placed_at", placed_at)
                 .finish(),
             Self::CompleteOffChainOrder {
                 offchain_order_id,
@@ -1701,6 +1871,43 @@ mod tests {
             events[1],
             PositionEvent::OnChainFillApplied { .. }
         ));
+    }
+
+    /// Covers the fixture-only `AcknowledgeOnChainFillAt` sibling of
+    /// `AcknowledgeOnChainFill`: it must thread the caller-supplied `seen_at`
+    /// through to the emitted event's field rather than silently falling
+    /// back to `Utc::now()`.
+    #[tokio::test]
+    async fn acknowledge_on_chain_fill_at_uses_supplied_timestamp() {
+        let seen_at = Utc::now() - chrono::Duration::hours(3);
+
+        let events = TestHarness::<Position>::with(())
+            .given_no_previous_events()
+            .when(PositionCommand::AcknowledgeOnChainFillAt {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(0.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: Utc::now(),
+                seen_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 3);
+        let PositionEvent::OnChainOrderFilled {
+            seen_at: event_seen_at,
+            ..
+        } = &events[1]
+        else {
+            panic!("Expected OnChainOrderFilled, got: {:?}", events[1]);
+        };
+        assert_eq!(*event_seen_at, seen_at);
     }
 
     /// Reproduction for the double-count half of the Witness/Acknowledge
@@ -2056,6 +2263,56 @@ mod tests {
             .events();
 
         assert_eq!(events.len(), 1);
+    }
+
+    /// Covers the fixture-only `PlaceOffChainOrderAt` sibling of
+    /// `PlaceOffChainOrder`: it must thread the caller-supplied `placed_at`
+    /// through to the emitted event's field rather than silently falling
+    /// back to `Utc::now()`.
+    #[tokio::test]
+    async fn place_offchain_order_at_uses_supplied_timestamp() {
+        let threshold = one_share_threshold();
+        let placed_at = Utc::now() - chrono::Duration::hours(1);
+
+        let events = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    threshold,
+                    initialized_at: Utc::now(),
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 1,
+                    },
+                    amount: FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: Utc::now(),
+                    seen_at: Utc::now(),
+                },
+            ])
+            .when(PositionCommand::PlaceOffChainOrderAt {
+                offchain_order_id: OffchainOrderId::new(),
+                shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor: SupportedExecutor::DryRun,
+                threshold,
+                placed_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let PositionEvent::OffChainOrderPlaced {
+            placed_at: event_placed_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected OffChainOrderPlaced, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_placed_at, placed_at);
     }
 
     #[tokio::test]

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -203,11 +203,30 @@ pub(crate) enum TokenizedEquityMintCommand {
         quantity: Float,
         wallet: Address,
     },
+    /// Test/fixture-only: identical to `RequestMint` but takes `requested_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    RequestMintAt {
+        issuer_request_id: IssuerRequestId,
+        symbol: Symbol,
+        quantity: Float,
+        wallet: Address,
+        requested_at: DateTime<Utc>,
+    },
     /// Calls `poll_mint_until_complete()` on the tokenizer service.
     ///
     /// Emits TokensReceived (success)
     ///     or MintAcceptanceFailed (rejection/timeout/error)
     Poll,
+    /// Test/fixture-only: identical to `Poll` but takes `received_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history. Only the success (`TokensReceived`) path
+    /// honours the timestamp; the fixture never drives a rejection.
+    #[cfg(any(test, feature = "test-support"))]
+    PollAt {
+        received_at: DateTime<Utc>,
+    },
     /// Record that a wrap transaction has been submitted (before confirmation).
     SubmitWrap {
         wrap_tx_hash: TxHash,
@@ -224,8 +243,26 @@ pub(crate) enum TokenizedEquityMintCommand {
         /// deposit. The persisted event keeps `Option<u64>` for legacy replay.
         wrap_block: u64,
     },
+    /// Test/fixture-only: identical to `WrapTokens` but takes `wrapped_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    WrapTokensAt {
+        wrap_tx_hash: TxHash,
+        wrapped_shares: U256,
+        wrap_block: u64,
+        wrapped_at: DateTime<Utc>,
+    },
     DepositToVault {
         vault_deposit_tx_hash: TxHash,
+    },
+    /// Test/fixture-only: identical to `DepositToVault` but takes
+    /// `deposited_at` explicitly instead of stamping `Utc::now()`, so
+    /// fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    DepositToVaultAt {
+        vault_deposit_tx_hash: TxHash,
+        deposited_at: DateTime<Utc>,
     },
     /// Operator or timeout-driven failure from `MintAccepted` state, or operator
     /// force-fail from `MintRequested` (requested at the provider but never
@@ -1785,14 +1822,22 @@ impl EventSourced for TokenizedEquityMint {
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use TokenizedEquityMintEvent::*;
 
-        let TokenizedEquityMintCommand::RequestMint {
-            issuer_request_id,
-            symbol,
-            quantity,
-            wallet,
-        } = command
-        else {
-            return Err(TokenizedEquityMintError::NotInitialized);
+        let (issuer_request_id, symbol, quantity, wallet, now) = match command {
+            TokenizedEquityMintCommand::RequestMint {
+                issuer_request_id,
+                symbol,
+                quantity,
+                wallet,
+            } => (issuer_request_id, symbol, quantity, wallet, Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            TokenizedEquityMintCommand::RequestMintAt {
+                issuer_request_id,
+                symbol,
+                quantity,
+                wallet,
+                requested_at,
+            } => (issuer_request_id, symbol, quantity, wallet, requested_at),
+            _ => return Err(TokenizedEquityMintError::NotInitialized),
         };
 
         if quantity.lt(Float::zero()?)? {
@@ -1807,7 +1852,6 @@ impl EventSourced for TokenizedEquityMint {
             "Initiating mint request"
         );
 
-        let now = Utc::now();
         let mint_requested = MintRequested {
             symbol: symbol.clone(),
             quantity,
@@ -1876,104 +1920,17 @@ impl EventSourced for TokenizedEquityMint {
             TokenizedEquityMintCommand::RequestMint { .. } => {
                 Err(TokenizedEquityMintError::AlreadyInProgress)
             }
+            #[cfg(any(test, feature = "test-support"))]
+            TokenizedEquityMintCommand::RequestMintAt { .. } => {
+                Err(TokenizedEquityMintError::AlreadyInProgress)
+            }
 
-            TokenizedEquityMintCommand::Poll => match self {
-                Self::MintAccepted {
-                    symbol,
-                    quantity,
-                    tokenization_request_id,
-                    ..
-                } => {
-                    let completed = match services
-                        .tokenizer
-                        .poll_mint_until_complete(tokenization_request_id)
-                        .await
-                    {
-                        Ok(req) => req,
-                        Err(error) => {
-                            warn!(target: "tokenization", %error, %symbol, %tokenization_request_id, "Polling failed");
-                            return Ok(vec![MintAcceptanceFailed {
-                                reason: format!("Polling failed: {error}"),
-                                failed_at: Utc::now(),
-                            }]);
-                        }
-                    };
+            TokenizedEquityMintCommand::Poll => self.transition_poll(services, None).await,
 
-                    match completed.status {
-                        TokenizationRequestStatus::Completed => {
-                            let tx_hash = completed
-                                .tx_hash
-                                .ok_or(TokenizedEquityMintError::MissingTxHash)?;
-
-                            // Validate that Alpaca returned the expected
-                            // tokenized symbol (e.g. "tAAPL" for AAPL).
-                            let expected_token_symbol = format!("t{symbol}");
-                            match &completed.token_symbol {
-                                Some(actual) if *actual == expected_token_symbol => {}
-                                Some(actual) => {
-                                    return Err(TokenizedEquityMintError::TokenSymbolMismatch {
-                                        expected_symbol: symbol.clone(),
-                                        actual_token_symbol: actual.clone(),
-                                    });
-                                }
-                                None => {
-                                    return Err(TokenizedEquityMintError::MissingTokenSymbol {
-                                        expected_symbol: symbol.clone(),
-                                    });
-                                }
-                            }
-
-                            let shares_minted = quantity_to_u256_18_decimals(*quantity)?;
-
-                            info!(
-                                target: "tokenization",
-                                %symbol,
-                                %tx_hash,
-                                "Mint polling completed: tokens received"
-                            );
-
-                            Ok(vec![TokensReceived {
-                                tx_hash,
-                                shares_minted,
-                                fees: completed.fees,
-                                received_at: Utc::now(),
-                            }])
-                        }
-                        TokenizationRequestStatus::Rejected => {
-                            warn!(
-                                target: "tokenization",
-                                %symbol,
-                                "Mint rejected by Alpaca after acceptance"
-                            );
-                            Ok(vec![MintAcceptanceFailed {
-                                reason: "Rejected by Alpaca after acceptance".to_string(),
-                                failed_at: Utc::now(),
-                            }])
-                        }
-                        TokenizationRequestStatus::Pending => {
-                            warn!(
-                                target: "tokenization",
-                                %symbol,
-                                "Unexpected pending status after polling"
-                            );
-                            Ok(vec![MintAcceptanceFailed {
-                                reason: "Unexpected Pending status after polling".to_string(),
-                                failed_at: Utc::now(),
-                            }])
-                        }
-                    }
-                }
-                Self::MintRequested { .. } => Err(TokenizedEquityMintError::NotAccepted),
-                Self::TokensReceived { .. }
-                | Self::WrapSubmitted { .. }
-                | Self::TokensWrapped { .. }
-                | Self::VaultDepositSubmitted { .. }
-                | Self::DepositedIntoRaindex { .. } => {
-                    Err(TokenizedEquityMintError::AlreadyCompleted)
-                }
-                Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
-                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
-            },
+            #[cfg(any(test, feature = "test-support"))]
+            TokenizedEquityMintCommand::PollAt { received_at } => {
+                self.transition_poll(services, Some(received_at)).await
+            }
 
             TokenizedEquityMintCommand::SubmitWrap { wrap_tx_hash } => match self {
                 Self::TokensReceived { .. } => Ok(vec![WrapSubmitted {
@@ -2015,46 +1972,23 @@ impl EventSourced for TokenizedEquityMint {
                 wrap_tx_hash,
                 wrapped_shares,
                 wrap_block,
-            } => match self {
-                Self::TokensReceived { .. } | Self::WrapSubmitted { .. } => {
-                    Ok(vec![TokensWrapped {
-                        wrap_tx_hash,
-                        wrapped_shares,
-                        wrapped_at: Utc::now(),
-                        wrap_block: Some(wrap_block),
-                    }])
-                }
-                Self::MintRequested { .. } | Self::MintAccepted { .. } => {
-                    Err(TokenizedEquityMintError::TokensNotReceivedForWrap)
-                }
-                Self::TokensWrapped { .. }
-                | Self::VaultDepositSubmitted { .. }
-                | Self::DepositedIntoRaindex { .. } => {
-                    Err(TokenizedEquityMintError::AlreadyCompleted)
-                }
-                Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
-                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
-            },
+            } => self.transition_wrap_tokens(wrap_tx_hash, wrapped_shares, wrap_block, Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            TokenizedEquityMintCommand::WrapTokensAt {
+                wrap_tx_hash,
+                wrapped_shares,
+                wrap_block,
+                wrapped_at,
+            } => self.transition_wrap_tokens(wrap_tx_hash, wrapped_shares, wrap_block, wrapped_at),
 
             TokenizedEquityMintCommand::DepositToVault {
                 vault_deposit_tx_hash,
-            } => match self {
-                Self::TokensWrapped { .. } | Self::VaultDepositSubmitted { .. } => {
-                    Ok(vec![DepositedIntoRaindex {
-                        vault_deposit_tx_hash,
-                        deposited_at: Utc::now(),
-                    }])
-                }
-                Self::MintRequested { .. }
-                | Self::MintAccepted { .. }
-                | Self::TokensReceived { .. }
-                | Self::WrapSubmitted { .. } => Err(TokenizedEquityMintError::TokensNotWrapped),
-                Self::DepositedIntoRaindex { .. } => {
-                    Err(TokenizedEquityMintError::AlreadyCompleted)
-                }
-                Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
-                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
-            },
+            } => self.transition_deposit_to_vault(vault_deposit_tx_hash, Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            TokenizedEquityMintCommand::DepositToVaultAt {
+                vault_deposit_tx_hash,
+                deposited_at,
+            } => self.transition_deposit_to_vault(vault_deposit_tx_hash, deposited_at),
 
             TokenizedEquityMintCommand::FailAcceptance { reason } => match self {
                 // `MintRequested` is pre-acceptance: a mint stuck there (requested
@@ -2168,6 +2102,168 @@ impl EventSourced for TokenizedEquityMint {
                 Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
                 _ => Err(TokenizedEquityMintError::NotFailed),
             },
+        }
+    }
+}
+
+impl TokenizedEquityMint {
+    /// Shared body for `WrapTokens`/`WrapTokensAt`.
+    fn transition_wrap_tokens(
+        &self,
+        wrap_tx_hash: TxHash,
+        wrapped_shares: U256,
+        wrap_block: u64,
+        wrapped_at: DateTime<Utc>,
+    ) -> Result<Vec<TokenizedEquityMintEvent>, TokenizedEquityMintError> {
+        use TokenizedEquityMintEvent::*;
+
+        match self {
+            Self::TokensReceived { .. } | Self::WrapSubmitted { .. } => Ok(vec![TokensWrapped {
+                wrap_tx_hash,
+                wrapped_shares,
+                wrapped_at,
+                wrap_block: Some(wrap_block),
+            }]),
+            Self::MintRequested { .. } | Self::MintAccepted { .. } => {
+                Err(TokenizedEquityMintError::TokensNotReceivedForWrap)
+            }
+            Self::TokensWrapped { .. }
+            | Self::VaultDepositSubmitted { .. }
+            | Self::DepositedIntoRaindex { .. } => Err(TokenizedEquityMintError::AlreadyCompleted),
+            Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
+        }
+    }
+
+    /// Shared body for `DepositToVault`/`DepositToVaultAt`.
+    fn transition_deposit_to_vault(
+        &self,
+        vault_deposit_tx_hash: TxHash,
+        deposited_at: DateTime<Utc>,
+    ) -> Result<Vec<TokenizedEquityMintEvent>, TokenizedEquityMintError> {
+        use TokenizedEquityMintEvent::*;
+
+        match self {
+            Self::TokensWrapped { .. } | Self::VaultDepositSubmitted { .. } => {
+                Ok(vec![DepositedIntoRaindex {
+                    vault_deposit_tx_hash,
+                    deposited_at,
+                }])
+            }
+            Self::MintRequested { .. }
+            | Self::MintAccepted { .. }
+            | Self::TokensReceived { .. }
+            | Self::WrapSubmitted { .. } => Err(TokenizedEquityMintError::TokensNotWrapped),
+            Self::DepositedIntoRaindex { .. } => Err(TokenizedEquityMintError::AlreadyCompleted),
+            Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
+        }
+    }
+
+    /// Shared body for `Poll`/`PollAt`: only `received_at` (the success
+    /// path's timestamp) is parameterized -- the failure paths keep
+    /// `Utc::now()` since fixture seeding only ever drives the happy path.
+    async fn transition_poll(
+        &self,
+        services: &EquityTransferServices,
+        override_received_at: Option<DateTime<Utc>>,
+    ) -> Result<Vec<TokenizedEquityMintEvent>, TokenizedEquityMintError> {
+        use TokenizedEquityMintEvent::*;
+
+        match self {
+            Self::MintAccepted {
+                symbol,
+                quantity,
+                tokenization_request_id,
+                ..
+            } => {
+                let completed = match services
+                    .tokenizer
+                    .poll_mint_until_complete(tokenization_request_id)
+                    .await
+                {
+                    Ok(req) => req,
+                    Err(error) => {
+                        warn!(target: "tokenization", %error, %symbol, %tokenization_request_id, "Polling failed");
+                        return Ok(vec![MintAcceptanceFailed {
+                            reason: format!("Polling failed: {error}"),
+                            failed_at: Utc::now(),
+                        }]);
+                    }
+                };
+
+                match completed.status {
+                    TokenizationRequestStatus::Completed => {
+                        let tx_hash = completed
+                            .tx_hash
+                            .ok_or(TokenizedEquityMintError::MissingTxHash)?;
+
+                        // Validate that Alpaca returned the expected
+                        // tokenized symbol (e.g. "tAAPL" for AAPL).
+                        let expected_token_symbol = format!("t{symbol}");
+                        match &completed.token_symbol {
+                            Some(actual) if *actual == expected_token_symbol => {}
+                            Some(actual) => {
+                                return Err(TokenizedEquityMintError::TokenSymbolMismatch {
+                                    expected_symbol: symbol.clone(),
+                                    actual_token_symbol: actual.clone(),
+                                });
+                            }
+                            None => {
+                                return Err(TokenizedEquityMintError::MissingTokenSymbol {
+                                    expected_symbol: symbol.clone(),
+                                });
+                            }
+                        }
+
+                        let shares_minted = quantity_to_u256_18_decimals(*quantity)?;
+
+                        info!(
+                            target: "tokenization",
+                            %symbol,
+                            %tx_hash,
+                            "Mint polling completed: tokens received"
+                        );
+
+                        Ok(vec![TokensReceived {
+                            tx_hash,
+                            shares_minted,
+                            fees: completed.fees,
+                            received_at: override_received_at.unwrap_or_else(Utc::now),
+                        }])
+                    }
+                    TokenizationRequestStatus::Rejected => {
+                        warn!(
+                            target: "tokenization",
+                            %symbol,
+                            "Mint rejected by Alpaca after acceptance"
+                        );
+                        Ok(vec![MintAcceptanceFailed {
+                            reason: "Rejected by Alpaca after acceptance".to_string(),
+                            failed_at: Utc::now(),
+                        }])
+                    }
+                    TokenizationRequestStatus::Pending => {
+                        warn!(
+                            target: "tokenization",
+                            %symbol,
+                            "Unexpected pending status after polling"
+                        );
+                        Ok(vec![MintAcceptanceFailed {
+                            reason: "Unexpected Pending status after polling".to_string(),
+                            failed_at: Utc::now(),
+                        }])
+                    }
+                }
+            }
+            Self::MintRequested { .. } => Err(TokenizedEquityMintError::NotAccepted),
+            Self::TokensReceived { .. }
+            | Self::WrapSubmitted { .. }
+            | Self::TokensWrapped { .. }
+            | Self::VaultDepositSubmitted { .. }
+            | Self::DepositedIntoRaindex { .. } => Err(TokenizedEquityMintError::AlreadyCompleted),
+            Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
         }
     }
 }
@@ -2847,6 +2943,122 @@ mod tests {
             matches!(entity, TokenizedEquityMint::DepositedIntoRaindex { .. }),
             "Expected DepositedIntoRaindex, got: {entity:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn poll_at_uses_supplied_timestamp() {
+        let received_at = Utc::now() - chrono::Duration::hours(2);
+
+        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given(vec![mint_requested_event(), mint_accepted_event()])
+            .when(TokenizedEquityMintCommand::PollAt { received_at })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let TokenizedEquityMintEvent::TokensReceived {
+            received_at: event_received_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected TokensReceived, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_received_at, received_at);
+    }
+
+    #[tokio::test]
+    async fn wrap_tokens_at_uses_supplied_timestamp() {
+        let wrapped_at = Utc::now() - chrono::Duration::hours(3);
+
+        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given(vec![
+                mint_requested_event(),
+                mint_accepted_event(),
+                tokens_received_event(),
+            ])
+            .when(TokenizedEquityMintCommand::WrapTokensAt {
+                wrap_tx_hash: TxHash::random(),
+                wrapped_shares: U256::from(10_000_000_000_000_000_000_u128),
+                wrap_block: 1,
+                wrapped_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let TokenizedEquityMintEvent::TokensWrapped {
+            wrapped_at: event_wrapped_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected TokensWrapped, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_wrapped_at, wrapped_at);
+    }
+
+    #[tokio::test]
+    async fn deposit_to_vault_at_uses_supplied_timestamp() {
+        let deposited_at = Utc::now() - chrono::Duration::hours(4);
+
+        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given(vec![
+                mint_requested_event(),
+                mint_accepted_event(),
+                tokens_received_event(),
+                tokens_wrapped_event(),
+            ])
+            .when(TokenizedEquityMintCommand::DepositToVaultAt {
+                vault_deposit_tx_hash: TxHash::random(),
+                deposited_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let TokenizedEquityMintEvent::DepositedIntoRaindex {
+            deposited_at: event_deposited_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected DepositedIntoRaindex, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_deposited_at, deposited_at);
+    }
+
+    #[tokio::test]
+    async fn request_mint_at_uses_supplied_timestamp() {
+        let requested_at = Utc::now() - chrono::Duration::hours(5);
+
+        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given_no_previous_events()
+            .when(TokenizedEquityMintCommand::RequestMintAt {
+                issuer_request_id: issuer_request_id("ISS001"),
+                symbol: Symbol::new("AAPL").unwrap(),
+                quantity: float!(10),
+                wallet: Address::ZERO,
+                requested_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 2);
+        let TokenizedEquityMintEvent::MintRequested {
+            requested_at: event_requested_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected MintRequested, got: {:?}", events[0]);
+        };
+        assert_eq!(*event_requested_at, requested_at);
+
+        let TokenizedEquityMintEvent::MintAccepted {
+            accepted_at: event_accepted_at,
+            ..
+        } = &events[1]
+        else {
+            panic!("Expected MintAccepted, got: {:?}", events[1]);
+        };
+        assert_eq!(*event_accepted_at, requested_at);
     }
 
     #[tokio::test]

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -273,9 +273,27 @@ pub(crate) enum UsdcRebalanceCommand {
         amount: Usdc,
         order_id: ClientOrderId,
     },
+    /// Test/fixture-only: identical to `InitiateConversion` but takes
+    /// `initiated_at` explicitly instead of stamping `Utc::now()`, so
+    /// fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    InitiateConversionAt {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        order_id: ClientOrderId,
+        initiated_at: DateTime<Utc>,
+    },
     /// Confirm successful conversion. Valid only from `Converting` state.
     /// Contains the source amount sold and the destination amount received.
     ConfirmConversion { conversion: ConversionAmounts },
+    /// Test/fixture-only: identical to `ConfirmConversion` but takes
+    /// `converted_at` explicitly instead of stamping `Utc::now()`, so
+    /// fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    ConfirmConversionAt {
+        conversion: ConversionAmounts,
+        converted_at: DateTime<Utc>,
+    },
     /// Record conversion failure. Valid only from `Converting` state.
     FailConversion { reason: String },
     /// Start post-deposit conversion for BaseToAlpaca direction.
@@ -285,6 +303,15 @@ pub(crate) enum UsdcRebalanceCommand {
     InitiatePostDepositConversion {
         order_id: ClientOrderId,
         amount: Usdc,
+    },
+    /// Test/fixture-only: identical to `InitiatePostDepositConversion` but
+    /// takes `initiated_at` explicitly instead of stamping `Utc::now()`, so
+    /// fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    InitiatePostDepositConversionAt {
+        order_id: ClientOrderId,
+        amount: Usdc,
+        initiated_at: DateTime<Utc>,
     },
     /// Record the intent to withdraw from source BEFORE the on-chain call.
     /// Captures the chain head (`from_block`) so a crash mid-withdrawal can be
@@ -296,6 +323,16 @@ pub(crate) enum UsdcRebalanceCommand {
         amount: Usdc,
         from_block: u64,
     },
+    /// Test/fixture-only: identical to `BeginWithdrawal` but takes
+    /// `submitting_at` explicitly instead of stamping `Utc::now()`, so
+    /// fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    BeginWithdrawalAt {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        from_block: u64,
+        submitting_at: DateTime<Utc>,
+    },
     /// Start a new rebalancing operation by recording the submitted withdrawal
     /// transaction. Valid only from `WithdrawalSubmitting` state.
     Initiate {
@@ -303,10 +340,28 @@ pub(crate) enum UsdcRebalanceCommand {
         amount: Usdc,
         withdrawal: TransferRef,
     },
+    /// Test/fixture-only: identical to `Initiate` but takes `initiated_at`
+    /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
+    /// backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    InitiateAt {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        withdrawal: TransferRef,
+        initiated_at: DateTime<Utc>,
+    },
     /// Confirm successful withdrawal from source. Valid only from `Withdrawing` state.
     /// `withdrawal_tx` carries the on-chain tx hash when the source provides one
     /// (AlpacaToBase), so the confirmation-depth gate can re-run on apalis redrive.
     ConfirmWithdrawal { withdrawal_tx: Option<TxHash> },
+    /// Test/fixture-only: identical to `ConfirmWithdrawal` but takes
+    /// `confirmed_at` explicitly instead of stamping `Utc::now()`, so
+    /// fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    ConfirmWithdrawalAt {
+        withdrawal_tx: Option<TxHash>,
+        confirmed_at: DateTime<Utc>,
+    },
     /// Record the intent to burn for CCTP bridging BEFORE the on-chain call.
     /// Captures the chain head (`from_block`) for crash recovery, mirroring
     /// [`BeginWithdrawal`]. Valid only from `WithdrawalComplete` state.
@@ -314,8 +369,25 @@ pub(crate) enum UsdcRebalanceCommand {
         from_block: u64,
         burn_amount: Option<Usdc>,
     },
+    /// Test/fixture-only: identical to `BeginBridging` but takes
+    /// `submitting_at` explicitly instead of stamping `Utc::now()`, so
+    /// fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    BeginBridgingAt {
+        from_block: u64,
+        burn_amount: Option<Usdc>,
+        submitting_at: DateTime<Utc>,
+    },
     /// Record the CCTP burn transaction. Valid only from `BridgingSubmitting` state.
     InitiateBridging { burn_tx: TxHash },
+    /// Test/fixture-only: identical to `InitiateBridging` but takes
+    /// `burned_at` explicitly instead of stamping `Utc::now()`, so fixture
+    /// seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    InitiateBridgingAt {
+        burn_tx: TxHash,
+        burned_at: DateTime<Utc>,
+    },
     /// Record the broadcast CCTP burn tx hash while still in `BridgingSubmitting`,
     /// BEFORE awaiting its receipt, so a crash/timeout redrive checks that exact
     /// tx instead of a mempool-blind log scan. Valid only from `BridgingSubmitting`.
@@ -339,6 +411,17 @@ pub(crate) enum UsdcRebalanceCommand {
         message: Vec<u8>,
         mint_scan_from_block: u64,
     },
+    /// Test/fixture-only: identical to `ReceiveAttestation` but takes
+    /// `attested_at` explicitly instead of stamping `Utc::now()`, so
+    /// fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    ReceiveAttestationAt {
+        attestation: Vec<u8>,
+        cctp_nonce: B256,
+        message: Vec<u8>,
+        mint_scan_from_block: u64,
+        attested_at: DateTime<Utc>,
+    },
     /// Record that Circle attestation polling timed out while the burn remains
     /// recoverable. Valid only from `Bridging` state.
     TimeoutAttestation { retry_deadline_at: DateTime<Utc> },
@@ -351,10 +434,33 @@ pub(crate) enum UsdcRebalanceCommand {
         /// CCTP fee collected (from MintAndWithdraw event)
         fee_collected: Usdc,
     },
+    /// Test/fixture-only: identical to `ConfirmBridging` but takes
+    /// `minted_at` explicitly instead of stamping `Utc::now()`, so fixture
+    /// seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    ConfirmBridgingAt {
+        mint_tx: TxHash,
+        amount_received: Usdc,
+        fee_collected: Usdc,
+        minted_at: DateTime<Utc>,
+    },
     /// Start deposit to destination. Valid only from `Bridged` state.
     InitiateDeposit { deposit: TransferRef },
+    /// Test/fixture-only: identical to `InitiateDeposit` but takes
+    /// `deposit_initiated_at` explicitly instead of stamping `Utc::now()`,
+    /// so fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    InitiateDepositAt {
+        deposit: TransferRef,
+        deposit_initiated_at: DateTime<Utc>,
+    },
     /// Confirm successful deposit. Valid only from `DepositInitiated` state.
     ConfirmDeposit,
+    /// Test/fixture-only: identical to `ConfirmDeposit` but takes
+    /// `deposit_confirmed_at` explicitly instead of stamping `Utc::now()`,
+    /// so fixture seeding can backdate synthetic history.
+    #[cfg(any(test, feature = "test-support"))]
+    ConfirmDepositAt { deposit_confirmed_at: DateTime<Utc> },
     /// Record withdrawal failure. Valid only from `Withdrawing` state.
     FailWithdrawal { reason: String },
     /// Record bridging failure. Valid from `Bridging` or `Attested` states.
@@ -2188,32 +2294,32 @@ impl EventSourced for UsdcRebalance {
                 initiated_at: Utc::now(),
             }]),
 
+            #[cfg(any(test, feature = "test-support"))]
+            InitiateConversionAt {
+                direction,
+                amount,
+                order_id,
+                initiated_at,
+            } => Ok(vec![ConversionInitiated {
+                direction,
+                amount,
+                order_id,
+                initiated_at,
+            }]),
+
             BeginWithdrawal {
                 direction,
                 amount,
                 from_block,
-            } => {
-                // Fresh-start withdrawal intent is BaseToAlpaca-only. An
-                // AlpacaToBase transfer converts USD->USDC first and reaches
-                // `WithdrawalSubmitting` through the post-conversion path
-                // (`transition_begin_withdrawal` from `ConversionComplete`);
-                // recording a fresh AlpacaToBase intent here would materialize a
-                // withdrawal with no conversion history.
-                if direction != RebalanceDirection::BaseToAlpaca {
-                    return Err(UsdcRebalanceError::InvalidCommand {
-                        command: "BeginWithdrawal".to_string(),
-                        state: "Uninitialized (fresh withdrawal is BaseToAlpaca-only; \
-                                AlpacaToBase must convert before withdrawing)"
-                            .to_string(),
-                    });
-                }
-                Ok(vec![WithdrawalSubmitting {
-                    direction,
-                    amount,
-                    from_block,
-                    submitting_at: Utc::now(),
-                }])
-            }
+            } => Self::begin_withdrawal_init_events(direction, amount, from_block, Utc::now()),
+
+            #[cfg(any(test, feature = "test-support"))]
+            BeginWithdrawalAt {
+                direction,
+                amount,
+                from_block,
+                submitting_at,
+            } => Self::begin_withdrawal_init_events(direction, amount, from_block, submitting_at),
 
             Initiate {
                 direction,
@@ -2226,31 +2332,62 @@ impl EventSourced for UsdcRebalance {
                 initiated_at: Utc::now(),
             }]),
 
+            #[cfg(any(test, feature = "test-support"))]
+            InitiateAt {
+                direction,
+                amount,
+                withdrawal,
+                initiated_at,
+            } => Ok(vec![Initiated {
+                direction,
+                amount,
+                withdrawal_ref: withdrawal,
+                initiated_at,
+            }]),
+
             ConfirmConversion { .. } | FailConversion { .. } => {
                 Err(UsdcRebalanceError::ConversionNotInitiated)
             }
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmConversionAt { .. } => Err(UsdcRebalanceError::ConversionNotInitiated),
 
             InitiatePostDepositConversion { .. } => Err(UsdcRebalanceError::DepositNotConfirmed),
+            #[cfg(any(test, feature = "test-support"))]
+            InitiatePostDepositConversionAt { .. } => Err(UsdcRebalanceError::DepositNotConfirmed),
 
             ConfirmWithdrawal { .. } | FailWithdrawal { .. } => {
                 Err(UsdcRebalanceError::WithdrawalNotInitiated)
             }
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmWithdrawalAt { .. } => Err(UsdcRebalanceError::WithdrawalNotInitiated),
 
             BeginBridging { .. }
             | InitiateBridging { .. }
             | RecordPendingBurn { .. }
             | ClearPendingBurn => Err(UsdcRebalanceError::WithdrawalNotConfirmed),
+            #[cfg(any(test, feature = "test-support"))]
+            BeginBridgingAt { .. } => Err(UsdcRebalanceError::WithdrawalNotConfirmed),
+            #[cfg(any(test, feature = "test-support"))]
+            InitiateBridgingAt { .. } => Err(UsdcRebalanceError::WithdrawalNotConfirmed),
 
             ReceiveAttestation { .. }
             | TimeoutAttestation { .. }
             | FailBridging { .. }
             | RecoverBridging { .. } => Err(UsdcRebalanceError::BridgingNotInitiated),
+            #[cfg(any(test, feature = "test-support"))]
+            ReceiveAttestationAt { .. } => Err(UsdcRebalanceError::BridgingNotInitiated),
 
             ConfirmBridging { .. } => Err(UsdcRebalanceError::AttestationNotReceived),
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmBridgingAt { .. } => Err(UsdcRebalanceError::AttestationNotReceived),
 
             InitiateDeposit { .. } => Err(UsdcRebalanceError::BridgingNotCompleted),
+            #[cfg(any(test, feature = "test-support"))]
+            InitiateDepositAt { .. } => Err(UsdcRebalanceError::BridgingNotCompleted),
 
             ConfirmDeposit | FailDeposit { .. } => Err(UsdcRebalanceError::DepositNotInitiated),
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmDepositAt { .. } => Err(UsdcRebalanceError::DepositNotInitiated),
 
             ReconcileStuckRebalance { .. } => Err(UsdcRebalanceError::InvalidCommand {
                 command: "ReconcileStuckRebalance".to_string(),
@@ -2267,32 +2404,87 @@ impl EventSourced for UsdcRebalance {
         use UsdcRebalanceCommand::*;
         match command {
             InitiateConversion { .. } => Err(UsdcRebalanceError::AlreadyInitiated),
-            ConfirmConversion { conversion } => self.transition_confirm_conversion(conversion),
-            FailConversion { reason } => self.transition_fail_conversion(reason),
-            InitiatePostDepositConversion { order_id, amount } => {
-                self.transition_post_deposit_conversion(order_id, amount)
+            #[cfg(any(test, feature = "test-support"))]
+            InitiateConversionAt { .. } => Err(UsdcRebalanceError::AlreadyInitiated),
+
+            ConfirmConversion { conversion } => {
+                self.transition_confirm_conversion(conversion, Utc::now())
             }
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmConversionAt {
+                conversion,
+                converted_at,
+            } => self.transition_confirm_conversion(conversion, converted_at),
+
+            FailConversion { reason } => self.transition_fail_conversion(reason),
+
+            InitiatePostDepositConversion { order_id, amount } => {
+                self.transition_post_deposit_conversion(order_id, amount, Utc::now())
+            }
+            #[cfg(any(test, feature = "test-support"))]
+            InitiatePostDepositConversionAt {
+                order_id,
+                amount,
+                initiated_at,
+            } => self.transition_post_deposit_conversion(order_id, amount, initiated_at),
+
             BeginWithdrawal {
                 direction,
                 amount,
                 from_block,
-            } => self.transition_begin_withdrawal(direction, amount, from_block),
+            } => self.transition_begin_withdrawal(direction, amount, from_block, Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            BeginWithdrawalAt {
+                direction,
+                amount,
+                from_block,
+                submitting_at,
+            } => self.transition_begin_withdrawal(direction, amount, from_block, submitting_at),
+
             Initiate {
                 direction,
                 amount,
                 withdrawal,
-            } => self.transition_initiate_withdrawal(direction, amount, withdrawal),
+            } => self.transition_initiate_withdrawal(direction, amount, withdrawal, Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            InitiateAt {
+                direction,
+                amount,
+                withdrawal,
+                initiated_at,
+            } => self.transition_initiate_withdrawal(direction, amount, withdrawal, initiated_at),
+
             ConfirmWithdrawal { withdrawal_tx } => {
-                self.transition_confirm_withdrawal(withdrawal_tx)
+                self.transition_confirm_withdrawal(withdrawal_tx, Utc::now())
             }
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmWithdrawalAt {
+                withdrawal_tx,
+                confirmed_at,
+            } => self.transition_confirm_withdrawal(withdrawal_tx, confirmed_at),
+
             FailWithdrawal { reason } => self.transition_fail_withdrawal(reason),
+
             BeginBridging {
                 from_block,
                 burn_amount,
-            } => self.transition_begin_bridging(from_block, burn_amount),
-            InitiateBridging { burn_tx } => self.transition_initiate_bridging(burn_tx),
+            } => self.transition_begin_bridging(from_block, burn_amount, Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            BeginBridgingAt {
+                from_block,
+                burn_amount,
+                submitting_at,
+            } => self.transition_begin_bridging(from_block, burn_amount, submitting_at),
+
+            InitiateBridging { burn_tx } => self.transition_initiate_bridging(burn_tx, Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            InitiateBridgingAt { burn_tx, burned_at } => {
+                self.transition_initiate_bridging(burn_tx, burned_at)
+            }
+
             RecordPendingBurn { burn_tx } => self.transition_record_pending_burn(burn_tx),
             ClearPendingBurn => self.transition_clear_pending_burn(),
+
             ReceiveAttestation {
                 attestation,
                 cctp_nonce,
@@ -2303,23 +2495,67 @@ impl EventSourced for UsdcRebalance {
                 cctp_nonce,
                 message,
                 mint_scan_from_block,
+                Utc::now(),
             ),
+            #[cfg(any(test, feature = "test-support"))]
+            ReceiveAttestationAt {
+                attestation,
+                cctp_nonce,
+                message,
+                mint_scan_from_block,
+                attested_at,
+            } => self.transition_receive_attestation(
+                attestation,
+                cctp_nonce,
+                message,
+                mint_scan_from_block,
+                attested_at,
+            ),
+
             TimeoutAttestation { retry_deadline_at } => {
                 self.transition_timeout_attestation(retry_deadline_at)
             }
+
             ConfirmBridging {
                 mint_tx,
                 amount_received,
                 fee_collected,
-            } => self.transition_confirm_bridging(mint_tx, amount_received, fee_collected),
+            } => self.transition_confirm_bridging(
+                mint_tx,
+                amount_received,
+                fee_collected,
+                Utc::now(),
+            ),
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmBridgingAt {
+                mint_tx,
+                amount_received,
+                fee_collected,
+                minted_at,
+            } => {
+                self.transition_confirm_bridging(mint_tx, amount_received, fee_collected, minted_at)
+            }
+
             FailBridging { reason } => self.transition_fail_bridging(reason),
             RecoverBridging {
                 mint_tx,
                 amount_received,
                 fee_collected,
             } => self.transition_recover_bridging(mint_tx, amount_received, fee_collected),
-            InitiateDeposit { deposit } => self.transition_initiate_deposit(deposit),
-            ConfirmDeposit => self.transition_confirm_deposit(),
+
+            InitiateDeposit { deposit } => self.transition_initiate_deposit(deposit, Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            InitiateDepositAt {
+                deposit,
+                deposit_initiated_at,
+            } => self.transition_initiate_deposit(deposit, deposit_initiated_at),
+
+            ConfirmDeposit => self.transition_confirm_deposit(Utc::now()),
+            #[cfg(any(test, feature = "test-support"))]
+            ConfirmDepositAt {
+                deposit_confirmed_at,
+            } => self.transition_confirm_deposit(deposit_confirmed_at),
+
             FailDeposit { reason } => self.transition_fail_deposit(reason),
             ReconcileStuckRebalance { reason } => self.transition_reconcile_stuck_rebalance(reason),
         }
@@ -2334,13 +2570,14 @@ impl UsdcRebalance {
     fn transition_confirm_conversion(
         &self,
         conversion: ConversionAmounts,
+        converted_at: DateTime<Utc>,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         match self {
             Self::Converting { direction, .. } => Ok(vec![ConversionConfirmed {
                 direction: *direction,
                 conversion,
-                converted_at: Utc::now(),
+                converted_at,
             }]),
             Self::ConversionComplete { .. } | Self::ConversionFailed { .. } => {
                 Err(UsdcRebalanceError::ConversionAlreadyCompleted)
@@ -2370,6 +2607,7 @@ impl UsdcRebalance {
         &self,
         order_id: ClientOrderId,
         command_amount: Usdc,
+        initiated_at: DateTime<Utc>,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         let Self::DepositConfirmed {
@@ -2391,7 +2629,39 @@ impl UsdcRebalance {
             direction: *direction,
             amount: *amount,
             order_id,
-            initiated_at: Utc::now(),
+            initiated_at,
+        }])
+    }
+
+    /// Records the BaseToAlpaca fresh-start withdrawal intent (the chain
+    /// head) before the on-chain withdraw. Shared by `initialize()`'s real
+    /// `BeginWithdrawal` command and its fixture-only `BeginWithdrawalAt`
+    /// sibling, which differ only in the timestamp source.
+    fn begin_withdrawal_init_events(
+        direction: RebalanceDirection,
+        amount: Usdc,
+        from_block: u64,
+        submitting_at: DateTime<Utc>,
+    ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
+        // Fresh-start withdrawal intent is BaseToAlpaca-only. An
+        // AlpacaToBase transfer converts USD->USDC first and reaches
+        // `WithdrawalSubmitting` through the post-conversion path
+        // (`transition_begin_withdrawal` from `ConversionComplete`);
+        // recording a fresh AlpacaToBase intent here would materialize a
+        // withdrawal with no conversion history.
+        if direction != RebalanceDirection::BaseToAlpaca {
+            return Err(UsdcRebalanceError::InvalidCommand {
+                command: "BeginWithdrawal".to_string(),
+                state: "Uninitialized (fresh withdrawal is BaseToAlpaca-only; \
+                        AlpacaToBase must convert before withdrawing)"
+                    .to_string(),
+            });
+        }
+        Ok(vec![UsdcRebalanceEvent::WithdrawalSubmitting {
+            direction,
+            amount,
+            from_block,
+            submitting_at,
         }])
     }
 
@@ -2403,6 +2673,7 @@ impl UsdcRebalance {
         direction: RebalanceDirection,
         amount: Usdc,
         from_block: u64,
+        submitting_at: DateTime<Utc>,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         let Self::ConversionComplete {
@@ -2436,7 +2707,7 @@ impl UsdcRebalance {
             direction,
             amount: conversion.received_amount,
             from_block,
-            submitting_at: Utc::now(),
+            submitting_at,
         }])
     }
 
@@ -2448,6 +2719,7 @@ impl UsdcRebalance {
         direction: RebalanceDirection,
         amount: Usdc,
         withdrawal: TransferRef,
+        initiated_at: DateTime<Utc>,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         let (expected_direction, expected_amount) = match self {
@@ -2484,18 +2756,19 @@ impl UsdcRebalance {
             direction,
             amount: *expected_amount,
             withdrawal_ref: withdrawal,
-            initiated_at: Utc::now(),
+            initiated_at,
         }])
     }
 
     fn transition_confirm_withdrawal(
         &self,
         withdrawal_tx: Option<TxHash>,
+        confirmed_at: DateTime<Utc>,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         match self {
             Self::Withdrawing { .. } => Ok(vec![WithdrawalConfirmed {
-                confirmed_at: Utc::now(),
+                confirmed_at,
                 withdrawal_tx,
             }]),
             Self::WithdrawalComplete { .. }
@@ -2544,6 +2817,7 @@ impl UsdcRebalance {
         &self,
         from_block: u64,
         burn_amount: Option<Usdc>,
+        submitting_at: DateTime<Utc>,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         match self {
@@ -2591,7 +2865,7 @@ impl UsdcRebalance {
 
                 Ok(vec![BridgingSubmitting {
                     from_block,
-                    submitting_at: Utc::now(),
+                    submitting_at,
                     burn_amount,
                 }])
             }
@@ -2616,6 +2890,7 @@ impl UsdcRebalance {
     fn transition_initiate_bridging(
         &self,
         burn_tx: TxHash,
+        burned_at: DateTime<Utc>,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         match self {
@@ -2630,7 +2905,7 @@ impl UsdcRebalance {
             Self::WithdrawalComplete { .. } | Self::BridgingSubmitting { .. } => {
                 Ok(vec![BridgingInitiated {
                     burn_tx_hash: burn_tx,
-                    burned_at: Utc::now(),
+                    burned_at,
                 }])
             }
             Self::Bridging { .. }
@@ -2723,6 +2998,7 @@ impl UsdcRebalance {
         cctp_nonce: B256,
         message: Vec<u8>,
         mint_scan_from_block: u64,
+        attested_at: DateTime<Utc>,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         match self {
@@ -2740,7 +3016,7 @@ impl UsdcRebalance {
                     cctp_nonce,
                     message: Some(message),
                     mint_scan_from_block: Some(mint_scan_from_block),
-                    attested_at: Utc::now(),
+                    attested_at,
                 }])
             }
             Self::Attested { .. } => Err(UsdcRebalanceError::InvalidCommand {
@@ -2797,6 +3073,7 @@ impl UsdcRebalance {
         mint_tx: TxHash,
         amount_received: Usdc,
         fee_collected: Usdc,
+        minted_at: DateTime<Utc>,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         match self {
@@ -2814,7 +3091,7 @@ impl UsdcRebalance {
                 mint_tx_hash: mint_tx,
                 amount_received,
                 fee_collected,
-                minted_at: Utc::now(),
+                minted_at,
             }]),
             Self::Bridged { .. }
             | Self::BridgingFailed { .. }
@@ -2927,6 +3204,7 @@ impl UsdcRebalance {
     fn transition_initiate_deposit(
         &self,
         deposit: TransferRef,
+        deposit_initiated_at: DateTime<Utc>,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         match self {
@@ -2944,7 +3222,7 @@ impl UsdcRebalance {
             | Self::BridgingFailed { .. } => Err(UsdcRebalanceError::BridgingNotCompleted),
             Self::Bridged { .. } => Ok(vec![DepositInitiated {
                 deposit_ref: deposit,
-                deposit_initiated_at: Utc::now(),
+                deposit_initiated_at,
             }]),
             Self::DepositInitiated { .. }
             | Self::DepositConfirmed { .. }
@@ -2956,7 +3234,10 @@ impl UsdcRebalance {
         }
     }
 
-    fn transition_confirm_deposit(&self) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
+    fn transition_confirm_deposit(
+        &self,
+        deposit_confirmed_at: DateTime<Utc>,
+    ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         match self {
             Self::Converting { .. }
@@ -2974,7 +3255,7 @@ impl UsdcRebalance {
             | Self::Bridged { .. } => Err(UsdcRebalanceError::DepositNotInitiated),
             Self::DepositInitiated { direction, .. } => Ok(vec![DepositConfirmed {
                 direction: *direction,
-                deposit_confirmed_at: Utc::now(),
+                deposit_confirmed_at,
             }]),
             Self::DepositConfirmed { .. }
             | Self::DepositFailed { .. }
@@ -7760,6 +8041,508 @@ mod tests {
             ),
             "Expected ConversionAmountMismatch with expected=99.99 and provided=500, got: {error:?}"
         );
+    }
+
+    /// Covers the fixture-only `*At` siblings of the async transitions that
+    /// take an explicit timestamp instead of `Utc::now()`: each must thread
+    /// the caller-supplied timestamp through to the emitted event's field
+    /// rather than silently falling back to the current time.
+    #[tokio::test]
+    async fn initiate_conversion_at_uses_supplied_timestamp() {
+        let initiated_at = Utc::now() - chrono::Duration::hours(3);
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given_no_previous_events()
+            .when(UsdcRebalanceCommand::InitiateConversionAt {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(1000.00)),
+                order_id,
+                initiated_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::ConversionInitiated {
+            initiated_at: event_initiated_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected ConversionInitiated event");
+        };
+        assert_eq!(*event_initiated_at, initiated_at);
+    }
+
+    #[tokio::test]
+    async fn confirm_conversion_at_uses_supplied_timestamp() {
+        let converted_at = Utc::now() - chrono::Duration::hours(2);
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
+        let conversion = par_conversion(Usdc::new(float!(998)));
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![UsdcRebalanceEvent::ConversionInitiated {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(1000.00)),
+                order_id,
+                initiated_at: Utc::now(),
+            }])
+            .when(UsdcRebalanceCommand::ConfirmConversionAt {
+                conversion,
+                converted_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::ConversionConfirmed {
+            converted_at: event_converted_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected ConversionConfirmed event");
+        };
+        assert_eq!(*event_converted_at, converted_at);
+    }
+
+    #[tokio::test]
+    async fn initiate_post_deposit_conversion_at_uses_supplied_timestamp() {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+        let initiated_at = Utc::now() - chrono::Duration::hours(1);
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(1000.00)),
+                    withdrawal_ref: TransferRef::OnchainTx(burn_tx),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
+                },
+                UsdcRebalanceEvent::BridgingInitiated {
+                    burn_tx_hash: burn_tx,
+                    burned_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgeAttestationReceived {
+                    attestation: vec![0x01],
+                    cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
+                    mint_scan_from_block: Some(100),
+                    attested_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::Bridged {
+                    mint_tx_hash: mint_tx,
+                    amount_received: Usdc::new(float!(99.99)),
+                    fee_collected: Usdc::new(float!(0.01)),
+                    minted_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::DepositInitiated {
+                    deposit_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+                    deposit_initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::DepositConfirmed {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    deposit_confirmed_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::InitiatePostDepositConversionAt {
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                amount: Usdc::new(float!(99.99)),
+                initiated_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::ConversionInitiated {
+            initiated_at: event_initiated_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected ConversionInitiated event");
+        };
+        assert_eq!(*event_initiated_at, initiated_at);
+    }
+
+    #[tokio::test]
+    async fn begin_withdrawal_at_uses_supplied_timestamp() {
+        let submitting_at = Utc::now() - chrono::Duration::hours(4);
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given_no_previous_events()
+            .when(UsdcRebalanceCommand::BeginWithdrawalAt {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500.00)),
+                from_block: 42,
+                submitting_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::WithdrawalSubmitting {
+            submitting_at: event_submitting_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected WithdrawalSubmitting event");
+        };
+        assert_eq!(*event_submitting_at, submitting_at);
+    }
+
+    #[tokio::test]
+    async fn initiate_at_uses_supplied_timestamp() {
+        let initiated_at = Utc::now() - chrono::Duration::hours(5);
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![UsdcRebalanceEvent::WithdrawalSubmitting {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500.00)),
+                from_block: 42,
+                submitting_at: Utc::now(),
+            }])
+            .when(UsdcRebalanceCommand::InitiateAt {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500.00)),
+                withdrawal: TransferRef::AlpacaId(transfer_id),
+                initiated_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::Initiated {
+            initiated_at: event_initiated_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected Initiated event");
+        };
+        assert_eq!(*event_initiated_at, initiated_at);
+    }
+
+    #[tokio::test]
+    async fn confirm_withdrawal_at_uses_supplied_timestamp() {
+        let confirmed_at = Utc::now() - chrono::Duration::hours(6);
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500.00)),
+                withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                initiated_at: Utc::now(),
+            }])
+            .when(UsdcRebalanceCommand::ConfirmWithdrawalAt {
+                withdrawal_tx: None,
+                confirmed_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::WithdrawalConfirmed {
+            confirmed_at: event_confirmed_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected WithdrawalConfirmed event");
+        };
+        assert_eq!(*event_confirmed_at, confirmed_at);
+    }
+
+    #[tokio::test]
+    async fn begin_bridging_at_uses_supplied_timestamp() {
+        let submitting_at = Utc::now() - chrono::Duration::hours(7);
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(500.00)),
+                    withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
+                },
+            ])
+            .when(UsdcRebalanceCommand::BeginBridgingAt {
+                from_block: 100,
+                burn_amount: None,
+                submitting_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::BridgingSubmitting {
+            submitting_at: event_submitting_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected BridgingSubmitting event");
+        };
+        assert_eq!(*event_submitting_at, submitting_at);
+    }
+
+    #[tokio::test]
+    async fn initiate_bridging_at_uses_supplied_timestamp() {
+        let burned_at = Utc::now() - chrono::Duration::hours(8);
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(500.00)),
+                    withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
+                },
+            ])
+            .when(UsdcRebalanceCommand::InitiateBridgingAt { burn_tx, burned_at })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::BridgingInitiated {
+            burned_at: event_burned_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected BridgingInitiated event");
+        };
+        assert_eq!(*event_burned_at, burned_at);
+    }
+
+    #[tokio::test]
+    async fn receive_attestation_at_uses_supplied_timestamp() {
+        let attested_at = Utc::now() - chrono::Duration::hours(9);
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(500.00)),
+                    withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
+                },
+                UsdcRebalanceEvent::BridgingInitiated {
+                    burn_tx_hash: burn_tx,
+                    burned_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::ReceiveAttestationAt {
+                attestation: vec![0x01],
+                cctp_nonce: TEST_CCTP_NONCE,
+                message: vec![0xDE, 0xAD],
+                mint_scan_from_block: 100,
+                attested_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::BridgeAttestationReceived {
+            attested_at: event_attested_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected BridgeAttestationReceived event");
+        };
+        assert_eq!(*event_attested_at, attested_at);
+    }
+
+    #[tokio::test]
+    async fn confirm_bridging_at_uses_supplied_timestamp() {
+        let minted_at = Utc::now() - chrono::Duration::hours(10);
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(500.00)),
+                    withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
+                },
+                UsdcRebalanceEvent::BridgingInitiated {
+                    burn_tx_hash: burn_tx,
+                    burned_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgeAttestationReceived {
+                    attestation: vec![0x01],
+                    cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
+                    mint_scan_from_block: Some(100),
+                    attested_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::ConfirmBridgingAt {
+                mint_tx,
+                amount_received: Usdc::new(float!(499.50)),
+                fee_collected: Usdc::new(float!(0.50)),
+                minted_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::Bridged {
+            minted_at: event_minted_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected Bridged event");
+        };
+        assert_eq!(*event_minted_at, minted_at);
+    }
+
+    #[tokio::test]
+    async fn initiate_deposit_at_uses_supplied_timestamp() {
+        let deposit_initiated_at = Utc::now() - chrono::Duration::hours(11);
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(500.00)),
+                    withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
+                },
+                UsdcRebalanceEvent::BridgingInitiated {
+                    burn_tx_hash: burn_tx,
+                    burned_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgeAttestationReceived {
+                    attestation: vec![0x01],
+                    cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
+                    mint_scan_from_block: Some(100),
+                    attested_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::Bridged {
+                    mint_tx_hash: mint_tx,
+                    amount_received: Usdc::new(float!(499.50)),
+                    fee_collected: Usdc::new(float!(0.50)),
+                    minted_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::InitiateDepositAt {
+                deposit: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+                deposit_initiated_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::DepositInitiated {
+            deposit_initiated_at: event_deposit_initiated_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected DepositInitiated event");
+        };
+        assert_eq!(*event_deposit_initiated_at, deposit_initiated_at);
+    }
+
+    #[tokio::test]
+    async fn confirm_deposit_at_uses_supplied_timestamp() {
+        let deposit_confirmed_at = Utc::now() - chrono::Duration::hours(12);
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(500.00)),
+                    withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
+                },
+                UsdcRebalanceEvent::BridgingInitiated {
+                    burn_tx_hash: burn_tx,
+                    burned_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgeAttestationReceived {
+                    attestation: vec![0x01],
+                    cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
+                    mint_scan_from_block: Some(100),
+                    attested_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::Bridged {
+                    mint_tx_hash: mint_tx,
+                    amount_received: Usdc::new(float!(499.50)),
+                    fee_collected: Usdc::new(float!(0.50)),
+                    minted_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::DepositInitiated {
+                    deposit_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+                    deposit_initiated_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::ConfirmDepositAt {
+                deposit_confirmed_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::DepositConfirmed {
+            deposit_confirmed_at: event_deposit_confirmed_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected DepositConfirmed event");
+        };
+        assert_eq!(*event_deposit_confirmed_at, deposit_confirmed_at);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

- Adds the `EquityTimingProjection`, `equity_stage_timing` read model, and `/performance/equity-rebalances` API/DTO surface.
- Wires the projection through conductor startup and the CLI rebuild path.
- Adds `test-support` timestamp fixture commands and deterministic seed helpers for simulated USDC-rebalance, equity mint/redemption, and hedge timing history.
- Makes hedge latency report buckets dense across the requested range so sparse simulated history preserves chart positioning (backend prep only — see "Anything else").

## Why

USDC rebalance timing already had a Performance tab backend path, but equity mint/redemption timing did not. The 14-day simulation fixture also needs explicit timestamps and dense latency buckets so seeded history renders as a real time series instead of a stretched sparse series.

## How

- Folds mint/redemption lifecycle events into one JSON timing row per `operation_id` (per-stage breakdown lives inside the row's timing blob).
- `equity_timing/` is split by pipeline: `mod.rs` holds the shared projection/reactor, read path, stored types, and stage helpers; `mint.rs` and `redemption.rs` each own their `apply_*` fold and observed-at helper plus tests.
- Adds optional timestamp overrides for test-support commands without changing production command paths.
- Rebuilds the read model from event streams and caps range parsing through the existing Performance API conventions.

## Testing

- Added equity timing projection, API, CLI, simulated transfer, timestamp command, and hedge report bucket tests.
- Ran `nix develop -c cargo nextest run -p st0x-hedge simulated_hedge_latency_history_populates_daily_percentile_buckets report_buckets_fills_by_day report_buckets_weekly_for_ranges_over_a_month report_buckets_monthly_for_ranges_over_half_a_year report_empty_input_has_no_stats`.
- Previously ran `nix develop -c cargo check -p st0x-hedge --all-features` and pre-commit hooks before submit.

## Anything else

- Additive read-model migration; additive `/performance/equity-rebalances` route and response fields.
- **Behavioral change:** all `/performance/*` range queries now reject spans over `MAX_PERFORMANCE_RANGE_DAYS` (3650 days).
- **Behavioral change:** `/performance/latencies` now returns dense buckets across the full requested range, including empty buckets, instead of only populated indices.
- **Dense buckets are backend prep only.** The dashboard's `layoutPercentileSeries` on master still filters null buckets and lays out x from `sampled.length`, so hedge-chart gaps stay collapsed until the upstack LayerChart PR lands. This PR is backward compatible, but the user-visible chart fix does not come from #990 alone.
