### PR TITLE
fix: gate CCTP burn Dropped verdicts on node freshness

### DIFF
--- a/crates/bridge/src/cctp/evm.rs
+++ b/crates/bridge/src/cctp/evm.rs
@@ -459,11 +459,17 @@ impl<W: Wallet> CctpEndpoint<W> {
 
     /// Resolves the on-chain status of a broadcast burn tx for crash-safe resume,
     /// using this endpoint's configured drop policy (`burn_drop_config`).
+    ///
+    /// `submitted_after_block` is the chain head recorded before the burn was
+    /// broadcast (the same pre-burn head `find_recent_burn` scans from): the
+    /// burn can only have mined strictly after it, so it anchors the
+    /// node-freshness gate on the `Dropped` verdict.
     pub(super) async fn burn_status(
         &self,
         tx_hash: TxHash,
+        submitted_after_block: u64,
     ) -> Result<crate::BurnTxStatus, CctpError> {
-        self.burn_status_with_config(tx_hash, self.burn_drop_config)
+        self.burn_status_with_config(tx_hash, submitted_after_block, self.burn_drop_config)
             .await
     }
 
@@ -478,8 +484,15 @@ impl<W: Wallet> CctpEndpoint<W> {
     ///   [`BurnTxStatus::Pending`] (returns immediately)
     /// - no receipt and tx absent from the mempool -> KEEPS POLLING (does NOT
     ///   return `Pending` early); only once `config.grace` has elapsed AND
-    ///   `config.consecutive_misses` consecutive post-grace absences are observed
-    ///   does it return [`BurnTxStatus::Dropped`].
+    ///   `config.consecutive_misses` consecutive post-grace absences are
+    ///   observed **by a node provably past where the burn could have mined**
+    ///   does it return [`BurnTxStatus::Dropped`]. An absence reported by a
+    ///   node whose head is not `SCAN_FINALITY_MARGIN` blocks past
+    ///   `submitted_after_block` is no evidence at all (a lagging dRPC backend
+    ///   returns `None` for an already-mined tx it has not indexed); once the
+    ///   grace has elapsed such a node resolves the poll as
+    ///   [`BurnTxStatus::Pending`] -- retryable by the caller's redrive --
+    ///   never `Dropped`.
     ///
     /// A still-pending burn (broadcast but unmined) thus never reports `Dropped`,
     /// so the caller never re-burns a tx that may still land -- the exact
@@ -487,6 +500,7 @@ impl<W: Wallet> CctpEndpoint<W> {
     pub(super) async fn burn_status_with_config(
         &self,
         tx_hash: TxHash,
+        submitted_after_block: u64,
         config: BurnDropConfig,
     ) -> Result<crate::BurnTxStatus, CctpError> {
         let provider = self.wallet.provider();
@@ -526,12 +540,33 @@ impl<W: Wallet> CctpEndpoint<W> {
                 return Ok(crate::BurnTxStatus::Pending);
             }
 
-            // Absent from both receipt and mempool. Keep polling within this call
-            // rather than returning early: only after the grace period AND
-            // `consecutive_misses` consecutive absences is the absence trusted as a
-            // true drop. Before that, a transient absence (lagging node, not-yet-
-            // propagated tx) keeps polling so a tx that mines late is still seen and
-            // a still-pending tx is never re-burned.
+            // Absent from both receipt and mempool. An absence only counts as
+            // evidence when the answering node's head is provably past the
+            // region where this burn could have mined: the burn broadcast after
+            // the pre-burn head `submitted_after_block`, so a node that is not
+            // `SCAN_FINALITY_MARGIN` blocks beyond it may simply not have
+            // indexed the mined burn yet (a synced node never returns `None`
+            // for a mined tx; a lagging dRPC backend routinely does).
+            let head = provider.get_block_number().await?;
+            let node_caught_up = head >= submitted_after_block.saturating_add(SCAN_FINALITY_MARGIN);
+
+            if !node_caught_up {
+                // A lagging node cannot prove a drop. Within the grace window
+                // keep polling (a later tick may hit a synced backend); past it,
+                // resolve as Pending -- retryable by the caller's redrive --
+                // rather than spinning here until the fleet catches up.
+                if start.elapsed() >= config.grace {
+                    return Ok(crate::BurnTxStatus::Pending);
+                }
+                continue;
+            }
+
+            // Keep polling within this call rather than returning early: only
+            // after the grace period AND `consecutive_misses` caught-up-node
+            // absences is the absence trusted as a true drop. Before that, a
+            // transient absence (not-yet-propagated tx) keeps polling so a tx
+            // that mines late is still seen and a still-pending tx is never
+            // re-burned.
             if start.elapsed() >= config.grace {
                 consecutive_misses += 1;
                 if consecutive_misses >= config.consecutive_misses {

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -1164,10 +1164,17 @@ where
         &self,
         direction: BridgeDirection,
         tx_hash: TxHash,
+        submitted_after_block: u64,
     ) -> Result<crate::BurnTxStatus, Self::Error> {
         match direction {
-            BridgeDirection::EthereumToBase => self.ethereum.burn_status(tx_hash).await,
-            BridgeDirection::BaseToEthereum => self.base.burn_status(tx_hash).await,
+            BridgeDirection::EthereumToBase => {
+                self.ethereum
+                    .burn_status(tx_hash, submitted_after_block)
+                    .await
+            }
+            BridgeDirection::BaseToEthereum => {
+                self.base.burn_status(tx_hash, submitted_after_block).await
+            }
         }
     }
 
@@ -4610,7 +4617,7 @@ mod tests {
         assert_eq!(
             bridge
                 .ethereum
-                .burn_status(success_receipt.transaction_hash)
+                .burn_status(success_receipt.transaction_hash, 0)
                 .await
                 .unwrap(),
             crate::BurnTxStatus::MinedSuccess
@@ -4618,7 +4625,7 @@ mod tests {
         assert_eq!(
             bridge
                 .ethereum
-                .burn_status(reverted_receipt.transaction_hash)
+                .burn_status(reverted_receipt.transaction_hash, 0)
                 .await
                 .unwrap(),
             crate::BurnTxStatus::MinedReverted
@@ -4662,7 +4669,7 @@ mod tests {
         // for a truly-absent tx), a mempool-visible tx must be Pending.
         let status = bridge
             .ethereum
-            .burn_status_with_config(pending_tx, super::evm::BurnDropConfig::fast())
+            .burn_status_with_config(pending_tx, 0, super::evm::BurnDropConfig::fast())
             .await
             .unwrap();
 
@@ -4674,9 +4681,10 @@ mod tests {
     }
 
     /// A tx absent from both the receipt lookup and the mempool, observed past the
-    /// grace window and the consecutive-miss threshold, classifies as `Dropped`
-    /// so the caller can fail closed and require operator verification. Uses a
-    /// zero grace + single miss to keep the test fast.
+    /// grace window and the consecutive-miss threshold BY A CAUGHT-UP NODE (head
+    /// confirmations-deep past the pre-burn block), classifies as `Dropped` so the
+    /// caller can fail closed and require operator verification. Uses a zero grace
+    /// + single miss to keep the test fast.
     #[tokio::test]
     async fn burn_status_reports_dropped_for_absent_tx_past_grace() {
         let (_anvil, endpoint, private_key) = setup_anvil();
@@ -4684,12 +4692,17 @@ mod tests {
             .await
             .unwrap();
 
+        // Advance the head past the freshness margin so the node's absence
+        // report is trusted as evidence (submitted_after_block = 0).
+        let provider = ProviderBuilder::new().connect(&endpoint).await.unwrap();
+        provider.anvil_mine(Some(5), None).await.unwrap();
+
         let unknown_tx =
             b256!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
 
         let status = bridge
             .ethereum
-            .burn_status_with_config(unknown_tx, super::evm::BurnDropConfig::fast())
+            .burn_status_with_config(unknown_tx, 0, super::evm::BurnDropConfig::fast())
             .await
             .unwrap();
 
@@ -4697,6 +4710,38 @@ mod tests {
             status,
             crate::BurnTxStatus::Dropped,
             "an absent tx past the grace + consecutive-miss threshold must classify as Dropped"
+        );
+    }
+
+    /// The RAI-1241 incident shape: a mined-but-lagging node reports BOTH the
+    /// receipt and `get_transaction_by_hash` as `None` while its head is still
+    /// behind the pre-burn block. Such a node proves nothing, so the verdict
+    /// must be `Pending` (retryable), never `Dropped` -- a synced node would
+    /// never return `None` for a mined tx.
+    #[tokio::test]
+    async fn burn_status_reports_pending_when_node_lags_submission_block() {
+        let (_anvil, endpoint, private_key) = setup_anvil();
+        let bridge = create_bridge(&endpoint, &endpoint, &private_key, USDC_ETHEREUM)
+            .await
+            .unwrap();
+
+        // Fresh anvil head is 0; claiming the burn broadcast after block 100
+        // makes this node provably NOT confirmations-deep past the submission
+        // block -- the lagging-backend scenario.
+        let unknown_tx =
+            b256!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+
+        let status = bridge
+            .ethereum
+            .burn_status_with_config(unknown_tx, 100, super::evm::BurnDropConfig::fast())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            status,
+            crate::BurnTxStatus::Pending,
+            "a node behind the pre-burn block cannot prove a drop; the verdict must be \
+             Pending (retryable), never Dropped"
         );
     }
 

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -133,12 +133,16 @@ pub trait Bridge: Send + Sync + 'static {
     /// receipt consults the mempool: a tx still known to the node is
     /// [`BurnTxStatus::Pending`], and a tx absent from the mempool is only
     /// reported [`BurnTxStatus::Dropped`] after a grace window plus consecutive
-    /// misses (mirroring the wallet's `wait_for_receipt` drop policy), so a
-    /// still-pending tx is never re-burned.
+    /// misses (mirroring the wallet's `wait_for_receipt` drop policy) observed
+    /// by a node whose head is provably past `submitted_after_block` -- the
+    /// pre-burn chain head the transfer recorded. A lagging load-balanced
+    /// backend returns `None` even for a mined tx, so its absences prove
+    /// nothing and resolve as `Pending` (retryable), never `Dropped`.
     async fn burn_status(
         &self,
         direction: BridgeDirection,
         tx_hash: TxHash,
+        submitted_after_block: u64,
     ) -> Result<BurnTxStatus, Self::Error>;
 
     /// Polls for an attestation confirming the burn.

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -839,6 +839,17 @@ const DROPPED_TX_GRACE: std::time::Duration = std::time::Duration::from_secs(30)
 #[cfg(any(feature = "turnkey", feature = "local-signer"))]
 const DROPPED_TX_CONSECUTIVE_MISSES: u32 = 3;
 
+/// Blocks the answering node's head must advance past the head observed at the
+/// first post-grace absence before a drop verdict is trusted. A lagging
+/// load-balanced backend returns `None` for a tx that actually mined — a
+/// synced node never does — so absences only count as evidence once the node
+/// has provably moved past the region where the tx could have mined. A node
+/// whose head is frozen (fully stalled backend) therefore never concludes
+/// `Dropped`; the wait ends in the retryable inclusion timeout instead.
+/// Mirrors the CCTP bridge's `SCAN_FINALITY_MARGIN` discipline.
+#[cfg(any(feature = "turnkey", feature = "local-signer"))]
+const DROPPED_TX_HEAD_ADVANCE: u64 = 2;
+
 /// Consecutive transport errors (with no successful poll in between) tolerated
 /// while polling before giving up. A transient blip on a load-balanced RPC
 /// recovers within a poll or two and a successful poll resets the count; this
@@ -863,6 +874,9 @@ pub(crate) struct ReceiptWaitConfig {
     pub(crate) dropped_grace: std::time::Duration,
     /// Consecutive mempool-absence observations required to conclude a drop.
     pub(crate) dropped_consecutive_misses: u32,
+    /// Head advance (blocks, from the first post-grace absence) the answering
+    /// node must show before its absences are trusted as a drop verdict.
+    pub(crate) dropped_head_advance: u64,
 }
 
 #[cfg(any(feature = "turnkey", feature = "local-signer"))]
@@ -876,6 +890,7 @@ impl ReceiptWaitConfig {
             confirmation_timeout: CONFIRMATION_TIMEOUT,
             dropped_grace: DROPPED_TX_GRACE,
             dropped_consecutive_misses: DROPPED_TX_CONSECUTIVE_MISSES,
+            dropped_head_advance: DROPPED_TX_HEAD_ADVANCE,
         }
     }
 }
@@ -925,6 +940,11 @@ pub(crate) async fn wait_for_receipt_with_config(
         // before concluding the tx was dropped.
         let mut consecutive_misses = 0u32;
         let mut consecutive_transport_errors = 0u32;
+        // Head observed at the first post-grace absence: the drop verdict
+        // additionally requires the node's head to advance past this by
+        // `dropped_head_advance`, proving the absences come from a node that
+        // is live and moving past where the tx could have mined.
+        let mut drop_reference_head: Option<u64> = None;
 
         loop {
             poll.tick().await;
@@ -962,6 +982,7 @@ pub(crate) async fn wait_for_receipt_with_config(
                     start,
                     &mut consecutive_misses,
                     &mut consecutive_transport_errors,
+                    &mut drop_reference_head,
                 )
                 .await?;
                 continue;
@@ -1026,7 +1047,9 @@ pub(crate) async fn wait_for_receipt_with_config(
 /// Classify an inclusion poll whose receipt is absent. Returns `Ok(())` to keep
 /// waiting; returns a terminal `Err` when the tx is confirmed dropped (missing
 /// from the receipt lookup and the mempool past the grace period for
-/// `dropped_consecutive_misses` polls) or the RPC is down past the transport cap.
+/// `dropped_consecutive_misses` polls, observed by a node whose head advanced
+/// `dropped_head_advance` blocks past the first post-grace absence) or the RPC
+/// is down past the transport cap.
 #[cfg(any(feature = "turnkey", feature = "local-signer"))]
 async fn classify_pending_receipt(
     provider: &impl Provider,
@@ -1035,6 +1058,7 @@ async fn classify_pending_receipt(
     start: std::time::Instant,
     consecutive_misses: &mut u32,
     consecutive_transport_errors: &mut u32,
+    drop_reference_head: &mut Option<u64>,
 ) -> Result<(), EvmError> {
     // Before the grace period a missing tx is almost certainly still propagating
     // or awaiting its first block. The receipt poll itself succeeded, so the
@@ -1074,10 +1098,37 @@ async fn classify_pending_receipt(
         return Ok(());
     }
 
-    // Absent from both the receipt lookup and the mempool past the grace period.
-    *consecutive_misses += 1;
+    // Absent from both the receipt lookup and the mempool past the grace
+    // period. The absence only becomes a verdict once the answering node also
+    // proves it is live and past where the tx could have mined: a lagging
+    // load-balanced backend returns `None` for an already-mined tx (a synced
+    // node never does), so without the head-advance proof the miss run keeps
+    // polling and a truly stalled node ends in the retryable inclusion
+    // timeout, never a false `Dropped`.
+    let head = match provider.get_block_number().await {
+        Ok(head) => {
+            *consecutive_transport_errors = 0;
+            head
+        }
+        Err(transport_error) => {
+            // Same rationale as the mempool arm: a transport error is not a
+            // confirmed observation, so it breaks the consecutive-miss run.
+            *consecutive_misses = 0;
+            note_receipt_poll_transport_error(
+                consecutive_transport_errors,
+                transport_error,
+                "polling block number for drop verdict",
+            )?;
+            return Ok(());
+        }
+    };
 
-    if *consecutive_misses >= config.dropped_consecutive_misses {
+    *consecutive_misses += 1;
+    let reference = *drop_reference_head.get_or_insert(head);
+
+    if *consecutive_misses >= config.dropped_consecutive_misses
+        && head >= reference.saturating_add(config.dropped_head_advance)
+    {
         return Err(EvmError::TransactionDropped {
             tx_hash,
             elapsed_secs: start.elapsed().as_secs(),
@@ -1661,6 +1712,7 @@ mod tests {
                 confirmation_timeout: std::time::Duration::from_secs(1),
                 dropped_grace: std::time::Duration::from_secs(60),
                 dropped_consecutive_misses: 3,
+                dropped_head_advance: DROPPED_TX_HEAD_ADVANCE,
             },
         )
         .await;
@@ -1706,6 +1758,7 @@ mod tests {
                 dropped_grace: std::time::Duration::ZERO,
                 // High, so the drop check never fires before the transport cap.
                 dropped_consecutive_misses: 100,
+                dropped_head_advance: DROPPED_TX_HEAD_ADVANCE,
             },
         )
         .await;
@@ -1774,6 +1827,7 @@ mod tests {
                 confirmation_timeout: std::time::Duration::from_secs(30),
                 dropped_grace: std::time::Duration::from_secs(60),
                 dropped_consecutive_misses: 3,
+                dropped_head_advance: DROPPED_TX_HEAD_ADVANCE,
             },
         )
         .await;
@@ -1829,6 +1883,7 @@ mod tests {
                 // Large, so the Ok(None) poll stays in the before-grace reset path.
                 dropped_grace: std::time::Duration::from_secs(60),
                 dropped_consecutive_misses: 3,
+                dropped_head_advance: DROPPED_TX_HEAD_ADVANCE,
             },
         )
         .await;
@@ -1887,6 +1942,7 @@ mod tests {
                 confirmation_timeout: std::time::Duration::from_secs(30),
                 dropped_grace: std::time::Duration::from_secs(60),
                 dropped_consecutive_misses: 3,
+                dropped_head_advance: DROPPED_TX_HEAD_ADVANCE,
             },
         )
         .await;
@@ -1906,9 +1962,10 @@ mod tests {
         // dropped on the fourth poll -- before it is seen mined.
         let tx_hash = alloy::primitives::B256::random();
         let asserter = Asserter::new();
-        // Poll 1: receipt None, mempool absent -> miss 1.
+        // Poll 1: receipt None, mempool absent, head 10 -> miss 1.
         asserter.push_success(&serde_json::Value::Null);
         asserter.push_success(&serde_json::Value::Null);
+        asserter.push_success(&serde_json::Value::from(10u64));
         // Poll 2: receipt None, mempool transport error -> reset the miss run.
         asserter.push_success(&serde_json::Value::Null);
         asserter.push_failure(alloy::rpc::json_rpc::ErrorPayload {
@@ -1916,12 +1973,15 @@ mod tests {
             message: "mempool backend blip".into(),
             data: None,
         });
-        // Poll 3: receipt None, mempool absent -> miss 1 (not 2).
+        // Poll 3: receipt None, mempool absent, head 11 -> miss 1 (not 2).
         asserter.push_success(&serde_json::Value::Null);
         asserter.push_success(&serde_json::Value::Null);
-        // Poll 4: receipt None, mempool absent -> miss 2 (not 3 -> no false drop).
+        asserter.push_success(&serde_json::Value::from(11u64));
+        // Poll 4: receipt None, mempool absent, head 12 -> miss 2 (not 3 -> no
+        // false drop).
         asserter.push_success(&serde_json::Value::Null);
         asserter.push_success(&serde_json::Value::Null);
+        asserter.push_success(&serde_json::Value::from(12u64));
         // Poll 5: the tx is finally mined at block 0, ending Phase 1.
         asserter.push_success(&mined_receipt(tx_hash));
         // Phase 2 with required_confirmations = 1: satisfied immediately.
@@ -1939,6 +1999,7 @@ mod tests {
                 // Check the mempool from the first poll so the interleave runs.
                 dropped_grace: std::time::Duration::ZERO,
                 dropped_consecutive_misses: 3,
+                dropped_head_advance: DROPPED_TX_HEAD_ADVANCE,
             },
         )
         .await;
@@ -1967,6 +2028,9 @@ mod tests {
                 confirmation_timeout: std::time::Duration::from_secs(60),
                 dropped_grace: std::time::Duration::ZERO,
                 dropped_consecutive_misses: 1,
+                // Anvil's head stays frozen in these fixtures; the freshness
+                // gate is exercised by its own dedicated tests below.
+                dropped_head_advance: 0,
             },
         )
         .await;
@@ -2017,6 +2081,9 @@ mod tests {
                 // logic — the tx is in the mempool, so it must not be dropped.
                 dropped_grace: std::time::Duration::ZERO,
                 dropped_consecutive_misses: 1,
+                // Anvil's head stays frozen in these fixtures; the freshness
+                // gate is exercised by its own dedicated tests below.
+                dropped_head_advance: 0,
             },
         )
         .await;
@@ -2051,6 +2118,9 @@ mod tests {
                 confirmation_timeout: std::time::Duration::from_secs(60),
                 dropped_grace: grace,
                 dropped_consecutive_misses: 1,
+                // Anvil's head stays frozen in these fixtures; the freshness
+                // gate is exercised by its own dedicated tests below.
+                dropped_head_advance: 0,
             },
         )
         .await;
@@ -2063,6 +2133,90 @@ mod tests {
         assert!(
             elapsed >= grace,
             "drop must not be declared before the grace period: elapsed {elapsed:?} < {grace:?}"
+        );
+    }
+
+    /// The RAI-1241 incident shape: a lagging load-balanced backend reports the
+    /// tx absent from BOTH the receipt lookup and the mempool while its head is
+    /// frozen. A synced node never returns `None` for a mined tx, so absences
+    /// from a node that is not provably advancing past where the tx could have
+    /// mined must never conclude `Dropped` — the wait ends in the retryable
+    /// inclusion timeout instead.
+    #[cfg(any(feature = "turnkey", feature = "local-signer"))]
+    #[tokio::test]
+    async fn wait_for_receipt_does_not_drop_when_node_head_is_frozen() {
+        let tx_hash = alloy::primitives::B256::random();
+        let asserter = Asserter::new();
+        // Every poll: receipt None, mempool None, head STUCK at 42. Misses
+        // accumulate far past the threshold, but the head never advances, so
+        // the drop verdict must stay gated. Enough cycles are queued to outlast
+        // the inclusion timeout at the 1ms poll interval.
+        for _ in 0..500 {
+            asserter.push_success(&serde_json::Value::Null);
+            asserter.push_success(&serde_json::Value::Null);
+            asserter.push_success(&serde_json::Value::from(42u64));
+        }
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let result = wait_for_receipt_with_config(
+            &provider,
+            tx_hash,
+            1,
+            ReceiptWaitConfig {
+                poll_interval: std::time::Duration::from_millis(1),
+                // Short, so the gated wait resolves as ReceiptTimeout quickly.
+                inclusion_timeout: std::time::Duration::from_millis(100),
+                confirmation_timeout: std::time::Duration::from_secs(1),
+                dropped_grace: std::time::Duration::ZERO,
+                dropped_consecutive_misses: 3,
+                dropped_head_advance: 2,
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(EvmError::ReceiptTimeout { tx_hash: ht, .. }) if ht == tx_hash),
+            "a frozen-head node cannot prove a drop; expected the retryable \
+             ReceiptTimeout, got: {result:?}"
+        );
+    }
+
+    /// Complement of the frozen-head case: once the answering node's head has
+    /// advanced `dropped_head_advance` past the first post-grace absence while
+    /// the tx stays missing from both lookups, the drop verdict fires.
+    #[cfg(any(feature = "turnkey", feature = "local-signer"))]
+    #[tokio::test]
+    async fn wait_for_receipt_drops_when_head_advances_past_absent_tx() {
+        let tx_hash = alloy::primitives::B256::random();
+        let asserter = Asserter::new();
+        // Three misses with the head advancing 42 -> 43 -> 44 (= reference + 2):
+        // the third miss satisfies both the miss threshold and the head gate.
+        for head in [42u64, 43, 44] {
+            asserter.push_success(&serde_json::Value::Null);
+            asserter.push_success(&serde_json::Value::Null);
+            asserter.push_success(&serde_json::Value::from(head));
+        }
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let result = wait_for_receipt_with_config(
+            &provider,
+            tx_hash,
+            1,
+            ReceiptWaitConfig {
+                poll_interval: std::time::Duration::from_millis(1),
+                inclusion_timeout: std::time::Duration::from_secs(30),
+                confirmation_timeout: std::time::Duration::from_secs(1),
+                dropped_grace: std::time::Duration::ZERO,
+                dropped_consecutive_misses: 3,
+                dropped_head_advance: 2,
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(EvmError::TransactionDropped { tx_hash: ht, .. }) if ht == tx_hash),
+            "an absent tx observed by an advancing (caught-up) node past the miss \
+             threshold must classify as Dropped, got: {result:?}"
         );
     }
 

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -2792,7 +2792,13 @@ impl<
         pending_burn_tx: Option<TxHash>,
     ) -> Result<BurnReceipt, UsdcTransferError> {
         if let Some(adopted) = self
-            .check_pending_burn(id, BridgeDirection::BaseToEthereum, amount, pending_burn_tx)
+            .check_pending_burn(
+                id,
+                BridgeDirection::BaseToEthereum,
+                amount,
+                pending_burn_tx,
+                from_block,
+            )
             .await?
         {
             return self.record_cctp_burn(id, adopted).await;
@@ -3119,6 +3125,7 @@ impl<
         direction: BridgeDirection,
         amount: U256,
         pending_burn_tx: Option<TxHash>,
+        from_block: u64,
     ) -> Result<Option<BurnReceipt>, UsdcTransferError> {
         let Some(burn_tx) = pending_burn_tx else {
             // No recorded hash: fall through to the scan, which ADOPTS an already-mined
@@ -3128,9 +3135,13 @@ impl<
             return Ok(None);
         };
 
+        // `from_block` is the pre-burn chain head the transfer recorded (the
+        // same anchor the log scan uses): the burn can only have mined after
+        // it, so `burn_status` gates its `Dropped` verdict on the polled node
+        // being provably past it rather than trusting a lagging backend.
         let status = self
             .cctp_bridge
-            .burn_status(direction, burn_tx)
+            .burn_status(direction, burn_tx, from_block)
             .await
             .map_err(|error| UsdcTransferError::SettlementCheckTransient {
                 id: id.clone(),
@@ -3291,7 +3302,13 @@ impl<
         pending_burn_tx: Option<TxHash>,
     ) -> Result<BurnReceipt, UsdcTransferError> {
         if let Some(adopted) = self
-            .check_pending_burn(id, BridgeDirection::EthereumToBase, amount, pending_burn_tx)
+            .check_pending_burn(
+                id,
+                BridgeDirection::EthereumToBase,
+                amount,
+                pending_burn_tx,
+                from_block,
+            )
             .await?
         {
             return self.record_cctp_burn(id, adopted).await;
@@ -3672,6 +3689,7 @@ mod tests {
             &self,
             _direction: BridgeDirection,
             _tx_hash: TxHash,
+            _submitted_after_block: u64,
         ) -> Result<st0x_bridge::BurnTxStatus, CctpError> {
             unimplemented!("MockBridge: burn_status not used in this test")
         }
@@ -7940,7 +7958,12 @@ mod tests {
     #[tokio::test]
     async fn resume_alpaca_to_base_from_deposit_initiated_reverifies_deposit_tx() {
         let server = MockServer::start();
-        let (_anvil, endpoint, private_key) = setup_anvil();
+        // Auto-mining keeps the head advancing so the wallet's drop verdict
+        // (which requires the node to prove liveness via head advance before
+        // trusting an absence) can actually fire for the fabricated tx.
+        let anvil = Anvil::new().block_time(1).spawn();
+        let endpoint = anvil.endpoint();
+        let private_key = B256::from_slice(&anvil.keys()[0].to_bytes());
 
         let alpaca_broker = InstrumentedAlpacaBroker::new(
             create_test_broker_service(&server).await,
@@ -11884,6 +11907,11 @@ mod tests {
         let from_block = provider.get_block_number().await.unwrap();
         advance_to_bridging_submitting_alpaca_to_base(&cqrs, &id, amount, from_block).await;
 
+        // Advance the head past the freshness margin so the node's absence
+        // report is trusted as drop evidence (a node still at `from_block`
+        // reads as a lagging backend and classifies Pending instead).
+        provider.anvil_mine(Some(5), None).await.unwrap();
+
         let error = manager
             .resume_bridging_submitting_ethereum(&id, amount_u256, from_block, Some(dropped_tx))
             .await
@@ -12455,6 +12483,11 @@ mod tests {
         let from_block = provider.get_block_number().await.unwrap();
         advance_to_bridging_submitting_base_to_alpaca(&cqrs, &id, amount, from_block).await;
 
+        // Advance the head past the freshness margin so the node's absence
+        // report is trusted as drop evidence (a node still at `from_block`
+        // reads as a lagging backend and classifies Pending instead).
+        provider.anvil_mine(Some(5), None).await.unwrap();
+
         let error = manager
             .resume_bridging_submitting(&id, amount_u256, from_block, Some(dropped_tx))
             .await
@@ -12712,6 +12745,7 @@ mod tests {
                 BridgeDirection::BaseToEthereum,
                 amount_u256,
                 Some(pending_tx),
+                0,
             )
             .await
             .unwrap_err();


### PR DESCRIPTION
## What

Fixes RAI-1241. Gates every CCTP burn `Dropped` verdict (and the wallet's `wait_for_receipt` drop verdict) on node freshness: an absence reported by a possibly-lagging load-balanced backend never concludes `Dropped`.

## Why

The drop-detection concluded `Dropped` from a single node's `eth_getTransactionByHash == None`, but on dRPC a lagging backend returns `None` for a tx it hasn't indexed yet — including one already mined. In the 2026-07-07 `5c6f3fdd` incident the burn had mined the whole time; the false verdict paged the operator and stalled the transfer ~26 minutes. A synced node never returns `None` for a mined tx, so absence from a possibly-lagging node is not evidence of a drop.

## How

- `CctpEndpoint::burn_status` now takes `submitted_after_block` (the pre-burn chain head the transfer already records for the log scan) and only counts an absence toward the drop threshold when the answering node's head is `SCAN_FINALITY_MARGIN` blocks past it — the same discipline `find_recent_burn` already applies. A lagging node resolves as `Pending` (retryable) after the grace window, never `Dropped`.
- `wait_for_receipt` has no submission block available through the wallet trait, so it anchors on the head observed at the first post-grace absence and requires `dropped_head_advance` (2 blocks) of advance before trusting the miss run — a frozen-head backend can never conclude `Dropped` and falls out via the retryable inclusion timeout.
- The `Bridge::burn_status` trait and `check_pending_burn` thread the recorded `from_block` through.

## Testing

- New: `burn_status_reports_pending_when_node_lags_submission_block` (the incident shape: both lookups `None`, head behind the pre-burn block → `Pending`).
- New: `wait_for_receipt_does_not_drop_when_node_head_is_frozen` and `wait_for_receipt_drops_when_head_advances_past_absent_tx`.
- Existing drop-path fixtures updated to advance the anvil head past the margin (a frozen fixture head now correctly reads as a lagging node).

## Anything else

Stacked under the RAI-1242 cross-check (`DepositForBurn` scan before paging), which closes the second half of the same incident.
