### PR TITLE
refactor: replace raw i64 cents fields with typed Usdc in inventory

### DIFF
--- a/crates/finance/src/lib.rs
+++ b/crates/finance/src/lib.rs
@@ -20,7 +20,9 @@ pub use id::{BlankIdError, Id};
 pub use shares::{FractionalShares, SharesConversionError};
 pub use symbol::{EmptySymbolError, Symbol};
 pub use usd::{Usd, UsdToCentsError};
-pub use usdc::{Usdc, UsdcConversionError};
+pub use usdc::{
+    Usdc, UsdcConversionError, UsdcToCentsError, cents as usdc_cents, opt_cents as usdc_opt_cents,
+};
 
 /// Trait for types that have a zero value and can be compared to it.
 ///

--- a/crates/finance/src/usdc.rs
+++ b/crates/finance/src/usdc.rs
@@ -15,6 +15,17 @@ use crate::HasZero;
 #[derive(Clone, Copy)]
 pub struct Usdc(Float);
 
+/// Error returned by [`Usdc::to_cents`].
+#[derive(Debug, thiserror::Error)]
+pub enum UsdcToCentsError {
+    #[error("USDC value {0} has sub-cent precision; whole cents required")]
+    SubCentPrecision(Usdc),
+    #[error("USDC value {0} out of range for whole-cent representation")]
+    Overflow(Usdc),
+    #[error(transparent)]
+    Float(#[from] FloatError),
+}
+
 impl std::fmt::Debug for Usdc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Usdc({})", format_float_with_fallback(&self.0))
@@ -36,6 +47,27 @@ impl Usdc {
         let cents_float = Float::parse(cents.to_string()).ok()?;
         let hundred = Float::parse("100".to_string()).ok()?;
         (cents_float / hundred).ok().map(Self)
+    }
+
+    /// Converts to cents exactly.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsdcToCentsError`] if the value has sub-cent precision or
+    /// overflows `i64`.
+    pub fn to_cents(self) -> Result<i64, UsdcToCentsError> {
+        let scaled = (self.0 * float_result!(100)?)?;
+        let frac = scaled.frac()?;
+
+        if !frac.is_zero()? {
+            return Err(UsdcToCentsError::SubCentPrecision(self));
+        }
+
+        let formatted = scaled.format_with_scientific(false)?;
+        let integer_str = formatted.split('.').next().unwrap_or(&formatted);
+        integer_str
+            .parse::<i64>()
+            .map_err(|_| UsdcToCentsError::Overflow(self))
     }
 
     /// Fallible equality comparison.
@@ -165,7 +197,67 @@ mod alloy_support {
 }
 
 pub use alloy_support::UsdcConversionError;
-use st0x_float_macro::float;
+use st0x_float_macro::{float, float_result};
+
+/// Serde adapter persisting a [`Usdc`] as an `i64` cents integer on the wire.
+///
+/// Use with `#[serde(with = "st0x_finance::usdc_cents")]` on fields whose
+/// persisted representation predates the `Usdc` newtype and must remain
+/// integer cents for compatibility.
+pub mod cents {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use super::Usdc;
+
+    pub fn serialize<S>(usdc: &Usdc, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let cents = usdc.to_cents().map_err(serde::ser::Error::custom)?;
+        cents.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Usdc, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let cents = i64::deserialize(deserializer)?;
+        Usdc::from_cents(cents).ok_or_else(|| {
+            serde::de::Error::custom(format!("failed to convert {cents} cents to Usdc"))
+        })
+    }
+}
+
+/// Serde adapter persisting an [`Option<Usdc>`] as an optional `i64` cents
+/// integer on the wire. The `Option` counterpart of [`cents`].
+pub mod opt_cents {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use super::Usdc;
+
+    pub fn serialize<S>(usdc: &Option<Usdc>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        usdc.map(Usdc::to_cents)
+            .transpose()
+            .map_err(serde::ser::Error::custom)?
+            .serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Usdc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<i64>::deserialize(deserializer)?
+            .map(|cents| {
+                Usdc::from_cents(cents).ok_or_else(|| {
+                    serde::de::Error::custom(format!("failed to convert {cents} cents to Usdc"))
+                })
+            })
+            .transpose()
+    }
+}
 
 impl std::ops::Mul<Float> for Usdc {
     type Output = Result<Self, FloatError>;
@@ -250,6 +342,72 @@ mod tests {
         let json = serde_json::to_string(&usdc).unwrap();
         let roundtripped: Usdc = serde_json::from_str(&json).unwrap();
         assert_eq!(usdc, roundtripped);
+    }
+
+    #[test]
+    fn to_cents_converts_whole_dollars() {
+        let usdc = Usdc::new(float!(500));
+        assert_eq!(usdc.to_cents().unwrap(), 50_000);
+    }
+
+    #[test]
+    fn to_cents_converts_dollars_and_cents() {
+        let usdc = Usdc::new(float!(123.45));
+        assert_eq!(usdc.to_cents().unwrap(), 12_345);
+    }
+
+    #[test]
+    fn to_cents_converts_negative() {
+        let usdc = Usdc::from_cents(-500).unwrap();
+        assert_eq!(usdc.to_cents().unwrap(), -500);
+    }
+
+    #[test]
+    fn to_cents_rejects_sub_cent_precision() {
+        let usdc = Usdc::new(float!(1.005));
+        assert!(matches!(
+            usdc.to_cents(),
+            Err(UsdcToCentsError::SubCentPrecision(_))
+        ));
+    }
+
+    #[test]
+    fn cents_serde_writes_integer_cents() {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Wire {
+            #[serde(with = "super::cents")]
+            amount: Usdc,
+        }
+
+        let json = serde_json::to_value(Wire {
+            amount: Usdc::from_cents(12_345).unwrap(),
+        })
+        .unwrap();
+        assert_eq!(json, serde_json::json!({ "amount": 12345 }));
+
+        let parsed: Wire = serde_json::from_value(serde_json::json!({ "amount": 12345 })).unwrap();
+        assert_eq!(parsed.amount, Usdc::new(float!(123.45)));
+    }
+
+    #[test]
+    fn opt_cents_serde_writes_optional_integer_cents() {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Wire {
+            #[serde(with = "super::opt_cents")]
+            amount: Option<Usdc>,
+        }
+
+        let json = serde_json::to_value(Wire {
+            amount: Some(Usdc::from_cents(500).unwrap()),
+        })
+        .unwrap();
+        assert_eq!(json, serde_json::json!({ "amount": 500 }));
+
+        let json = serde_json::to_value(Wire { amount: None }).unwrap();
+        assert_eq!(json, serde_json::json!({ "amount": null }));
+
+        let parsed: Wire = serde_json::from_value(serde_json::json!({ "amount": null })).unwrap();
+        assert_eq!(parsed.amount, None);
     }
 
     #[test]

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -129,8 +129,6 @@ pub(crate) enum ReserveError {
     CentsConversion(#[from] UsdToCentsError),
     #[error("failed to convert broker cents {cents} to Usd")]
     BrokerCentsConversion { cents: i64 },
-    #[error("failed to convert available broker cents {cents} to Usdc")]
-    AvailableUsdcConversion { cents: i64 },
 }
 
 pub(crate) struct WalletPollingCtx {
@@ -706,28 +704,37 @@ where
 
         let positions = self.normalize_offchain_positions(inventory.positions);
 
-        let (gross_usd_cents, available_usd_cents) =
+        let (gross_usd, available_usd) =
             compute_available_cash(inventory.usd_balance_cents, self.reserved_cash)?;
+
+        let cash_buying_power = inventory
+            .cash_buying_power_cents
+            .map(|cents| {
+                Usdc::from_cents(cents).ok_or(ReserveError::BrokerCentsConversion { cents })
+            })
+            .transpose()?;
+
+        let cash_withdrawable = inventory
+            .cash_withdrawable_cents
+            .map(|cents| {
+                Usdc::from_cents(cents).ok_or(ReserveError::BrokerCentsConversion { cents })
+            })
+            .transpose()?;
 
         self.persist_snapshot_command(InventorySnapshotCommand::RecordOffchainObservation {
             positions,
-            usd_balance_cents: available_usd_cents,
-            gross_usd_cents,
-            cash_buying_power_cents: inventory.cash_buying_power_cents,
-            cash_withdrawable_cents: inventory.cash_withdrawable_cents,
+            usd_balance: available_usd,
+            gross_usd,
+            cash_buying_power,
+            cash_withdrawable,
             alpaca_usdc: inventory.alpaca_usdc,
             observed_at,
         })
         .await?;
 
         if let Some(observer) = &self.fresh_offchain_usd_observer {
-            let available = Usdc::from_cents(available_usd_cents).ok_or(
-                ReserveError::AvailableUsdcConversion {
-                    cents: available_usd_cents,
-                },
-            )?;
             observer
-                .observe_fresh_offchain_usd(available, Utc::now())
+                .observe_fresh_offchain_usd(available_usd, Utc::now())
                 .await
                 .map_err(InventoryPollingError::FreshOffchainUsdObserver)?;
         }
@@ -1056,11 +1063,11 @@ where
     }
 }
 
-/// Computes gross and reserve-adjusted available cash in cents.
+/// Computes gross and reserve-adjusted available cash.
 ///
-/// Returns `(gross_usd_cents, available_usd_cents)`. `gross_usd_cents` is
-/// `None` when `reserved_cash` is zero (no reserve configured), so the
-/// dashboard can hide reserve-specific context for no-reserve deployments.
+/// Returns `(gross_usd, available_usd)`. `gross_usd` is `None` when
+/// `reserved_cash` is zero (no reserve configured), so the dashboard can hide
+/// reserve-specific context for no-reserve deployments.
 ///
 /// When the broker balance is below the configured reserve, available cash is
 /// explicitly zero. This is a valid capacity state: all Alpaca cash is protected
@@ -1068,7 +1075,7 @@ where
 fn compute_available_cash(
     broker_usd_balance_cents: i64,
     reserved_cash: Usd,
-) -> Result<(Option<i64>, i64), ReserveError> {
+) -> Result<(Option<Usdc>, Usdc), ReserveError> {
     let gross =
         Usd::from_cents(broker_usd_balance_cents).ok_or(ReserveError::BrokerCentsConversion {
             cents: broker_usd_balance_cents,
@@ -1086,14 +1093,13 @@ fn compute_available_cash(
         (gross - reserved_cash)?
     };
 
-    let gross_usd_cents = if reserved_cash > Usd::ZERO {
-        Some(gross.to_cents()?)
+    let gross_usd = if reserved_cash > Usd::ZERO {
+        Some(Usdc::new(gross.inner()))
     } else {
         None
     };
-    let available_usd_cents = available.to_cents()?;
 
-    Ok((gross_usd_cents, available_usd_cents))
+    Ok((gross_usd, Usdc::new(available.inner())))
 }
 
 /// Erases the `Chain` and `Exe` parameters of [`InventoryPollingService`]
@@ -1614,14 +1620,12 @@ mod tests {
             .find(|event| matches!(event, InventorySnapshotEvent::OffchainUsd { .. }))
             .expect("Expected OffchainUsd event to be emitted");
 
-        let InventorySnapshotEvent::OffchainUsd {
-            usd_balance_cents, ..
-        } = offchain_usd_event
-        else {
+        let InventorySnapshotEvent::OffchainUsd { usd_balance, .. } = offchain_usd_event else {
             panic!("Expected OffchainUsd event, got {offchain_usd_event:?}");
         };
         assert_eq!(
-            *usd_balance_cents, 25_000_000,
+            *usd_balance,
+            Usdc::from_cents(25_000_000).unwrap(),
             "Cash balance mismatch: expected $250,000.00"
         );
     }
@@ -1718,8 +1722,8 @@ mod tests {
             .expect("Expected OffchainUsd event");
 
         let InventorySnapshotEvent::OffchainUsd {
-            usd_balance_cents,
-            gross_usd_cents,
+            usd_balance,
+            gross_usd,
             ..
         } = offchain_usd_event
         else {
@@ -1727,13 +1731,14 @@ mod tests {
         };
 
         assert_eq!(
-            *usd_balance_cents, 5_000_000,
-            "Available balance should be $100k - $50k reserved = $50k ($5,000,000 cents)"
+            *usd_balance,
+            Usdc::from_cents(5_000_000).unwrap(),
+            "Available balance should be $100k - $50k reserved = $50k"
         );
         assert_eq!(
-            *gross_usd_cents,
-            Some(10_000_000),
-            "Gross balance should be the full broker balance ($10,000,000 cents)"
+            *gross_usd,
+            Some(Usdc::from_cents(10_000_000).unwrap()),
+            "Gross balance should be the full broker balance ($100,000)"
         );
     }
 
@@ -1779,8 +1784,8 @@ mod tests {
             .expect("Expected OffchainUsd event");
 
         let InventorySnapshotEvent::OffchainUsd {
-            usd_balance_cents,
-            gross_usd_cents,
+            usd_balance,
+            gross_usd,
             ..
         } = offchain_usd_event
         else {
@@ -1788,12 +1793,13 @@ mod tests {
         };
 
         assert_eq!(
-            *usd_balance_cents, 0,
+            *usd_balance,
+            Usdc::ZERO,
             "Reserve-adjusted available cash should be zero when gross is below reserve"
         );
         assert_eq!(
-            *gross_usd_cents,
-            Some(3_000_000),
+            *gross_usd,
+            Some(Usdc::from_cents(3_000_000).unwrap()),
             "Gross balance should still be emitted so the dashboard can show cash below reserve"
         );
     }
@@ -1838,8 +1844,8 @@ mod tests {
             .expect("Expected OffchainUsd event");
 
         let InventorySnapshotEvent::OffchainUsd {
-            usd_balance_cents,
-            gross_usd_cents,
+            usd_balance,
+            gross_usd,
             ..
         } = offchain_usd_event
         else {
@@ -1847,11 +1853,12 @@ mod tests {
         };
 
         assert_eq!(
-            *usd_balance_cents, 10_000_000,
+            *usd_balance,
+            Usdc::from_cents(10_000_000).unwrap(),
             "With zero reserve, full balance should pass through"
         );
-        assert!(
-            gross_usd_cents.is_none(),
+        assert_eq!(
+            *gross_usd, None,
             "With zero reserve, gross should be None (no reserve configured)"
         );
     }

--- a/src/inventory/projection.rs
+++ b/src/inventory/projection.rs
@@ -201,12 +201,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn apply_offchain_usd_converts_and_updates_view() {
+    async fn apply_offchain_usd_updates_view() {
         let (projection, inventory) = make_projection();
 
         let event = InventorySnapshotEvent::OffchainUsd {
-            usd_balance_cents: 12345,
-            gross_usd_cents: None,
+            usd_balance: Usdc::from_cents(12345).unwrap(),
+            gross_usd: None,
             fetched_at: Utc::now(),
         };
 
@@ -215,7 +215,7 @@ mod tests {
         assert_eq!(
             read_usdc_available(&inventory, Venue::Hedging).await,
             Some(Usdc::from_cents(12345).unwrap()),
-            "offchain usdc available should reflect converted cents",
+            "offchain usdc available should reflect the typed balance",
         );
     }
 
@@ -343,24 +343,26 @@ mod tests {
 
     /// Force-apply must leave untouched venue slots alone while
     /// overwriting the event's targeted slot. Tested at the view level
-    /// because the only `InventoryViewError` reachable from
-    /// `apply_snapshot_event` (`UsdBalanceConversion`) fails identically
-    /// in `force_apply_snapshot_event`, so the projection's recovery
+    /// because every `InventoryViewError` reachable from
+    /// `apply_snapshot_event` fails identically in
+    /// `force_apply_snapshot_event`, so the projection's recovery
     /// branch is not reachable via a real event.
     #[tokio::test]
     async fn force_apply_preserves_unrelated_state_and_overwrites_target() {
         let seed = InventoryView::default()
             .apply_snapshot_event(
                 &InventorySnapshotEvent::OffchainUsd {
-                    usd_balance_cents: 500_000,
-                    gross_usd_cents: None,
+                    usd_balance: Usdc::from_cents(500_000).unwrap(),
+                    gross_usd: None,
                     fetched_at: Utc::now(),
                 },
                 Utc::now(),
             )
             .unwrap();
 
-        let reason = Arc::new(InventoryViewError::UsdBalanceConversion(-1));
+        let reason = Arc::new(InventoryViewError::Float(
+            rain_math_float::FloatError::InvalidHex("test".to_string()),
+        ));
         let forced = seed
             .force_apply_snapshot_event(
                 &InventorySnapshotEvent::OnchainUsdc {
@@ -392,8 +394,8 @@ mod tests {
 
         projection
             .apply(&InventorySnapshotEvent::OffchainUsd {
-                usd_balance_cents: 500_000,
-                gross_usd_cents: None,
+                usd_balance: Usdc::from_cents(500_000).unwrap(),
+                gross_usd: None,
                 fetched_at: Utc::now(),
             })
             .await

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -93,23 +93,40 @@ pub(crate) struct InventorySnapshot {
     pub(crate) offchain_equity: BTreeMap<Symbol, FractionalShares>,
     #[serde(default)]
     pub(crate) offchain_equity_fetched_at: Option<DateTime<Utc>>,
-    /// Latest offchain USD balance in cents (post-reserve, available for trading)
-    pub(crate) offchain_usd_cents: Option<i64>,
+    /// Latest offchain USD balance (post-reserve, available for trading).
+    /// Persisted as integer cents for snapshot compatibility.
+    #[serde(rename = "offchain_usd_cents", with = "st0x_finance::usdc_opt_cents")]
+    pub(crate) offchain_usd: Option<Usdc>,
     #[serde(default)]
     pub(crate) offchain_usd_fetched_at: Option<DateTime<Utc>>,
-    /// Latest offchain gross USD balance in cents (before reserve subtraction)
-    #[serde(default)]
-    pub(crate) offchain_gross_usd_cents: Option<i64>,
-    /// Latest offchain cash buying power in cents (Alpaca's `cash` field --
+    /// Latest offchain gross USD balance (before reserve subtraction).
+    /// Persisted as integer cents for snapshot compatibility.
+    #[serde(
+        rename = "offchain_gross_usd_cents",
+        default,
+        with = "st0x_finance::usdc_opt_cents"
+    )]
+    pub(crate) offchain_gross_usd: Option<Usdc>,
+    /// Latest offchain cash buying power (Alpaca's `cash` field --
     /// includes unsettled T+1 equity-sale proceeds, excludes margin. The same
     /// value used for counter-trade preflight checks.) See
     /// adrs/1-cash-bp-for-equity-hedges.md.
-    pub(crate) offchain_cash_buying_power_cents: Option<i64>,
-    /// Latest offchain settled (withdrawable) cash in cents (Alpaca's
+    /// Persisted as integer cents for snapshot compatibility.
+    #[serde(
+        rename = "offchain_cash_buying_power_cents",
+        with = "st0x_finance::usdc_opt_cents"
+    )]
+    pub(crate) offchain_cash_buying_power: Option<Usdc>,
+    /// Latest offchain settled (withdrawable) cash (Alpaca's
     /// `cash_withdrawable` field -- excludes T+1 unsettled equity-sale
     /// proceeds). What's actually movable to Raindex during rebalancing.
-    #[serde(default)]
-    pub(crate) offchain_cash_withdrawable_cents: Option<i64>,
+    /// Persisted as integer cents for snapshot compatibility.
+    #[serde(
+        rename = "offchain_cash_withdrawable_cents",
+        default,
+        with = "st0x_finance::usdc_opt_cents"
+    )]
+    pub(crate) offchain_cash_withdrawable: Option<Usdc>,
     /// Latest USDC token balance held in the Alpaca account.
     #[serde(default)]
     pub(crate) alpaca_usdc: Option<Usdc>,
@@ -158,11 +175,11 @@ impl EventSourced for InventorySnapshot {
             onchain_usdc_fetched_at: None,
             offchain_equity: BTreeMap::new(),
             offchain_equity_fetched_at: None,
-            offchain_usd_cents: None,
+            offchain_usd: None,
             offchain_usd_fetched_at: None,
-            offchain_gross_usd_cents: None,
-            offchain_cash_buying_power_cents: None,
-            offchain_cash_withdrawable_cents: None,
+            offchain_gross_usd: None,
+            offchain_cash_buying_power: None,
+            offchain_cash_withdrawable: None,
             alpaca_usdc: None,
             ethereum_usdc: None,
             base_wallet_usdc: None,
@@ -204,25 +221,25 @@ impl EventSourced for InventorySnapshot {
                 fetched_at: now,
             },
             OffchainUsd {
-                usd_balance_cents,
-                gross_usd_cents,
+                usd_balance,
+                gross_usd,
             } => InventorySnapshotEvent::OffchainUsd {
-                usd_balance_cents,
-                gross_usd_cents,
+                usd_balance,
+                gross_usd,
                 fetched_at: now,
             },
-            OffchainCashBuyingPower {
-                cash_buying_power_cents,
-            } => InventorySnapshotEvent::OffchainCashBuyingPower {
-                cash_buying_power_cents,
-                fetched_at: now,
-            },
-            OffchainCashWithdrawable {
-                cash_withdrawable_cents,
-            } => InventorySnapshotEvent::OffchainCashWithdrawable {
-                cash_withdrawable_cents,
-                fetched_at: now,
-            },
+            OffchainCashBuyingPower { cash_buying_power } => {
+                InventorySnapshotEvent::OffchainCashBuyingPower {
+                    cash_buying_power,
+                    fetched_at: now,
+                }
+            }
+            OffchainCashWithdrawable { cash_withdrawable } => {
+                InventorySnapshotEvent::OffchainCashWithdrawable {
+                    cash_withdrawable,
+                    fetched_at: now,
+                }
+            }
             AlpacaUsdc { usdc_balance } => InventorySnapshotEvent::AlpacaUsdc {
                 usdc_balance,
                 fetched_at: now,
@@ -258,19 +275,19 @@ impl EventSourced for InventorySnapshot {
             }
             RecordOffchainObservation {
                 positions,
-                usd_balance_cents,
-                gross_usd_cents,
-                cash_buying_power_cents,
-                cash_withdrawable_cents,
+                usd_balance,
+                gross_usd,
+                cash_buying_power,
+                cash_withdrawable,
                 alpaca_usdc,
                 observed_at,
             } => {
                 return Ok(OffchainObservation {
                     positions,
-                    usd_balance_cents,
-                    gross_usd_cents,
-                    cash_buying_power_cents,
-                    cash_withdrawable_cents,
+                    usd_balance,
+                    gross_usd,
+                    cash_buying_power,
+                    cash_withdrawable,
                     alpaca_usdc,
                     observed_at,
                 }
@@ -323,39 +340,33 @@ impl EventSourced for InventorySnapshot {
                 }])
             }
             OffchainUsd {
-                usd_balance_cents,
-                gross_usd_cents,
+                usd_balance,
+                gross_usd,
             } => {
-                if self.offchain_usd_cents == Some(usd_balance_cents)
-                    && self.offchain_gross_usd_cents == gross_usd_cents
-                {
+                if self.offchain_usd == Some(usd_balance) && self.offchain_gross_usd == gross_usd {
                     return Ok(vec![]);
                 }
                 Ok(vec![InventorySnapshotEvent::OffchainUsd {
-                    usd_balance_cents,
-                    gross_usd_cents,
+                    usd_balance,
+                    gross_usd,
                     fetched_at: now,
                 }])
             }
-            OffchainCashBuyingPower {
-                cash_buying_power_cents,
-            } => {
-                if self.offchain_cash_buying_power_cents == cash_buying_power_cents {
+            OffchainCashBuyingPower { cash_buying_power } => {
+                if self.offchain_cash_buying_power == cash_buying_power {
                     return Ok(vec![]);
                 }
                 Ok(vec![InventorySnapshotEvent::OffchainCashBuyingPower {
-                    cash_buying_power_cents,
+                    cash_buying_power,
                     fetched_at: now,
                 }])
             }
-            OffchainCashWithdrawable {
-                cash_withdrawable_cents,
-            } => {
-                if self.offchain_cash_withdrawable_cents == cash_withdrawable_cents {
+            OffchainCashWithdrawable { cash_withdrawable } => {
+                if self.offchain_cash_withdrawable == cash_withdrawable {
                     return Ok(vec![]);
                 }
                 Ok(vec![InventorySnapshotEvent::OffchainCashWithdrawable {
-                    cash_withdrawable_cents,
+                    cash_withdrawable,
                     fetched_at: now,
                 }])
             }
@@ -433,18 +444,18 @@ impl EventSourced for InventorySnapshot {
             }
             RecordOffchainObservation {
                 positions,
-                usd_balance_cents,
-                gross_usd_cents,
-                cash_buying_power_cents,
-                cash_withdrawable_cents,
+                usd_balance,
+                gross_usd,
+                cash_buying_power,
+                cash_withdrawable,
                 alpaca_usdc,
                 observed_at,
             } => Ok(OffchainObservation {
                 positions,
-                usd_balance_cents,
-                gross_usd_cents,
-                cash_buying_power_cents,
-                cash_withdrawable_cents,
+                usd_balance,
+                gross_usd,
+                cash_buying_power,
+                cash_withdrawable,
                 alpaca_usdc,
                 observed_at,
             }
@@ -529,26 +540,26 @@ impl InventorySnapshot {
             });
         }
 
-        if let (Some(usd_balance_cents), Some(fetched_at)) =
-            (self.offchain_usd_cents, self.offchain_usd_fetched_at)
+        if let (Some(usd_balance), Some(fetched_at)) =
+            (self.offchain_usd, self.offchain_usd_fetched_at)
         {
             emit(InventorySnapshotEvent::OffchainUsd {
-                usd_balance_cents,
-                gross_usd_cents: self.offchain_gross_usd_cents,
+                usd_balance,
+                gross_usd: self.offchain_gross_usd,
                 fetched_at,
             });
         }
 
-        if self.offchain_cash_buying_power_cents.is_some() {
+        if self.offchain_cash_buying_power.is_some() {
             emit(InventorySnapshotEvent::OffchainCashBuyingPower {
-                cash_buying_power_cents: self.offchain_cash_buying_power_cents,
+                cash_buying_power: self.offchain_cash_buying_power,
                 fetched_at,
             });
         }
 
-        if self.offchain_cash_withdrawable_cents.is_some() {
+        if self.offchain_cash_withdrawable.is_some() {
             emit(InventorySnapshotEvent::OffchainCashWithdrawable {
-                cash_withdrawable_cents: self.offchain_cash_withdrawable_cents,
+                cash_withdrawable: self.offchain_cash_withdrawable,
                 fetched_at,
             });
         }
@@ -644,28 +655,26 @@ impl InventorySnapshot {
                 self.offchain_equity_fetched_at = Some(*fetched_at);
             }
             InventorySnapshotEvent::OffchainUsd {
-                usd_balance_cents,
-                gross_usd_cents,
+                usd_balance,
+                gross_usd,
                 fetched_at,
             } if self
                 .offchain_usd_fetched_at
                 .is_none_or(|current| *fetched_at >= current) =>
             {
-                self.offchain_usd_cents = Some(*usd_balance_cents);
-                self.offchain_gross_usd_cents = *gross_usd_cents;
+                self.offchain_usd = Some(*usd_balance);
+                self.offchain_gross_usd = *gross_usd;
                 self.offchain_usd_fetched_at = Some(*fetched_at);
             }
             InventorySnapshotEvent::OffchainCashBuyingPower {
-                cash_buying_power_cents,
-                ..
+                cash_buying_power, ..
             } => {
-                self.offchain_cash_buying_power_cents = *cash_buying_power_cents;
+                self.offchain_cash_buying_power = *cash_buying_power;
             }
             InventorySnapshotEvent::OffchainCashWithdrawable {
-                cash_withdrawable_cents,
-                ..
+                cash_withdrawable, ..
             } => {
-                self.offchain_cash_withdrawable_cents = *cash_withdrawable_cents;
+                self.offchain_cash_withdrawable = *cash_withdrawable;
             }
             InventorySnapshotEvent::AlpacaUsdc { usdc_balance, .. } => {
                 self.alpaca_usdc = Some(*usdc_balance);
@@ -722,16 +731,16 @@ pub(crate) enum InventorySnapshotCommand {
         positions: BTreeMap<Symbol, FractionalShares>,
     },
     OffchainUsd {
-        usd_balance_cents: i64,
+        usd_balance: Usdc,
         /// Gross USD balance before reserve subtraction. `None` when no
         /// cash reserve is configured, so the dashboard hides the row.
-        gross_usd_cents: Option<i64>,
+        gross_usd: Option<Usdc>,
     },
     OffchainCashBuyingPower {
-        cash_buying_power_cents: Option<i64>,
+        cash_buying_power: Option<Usdc>,
     },
     OffchainCashWithdrawable {
-        cash_withdrawable_cents: Option<i64>,
+        cash_withdrawable: Option<Usdc>,
     },
     AlpacaUsdc {
         usdc_balance: Usdc,
@@ -750,10 +759,10 @@ pub(crate) enum InventorySnapshotCommand {
     },
     RecordOffchainObservation {
         positions: BTreeMap<Symbol, FractionalShares>,
-        usd_balance_cents: i64,
-        gross_usd_cents: Option<i64>,
-        cash_buying_power_cents: Option<i64>,
-        cash_withdrawable_cents: Option<i64>,
+        usd_balance: Usdc,
+        gross_usd: Option<Usdc>,
+        cash_buying_power: Option<Usdc>,
+        cash_withdrawable: Option<Usdc>,
         alpaca_usdc: Option<Usdc>,
         observed_at: DateTime<Utc>,
     },
@@ -790,18 +799,38 @@ pub(crate) enum InventorySnapshotEvent {
     },
     #[serde(alias = "OffchainCash")]
     OffchainUsd {
-        #[serde(alias = "cash_balance_cents")]
-        usd_balance_cents: i64,
-        #[serde(default)]
-        gross_usd_cents: Option<i64>,
+        /// Persisted as integer cents for event-stream compatibility.
+        #[serde(
+            rename = "usd_balance_cents",
+            alias = "cash_balance_cents",
+            with = "st0x_finance::usdc_cents"
+        )]
+        usd_balance: Usdc,
+        /// Persisted as integer cents for event-stream compatibility.
+        #[serde(
+            rename = "gross_usd_cents",
+            default,
+            with = "st0x_finance::usdc_opt_cents"
+        )]
+        gross_usd: Option<Usdc>,
         fetched_at: DateTime<Utc>,
     },
     OffchainCashBuyingPower {
-        cash_buying_power_cents: Option<i64>,
+        /// Persisted as integer cents for event-stream compatibility.
+        #[serde(
+            rename = "cash_buying_power_cents",
+            with = "st0x_finance::usdc_opt_cents"
+        )]
+        cash_buying_power: Option<Usdc>,
         fetched_at: DateTime<Utc>,
     },
     OffchainCashWithdrawable {
-        cash_withdrawable_cents: Option<i64>,
+        /// Persisted as integer cents for event-stream compatibility.
+        #[serde(
+            rename = "cash_withdrawable_cents",
+            with = "st0x_finance::usdc_opt_cents"
+        )]
+        cash_withdrawable: Option<Usdc>,
         fetched_at: DateTime<Utc>,
     },
     AlpacaUsdc {
@@ -893,10 +922,10 @@ impl DomainEvent for InventorySnapshotEvent {
 
 struct OffchainObservation {
     positions: BTreeMap<Symbol, FractionalShares>,
-    usd_balance_cents: i64,
-    gross_usd_cents: Option<i64>,
-    cash_buying_power_cents: Option<i64>,
-    cash_withdrawable_cents: Option<i64>,
+    usd_balance: Usdc,
+    gross_usd: Option<Usdc>,
+    cash_buying_power: Option<Usdc>,
+    cash_withdrawable: Option<Usdc>,
     alpaca_usdc: Option<Usdc>,
     observed_at: DateTime<Utc>,
 }
@@ -905,10 +934,10 @@ impl OffchainObservation {
     fn into_events(self, current: Option<&InventorySnapshot>) -> Vec<InventorySnapshotEvent> {
         let Self {
             positions,
-            usd_balance_cents,
-            gross_usd_cents,
-            cash_buying_power_cents,
-            cash_withdrawable_cents,
+            usd_balance,
+            gross_usd,
+            cash_buying_power,
+            cash_withdrawable,
             alpaca_usdc,
             observed_at,
         } = self;
@@ -921,28 +950,23 @@ impl OffchainObservation {
             });
         }
         if current.is_none_or(|snapshot| {
-            snapshot.offchain_usd_cents != Some(usd_balance_cents)
-                || snapshot.offchain_gross_usd_cents != gross_usd_cents
+            snapshot.offchain_usd != Some(usd_balance) || snapshot.offchain_gross_usd != gross_usd
         }) {
             events.push(InventorySnapshotEvent::OffchainUsd {
-                usd_balance_cents,
-                gross_usd_cents,
+                usd_balance,
+                gross_usd,
                 fetched_at: observed_at,
             });
         }
-        if current.is_none_or(|snapshot| {
-            snapshot.offchain_cash_buying_power_cents != cash_buying_power_cents
-        }) {
+        if current.is_none_or(|snapshot| snapshot.offchain_cash_buying_power != cash_buying_power) {
             events.push(InventorySnapshotEvent::OffchainCashBuyingPower {
-                cash_buying_power_cents,
+                cash_buying_power,
                 fetched_at: observed_at,
             });
         }
-        if current.is_none_or(|snapshot| {
-            snapshot.offchain_cash_withdrawable_cents != cash_withdrawable_cents
-        }) {
+        if current.is_none_or(|snapshot| snapshot.offchain_cash_withdrawable != cash_withdrawable) {
             events.push(InventorySnapshotEvent::OffchainCashWithdrawable {
-                cash_withdrawable_cents,
+                cash_withdrawable,
                 fetched_at: observed_at,
             });
         }
@@ -977,6 +1001,124 @@ mod tests {
 
     use super::*;
     use st0x_event_sorcery::{TestHarness, replay};
+
+    /// The typed cash fields must keep serializing as integer cents under
+    /// their legacy field names: the events table and compacted aggregate
+    /// snapshots hold that exact shape, and `CompactAfterSnapshot` forbids
+    /// a schema bump for this aggregate.
+    #[test]
+    fn offchain_cash_events_keep_legacy_cents_wire_format() {
+        let fetched_at = "2026-01-02T03:04:05Z".parse::<DateTime<Utc>>().unwrap();
+
+        let event = InventorySnapshotEvent::OffchainUsd {
+            usd_balance: Usdc::from_cents(5_000_000).unwrap(),
+            gross_usd: Some(Usdc::from_cents(10_000_000).unwrap()),
+            fetched_at,
+        };
+        assert_eq!(
+            serde_json::to_value(&event).unwrap(),
+            serde_json::json!({
+                "OffchainUsd": {
+                    "usd_balance_cents": 5_000_000,
+                    "gross_usd_cents": 10_000_000,
+                    "fetched_at": "2026-01-02T03:04:05Z",
+                }
+            })
+        );
+
+        let event = InventorySnapshotEvent::OffchainCashBuyingPower {
+            cash_buying_power: Some(Usdc::from_cents(3_000_000).unwrap()),
+            fetched_at,
+        };
+        assert_eq!(
+            serde_json::to_value(&event).unwrap(),
+            serde_json::json!({
+                "OffchainCashBuyingPower": {
+                    "cash_buying_power_cents": 3_000_000,
+                    "fetched_at": "2026-01-02T03:04:05Z",
+                }
+            })
+        );
+
+        let event = InventorySnapshotEvent::OffchainCashWithdrawable {
+            cash_withdrawable: None,
+            fetched_at,
+        };
+        assert_eq!(
+            serde_json::to_value(&event).unwrap(),
+            serde_json::json!({
+                "OffchainCashWithdrawable": {
+                    "cash_withdrawable_cents": null,
+                    "fetched_at": "2026-01-02T03:04:05Z",
+                }
+            })
+        );
+    }
+
+    /// Events persisted before this change (integer cents, including the
+    /// pre-rename `OffchainCash`/`cash_balance_cents` aliases and events
+    /// lacking `gross_usd_cents`) must deserialize into the typed fields.
+    #[test]
+    fn legacy_cents_events_deserialize_into_typed_fields() {
+        let event: InventorySnapshotEvent = serde_json::from_value(serde_json::json!({
+            "OffchainUsd": {
+                "usd_balance_cents": 12_345,
+                "fetched_at": "2026-01-02T03:04:05Z",
+            }
+        }))
+        .unwrap();
+        let InventorySnapshotEvent::OffchainUsd {
+            usd_balance,
+            gross_usd,
+            ..
+        } = event
+        else {
+            panic!("expected OffchainUsd, got {event:?}");
+        };
+        assert_eq!(usd_balance, Usdc::from_cents(12_345).unwrap());
+        assert_eq!(gross_usd, None);
+
+        let event: InventorySnapshotEvent = serde_json::from_value(serde_json::json!({
+            "OffchainCash": {
+                "cash_balance_cents": 4_200,
+                "fetched_at": "2026-01-02T03:04:05Z",
+            }
+        }))
+        .unwrap();
+        let InventorySnapshotEvent::OffchainUsd { usd_balance, .. } = event else {
+            panic!("expected OffchainUsd, got {event:?}");
+        };
+        assert_eq!(usd_balance, Usdc::from_cents(4_200).unwrap());
+    }
+
+    /// The aggregate state itself is persisted in the snapshots table, so
+    /// its cents fields must keep the legacy wire shape and old snapshots
+    /// must keep deserializing.
+    #[test]
+    fn aggregate_snapshot_keeps_legacy_cents_wire_format() {
+        let snapshot = replay::<InventorySnapshot>(vec![InventorySnapshotEvent::OffchainUsd {
+            usd_balance: Usdc::from_cents(42_00).unwrap(),
+            gross_usd: Some(Usdc::from_cents(50_00).unwrap()),
+            fetched_at: Utc::now(),
+        }])
+        .unwrap()
+        .unwrap();
+
+        let json = serde_json::to_value(&snapshot).unwrap();
+        assert_eq!(json["offchain_usd_cents"], serde_json::json!(4_200));
+        assert_eq!(json["offchain_gross_usd_cents"], serde_json::json!(5_000));
+        assert_eq!(
+            json["offchain_cash_buying_power_cents"],
+            serde_json::json!(null)
+        );
+
+        let reconstructed: InventorySnapshot = serde_json::from_value(json).unwrap();
+        assert_eq!(reconstructed.offchain_usd, snapshot.offchain_usd);
+        assert_eq!(
+            reconstructed.offchain_gross_usd,
+            snapshot.offchain_gross_usd
+        );
+    }
 
     #[test]
     fn inventory_snapshot_id_roundtrips_through_display_and_parse() {
@@ -1128,13 +1270,13 @@ mod tests {
 
     #[tokio::test]
     async fn record_offchain_usd_emits_event() {
-        let usd_balance_cents = 50_000_000; // $500,000.00
+        let usd_balance = Usdc::from_cents(50_000_000).unwrap(); // $500,000.00
 
         let events = TestHarness::<InventorySnapshot>::with(())
             .given_no_previous_events()
             .when(InventorySnapshotCommand::OffchainUsd {
-                usd_balance_cents,
-                gross_usd_cents: None,
+                usd_balance,
+                gross_usd: None,
             })
             .await
             .events();
@@ -1142,10 +1284,10 @@ mod tests {
         assert_eq!(events.len(), 1);
         match &events[0] {
             InventorySnapshotEvent::OffchainUsd {
-                usd_balance_cents: event_cents,
+                usd_balance: event_balance,
                 ..
             } => {
-                assert_eq!(*event_cents, usd_balance_cents);
+                assert_eq!(*event_balance, usd_balance);
             }
             _ => panic!("Expected OffchainUsd event"),
         }
@@ -1153,16 +1295,14 @@ mod tests {
 
     #[tokio::test]
     async fn offchain_cash_buying_power_skips_unchanged_value() {
-        let cash_buying_power_cents = Some(3_000_000);
+        let cash_buying_power = Some(Usdc::from_cents(3_000_000).unwrap());
 
         let events = TestHarness::<InventorySnapshot>::with(())
             .given(vec![InventorySnapshotEvent::OffchainCashBuyingPower {
-                cash_buying_power_cents,
+                cash_buying_power,
                 fetched_at: Utc::now(),
             }])
-            .when(InventorySnapshotCommand::OffchainCashBuyingPower {
-                cash_buying_power_cents,
-            })
+            .when(InventorySnapshotCommand::OffchainCashBuyingPower { cash_buying_power })
             .await
             .events();
 
@@ -1179,7 +1319,7 @@ mod tests {
         let usdc_balance = Usdc::from_str("1000").unwrap();
         let mut positions = BTreeMap::new();
         positions.insert(test_symbol("AAPL"), test_shares(75));
-        let usd_balance_cents = 50_000_000;
+        let offchain_usd_balance = Usdc::from_cents(50_000_000).unwrap();
         let fetched_at = Utc::now();
 
         let cases = vec![
@@ -1206,13 +1346,13 @@ mod tests {
             ),
             (
                 vec![InventorySnapshotEvent::OffchainUsd {
-                    usd_balance_cents,
-                    gross_usd_cents: None,
+                    usd_balance: offchain_usd_balance,
+                    gross_usd: None,
                     fetched_at,
                 }],
                 InventorySnapshotCommand::OffchainUsd {
-                    usd_balance_cents,
-                    gross_usd_cents: None,
+                    usd_balance: offchain_usd_balance,
+                    gross_usd: None,
                 },
             ),
         ];
@@ -1266,10 +1406,10 @@ mod tests {
             .given_no_previous_events()
             .when(InventorySnapshotCommand::RecordOffchainObservation {
                 positions: positions.clone(),
-                usd_balance_cents: 42_00,
-                gross_usd_cents: Some(50_00),
-                cash_buying_power_cents: Some(10_000),
-                cash_withdrawable_cents: Some(38_00),
+                usd_balance: Usdc::from_cents(42_00).unwrap(),
+                gross_usd: Some(Usdc::from_cents(50_00).unwrap()),
+                cash_buying_power: Some(Usdc::from_cents(10_000).unwrap()),
+                cash_withdrawable: Some(Usdc::from_cents(38_00).unwrap()),
                 alpaca_usdc: Some(alpaca_usdc),
                 observed_at,
             })
@@ -1284,16 +1424,16 @@ mod tests {
                     fetched_at: observed_at,
                 },
                 InventorySnapshotEvent::OffchainUsd {
-                    usd_balance_cents: 42_00,
-                    gross_usd_cents: Some(50_00),
+                    usd_balance: Usdc::from_cents(42_00).unwrap(),
+                    gross_usd: Some(Usdc::from_cents(50_00).unwrap()),
                     fetched_at: observed_at,
                 },
                 InventorySnapshotEvent::OffchainCashBuyingPower {
-                    cash_buying_power_cents: Some(10_000),
+                    cash_buying_power: Some(Usdc::from_cents(10_000).unwrap()),
                     fetched_at: observed_at,
                 },
                 InventorySnapshotEvent::OffchainCashWithdrawable {
-                    cash_withdrawable_cents: Some(38_00),
+                    cash_withdrawable: Some(Usdc::from_cents(38_00).unwrap()),
                     fetched_at: observed_at,
                 },
                 InventorySnapshotEvent::AlpacaUsdc {
@@ -1320,16 +1460,16 @@ mod tests {
                 fetched_at: previous_observed_at,
             },
             InventorySnapshotEvent::OffchainUsd {
-                usd_balance_cents: 42_00,
-                gross_usd_cents: Some(50_00),
+                usd_balance: Usdc::from_cents(42_00).unwrap(),
+                gross_usd: Some(Usdc::from_cents(50_00).unwrap()),
                 fetched_at: previous_observed_at,
             },
             InventorySnapshotEvent::OffchainCashBuyingPower {
-                cash_buying_power_cents: Some(10_000),
+                cash_buying_power: Some(Usdc::from_cents(10_000).unwrap()),
                 fetched_at: previous_observed_at,
             },
             InventorySnapshotEvent::OffchainCashWithdrawable {
-                cash_withdrawable_cents: Some(38_00),
+                cash_withdrawable: Some(Usdc::from_cents(38_00).unwrap()),
                 fetched_at: previous_observed_at,
             },
             InventorySnapshotEvent::AlpacaUsdc {
@@ -1346,10 +1486,10 @@ mod tests {
             .given(previous_events)
             .when(InventorySnapshotCommand::RecordOffchainObservation {
                 positions,
-                usd_balance_cents: 42_00,
-                gross_usd_cents: Some(50_00),
-                cash_buying_power_cents: Some(10_000),
-                cash_withdrawable_cents: Some(38_00),
+                usd_balance: Usdc::from_cents(42_00).unwrap(),
+                gross_usd: Some(Usdc::from_cents(50_00).unwrap()),
+                cash_buying_power: Some(Usdc::from_cents(10_000).unwrap()),
+                cash_withdrawable: Some(Usdc::from_cents(38_00).unwrap()),
                 alpaca_usdc: Some(alpaca_usdc),
                 observed_at,
             })
@@ -2198,11 +2338,11 @@ mod tests {
             onchain_usdc_fetched_at: None,
             offchain_equity: BTreeMap::new(),
             offchain_equity_fetched_at: None,
-            offchain_usd_cents: None,
+            offchain_usd: None,
             offchain_usd_fetched_at: None,
-            offchain_gross_usd_cents: None,
-            offchain_cash_buying_power_cents: None,
-            offchain_cash_withdrawable_cents: None,
+            offchain_gross_usd: None,
+            offchain_cash_buying_power: None,
+            offchain_cash_withdrawable: None,
             alpaca_usdc: None,
             ethereum_usdc: None,
             base_wallet_usdc: None,
@@ -2235,11 +2375,11 @@ mod tests {
             onchain_usdc_fetched_at: Some(now),
             offchain_equity: BTreeMap::new(),
             offchain_equity_fetched_at: None,
-            offchain_usd_cents: Some(42_00),
+            offchain_usd: Some(Usdc::from_cents(42_00).unwrap()),
             offchain_usd_fetched_at: Some(now),
-            offchain_gross_usd_cents: Some(50_00),
-            offchain_cash_buying_power_cents: Some(10_000),
-            offchain_cash_withdrawable_cents: Some(38_00),
+            offchain_gross_usd: Some(Usdc::from_cents(50_00).unwrap()),
+            offchain_cash_buying_power: Some(Usdc::from_cents(10_000).unwrap()),
+            offchain_cash_withdrawable: Some(Usdc::from_cents(38_00).unwrap()),
             alpaca_usdc: Some(Usdc::from_str("125").unwrap()),
             ethereum_usdc: None,
             base_wallet_usdc: None,
@@ -2260,13 +2400,10 @@ mod tests {
 
         assert_eq!(reconstructed.onchain_equity, original.onchain_equity);
         assert_eq!(reconstructed.onchain_usdc, original.onchain_usdc);
+        assert_eq!(reconstructed.offchain_usd, original.offchain_usd);
         assert_eq!(
-            reconstructed.offchain_usd_cents,
-            original.offchain_usd_cents
-        );
-        assert_eq!(
-            reconstructed.offchain_cash_buying_power_cents,
-            original.offchain_cash_buying_power_cents
+            reconstructed.offchain_cash_buying_power,
+            original.offchain_cash_buying_power
         );
         assert_eq!(reconstructed.alpaca_usdc, original.alpaca_usdc);
         assert_eq!(reconstructed.inflight_mints, original.inflight_mints);

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -31,8 +31,6 @@ pub(crate) enum InventoryViewError {
     Usdc(#[from] InventoryError<Usdc>),
     #[error("float arithmetic error: {0}")]
     Float(#[from] FloatError),
-    #[error("failed to convert USD balance cents {0} to USDC")]
-    UsdBalanceConversion(i64),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -595,17 +593,17 @@ pub(crate) struct InventoryView {
     usdc: Inventory<Usdc>,
     equities: HashMap<Symbol, Inventory<FractionalShares>>,
     last_updated: DateTime<Utc>,
-    /// Margin-safe buying power in cents from the offchain broker.
+    /// Margin-safe buying power from the offchain broker.
     #[serde(default)]
-    buying_power_cents: Option<i64>,
-    /// Settled (withdrawable) cash in cents from the offchain broker.
+    buying_power: Option<Usdc>,
+    /// Settled (withdrawable) cash from the offchain broker.
     /// Excludes T+1 unsettled equity-sale proceeds; this is the amount
     /// actually movable to Raindex during rebalancing.
     #[serde(default)]
-    withdrawable_cash_cents: Option<i64>,
-    /// Gross offchain USD balance in cents (before cash reserve subtraction).
+    withdrawable_cash: Option<Usdc>,
+    /// Gross offchain USD balance (before cash reserve subtraction).
     #[serde(default)]
-    offchain_gross_usd_cents: Option<i64>,
+    offchain_gross_usd: Option<Usdc>,
     /// USDC token balance held in the Alpaca account.
     #[serde(default)]
     alpaca_usdc: Option<Usdc>,
@@ -780,10 +778,8 @@ impl InventoryView {
         }
 
         let onchain = onchain_venue.total()?;
-        let offchain = match (self.offchain_gross_usd_cents, reserved) {
-            (Some(cents), _) => {
-                Usdc::from_cents(cents).ok_or(InventoryViewError::UsdBalanceConversion(cents))?
-            }
+        let offchain = match (self.offchain_gross_usd, reserved) {
+            (Some(gross), _) => gross,
             (None, None) => offchain_venue.total()?,
             (None, Some(_)) => {
                 tracing::warn!(
@@ -831,11 +827,9 @@ impl InventoryView {
         &self,
         reserved: Option<Usd>,
     ) -> Result<Option<Usdc>, InventoryViewError> {
-        let Some(withdrawable_cents) = self.withdrawable_cash_cents else {
+        let Some(withdrawable) = self.withdrawable_cash else {
             return Ok(None);
         };
-        let withdrawable = Usdc::from_cents(withdrawable_cents)
-            .ok_or(InventoryViewError::UsdBalanceConversion(withdrawable_cents))?;
         let reserved = reserved.map_or(Usdc::ZERO, |amount| Usdc::new(amount.inner()));
 
         if reserved.gt(&withdrawable)? {
@@ -891,9 +885,9 @@ impl InventoryView {
 
         let (usdc_offchain_available, usdc_offchain_inflight) = venue_balances(self.usdc.offchain);
 
-        let withdrawable_cash = self.withdrawable_cash_cents.and_then(Usdc::from_cents);
+        let withdrawable_cash = self.withdrawable_cash;
 
-        let offchain_gross = self.offchain_gross_usd_cents.and_then(Usdc::from_cents);
+        let offchain_gross = self.offchain_gross_usd;
 
         let inflight_cash = InFlightCash {
             ethereum_wallet: self
@@ -941,9 +935,9 @@ impl Default for InventoryView {
             usdc: Inventory::default(),
             equities: HashMap::new(),
             last_updated: Utc::now(),
-            buying_power_cents: None,
-            withdrawable_cash_cents: None,
-            offchain_gross_usd_cents: None,
+            buying_power: None,
+            withdrawable_cash: None,
+            offchain_gross_usd: None,
             alpaca_usdc: None,
             inflight_cash: HashMap::new(),
             active_usdc_rebalance: None,
@@ -1062,7 +1056,7 @@ impl InventoryView {
     #[cfg(test)]
     pub(crate) fn with_offchain_gross_usd_cents(self, cents: i64) -> Self {
         Self {
-            offchain_gross_usd_cents: Some(cents),
+            offchain_gross_usd: Some(Usdc::from_cents(cents).expect("valid cents")),
             ..self
         }
     }
@@ -1071,7 +1065,7 @@ impl InventoryView {
     #[cfg(test)]
     pub(crate) fn with_withdrawable_cash_cents(self, cents: i64) -> Self {
         Self {
-            withdrawable_cash_cents: Some(cents),
+            withdrawable_cash: Some(Usdc::from_cents(cents).expect("valid cents")),
             ..self
         }
     }
@@ -1114,9 +1108,9 @@ impl InventoryView {
             equities,
             last_updated: now,
             usdc: self.usdc,
-            buying_power_cents: self.buying_power_cents,
-            withdrawable_cash_cents: self.withdrawable_cash_cents,
-            offchain_gross_usd_cents: self.offchain_gross_usd_cents,
+            buying_power: self.buying_power,
+            withdrawable_cash: self.withdrawable_cash,
+            offchain_gross_usd: self.offchain_gross_usd,
             alpaca_usdc: self.alpaca_usdc,
             inflight_cash: self.inflight_cash,
             active_usdc_rebalance: self.active_usdc_rebalance,
@@ -1142,9 +1136,9 @@ impl InventoryView {
             usdc: updated,
             last_updated: now,
             equities: self.equities,
-            buying_power_cents: self.buying_power_cents,
-            withdrawable_cash_cents: self.withdrawable_cash_cents,
-            offchain_gross_usd_cents: self.offchain_gross_usd_cents,
+            buying_power: self.buying_power,
+            withdrawable_cash: self.withdrawable_cash,
+            offchain_gross_usd: self.offchain_gross_usd,
             alpaca_usdc: self.alpaca_usdc,
             inflight_cash: self.inflight_cash,
             active_usdc_rebalance: self.active_usdc_rebalance,
@@ -1382,9 +1376,9 @@ impl InventoryView {
             equities,
             last_updated: now,
             usdc: self.usdc,
-            buying_power_cents: self.buying_power_cents,
-            withdrawable_cash_cents: self.withdrawable_cash_cents,
-            offchain_gross_usd_cents: self.offchain_gross_usd_cents,
+            buying_power: self.buying_power,
+            withdrawable_cash: self.withdrawable_cash,
+            offchain_gross_usd: self.offchain_gross_usd,
             alpaca_usdc: self.alpaca_usdc,
             inflight_cash: self.inflight_cash,
             active_usdc_rebalance: self.active_usdc_rebalance,
@@ -1411,9 +1405,9 @@ impl InventoryView {
             usdc: cleared,
             last_updated: now,
             equities: self.equities,
-            buying_power_cents: self.buying_power_cents,
-            withdrawable_cash_cents: self.withdrawable_cash_cents,
-            offchain_gross_usd_cents: self.offchain_gross_usd_cents,
+            buying_power: self.buying_power,
+            withdrawable_cash: self.withdrawable_cash,
+            offchain_gross_usd: self.offchain_gross_usd,
             alpaca_usdc: self.alpaca_usdc,
             inflight_cash: self.inflight_cash,
             active_usdc_rebalance: self.active_usdc_rebalance,
@@ -1680,48 +1674,44 @@ impl InventoryView {
             }
 
             OffchainUsd {
-                usd_balance_cents,
-                gross_usd_cents,
+                usd_balance,
+                gross_usd,
                 ..
             } => {
-                let usdc = Usdc::from_cents(*usd_balance_cents)
-                    .ok_or(InventoryViewError::UsdBalanceConversion(*usd_balance_cents))?;
                 let updated = self.update_usdc(
-                    Inventory::on_snapshot(Venue::Hedging, usdc, fetched_at),
+                    Inventory::on_snapshot(Venue::Hedging, *usd_balance, fetched_at),
                     now,
                 )?;
                 Ok(Self {
-                    offchain_gross_usd_cents: *gross_usd_cents,
+                    offchain_gross_usd: *gross_usd,
                     ..updated
                 })
             }
 
             OffchainCashBuyingPower {
-                cash_buying_power_cents,
-                ..
+                cash_buying_power, ..
             } => {
                 debug!(
                     target: "inventory",
-                    ?cash_buying_power_cents,
+                    ?cash_buying_power,
                     "apply_snapshot_event: OffchainCashBuyingPower"
                 );
                 Ok(Self {
-                    buying_power_cents: *cash_buying_power_cents,
+                    buying_power: *cash_buying_power,
                     ..self
                 })
             }
 
             OffchainCashWithdrawable {
-                cash_withdrawable_cents,
-                ..
+                cash_withdrawable, ..
             } => {
                 debug!(
                     target: "inventory",
-                    ?cash_withdrawable_cents,
+                    ?cash_withdrawable,
                     "apply_snapshot_event: OffchainCashWithdrawable"
                 );
                 Ok(Self {
-                    withdrawable_cash_cents: *cash_withdrawable_cents,
+                    withdrawable_cash: *cash_withdrawable,
                     ..self
                 })
             }
@@ -1855,35 +1845,31 @@ impl InventoryView {
                 }),
 
             OffchainUsd {
-                usd_balance_cents,
-                gross_usd_cents,
+                usd_balance,
+                gross_usd,
                 ..
             } => {
-                let usdc = Usdc::from_cents(*usd_balance_cents)
-                    .ok_or(InventoryViewError::UsdBalanceConversion(*usd_balance_cents))?;
                 let updated = self.update_usdc(
-                    Inventory::force_on_snapshot(Venue::Hedging, usdc, reason),
+                    Inventory::force_on_snapshot(Venue::Hedging, *usd_balance, reason),
                     now,
                 )?;
                 Ok(Self {
-                    offchain_gross_usd_cents: *gross_usd_cents,
+                    offchain_gross_usd: *gross_usd,
                     ..updated
                 })
             }
 
             OffchainCashBuyingPower {
-                cash_buying_power_cents,
-                ..
+                cash_buying_power, ..
             } => Ok(Self {
-                buying_power_cents: *cash_buying_power_cents,
+                buying_power: *cash_buying_power,
                 ..self
             }),
 
             OffchainCashWithdrawable {
-                cash_withdrawable_cents,
-                ..
+                cash_withdrawable, ..
             } => Ok(Self {
-                withdrawable_cash_cents: *cash_withdrawable_cents,
+                withdrawable_cash: *cash_withdrawable,
                 ..self
             }),
 
@@ -2140,9 +2126,9 @@ mod tests {
             usdc: usdc_make_inventory(1000, 0, 1000, 0),
             equities: equities.into_iter().collect(),
             last_updated: Utc::now(),
-            buying_power_cents: None,
-            withdrawable_cash_cents: None,
-            offchain_gross_usd_cents: None,
+            buying_power: None,
+            withdrawable_cash: None,
+            offchain_gross_usd: None,
             alpaca_usdc: None,
             inflight_cash: HashMap::new(),
             active_usdc_rebalance: None,
@@ -2172,9 +2158,9 @@ mod tests {
             ),
             equities: HashMap::new(),
             last_updated: Utc::now(),
-            buying_power_cents: None,
-            withdrawable_cash_cents: None,
-            offchain_gross_usd_cents: None,
+            buying_power: None,
+            withdrawable_cash: None,
+            offchain_gross_usd: None,
             alpaca_usdc: None,
             inflight_cash: HashMap::new(),
             active_usdc_rebalance: None,
@@ -2512,7 +2498,9 @@ mod tests {
     #[test]
     fn force_apply_snapshot_event_also_populates_inflight_cash() {
         let now = Utc::now();
-        let reason = std::sync::Arc::new(InventoryViewError::UsdBalanceConversion(-1));
+        let reason = std::sync::Arc::new(InventoryViewError::Float(
+            rain_math_float::FloatError::InvalidHex("test".to_string()),
+        ));
         let view = InventoryView::default()
             .force_apply_snapshot_event(
                 &InventorySnapshotEvent::EthereumUsdc {
@@ -2879,7 +2867,9 @@ mod tests {
     fn force_apply_snapshot_event_also_populates_inflight_equity() {
         let symbol_aapl = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
-        let reason = std::sync::Arc::new(InventoryViewError::UsdBalanceConversion(-1));
+        let reason = std::sync::Arc::new(InventoryViewError::Float(
+            rain_math_float::FloatError::InvalidHex("test".to_string()),
+        ));
 
         let mut unwrapped = BTreeMap::new();
         unwrapped.insert(symbol_aapl.clone(), shares(2));
@@ -3553,9 +3543,9 @@ mod tests {
             equities: std::iter::once((tsla, make_inventory(80, 20, 40, 10))).collect(),
             usdc: usdc_make_inventory(5000, 1000, 3000, 500),
             last_updated: Utc::now(),
-            buying_power_cents: None,
-            withdrawable_cash_cents: None,
-            offchain_gross_usd_cents: None,
+            buying_power: None,
+            withdrawable_cash: None,
+            offchain_gross_usd: None,
             alpaca_usdc: None,
             inflight_cash: HashMap::new(),
             active_usdc_rebalance: None,
@@ -3607,9 +3597,9 @@ mod tests {
             .collect(),
             usdc: Inventory::default(),
             last_updated: Utc::now(),
-            buying_power_cents: None,
-            withdrawable_cash_cents: None,
-            offchain_gross_usd_cents: None,
+            buying_power: None,
+            withdrawable_cash: None,
+            offchain_gross_usd: None,
             alpaca_usdc: None,
             inflight_cash: HashMap::new(),
             active_usdc_rebalance: None,
@@ -3666,7 +3656,7 @@ mod tests {
     #[test]
     fn to_dto_includes_withdrawable_cash() {
         let view = InventoryView {
-            withdrawable_cash_cents: Some(3_200_000),
+            withdrawable_cash: Some(Usdc::new(float!(32000))),
             ..InventoryView::default()
         };
 
@@ -3720,7 +3710,9 @@ mod tests {
     fn to_dto_exports_alpaca_usdc_from_force_applied_snapshot_event() {
         let now = Utc::now();
         let balance = Usdc::new(float!(12.5));
-        let reason = Arc::new(InventoryViewError::UsdBalanceConversion(0));
+        let reason = Arc::new(InventoryViewError::Float(
+            rain_math_float::FloatError::InvalidHex("test".to_string()),
+        ));
 
         let dto = InventoryView::default()
             .force_apply_snapshot_event(

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -11492,7 +11492,9 @@ mod tests {
 
         trigger
             .on_snapshot_recovery(
-                RebalancingServiceError::Inventory(InventoryViewError::UsdBalanceConversion(-1)),
+                RebalancingServiceError::Inventory(InventoryViewError::Float(
+                    rain_math_float::FloatError::InvalidHex("test".to_string()),
+                )),
                 InventorySnapshotEvent::OnchainUsdc {
                     usdc_balance: usdc(600),
                     fetched_at: Utc::now(),
@@ -11542,7 +11544,7 @@ mod tests {
             reactor.clone(),
             id,
             InventorySnapshotEvent::OffchainCashWithdrawable {
-                cash_withdrawable_cents: Some(50_000),
+                cash_withdrawable: Some(Usdc::from_cents(50_000).unwrap()),
                 fetched_at: Utc::now(),
             },
         )
@@ -11595,8 +11597,8 @@ mod tests {
             reactor.clone(),
             id.clone(),
             InventorySnapshotEvent::OffchainUsd {
-                usd_balance_cents: 90000,
-                gross_usd_cents: None,
+                usd_balance: Usdc::from_cents(90000).unwrap(),
+                gross_usd: None,
                 fetched_at: Utc::now(),
             },
         )


### PR DESCRIPTION
## What

Fixes RAI-370. The raw `i64`/`Option<i64>` cents fields in `src/inventory/` (aggregate state, events, commands, and `InventoryView`) are now typed `Usdc`, with the cents-to-`Usdc` conversion happening once at the Alpaca polling boundary instead of lazily inside the view.

## Why

Raw integer cents past the API boundary is boolean-blindness for money: every consumer had to remember which integer carries cents and redo `Usdc::from_cents` (with its own error handling) at the point of use. `Usdc` is the domain newtype with precision-safe `Float` arithmetic; carrying it end-to-end removes the repeated conversions and the `UsdBalanceConversion` error path from the view entirely.

## How

- The persisted wire format is unchanged: events and the compacted aggregate snapshot keep their `*_cents: i64` JSON fields via a new `st0x_finance::usdc_cents`/`usdc_opt_cents` serde adapter plus `#[serde(rename)]`. No migration, no `SCHEMA_VERSION` bump — which `CompactAfterSnapshot` on `InventorySnapshot` would refuse anyway, since clearing a compacted aggregate's snapshots loses state.
- `Usdc::to_cents` is added to the finance crate (mirroring `Usd::to_cents`, exact whole-cent conversion, fails on sub-cent precision or overflow) to support serialization.
- `compute_available_cash` now returns typed `(Option<Usdc>, Usdc)`; the buying-power and withdrawable-cash cents from the broker DTO convert to `Usdc` fail-fast in `poll_offchain`.
- `InventoryView` (in-memory only, always seeded from `default()`) drops its lazy conversions; capacity and imbalance reads use the typed fields directly.

## Testing

- `offchain_cash_events_keep_legacy_cents_wire_format` / `aggregate_snapshot_keeps_legacy_cents_wire_format`: JSON-literal assertions that the typed fields still serialize to exactly the legacy integer-cents shape.
- `legacy_cents_events_deserialize_into_typed_fields`: pre-change payloads (including the `OffchainCash`/`cash_balance_cents` aliases and missing `gross_usd_cents`) deserialize into the typed events.
- Finance-crate unit tests for `Usdc::to_cents` and both serde adapters.
- Full workspace suite passes unchanged.

## Screenshots (if applicable)

N/A

## Anything else?

The Alpaca DTO in `st0x-execution` keeps `i64` cents — that is the API boundary where cents legitimately live.
