### PR TITLE
fix: clear USDC rebalance guard even when inflight release underflows

### DIFF
--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -920,6 +920,30 @@ impl InventoryView {
         }
     }
 
+    /// Sets USDC inventory with explicit available *and* inflight balances per
+    /// venue. Unlike [`Self::with_usdc`], this can seed the resume-desync state
+    /// where inflight is reserved but the matching available debit was lost
+    /// (e.g. a snapshot reset `available` to broker/chain reality while
+    /// persisted inflight survived a restart) -- a state no single event
+    /// produces on its own.
+    #[cfg(test)]
+    pub(crate) fn with_usdc_inflight(
+        self,
+        onchain_available: Usdc,
+        onchain_inflight: Usdc,
+        offchain_available: Usdc,
+        offchain_inflight: Usdc,
+    ) -> Self {
+        Self {
+            usdc: Inventory {
+                onchain: Some(VenueBalance::new(onchain_available, onchain_inflight)),
+                offchain: Some(VenueBalance::new(offchain_available, offchain_inflight)),
+                last_rebalancing: None,
+            },
+            ..self
+        }
+    }
+
     /// Sets the gross offchain cash balance recorded by the inventory poller.
     #[cfg(test)]
     pub(crate) fn with_offchain_gross_usd_cents(self, cents: i64) -> Self {

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -9699,6 +9699,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn alpaca_to_base_terminal_deposit_with_reserved_inflight_enqueues_one_check() {
+        // Companion to the DeferredToSnapshot-path tests above: a normal
+        // successful settlement (inflight properly reserved via the Initiated
+        // event, so settle_transfer succeeds and returns Reconciled) must
+        // still enqueue exactly one fresh USDC imbalance check.
+        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
+        let trigger = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(500)),
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_bridged_with_amounts(usdc(499), usdc(1)),
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<UsdcRebalance>(
+                id,
+                make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            usdc::drain_pending_usdc_jobs(&trigger).await,
+            1,
+            "a Reconciled settlement must enqueue exactly one fresh USDC \
+             imbalance check against the post-rebalance inventory"
+        );
+    }
+
+    #[tokio::test]
     async fn alpaca_to_base_usdc_lifecycle_tracks_started_and_cleared_inflight() {
         let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
         let trigger = make_trigger_with_inventory(inventory).await;
@@ -10558,6 +10601,11 @@ mod tests {
         // Available unchanged (500), inflight zeroed -- funds left the source.
         assert_usdc_inventory_balances(&trigger, usdc(500), Usdc::ZERO, usdc(100), Usdc::ZERO)
             .await;
+        assert_eq!(
+            usdc::drain_pending_usdc_jobs(&trigger).await,
+            0,
+            "operator reconcile must defer the imbalance check to the next snapshot poll"
+        );
     }
 
     /// Post-restart the reactor has no in-memory tracking, yet an operator
@@ -10620,6 +10668,11 @@ mod tests {
         // Available unchanged (500), inflight zeroed via the event's direction.
         assert_usdc_inventory_balances(&trigger, usdc(500), Usdc::ZERO, usdc(100), Usdc::ZERO)
             .await;
+        assert_eq!(
+            usdc::drain_pending_usdc_jobs(&trigger).await,
+            0,
+            "operator reconcile must defer the imbalance check to the next snapshot poll"
+        );
     }
 
     /// Mirror of `operator_reconcile_works_when_tracking_absent` for the other
@@ -10679,6 +10732,11 @@ mod tests {
         // Hedging available are both untouched (post-burn: no credit).
         assert_usdc_inventory_balances(&trigger, usdc(100), Usdc::ZERO, usdc(500), Usdc::ZERO)
             .await;
+        assert_eq!(
+            usdc::drain_pending_usdc_jobs(&trigger).await,
+            0,
+            "operator reconcile must defer the imbalance check to the next snapshot poll"
+        );
     }
 
     /// A `Reconciled` aggregate is a clearing terminal: startup guard recovery
@@ -18240,6 +18298,14 @@ mod tests {
             "clearing the guard with no tracking must not reconcile offchain USDC inventory"
         );
         drop(inventory);
+
+        assert_eq!(
+            usdc::drain_pending_usdc_jobs(&trigger).await,
+            0,
+            "a DeferredToSnapshot settlement must skip the immediate \
+             enqueue_check, leaving the fresh imbalance check to the next \
+             periodic snapshot poll rather than a duplicate immediate check"
+        );
     }
 
     #[tokio::test]
