### PR TITLE
feat: seed simulate-14d performance history

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,11 @@ continuous user trades at ~10-second intervals. Use this when you want to
 observe long-running liquidity cycling rather than a single bounded chaos
 scenario.
 
+`nix run .#simulate-14d` starts the same stack as `simulate-market`, but
+preloads 14 days of seeded hedge-latency, mint, redemption, and USDC-rebalance
+history so Performance tab trends and the Transfers panel are populated
+immediately.
+
 `nix run .#simulate-failures` starts the same stack as `simulate-market`, then
 creates failed mint and redemption rebalances whose mock Alpaca provider later
 completes and prints the `transfer recheck` commands that recover them.
@@ -300,6 +305,17 @@ What `simulate-market` does:
 5. Starts the dashboard dev server
 6. Continuously takes orders at 10-second intervals, simulating users buying and
    selling tokenized equities
+
+The `simulate-14d` variant also preloads 14 days of history -- hedge-latency
+cycles, equity mints, equity redemptions, and USDC rebalances (alternating
+Alpaca<->Base direction) -- before live trades begin, so the Performance tab's
+percentile charts and rebalance-stage breakdown, and the dashboard's Transfers
+panel, all show a trend immediately instead of waiting for historical data to
+accumulate. The dashboard's default `1W` view renders the most recent week of
+that seed at daily granularity; switch to `2W` to see the full 14-day history,
+still at daily granularity (within ~12h of the bot starting -- the seed is a
+fixed point in time, so a much longer-running session ages its oldest day out of
+the `2W` window).
 
 The bot counter-trades each fill on the mock broker, mints/redeems to rebalance
 equity supply between venues, and bridges USDC via mock CCTP to keep cash

--- a/flake.nix
+++ b/flake.nix
@@ -236,15 +236,23 @@
               pkgs.openssl
               pkgs.sqlite
               pkgs.pkg-config
+              pkgs.datasette
               rustToolchain
             ];
 
             # Mock infra + bot + dashboard + e2e driver. Picks the lowest port
-            # offset whose bot/vite/mock-api ports are all free so multiple
-            # instances can run side-by-side without collisions. The dashboard
-            # auto-opens in the browser on start. Press `q` to exit.
+            # offset whose bot/board/vite/mock-api ports are all free so
+            # multiple instances can run side-by-side without collisions. The
+            # dashboard auto-opens in the browser on start. Press `q` to exit.
             mkSimulation =
-              { name, testFilter }:
+              {
+                name,
+                testFilter,
+                backendEnv ? "",
+              }:
+              let
+                backendEnvPrefix = if backendEnv == "" then "" else "${backendEnv} ";
+              in
               pkgs.writeShellApplication {
                 inherit name;
                 runtimeInputs = simulationRuntimeInputs;
@@ -263,11 +271,15 @@
                   max_offset=9
                   while (( offset <= max_offset )); do
                     bot_port=$((8001 + offset))
+                    board_port=$((8002 + offset))
                     vite_port=$((5173 + offset))
                     mock_api_port=$((8099 + offset))
+                    datasette_port=$((8200 + offset))
                     if port_free "$bot_port" \
+                      && port_free "$board_port" \
                       && port_free "$vite_port" \
-                      && port_free "$mock_api_port"; then
+                      && port_free "$mock_api_port" \
+                      && port_free "$datasette_port"; then
                       break
                     fi
                     offset=$((offset + 1))
@@ -279,9 +291,29 @@
                   fi
 
                   echo "${name}: offset=$offset (bot=$bot_port \
-                    vite=$vite_port mock_api=$mock_api_port)"
+                    board=$board_port vite=$vite_port mock_api=$mock_api_port \
+                    datasette=$datasette_port)"
 
