### PR TITLE
refactor: unify USDC terminal classification with settlement outcome

### DIFF
--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -67,7 +67,7 @@ use crate::unwrapped_equity_recovery::{
 };
 use crate::usdc_rebalance::{
     AlpacaToBaseReservationRecovery, InterruptedUsdcRebalances, RebalanceDirection, UsdcRebalance,
-    UsdcRebalanceEvent, UsdcRebalanceId, interrupted_usdc_rebalance_ids,
+    UsdcRebalanceId, interrupted_usdc_rebalance_ids,
 };
 use crate::vault_registry::{VaultRegistry, VaultRegistryId};
 use crate::wrapped_equity_recovery::aggregate::WrappedEquityRecoveryId;
@@ -5195,27 +5195,6 @@ impl RebalancingService {
             | Detected { .. } => false,
         }
     }
-
-    fn is_terminal_usdc_rebalance_event(event: &UsdcRebalanceEvent) -> bool {
-        use UsdcRebalanceEvent::*;
-
-        matches!(
-            event,
-            WithdrawalFailed { .. }
-                | BridgingFailed { .. }
-                | DepositFailed { .. }
-                | ConversionFailed { .. }
-                | OperatorReconciled { .. }
-                | ConversionConfirmed {
-                    direction: RebalanceDirection::BaseToAlpaca,
-                    ..
-                }
-                | DepositConfirmed {
-                    direction: RebalanceDirection::AlpacaToBase,
-                    ..
-                }
-        )
-    }
 }
 
 /// Test fixture: drain every pending equity- and USDC-check row the service
@@ -5283,9 +5262,11 @@ mod tests {
     use crate::test_utils::rebalancing_enabled_equities;
     use crate::tokenized_equity_mint::TokenizedEquityMintCommand;
     use crate::usdc_rebalance::{
-        ConversionAmounts, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
+        ConversionAmounts, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceEvent,
+        UsdcRebalanceId,
     };
     use crate::vault_registry::VaultRegistryCommand;
+    use usdc::UsdcEventDisposition;
 
     #[test]
     fn mint_inventory_update_skips_cancel_for_pre_acceptance_fail() {
@@ -19141,82 +19122,105 @@ mod tests {
         drop(inventory);
     }
 
-    #[test]
-    fn usdc_failure_events_are_terminal() {
-        assert!(RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_withdrawal_failed()
-        ));
-        assert!(RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_bridging_failed()
-        ));
-        assert!(RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_deposit_failed()
-        ));
-        assert!(RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_conversion_failed()
-        ));
+    /// Terminal failure events always classify as terminal (clear or
+    /// preserve, never `NotTerminal`). The classification now comes from the
+    /// same exhaustive match that produces the settlement outcome, so these
+    /// pin the disposition rather than a separate terminality predicate.
+    /// Whether a given failure clears or preserves depends on post-burn
+    /// evidence (e.g. the fixture's `BridgingFailed` carries a burn hash and
+    /// so preserves), which the guard-lifecycle tests cover.
+    #[tokio::test]
+    async fn usdc_failure_events_classify_as_terminal() {
+        for event in [
+            make_usdc_withdrawal_failed(),
+            make_usdc_bridging_failed(),
+            make_usdc_deposit_failed(),
+            make_usdc_conversion_failed(),
+        ] {
+            let trigger = make_trigger().await;
+            let id = UsdcRebalanceId(Uuid::new_v4());
+            let disposition = trigger
+                .apply_usdc_rebalance_event(&id, &event)
+                .await
+                .unwrap();
+            assert!(
+                !matches!(disposition, UsdcEventDisposition::NotTerminal),
+                "a terminal failure must classify as terminal (clear or \
+                 preserve), got {disposition:?} for {event:?}"
+            );
+        }
     }
 
