### PR TITLE
fix(config): point prod cash vault at 0xfab2

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -97,7 +97,7 @@ realert_interval = 43200
 # USDC vault and rebalancing settings.
 [assets.cash]
 # Raindex vault ID for USDC deposits/withdrawals.
-vault_id = "0xfab4"
+vault_id = "0xfab2"
 # Whether automatic USDC rebalancing between venues is active.
 rebalancing = "enabled"
 # Maximum USDC moved per rebalance operation.


### PR DESCRIPTION
## What

- Points `[assets.cash] vault_id` in `config/prod/st0x-hedge.toml` at `0xfab2` instead of `0xfab4`. Config only, no code.

## Why

- The live orders settle USDC into two vaults. Almost all the cash is in `0xfab2` (~11.4k USDC). `0xfab4` only ever holds small transient balances that fills eat, and it had drained to 0.
- Inventory sums USDC across every vault it discovers, but withdrawals only ever hit the one vault pinned in config, which was `0xfab4`.
- So the rebalancer sized a Base->Alpaca transfer off total inventory (~2.5k), `withdraw4` pulled only the dust actually sitting in `0xfab4`, and then `depositForBurn` for the full amount reverted with `ERC20: transfer amount exceeds balance` and latched the transfer at `BridgingSubmitting`.

## How

- The configured vault now actually holds enough to cover a rebalance, so the burn stops reverting.
- Keep in mind this does not fix the real mismatch (inventory is multi-vault, withdrawal is single-vault). It just stops the bleeding. Follow-ups below.

## Testing

No automated tests, it's a prod config change. What I checked on prod:

- Before: `vaultBalance2(MM, USDC, 0xfab4) = 0` while `0xfab2` held 11421.418474 USDC, which matches the bot's `InventorySnapshotEvent::OnchainUsdc` reading exactly.
- After the live hotfix + restart: bot logs `Registered USDC vault has a positive balance but is no longer configured vault_id=0x…fab4`, so the new value is loaded.

## Anything else

To be clear, prod is already hotfixed live (backup at `/run/st0x/st0x-hedge.config.bak-fab4`). That edit gets reverted on the next deploy, so this PR is what makes it stick.

Recovery is already done too: the four `UsdcRebalance` aggregates that latched pre-burn were cleared with `fail-usdc-transfer`, and the 1375.61 USDC they stranded in the market-making wallet went back into `0xfab2`. No burn ever executed for any of them (`eth_getLogs` shows zero outgoing USDC transfers from the wallet), so there was nothing to reconcile on the CCTP side.

Follow-ups to file, all pre-existing, none of them introduced here:

- The in-progress guard only clears on bot restart. `fail-usdc-transfer` moves the aggregate out of the guard-holding state, but the guard itself is rebuilt at startup and only released on the next boot.
- A `revert-class, no on-chain state change` revert is provably safe to retry, but the resume path fails closed and latches anyway. That's what turns each failure into a stuck aggregate.
- Inventory and withdrawal disagree on vault scope, and nothing stops this drifting again. Either withdraw across all discovered USDC vaults, or fail startup when a discovered vault holds materially more than the configured one.
