### PR TITLE
chore(staging): ship telemetry to the st0x-observability GCP VM

### DIFF
--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -13,11 +13,12 @@ apalis_finished_job_cleanup_interval_secs = 3600
 [telemetry]
 service_name = "st0x-liquidity"
 environment = "staging"
-# Shared st0x-management-observability box (same as prod); staging traces/logs
-# are distinguished by deployment.environment, not endpoint. Reachable once the
-# bot is migrated onto the st0x tailnet; until then exports drop best-effort.
-traces_endpoint = "http://100.93.167.114:10428"
-logs_endpoint = "http://100.93.167.114:9428"
+# st0x-observability GCP VM (replaces the DO st0x-management-observability
+# droplet, which is being decommissioned); staging traces/logs are
+# distinguished by deployment.environment, not endpoint. MagicDNS FQDN rather
+# than a pinned tailnet IP so the endpoint survives VM rebuilds.
+traces_endpoint = "http://st0x-observability.tail6094d7.ts.net:10428"
+logs_endpoint = "http://st0x-observability.tail6094d7.ts.net:9428"
 
 # Slippage tolerance (basis points) for counter-trades that hedge
 # incoming orderbook fills.

--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,7 @@
           volumeName = "st0x-liquidity-staging-data";
           hostKey = keys.host-staging;
           # Migrated to the st0x.io tailnet (tail6094d7.ts.net) so telemetry can
-          # reach st0x-management-observability (100.93.167.114).
+          # reach the st0x-observability GCP VM.
           tailscaleMagicDnsName = "st0x-liquidity-staging.tail6094d7.ts.net";
         };
       };


### PR DESCRIPTION
## What

Repoints the staging bot's traces/logs endpoints from the DO observability droplet (`st0x-management-observability`, pinned tailnet IP `100.93.167.114`) to its GCP replacement, `st0x-observability.tail6094d7.ts.net` (ST0x-Technology/st0x.devops `terraform/observability/`). Also refreshes the stale flake.nix comment that referenced the old box.

## Why

The DO observability droplet is being decommissioned. Its replacement — a Shielded GCE VM running the same Grafana + Victoria stack — is up, verified, and already scraping `st0x-liquidity-staging:8001` for metrics; traces and logs are push-based from the bot, so the bot config is the remaining producer-side change. This is the "st0x.liquidity configs" line item of the cutover checklist in st0x.devops `terraform/observability/README.md`.

## How

- `traces_endpoint` → `http://st0x-observability.tail6094d7.ts.net:10428` (VictoriaTraces)
- `logs_endpoint` → `http://st0x-observability.tail6094d7.ts.net:9428` (VictoriaLogs)

MagicDNS FQDN instead of a pinned tailnet IP so the endpoint survives VM rebuilds. The tailnet ACL already allows 9428/10428 between `tag:st0x-infra` nodes (both the staging bot and the GCP VM carry that tag), so no ACL change is needed.

## Testing

Config-only change (no code). Will deploy to staging from this branch via `deploy-staging` and verify on the GCP box that VictoriaLogs receives `st0x-liquidity` staging log streams and VictoriaTraces lists the `st0x-liquidity` service; results will be posted here.

## Screenshots

N/A

## Anything else

Prod is untouched — the prod bot is still on the rainlang.xyz tailnet and migrates separately. Metrics needed no change: the GCP stack's scrape job `st0x-liquidity-staging:8001` is already `up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785864252&installation_id=125569124&pr_number=994&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F994&signature=f71931fabacaaf0920c526c4b05d7b6e33b7983459679de8e119f2528c4c8884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging observability settings to point to the new MagicDNS address for traces and logs.
  * Refreshed environment notes to reflect the current staging setup and decommissioned infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->