@@ -22135,6 +22201,495 @@ mod tests {
         assert!(
             !trigger.usdc_tracking.read().await.contains_key(&id),
             "completing without tracking should not fabricate a context"
+        );
+        assert_eq!(
+            usdc::drain_pending_usdc_jobs(&trigger).await,
+            0,
+            "a DeferredToSnapshot settlement must skip the immediate \
+             enqueue_check, leaving the fresh imbalance check to the next \
+             periodic snapshot poll rather than a duplicate immediate check"
+        );
+    }
+
+    #[tokio::test]
+    async fn deposit_confirmed_with_unreserved_inflight_clears_guard() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        // Zero inflight at both venues reproduces a resumed-from-None
+        // AlpacaToBase withdrawal whose Venue::Hedging inflight reservation
+        // was never rebuilt before the deposit settles.
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(5000), usdc(5000))
+            .set_active_usdc_rebalance(id.clone());
+        let trigger = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        // Tracking IS present (unlike the "no tracking" regression test
+        // above), but initiated_amount has no matching inflight reservation
+        // at the source venue, so settle_transfer's confirm_inflight
+        // underflows.
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: usdc(224),
+                bridged_amount_received: Some(usdc(224)),
+                stage: usdc::UsdcRebalanceStage::Bridged,
+                last_progress_at: Utc::now(),
+            },
+        );
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "guard must clear on a terminal DepositConfirmed even when the \
+             source inflight was never reserved (resume bug)"
+        );
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "tracking must be removed on terminal cleanup despite the inflight \
+             underflow"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            None,
+            "active USDC rebalance id must clear on terminal cleanup despite \
+             the inflight underflow"
+        );
+        let (mm_available, hedging_available, mm_inflight, hedging_inflight) = {
+            let inventory = trigger.inventory.read().await;
+            (
+                inventory.usdc_available(Venue::MarketMaking),
+                inventory.usdc_available(Venue::Hedging),
+                inventory.usdc_inflight(Venue::MarketMaking),
+                inventory.usdc_inflight(Venue::Hedging),
+            )
+        };
+        assert_eq!(
+            mm_available,
+            Some(usdc(5000)),
+            "the inflight underflow must skip the destination credit, leaving \
+             MarketMaking available untouched"
+        );
+        assert_eq!(
+            hedging_available,
+            Some(usdc(5000)),
+            "the inflight underflow must skip the source-inflight release, \
+             leaving Hedging available untouched"
+        );
+        assert_eq!(
+            mm_inflight,
+            Some(Usdc::ZERO),
+            "inflight underflow must not mutate MarketMaking inflight"
+        );
+        assert_eq!(
+            hedging_inflight,
+            Some(Usdc::ZERO),
+            "inflight underflow must not mutate Hedging inflight"
+        );
+        assert_eq!(
+            usdc::drain_pending_usdc_jobs(&trigger).await,
+            0,
+            "a DeferredToSnapshot settlement must skip the immediate \
+             enqueue_check, leaving the fresh imbalance check to the next \
+             periodic snapshot poll rather than a duplicate immediate check"
+        );
+    }
+
+    #[tokio::test]
+    async fn conversion_confirmed_base_to_alpaca_with_unreserved_inflight_clears_guard() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        // Zero inflight at both venues reproduces a resumed-from-None
+        // BaseToAlpaca withdrawal whose Venue::MarketMaking inflight
+        // reservation was never rebuilt before the conversion settles.
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(5000), usdc(5000))
+            .set_active_usdc_rebalance(id.clone());
+        let trigger = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::BaseToAlpaca,
+                initiated_amount: usdc(150),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::ConversionInitiated,
+                last_progress_at: Utc::now(),
+            },
+        );
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(150),
+                    usdc(150),
+                ),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "guard must clear on a terminal ConversionConfirmed even when the \
+             source inflight was never reserved"
+        );
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "tracking must be removed on terminal cleanup despite the inflight \
+             underflow"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            None,
+            "active USDC rebalance id must clear on terminal cleanup despite \
+             the inflight underflow"
+        );
+        let (mm_available, hedging_available, mm_inflight, hedging_inflight) = {
+            let inventory = trigger.inventory.read().await;
+            (
+                inventory.usdc_available(Venue::MarketMaking),
+                inventory.usdc_available(Venue::Hedging),
+                inventory.usdc_inflight(Venue::MarketMaking),
+                inventory.usdc_inflight(Venue::Hedging),
+            )
+        };
+        assert_eq!(
+            mm_available,
+            Some(usdc(5000)),
+            "the inflight underflow must skip the source-inflight release, \
+             leaving MarketMaking available untouched"
+        );
+        assert_eq!(
+            hedging_available,
+            Some(usdc(5000)),
+            "the inflight underflow must skip the destination credit, leaving \
+             Hedging available untouched"
+        );
+        assert_eq!(
+            mm_inflight,
+            Some(Usdc::ZERO),
+            "inflight underflow must not mutate MarketMaking inflight"
+        );
+        assert_eq!(
+            hedging_inflight,
+            Some(Usdc::ZERO),
+            "inflight underflow must not mutate Hedging inflight"
+        );
+        assert_eq!(
+            usdc::drain_pending_usdc_jobs(&trigger).await,
+            0,
+            "a DeferredToSnapshot settlement must skip the immediate \
+             enqueue_check, leaving the fresh imbalance check to the next \
+             periodic snapshot poll rather than a duplicate immediate check"
+        );
+    }
+
+    #[tokio::test]
+    async fn deposit_confirmed_with_partial_inflight_clears_residual_source_inflight() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        // Partial reservation: Hedging (the AlpacaToBase source venue) has a
+        // POSITIVE inflight smaller than the tracked initiated_amount -- a job
+        // resumed mid-transfer after only part of the amount was ever
+        // reserved. confirm_inflight underflows on the shortfall, not
+        // because inflight was zero, so this exercises the partial case
+        // distinct from the zero-inflight sibling tests above.
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(5000), usdc(5000))
+            .update_usdc(
+                Inventory::set_inflight(Venue::Hedging, usdc(50)),
+                Utc::now(),
+            )
+            .unwrap()
+            .set_active_usdc_rebalance(id.clone());
+        let trigger = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: usdc(224),
+                bridged_amount_received: Some(usdc(224)),
+                stage: usdc::UsdcRebalanceStage::Bridged,
+                last_progress_at: Utc::now(),
+            },
+        );
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "guard must clear on a terminal DepositConfirmed even when the \
+             source inflight was only partially reserved"
+        );
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "tracking must be removed on terminal cleanup despite the partial \
+             inflight underflow"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            None,
+            "active USDC rebalance id must clear on terminal cleanup despite \
+             the partial inflight underflow"
+        );
+
+        let hedging_inflight = {
+            let inventory = trigger.inventory.read().await;
+            inventory.usdc_inflight(Venue::Hedging)
+        };
+        assert_eq!(
+            hedging_inflight,
+            Some(Usdc::ZERO),
+            "the residual partial source inflight must be zeroed so \
+             has_inflight() can clear and future snapshots resume healing"
+        );
+        assert_eq!(
+            usdc::drain_pending_usdc_jobs(&trigger).await,
+            0,
+            "a DeferredToSnapshot settlement must skip the immediate \
+             enqueue_check, leaving the fresh imbalance check to the next \
+             periodic snapshot poll rather than a duplicate immediate check"
+        );
+    }
+
+    #[tokio::test]
+    async fn withdrawal_failed_with_unreserved_inflight_clears_guard() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        // Zero inflight at Hedging (the AlpacaToBase source venue) reproduces
+        // a resumed-from-None withdrawal whose inflight reservation was
+        // never rebuilt before the failure event arrives -- the same resume
+        // desync as the terminal-success InsufficientInflight tests above,
+        // but exercised on the cancel/failure path (cancel_inflight
+        // underflows instead of confirm_inflight).
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(5000), usdc(5000))
+            .set_active_usdc_rebalance(id.clone());
+        let trigger = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        // Tracking IS present with source_transfer_started() true (stage
+        // Initiated, past the pre-withdrawal ConversionInitiated/Confirmed
+        // stages), but initiated_amount has no matching inflight reservation
+        // at the source venue, so the cancel's cancel_inflight underflows.
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: usdc(400),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::Initiated,
+                last_progress_at: Utc::now(),
+            },
+        );
+
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_withdrawal_failed())
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "guard must clear on a terminal WithdrawalFailed even when the \
+             source inflight was never reserved (resume bug)"
+        );
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "tracking must be removed on terminal cleanup despite the inflight \
+             underflow"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            None,
+            "active USDC rebalance id must clear on terminal cleanup despite \
+             the inflight underflow"
+        );
+
+        let hedging_inflight = {
+            let inventory = trigger.inventory.read().await;
+            inventory.usdc_inflight(Venue::Hedging)
+        };
+        assert_eq!(
+            hedging_inflight,
+            Some(Usdc::ZERO),
+            "the residual source inflight must be zeroed so has_inflight() \
+             can clear and future snapshots resume healing"
+        );
+        assert_eq!(
+            usdc::drain_pending_usdc_jobs(&trigger).await,
+            0,
+            "a DeferredToSnapshot cancel must skip the immediate \
+             enqueue_check, leaving the fresh imbalance check to the next \
+             periodic snapshot poll rather than a duplicate immediate check"
+        );
+    }
+
+    #[tokio::test]
+    async fn deposit_confirmed_with_destination_overflow_hard_fails_and_leaves_guard_latched() {
+        // Forces the generic (non-InsufficientInflight) error arm of
+        // complete_usdc_rebalance: the destination venue's available balance
+        // is already at Float's max representable value, so add_available's
+        // Float addition overflows with a non-InsufficientInflight
+        // InventoryError::Arithmetic. Unlike the underflow path above, this
+        // must hard-fail and leave the guard/tracking/active-rebalance
+        // untouched -- the ledger here is genuinely corrupted, not merely
+        // stale, so there is nothing safe to reconcile away.
+        let max_positive = Usdc::new(Float::max_positive_value().unwrap());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        // Both the destination (MarketMaking) available balance AND the
+        // transferred amount are the max representable Float, so the
+        // destination credit doubles the already-maximal value -- genuinely
+        // unrepresentable regardless of exponent renormalization, unlike
+        // adding a small amount to a near-max balance (which the library
+        // silently absorbs via precision loss rather than overflowing).
+        let inventory = InventoryView::default().with_usdc(max_positive, max_positive);
+        let trigger = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::AlpacaToBase, max_positive),
+            )
+            .await
+            .unwrap();
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_bridged_with_amounts(max_positive, Usdc::ZERO),
+            )
+            .await
+            .unwrap();
+
+        let error = harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                RebalancingServiceError::Inventory(InventoryViewError::Usdc(
+                    InventoryError::Arithmetic(_)
+                ))
+            ),
+            "expected a generic Arithmetic InventoryError from destination overflow, got {error:?}"
+        );
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "a hard failure outside InsufficientInflight must leave the \
+             in-progress guard latched, not silently clear it"
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "a hard failure outside InsufficientInflight must leave tracking \
+             context in place for investigation"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            Some(&id),
+            "a hard failure outside InsufficientInflight must leave the \
+             active USDC rebalance id in place"
+        );
+    }
+
+    #[tokio::test]
+    async fn withdrawal_failed_with_source_credit_overflow_hard_fails_and_leaves_guard_latched() {
+        // Cancel-path twin of
+        // deposit_confirmed_with_destination_overflow_hard_fails_and_leaves_guard_latched.
+        // cancel_tracked_usdc_rebalance's Cancel op releases source inflight and
+        // then credits the amount back to source available; with source available
+        // already at Float's max, that credit-back overflows with a generic
+        // (non-InsufficientInflight) InventoryError::Arithmetic, forcing the
+        // Err(error) arm of cancel_tracked_usdc_rebalance. Like the settle-path
+        // twin, this must hard-fail and leave the guard/tracking/active-rebalance
+        // untouched -- the ledger is genuinely corrupted, not merely stale.
+        let max_positive = Usdc::new(Float::max_positive_value().unwrap());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        // Hedging (the AlpacaToBase source venue) has both available AND inflight
+        // at the max representable Float: inflight = amount lets cancel_inflight
+        // succeed (max - max = 0), but the subsequent available credit-back
+        // (max + max) doubles the already-maximal value and genuinely overflows.
+        // Seeding inflight without the matching available debit mirrors a resume
+        // desync where a snapshot reset available to reality while persisted
+        // inflight survived a restart.
+        let inventory = InventoryView::default()
+            .with_usdc_inflight(Usdc::ZERO, Usdc::ZERO, max_positive, max_positive)
+            .set_active_usdc_rebalance(id.clone());
+        let trigger = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        // Tracking is present with source_transfer_started() true (stage
+        // Initiated, past the pre-withdrawal conversion stages) so the cancel
+        // path runs its inventory update rather than short-circuiting to
+        // Reconciled.
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: max_positive,
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::Initiated,
+                last_progress_at: Utc::now(),
+            },
+        );
+
+        let error = harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_withdrawal_failed())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                RebalancingServiceError::Inventory(InventoryViewError::Usdc(
+                    InventoryError::Arithmetic(_)
+                ))
+            ),
+            "expected a generic Arithmetic InventoryError from the source \
+             credit-back overflow, got {error:?}"
+        );
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "a hard failure outside InsufficientInflight must leave the \
+             in-progress guard latched, not silently clear it"
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "a hard failure outside InsufficientInflight must leave tracking \
+             context in place for investigation"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            Some(&id),
+            "a hard failure outside InsufficientInflight must leave the \
+             active USDC rebalance id in place"
         );
     }
 

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -13,7 +13,8 @@ use st0x_finance::{Usd, Usdc};
 use super::{RebalancingService, RebalancingServiceError};
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::inventory::{
-    BroadcastingInventory, Imbalance, ImbalanceThreshold, Inventory, TransferOp, Venue,
+    BroadcastingInventory, Imbalance, ImbalanceThreshold, Inventory, InventoryError,
+    InventoryViewError, TransferOp, Venue,
 };
 use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalanceEvent, UsdcRebalanceId};
 
