### PR TITLE
feat: notify completed dividend NAV bumps

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4157,6 +4157,13 @@ other, startup fails fast rather than running with a half-configured alert
 channel. A notification delivery failure is logged but never crashes the
 monitor.
 
+After a wrapper donation is confirmed, the bot sends a dividend NAV-bump
+completion notification containing the equity symbol and transaction hash, but
+no share quantity. Delivery is best-effort: a Telegram failure is logged without
+turning the confirmed on-chain operation into a CLI failure. Telegram errors
+never expose the bot-token URL or response body, and an HTTP-success response
+whose Bot API envelope reports `ok: false` is treated as failed delivery.
+
 ### BaseToAlpaca deposit send
 
 The CCTP mint on the BaseToAlpaca leg sets `mintRecipient` to the bot's own

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -1,5 +1,5 @@
-//! Operational alerting: out-of-band notifications for conditions an operator
-//! must react to (currently, a low native-gas balance on the bot wallet).
+//! Operational alerting: out-of-band notifications for conditions and completed
+//! lifecycle operations an operator needs to see.
 //!
 //! The [`Notifier`] trait abstracts the delivery channel; [`TelegramNotifier`]
 //! is the only implementation today. Monitors that raise alerts (see
@@ -17,6 +17,10 @@ pub(crate) use telegram::TelegramNotifier;
 
 use async_trait::async_trait;
 use reqwest::StatusCode;
+use std::sync::Arc;
+use tracing::{debug, info};
+
+use st0x_config::AlertsCtx;
 
 /// Sends an operational alert over some channel.
 ///
@@ -27,14 +31,32 @@ pub(crate) trait Notifier: Send + Sync {
     async fn notify(&self, message: &str) -> Result<(), NotifierError>;
 }
 