-                  backend="SIMULATE_BOT_PORT=$bot_port \
+                  # Mirrors the DB path `simulate()` hardcodes in
+                  # tests/e2e/full_system.rs. Datasette serves it under a
+                  # route named after the file's basename (extension
+                  # stripped); the trailing .json forces a JSON response --
+                  # without it, Datasette content-negotiates to an HTML page
+                  # for a plain fetch() and sql-source.ts's response.json()
+                  # parse fails.
+                  db_path="/tmp/st0x-liquidity-simulate-$bot_port.sqlite"
+                  pnl_sql_api_url="http://127.0.0.1:$datasette_port/st0x-liquidity-simulate-$bot_port.json"
+
+                  # A stale $db_path from a previous run at this same port
+                  # offset would let datasette's `-f` check below pass
+                  # immediately, opening the old file before `simulate()`
+                  # removes and recreates it -- leaving datasette serving a
+                  # frozen, unlinked database forever. Clear it up front so
+                  # datasette only ever opens the file the bot creates now.
+                  rm -f "$db_path" "$db_path-shm" "$db_path-wal"
+
+                  backend="${backendEnvPrefix}SIMULATE_BOT_PORT=$bot_port \
+                    SIMULATE_BOARD_PORT=$board_port \
                     cargo nextest run --test e2e \
                     -E 'test(=full_system::${testFilter})' \
                     --run-ignored ignored-only --no-capture"
@@ -289,6 +321,7 @@
                   dashboard="cd dashboard && \
                     BACKEND_PORT=$bot_port \
                     PUBLIC_BACKEND_PORT=$bot_port \
+                    PUBLIC_PNL_SQL_API_URL=$pnl_sql_api_url \
                     PUBLIC_SIMULATE_REV=${self.shortRev or self.dirtyShortRev or "unknown"} \
                     PUBLIC_SIMULATE_SOURCE_ID=${builtins.substring 0 8 (baseNameOf self.outPath)} \
                     bun run dev --port=$vite_port --strictPort --open"
@@ -296,7 +329,14 @@
                   mockApi="MOCK_REST_API_PORT=$mock_api_port \
                     bun run e2e/mock-rest-api.ts"
 
-                  exec mprocs "$backend" "$dashboard" "$mockApi"
+                  # The bot creates $db_path on startup (after this script
+                  # launches all panes concurrently), so wait for it to exist
+                  # before datasette tries to open it -- otherwise it exits
+                  # immediately with no file to serve.
+                  datasette="while [ ! -f $db_path ]; do sleep 1; done; \
+                    exec datasette serve $db_path -p $datasette_port -h 127.0.0.1"
+
+                  exec mprocs "$backend" "$dashboard" "$mockApi" "$datasette"
                 '';
               };
 
@@ -354,6 +394,15 @@
               "simulate-market" = mkSimulation {
                 name = "simulate-market";
                 testFilter = "simulate";
+              };
+
+              # Same live dashboard stack as `simulate-market`, but preloads the
+              # hedge-latency read model with 14 days of completed cycles so
+              # Performance tab trends can be inspected immediately.
+              "simulate-14d" = mkSimulation {
+                name = "simulate-14d";
+                testFilter = "simulate";
+                backendEnv = "SIMULATE_LATENCY_FIXTURE_DAYS=14";
               };
 
               # Same live dashboard stack as `simulate-market`, but first creates

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -35,7 +35,7 @@ use st0x_float_macro::float;
 use tokio::sync::broadcast;
 use tracing::{debug, info};
 
-use st0x_config::{BrokerCtx, Ctx};
+use st0x_config::{BrokerCtx, Ctx, configure_sqlite_pool};
 use st0x_dto::Statement;
 use st0x_event_sorcery::Projection;
 use st0x_evm::Wallet;
