### PR TITLE
chore(prod): migrate telemetry to the st0x-observability GCP VM

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -72,11 +72,11 @@ jobs:
         # can SSH.
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
         with:
-          # BLOCKED: fill both from the st0x.devops PR #65 apply output
-          # (`terraform output liquidity_deploy_production_federated_identity`).
-          # These are non-secret identifiers, hardcoded like st0x.devops does.
-          oauth-client-id: FILL_FROM_ST0X_DEVOPS_TF_OUTPUT
-          audience: FILL_FROM_ST0X_DEVOPS_TF_OUTPUT
+          # From st0x.devops liquidity_deploy_production_federated_identity
+          # (terraform/tailscale/liquidity-wif.tf, applied in #65). Non-secret
+          # identifiers, hardcoded like st0x.devops does.
+          oauth-client-id: TpQCTWg3NM11CNTRL-kuSMK7npcv11CNTRL
+          audience: api.tailscale.com/TpQCTWg3NM11CNTRL-kuSMK7npcv11CNTRL
           tags: tag:ci
           hostname: liquidity-deploy-${{ github.run_id }}
 

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -22,6 +22,11 @@ permissions:
 jobs:
   deploy:
     environment: production
+    permissions:
+      # id-token lets tailscale/github-action fetch the GitHub OIDC JWT and
+      # redeem it for a keyless tailnet join (no stored TS_AUTHKEY).
+      id-token: write
+      contents: read
     concurrency:
       group: deploy-prod
       cancel-in-progress: false
@@ -59,9 +64,21 @@ jobs:
         continue-on-error: true
 
       - name: Connect to Tailscale
-        uses: tailscale/github-action@v4
+        # Keyless join via GitHub OIDC federation (no stored TS_AUTHKEY): the
+        # runner presents its OIDC token and redeems the liquidity_deploy_production
+        # federated identity for an ephemeral tag:ci node. Mirrors st0x.devops
+        # health-runtime.yml. The prod bot lives on tag:st0x-liquidity; tag:ci ->
+        # tag:st0x-liquidity:22 is granted in st0x.devops policy.hujson so deploy-rs
+        # can SSH.
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          # BLOCKED: fill both from the st0x.devops PR #65 apply output
+          # (`terraform output liquidity_deploy_production_federated_identity`).
+          # These are non-secret identifiers, hardcoded like st0x.devops does.
+          oauth-client-id: FILL_FROM_ST0X_DEVOPS_TF_OUTPUT
+          audience: FILL_FROM_ST0X_DEVOPS_TF_OUTPUT
+          tags: tag:ci
+          hostname: liquidity-deploy-${{ github.run_id }}
 
       - name: Resolve deploy host via Tailscale
         run: |

--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -13,12 +13,15 @@ apalis_finished_job_cleanup_interval_secs = 3600
 [telemetry]
 service_name = "st0x-liquidity"
 environment = "production"
-# st0x-management-observability on the st0x tailnet (VictoriaTraces :10428,
-# VictoriaLogs :9428). Reachable once the bot is migrated onto the st0x tailnet;
-# until then the OTLP exporters fail closed and drop best-effort (no startup
-# impact, file/console logging unaffected).
-traces_endpoint = "http://100.93.167.114:10428"
-logs_endpoint = "http://100.93.167.114:9428"
+# st0x-observability GCP VM (VictoriaTraces :10428, VictoriaLogs :9428),
+# replacing the decommissioned st0x-management-observability DO droplet. Staging
+# and prod are told apart by deployment.environment, not endpoint. MagicDNS FQDN
+# rather than a pinned tailnet IP so the endpoint survives VM rebuilds. Reachable
+# once the bot is migrated onto the st0x.io tailnet; until then the OTLP exporters
+# fail closed and drop best-effort (no startup impact, file/console logging
+# unaffected).
+traces_endpoint = "http://st0x-observability.tail6094d7.ts.net:10428"
+logs_endpoint = "http://st0x-observability.tail6094d7.ts.net:9428"
 
 # Slippage tolerance (basis points) for counter-trades that hedge
 # incoming orderbook fills.

--- a/flake.nix
+++ b/flake.nix
@@ -84,9 +84,11 @@
           nodeName = "st0x-liquidity";
           volumeName = "st0x-liquidity-data";
           hostKey = keys.host-prod;
