### PR TITLE
fix: disarm session guard after coordinated shutdown

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,11 +256,10 @@ async fn run_bot_session_inner(
     // trading against the database and the bound server port would leak. This
     // guard aborts the conductor and shuts the supervisor down on drop, so a
     // cancelled session actually stops. The graceful path already stops both
-    // before this guard drops, making it a no-op there.
-    let _session_guard = SessionTaskGuard {
-        conductor: bot_task.abort_handle(),
-        server_supervisor: server_supervisor.clone(),
-    };
+    // before this guard drops, so the guard is disarmed after the coordinator
+    // returns.
+    let mut session_guard =
+        SessionTaskGuard::new(bot_task.abort_handle(), server_supervisor.clone());
 
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
         .context("failed to register SIGTERM handler")?;
@@ -271,14 +270,16 @@ async fn run_bot_session_inner(
         }
     };
 
-    await_shutdown(
+    let shutdown_result = await_shutdown(
         server_supervisor,
         bot_task,
         shutdown_token,
         shutdown_signal,
         GRACEFUL_SHUTDOWN_TIMEOUT,
     )
-    .await?;
+    .await;
+    session_guard.disarm();
+    shutdown_result?;
 
     info!(target: "startup", "Shutdown complete");
     Ok(())
@@ -298,14 +299,35 @@ async fn run_bot_session_inner(
 /// synchronously, so callers must not assume the conductor has stopped the
 /// instant the session future returns.
 struct SessionTaskGuard {
+    tasks: Option<SessionTasks>,
+}
+
+struct SessionTasks {
     conductor: AbortHandle,
     server_supervisor: SupervisorHandle,
 }
 
+impl SessionTaskGuard {
+    fn new(conductor: AbortHandle, server_supervisor: SupervisorHandle) -> Self {
+        Self {
+            tasks: Some(SessionTasks {
+                conductor,
+                server_supervisor,
+            }),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.tasks = None;
+    }
+}
+
 impl Drop for SessionTaskGuard {
     fn drop(&mut self) {
-        self.conductor.abort();
-        shutdown_supervisor(&self.server_supervisor);
+        if let Some(tasks) = &self.tasks {
+            tasks.conductor.abort();
+            shutdown_supervisor(&tasks.server_supervisor);
+        }
     }
 }
 
@@ -657,6 +679,34 @@ mod tests {
             post_wait.is_ok(),
             "supervisor.wait() should return after await_shutdown shut it down"
         );
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn disarmed_session_guard_does_not_repeat_supervisor_shutdown() {
+        let shutdown_token = CancellationToken::new();
+        let bot_task = tokio::spawn(async { Ok(()) });
+        let supervisor = SupervisorBuilder::default().build().run();
+        let mut session_guard = SessionTaskGuard::new(bot_task.abort_handle(), supervisor.clone());
+        let supervisor_for_wait = supervisor.clone();
+
+        await_shutdown(
+            supervisor,
+            bot_task,
+            shutdown_token,
+            std::future::pending::<()>(),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), supervisor_for_wait.wait())
+            .await
+            .unwrap()
+            .unwrap();
+        session_guard.disarm();
+        drop(session_guard);
+
+        assert!(!logs_contain("Failed to shutdown server supervisor"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Related to [RAI-1042](https://linear.app/makeitrain/issue/RAI-1042/liquidity-issuance-v1). Prevent the session cancellation guard from requesting a second server-supervisor shutdown after the coordinated shutdown path has already completed.

## Why

The full package suite exposed an error-level channel-closed log during an otherwise successful bot shutdown. The guard exists to stop detached tasks when the session future is cancelled; on the normal path, the shutdown coordinator has already stopped those tasks.

## How

The guard owns an optional bundle of the conductor abort handle and server-supervisor handle. It stays armed while the session future can be cancelled, then is explicitly disarmed after await_shutdown returns and before its result is propagated.

## Testing

- Added a traced regression test that waits for the supervisor channel to close, drops the disarmed guard, and asserts that no duplicate-shutdown error is logged
- Passed nix run .#ci across backend and dashboard

## Screenshots

Not applicable.

## Anything else

This issue was discovered while validating the dividend NAV-bump notification and is isolated here for focused review.