-    #[test]
-    fn non_terminal_usdc_events_are_not_terminal() {
-        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(1000))
-        ));
-        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_withdrawal_confirmed()
-        ));
-        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_bridging_initiated()
-        ));
-        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_bridged()
-        ));
-        // A recovered post-burn bridge re-enters the Bridged stage and must stay
-        // non-terminal so the guard holds until the terminal deposit leg.
-        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_bridging_completion_recovered()
-        ));
+    #[tokio::test]
+    async fn non_terminal_usdc_events_classify_as_not_terminal() {
+        // Funded inventory: `Initiated` deducts the rebalanced amount from
+        // the source venue's available balance as a tracking side effect.
+        let trigger =
+            make_trigger_with_inventory(InventoryView::default().with_usdc(usdc(5000), usdc(5000)))
+                .await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        // Applied in flow order so stage-tracking side effects see the
+        // tracking context a live flow would have. A recovered post-burn
+        // bridge re-enters the Bridged stage and must stay non-terminal so
+        // the guard holds until the terminal deposit leg.
+        for event in [
+            make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(1000)),
+            make_usdc_withdrawal_confirmed(),
+            make_usdc_bridging_initiated(),
+            make_usdc_bridged(),
+            make_usdc_bridging_completion_recovered(),
+            make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(1000), usdc(998)),
+            make_usdc_deposit_confirmed(RebalanceDirection::BaseToAlpaca),
+        ] {
+            let disposition = trigger
+                .apply_usdc_rebalance_event(&id, &event)
+                .await
+                .unwrap();
+            assert!(
+                matches!(disposition, UsdcEventDisposition::NotTerminal),
+                "a progress event must keep the claim held with no settlement \
+                 outcome, got {disposition:?} for {event:?}"
+            );
+        }
     }
 
-    #[test]
-    fn conversion_confirmed_is_terminal_for_base_to_alpaca() {
-        // For BaseToAlpaca, ConversionConfirmed IS the terminal event.
-        assert!(RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_conversion_confirmed(
-                RebalanceDirection::BaseToAlpaca,
-                usdc(1000),
-                usdc(998),
+    /// For BaseToAlpaca, ConversionConfirmed IS the terminal event; for
+    /// AlpacaToBase, DepositConfirmed is. Both clear the claim with a
+    /// settlement outcome; their direction-mirrored counterparts are covered
+    /// as non-terminal above.
+    #[tokio::test]
+    async fn direction_specific_terminal_events_classify_as_clear() {
+        let trigger = make_trigger().await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        let conversion = trigger
+            .apply_usdc_rebalance_event(
+                &id,
+                &make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(1000),
+                    usdc(998),
+                ),
             )
-        ));
-    }
+            .await
+            .unwrap();
+        assert!(
+            matches!(conversion, UsdcEventDisposition::Clear(_)),
+            "BaseToAlpaca ConversionConfirmed is the terminal event, got {conversion:?}"
+        );
 
-    #[test]
-    fn conversion_confirmed_is_not_terminal_for_alpaca_to_base() {
-        // For AlpacaToBase, ConversionConfirmed is NOT terminal (flow continues
-        // to withdrawal).
-        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_conversion_confirmed(
-                RebalanceDirection::AlpacaToBase,
-                usdc(1000),
-                usdc(998),
+        let deposit = trigger
+            .apply_usdc_rebalance_event(
+                &id,
+                &make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase),
             )
-        ));
-    }
-
-    #[test]
-    fn deposit_confirmed_is_terminal_for_alpaca_to_base() {
-        assert!(RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase)
-        ));
-    }
-
-    #[test]
-    fn deposit_confirmed_is_not_terminal_for_base_to_alpaca() {
-        // For BaseToAlpaca, DepositConfirmed is NOT terminal because
-        // post-deposit conversion (USDC->USD) is still required.
-        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_deposit_confirmed(RebalanceDirection::BaseToAlpaca)
-        ));
+            .await
+            .unwrap();
+        assert!(
+            matches!(deposit, UsdcEventDisposition::Clear(_)),
+            "AlpacaToBase DepositConfirmed is the terminal event, got {deposit:?}"
+        );
     }
 
     #[tokio::test]
@@ -19265,16 +19269,17 @@ mod tests {
     }
 
     /// Spy reactor that records all dispatched events for verification.
