### PR TITLE
feat: hold pre-send redemption resumes while the asset is frozen

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -121,7 +121,7 @@ use crate::wrapped_equity_recovery::{
 };
 
 pub(crate) use builder::CqrsFrameworks;
-use manifest::QueryManifest;
+use manifest::{BuiltFrameworks, QueryManifest};
 use trading_queues::{EquityRecoveryInputs, TradingJobQueues, setup_trading_job_queues};
 
 /// CQRS/event-store and apalis worker pools over the same SQLite database.
@@ -1273,17 +1273,21 @@ impl PositionAndRebalancing {
     }
 }
 
-/// Wires the dividend freeze guard onto the rebalancing service when enabled.
+/// Wires the dividend freeze guard onto the rebalancing service before its
+/// CQRS frameworks are built, so catch-up cannot observe an unwired fail-open
+/// trigger. Returns the shared reader for the redemption-resume gate, which is
+/// wired after the transfer service's stores exist.
 ///
-/// When disabled, the trigger's `freeze_status` stays `None` and the equity gate
-/// fails open -- an operator escape hatch for an issuance outage that would
-/// otherwise fail closed every equity cycle. Issuance secrets remain mandatory
-/// either way, so re-enabling is a pure plaintext-config change.
-async fn wire_freeze_guard(
+/// When disabled, both `freeze_status` readers stay `None` and the gates fail
+/// open -- an operator escape hatch for an issuance outage that would
+/// otherwise fail closed every equity cycle and hold every redemption resume.
+/// Issuance secrets remain mandatory either way, so re-enabling is a pure
+/// plaintext-config change.
+async fn wire_rebalancing_freeze_guard(
     rebalancing_service: &RebalancingService,
     freeze_check: OperationMode,
     issuance: &IssuanceStatusCtx,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Option<Arc<IssuanceClient>>> {
     match freeze_check {
         OperationMode::Enabled => {
             let reader = Arc::new(IssuanceClient::new(
@@ -1291,18 +1295,20 @@ async fn wire_freeze_guard(
                 issuance.api_key.header_value(),
             )?);
 
-            rebalancing_service.set_freeze_status_reader(reader).await;
+            rebalancing_service
+                .set_freeze_status_reader(reader.clone())
+                .await;
+            Ok(Some(reader))
         }
         OperationMode::Disabled => {
             warn!(
                 target: "rebalance",
-                "Dividend freeze guard is disabled by config; equity rebalancing will \
-                 proceed without consulting issuance"
+                "Dividend freeze guard is disabled by config; equity rebalancing and \
+                 redemption resumes will proceed without consulting issuance"
             );
+            Ok(None)
         }
     }
-
-    Ok(())
 }
 
 /// Builds the rebalancing [`RaindexService`]: writes settle through the shared
@@ -1469,32 +1475,20 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             usdc_notifier.clone(),
         ));
 
-        wire_freeze_guard(
+        let freeze_status_reader = wire_rebalancing_freeze_guard(
             &rebalancing_service,
             rebalancing_ctx.freeze_check,
             &deps.ctx.issuance,
         )
         .await?;
 
-        let broadcaster = Arc::new(Broadcaster::new(deps.event_sender, deps.pool.clone()));
-        let hedge_latency = HedgeLatencyProjection::new(deps.pool.clone());
-        let rebalance_timing = RebalanceTimingProjection::new(deps.pool.clone());
-        let equity_timing = EquityTimingProjection::new(deps.pool.clone());
-        let lifecycle_failure = LifecycleFailureProjection::new(deps.pool.clone());
-        catch_up_stage_timing_projections(&rebalance_timing, &equity_timing).await?;
-
-        let manifest = QueryManifest::new(
+        let built = build_rebalancing_frameworks(
+            &deps.pool,
+            deps.event_sender,
             rebalancing_service.clone(),
-            broadcaster,
-            hedge_latency,
-            rebalance_timing,
-            equity_timing,
-            lifecycle_failure,
-        );
-
-        let built = manifest
-            .build(deps.pool.clone(), equity_transfer_services)
-            .await?;
+            equity_transfer_services,
+        )
+        .await?;
 
         rebalancing_service
             .recover_pending_offchain_order_symbols(&built.position_projection)
@@ -1517,6 +1511,10 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             built.mint.clone(),
             built.redemption.clone(),
         ));
