### PR TITLE
fix: fail deploys when the bot does not become ready

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,11 +140,6 @@ uuid = { version = "1.11", features = ["serde", "v4", "v5"] }
 # newer crates require >=0.2.122).
 wasm-bindgen = "=0.2.122"
 
-[workspace.dependencies.sqlite-es]
-git = "https://github.com/ST0x-Technology/event-sorcery.git"
-tag = "0.1.1"
-package = "sqlite-es"
-
 [workspace.dependencies.st0x-event-sorcery]
 git = "https://github.com/ST0x-Technology/event-sorcery.git"
 tag = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -163,6 +163,16 @@ NixOS host (DigitalOcean droplet)
 Services are deployed as independent nix profiles, allowing per-service updates
 and rollbacks without affecting other services.
 
+The bot unit exposes a PID-scoped startup signal in its systemd runtime
+directory. A bot deployment succeeds only after Conductor finishes startup
+initialization and every essential runtime task has entered its run loop; an
+early exit or a missing readiness signal fails within five minutes, emits unit
+status and recent journal output in the deploy log, and triggers deploy-rs
+rollback. The first rollout requires deploying the system profile before the
+service profile; service-only deploys verify that prerequisite before stopping
+the current bot. Local server runs omit the systemd ready-file environment and
+use a no-op notifier.
+
 ### Key Files
 
 | File                | Purpose                                                |

--- a/SPEC.md
+++ b/SPEC.md
@@ -643,7 +643,21 @@ systemd unit:
 
 - `st0x-hedge` (kind = `st0x`) - hedging bot binary. Full pipeline: decrypts
   agenix secret, installs plaintext config, runs `validate-config`, chowns data
-  files, writes git-rev marker, touches readiness marker, restarts unit.
+  files, writes git-rev marker, touches the activation marker, and restarts the
+  unit. The server writes its PID to a systemd-managed runtime-directory file
+  only after Conductor has completed startup initialization and every essential
+  supervised runtime task has reached a pending run state. Activation waits for
+  that PID to match the unit's live main process with a bounded startup timeout.
+  If the process exits, readiness reporting fails, or the timeout expires first,
+  activation prints the unit status and recent journal, exits non-zero, and
+  deploy-rs rolls the profile back. The unit remains `Type=simple` so automatic
+  rollback stays compatible with service generations from before the readiness
+  handshake was introduced. The first rollout requires deploying the system
+  profile before the service profile; a service-only deploy verifies the
+  installed unit exposes the expected ready file before stopping the running bot
+  and otherwise fails immediately with the required rollout order. Outside
+  systemd, the server uses a no-op readiness notifier so local runs remain
+  available.
 - `dashboard` (kind = `static`) - frontend assets served by nginx; the deploy
   step is `systemctl reload nginx` and there is no managed systemd unit.
 - `datasette` (kind = `plain`) - read-only SQLite explorer over the hedge DB.

--- a/deploy.nix
+++ b/deploy.nix
@@ -48,9 +48,57 @@ let
       let
         configFile = ./config/${env}/${name}.toml;
         secretsFile = ./secret/${cfg.encryptedSecret};
+        startupReadyFile = "/run/${name}/startup-ready";
+        startupWaitCommand = ''
+          startup_ready=0
+          startup_failure_state=
+          for _ in $(seq 1 300); do
+            ready_pid=$(cat ${startupReadyFile} 2>/dev/null || true)
+            main_pid=$(systemctl show --property MainPID --value ${name} 2>/dev/null || true)
+            if [ -n "$ready_pid" ] && [ "$ready_pid" = "$main_pid" ] && systemctl is-active --quiet ${name}; then
+              startup_ready=1
+              break
+            fi
+            active_state=$(systemctl show --property ActiveState --value ${name} 2>/dev/null || true)
+            sub_state=$(systemctl show --property SubState --value ${name} 2>/dev/null || true)
+            case "$active_state/$sub_state" in
+              failed/*|inactive/*|*/auto-restart)
+                startup_failure_state="$active_state/$sub_state"
+                break
+                ;;
+            esac
+            sleep 1
+          done
+          if [ "$startup_ready" -ne 1 ]; then
+            if [ -n "$startup_failure_state" ]; then
+              echo "${name} entered $startup_failure_state before reporting startup readiness" >&2
+            else
+              echo "${name} did not report startup readiness within 5 minutes" >&2
+            fi
+            systemctl status --no-pager --full ${name} >&2 || true
+            journalctl --no-pager --unit ${name} --lines 100 >&2 || true
+            rm -f ${cfg.markerFile}
+            exit 1
+          fi
+        '';
       in
+      assert lib.assertMsg (
+        lib.hasInfix "--property ActiveState" startupWaitCommand
+        && lib.hasInfix "--property SubState" startupWaitCommand
+        && lib.hasInfix "*/auto-restart" startupWaitCommand
+      ) "st0x activation must stop waiting when the restarted unit cannot become ready";
       activate.custom pkg (
         builtins.concatStringsSep " && " [
+          # The readiness environment ships in the system profile, while this
+          # activation ships the binary and wait loop. Enforce system-first on
+          # the handshake's first rollout before touching the running service.
+          ''
+            if ! systemctl show --property Environment --value ${name} 2>/dev/null \
+              | grep --fixed-strings --quiet 'ST0X_STARTUP_READY_FILE=${startupReadyFile}'; then
+              echo "${name} systemd unit does not expose ${startupReadyFile}; deploy the system profile before the service profile" >&2
+              exit 1
+            fi
+          ''
           "systemctl stop ${name} || true"
           "rm -f ${cfg.markerFile}"
           "mkdir -p /run/st0x"
@@ -73,7 +121,12 @@ let
           "(chown -R st0x:st0x /mnt/data/logs 2>/dev/null || true)"
           "echo '${gitRev}' > /run/st0x/${name}.git-rev"
           "touch ${cfg.markerFile}"
-          "systemctl restart ${name}"
+          # Restart returns after process launch; the PID-scoped readiness file
+          # is written only after all essential runtime components reach their
+          # run loops. Waiting here keeps the unit Type=simple, so rollback to a
+          # pre-readiness binary remains possible during the first rollout.
+          "systemctl restart ${name} || { restart_status=$?; systemctl status --no-pager --full ${name} >&2 || true; journalctl --no-pager --unit ${name} --lines 100 >&2 || true; rm -f ${cfg.markerFile}; exit $restart_status; }"
+          startupWaitCommand
         ]
       )
     else if cfg.kind == "cli" then
@@ -125,10 +178,17 @@ let
     else
       throw "services.${name}: unknown kind ${cfg.kind}";
 