@@ -54,6 +54,8 @@ use st0x_hedge::mock_api::{
 use st0x_hedge::{
     AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, ImbalanceThreshold,
     OperationMode, Position, RebalancingCtx, TradingMode, UsdcRebalancing,
+    seed_simulated_equity_redemption_history, seed_simulated_hedge_latency_history,
+    seed_simulated_mint_history, seed_simulated_usdc_rebalance_history,
 };
 
 use crate::assert::ExpectedPosition;
@@ -172,6 +174,166 @@ pub(crate) fn build_full_system_ctx<P: Provider + Clone>(
         .redemption_wallet(REDEMPTION_WALLET)
         .call()
         .map_err(Into::into)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SimulationPorts {
+    server_port: u16,
+    board_port: u16,
+}
+
+fn simulation_ports(command: &str) -> anyhow::Result<SimulationPorts> {
+    let raw_server_port = std::env::var("SIMULATE_BOT_PORT").map_err(|error| {
+        anyhow::anyhow!("SIMULATE_BOT_PORT must be set (run via `nix run .#{command}`): {error}")
+    })?;
+
+    let raw_board_port = match std::env::var("SIMULATE_BOARD_PORT") {
+        Ok(raw) => Some(raw),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(error) => {
+            return Err(anyhow::anyhow!(
+                "SIMULATE_BOARD_PORT could not be read for `nix run .#{command}`: {error}"
+            ));
+        }
+    };
+
+    simulation_ports_from_raw(&raw_server_port, raw_board_port.as_deref())
+}
+
+fn simulation_ports_from_raw(
+    raw_server_port: &str,
+    raw_board_port: Option<&str>,
+) -> anyhow::Result<SimulationPorts> {
+    let server_port = parse_simulation_port("SIMULATE_BOT_PORT", raw_server_port)?;
+    let board_port = match raw_board_port {
+        Some(raw) => parse_simulation_port("SIMULATE_BOARD_PORT", raw)?,
+        None => server_port.checked_add(1).ok_or_else(|| {
+            anyhow::anyhow!("SIMULATE_BOARD_PORT must be set when SIMULATE_BOT_PORT is 65535")
+        })?,
+    };
+
+    Ok(SimulationPorts {
+        server_port,
+        board_port,
+    })
+}
+
+fn parse_simulation_port(env_name: &str, raw: &str) -> anyhow::Result<u16> {
+    let port = raw
+        .parse()
+        .map_err(|error| anyhow::anyhow!("{env_name} must be a valid u16 port number: {error}"))?;
+    anyhow::ensure!(port != 0, "{env_name} must be a non-zero TCP port");
+    Ok(port)
+}
+
+/// Seeds all four simulated-history read models into `pool` for `days` of
+/// history anchored at `seed_now`: hedge-latency, equity mint, USDC-rebalance,
+/// and equity-redemption. Each helper runs its own schema migrations before
+/// touching the CQRS tables. Extracted from the `SIMULATE_LATENCY_FIXTURE_DAYS`
+/// wiring below so the orchestration is testable without spinning up the bot.
+async fn seed_all_simulated_history(
+    pool: &sqlx::SqlitePool,
+    seed_now: chrono::DateTime<chrono::Utc>,
+    days: u32,
+) -> anyhow::Result<()> {
+    seed_simulated_hedge_latency_history(pool, seed_now, days).await?;
+    seed_simulated_mint_history(pool, seed_now, days).await?;
+    seed_simulated_usdc_rebalance_history(pool, seed_now, days).await?;
+    seed_simulated_equity_redemption_history(pool, seed_now, days).await?;
+
+    Ok(())
+}
+
+#[test]
+fn simulation_ports_default_board_port_follows_server_port() {
+    let ports = simulation_ports_from_raw("8101", None).unwrap();
+
+    assert_eq!(
+        ports,
+        SimulationPorts {
+            server_port: 8101,
+            board_port: 8102,
+        }
+    );
+}
+
+#[test]
+fn simulation_ports_accept_independent_board_port() {
+    let ports = simulation_ports_from_raw("8101", Some("8201")).unwrap();
+
+    assert_eq!(
+        ports,
+        SimulationPorts {
+            server_port: 8101,
+            board_port: 8201,
+        }
+    );
+}
+
+#[test]
+fn simulation_ports_from_raw_errors_when_default_board_port_overflows() {
+    let error = simulation_ports_from_raw("65535", None).unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "SIMULATE_BOARD_PORT must be set when SIMULATE_BOT_PORT is 65535"
+    );
+}
+
+#[test]
+fn simulation_ports_from_raw_rejects_zero_port() {
+    let error = simulation_ports_from_raw("0", None).unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "SIMULATE_BOT_PORT must be a non-zero TCP port"
+    );
+}
+
+/// Guards the `SIMULATE_LATENCY_FIXTURE_DAYS` seeding path: a broken seed helper
+/// that silently writes nothing would otherwise pass CI, since the full-system
+/// e2e (which requires anvil/CCTP) is the only other exercise of this wiring.
+#[tokio::test]
+async fn seed_all_simulated_history_populates_every_read_model() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("simulate-seed.sqlite");
+    let pool = configure_sqlite_pool(&db_path.display().to_string())
+        .await
+        .unwrap();
+
+    seed_all_simulated_history(&pool, chrono::Utc::now(), 2)
+        .await
+        .unwrap();
+
+    // Literal-per-table queries (not a `format!`ed loop) to satisfy the
+    // dynamic-SQL lint; the tuple's label names the read model each guards.
+    let (hedge_cycles,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM hedge_cycle")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let (rebalance_rows,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM rebalance_stage_timing")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let (equity_rows,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM equity_stage_timing")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert!(
+        hedge_cycles > 0,
+        "expected the hedge-latency read model (hedge_cycle) to hold seeded rows, got {hedge_cycles}"
+    );
+    assert!(
+        rebalance_rows > 0,
+        "expected the rebalance-timing read model (rebalance_stage_timing) to hold seeded rows, got {rebalance_rows}"
+    );
+    assert!(
+        equity_rows > 0,
+        "expected the equity-timing read model (equity_stage_timing) to hold seeded rows, got {equity_rows}"
+    );
+
+    pool.close().await;
 }
 
 struct AcceptedMintIds {
@@ -813,10 +975,10 @@ async fn full_system_concurrent() -> anyhow::Result<()> {
 #[ignore = "infinite simulation -- run via nix run .#simulate-market"]
 #[allow(clippy::too_many_lines)]
 async fn simulate() -> anyhow::Result<()> {
-    let server_port: u16 = std::env::var("SIMULATE_BOT_PORT")
-        .expect("SIMULATE_BOT_PORT must be set (run via `nix run .#simulate-market`)")
-        .parse()
-        .expect("SIMULATE_BOT_PORT must be a valid u16 port number");
+    let SimulationPorts {
+        server_port,
+        board_port,
+    } = simulation_ports("simulate")?;
 
     let log_dir = std::path::PathBuf::from(format!("/tmp/st0x-simulate-logs-{server_port}"));
     std::fs::create_dir_all(&log_dir)?;
@@ -926,10 +1088,44 @@ async fn simulate() -> anyhow::Result<()> {
         .cctp(cctp.cctp_overrides())
         .cash_reserved(Positive::new(Usd::new(float!(25000)))?)
         .server_port(server_port)
-        .board_port(server_port + 1)
+        .board_port(board_port)
         .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
     ctx.log_dir = Some(log_dir.display().to_string());
+
+    // Seeded BEFORE the bot starts: the fixture's temporary
+    // `Store<Position>`/`Store<OffchainOrder>` are wired only with
+    // `HedgeLatencyProjection`, never `RebalancingService`, so they must not
+    // coexist with the bot's own real, RebalancingService-wired stores. The
+    // bot hasn't run its own startup migrations yet, so
+    // `configure_sqlite_pool` (not `connect_db`) is used here -- it sets
+    // `create_if_missing(true)` and matches the bot's own pool
+    // configuration, and `seed_simulated_hedge_latency_history` runs the
+    // schema migrations itself before touching the CQRS tables.
+    match std::env::var("SIMULATE_LATENCY_FIXTURE_DAYS") {
+        Ok(raw_days) => {
+            let days: u32 = raw_days.parse().map_err(|error| {
+                anyhow::anyhow!(
+                    "SIMULATE_LATENCY_FIXTURE_DAYS must be a valid u32 day count: {error}"
+                )
+            })?;
+            let pool = configure_sqlite_pool(&infra.db_path.display().to_string()).await?;
+            let seed_now = chrono::Utc::now();
+            seed_all_simulated_history(&pool, seed_now, days).await?;
+            pool.close().await;
+            info!(
+                days,
+                "Seeded simulated hedge-latency, mint, USDC-rebalance, and equity-redemption \
+                 history for dashboard inspection"
+            );
+        }
+        Err(std::env::VarError::NotPresent) => {}
+        Err(error) => {
+            return Err(anyhow::anyhow!(
+                "SIMULATE_LATENCY_FIXTURE_DAYS could not be read: {error}"
+            ));
+        }
+    }
 
     debug!("Starting bot");
     let mut bot = spawn_bot_with_event_channel(ctx, event_sender);
@@ -1007,10 +1203,10 @@ async fn simulate() -> anyhow::Result<()> {
 #[ignore = "failure simulation -- run via nix run .#simulate-failures"]
 #[allow(clippy::too_many_lines)]
 async fn simulate_failures() -> anyhow::Result<()> {
-    let server_port: u16 = std::env::var("SIMULATE_BOT_PORT")
-        .expect("SIMULATE_BOT_PORT must be set (run via `nix run .#simulate-failures`)")
-        .parse()
-        .expect("SIMULATE_BOT_PORT must be a valid u16 port number");
+    let SimulationPorts {
+        server_port,
+        board_port,
+    } = simulation_ports("simulate-failures")?;
 
     let log_dir =
         std::path::PathBuf::from(format!("/tmp/st0x-simulate-failures-logs-{server_port}"));
@@ -1126,7 +1322,7 @@ async fn simulate_failures() -> anyhow::Result<()> {
         .cctp(cctp.cctp_overrides())
         .cash_reserved(Positive::new(Usd::new(float!(25000)))?)
         .server_port(server_port)
-        .board_port(server_port + 1)
+        .board_port(board_port)
         .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
     ctx.log_dir = Some(log_dir.display().to_string());
@@ -1136,7 +1332,7 @@ async fn simulate_failures() -> anyhow::Result<()> {
         &infra,
         &cctp,
         server_port,
-        server_port + 1,
+        board_port,
         current_block,
         usdc_vault_id,
         &equity_vault_ids,


### PR DESCRIPTION
## What

- Adds `nix run .#simulate-14d`, which runs the existing simulation stack with 14 days of seeded hedge-latency, equity mint/redemption, and USDC rebalance history.
- Extends `mkSimulation` with a Datasette pane serving the simulation SQLite database and passes `PUBLIC_PNL_SQL_API_URL` to the dashboard.
- Lets e2e simulation tests accept an explicit `SIMULATE_BOARD_PORT` instead of assuming `server_port + 1`.
- Documents the seeded simulation mode in `README.md`.

## Why

- The Performance tab and Transfers panel are hard to inspect locally when they start from an empty database.
- Datasette makes the simulation database inspectable while the dashboard is running, without adding a managed service outside the simulation process group.

## How

- Sets `SIMULATE_LATENCY_FIXTURE_DAYS=14` for the new flake app and seeds history before the bot starts against the fresh simulation database.
- Clears stale simulation database files before Datasette starts so it cannot serve an unlinked file from a previous run.
- Adds `simulation_ports_from_raw` tests for default, explicit, and overflow board-port handling.

## Testing

- `tests/e2e/full_system.rs`: `simulation_ports_default_board_port_follows_server_port`, `simulation_ports_accept_independent_board_port`, and `simulation_ports_from_raw_errors_when_default_board_port_overflows`.
- Local: `nix develop -c cargo check -p st0x-hedge --all-features`; `nix develop .#ci-hooks -c pre-commit run --all-files`.

## Screenshots

N/a.

## Anything else

- This branch wires the fixture helpers introduced downstack into the local simulation entrypoint; it does not change production startup behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `simulate-14d` local simulation option that starts the full dashboard stack with 14 days of seeded history, so charts and performance views appear populated right away.
  * The simulation environment now includes a live data API for the dashboard, improving visibility into simulated results during local runs.

* **Bug Fixes**
  * Improved simulation port handling so the dashboard and backend use the correct ports more reliably across scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->