+
+        if let Some(reader) = freeze_status_reader {
+            recovery_transfer.set_freeze_status_reader(reader).await;
+        }
 
         // Built outside `QueryManifest`: services depend on mint/redemption stores
         // that the manifest produces.
@@ -1638,6 +1636,34 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             resume_tokenization_queue,
         })
     })
+}
+
+/// Wires the rebalancing read models and builds the CQRS frameworks: catches
+/// the stage-timing projections up to the event log, then hands every query
+/// processor to [`QueryManifest`] so a new one cannot be forgotten.
+async fn build_rebalancing_frameworks(
+    pool: &SqlitePool,
+    event_sender: broadcast::Sender<Statement>,
+    rebalancing_service: Arc<RebalancingService>,
+    equity_transfer_services: EquityTransferServices,
+) -> anyhow::Result<BuiltFrameworks> {
+    let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
+    let hedge_latency = HedgeLatencyProjection::new(pool.clone());
+    let rebalance_timing = RebalanceTimingProjection::new(pool.clone());
+    let equity_timing = EquityTimingProjection::new(pool.clone());
+    let lifecycle_failure = LifecycleFailureProjection::new(pool.clone());
+    catch_up_stage_timing_projections(&rebalance_timing, &equity_timing).await?;
+
+    let manifest = QueryManifest::new(
+        rebalancing_service,
+        broadcaster,
+        hedge_latency,
+        rebalance_timing,
+        equity_timing,
+        lifecycle_failure,
+    );
+
+    manifest.build(pool.clone(), equity_transfer_services).await
 }
 
 /// Catches the lifecycle-failure read model up to the event log before its
@@ -3683,33 +3709,74 @@ mod tests {
         ))
     }
 
+    async fn freeze_guard_test_transfer() -> CrossVenueEquityTransfer {
+        let (pool, _apalis_pool) = setup_test_pools().await;
+        let raindex: Arc<dyn Raindex> = Arc::new(crate::onchain::mock::MockRaindex::new());
+        let wrapper: Arc<dyn st0x_wrapper::Wrapper> = Arc::new(MockWrapper::new());
+        let tokenizer: Arc<dyn st0x_tokenization::Tokenizer> =
+            Arc::new(st0x_tokenization::mock::MockTokenizer::new());
+        let vault_lookup = Arc::new(crate::vault_lookup::MockVaultLookup::new());
+
+        let services = crate::rebalancing::equity::EquityTransferServices {
+            raindex: raindex.clone(),
+            vault_lookup: vault_lookup.clone(),
+            tokenizer: tokenizer.clone(),
+            wrapper: wrapper.clone(),
+        };
+        let mint_store = Arc::new(test_store(pool.clone(), services.clone()));
+        let redemption_store = Arc::new(test_store(pool, services));
+
+        CrossVenueEquityTransfer::new(
+            raindex,
+            vault_lookup,
+            tokenizer,
+            wrapper,
+            Address::ZERO,
+            mint_store,
+            redemption_store,
+        )
+    }
+
     #[tokio::test]