-  mkProfile = env: name: {
-    path = mkServiceProfile env name;
-    profilePath = "${profileBase}/${name}";
-  };
+  mkProfile =
+    env: name:
+    {
+      path = mkServiceProfile env name;
+      profilePath = "${profileBase}/${name}";
+    }
+    // lib.optionalAttrs (enabled.${name}.kind == "st0x") {
+      # Five minutes for startup plus enough time for deploy-rs to reactivate
+      # the previous generation and complete rollback diagnostics.
+      activationTimeout = 900;
+    };
 
   # `hostname` here is an eval-time placeholder that keeps the flake pure.
   # The real SSH target is the public IPv4 resolved from terraform state

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -330,6 +330,19 @@ Phase 3: setup_rebalancing (optional) | requeue_orphaned jobs | hydrate inventor
 Phase 4: builder::spawn() starts supervisor + apalis workers
 ```
 
+After Phase 4 completes, Conductor acknowledges its startup token. The session
+reports startup readiness only after Conductor, both HTTP servers, the apalis
+monitor, finished-job cleanup, and every configured task-supervisor loop have
+all reached pending run states. Disabled optional supervisor tasks acknowledge
+their slots during assembly. The deployed server writes its PID to a
+systemd-managed runtime-directory file, and activation fails if that PID does
+not match the live unit before the configured startup timeout. Non-deployment
+sessions use the same barrier with a no-op notifier. On the first rollout, the
+system profile that supplies the readiness environment must be deployed before
+the service profile. A service-only deploy checks that prerequisite before
+stopping the current bot and fails immediately when the installed unit is still
+from before the handshake.
+
 There is no WebSocket and no pre-runtime backfill pass. `Conductor::run()`
 creates a single HTTP provider before spawn; `OrderFillMonitor` clones it and
 uses it for each poll tick.

--- a/nix/upgradeable-services.nix
+++ b/nix/upgradeable-services.nix
@@ -69,6 +69,13 @@ let
         ExecStart = utils.escapeSystemdExecArgs ([ "${cfg.profilePath}/bin/${cfg.bin}" ] ++ execStartArgs);
         Restart = "always";
         RestartSec = 30;
+      }
+      // lib.optionalAttrs (cfg.kind == "st0x") {
+        # The server writes its PID here only after all essential runtime
+        # components reach their run loops. The per-service deploy activation
+        # waits for that PID before succeeding.
+        RuntimeDirectory = name;
+        Environment = "ST0X_STARTUP_READY_FILE=/run/${name}/startup-ready";
       };
     };
 in

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
+
 use st0x_config::{Ctx, Env};
-use st0x_hedge::run_bot_session;
-use st0x_hedge::{apalis_board_tracing_layer, setup_tracing};
+use st0x_hedge::{apalis_board_tracing_layer, run_server_bot_session, setup_tracing};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
         (file_guard, None)
     };
 
-    let result = run_bot_session(ctx).await;
+    let result = run_server_bot_session(ctx).await;
 
     // Explicitly drop the telemetry guard to ensure TelemetryGuard::drop runs
     // before we return. Drop flushes pending spans and shuts down the tracer

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 use std::num::TryFromIntError;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use task_supervisor::SupervisorHandle;
+use task_supervisor::{SupervisorHandle, SupervisorHandleError};
 use tokio::sync::{Mutex, broadcast};
 use tokio::task::{JoinError, JoinHandle};
 use tokio::time::MissedTickBehavior;
@@ -98,6 +98,7 @@ use crate::rebalancing::{
     RebalancerServices, RebalancingSchedulers, RebalancingService, RebalancingServiceConfig,
     to_wrapped_equities,
 };
+use crate::startup::StartupToken;
 use crate::telemetry::broker::InstrumentedAlpacaBroker;
 use crate::telemetry::executor::InstrumentedExecutor;
 use crate::telemetry::rpc::RpcTelemetryLayer;
@@ -128,6 +129,28 @@ use trading_queues::{EquityRecoveryInputs, TradingJobQueues, setup_trading_job_q
 pub(crate) struct DatabasePools {
     pub(crate) cqrs: SqlitePool,
     pub(crate) apalis: apalis_sqlite::SqlitePool,
+}
+
+pub(crate) struct ConductorRuntime {
+    pub(crate) event_sender: broadcast::Sender<Statement>,
+    pub(crate) inventory: Arc<BroadcastingInventory>,
+    pub(crate) shutdown_token: CancellationToken,
+    pub(crate) recovery_cell: Arc<tokio::sync::OnceCell<crate::api::RecoveryHandle>>,
+    pub(crate) startup_tokens: ConductorStartupTokens,
+}
+
+pub(crate) struct ConductorStartupTokens {
+    pub(crate) initialized: StartupToken,
+    pub(crate) apalis_monitor: StartupToken,
+    pub(crate) job_cleanup: StartupToken,
+    pub(crate) supervisor: SupervisorStartupTokens,
+}
+
+pub(crate) struct SupervisorStartupTokens {
+    pub(crate) order_fill_monitor: StartupToken,
+    pub(crate) inventory_monitor: StartupToken,
+    pub(crate) executor_maintenance: StartupToken,
+    pub(crate) gas_monitor: StartupToken,
 }
 
 /// Opens an apalis-side pool (sqlx 0.8) against the same database as the
@@ -244,6 +267,9 @@ pub(crate) struct Conductor {
     /// Independent token for apalis — cancelled explicitly in Phase 2 after
     /// producers are stopped.
     apalis_shutdown_token: CancellationToken,
+    /// Cleared once every owned task has been stopped, preventing `Drop` from
+    /// issuing a second supervisor shutdown against an already-closed channel.
+    cleanup_armed: bool,
 }
 
 /// Resets a transfer queue's orphaned `Running`/`Queued` rows back to `Pending`
@@ -519,10 +545,7 @@ impl Conductor {
         executor_ctx: impl TryIntoExecutor<Executor = E>,
         ctx: Ctx,
         pools: DatabasePools,
-        event_sender: broadcast::Sender<Statement>,
-        inventory: Arc<BroadcastingInventory>,
-        shutdown_token: CancellationToken,
-        recovery_cell: Arc<tokio::sync::OnceCell<crate::api::RecoveryHandle>>,
+        runtime: ConductorRuntime,
         #[cfg(any(test, feature = "test-support"))]
         failure_injector: crate::conductor::job::FailureInjector,
     ) -> anyhow::Result<()>
@@ -535,6 +558,19 @@ impl Conductor {
             cqrs: pool,
             apalis: apalis_pool,
         } = pools;
+        let ConductorRuntime {
+            event_sender,
+            inventory,
+            shutdown_token,
+            recovery_cell,
+            startup_tokens,
+        } = runtime;
+        let ConductorStartupTokens {
+            initialized,
+            apalis_monitor: apalis_startup,
+            job_cleanup: cleanup_startup,
+            supervisor: supervisor_startup,
+        } = startup_tokens;
 
         let (executor, provider, telemetry_writer, telemetry) =
             setup_instrumentation(executor_ctx, &ctx.evm, pool.clone()).await?;
@@ -681,6 +717,7 @@ impl Conductor {
             pool.clone(),
             apalis_pool.clone(),
             Duration::from_secs(ctx.apalis_finished_job_cleanup_interval_secs),
+            cleanup_startup,
         );
 
         let conductor_ctx = builder::ConductorCtx {
@@ -694,6 +731,8 @@ impl Conductor {
             wallet_polling,
             tokenizer,
             shutdown_token: shutdown_token.clone(),
+            startup_token: apalis_startup,
+            supervisor_startup,
             #[cfg(any(test, feature = "test-support"))]
             failure_injector,
         };
@@ -721,7 +760,7 @@ impl Conductor {
         let resume_tokenization_queue = resume_tokenization_queue
             .unwrap_or_else(|| ResumeTokenizationJobQueue::new(&apalis_pool));
 
-        let mut conductor = builder::spawn()
+        let conductor = builder::spawn()
             .context(conductor_ctx)
             .job_queue(job_queue)
             .backfill_queue(backfill_queue)
@@ -765,10 +804,15 @@ impl Conductor {
             });
         }
 
+        conductor.run_until_completion(initialized).await
+    }
+
+    async fn run_until_completion(mut self, initialized: StartupToken) -> anyhow::Result<()> {
+        initialized.acknowledge();
         info!("Conductor is running");
-        let result = conductor.wait_for_completion().await;
+        let result = self.wait_for_completion().await;
         if result.is_err() {
-            conductor.abort_all();
+            self.abort_all();
         }
         result
     }
@@ -796,9 +840,7 @@ impl Conductor {
         // Phase 1: stop supervised tasks (OrderFillMonitor, PositionMonitor)
         // so they stop enqueuing new jobs.
         info!(target: "shutdown", "Phase 1: stopping producers (supervisor)");
-        if let Err(error) = self.supervisor.shutdown() {
-            error!(target: "shutdown", %error, "Failed to shutdown supervisor");
-        }
+        self.shutdown_supervisor();
 
         // Wait for the supervisor to fully exit so producers are actually
         // stopped before Phase 2 begins draining consumers.
@@ -819,22 +861,44 @@ impl Conductor {
         self.apalis_shutdown_token.cancel();
         let monitor_result = check_monitor_drain_result((&mut self.monitor).await);
         self.telemetry_writer.abort();
+        self.cleanup_armed = false;
         monitor_result
     }
 
     /// Abort all conductor tasks (force shutdown fallback).
-    pub(crate) fn abort_all(&self) {
-        info!(target: "shutdown", "Aborting all conductor tasks");
-        if let Err(error) = self.supervisor.shutdown() {
-            error!(%error, "Failed to shutdown supervisor");
+    pub(crate) fn abort_all(&mut self) {
+        if !self.cleanup_armed {
+            return;
         }
+
+        self.cleanup_armed = false;
+        info!(target: "shutdown", "Aborting all conductor tasks");
+        self.shutdown_supervisor();
         self.monitor.abort();
         self.abort_background_tasks();
+    }
+
+    fn shutdown_supervisor(&self) {
+        match self.supervisor.shutdown() {
+            Ok(()) => {}
+            Err(SupervisorHandleError::SendError) => {
+                debug!(target: "shutdown", "Supervisor was already stopped");
+            }
+            Err(error @ SupervisorHandleError::RecvError(_)) => {
+                error!(target: "shutdown", %error, "Failed to shutdown supervisor");
+            }
+        }
     }
 
     fn abort_background_tasks(&self) {
         self.job_cleanup.abort();
         self.telemetry_writer.abort();
+    }
+}
+
+impl Drop for Conductor {
+    fn drop(&mut self) {
+        self.abort_all();
     }
 }
 
@@ -1017,8 +1081,9 @@ fn spawn_finished_job_cleanup(
     pool: SqlitePool,
     apalis_pool: apalis_sqlite::SqlitePool,
     cleanup_interval: Duration,
+    startup_token: StartupToken,
 ) -> JoinHandle<()> {
-    tokio::spawn(async move {
+    tokio::spawn(startup_token.wrap(async move {
         let mut interval = tokio::time::interval(cleanup_interval);
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
@@ -1068,7 +1133,7 @@ fn spawn_finished_job_cleanup(
                 }
             }
         }
-    })
+    }))
 }
 
 async fn compact_inventory_snapshot_events(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
@@ -3505,7 +3570,7 @@ mod tests {
     use rain_math_float::Float;
     use sqlx::{ConnectOptions, SqlitePool};
     use std::future::pending;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, RwLock};
     use task_supervisor::SupervisorBuilder;
     use tokio::sync::broadcast;
@@ -3556,6 +3621,19 @@ mod tests {
     use crate::unwrapped_equity_recovery::UnwrappedEquityRecoveryJob;
     use crate::unwrapped_equity_recovery::aggregate::UnwrappedEquityRecoveryId;
     use crate::vault_lookup::MockVaultLookup;
+
+    struct TaskDropFlag(Arc<AtomicBool>);
+
+    impl Drop for TaskDropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    async fn pending_until_aborted<T>(dropped: Arc<AtomicBool>) -> T {
+        let _drop_flag = TaskDropFlag(dropped);
+        pending::<T>().await
+    }
 
     fn one_to_one_ratio() -> UnderlyingPerWrapped {
         UnderlyingPerWrapped::new(RATIO_ONE).unwrap()
@@ -3695,6 +3773,7 @@ mod tests {
             telemetry_writer: tokio::spawn(pending::<()>()),
             shutdown_token: CancellationToken::new(),
             apalis_shutdown_token: CancellationToken::new(),
+            cleanup_armed: true,
         }
     }
 
@@ -4494,12 +4573,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dropping_conductor_aborts_owned_background_tasks() {
+        let monitor_dropped = Arc::new(AtomicBool::new(false));
+        let cleanup_dropped = Arc::new(AtomicBool::new(false));
+        let telemetry_dropped = Arc::new(AtomicBool::new(false));
+        let supervisor = SupervisorBuilder::default().build().run();
+        let monitor = tokio::spawn(pending_until_aborted::<Result<(), MonitorTaskError>>(
+            Arc::clone(&monitor_dropped),
+        ));
+        let job_cleanup = tokio::spawn(pending_until_aborted::<()>(Arc::clone(&cleanup_dropped)));
+        let telemetry_writer =
+            tokio::spawn(pending_until_aborted::<()>(Arc::clone(&telemetry_dropped)));
+        tokio::task::yield_now().await;
+
+        drop(Conductor {
+            supervisor,
+            monitor,
+            job_cleanup,
+            telemetry_writer,
+            shutdown_token: CancellationToken::new(),
+            apalis_shutdown_token: CancellationToken::new(),
+            cleanup_armed: true,
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !monitor_dropped.load(Ordering::SeqCst)
+                || !cleanup_dropped.load(Ordering::SeqCst)
+                || !telemetry_dropped.load(Ordering::SeqCst)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropping Conductor should abort every owned task");
+    }
+
+    #[tokio::test]
     async fn spawn_finished_job_cleanup_runs_until_aborted() {
         let (pool, apalis_pool) = setup_test_pools().await;
         insert_finished_job(&apalis_pool, "done").await;
 
-        let handle =
-            spawn_finished_job_cleanup(pool.clone(), apalis_pool.clone(), Duration::from_secs(60));
+        let handle = spawn_finished_job_cleanup(
+            pool.clone(),
+            apalis_pool.clone(),
+            Duration::from_secs(60),
+            crate::startup::StartupBarrier::new(1).token(),
+        );
 
         wait_for_job_count(&apalis_pool, 0).await;
         handle.abort();
@@ -4542,8 +4661,12 @@ mod tests {
         )
         .await;
 
-        let handle =
-            spawn_finished_job_cleanup(pool.clone(), apalis_pool.clone(), Duration::from_secs(60));
+        let handle = spawn_finished_job_cleanup(
+            pool.clone(),
+            apalis_pool.clone(),
+            Duration::from_secs(60),
+            crate::startup::StartupBarrier::new(1).token(),
+        );
 
         // The two non-transfer finished rows are pruned; the two transfer rows remain.
         wait_for_job_count(&apalis_pool, 2).await;
@@ -9965,10 +10088,15 @@ mod tests {
             telemetry_writer: tokio::spawn(pending::<()>()),
             shutdown_token: shutdown_token.clone(),
             apalis_shutdown_token,
+            cleanup_armed: true,
         };
 
         shutdown_token.cancel();
         conductor.wait_for_completion().await.unwrap();
+        assert!(
+            !conductor.cleanup_armed,
+            "graceful drain should disarm drop cleanup"
+        );
     }
 
     #[tokio::test]
@@ -9993,6 +10121,7 @@ mod tests {
             telemetry_writer: tokio::spawn(pending::<()>()),
             shutdown_token: shutdown_token.clone(),
             apalis_shutdown_token,
+            cleanup_armed: true,
         };
 
         shutdown_token.cancel();
@@ -10000,6 +10129,10 @@ mod tests {
         assert!(
             result.is_err(),
             "monitor error during drain should propagate"
+        );
+        assert!(
+            !conductor.cleanup_armed,
+            "a completed drain should disarm drop cleanup even when the monitor failed"
         );
     }
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -34,6 +34,7 @@ use super::monitor::gas::{GasMonitor, ProviderBalanceReader};
 use super::monitor::inventory::InventoryMonitor;
 use super::monitor::order_fills::OrderFillMonitor;
 use crate::alerts::TelegramNotifier;
+use crate::conductor::SupervisorStartupTokens;
 use crate::inventory::{
     InventoryPollingService, InventorySnapshot, InventorySnapshotId, WalletPollingCtx,
 };
@@ -64,6 +65,7 @@ use crate::rebalancing::{
     EquityRebalancingCheck, EquityRebalancingCheckScheduler, RebalancingService,
     UsdcRebalancingCheck, UsdcRebalancingCheckScheduler,
 };
+use crate::startup::{StartupTask, StartupToken};
 use crate::trading::offchain::hedge::{HedgeCtx, HedgeJobQueue, PlaceHedge};
 use crate::trading::onchain::trade_accountant::{
     AccountForDexTrade, AccountantCtx, DexTradeAccountingJobQueue, TradeAccountingError,
@@ -100,6 +102,8 @@ pub(crate) struct ConductorCtx<Prov, Exec> {
     pub(crate) wallet_polling: Option<WalletPollingCtx>,
     pub(crate) tokenizer: Option<Arc<dyn Tokenizer>>,
     pub(crate) shutdown_token: CancellationToken,
+    pub(crate) startup_token: StartupToken,
+    pub(crate) supervisor_startup: SupervisorStartupTokens,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) failure_injector: FailureInjector,
 }
@@ -343,6 +347,13 @@ where
     let apalis_shutdown_token = CancellationToken::new();
     let apalis_shutdown_token_for_struct = apalis_shutdown_token.clone();
 
+    let SupervisorStartupTokens {
+        order_fill_monitor: order_fill_startup,
+        inventory_monitor: inventory_startup,
+        executor_maintenance: executor_maintenance_startup,
+        gas_monitor: gas_monitor_startup,
+    } = context.supervisor_startup;
+
     let order_fill_monitor = OrderFillMonitor::new(
         context.ctx.evm.clone(),
         backfill_queue.clone(),
@@ -360,22 +371,47 @@ where
         .with_max_backoff_exponent(if is_test { 2 } else { 8 })
         .with_base_restart_delay(std::time::Duration::from_secs(1))
         .with_dead_tasks_threshold(Some(0.0))
-        .with_task("order-fill-monitor", order_fill_monitor)
-        .with_task("inventory-monitor", inventory_monitor);
+        .with_task(
+            "order-fill-monitor",
+            StartupTask {
+                task: order_fill_monitor,
+                token: order_fill_startup,
+            },
+        )
+        .with_task(
+            "inventory-monitor",
+            StartupTask {
+                task: inventory_monitor,
+                token: inventory_startup,
+            },
+        );
 
     log_optional_task_status("executor maintenance", maintenance_interval.is_some());
 
     if let Some(interval) = maintenance_interval {
         supervisor_builder = supervisor_builder.with_task(
             "executor-maintenance",
-            ExecutorMaintenance::new(context.executor, interval),
+            StartupTask {
+                task: ExecutorMaintenance::new(context.executor, interval),
+                token: executor_maintenance_startup,
+            },
         );
+    } else {
+        executor_maintenance_startup.acknowledge();
     }
 
     log_optional_task_status("gas monitor", gas_monitor.is_some());
 
     if let Some(gas_monitor) = gas_monitor {
-        supervisor_builder = supervisor_builder.with_task("gas-monitor", gas_monitor);
+        supervisor_builder = supervisor_builder.with_task(
+            "gas-monitor",
+            StartupTask {
+                task: gas_monitor,
+                token: gas_monitor_startup,
+            },
+        );
+    } else {
+        gas_monitor_startup.acknowledge();
     }
 
     let supervisor = supervisor_builder.build().run();
@@ -414,6 +450,7 @@ where
         resume_tokenization_ctx,
         apalis_shutdown_token,
         seed_vault_registry_queue,
+        startup_token: context.startup_token,
         #[cfg(any(test, feature = "test-support"))]
         failure_injector: context.failure_injector,
     }
@@ -426,6 +463,7 @@ where
         telemetry_writer,
         shutdown_token: context.shutdown_token,
         apalis_shutdown_token: apalis_shutdown_token_for_struct,
+        cleanup_armed: true,
     }
 }
 
@@ -473,6 +511,7 @@ where
     resume_tokenization_ctx: Option<Arc<ResumeTokenizationCtx>>,
     apalis_shutdown_token: CancellationToken,
     seed_vault_registry_queue: SeedVaultRegistryJobQueue,
+    startup_token: StartupToken,
     #[cfg(any(test, feature = "test-support"))]
     failure_injector: FailureInjector,
 }
@@ -520,6 +559,7 @@ where
             resume_tokenization_ctx,
             apalis_shutdown_token,
             seed_vault_registry_queue,
+            startup_token,
             #[cfg(any(test, feature = "test-support"))]
             failure_injector,
         } = self;
@@ -594,7 +634,7 @@ where
         let fail_stop_for_transfer_equity_to_hedging = fail_stop.clone();
         let accountant_ctx_for_backfill = accountant_ctx.clone();
 
-        tokio::spawn(async move {
+        tokio::spawn(startup_token.wrap(async move {
             let monitor = Monitor::new()
                 .should_restart(|_ctx, _error, _attempt| false)
                 .register(move |index| {
@@ -822,7 +862,7 @@ where
                     Err(source) => Err(MonitorTaskError::UnexpectedExit { source: Some(source) }),
                 },
             }
-        })
+        }))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,22 +15,25 @@ use std::future::Future;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 use task_supervisor::{
-    SupervisedTask, SupervisorBuilder, SupervisorError, SupervisorHandle, TaskResult,
+    SupervisedTask, SupervisorBuilder, SupervisorError, SupervisorHandle, SupervisorHandleError,
+    TaskResult,
 };
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use tokio::task::{AbortHandle, JoinError, JoinHandle};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use tracing_subscriber::Layer;
 
 use st0x_config::{BrokerCtx, Ctx};
 use st0x_dto::Statement;
 use st0x_execution::MockExecutorCtx;
 
+use crate::conductor::{
+    ConductorRuntime, ConductorStartupTokens, DatabasePools, SupervisorStartupTokens,
+};
 use crate::trading::offchain::hedge::HedgeJobQueue;
 use crate::trading::onchain::trade_accountant::DexTradeAccountingJobQueue;
-use conductor::DatabasePools;
 
 /// Outer timeout for the entire graceful shutdown sequence. Must exceed
 /// the rebalancer drain timeout (60s) plus margin for supervisor shutdown
@@ -57,6 +60,7 @@ mod performance;
 mod position;
 mod position_check;
 mod rebalancing;
+mod startup;
 mod telemetry;
 mod trading;
 #[cfg(feature = "mock")]
@@ -156,6 +160,24 @@ pub async fn run_bot_session(ctx: Ctx) -> anyhow::Result<()> {
 }
 
 #[tracing::instrument(skip_all, target = "startup", level = tracing::Level::INFO)]
+pub async fn run_server_bot_session(ctx: Ctx) -> anyhow::Result<()> {
+    let (event_sender, _) = broadcast::channel::<Statement>(256);
+    let startup_notifier: Arc<dyn startup::StartupNotifier> =
+        match startup::DeploymentStartupNotifier::from_env() {
+            Some(notifier) => Arc::new(notifier),
+            None => Arc::new(startup::NoopStartupNotifier),
+        };
+    run_bot_session_inner(
+        ctx,
+        event_sender,
+        startup_notifier,
+        #[cfg(any(test, feature = "test-support"))]
+        FailureInjector::new(),
+    )
+    .await
+}
+
+#[tracing::instrument(skip_all, target = "startup", level = tracing::Level::INFO)]
 pub async fn run_bot_session_with_event_channel(
     ctx: Ctx,
     event_sender: broadcast::Sender<Statement>,
@@ -163,6 +185,7 @@ pub async fn run_bot_session_with_event_channel(
     run_bot_session_inner(
         ctx,
         event_sender,
+        Arc::new(startup::NoopStartupNotifier),
         #[cfg(any(test, feature = "test-support"))]
         FailureInjector::new(),
     )
@@ -178,12 +201,19 @@ pub async fn run_bot_session_with_injector(
     event_sender: broadcast::Sender<Statement>,
     failure_injector: FailureInjector,
 ) -> anyhow::Result<()> {
-    run_bot_session_inner(ctx, event_sender, failure_injector).await
+    run_bot_session_inner(
+        ctx,
+        event_sender,
+        Arc::new(startup::NoopStartupNotifier),
+        failure_injector,
+    )
+    .await
 }
 
 async fn run_bot_session_inner(
     ctx: Ctx,
     event_sender: broadcast::Sender<Statement>,
+    startup_notifier: Arc<dyn startup::StartupNotifier>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> anyhow::Result<()> {
     let pool = ctx.get_sqlite_pool().await?;
@@ -226,14 +256,33 @@ async fn run_bot_session_inner(
         resume_lock,
         metrics_handle,
     };
-    let server_supervisor = spawn_server_supervisor(state, &pools, main_listener, board_listener);
-    let bot_task = tokio::spawn(Box::pin(run_conductor_session(
+    let startup_barrier = startup::StartupBarrier::new(9);
+    let server_supervisor = spawn_server_supervisor(
+        state,
+        &pools,
+        main_listener,
+        board_listener,
+        startup_barrier.token(),
+        startup_barrier.token(),
+    );
+    let mut bot_task = tokio::spawn(Box::pin(run_conductor_session(
         ctx,
         pools,
         event_sender,
         inventory,
         shutdown_token.clone(),
         recovery_cell,
+        ConductorStartupTokens {
+            initialized: startup_barrier.token(),
+            apalis_monitor: startup_barrier.token(),
+            job_cleanup: startup_barrier.token(),
+            supervisor: SupervisorStartupTokens {
+                order_fill_monitor: startup_barrier.token(),
+                inventory_monitor: startup_barrier.token(),
+                executor_maintenance: startup_barrier.token(),
+                gas_monitor: startup_barrier.token(),
+            },
+        },
         #[cfg(any(test, feature = "test-support"))]
         failure_injector,
     )));
@@ -247,9 +296,10 @@ async fn run_bot_session_inner(
     // guard aborts the conductor and shuts the supervisor down on drop, so a
     // cancelled session actually stops. The graceful path already stops both
     // before this guard drops, making it a no-op there.
-    let _session_guard = SessionTaskGuard {
+    let mut session_guard = SessionTaskGuard {
         conductor: bot_task.abort_handle(),
         server_supervisor: server_supervisor.clone(),
+        armed: true,
     };
 
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
@@ -260,15 +310,40 @@ async fn run_bot_session_inner(
             _ = sigterm.recv() => info!(target: "shutdown", "Received SIGTERM"),
         }
     };
+    tokio::pin!(shutdown_signal);
 
-    await_shutdown(
-        server_supervisor,
-        bot_task,
-        shutdown_token,
-        shutdown_signal,
-        GRACEFUL_SHUTDOWN_TIMEOUT,
+    let startup_outcome = report_when_started(
+        &server_supervisor,
+        &mut bot_task,
+        &startup_barrier,
+        startup_notifier.as_ref(),
+        shutdown_signal.as_mut(),
     )
     .await?;
+
+    let shutdown_result = match startup_outcome {
+        StartupOutcome::Started => {
+            await_shutdown(
+                server_supervisor,
+                bot_task,
+                shutdown_token,
+                shutdown_signal,
+                GRACEFUL_SHUTDOWN_TIMEOUT,
+            )
+            .await
+        }
+        StartupOutcome::ShutdownSignal => {
+            drain_for_shutdown_signal(
+                &server_supervisor,
+                bot_task,
+                shutdown_token,
+                GRACEFUL_SHUTDOWN_TIMEOUT,
+            )
+            .await
+        }
+    };
+    session_guard.disarm();
+    shutdown_result?;
 
     info!(target: "startup", "Shutdown complete");
     Ok(())
@@ -290,10 +365,21 @@ async fn run_bot_session_inner(
 struct SessionTaskGuard {
     conductor: AbortHandle,
     server_supervisor: SupervisorHandle,
+    armed: bool,
+}
+
+impl SessionTaskGuard {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
 }
 
 impl Drop for SessionTaskGuard {
     fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
         self.conductor.abort();
         shutdown_supervisor(&self.server_supervisor);
     }
@@ -312,6 +398,7 @@ impl Drop for SessionTaskGuard {
 struct ServerTask {
     router: Router,
     listener: Arc<Mutex<Option<TcpListener>>>,
+    startup_token: startup::StartupToken,
 }
 
 impl SupervisedTask for ServerTask {
@@ -327,7 +414,11 @@ impl SupervisedTask for ServerTask {
             )?;
         let port = listener.local_addr().map(|addr| addr.port()).ok();
         info!(target: "startup", ?port, "Server listening");
-        axum::serve(listener, self.router.clone()).await?;
+        let router = self.router.clone();
+        self.startup_token
+            .clone()
+            .wrap(async move { axum::serve(listener, router).await })
+            .await?;
         Err("axum server exited unexpectedly".into())
     }
 }
@@ -337,6 +428,8 @@ fn spawn_server_supervisor(
     pools: &DatabasePools,
     main_listener: TcpListener,
     board_listener: TcpListener,
+    main_startup_token: startup::StartupToken,
+    board_startup_token: startup::StartupToken,
 ) -> SupervisorHandle {
     let main_router = Router::new()
         .merge(api::routes())
@@ -369,6 +462,7 @@ fn spawn_server_supervisor(
             ServerTask {
                 router: main_router,
                 listener: Arc::new(Mutex::new(Some(main_listener))),
+                startup_token: main_startup_token,
             },
         )
         .with_task(
@@ -376,6 +470,7 @@ fn spawn_server_supervisor(
             ServerTask {
                 router: board_router,
                 listener: Arc::new(Mutex::new(Some(board_listener))),
+                startup_token: board_startup_token,
             },
         )
         .build()
@@ -392,7 +487,6 @@ async fn await_shutdown<S>(
 where
     S: Future<Output = ()>,
 {
-    let bot_abort = bot_task.abort_handle();
     tokio::pin!(shutdown_signal);
 
     let trigger: ShutdownTrigger = tokio::select! {
@@ -403,14 +497,13 @@ where
 
     match trigger {
         ShutdownTrigger::Signal => {
-            info!(target: "shutdown", "Shutdown signal received, draining gracefully");
-            shutdown_token.cancel();
-            shutdown_supervisor(&server_supervisor);
-            drain_bot_with_timeout(bot_task, bot_abort, drain_timeout).await
+            drain_for_shutdown_signal(&server_supervisor, bot_task, shutdown_token, drain_timeout)
+                .await
         }
         ShutdownTrigger::ServerExit(result) => {
             info!(target: "shutdown", "Server supervisor exited, draining bot");
             shutdown_token.cancel();
+            let bot_abort = bot_task.abort_handle();
             drain_bot_with_timeout(bot_task, bot_abort, drain_timeout).await?;
             check_server_result(result)
         }
@@ -419,6 +512,48 @@ where
             check_bot_result(result)
         }
     }
+}
+
+async fn drain_for_shutdown_signal(
+    server_supervisor: &SupervisorHandle,
+    bot_task: JoinHandle<anyhow::Result<()>>,
+    shutdown_token: CancellationToken,
+    drain_timeout: Duration,
+) -> anyhow::Result<()> {
+    info!(target: "shutdown", "Shutdown signal received, draining gracefully");
+    shutdown_token.cancel();
+    shutdown_supervisor(server_supervisor);
+    let bot_abort = bot_task.abort_handle();
+    drain_bot_with_timeout(bot_task, bot_abort, drain_timeout).await
+}
+
+async fn report_when_started(
+    server_supervisor: &SupervisorHandle,
+    bot_task: &mut JoinHandle<anyhow::Result<()>>,
+    startup_barrier: &startup::StartupBarrier,
+    startup_notifier: &dyn startup::StartupNotifier,
+    shutdown_signal: impl Future<Output = ()>,
+) -> anyhow::Result<StartupOutcome> {
+    tokio::select! {
+        biased;
+        result = server_supervisor.wait() => {
+            return check_startup_server_result(result).map(|()| StartupOutcome::Started);
+        }
+        result = bot_task => {
+            return check_startup_bot_result(result).map(|()| StartupOutcome::Started);
+        }
+        () = shutdown_signal => return Ok(StartupOutcome::ShutdownSignal),
+        () = startup_barrier.wait() => {}
+    }
+
+    startup::report_ready(startup_notifier)?;
+    Ok(StartupOutcome::Started)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StartupOutcome {
+    Started,
+    ShutdownSignal,
 }
 
 enum ShutdownTrigger {
@@ -455,8 +590,14 @@ async fn drain_bot_with_timeout(
 
 fn shutdown_supervisor(handle: &SupervisorHandle) {
     info!(target: "startup", name = "server", "Shutting down supervisor");
-    if let Err(error) = handle.shutdown() {
-        error!(target: "startup", %error, "Failed to shutdown server supervisor");
+    match handle.shutdown() {
+        Ok(()) => {}
+        Err(SupervisorHandleError::SendError) => {
+            debug!(target: "startup", "Server supervisor was already stopped");
+        }
+        Err(error @ SupervisorHandleError::RecvError(_)) => {
+            error!(target: "startup", %error, "Failed to shutdown server supervisor");
+        }
     }
 }
 
@@ -470,6 +611,15 @@ fn check_server_result(result: Result<(), SupervisorError>) -> anyhow::Result<()
             error!(target: "startup", %error, "Server supervisor failed");
             Err(anyhow::anyhow!("Server supervisor failed: {error}"))
         }
+    }
+}
+
+fn check_startup_server_result(result: Result<(), SupervisorError>) -> anyhow::Result<()> {
+    match result {
+        Ok(()) => Err(anyhow::anyhow!(
+            "Server supervisor exited before startup completed"
+        )),
+        Err(error) => check_server_result(Err(error)),
     }
 }
 
@@ -490,6 +640,13 @@ fn check_bot_result(result: Result<anyhow::Result<()>, JoinError>) -> anyhow::Re
     }
 }
 
+fn check_startup_bot_result(result: Result<anyhow::Result<()>, JoinError>) -> anyhow::Result<()> {
+    match result {
+        Ok(Ok(())) => Err(anyhow::anyhow!("Bot exited before startup completed")),
+        other => check_bot_result(other),
+    }
+}
+
 /// Runs a single conductor session with the configured broker executor.
 #[tracing::instrument(skip_all, target = "startup", level = tracing::Level::INFO)]
 async fn run_conductor_session(
@@ -499,6 +656,7 @@ async fn run_conductor_session(
     inventory: Arc<inventory::BroadcastingInventory>,
     shutdown_token: tokio_util::sync::CancellationToken,
     recovery_cell: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
+    startup_tokens: ConductorStartupTokens,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> anyhow::Result<()> {
     let result = match ctx.broker.clone() {
@@ -509,10 +667,13 @@ async fn run_conductor_session(
                 MockExecutorCtx,
                 ctx,
                 pools,
-                event_sender,
-                inventory,
-                shutdown_token,
-                recovery_cell,
+                ConductorRuntime {
+                    event_sender,
+                    inventory,
+                    shutdown_token,
+                    recovery_cell,
+                    startup_tokens,
+                },
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector,
             ))
@@ -524,10 +685,13 @@ async fn run_conductor_session(
                 alpaca_auth,
                 ctx,
                 pools,
-                event_sender,
-                inventory,
-                shutdown_token,
-                recovery_cell,
+                ConductorRuntime {
+                    event_sender,
+                    inventory,
+                    shutdown_token,
+                    recovery_cell,
+                    startup_tokens,
+                },
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector,
             ))
@@ -550,11 +714,30 @@ async fn run_conductor_session(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::address;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::io;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use st0x_config::create_test_ctx_with_order_owner;
 
     use super::*;
+
+    #[derive(Clone)]
+    struct PendingSupervisorTask;
+
+    impl SupervisedTask for PendingSupervisorTask {
+        async fn run(&mut self) -> TaskResult {
+            std::future::pending().await
+        }
+    }
+
+    struct RecordingStartupNotifier<'a>(&'a AtomicUsize);
+
+    impl startup::StartupNotifier for RecordingStartupNotifier<'_> {
+        fn notify_ready(&self) -> io::Result<()> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
 
     // `Ctx::load_files` parses `orderbook` into `Address`, so runtime tests
     // only exercise already-validated addresses. Invalid orderbook input is
@@ -571,6 +754,160 @@ mod tests {
             inventory::InventoryView::default(),
             sender,
         ))
+    }
+
+    fn create_test_startup_tokens() -> ConductorStartupTokens {
+        let barrier = startup::StartupBarrier::new(7);
+        ConductorStartupTokens {
+            initialized: barrier.token(),
+            apalis_monitor: barrier.token(),
+            job_cleanup: barrier.token(),
+            supervisor: SupervisorStartupTokens {
+                order_fill_monitor: barrier.token(),
+                inventory_monitor: barrier.token(),
+                executor_maintenance: barrier.token(),
+                gas_monitor: barrier.token(),
+            },
+        }
+    }
+
+    fn pending_test_supervisor() -> SupervisorHandle {
+        SupervisorBuilder::default()
+            .with_task("pending", PendingSupervisorTask)
+            .build()
+            .run()
+    }
+
+    #[tokio::test]
+    async fn startup_exit_does_not_report_readiness() {
+        let supervisor = pending_test_supervisor();
+        let barrier = startup::StartupBarrier::new(1);
+        let notifications = AtomicUsize::new(0);
+        let notifier = RecordingStartupNotifier(&notifications);
+        let mut bot_task = tokio::spawn(async { anyhow::bail!("startup failed") });
+
+        let error = report_when_started(
+            &supervisor,
+            &mut bot_task,
+            &barrier,
+            &notifier,
+            std::future::pending(),
+        )
+        .await
+        .expect_err("an immediate task exit should fail startup");
+
+        assert_eq!(error.to_string(), "startup failed");
+        assert_eq!(notifications.load(Ordering::SeqCst), 0);
+        shutdown_supervisor(&supervisor);
+    }
+
+    #[tokio::test]
+    async fn clean_bot_exit_before_startup_does_not_report_readiness() {
+        let supervisor = pending_test_supervisor();
+        let barrier = startup::StartupBarrier::new(1);
+        let notifications = AtomicUsize::new(0);
+        let notifier = RecordingStartupNotifier(&notifications);
+        let mut bot_task = tokio::spawn(async { Ok(()) });
+
+        let error = report_when_started(
+            &supervisor,
+            &mut bot_task,
+            &barrier,
+            &notifier,
+            std::future::pending(),
+        )
+        .await
+        .expect_err("a clean early bot exit should fail startup");
+
+        assert_eq!(error.to_string(), "Bot exited before startup completed");
+        assert_eq!(notifications.load(Ordering::SeqCst), 0);
+        shutdown_supervisor(&supervisor);
+    }
+
+    #[test]
+    fn clean_server_exit_before_startup_is_an_error() {
+        let error = check_startup_server_result(Ok(()))
+            .expect_err("a clean early server exit should fail startup");
+
+        assert_eq!(
+            error.to_string(),
+            "Server supervisor exited before startup completed"
+        );
+    }
+
+    #[tokio::test]
+    async fn completed_startup_barrier_reports_readiness_once() {
+        let supervisor = pending_test_supervisor();
+        let barrier = startup::StartupBarrier::new(1);
+        barrier.token().acknowledge();
+        let notifications = AtomicUsize::new(0);
+        let notifier = RecordingStartupNotifier(&notifications);
+        let mut bot_task = tokio::spawn(std::future::pending::<anyhow::Result<()>>());
+
+        let outcome = report_when_started(
+            &supervisor,
+            &mut bot_task,
+            &barrier,
+            &notifier,
+            std::future::pending(),
+        )
+        .await
+        .expect("completed startup should report readiness");
+
+        assert_eq!(outcome, StartupOutcome::Started);
+        assert_eq!(notifications.load(Ordering::SeqCst), 1);
+        bot_task.abort();
+        shutdown_supervisor(&supervisor);
+    }
+
+    #[tokio::test]
+    async fn shutdown_signal_before_startup_does_not_report_readiness() {
+        let supervisor = pending_test_supervisor();
+        let barrier = startup::StartupBarrier::new(1);
+        let notifications = AtomicUsize::new(0);
+        let notifier = RecordingStartupNotifier(&notifications);
+        let mut bot_task = tokio::spawn(std::future::pending::<anyhow::Result<()>>());
+
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(1),
+            report_when_started(
+                &supervisor,
+                &mut bot_task,
+                &barrier,
+                &notifier,
+                std::future::ready(()),
+            ),
+        )
+        .await
+        .expect("the startup wait should observe the shutdown signal")
+        .expect("the shutdown signal should be a clean startup outcome");
+
+        assert_eq!(outcome, StartupOutcome::ShutdownSignal);
+        assert_eq!(notifications.load(Ordering::SeqCst), 0);
+        bot_task.abort();
+        shutdown_supervisor(&supervisor);
+    }
+
+    #[tokio::test]
+    async fn disarmed_session_guard_leaves_completed_shutdown_untouched() {
+        let conductor_task = tokio::spawn(std::future::pending::<()>());
+        let supervisor = pending_test_supervisor();
+        let mut guard = SessionTaskGuard {
+            conductor: conductor_task.abort_handle(),
+            server_supervisor: supervisor.clone(),
+            armed: true,
+        };
+
+        guard.disarm();
+        drop(guard);
+        tokio::task::yield_now().await;
+
+        assert!(
+            !conductor_task.is_finished(),
+            "a disarmed cleanup guard must not abort an already-managed task"
+        );
+        conductor_task.abort();
+        shutdown_supervisor(&supervisor);
     }
 
     #[tokio::test]
@@ -735,6 +1072,7 @@ mod tests {
             create_test_inventory(),
             tokio_util::sync::CancellationToken::new(),
             Arc::new(tokio::sync::OnceCell::new()),
+            create_test_startup_tokens(),
             FailureInjector::new(),
         ))
         .await
@@ -765,6 +1103,7 @@ mod tests {
             create_test_inventory(),
             tokio_util::sync::CancellationToken::new(),
             Arc::new(tokio::sync::OnceCell::new()),
+            create_test_startup_tokens(),
             FailureInjector::new(),
         ))
         .await

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,0 +1,272 @@
+//! Coordinates startup acknowledgements and deployment readiness reporting.
+//!
+//! [`StartupBarrier`] waits for one acknowledgement from each essential run
+//! loop, while [`StartupToken`] acknowledges only after its wrapped future has
+//! reached a pending state. Once the barrier completes, the deployment notifier
+//! writes the ready process ID that activation validates against systemd.
+
+use anyhow::Context;
+use std::future::Future;
+use std::io;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::task::{Context as TaskContext, Poll};
+use task_supervisor::{SupervisedTask, TaskResult};
+use tokio::sync::Notify;
+
+const READY_FILE_ENV: &str = "ST0X_STARTUP_READY_FILE";
+
+pub(crate) trait StartupNotifier: Send + Sync {
+    fn notify_ready(&self) -> io::Result<()>;
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct NoopStartupNotifier;
+
+impl StartupNotifier for NoopStartupNotifier {
+    fn notify_ready(&self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct DeploymentStartupNotifier {
+    ready_file: PathBuf,
+}
+
+impl DeploymentStartupNotifier {
+    pub(crate) fn from_env() -> Option<Self> {
+        std::env::var_os(READY_FILE_ENV).map(|ready_file| Self {
+            ready_file: PathBuf::from(ready_file),
+        })
+    }
+}
+
+impl StartupNotifier for DeploymentStartupNotifier {
+    fn notify_ready(&self) -> io::Result<()> {
+        std::fs::write(&self.ready_file, format!("{}\n", std::process::id()))
+    }
+}
+
+pub(crate) fn report_ready(notifier: &dyn StartupNotifier) -> anyhow::Result<()> {
+    notifier
+        .notify_ready()
+        .context("failed to report that startup completed")
+}
+
+#[derive(Debug)]
+pub(crate) struct StartupBarrier {
+    required: usize,
+    acknowledged: Arc<AtomicUsize>,
+    notify: Arc<Notify>,
+}
+
+impl StartupBarrier {
+    pub(crate) fn new(required: usize) -> Self {
+        Self {
+            required,
+            acknowledged: Arc::new(AtomicUsize::new(0)),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    pub(crate) fn token(&self) -> StartupToken {
+        StartupToken {
+            acknowledged: Arc::new(AtomicBool::new(false)),
+            acknowledged_count: Arc::clone(&self.acknowledged),
+            notify: Arc::clone(&self.notify),
+        }
+    }
+
+    pub(crate) async fn wait(&self) {
+        loop {
+            let notified = self.notify.notified();
+
+            if self.acknowledged.load(Ordering::Acquire) >= self.required {
+                return;
+            }
+
+            notified.await;
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct StartupToken {
+    acknowledged: Arc<AtomicBool>,
+    acknowledged_count: Arc<AtomicUsize>,
+    notify: Arc<Notify>,
+}
+
+impl StartupToken {
+    pub(crate) fn acknowledge(&self) {
+        if !self.acknowledged.swap(true, Ordering::AcqRel) {
+            self.acknowledged_count.fetch_add(1, Ordering::AcqRel);
+            self.notify.notify_waiters();
+        }
+    }
+
+    pub(crate) fn wrap<F>(self, future: F) -> StartupFuture<F>
+    where
+        F: Future,
+    {
+        StartupFuture {
+            future: Box::pin(future),
+            token: self,
+        }
+    }
+}
+
+pub(crate) struct StartupFuture<F> {
+    future: Pin<Box<F>>,
+    token: StartupToken,
+}
+
+impl<F> Future for StartupFuture<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        match this.future.as_mut().poll(cx) {
+            Poll::Pending => {
+                this.token.acknowledge();
+                Poll::Pending
+            }
+            Poll::Ready(output) => Poll::Ready(output),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct StartupTask<T> {
+    pub(crate) task: T,
+    pub(crate) token: StartupToken,
+}
+
+impl<T> SupervisedTask for StartupTask<T>
+where
+    T: SupervisedTask,
+{
+    async fn run(&mut self) -> TaskResult {
+        self.token.clone().wrap(self.task.run()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+    use std::future::{pending, ready};
+    use std::io;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use task_supervisor::{SupervisedTask, TaskResult};
+    use tempfile::tempdir;
+
+    use super::{
+        DeploymentStartupNotifier, StartupBarrier, StartupNotifier, StartupTask, report_ready,
+    };
+
+    #[derive(Clone)]
+    struct PendingTask;
+
+    impl SupervisedTask for PendingTask {
+        async fn run(&mut self) -> TaskResult {
+            pending().await
+        }
+    }
+
+    struct RecordingNotifier<'a> {
+        notifications: &'a AtomicUsize,
+        error_kind: Option<io::ErrorKind>,
+    }
+
+    impl StartupNotifier for RecordingNotifier<'_> {
+        fn notify_ready(&self) -> io::Result<()> {
+            self.notifications.fetch_add(1, Ordering::SeqCst);
+
+            self.error_kind
+                .map_or(Ok(()), |kind| Err(io::Error::from(kind)))
+        }
+    }
+
+    #[test]
+    fn deployment_notification_writes_the_current_process_id() {
+        let directory = tempdir().expect("temporary directory should be created");
+        let ready_file = directory.path().join("ready");
+        let notifier = DeploymentStartupNotifier {
+            ready_file: ready_file.clone(),
+        };
+
+        report_ready(&notifier).expect("readiness notification should succeed");
+
+        let contents = std::fs::read_to_string(ready_file).expect("ready file should be readable");
+        assert_eq!(contents, format!("{}\n", std::process::id()));
+    }
+
+    #[test]
+    fn readiness_notification_failure_preserves_the_source() {
+        let notifications = AtomicUsize::new(0);
+        let notifier = RecordingNotifier {
+            notifications: &notifications,
+            error_kind: Some(io::ErrorKind::PermissionDenied),
+        };
+
+        let error = report_ready(&notifier).expect_err("notification should fail");
+        let source = error
+            .downcast_ref::<io::Error>()
+            .expect("the notification source should be preserved");
+
+        assert_eq!(source.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(notifications.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn immediately_ready_future_does_not_acknowledge_startup() {
+        let barrier = StartupBarrier::new(1);
+        let token = barrier.token();
+
+        token.wrap(ready(Ok::<(), Infallible>(()))).await.unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_millis(10), barrier.wait())
+            .await
+            .expect_err("an immediately ready future must not acknowledge startup");
+    }
+
+    #[tokio::test]
+    async fn pending_future_acknowledges_startup_once_across_clones() {
+        let barrier = StartupBarrier::new(1);
+        let token = barrier.token();
+        let cloned = token.clone();
+        let first = tokio::spawn(token.wrap(pending::<()>()));
+        let second = tokio::spawn(cloned.wrap(pending::<()>()));
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), barrier.wait())
+            .await
+            .expect("pending future should acknowledge startup");
+
+        first.abort();
+        second.abort();
+    }
+
+    #[tokio::test]
+    async fn supervised_task_acknowledges_after_reaching_its_run_loop() {
+        let barrier = StartupBarrier::new(1);
+        let mut task = StartupTask {
+            task: PendingTask,
+            token: barrier.token(),
+        };
+        let task_handle = tokio::spawn(async move { task.run().await });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), barrier.wait())
+            .await
+            .expect("a pending supervised task should acknowledge startup");
+
+        task_handle.abort();
+    }
+}


### PR DESCRIPTION
## What

Closes RAI-1358.

Adds a deterministic, PID-scoped readiness handshake to bot deployments so deploy-rs only reports success after the new process has completed startup and entered its essential run loops.

## Why

The systemd unit uses `Type=simple`, so a successful `systemctl restart` only proves that a process launched. The bot could still exit during Conductor initialization or fail to start an essential runtime task while the deployment was already considered successful.

## How

- Thread a startup acknowledgement token through server launch and Conductor startup.
- Acknowledge readiness only after initialization completes and every essential supervised task has reached its pending run state.
- Write the ready process PID in the systemd runtime directory and remove stale readiness state before each restart.
- Make activation wait up to five minutes for the ready PID to match the live systemd `MainPID` while the unit remains active.
- On early exit or timeout, print unit status and recent journal output, clear the activation marker, fail activation, and let deploy-rs roll back.
- Preserve mixed-generation rollback compatibility while retaining `Type=simple`.

## Testing

- [x] `nix run .#ci`
- [x] `nix build .#st0x-liquidity`
- [x] `./scripts/validate-deploy-migration.sh`
- [x] `nix develop .#ci-hooks -c pre-commit run --all-files`
- [x] Unit and lifecycle tests cover acknowledgement timing, essential-task startup failure, stale or mismatched PIDs, timeout, and early process exit

## Screenshots

N/A

## Anything else

Stack order:

1. #1035 - deterministic service readiness
2. #1036 - Turnkey approval policy coverage gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup readiness checks for the hedging bot and its supporting services.
  * Deployments now confirm that services are fully initialized before completing.
  * Failed or timed-out startups automatically capture diagnostics and trigger rollback.
  * Added systemd runtime signaling for reliable process readiness detection.

* **Documentation**
  * Documented startup coordination, readiness behavior, deployment timeouts, and rollback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->