+/// Builds the configured operational notification channel.
+///
+/// An absent `[alerts]` section is represented explicitly by [`NoopNotifier`].
+/// If the section is present, construction failures propagate so callers never
+/// silently discard notifications an operator configured.
+pub(crate) fn build_notifier(
+    alerts: Option<&AlertsCtx>,
+) -> Result<Arc<dyn Notifier>, NotifierError> {
+    let Some(alerts) = alerts else {
+        debug!("Operational alerting is not configured; using NoopNotifier");
+        return Ok(Arc::new(NoopNotifier));
+    };
+    let notifier =
+        TelegramNotifier::new(&alerts.bot_token, alerts.chat_id, alerts.message_thread_id)?;
+    info!("Telegram operational notifier configured");
+    Ok(Arc::new(notifier))
+}
+
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum NotifierError {
     #[error("failed to build Telegram HTTP client")]
     ClientBuild(#[source] reqwest::Error),
     #[error("Telegram sendMessage request failed")]
     Request(#[source] reqwest::Error),
-    #[error("Telegram API returned error status {status}: {body}")]
-    ApiError { status: StatusCode, body: String },
+    #[error("Telegram API reported failed delivery with HTTP status {status}")]
+    ApiError { status: StatusCode },
 }
 
 /// A [`Notifier`] that discards every message without error.

--- a/src/alerts/telegram.rs
+++ b/src/alerts/telegram.rs
@@ -5,6 +5,7 @@
 //! monitor can be exercised against a capturing mock in tests.
 
 use async_trait::async_trait;
+use serde::Deserialize;
 use serde_json::json;
 
 use super::{Notifier, NotifierError};
@@ -87,16 +88,28 @@ impl Notifier for TelegramNotifier {
             .json(&body)
             .send()
             .await
-            .map_err(NotifierError::Request)?;
+            .map_err(|error| NotifierError::Request(error.without_url()))?;
 
         let status = response.status();
-        if status.is_success() {
-            return Ok(());
+        if !status.is_success() {
+            return Err(NotifierError::ApiError { status });
         }
+        let envelope = response
+            .json::<TelegramResponse>()
+            .await
+            .map_err(|error| NotifierError::Request(error.without_url()))?;
 
-        let body = response.text().await.map_err(NotifierError::Request)?;
-        Err(NotifierError::ApiError { status, body })
+        if envelope.ok {
+            Ok(())
+        } else {
+            Err(NotifierError::ApiError { status })
+        }
     }
+}
+
+#[derive(Deserialize)]
+struct TelegramResponse {
+    ok: bool,
 }
 
 #[cfg(test)]
@@ -104,7 +117,7 @@ mod tests {
     use httpmock::Method::POST;
     use httpmock::MockServer;
     use reqwest::StatusCode;
-    use serde_json::{Value, json};
+    use serde_json::json;
 
     use super::*;
 
@@ -183,7 +196,7 @@ mod tests {
                     .json_body(json!({
                         "ok": false,
                         "error_code": 400,
-                        "description": "Bad Request: chat not found",
+                        "description": "SENSITIVE_PROVIDER_BODY",
                     }));
             })
             .await;
@@ -192,15 +205,53 @@ mod tests {
             TelegramNotifier::with_base_url(&server.base_url(), "123:abc", 42, None).unwrap();
 
         let error = notifier.notify("hello").await.unwrap_err();
+        let rendered_error = format!("{error:?}");
 
-        let NotifierError::ApiError { status, body } = error else {
+        let NotifierError::ApiError { status, .. } = error else {
             panic!("expected ApiError, got: {error}");
         };
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
-        let parsed: Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(parsed["description"], json!("Bad Request: chat not found"));
+        assert!(!rendered_error.contains("SENSITIVE_PROVIDER_BODY"));
 
         mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn notify_redacts_token_bearing_url_from_request_errors() {
+        let notifier =
+            TelegramNotifier::with_base_url("http://127.0.0.1:1", "SENSITIVE_BOT_TOKEN", 42, None)
+                .unwrap();
+
+        let error = notifier.notify("hello").await.unwrap_err();
+
+        assert!(!format!("{error:?}").contains("SENSITIVE_BOT_TOKEN"));
+    }
+
+    #[tokio::test]
+    async fn notify_rejects_unsuccessful_bot_api_envelope() {
+        let server = MockServer::start_async().await;
+
+        server
+            .mock_async(|when, then| {
+                when.method(POST).path("/bot123:abc/sendMessage");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(json!({
+                        "ok": false,
+                        "error_code": 400,
+                        "description": "chat not found",
+                    }));
+            })
+            .await;
+        let notifier =
+            TelegramNotifier::with_base_url(&server.base_url(), "123:abc", 42, None).unwrap();
+
+        let error = notifier.notify("hello").await.unwrap_err();
+
+        let NotifierError::ApiError { status, .. } = error else {
+            panic!("expected ApiError, got: {error}");
+        };
+        assert_eq!(status, StatusCode::OK);
     }
 }

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -7,6 +7,7 @@ use st0x_config::Ctx;
 use st0x_execution::{FractionalShares, Positive, Symbol};
 use st0x_wrapper::{Wrapper, WrapperService};
 
+use crate::alerts::{Notifier, build_notifier};
 use crate::rebalancing::to_wrapped_equities;
 
 pub(super) async fn wrap_equity_command<Writer: Write>(
@@ -144,13 +145,15 @@ pub(super) async fn donate_equity_command<Writer: Write>(
         base_wallet,
         to_wrapped_equities(&ctx.assets.equities.symbols),
     );
+    let notifier = build_notifier(ctx.alerts.as_ref())?;
 
-    donate_equity_with_wrapper(stdout, &wrapper, owner, symbol, quantity).await
+    donate_equity_with_wrapper(stdout, &wrapper, notifier.as_ref(), owner, symbol, quantity).await
 }
 
 async fn donate_equity_with_wrapper<Writer: Write, WrapperImpl: Wrapper + ?Sized>(
     stdout: &mut Writer,
     wrapper: &WrapperImpl,
+    notifier: &dyn Notifier,
     owner: Address,
     symbol: Symbol,
     quantity: Positive<FractionalShares>,
@@ -181,6 +184,17 @@ async fn donate_equity_with_wrapper<Writer: Write, WrapperImpl: Wrapper + ?Sized
 
     let donate_tx_hash = wrapper.donate(wrapped_token, underlying_amount).await?;
 
+    let notification =
+        format!("Dividend NAV bump completed: {symbol}; transaction {donate_tx_hash}");
+    if let Err(error) = notifier.notify(&notification).await {
+        tracing::error!(
+            target: "dividend",
+            ?error,
+            %symbol,
+            %donate_tx_hash,
+            "Dividend NAV bump notification delivery failed"
+        );
+    }
     writeln!(stdout, "   Transaction hash: {donate_tx_hash}")?;
     writeln!(stdout, "Donation completed successfully!")?;
 
@@ -190,6 +204,8 @@ async fn donate_equity_with_wrapper<Writer: Write, WrapperImpl: Wrapper + ?Sized
 #[cfg(test)]
 mod tests {
     use alloy::primitives::Address;
+    use async_trait::async_trait;
+    use reqwest::StatusCode;
     use url::Url;
 
     use st0x_config::ExecutionThreshold;
@@ -203,6 +219,7 @@ mod tests {
         donate_equity_command, donate_equity_with_wrapper, unwrap_equity_command,
         unwrap_equity_with_wrapper, wrap_equity_command, wrap_equity_with_wrapper,
     };
+    use crate::alerts::{CapturingNotifier, NoopNotifier, Notifier, NotifierError};
     use crate::test_utils::positive_shares;
 
     fn create_ctx_without_rebalancing() -> Ctx {
@@ -245,6 +262,41 @@ mod tests {
             rest_api: None,
             issuance: create_test_issuance_ctx(),
             redemption_wallet: None,
+        }
+    }
+
+    struct FailingNotifier;
+
+    #[async_trait]
+    impl Notifier for FailingNotifier {
+        async fn notify(&self, _message: &str) -> Result<(), NotifierError> {
+            Err(NotifierError::ApiError {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct RejectTransactionHashWriter {
+        output: Vec<u8>,
+    }
+
+    impl std::io::Write for RejectTransactionHashWriter {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            let mut candidate = self.output.clone();
+            candidate.extend_from_slice(buffer);
+            if String::from_utf8_lossy(&candidate).contains("Transaction hash:") {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "transaction hash output rejected",
+                ));
+            }
+            self.output.extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
         }
     }
 
@@ -459,11 +511,13 @@ mod tests {
         let wrapper = MockWrapper::new()
             .with_wrapped_token(wrapped_token)
             .with_tokenized_shares(underlying_token);
+        let notifier = CapturingNotifier::default();
         let mut stdout = Vec::new();
 
         donate_equity_with_wrapper(
             &mut stdout,
             &wrapper,
+            &notifier,
             Address::repeat_byte(0xaa),
             Symbol::new("AAPL").unwrap(),
             positive_shares("10.5"),
@@ -480,6 +534,62 @@ mod tests {
         assert!(output.contains("no shares minted"));
         assert!(output.contains("Transaction hash:"));
         assert!(output.contains("Donation completed successfully"));
+        let transaction_hash = output
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("Transaction hash: "))
+            .unwrap();
+        let messages = notifier.messages();
+        assert_eq!(
+            messages,
+            vec![format!(
+                "Dividend NAV bump completed: AAPL; transaction {transaction_hash}"
+            )]
+        );
+        assert!(!messages[0].contains("10.5"));
+    }
+
+    #[tokio::test]
+    async fn donate_equity_succeeds_when_notification_delivery_fails() {
+        let wrapper = MockWrapper::new()
+            .with_wrapped_token(Address::repeat_byte(0x22))
+            .with_tokenized_shares(Address::repeat_byte(0x11));
+        let mut stdout = Vec::new();
+
+        donate_equity_with_wrapper(
+            &mut stdout,
+            &wrapper,
+            &FailingNotifier,
+            Address::repeat_byte(0xaa),
+            Symbol::new("AAPL").unwrap(),
+            positive_shares("10.5"),
+        )
+        .await
+        .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(output.contains("Donation completed successfully"));
+    }
+
+    #[tokio::test]
+    async fn donate_equity_notifies_after_confirmation_even_if_stdout_closes() {
+        let wrapper = MockWrapper::new()
+            .with_wrapped_token(Address::repeat_byte(0x22))
+            .with_tokenized_shares(Address::repeat_byte(0x11));
+        let notifier = CapturingNotifier::default();
+        let mut stdout = RejectTransactionHashWriter::default();
+
+        donate_equity_with_wrapper(
+            &mut stdout,
+            &wrapper,
+            &notifier,
+            Address::repeat_byte(0xaa),
+            Symbol::new("AAPL").unwrap(),
+            positive_shares("10.5"),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(notifier.messages().len(), 1);
     }
 
     #[tokio::test]
@@ -490,6 +600,7 @@ mod tests {
         let error = donate_equity_with_wrapper(
             &mut stdout,
             &wrapper,
+            &NoopNotifier,
             Address::repeat_byte(0xaa),
             Symbol::new("AAPL").unwrap(),
             positive_shares("10.5"),
@@ -511,6 +622,7 @@ mod tests {
         let error = donate_equity_with_wrapper(
             &mut stdout,
             &wrapper,
+            &NoopNotifier,
             Address::repeat_byte(0xaa),
             Symbol::new("AAPL").unwrap(),
             positive_shares("10.5"),

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -52,7 +52,7 @@ use st0x_tokenization::AlpacaTokenizationService;
 use st0x_tokenization::Tokenizer;
 use st0x_wrapper::WrapperService;
 
-use crate::alerts::{NoopNotifier, NotifierError, TelegramNotifier};
+use crate::alerts::build_notifier;
 use crate::conductor::exit::{ConductorExit, MonitorTaskError};
 use crate::conductor::monitor::order_fills::{CutoffProbe, probe_cutoff_block_support};
 use crate::dashboard::Broadcaster;
@@ -584,7 +584,7 @@ impl Conductor {
             Err(CtxError::NotRebalancing) => None,
             Err(error) => return Err(error.into()),
         };
-        let notifier = build_operational_notifier(ctx.alerts.as_ref())?;
+        let notifier = build_notifier(ctx.alerts.as_ref())?;
 
         let PositionAndRebalancing {
             position,
@@ -1271,29 +1271,6 @@ impl PositionAndRebalancing {
             })
         }
     }
-}
-
-/// Builds the shared operational alerting notifier.
-///
-/// Returns `Ok(Arc<NoopNotifier>)` when `[alerts]` is absent — silence is
-/// the correct behaviour for an unconfigured optional channel.
-///
-/// Returns `Err` when `[alerts]` IS present but `TelegramNotifier` fails to
-/// initialise. The caller must propagate this so the server fails to start:
-/// an operator who configured `[alerts]` believes alerts are active; silently
-/// falling back to Noop would suppress all redrive-limit and terminal-error
-/// pages with no runtime indication.
-fn build_operational_notifier(
-    alerts: Option<&st0x_config::AlertsCtx>,
-) -> Result<Arc<dyn crate::alerts::Notifier>, NotifierError> {
-    let Some(alerts) = alerts else {
-        debug!("Operational alerting: [alerts] section absent, using NoopNotifier");
-        return Ok(Arc::new(NoopNotifier));
-    };
-    let notifier =
-        TelegramNotifier::new(&alerts.bot_token, alerts.chat_id, alerts.message_thread_id)?;
-    info!("Operational alerting: Telegram notifier configured");
-    Ok(Arc::new(notifier))
 }
 
 /// Wires the dividend freeze guard onto the rebalancing service when enabled.
@@ -3702,7 +3679,7 @@ mod tests {
             inventory,
             Arc::new(MockWrapper::new()),
             RebalancingSchedulers::new(&apalis_pool),
-            Arc::new(NoopNotifier),
+            Arc::new(crate::alerts::NoopNotifier),
         ))
     }
 
@@ -8411,7 +8388,7 @@ mod tests {
                 vault_registry_projection,
                 schedulers: RebalancingSchedulers::new(&apalis_pool),
                 telemetry: TelemetrySender::disabled(),
-                notifier: Arc::new(NoopNotifier),
+                notifier: Arc::new(crate::alerts::NoopNotifier),
             },
         )
         .await
@@ -10683,18 +10660,18 @@ mod tests {
         );
     }
 
-    /// When `[alerts]` is absent, `build_operational_notifier` returns a `NoopNotifier`
+    /// When `[alerts]` is absent, `build_notifier` returns a `NoopNotifier`
     /// that silently discards notifications without error.
     #[tokio::test]
-    async fn build_operational_notifier_returns_ok_noop_when_alerts_absent() {
-        let notifier = build_operational_notifier(None).unwrap();
+    async fn build_notifier_returns_ok_noop_when_alerts_absent() {
+        let notifier = build_notifier(None).unwrap();
         notifier
             .notify("test message")
             .await
             .expect("NoopNotifier must not error on notify");
     }
 
-    /// When `[alerts]` IS present, `build_operational_notifier` constructs a real
+    /// When `[alerts]` IS present, `build_notifier` constructs a real
     /// Telegram notifier and returns `Ok` -- it must NOT fail startup for a
     /// well-formed config, and it must NOT silently fall back to `NoopNotifier`
     /// (which would suppress every redrive-limit and terminal-error page).
@@ -10706,7 +10683,7 @@ mod tests {
     /// `notify()` is deliberately not exercised: the present-branch notifier posts
     /// to the live Telegram API, which a unit test must never reach.
     #[tokio::test]
-    async fn build_operational_notifier_returns_ok_telegram_when_alerts_present() {
+    async fn build_notifier_returns_ok_telegram_when_alerts_present() {
         let alerts = st0x_config::AlertsCtx {
             chat_id: 123,
             bot_token: "test-bot-token".to_string(),
@@ -10716,7 +10693,7 @@ mod tests {
             message_thread_id: Some(42),
         };
 
-        build_operational_notifier(Some(&alerts))
+        build_notifier(Some(&alerts))
             .expect("a well-formed [alerts] config must yield a notifier, not a startup error");
     }
 }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -16305,7 +16305,6 @@ mod tests {
             if should_fail {
                 return Err(crate::alerts::NotifierError::ApiError {
                     status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
-                    body: "simulated transient failure".to_string(),
                 });
             }
 

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -2658,7 +2658,6 @@ mod tests {
         async fn notify(&self, _message: &str) -> Result<(), crate::alerts::NotifierError> {
             Err(crate::alerts::NotifierError::ApiError {
                 status: StatusCode::INTERNAL_SERVER_ERROR,
-                body: "injected test failure".to_string(),
             })
         }
     }


### PR DESCRIPTION
## What

Advances [RAI-1042](https://linear.app/makeitrain/issue/RAI-1042/liquidity-issuance-v1) by notifying operators when a dividend NAV bump has completed onchain.

## Why

The wrapper donation command confirmed the transaction only in local CLI output. Dividend operations need a positive lifecycle signal that reaches the configured operations channel without exposing the donated share quantity.

## How

- Build the configured notifier through one shared alerts boundary used by both the conductor and CLI
- Send the completion notification only after the wrapper donation is confirmed
- Include the equity symbol and transaction hash, but no share quantity
- Keep delivery best-effort so a Telegram failure cannot turn a confirmed onchain donation into a CLI failure
- Parse Telegram Bot API envelopes so HTTP 200 with ok false is a delivery failure
- Strip token-bearing URLs and provider response bodies from notification errors

## Testing

- Added success-path coverage for the exact notification and absence of the share quantity
- Added coverage proving notification failure preserves CLI success after confirmation
- Added Telegram coverage for redacted request URLs, redacted API bodies, and HTTP-success envelopes that report failure
- Passed nix run .#ci across backend and dashboard

## Screenshots

Not applicable.

## Anything else

The notification transport hardening applies to existing operational alerts as well as this dividend lifecycle signal.