-    async fn wire_freeze_guard_enabled_wires_the_reader() {
+    async fn wire_rebalancing_freeze_guard_enabled_returns_reader_for_resume_gate() {
         let service = freeze_guard_test_service().await;
+        let transfer = freeze_guard_test_transfer().await;
         let issuance = test_issuance_status_ctx(Url::parse("http://issuance.test:8000").unwrap());
 
-        wire_freeze_guard(&service, OperationMode::Enabled, &issuance)
+        let reader = wire_rebalancing_freeze_guard(&service, OperationMode::Enabled, &issuance)
             .await
-            .unwrap();
+            .unwrap()
+            .expect("enabled guard must return the shared reader");
 
         assert!(
             service.has_freeze_status_reader().await,
-            "Enabled must wire the issuance freeze-status reader onto the rebalancing service"
+            "Enabled must wire the reader before rebalancing frameworks are built"
+        );
+        transfer.set_freeze_status_reader(reader).await;
+        assert!(
+            transfer.has_freeze_status_reader().await,
+            "The returned reader must wire the later-built redemption resume gate"
         );
     }
 
     #[tokio::test]
-    async fn wire_freeze_guard_disabled_leaves_the_reader_unset() {
+    async fn wire_rebalancing_freeze_guard_disabled_returns_no_reader() {
         let service = freeze_guard_test_service().await;
+        let transfer = freeze_guard_test_transfer().await;
         let issuance = test_issuance_status_ctx(Url::parse("http://issuance.test:8000").unwrap());
 
-        wire_freeze_guard(&service, OperationMode::Disabled, &issuance)
+        let reader = wire_rebalancing_freeze_guard(&service, OperationMode::Disabled, &issuance)
             .await
             .unwrap();
 
+        assert!(reader.is_none());
         assert!(
             !service.has_freeze_status_reader().await,
-            "Disabled must leave the freeze guard unwired so the equity gate fails open"
+            "Disabled must leave the equity trigger gate unwired"
+        );
+        assert!(
+            !transfer.has_freeze_status_reader().await,
+            "No reader must be available to wire the redemption resume gate"
         );
     }
 

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -1061,6 +1061,49 @@ impl EquityRedemption {
         }
     }
 
+    /// Returns `true` before the durable `SendPending` intent commits the
+    /// redemption to sending tokens to the issuer's wallet. The freeze check
+    /// cannot be atomic with the external send, so `SendPending` is the stable
+    /// event-sourced boundary: retries from that state must complete even if a
+    /// freeze begins after the intent was recorded.
+    ///
+    /// Exhaustive `match` so a new variant forces re-classification.
+    pub(crate) fn is_pre_send(&self) -> bool {
+        match self {
+            Self::VaultWithdrawPending { .. }
+            | Self::VaultWithdrawSubmitted { .. }
+            | Self::WithdrawnFromRaindex { .. }
+            | Self::UnwrapPending { .. }
+            | Self::UnwrapSubmitted { .. }
+            | Self::TokensUnwrapped { .. } => true,
+            Self::SendPending { .. }
+            | Self::TokensSent { .. }
+            | Self::Pending { .. }
+            | Self::Completed { .. }
+            | Self::Failed { .. }
+            | Self::Reconciled { .. } => false,
+        }
+    }
+
+    /// The symbol this redemption operates on; every lifecycle state carries
+    /// it.
+    pub(crate) fn symbol(&self) -> &Symbol {
+        match self {
+            Self::VaultWithdrawPending { symbol, .. }
+            | Self::VaultWithdrawSubmitted { symbol, .. }
+            | Self::WithdrawnFromRaindex { symbol, .. }
+            | Self::UnwrapPending { symbol, .. }
+            | Self::UnwrapSubmitted { symbol, .. }
+            | Self::TokensUnwrapped { symbol, .. }
+            | Self::SendPending { symbol, .. }
+            | Self::TokensSent { symbol, .. }
+            | Self::Pending { symbol, .. }
+            | Self::Completed { symbol, .. }
+            | Self::Failed { symbol, .. }
+            | Self::Reconciled { symbol, .. } => symbol,
+        }
+    }
+
     pub(crate) fn to_dto(&self, id: &RedemptionAggregateId) -> TransferOperation {
         match self {
             Self::VaultWithdrawPending {

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -33,6 +33,7 @@ use async_trait::async_trait;
 use sqlx::SqlitePool;
 use std::sync::Arc;
 use thiserror::Error;
+use tokio::sync::RwLock;
 use tracing::{debug, error, info, instrument, warn};
 
 use st0x_event_sorcery::{SendError, Store};
@@ -50,6 +51,7 @@ use st0x_wrapper::{
 
 use super::RebalancingService;
 use super::trigger::RecoveryClaim;
+use super::trigger::freeze::FreezeStatusReader;
 use crate::equity_redemption::{
     DetectionFailure, EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId,
 };
@@ -578,6 +580,11 @@ pub(crate) struct CrossVenueEquityTransfer {
     wallet: Address,
     mint_store: Arc<Store<TokenizedEquityMint>>,
     redemption_store: Arc<Store<EquityRedemption>>,
+    /// Dividend freeze gate for redemption resumes, mirroring the trigger's
+    /// reader: `None` until the conductor wires the issuance client (or when
+    /// the guard is disabled by config, the documented fail-open escape
+    /// hatch for an issuance outage).
+    freeze_status: RwLock<Option<Arc<dyn FreezeStatusReader>>>,
 }
 
 impl CrossVenueEquityTransfer {
@@ -598,7 +605,22 @@ impl CrossVenueEquityTransfer {
             wallet,
             mint_store,
             redemption_store,
+            freeze_status: RwLock::new(None),
         }
+    }
+
+    /// Wires the dividend freeze reader used by [`Self::resume_redemption`]'s
+    /// pre-send guard. Called by the conductor alongside the rebalancing
+    /// trigger's reader when the freeze check is enabled.
+    pub(crate) async fn set_freeze_status_reader(&self, reader: Arc<dyn FreezeStatusReader>) {
+        *self.freeze_status.write().await = Some(reader);
+    }
+
+    /// Test-only introspection so conductor wiring tests can assert the guard
+    /// state without reaching into the private `freeze_status` field.
+    #[cfg(test)]
+    pub(crate) async fn has_freeze_status_reader(&self) -> bool {
+        self.freeze_status.read().await.is_some()
     }
 
     /// Loads the aggregate after Poll and extracts fields from the
@@ -1146,13 +1168,74 @@ impl CrossVenueEquityTransfer {
             })
     }
 
+    /// Returns whether the redemption must hold because its asset is frozen
+    /// for a dividend, failing closed when the status cannot be confirmed.
+    /// `None` reader means the guard is disabled by config (or unwired in
+    /// tests) and the resume proceeds.
+    async fn held_by_dividend_freeze(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        symbol: &Symbol,
+    ) -> bool {
+        let reader = self.freeze_status.read().await.clone();
+        let Some(reader) = reader else {
+            return false;
+        };
+
+        match reader.is_frozen(symbol).await {
+            Ok(false) => false,
+            Ok(true) => {
+                warn!(
+                    target: "rebalance",
+                    %aggregate_id,
+                    %symbol,
+                    "Holding pre-send redemption resume: asset is frozen for a \
+                     dividend; it will resume after unfreeze"
+                );
+                true
+            }
+            Err(error) => {
+                // Fail closed: sending tokens for a frozen asset strands them
+                // in issuance's redemption wallet until unfreeze, so when the
+                // freeze status cannot be confirmed the resume holds and the
+                // recovery machinery retries later.
+                error!(
+                    target: "rebalance",
+                    %aggregate_id,
+                    %symbol,
+                    ?error,
+                    "Holding pre-send redemption resume: could not confirm the \
+                     asset is not frozen; failing closed"
+                );
+                true
+            }
+        }
+    }
+
     #[allow(clippy::cognitive_complexity)]
     pub(crate) async fn resume_redemption(
         &self,
         aggregate_id: &RedemptionAggregateId,
     ) -> Result<(), RedemptionError> {
         loop {
-            match self.load_redemption_entity(aggregate_id).await? {
+            let entity = self.load_redemption_entity(aggregate_id).await?;
+
+            // States before the durable `SendPending` intent hold during a
+            // dividend freeze. The freeze check cannot be atomic with the
+            // external token send, so the persisted intent is the stable
+            // commitment boundary: from `SendPending` onward the redemption
+            // MUST complete even if a freeze begins after that intent. Holding
+            // returns Ok; inventory-poll recovery re-drives the aggregate and
+            // re-checks the freeze on each attempt.
+            if entity.is_pre_send()
+                && self
+                    .held_by_dividend_freeze(aggregate_id, entity.symbol())
+                    .await
+            {
+                return Ok(());
+            }
+
+            match entity {
                 EquityRedemption::VaultWithdrawPending { .. } => {
                     info!(%aggregate_id, "Resuming pending vault withdrawal");
                     self.redemption_store
@@ -1717,6 +1800,7 @@ mod tests {
         BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, Venue,
     };
     use crate::onchain::mock::{DepositBehavior, MockRaindex};
+    use crate::rebalancing::trigger::freeze::StubFreezeReader;
     use crate::rebalancing::{RebalancingSchedulers, RebalancingServiceConfig};
     use crate::tokenized_equity_mint::TokenizedEquityMintEvent;
     use crate::usdc_rebalance::UsdcRebalance;
@@ -2606,6 +2690,225 @@ mod tests {
         assert!(
             matches!(entity, EquityRedemption::Completed { .. }),
             "Expected completed redemption after resume, got: {entity:?}"
+        );
+    }
+
+    /// Drives a redemption to `TokensUnwrapped`, immediately before the durable
+    /// send intent, without touching the tokenizer.
+    async fn seed_tokens_unwrapped(
+        transfer: &CrossVenueEquityTransfer,
+        id: &RedemptionAggregateId,
+        symbol: &Symbol,
+    ) {
+        transfer
+            .redemption_store
+            .send(
+                id,
+                EquityRedemptionCommand::Redeem {
+                    symbol: symbol.clone(),
+                    quantity: float!(50),
+                    token: Address::ZERO,
+                    amount: U256::from(50_000_000_000_000_000_000_u128),
+                },
+            )
+            .await
+            .unwrap();
+        for command in [
+            EquityRedemptionCommand::SubmitWithdraw,
+            EquityRedemptionCommand::ConfirmWithdraw,
+            EquityRedemptionCommand::UnwrapTokens,
+            EquityRedemptionCommand::SubmitUnwrap,
+            EquityRedemptionCommand::ConfirmUnwrap,
+        ] {
+            transfer.redemption_store.send(id, command).await.unwrap();
+        }
+    }
+
+    async fn seed_send_pending(
+        transfer: &CrossVenueEquityTransfer,
+        id: &RedemptionAggregateId,
+        symbol: &Symbol,
+    ) {
+        seed_tokens_unwrapped(transfer, id, symbol).await;
+        transfer
+            .redemption_store
+            .send(id, EquityRedemptionCommand::PrepareSend)
+            .await
+            .unwrap();
+    }
+
+    /// A pre-send redemption holds during a dividend freeze: the resume
+    /// returns Ok without dispatching, the aggregate stays where it is, and
+    /// the issuer is never contacted. The inventory-poll recovery reactors
+    /// re-drive it later, re-checking the freeze each attempt.
+    #[tokio::test]
+    async fn resume_redemption_holds_pre_send_when_frozen() {
+        let tokenizer = Arc::new(MockTokenizer::new());
+        let transfer = create_equity_transfer(
+            tokenizer.clone(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+        transfer
+            .set_freeze_status_reader(Arc::new(StubFreezeReader::Frozen))
+            .await;
+
+        let id = redemption_aggregate_id("redeem-frozen-hold");
+        let symbol = Symbol::new("TEST").unwrap();
+        seed_tokens_unwrapped(&transfer, &id, &symbol).await;
+
+        let calls_before = tokenizer.call_count();
+        transfer.resume_redemption(&id).await.unwrap();
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::TokensUnwrapped { .. }),
+            "a frozen asset's pre-intent redemption must stay parked, got: {entity:?}"
+        );
+        assert_eq!(
+            tokenizer.call_count(),
+            calls_before,
+            "the issuer must not be contacted while the asset is frozen"
+        );
+    }
+
+    /// An unconfirmable freeze status fails closed exactly like a frozen one.
+    #[tokio::test]
+    async fn resume_redemption_holds_pre_send_when_freeze_indeterminate() {
+        let tokenizer = Arc::new(MockTokenizer::new());
+        let transfer = create_equity_transfer(
+            tokenizer.clone(),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+        transfer
+            .set_freeze_status_reader(Arc::new(StubFreezeReader::Indeterminate))
+            .await;
+
+        let id = redemption_aggregate_id("redeem-indeterminate-hold");
+        let symbol = Symbol::new("TEST").unwrap();
+        seed_tokens_unwrapped(&transfer, &id, &symbol).await;
+
+        transfer.resume_redemption(&id).await.unwrap();
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::TokensUnwrapped { .. }),
+            "an unconfirmable freeze status must fail closed, got: {entity:?}"
+        );
+        assert_eq!(tokenizer.call_count(), 0);
+    }
+
+    /// `SendPending` is the durable send intent. A freeze that begins after
+    /// this boundary must not strand or repeatedly reclassify the committed
+    /// operation.
+    #[tokio::test]
+    async fn resume_redemption_completes_send_intent_despite_freeze() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+            MockTokenizer::new()
+                .with_detection_outcome(MockDetectionOutcome::Detected)
+                .with_completion_outcome(MockCompletionOutcome::Completed),
+        );
+        let transfer = create_equity_transfer(
+            tokenizer,
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = redemption_aggregate_id("redeem-frozen-send-intent");
+        let symbol = Symbol::new("TEST").unwrap();
+        seed_send_pending(&transfer, &id, &symbol).await;
+        transfer
+            .set_freeze_status_reader(Arc::new(StubFreezeReader::Frozen))
+            .await;
+
+        transfer.resume_redemption(&id).await.unwrap();
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::Completed { .. }),
+            "a committed send intent must complete despite the freeze, got: {entity:?}"
+        );
+    }
+
+    /// From `TokensSent` onward the redemption has committed on-chain and
+    /// MUST complete even while the asset is frozen — blocking a committed
+    /// send strands funds worse than finishing it.
+    #[tokio::test]
+    async fn resume_redemption_completes_post_send_despite_freeze() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+            MockTokenizer::new()
+                .with_detection_outcome(MockDetectionOutcome::Detected)
+                .with_completion_outcome(MockCompletionOutcome::Completed),
+        );
+        let transfer = create_equity_transfer(
+            tokenizer,
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = redemption_aggregate_id("redeem-frozen-post-send");
+        let symbol = Symbol::new("TEST").unwrap();
+        seed_send_pending(&transfer, &id, &symbol).await;
+        transfer
+            .redemption_store
+            .send(&id, EquityRedemptionCommand::SendTokens)
+            .await
+            .unwrap();
+
+        transfer
+            .set_freeze_status_reader(Arc::new(StubFreezeReader::Frozen))
+            .await;
+
+        transfer.resume_redemption(&id).await.unwrap();
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::Completed { .. }),
+            "a post-send redemption must complete despite the freeze, got: {entity:?}"
+        );
+    }
+
+    /// A held redemption resumes to completion once the asset unfreezes.
+    #[tokio::test]
+    async fn resume_redemption_resumes_after_unfreeze() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+            MockTokenizer::new()
+                .with_detection_outcome(MockDetectionOutcome::Detected)
+                .with_completion_outcome(MockCompletionOutcome::Completed),
+        );
+        let transfer = create_equity_transfer(
+            tokenizer,
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+        transfer
+            .set_freeze_status_reader(Arc::new(StubFreezeReader::Frozen))
+            .await;
+
+        let id = redemption_aggregate_id("redeem-unfreeze-resume");
+        let symbol = Symbol::new("TEST").unwrap();
+        seed_tokens_unwrapped(&transfer, &id, &symbol).await;
+
+        transfer.resume_redemption(&id).await.unwrap();
+        let held = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(matches!(held, EquityRedemption::TokensUnwrapped { .. }));
+
+        transfer
+            .set_freeze_status_reader(Arc::new(StubFreezeReader::NotFrozen))
+            .await;
+
+        transfer.resume_redemption(&id).await.unwrap();
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::Completed { .. }),
+            "the held redemption must complete after unfreeze, got: {entity:?}"
         );
     }
 

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1,7 +1,7 @@
 //! Rebalancing trigger that reacts to inventory imbalances.
 
 mod equity;
