### PR TITLE
fix: eliminate Nix CI evaluation warnings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -520,7 +520,7 @@
           in
           rainixPkgs // infraPkgs.packages // deployScripts // abis // others // verifyMigrationsPkgs;
 
-        formatter = pkgs.nixfmt-rfc-style;
+        formatter = pkgs.nixfmt;
 
         devShells =
           let


### PR DESCRIPTION
## What

Eliminate repository-owned Nix evaluation warnings from the CI command by using the current nixfmt package name and pinning the fixed-output hash for the event-sorcery 0.1.1 Cargo dependency.

## Why

The full CI gate warned that nixfmt-rfc-style is deprecated and that the Cargo.lock event-sorcery source had no output hash. The existing outputHashes entry still referenced an obsolete rev rather than the current tag and commit.

## How

- Select pkgs.nixfmt as the flake formatter
- Replace the stale event-sorcery rev key with the exact tag and locked commit
- Pin the hash reported by Nix for that fixed-output derivation

## Testing

- Rebuilt nix run .#st0x-dto -- dashboard/src/lib/api without either repository evaluation warning
- Passed nix run .#ci across backend and dashboard

## Screenshots

Not applicable.

## Anything else

This warning cleanup is kept separate from the dividend behavior change for focused review.