+    /// Classification happens after the flow via
+    /// `apply_usdc_rebalance_event`, which takes one event at a time — so the
+    /// dispositions asserted below are inherently derived without history.
     struct EventCapturingReactor {
         captured_events: Arc<tokio::sync::Mutex<Vec<UsdcRebalanceEvent>>>,
-        terminal_detection_results: Arc<tokio::sync::Mutex<Vec<bool>>>,
     }
 
     impl EventCapturingReactor {
         fn new() -> Self {
             Self {
                 captured_events: Arc::new(tokio::sync::Mutex::new(Vec::new())),
-                terminal_detection_results: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             }
         }
     }
@@ -19292,14 +19297,30 @@ mod tests {
             let (_id, event) = event.into_inner();
             self.captured_events.lock().await.push(event.clone());
 
-            let is_terminal = RebalancingService::is_terminal_usdc_rebalance_event(&event);
-            self.terminal_detection_results
-                .lock()
-                .await
-                .push(is_terminal);
-
             Ok(())
         }
+    }
+
+    /// Classifies the last event the spy captured through a fresh trigger's
+    /// disposition method. The events these flow tests drive classify
+    /// state-independently, so a fresh trigger gives the same answer the
+    /// live reactor would.
+    async fn last_event_disposition(
+        spy: &EventCapturingReactor,
+        id: &UsdcRebalanceId,
+    ) -> UsdcEventDisposition {
+        let last_event = spy
+            .captured_events
+            .lock()
+            .await
+            .last()
+            .cloned()
+            .expect("flow dispatched events");
+        make_trigger()
+            .await
+            .apply_usdc_rebalance_event(id, &last_event)
+            .await
+            .unwrap()
     }
 
     #[tokio::test]
@@ -19385,14 +19406,11 @@ mod tests {
 
         // For BaseToAlpaca, DepositConfirmed is NOT terminal because post-deposit
         // conversion (USDC->USD) is still required
+        let disposition = last_event_disposition(&spy, &id).await;
         assert!(
-            !spy.terminal_detection_results
-                .lock()
-                .await
-                .last()
-                .copied()
-                .unwrap(),
-            "DepositConfirmed(BaseToAlpaca) should NOT be terminal - needs conversion"
+            matches!(disposition, UsdcEventDisposition::NotTerminal),
+            "DepositConfirmed(BaseToAlpaca) should NOT be terminal - needs \
+             conversion; got {disposition:?}"
         );
     }
 
@@ -19476,14 +19494,11 @@ mod tests {
             .await
             .unwrap();
 
+        let disposition = last_event_disposition(&spy, &id).await;
         assert!(
-            spy.terminal_detection_results
-                .lock()
-                .await
-                .last()
-                .copied()
-                .unwrap(),
-            "has_terminal_usdc_rebalance_event must identify DepositConfirmed alone as terminal"
+            matches!(disposition, UsdcEventDisposition::Clear(_)),
+            "DepositConfirmed(AlpacaToBase) alone must classify as a clearing \
+             terminal; got {disposition:?}"
         );
     }
 
@@ -19517,14 +19532,10 @@ mod tests {
             .await
             .unwrap();
 
+        let disposition = last_event_disposition(&spy, &id).await;
         assert!(
-            spy.terminal_detection_results
-                .lock()
-                .await
-                .last()
-                .copied()
-                .unwrap(),
-            "WithdrawalFailed should be terminal"
+            matches!(disposition, UsdcEventDisposition::Clear(_)),
+            "WithdrawalFailed should classify as a clearing terminal; got {disposition:?}"
         );
     }
 
@@ -19578,14 +19589,13 @@ mod tests {
             .await
             .unwrap();
 
+        // A post-burn BridgingFailed preserves the guard rather than clearing
+        // it; either way it must classify as terminal (never NotTerminal).
+        let disposition = last_event_disposition(&spy, &id).await;
         assert!(
-            spy.terminal_detection_results
-                .lock()
-                .await
-                .last()
-                .copied()
-                .unwrap(),
-            "has_terminal_usdc_rebalance_event must identify BridgingFailed alone as terminal"
+            !matches!(disposition, UsdcEventDisposition::NotTerminal),
+            "BridgingFailed alone must classify as terminal (clear or \
+             preserve); got {disposition:?}"
         );
     }
 