@@ -140,6 +141,28 @@ pub(super) enum UsdcTerminalAction {
     NotTerminal,
     Clear,
     PreservePostBurn,
+}
+
+/// Whether a terminal USDC settlement event reconciled the in-memory
+/// inventory ledger. `DeferredToSnapshot` means the settlement was accepted
+/// as authoritative (the durable event proves funds arrived) but the
+/// in-memory available bookkeeping was skipped -- either because a terminal
+/// *success* arrived with no tracking context to reconcile against (a
+/// post-restart resume where the transfer already settled), or because
+/// reconciliation underflowed (the resume desync that fails to reconstruct
+/// inflight). The no-tracking clause is terminal-success-only: a pre-burn
+/// terminal *failure* with no tracking context reconciles as `Reconciled`
+/// instead, because nothing moved, so an immediate imbalance check reads data
+/// as fresh as a post-snapshot one (see `cancel_tracked_usdc_rebalance`). In
+/// the underflow case, the source venue's residual inflight is zeroed so
+/// `has_inflight()` can clear and future snapshots resume healing; the
+/// available balances on both sides are left for the snapshot poll to
+/// correct. Callers must not act on `self.inventory` as if it reflects this
+/// settlement until the next snapshot poll heals it.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum UsdcSettlementOutcome {
+    Reconciled,
+    DeferredToSnapshot,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -572,7 +595,8 @@ impl RebalancingService {
         }
 
         let terminal_action = self.usdc_terminal_action(&id, &event).await;