-mod freeze;
+pub(crate) mod freeze;
 mod usdc;
 
 #[cfg(test)]


### PR DESCRIPTION
## What

[RAI-1139](https://linear.app/makeitrain/issue/RAI-1139)

Add the dividend freeze gate to automated redemption recovery and startup resume paths. Uncommitted redemptions hold while frozen or while status is unknown; `SendPending` and later states continue to completion.

## Why

The automatic rebalance trigger already respected the dividend freeze, but recovery jobs could bypass it and send a frozen asset to issuance’s redemption wallet. Conversely, stopping after durable send intent could strand a committed transfer. The gate therefore has to match the workflow’s commitment boundary rather than physical transfer completion.

## How

- Classify states before durable send intent as safe to hold.
- Treat `SendPending` as committed and allow it and all later states to continue.
- Fail closed when issuance freeze status cannot be confirmed.
- Reuse one `FreezeStatusReader` for trigger, recovery, and startup wiring.
- Install the reader before CQRS catch-up so replay cannot emit an ungated trigger.
- Leave held aggregates recoverable so later inventory polling can re-check status.

## Testing

Added coverage for:

- frozen and unknown-status holds before intent;
- disabled-guard behavior;
- `SendPending` continuation; and
- continuation through later send/completion states.

GitHub Actions static checks and backend build/test matrix pass.

## Screenshots

Not applicable.

## Anything else

This is liquidity-side defense in depth. Issuance remains the authoritative supply lock; liquidity avoids initiating an unsafe transfer while ensuring a durably committed send is not abandoned.