@@ -19618,14 +19628,10 @@ mod tests {
             .await
             .unwrap();
 
+        let disposition = last_event_disposition(&spy, &id).await;
         assert!(
-            spy.terminal_detection_results
-                .lock()
-                .await
-                .last()
-                .copied()
-                .unwrap(),
-            "has_terminal_usdc_rebalance_event must identify ConversionFailed alone as terminal"
+            !matches!(disposition, UsdcEventDisposition::NotTerminal),
+            "ConversionFailed alone must classify as terminal; got {disposition:?}"
         );
     }
 
@@ -19800,20 +19806,34 @@ mod tests {
             .await
             .unwrap();
 
-        // Our terminal detection receives only the latest event(s) per dispatch
-        let terminal_results = spy.terminal_detection_results.lock().await;
-        let deposit_confirmed_idx = 6;
-        assert!(
-            !terminal_results[deposit_confirmed_idx],
-            "DepositConfirmed(BaseToAlpaca) should NOT be terminal - needs conversion"
-        );
+        // Classification receives only one event at a time, so mid-flow
+        // events must classify on their own.
+        {
+            let (deposit_confirmed, conversion_initiated) = {
+                let captured = spy.captured_events.lock().await;
+                (captured[6].clone(), captured[7].clone())
+            };
+            let classifier = make_trigger().await;
 
-        let conversion_initiated_idx = 7;
-        assert!(
-            !terminal_results[conversion_initiated_idx],
-            "has_terminal_usdc_rebalance_event must NOT identify ConversionInitiated as terminal"
-        );
-        drop(terminal_results);
+            let disposition = classifier
+                .apply_usdc_rebalance_event(&id, &deposit_confirmed)
+                .await
+                .unwrap();
+            assert!(
+                matches!(disposition, UsdcEventDisposition::NotTerminal),
+                "DepositConfirmed(BaseToAlpaca) should NOT be terminal - needs \
+                 conversion; got {disposition:?}"
+            );
+
+            let disposition = classifier
+                .apply_usdc_rebalance_event(&id, &conversion_initiated)
+                .await
+                .unwrap();
+            assert!(
+                matches!(disposition, UsdcEventDisposition::NotTerminal),
+                "ConversionInitiated must NOT classify as terminal; got {disposition:?}"
+            );
+        }
 
         store
             .send(
@@ -19828,14 +19848,11 @@ mod tests {
             .await
             .unwrap();
 
+        let disposition = last_event_disposition(&spy, &id).await;
         assert!(
-            spy.terminal_detection_results
-                .lock()
-                .await
-                .last()
-                .copied()
-                .unwrap(),
-            "has_terminal_usdc_rebalance_event must identify ConversionConfirmed alone as terminal"
+            matches!(disposition, UsdcEventDisposition::Clear(_)),
+            "ConversionConfirmed(BaseToAlpaca) alone must classify as a \
+             clearing terminal; got {disposition:?}"
         );
     }
 

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -136,11 +136,26 @@ impl UsdcRebalanceTracking {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum UsdcTerminalAction {
+/// Single classification of a USDC rebalance event, driving everything the
+/// reactor does with it: whether the in-progress claim clears or must be
+/// preserved, and — only when it clears — whether the in-memory ledger was
+/// reconciled or must wait for the next snapshot poll. The settlement
+/// outcome exists only inside `Clear`, so consuming it for a non-terminal or
+/// preserved event is unrepresentable and non-terminal arms carry no
+/// placeholder value; the clear/preserve decision and the outcome come from
+/// the same classification, so the two can never drift.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum UsdcEventDisposition {
+    /// A progress or transient-marker event: the in-progress claim stays
+    /// held; there is no settlement to report.
     NotTerminal,
-    Clear,
+    /// Terminal post-burn failure: the burned funds left the source venue and
+    /// cannot be reconciled back, so the in-progress guard must outlive the
+    /// event (and restarts).
     PreservePostBurn,
+    /// Terminal event that releases the in-progress claim; the payload says
+    /// whether the ledger reconciled or the next snapshot poll must heal it.
+    Clear(UsdcSettlementOutcome),
 }
 
 /// Whether a terminal USDC settlement event reconciled the in-memory
@@ -594,45 +609,47 @@ impl RebalancingService {
             return Ok(());
         }
 
-        let terminal_action = self.usdc_terminal_action(&id, &event).await;
-        let settlement_outcome = self
-            .apply_usdc_rebalance_event(&id, &event, terminal_action)
-            .await?;
+        let disposition = self.apply_usdc_rebalance_event(&id, &event).await?;
 
-        let is_clearable_terminal = terminal_action == UsdcTerminalAction::Clear;
         {
             let mut inventory = self.inventory.write().await;
-            *inventory = if is_clearable_terminal {
-                inventory.clone().clear_active_usdc_rebalance()
-            } else {
-                inventory.clone().set_active_usdc_rebalance(id.clone())
+            *inventory = match disposition {
+                UsdcEventDisposition::Clear(_) => inventory.clone().clear_active_usdc_rebalance(),
+                UsdcEventDisposition::NotTerminal | UsdcEventDisposition::PreservePostBurn => {
+                    inventory.clone().set_active_usdc_rebalance(id.clone())
+                }
             };
         }
-        if is_clearable_terminal {
-            self.usdc_tracking.write().await.remove(&id);
-            let mut resume_gate = self.alpaca_to_base_resume_gate.write().await;
-            if resume_gate.as_ref().is_some_and(|gate| gate.id() == &id) {
-                *resume_gate = None;
+        match disposition {
+            UsdcEventDisposition::Clear(_) => {
+                self.usdc_tracking.write().await.remove(&id);
+                let mut resume_gate = self.alpaca_to_base_resume_gate.write().await;
+                if resume_gate.as_ref().is_some_and(|gate| gate.id() == &id) {
+                    *resume_gate = None;
+                }
+                drop(resume_gate);
+                self.clear_usdc_in_progress();
+                debug!(target: "rebalance", "Cleared USDC in-progress flag after rebalance terminal event");
             }
-            drop(resume_gate);
-            self.clear_usdc_in_progress();
-            debug!(target: "rebalance", "Cleared USDC in-progress flag after rebalance terminal event");
-        } else if terminal_action == UsdcTerminalAction::PreservePostBurn {
-            self.usdc_in_progress.store(true, Ordering::SeqCst);
-            warn!(
-                target: "rebalance",
-                id = %id,
-                ?event,
-                "Preserving USDC in-progress guard after post-burn terminal failure"
-            );
+            UsdcEventDisposition::PreservePostBurn => {
+                self.usdc_in_progress.store(true, Ordering::SeqCst);
+                warn!(
+                    target: "rebalance",
+                    id = %id,
+                    ?event,
+                    "Preserving USDC in-progress guard after post-burn terminal failure"
+                );
+            }
+            UsdcEventDisposition::NotTerminal => {}
         }
 
         drop(event_sync_guard);
 
         // A terminal USDC transfer cleared the in-progress claim, so we
         // cancel any pre-rebalance checks and push a fresh one against
-        // the post-rebalance inventory.
-        if is_clearable_terminal {
+        // the post-rebalance inventory. The settlement outcome only exists
+        // inside `Clear`, so this is the one place it can be consumed.
+        if let UsdcEventDisposition::Clear(settlement_outcome) = disposition {
             self.equity_scheduler.cancel_pending().await;
             self.usdc_scheduler.cancel_pending().await;
             match settlement_outcome {
@@ -657,22 +674,6 @@ impl RebalancingService {
         }
 
         Ok(())
-    }
-
-    async fn usdc_terminal_action(
-        &self,
-        id: &UsdcRebalanceId,
-        event: &UsdcRebalanceEvent,
-    ) -> UsdcTerminalAction {
-        if !Self::is_terminal_usdc_rebalance_event(event) {
-            return UsdcTerminalAction::NotTerminal;
-        }
-
-        if self.post_burn_failure(id, event).await {
-            UsdcTerminalAction::PreservePostBurn
-        } else {
-            UsdcTerminalAction::Clear
-        }
     }
 
     /// Whether a terminal failure event happened after the CCTP burn, so its
@@ -733,28 +734,33 @@ impl RebalancingService {
         }
     }
 
-    async fn apply_usdc_rebalance_event(
+    /// Applies one USDC rebalance event's tracking/ledger side effects and
+    /// classifies it into the single [`UsdcEventDisposition`] the caller acts
+    /// on. Terminality, the post-burn preserve decision, and the settlement
+    /// outcome all come from this one exhaustive match, so a new event
+    /// variant cannot compile without declaring its disposition — and a
+    /// non-terminal arm has no settlement outcome to get wrong.
+    pub(super) async fn apply_usdc_rebalance_event(
         &self,
         id: &UsdcRebalanceId,
         event: &UsdcRebalanceEvent,
-        terminal_action: UsdcTerminalAction,
-    ) -> Result<UsdcSettlementOutcome, RebalancingServiceError> {
+    ) -> Result<UsdcEventDisposition, RebalancingServiceError> {
         use UsdcRebalanceEvent::*;
 
-        let outcome = match event {
+        let disposition = match event {
             ConversionInitiated {
                 direction, amount, ..
             } => {
                 self.upsert_conversion_tracking(id, direction, *amount, event)
                     .await;
-                UsdcSettlementOutcome::Reconciled
+                UsdcEventDisposition::NotTerminal
             }
             Initiated {
                 direction, amount, ..
             } => {
                 self.track_initiated_usdc_rebalance(id, direction, *amount, event)
                     .await?;
-                UsdcSettlementOutcome::Reconciled
+                UsdcEventDisposition::NotTerminal
             }
             WithdrawalConfirmed { .. }
             | BridgingInitiated { .. }
@@ -769,7 +775,7 @@ impl RebalancingService {
                 ..
             } => {
                 self.track_usdc_stage_progress(id, event).await;
-                UsdcSettlementOutcome::Reconciled
+                UsdcEventDisposition::NotTerminal
             }
             Bridged {
                 amount_received, ..
@@ -785,24 +791,24 @@ impl RebalancingService {
                 // deposit, exactly like the normal bridge path.
                 self.track_bridged_amount(id, *amount_received).await?;
                 self.track_usdc_stage_progress(id, event).await;
-                UsdcSettlementOutcome::Reconciled
+                UsdcEventDisposition::NotTerminal
             }
             ConversionConfirmed {
                 direction: RebalanceDirection::BaseToAlpaca,
                 conversion,
                 ..
-            } => {
+            } => UsdcEventDisposition::Clear(
                 self.complete_usdc_rebalance(
                     id,
                     UsdcTrackingEvent::ConversionConfirmed,
                     conversion.received_amount,
                 )
-                .await?
-            }
+                .await?,
+            ),
             DepositConfirmed {
                 direction: RebalanceDirection::AlpacaToBase,
                 ..
-            } => self.complete_alpaca_to_base_deposit(id).await?,
+            } => UsdcEventDisposition::Clear(self.complete_alpaca_to_base_deposit(id).await?),
             // Transient intent markers persisted before the on-chain withdraw /
             // burn. Detailed stage tracking starts at the subsequent Initiated /
             // BridgingInitiated; the inventory's active-rebalance claim is set by
@@ -815,24 +821,23 @@ impl RebalancingService {
             | BridgingSubmitting { .. }
             | PendingBurnRecorded { .. }
             | PendingBurnCleared { .. }
-            | AttestationTimedOut { .. } => UsdcSettlementOutcome::Reconciled,
+            | AttestationTimedOut { .. } => UsdcEventDisposition::NotTerminal,
             // Withdrawal failure is always pre-burn -> reconcile to source.
-            WithdrawalFailed { .. } => self.cancel_tracked_usdc_rebalance(id).await?,
+            WithdrawalFailed { .. } => {
+                UsdcEventDisposition::Clear(self.cancel_tracked_usdc_rebalance(id).await?)
+            }
             // These failures may be pre- or post-burn (BridgingFailed by burn
             // stage; ConversionFailed by direction -- BaseToAlpaca's conversion
-            // is post-deposit; DepositFailed is always post-mint). The classifier
-            // decides: preserve post-burn, otherwise reconcile to source.
+            // is post-deposit; DepositFailed is always post-mint). Post-burn,
+            // preservation is achieved by NOT cancelling: the tracking entry,
+            // guard, and active id are all kept by the caller, and there is no
+            // settlement outcome to report. Pre-burn, reconcile to source.
             BridgingFailed { .. } | DepositFailed { .. } | ConversionFailed { .. } => {
-                if terminal_action == UsdcTerminalAction::PreservePostBurn {
-                    // Preservation is achieved by NOT cancelling: the tracking
-                    // entry, guard, and active id are all kept by the caller. This
-                    // call only surfaces a diagnostic if tracking is absent. The
-                    // guard stays held (not clearable), so the outcome value is
-                    // unused by the caller's enqueue gate.
+                if self.post_burn_failure(id, event).await {
                     self.warn_if_post_burn_tracking_missing(id).await;
-                    UsdcSettlementOutcome::Reconciled
+                    UsdcEventDisposition::PreservePostBurn
                 } else {
-                    self.cancel_tracked_usdc_rebalance(id).await?
+                    UsdcEventDisposition::Clear(self.cancel_tracked_usdc_rebalance(id).await?)
                 }
             }
             // Operator reconciliation of a post-burn `DepositFailed`: the minted
@@ -840,8 +845,8 @@ impl RebalancingService {
             // semantics -- zero the source-venue inflight WITHOUT crediting
             // available -- never a `Cancel` (which would wrongly credit
             // available). Derives the source venue from `direction`, so it works
-            // with tracking absent (post-restart). The caller's Clear terminal
-            // action removes tracking and clears the guard. `reconcile_operator_resolved`
+            // with tracking absent (post-restart). The `Clear` disposition
+            // removes tracking and clears the guard. `reconcile_operator_resolved`
             // zeroes source inflight WITHOUT crediting destination `available`
             // (by design, see its doc comment), so the ledger is only half
             // updated here: defer the immediate imbalance check to the next
@@ -849,11 +854,11 @@ impl RebalancingService {
             OperatorReconciled { direction, .. } => {
                 self.reconcile_operator_resolved(direction, Utc::now())
                     .await?;
-                UsdcSettlementOutcome::DeferredToSnapshot
+                UsdcEventDisposition::Clear(UsdcSettlementOutcome::DeferredToSnapshot)
             }
         };
 
-        Ok(outcome)
+        Ok(disposition)
     }
 
     /// Reconciles source-venue USDC inflight for an operator-reconciled,


### PR DESCRIPTION
## What

Fixes RAI-1331. USDC rebalance terminal detection and settlement-outcome derivation are unified into a single exhaustive match. `is_terminal_usdc_rebalance_event` (a `matches!` with a `_ => false` arm) and the separate `UsdcTerminalAction` two-step are gone; `apply_usdc_rebalance_event` alone classifies every event into a new `UsdcEventDisposition`.

## Why

Terminal detection and outcome derivation lived in two places that had to agree by convention: the `matches!`-based predicate decided *whether* a flow ended, and a separate match decided *what* to do about it. A new `UsdcRebalanceEvent` variant compiled clean through the `_ => false` arm and silently classified as non-terminal, leaking the trigger guard forever. The compiler must force new variants to be classified.

## How

- `UsdcEventDisposition { NotTerminal, PreservePostBurn, Clear(UsdcSettlementOutcome) }` is the single classification result; the exhaustive match in `apply_usdc_rebalance_event` produces it, so adding an event variant is a compile error until it's classified.
- The post-burn-evidence check (`post_burn_failure`) moves inside the classification, next to the failure arms it governs, instead of being a second call the caller had to remember.
- `on_usdc_rebalance` just matches on the disposition: preserve the guard, or clear it with the derived settlement outcome.

## Testing

- Table tests pin every event variant's disposition (`usdc_failure_events_classify_as_terminal`, `non_terminal_usdc_events_classify_as_not_terminal`, `direction_specific_terminal_events_classify_as_clear`).
- Existing guard-lifecycle flow tests converted to assert dispositions from real store-driven event sequences, including mid-flow events classifying alone and post-burn failures preserving the guard.

## Screenshots (if applicable)

N/A

## Anything else?

No behavior change intended; this is a compile-time-safety refactor of the classification path.