-        self.apply_usdc_rebalance_event(&id, &event, terminal_action)
+        let settlement_outcome = self
+            .apply_usdc_rebalance_event(&id, &event, terminal_action)
             .await?;
 
         let is_clearable_terminal = terminal_action == UsdcTerminalAction::Clear;
@@ -606,7 +630,25 @@ impl RebalancingService {
         if is_clearable_terminal {
             self.equity_scheduler.cancel_pending().await;
             self.usdc_scheduler.cancel_pending().await;
-            self.usdc_scheduler.enqueue_check().await;
+            match settlement_outcome {
+                UsdcSettlementOutcome::Reconciled => {
+                    self.usdc_scheduler.enqueue_check().await;
+                }
+                UsdcSettlementOutcome::DeferredToSnapshot => {
+                    // The in-memory ledger was not reconciled by this terminal
+                    // event (see UsdcSettlementOutcome::DeferredToSnapshot), so
+                    // checking imbalance now would read stale inventory and could
+                    // dispatch a duplicate transfer for funds that already
+                    // arrived. Defer the fresh check to the next periodic
+                    // snapshot poll, which heals the ledger.
+                    debug!(
+                        target: "rebalance",
+                        id = %id,
+                        "Deferring fresh USDC imbalance check to next snapshot poll: \
+                         in-memory inventory was not reconciled by this terminal event"
+                    );
+                }
+            }
         }
 
         Ok(())
@@ -691,21 +733,23 @@ impl RebalancingService {
         id: &UsdcRebalanceId,
         event: &UsdcRebalanceEvent,
         terminal_action: UsdcTerminalAction,
-    ) -> Result<(), RebalancingServiceError> {
+    ) -> Result<UsdcSettlementOutcome, RebalancingServiceError> {
         use UsdcRebalanceEvent::*;
 
-        match event {
+        let outcome = match event {
             ConversionInitiated {
                 direction, amount, ..
             } => {
                 self.upsert_conversion_tracking(id, direction, *amount, event)
                     .await;
+                UsdcSettlementOutcome::Reconciled
             }
             Initiated {
                 direction, amount, ..
             } => {
                 self.track_initiated_usdc_rebalance(id, direction, *amount, event)
                     .await?;
+                UsdcSettlementOutcome::Reconciled
             }
             WithdrawalConfirmed { .. }
             | BridgingInitiated { .. }
@@ -720,6 +764,7 @@ impl RebalancingService {
                 ..
             } => {
                 self.track_usdc_stage_progress(id, event).await;
+                UsdcSettlementOutcome::Reconciled
             }
             Bridged {
                 amount_received, ..
@@ -735,6 +780,7 @@ impl RebalancingService {
                 // deposit, exactly like the normal bridge path.
                 self.track_bridged_amount(id, *amount_received).await?;
                 self.track_usdc_stage_progress(id, event).await;
+                UsdcSettlementOutcome::Reconciled
             }
             ConversionConfirmed {
                 direction: RebalanceDirection::BaseToAlpaca,
@@ -746,14 +792,12 @@ impl RebalancingService {
                     UsdcTrackingEvent::ConversionConfirmed,
                     conversion.received_amount,
                 )
-                .await?;
+                .await?
             }
             DepositConfirmed {
                 direction: RebalanceDirection::AlpacaToBase,
                 ..
-            } => {
-                self.complete_alpaca_to_base_deposit(id).await?;
-            }
+            } => self.complete_alpaca_to_base_deposit(id).await?,
             // Transient intent markers persisted before the on-chain withdraw /
             // burn. Detailed stage tracking starts at the subsequent Initiated /
             // BridgingInitiated; the inventory's active-rebalance claim is set by
@@ -766,11 +810,9 @@ impl RebalancingService {
             | BridgingSubmitting { .. }
             | PendingBurnRecorded { .. }
             | PendingBurnCleared { .. }
-            | AttestationTimedOut { .. } => {}
+            | AttestationTimedOut { .. } => UsdcSettlementOutcome::Reconciled,
             // Withdrawal failure is always pre-burn -> reconcile to source.
-            WithdrawalFailed { .. } => {
-                self.cancel_tracked_usdc_rebalance(id).await?;
-            }
+            WithdrawalFailed { .. } => self.cancel_tracked_usdc_rebalance(id).await?,
             // These failures may be pre- or post-burn (BridgingFailed by burn
             // stage; ConversionFailed by direction -- BaseToAlpaca's conversion
             // is post-deposit; DepositFailed is always post-mint). The classifier
@@ -779,10 +821,13 @@ impl RebalancingService {
                 if terminal_action == UsdcTerminalAction::PreservePostBurn {
                     // Preservation is achieved by NOT cancelling: the tracking
                     // entry, guard, and active id are all kept by the caller. This
-                    // call only surfaces a diagnostic if tracking is absent.
+                    // call only surfaces a diagnostic if tracking is absent. The
+                    // guard stays held (not clearable), so the outcome value is
+                    // unused by the caller's enqueue gate.
                     self.warn_if_post_burn_tracking_missing(id).await;
+                    UsdcSettlementOutcome::Reconciled
                 } else {
-                    self.cancel_tracked_usdc_rebalance(id).await?;
+                    self.cancel_tracked_usdc_rebalance(id).await?
                 }
             }
             // Operator reconciliation of a post-burn `DepositFailed`: the minted
@@ -791,14 +836,19 @@ impl RebalancingService {
             // available -- never a `Cancel` (which would wrongly credit
             // available). Derives the source venue from `direction`, so it works
             // with tracking absent (post-restart). The caller's Clear terminal
-            // action removes tracking and clears the guard.
+            // action removes tracking and clears the guard. `reconcile_operator_resolved`
+            // zeroes source inflight WITHOUT crediting destination `available`
+            // (by design, see its doc comment), so the ledger is only half
+            // updated here: defer the immediate imbalance check to the next
+            // snapshot poll rather than reading stale inventory.
             OperatorReconciled { direction, .. } => {
                 self.reconcile_operator_resolved(direction, Utc::now())
                     .await?;
+                UsdcSettlementOutcome::DeferredToSnapshot
             }
-        }
+        };
 
-        Ok(())
+        Ok(outcome)
     }
 
     /// Reconciles source-venue USDC inflight for an operator-reconciled,
@@ -990,14 +1040,14 @@ impl RebalancingService {
     async fn complete_alpaca_to_base_deposit(
         &self,
         id: &UsdcRebalanceId,
-    ) -> Result<(), RebalancingServiceError> {
+    ) -> Result<UsdcSettlementOutcome, RebalancingServiceError> {
         let Some(tracking) = self.usdc_tracking.read().await.get(id).cloned() else {
             // Resumed after a restart with no rebuilt tracking: the transfer
             // already settled, so there is no inventory inflight to reconcile.
             // Return Ok so the caller clears the guard (terminal success) rather
             // than wedging it forever on a MissingUsdcTrackingContext error.
             warn!(target: "rebalance", id = %id, "DepositConfirmed event missing USDC tracking context; clearing guard without reconciliation (resumed after restart)");
-            return Ok(());
+            return Ok(UsdcSettlementOutcome::DeferredToSnapshot);
         };
 
         let Some(amount_received) = tracking.bridged_amount_received else {
@@ -1016,18 +1066,18 @@ impl RebalancingService {
     async fn cancel_tracked_usdc_rebalance(
         &self,
         id: &UsdcRebalanceId,
-    ) -> Result<(), RebalancingServiceError> {
+    ) -> Result<UsdcSettlementOutcome, RebalancingServiceError> {
         let Some(tracking) = self.usdc_tracking.read().await.get(id).cloned() else {
             debug!(
                 target: "rebalance",
                 id = %id,
                 "Terminal failure event had no USDC tracking context to cancel"
             );
-            return Ok(());
+            return Ok(UsdcSettlementOutcome::Reconciled);
         };
 
         if !tracking.source_transfer_started() {
-            return Ok(());
+            return Ok(UsdcSettlementOutcome::Reconciled);
         }
 
         let source_venue = tracking.source_venue();
@@ -1040,10 +1090,44 @@ impl RebalancingService {
         });
 
         let mut inventory = self.inventory.write().await;
-        *inventory = inventory.clone().update_usdc(update, now)?;
+        let outcome = match inventory.clone().update_usdc(update, now) {
+            Ok(updated) => {
+                *inventory = updated;
+                UsdcSettlementOutcome::Reconciled
+            }
+            Err(InventoryViewError::Usdc(InventoryError::InsufficientInflight {
+                requested,
+                inflight,
+            })) => {
+                // Same resume desync as complete_usdc_rebalance's underflow case:
+                // the durable terminal-failure event is authoritative that the
+                // transfer stopped, but the in-memory inflight bookkeeping never
+                // reserved (or under-reserved) the amount being cancelled back.
+                // The cancel's credit-back to source `available` is skipped
+                // along with the inflight release, so zero the residual
+                // inflight here (a no-op when it was already zero) so
+                // `has_inflight()` clears and the next snapshot poll can heal
+                // `available` from a fresh broker/chain read.
+                warn!(
+                    target: "rebalance",
+                    id = %id,
+                    source_venue = ?source_venue,
+                    ?initiated_amount,
+                    requested_release = ?requested,
+                    actual_inflight = ?inflight,
+                    "USDC source inflight underflow on terminal cancel; treating \
+                     the durable failure event as authoritative, zeroing residual \
+                     source inflight so snapshots can heal, and skipping in-memory \
+                     available reconciliation (heals on next snapshot poll)."
+                );
+                *inventory = inventory.clone().clear_usdc_inflight(source_venue, now)?;
+                UsdcSettlementOutcome::DeferredToSnapshot
+            }
+            Err(error) => return Err(error.into()),
+        };
         drop(inventory);
 
-        Ok(())
+        Ok(outcome)
     }
 
     async fn complete_usdc_rebalance(
@@ -1051,14 +1135,14 @@ impl RebalancingService {
         id: &UsdcRebalanceId,
         event: UsdcTrackingEvent,
         settled_amount: Usdc,
-    ) -> Result<(), RebalancingServiceError> {
+    ) -> Result<UsdcSettlementOutcome, RebalancingServiceError> {
         let Some(tracking) = self.usdc_tracking.read().await.get(id).cloned() else {
             // Resumed after a restart with no rebuilt tracking: the transfer
             // already settled, so there is no inventory inflight to reconcile.
             // Return Ok so the caller clears the guard (terminal success) rather
             // than wedging it forever on a MissingUsdcTrackingContext error.
             warn!(target: "rebalance", id = %id, ?event, "Terminal success event missing USDC tracking context; clearing guard without reconciliation (resumed after restart)");
-            return Ok(());
+            return Ok(UsdcSettlementOutcome::DeferredToSnapshot);
         };
 
         let source_venue = tracking.source_venue();
@@ -1091,10 +1175,54 @@ impl RebalancingService {
         });
 
         let mut inventory = self.inventory.write().await;
-        *inventory = inventory.clone().update_usdc(update, now)?;
+        let outcome = match inventory.clone().update_usdc(update, now) {
+            Ok(updated) => {
+                *inventory = updated;
+                UsdcSettlementOutcome::Reconciled
+            }
+            Err(InventoryViewError::Usdc(InventoryError::InsufficientInflight {
+                requested,
+                inflight,
+            })) => {
+                // The durable DepositConfirmed/ConversionConfirmed event is the
+                // source of truth that funds arrived on-chain; the in-memory
+                // inflight bookkeeping is a best-effort mirror that can drift
+                // when a job resumes mid-transfer without ever reserving
+                // inflight, or reserving less than what actually settled.
+                // settle_transfer confirms source inflight before
+                // crediting the destination in one atomic closure, so this
+                // underflow skips BOTH the source-inflight release AND the
+                // destination credit. The destination credit and the
+                // source-available correction are deferred to the next
+                // inventory snapshot poll (source available is desynced from
+                // reality here and only a fresh broker/chain snapshot can
+                // correct it). But the residual source inflight left behind by
+                // the failed confirm_inflight would otherwise never clear on
+                // its own -- has_inflight() would stay true forever and
+                // permanently block that healing snapshot -- so zero it here
+                // (a no-op when it was already zero).
+                warn!(
+                    target: "rebalance",
+                    id = %id,
+                    ?event,
+                    ?initiated_amount,
+                    ?settled_amount,
+                    requested_release = ?requested,
+                    actual_inflight = ?inflight,
+                    "USDC source inflight underflow on terminal settlement; \
+                     treating the durable settlement event as authoritative, \
+                     zeroing residual source inflight so snapshots can heal, \
+                     and skipping in-memory available reconciliation (heals \
+                     on next snapshot poll)."
+                );
+                *inventory = inventory.clone().clear_usdc_inflight(source_venue, now)?;
+                UsdcSettlementOutcome::DeferredToSnapshot
+            }
+            Err(error) => return Err(error.into()),
+        };
         drop(inventory);
 
-        Ok(())
+        Ok(outcome)
     }
 
     async fn track_usdc_stage_progress(&self, id: &UsdcRebalanceId, event: &UsdcRebalanceEvent) {


### PR DESCRIPTION
## What

- Terminal USDC transfer events now clear the trigger guard, tracking entry, and active-rebalance id even when the in-memory inflight release underflows (`InsufficientInflight`), so a transfer that already settled on-chain never latches USDC rebalancing off.
- New `UsdcSettlementOutcome` lets `on_usdc_rebalance` skip the immediate imbalance check when a terminal event left the in-memory ledger unreconciled, so it can't fire a duplicate transfer against stale inventory.

## Why

- Fixes [RAI-1322](https://linear.app/makeitrain/issue/RAI-1322/usdc-terminal-success-cleanup-skips-guardtracking-clear-when-inflight).
- In prod a transfer that had settled on-chain hit `InsufficientInflight` in `settle_transfer` (the inflight was never reserved after a mid-transfer restart). The reactor bailed on the `?` before cleanup ran, so `usdc_in_progress` stayed latched, the sweep re-selected the stale tracking entry every tick and paged a false "timed out after CCTP burn" alert, and USDC rebalancing was stuck until a bot restart.

## How

- `complete_usdc_rebalance` and `cancel_tracked_usdc_rebalance` catch `InsufficientInflight`, `warn!` with full context, zero any residual source inflight via `clear_usdc_inflight` (a leftover positive inflight keeps `has_inflight()` true, which blocks every future snapshot from healing the ledger), and return `DeferredToSnapshot`. Every other error still propagates, so `SettledUsdcExceedsInitiatedAmount` keeps preserving state.
- `apply_usdc_rebalance_event` is now an expression-match where every arm evaluates to a `UsdcSettlementOutcome`, so a new terminal arm can't silently fall through to the old implicit default. `OperatorReconciled` returns `DeferredToSnapshot`, cause it zeroes source inflight without crediting the destination.
- `on_usdc_rebalance` enqueues a fresh imbalance check only on `Reconciled`; on `DeferredToSnapshot` it defers to the next snapshot poll.

## Testing

- Regression tests: unreserved inflight (zero and partial) on the success and `WithdrawalFailed` cancel paths clears the guard/tracking/active id and zeroes residual source inflight; the generic-error arm still hard-fails and keeps the guard latched; every `DeferredToSnapshot` path (missing tracking, underflow, `OperatorReconciled`) leaves 0 pending imbalance-check jobs while a reserved settlement enqueues exactly 1.
- `cargo check`, `clippy`, and `nextest -p st0x-hedge` all green.

## Anything else

- The root cause (a resumed AlpacaToBase transfer never rebuilds its source inflight reservation) and two residual stale-inventory-window risks (per-venue USDC snapshots heal one venue at a time, and a guard-clear vs `cancel_pending` TOCTOU) are deferred to [RAI-1324](https://linear.app/makeitrain/issue/RAI-1324/alpacatobase-resume-from-statenone-does-not-reconstruct-inflight). This PR keeps a confirmed transfer from wedging rebalancing; RAI-1324 removes the desync at the root.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USDC rebalancing settlement handling to avoid duplicate imbalance checks.
  * Deferred fresh imbalance evaluation until the next snapshot when inventory reconciliation can’t complete immediately.
  * Enhanced terminal cleanup for deposits, conversions, and failed withdrawals, including better handling of unreserved/partially reserved inflight.
  * Improved recovery by clearing stale in-progress state and restoring healing in subsequent snapshots.
  * Preserved active rebalance state for unrecoverable destination overflow errors.
* **Tests**
  * Added/extended regression coverage for terminal USDC settlement paths, including Alpaca-to-base and deferral behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->