### PR TITLE
chore(config): add CEG, DRAM, TSM, ASML, SKHY tokenized equities

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -300,3 +300,48 @@ extended_hours_counter_trading = "disabled"
 vault_id = "0xfab"
 tokenized_equity = "0xc585AeB8B76c5F5e4215470A7625258e86ED7746"
 tokenized_equity_derivative = "0x19F89aaEf8a93f38A974beca9776f09aB844887F"
+
+[assets.equities.CEG]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x9a5D3cAeC90b0332b18C0B93fEF42F3F8C918289"
+tokenized_equity_derivative = "0x3aF952888Cd89DAD3e8AF67cf4b7E740B36829C3"
+
+[assets.equities.DRAM]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x96DE077262609298CD891E4Ab21bd34837dE33aB"
+tokenized_equity_derivative = "0x1A91Df4a970EBaB1bB4AF32Eb6d10509028eE4b8"
+
+[assets.equities.TSM]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x7001e2974F775f0Fd73a3D2e5914e591f3EC3fBB"
+tokenized_equity_derivative = "0x71C66449d2528E23514A9c197BFD55Ae9DB3B714"
+
+[assets.equities.ASML]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x722Cb373f1871A176fb5DC3953046f2EAE22F619"
+tokenized_equity_derivative = "0x8200c6d9AB9E02A25D7F2099244C476d99a085ef"
+
+[assets.equities.SKHY]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x4DBA41f0feb390F208a85e96168fF5d8aC2b6F5c"
+tokenized_equity_derivative = "0xFcD17aC4c4BF6a72c93018096F3fC09e66573Ff9"

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -283,3 +283,50 @@ extended_hours_counter_trading = "disabled"
 vault_id = "0xfab"
 tokenized_equity = "0xc585AeB8B76c5F5e4215470A7625258e86ED7746"
 tokenized_equity_derivative = "0x19F89aaEf8a93f38A974beca9776f09aB844887F"
+
+# Registered for parity with prod; staging only trades RKLB, so these stay
+# disabled.
+[assets.equities.CEG]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x9a5D3cAeC90b0332b18C0B93fEF42F3F8C918289"
+tokenized_equity_derivative = "0x3aF952888Cd89DAD3e8AF67cf4b7E740B36829C3"
+
+[assets.equities.DRAM]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x96DE077262609298CD891E4Ab21bd34837dE33aB"
+tokenized_equity_derivative = "0x1A91Df4a970EBaB1bB4AF32Eb6d10509028eE4b8"
+
+[assets.equities.TSM]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x7001e2974F775f0Fd73a3D2e5914e591f3EC3fBB"
+tokenized_equity_derivative = "0x71C66449d2528E23514A9c197BFD55Ae9DB3B714"
+
+[assets.equities.ASML]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x722Cb373f1871A176fb5DC3953046f2EAE22F619"
+tokenized_equity_derivative = "0x8200c6d9AB9E02A25D7F2099244C476d99a085ef"
+
+[assets.equities.SKHY]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x4DBA41f0feb390F208a85e96168fF5d8aC2b6F5c"
+tokenized_equity_derivative = "0xFcD17aC4c4BF6a72c93018096F3fC09e66573Ff9"


### PR DESCRIPTION
## What

- Add five Base tokenized equities from [st0x.registry#21](https://github.com/ST0x-Technology/st0x.registry/pull/21) to the prod and staging bot configs: `CEG`, `DRAM`, `TSM`, `ASML`, `SKHY`.
- prod: `trading`, `rebalancing`, `wrapped_equity_recovery`, and `extended_hours_counter_trading` all `enabled`, `vault_id = "0xfab"`.
- staging: registered for parity but all four flags `disabled` (staging only trades RKLB), matching the SPCX precedent.

## Why

- These tokens got added to the st0x registry, so the bot needs their Base contract addresses to recognize, account for, and hedge on-chain fills.

## How

- Config-only, no Rust changes.
- Addresses from the registry PR's `base.json` `tokenMap`: `tokenized_equity` = unwrapped SFT (`extensions.unwrappedAddress`), `tokenized_equity_derivative` = `wtTOKEN` wrapper (`address`). Verified the direction against the existing `SGOV` entry so they aren't flipped.
- `pyth_feed_id` left unset on all five (config only pins feeds confirmed on-chain, these are new), so analytics enrichment is skipped until confirmed. Hedging unaffected.
- Enabling `trading` in prod follows the default we've used for every add since SPCX (#805): live in prod, disabled in staging.

## Testing

- `cargo nextest run -p st0x-config --all-features` -> 168/168 pass. `server_config_toml_is_valid` and `all_repo_config_tomls_are_valid` `include_str!` the real prod/staging TOMLs, so they parse + validate the five new entries.

## Anything else

- This enables live prod trading on all five. To hold any back, flip its prod `trading` to `disabled` (one line per symbol).
- No Linear issue linked yet.