-          # Still on the rainlang.xyz tailnet; migrates to st0x.io last, after
-          # staging is validated on tail6094d7.ts.net.
-          tailscaleMagicDnsName = "st0x-liquidity-nixos.taile5cf8a.ts.net";
+          # Migrated to the st0x.io tailnet (tail6094d7.ts.net) so telemetry can
+          # reach the st0x-observability GCP VM. Joins on its own dedicated tag
+          # tag:st0x-liquidity (see the prod auth key), not the shared
+          # tag:st0x-infra that staging uses.
+          tailscaleMagicDnsName = "st0x-liquidity-nixos.tail6094d7.ts.net";
         };
         staging = {
           nodeName = "st0x-liquidity-staging";


### PR DESCRIPTION
## What

Migrates the **production** liquidity bot's telemetry to the `st0x-observability` GCP VM. Same shape as the staging cutover (#973 + #994): the bot moves off the rainlang.xyz tailnet (`taile5cf8a.ts.net`) onto **st0x.io** (`tail6094d7.ts.net`) and its telemetry points at the GCP box. The **only** deliberate difference from staging is that the CI deploy joins the tailnet **keyless** (GitHub OIDC), not via a stored `TS_AUTHKEY`.

## Why now

Prod config still targeted the DO obs box `100.93.167.114`, which was decommissioned (st0x.devops management plane torn down 2026-07-06), so prod telemetry is already dropping (fail-closed, no trading impact). This **restores** it — no telemetry regression to worry about.

## Changes

- **`flake.nix`** — prod `tailscaleMagicDnsName` → `st0x-liquidity-nixos.tail6094d7.ts.net`. The bot joins on a dedicated tag `tag:st0x-liquidity` (isolation; ACL in st0x.devops #65, applied).
- **`config/prod/st0x-hedge.toml`** — `traces_endpoint`/`logs_endpoint` → `st0x-observability.tail6094d7.ts.net` (MagicDNS FQDN). No `[alerts]`/`[assets]` changes — prod stays live and trading.
- **`deploy-prod.yaml`** — keyless GitHub-OIDC tailnet join (`tailscale/github-action` v4.1.3, `id-token: write`, `oauth-client-id`/`audience` from the `liquidity_deploy_production` identity applied in #65). Runner joins as `tag:ci`; `tag:ci → tag:st0x-liquidity:22` is granted in #65 for deploy-rs SSH.

**Bot enrollment is exactly like staging** — a normally-minted `tag:st0x-liquidity` auth key in `secret/tailscale-authkey-prod.age`, applied by a one-time `tailscale up --force-reauth`. No pipeline-mint machinery.

## Cutover runbook (operator)

Prod deploy is **tag-on-master only** (no branch-deploy), and only a manual force-reauth moves the host between tailnets:

0. **Safety net:** have DigitalOcean **console** access to the prod droplet before touching Tailscale (a bad key drops it off both tailnets → SSH gone).
1. Mint an st0x.io **`tag:st0x-liquidity`** reusable auth key; re-encrypt `secret/tailscale-authkey-prod.age` with it (ragenix). Merge this PR to master; tag it.
2. Over the existing rainlang SSH, on the prod box: `tailscale up --force-reauth --auth-key <new key>`. Verify it's on `tail6094d7` as `tag:st0x-liquidity`.
3. Deploy prod (`workflow_dispatch`, the master tag). The keyless runner joins st0x.io, SSHes the host, ships the new flake + endpoints.
4. Metrics only: st0x.devops #65 also adds the `st0x-liquidity` scrape job — its observability apply is currently red on an **unrelated** `MonitoredProject` 403 (datasource-consolidation IAM gap); once that's green, land `scrape.yml` on the box (instance replace or manual copy + `victoriametrics` restart). Logs/traces need none of this.

## Verify (on the GCP obs VM via IAP)

- Metrics: `curl http://st0x-observability:8428/api/v1/targets` → `st0x-liquidity` / `st0x-liquidity-nixos:8001` is `up`.
- Logs (VictoriaLogs :9428): stream `service.name="st0x-liquidity", deployment.environment="production"` has recent entries.
- Traces (VictoriaTraces Jaeger API): `st0x-liquidity` service present with fresh prod traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production deployments now use a keyless, more secure connection method for Tailscale access.
  * Telemetry traffic now routes through service names instead of fixed IP addresses for more reliable connectivity.

* **Bug Fixes**
  * Updated production network and observability settings to match the latest environment naming and routing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->