### PR TITLE
feat: gate deploys on Turnkey approval policy coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,11 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.89"
 
+[[bin]]
+name = "verify-approvals"
+path = "src/bin/verify-approvals.rs"
+required-features = ["wallet-turnkey"]
+
 [features]
 default = ["all-wallets"]
 all-wallets = ["wallet-private-key", "wallet-turnkey"]

--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ NixOS host (DigitalOcean droplet)
 Services are deployed as independent nix profiles, allowing per-service updates
 and rollbacks without affecting other services.
 
+Before the bot is stopped, activation validates staged config/secrets and, for
+Turnkey wallets, runs a read-only policy coverage check for every startup MAX
+approval. Coverage requires an allow policy whose consensus the authenticated
+API user can satisfy alone and whose target condition provably applies;
+applicable or unprovable denies take precedence. Missing token or wrapper
+coverage fails the deployment with the symbol and contract details while the
+existing bot and installed files remain untouched.
+
 The bot unit exposes a PID-scoped startup signal in its systemd runtime
 directory. A bot deployment succeeds only after Conductor finishes startup
 initialization and every essential runtime task has entered its run loop; an

--- a/SPEC.md
+++ b/SPEC.md
@@ -641,23 +641,34 @@ The set of deployed profiles is declared as a registry in `services.nix`. Each
 entry has a `kind` discriminating how it is activated and whether it has a
 systemd unit:
 
-- `st0x-hedge` (kind = `st0x`) - hedging bot binary. Full pipeline: decrypts
-  agenix secret, installs plaintext config, runs `validate-config`, chowns data
-  files, writes git-rev marker, touches the activation marker, and restarts the
-  unit. The server writes its PID to a systemd-managed runtime-directory file
-  only after Conductor has completed startup initialization and every essential
-  supervised runtime task has reached a pending run state. Activation waits for
-  that PID to match the unit's live main process with a bounded startup timeout.
-  If the process exits, readiness reporting fails, or the timeout expires first,
-  activation prints the unit status and recent journal, exits non-zero, and
-  deploy-rs rolls the profile back. The unit remains `Type=simple` so automatic
-  rollback stays compatible with service generations from before the readiness
-  handshake was introduced. The first rollout requires deploying the system
-  profile before the service profile; a service-only deploy verifies the
-  installed unit exposes the expected ready file before stopping the running bot
-  and otherwise fails immediately with the required rollout order. Outside
-  systemd, the server uses a no-op readiness notifier so local runs remain
-  available.
+- `st0x-hedge` (kind = `st0x`) - hedging bot binary. Full pipeline: decrypts the
+  candidate agenix secret into a temporary file, stages the plaintext config,
+  and runs `validate-config` while the old process is still running. For Turnkey
+  wallets it then lists policies through Turnkey's authenticated read-only API
+  and proves that every startup MAX approval target (enabled equity token to
+  wrapper, wrapper to orderbook, and USDC to orderbook) is covered by an allow
+  policy whose consensus the authenticated API user can satisfy alone and whose
+  target condition provably applies. Applicable deny policies take precedence;
+  unknown allow or deny applicability, unsupported consensus, and missing
+  coverage fail closed, naming the symbol, token contract, and spender. Only
+  after both gates pass may activation stop the old process and install the
+  candidate files, so a policy or config failure leaves the running bot
+  untouched; a failed stop aborts before candidate files are installed. It then
+  verifies migrations, chowns data files, writes the git-rev marker, touches the
+  activation marker, and restarts the unit. The server writes its PID to a
+  systemd-managed runtime-directory file only after Conductor has completed
+  startup initialization and every essential supervised runtime task has reached
+  a pending run state. Activation waits for that PID to match the unit's live
+  main process with a bounded startup timeout. If the process exits, readiness
+  reporting fails, or the timeout expires first, activation prints the unit
+  status and recent journal, exits non-zero, and deploy-rs rolls the profile
+  back. The unit remains `Type=simple` so automatic rollback stays compatible
+  with service generations from before the readiness handshake was introduced.
+  The first rollout requires deploying the system profile before the service
+  profile; a service-only deploy verifies the installed unit exposes the
+  expected ready file before stopping the running bot and otherwise fails
+  immediately with the required rollout order. Outside systemd, the server uses
+  a no-op readiness notifier so local runs remain available.
 - `dashboard` (kind = `static`) - frontend assets served by nginx; the deploy
   step is `systemctl reload nginx` and there is no managed systemd unit.
 - `datasette` (kind = `plain`) - read-only SQLite explorer over the hedge DB.
@@ -733,6 +744,19 @@ the `st0x-evm` crate and configured via the `[rebalancing.wallet]` TOML section
 The main crate forwards these as `wallet-turnkey` and `wallet-private-key`
 features. Domain logic is decoupled from the signing backend. See
 [crates/evm/](crates/evm/) for implementation details.
+
+The deploy-time Turnkey verifier never signs or submits an activity. It uses the
+same deterministic approval-target builder as server startup, identifies the
+authenticated API user, and lists policies. It accepts only allow policies whose
+consensus that user can satisfy alone and whose condition it can prove applies
+to `SIGN_TRANSACTION` V2 ERC20 `approve` calls for the target token. It trusts
+the raw `0x095ea7b3` selector, not ABI-derived function fields whose smart
+contract interface registration it cannot prove, and rejects applicable or
+unprovable deny policies. This check is intentionally conservative because
+Turnkey does not expose a policy-simulation endpoint. Condition and consensus
+matching ignores syntax whitespace only outside single-quoted literals; literal
+contents remain byte-for-byte significant so a policy with extra literal
+whitespace cannot be certified as covering the runtime activity.
 
 ## Crate Architecture
 

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -134,6 +134,17 @@ pub struct AssetsConfig {
     pub cash: Option<CashAssetConfig>,
 }
 
+/// Validated, network-free inputs required by the deploy-time Turnkey approval
+/// policy coverage check.
+#[cfg(feature = "wallet-turnkey")]
+#[derive(Clone, Debug)]
+pub struct TurnkeyApprovalPolicyInputs {
+    pub organization_id: st0x_evm::turnkey::TurnkeyOrganizationId,
+    pub api_private_key: st0x_evm::turnkey::TurnkeyApiPrivateKey,
+    pub orderbook: Address,
+    pub assets: AssetsConfig,
+}
+
 /// Parses a hex string (possibly short, e.g. `"0xfab"`) into a
 /// left-padded `B256`.
 fn parse_padded_b256(hex_str: &str) -> Result<B256, String> {
@@ -1064,6 +1075,52 @@ impl Ctx {
             })?;
         parse_and_validate(&config_str, config_path, &secrets_str, secrets_path)?;
         Ok(())
+    }
+
+    /// Loads deploy-time Turnkey policy inputs without constructing wallets or
+    /// connecting to the configured RPC endpoints.
+    #[cfg(feature = "wallet-turnkey")]
+    pub fn load_turnkey_approval_policy_inputs(
+        config_path: &Path,
+        secrets_path: &Path,
+    ) -> Result<Option<TurnkeyApprovalPolicyInputs>, CtxError> {
+        let config_str =
+            std::fs::read_to_string(config_path).map_err(|source| CtxError::ConfigIo {
+                path: config_path.to_path_buf(),
+                source,
+            })?;
+        let secrets_str =
+            std::fs::read_to_string(secrets_path).map_err(|source| CtxError::SecretsIo {
+                path: secrets_path.to_path_buf(),
+                source,
+            })?;
+        let parts = parse_and_validate(&config_str, config_path, &secrets_str, secrets_path)?;
+
+        if parts.wallet_meta.kind != "turnkey" {
+            return Ok(None);
+        }
+
+        let st0x_evm::turnkey::TurnkeySettings {
+            organization_id, ..
+        } = st0x_evm::turnkey::TurnkeySettings::deserialize(parts.wallet_inputs.config).map_err(
+            |source| CtxError::ConfigToml {
+                path: config_path.to_path_buf(),
+                source,
+            },
+        )?;
+        let st0x_evm::turnkey::TurnkeyCredentials { api_private_key } =
+            st0x_evm::turnkey::TurnkeyCredentials::deserialize(parts.wallet_inputs.secrets)
+                .map_err(|source| CtxError::SecretsToml {
+                    path: secrets_path.to_path_buf(),
+                    source,
+                })?;
+
+        Ok(Some(TurnkeyApprovalPolicyInputs {
+            organization_id,
+            api_private_key,
+            orderbook: parts.evm.orderbook,
+            assets: parts.assets,
+        }))
     }
 
     pub async fn get_sqlite_pool(&self) -> Result<SqlitePool, sqlx::Error> {
@@ -5216,6 +5273,87 @@ mod tests {
         let config = minimal_config_toml();
         let secrets = dry_run_secrets_toml();
         Ctx::validate_files(config.path(), secrets.path()).unwrap();
+    }
+
+    #[cfg(feature = "wallet-turnkey")]
+    #[test]
+    fn load_turnkey_approval_policy_inputs_extracts_validated_deploy_inputs() {
+        let config = toml_file(
+            r#"
+            database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
+            apalis_finished_job_cleanup_interval_secs = 3600
+
+            [assets.equities.AAPL]
+            tokenized_equity = "0x4444444444444444444444444444444444444444"
+            tokenized_equity_derivative = "0x5555555555555555555555555555555555555555"
+            trading = "enabled"
+            rebalancing = "disabled"
+            wrapped_equity_recovery = "disabled"
+            extended_hours_counter_trading = "disabled"
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+            inventory_mode = "managed"
+            inventory = "0x2222222222222222222222222222222222222222"
+            vault_owner = "0x3333333333333333333333333333333333333333"
+            deployment_block = 1
+            required_confirmations = 3
+            ingestion_cutoff = "safe"
+
+            [wallet]
+            kind = "turnkey"
+            address = "0x6666666666666666666666666666666666666666"
+            organization_id = "org-test"
+            "#,
+        );
+        let secrets = toml_file(
+            r#"
+            [evm]
+            rpc_url = "http://localhost:8545"
+            base_rpc_url = "https://base.example.com"
+            ethereum_rpc_url = "https://ethereum.example.com"
+
+            [broker]
+            type = "dry-run"
+
+            [wallet]
+            api_private_key = "secret-p256-key"
+
+            [issuance]
+            base_url = "http://issuance.test:8000"
+            api_key = "0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+            "#,
+        );
+
+        let inputs = Ctx::load_turnkey_approval_policy_inputs(config.path(), secrets.path())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(inputs.organization_id.as_str(), "org-test");
+        assert_eq!(
+            inputs.orderbook,
+            address!("0x1111111111111111111111111111111111111111")
+        );
+        assert!(
+            inputs
+                .assets
+                .is_trading_enabled(&Symbol::new("AAPL").unwrap())
+        );
+        assert!(!format!("{inputs:?}").contains("secret-p256-key"));
+    }
+
+    #[cfg(feature = "wallet-turnkey")]
+    #[test]
+    fn load_turnkey_approval_policy_inputs_skips_non_turnkey_wallet() {
+        let config = minimal_config_toml();
+        let secrets = dry_run_secrets_toml();
+
+        let inputs =
+            Ctx::load_turnkey_approval_policy_inputs(config.path(), secrets.path()).unwrap();
+
+        assert!(inputs.is_none());
     }
 
     #[test]

--- a/crates/evm/src/turnkey.rs
+++ b/crates/evm/src/turnkey.rs
@@ -33,7 +33,7 @@ use turnkey_client::generated::{
     immutable::activity::v1::{SignTransactionResult, result},
     immutable::common::v1::TransactionType,
 };
-use turnkey_client::{RetryConfig, TurnkeyClientError};
+use turnkey_client::{RetryConfig, TurnkeyClient, TurnkeyClientError};
 
 use crate::nonce::ResettableNonceManager;
 use crate::submit::send_with_recovery;
@@ -48,6 +48,10 @@ pub struct TurnkeyOrganizationId(String);
 impl TurnkeyOrganizationId {
     pub fn new(value: String) -> Self {
         Self(value)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
@@ -120,6 +124,135 @@ impl std::fmt::Debug for TurnkeyCredentials {
             .debug_struct("TurnkeyCredentials")
             .field("api_private_key", &"[REDACTED]")
             .finish()
+    }
+}
+
+/// Turnkey policy effect relevant to deploy-time coverage verification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnkeyPolicyEffect {
+    Allow,
+    Deny,
+    Unspecified,
+}
+
+/// Read-only policy data used by the deploy verifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnkeyPolicy {
+    pub effect: TurnkeyPolicyEffect,
+    pub consensus: Option<String>,
+    pub condition: Option<String>,
+}
+
+/// Policies plus the authenticated Turnkey API user's identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnkeyPolicySnapshot {
+    pub user_id: String,
+    pub policies: Vec<TurnkeyPolicy>,
+}
+
+/// Errors returned while constructing or querying the Turnkey policy client.
+#[derive(Debug, thiserror::Error)]
+pub enum TurnkeyPolicyError {
+    #[error(transparent)]
+    ApiKey(#[from] turnkey_api_key_stamper::StamperError),
+    #[error(transparent)]
+    Client(#[from] TurnkeyClientError),
+}
+
+/// Authenticated read-only client for listing an organization's policies.
+pub struct TurnkeyPolicyClient {
+    organization_id: TurnkeyOrganizationId,
+    client: TurnkeyClient<TurnkeyP256ApiKey>,
+}
+
+impl std::fmt::Debug for TurnkeyPolicyClient {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TurnkeyPolicyClient")
+            .field("organization_id", &self.organization_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TurnkeyPolicyClient {
+    pub fn new(
+        organization_id: TurnkeyOrganizationId,
+        api_private_key: &TurnkeyApiPrivateKey,
+    ) -> Result<Self, TurnkeyPolicyError> {
+        let TurnkeyApiPrivateKey(api_key_hex) = api_private_key;
+        let api_key = TurnkeyP256ApiKey::from_strings(api_key_hex, None)?;
+        Self::from_parts(organization_id, api_key, "https://api.turnkey.com")
+    }
+
+    #[cfg(test)]
+    fn for_base_url(
+        organization_id: TurnkeyOrganizationId,
+        api_key: TurnkeyP256ApiKey,
+        base_url: String,
+    ) -> Result<Self, TurnkeyPolicyError> {
+        Self::from_parts(organization_id, api_key, base_url)
+    }
+
+    fn from_parts(
+        organization_id: TurnkeyOrganizationId,
+        api_key: TurnkeyP256ApiKey,
+        base_url: impl Into<String>,
+    ) -> Result<Self, TurnkeyPolicyError> {
+        let client = TurnkeyClient::builder()
+            .api_key(api_key)
+            .base_url(base_url)
+            .timeout(Duration::from_secs(20))
+            .build()?;
+
+        Ok(Self {
+            organization_id,
+            client,
+        })
+    }
+
+    pub async fn list_policies(&self) -> Result<TurnkeyPolicySnapshot, TurnkeyPolicyError> {
+        let organization_id = self.organization_id.as_str().to_owned();
+        let whoami = self
+            .client
+            .get_whoami(
+                turnkey_client::generated::services::coordinator::public::v1::GetWhoamiRequest {
+                    organization_id: organization_id.clone(),
+                },
+            )
+            .await?;
+        let response = self
+            .client
+            .get_policies(
+                turnkey_client::generated::services::coordinator::public::v1::GetPoliciesRequest {
+                    organization_id,
+                },
+            )
+            .await?;
+
+        let policies = response
+            .policies
+            .into_iter()
+            .map(|policy| TurnkeyPolicy {
+                effect: match policy.effect {
+                    turnkey_client::generated::immutable::common::v1::Effect::Allow => {
+                        TurnkeyPolicyEffect::Allow
+                    }
+                    turnkey_client::generated::immutable::common::v1::Effect::Deny => {
+                        TurnkeyPolicyEffect::Deny
+                    }
+                    turnkey_client::generated::immutable::common::v1::Effect::Unspecified => {
+                        TurnkeyPolicyEffect::Unspecified
+                    }
+                },
+                consensus: policy.consensus,
+                condition: policy.condition,
+            })
+            .collect();
+
+        Ok(TurnkeyPolicySnapshot {
+            user_id: whoami.user_id,
+            policies,
+        })
     }
 }
 
@@ -750,6 +883,79 @@ mod tests {
             test_api_key(),
             retry_config,
         )
+    }
+
+    #[tokio::test]
+    async fn policy_client_lists_policy_effects_and_conditions() {
+        let server = MockServer::start();
+        let policies_mock = server.mock(|when, then| {
+            when.method("POST")
+                .path("/public/v1/query/list_policies")
+                .body_includes("\"organizationId\":\"org-test\"");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({
+                    "policies": [
+                        {
+                            "policyId": "policy-allow",
+                            "policyName": "allow approvals",
+                            "effect": "EFFECT_ALLOW",
+                            "notes": "",
+                            "consensus": "approvers.any(user, user.id == 'user-test')",
+                            "condition": "eth.tx.to == '0x1111111111111111111111111111111111111111'"
+                        },
+                        {
+                            "policyId": "policy-deny",
+                            "policyName": "deny transfers",
+                            "effect": "EFFECT_DENY",
+                            "notes": "",
+                            "condition": "eth.tx.function_name == 'transfer'"
+                        }
+                    ]
+                }));
+        });
+        let whoami_mock = server.mock(|when, then| {
+            when.method("POST")
+                .path("/public/v1/query/whoami")
+                .body_includes("\"organizationId\":\"org-test\"");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({
+                    "organizationId": "org-test",
+                    "organizationName": "Test",
+                    "userId": "user-test",
+                    "username": "Bot"
+                }));
+        });
+        let client = TurnkeyPolicyClient::for_base_url(
+            TurnkeyOrganizationId::new("org-test".to_string()),
+            test_api_key(),
+            server.base_url(),
+        )
+        .unwrap();
+
+        let snapshot = client.list_policies().await.unwrap();
+
+        policies_mock.assert();
+        whoami_mock.assert();
+        assert_eq!(snapshot.user_id, "user-test");
+        assert_eq!(
+            snapshot.policies,
+            vec![
+                TurnkeyPolicy {
+                    effect: TurnkeyPolicyEffect::Allow,
+                    consensus: Some("approvers.any(user, user.id == 'user-test')".to_string()),
+                    condition: Some(
+                        "eth.tx.to == '0x1111111111111111111111111111111111111111'".to_string()
+                    ),
+                },
+                TurnkeyPolicy {
+                    effect: TurnkeyPolicyEffect::Deny,
+                    consensus: None,
+                    condition: Some("eth.tx.function_name == 'transfer'".to_string()),
+                },
+            ]
+        );
     }
 
     /// Builds a well-formed EIP-1559 transaction (the only shape the bot's

--- a/deploy.nix
+++ b/deploy.nix
@@ -81,32 +81,42 @@ let
             exit 1
           fi
         '';
-      in
-      assert lib.assertMsg (
-        lib.hasInfix "--property ActiveState" startupWaitCommand
-        && lib.hasInfix "--property SubState" startupWaitCommand
-        && lib.hasInfix "*/auto-restart" startupWaitCommand
-      ) "st0x activation must stop waiting when the restarted unit cannot become ready";
-      activate.custom pkg (
-        builtins.concatStringsSep " && " [
+        stagedConfigPath = "/run/st0x/${name}.config.staged";
+        stagedSecretPath = "/run/st0x/${name}.secrets.staged";
+        validateCommand = "${cfg.profilePath}/bin/validate-config --config ${stagedConfigPath} --secrets ${stagedSecretPath}";
+        verifyApprovalsCommand = "${cfg.profilePath}/bin/verify-approvals --config ${stagedConfigPath} --secrets ${stagedSecretPath}";
+        readinessPrerequisiteCommand = ''
+          if ! systemctl show --property Environment --value ${name} 2>/dev/null \
+            | grep --fixed-strings --quiet 'ST0X_STARTUP_READY_FILE=${startupReadyFile}'; then
+            echo "${name} systemd unit does not expose ${startupReadyFile}; deploy the system profile before the service profile" >&2
+            exit 1
+          fi
+        '';
+        stopCommand = "systemctl stop ${name}";
+        installConfigCommand = "install -D -m 0640 -o root -g st0x ${stagedConfigPath} ${cfg.configPath}";
+        installSecretCommand = "install -D -m 0640 -o root -g st0x ${stagedSecretPath} ${cfg.decryptedSecretPath}";
+        beforeStopCommands = [
           # The readiness environment ships in the system profile, while this
           # activation ships the binary and wait loop. Enforce system-first on
           # the handshake's first rollout before touching the running service.
-          ''
-            if ! systemctl show --property Environment --value ${name} 2>/dev/null \
-              | grep --fixed-strings --quiet 'ST0X_STARTUP_READY_FILE=${startupReadyFile}'; then
-              echo "${name} systemd unit does not expose ${startupReadyFile}; deploy the system profile before the service profile" >&2
-              exit 1
-            fi
-          ''
-          "systemctl stop ${name} || true"
-          "rm -f ${cfg.markerFile}"
+          readinessPrerequisiteCommand
           "mkdir -p /run/st0x"
-          "install -D -m 0640 -o root -g st0x ${configFile} ${cfg.configPath}"
-          "${rage} -d -i ${hostKey} ${secretsFile} | install -D -m 0640 -o root -g st0x /dev/stdin ${cfg.decryptedSecretPath}"
-          # Validate config + secrets before restarting. If validation fails,
-          # the activation script exits non-zero and deploy-rs rolls back.
-          "${cfg.profilePath}/bin/validate-config --config ${cfg.configPath} --secrets ${cfg.decryptedSecretPath}"
+          # Stage and validate the candidate files while the old service is
+          # still running. The EXIT trap removes the decrypted staged secret on
+          # every success/failure path.
+          "trap 'rm -f ${stagedConfigPath} ${stagedSecretPath}' EXIT"
+          "install -D -m 0640 -o root -g st0x ${configFile} ${stagedConfigPath}"
+          "${rage} -d -i ${hostKey} ${secretsFile} | install -D -m 0640 -o root -g st0x /dev/stdin ${stagedSecretPath}"
+          validateCommand
+          # Query Turnkey policies read-only before stopping the old process.
+          # Missing coverage exits non-zero, leaving both the running bot and
+          # its installed config/secrets untouched.
+          verifyApprovalsCommand
+        ];
+        afterStopCommands = [
+          "rm -f ${cfg.markerFile}"
+          installConfigCommand
+          installSecretCommand
           # Dry-run migrations + full event replay against the live DB before
           # restarting -- the service is already stopped above (no
           # concurrent writer), and this only ever reads that file: it
@@ -127,8 +137,36 @@ let
           # pre-readiness binary remains possible during the first rollout.
           "systemctl restart ${name} || { restart_status=$?; systemctl status --no-pager --full ${name} >&2 || true; journalctl --no-pager --unit ${name} --lines 100 >&2 || true; rm -f ${cfg.markerFile}; exit $restart_status; }"
           startupWaitCommand
-        ]
-      )
+        ];
+        activationCommands =
+          assert lib.assertMsg (
+            lib.hasInfix "--property ActiveState" startupWaitCommand
+            && lib.hasInfix "--property SubState" startupWaitCommand
+            && lib.hasInfix "*/auto-restart" startupWaitCommand
+          ) "st0x activation must stop waiting when the restarted unit cannot become ready";
+          assert lib.assertMsg (builtins.elem readinessPrerequisiteCommand beforeStopCommands)
+            "st0x activation must verify the systemd readiness environment before stopping the service";
+          assert lib.assertMsg (builtins.elem verifyApprovalsCommand beforeStopCommands)
+            "st0x activation must verify Turnkey approval policies before stopping the service";
+          assert lib.assertMsg (
+            stopCommand == "systemctl stop ${name}"
+          ) "st0x activation must stop the running service successfully before installing candidate files";
+          assert lib.assertMsg (
+            !(builtins.elem stopCommand beforeStopCommands) && !(builtins.elem stopCommand afterStopCommands)
+          ) "st0x activation must have exactly one stop boundary between preflight and installation";
+          assert lib.assertMsg (
+            !(builtins.elem installConfigCommand beforeStopCommands)
+          ) "st0x activation must not install candidate config before policy verification";
+          assert lib.assertMsg (
+            !(builtins.elem installSecretCommand beforeStopCommands)
+          ) "st0x activation must not install candidate secrets before policy verification";
+          assert lib.assertMsg (builtins.elem installConfigCommand afterStopCommands)
+            "st0x activation must install candidate config after stopping the service";
+          assert lib.assertMsg (builtins.elem installSecretCommand afterStopCommands)
+            "st0x activation must install candidate secrets after stopping the service";
+          beforeStopCommands ++ [ stopCommand ] ++ afterStopCommands;
+      in
+      activate.custom pkg (builtins.concatStringsSep " && " activationCommands)
     else if cfg.kind == "cli" then
       # On-demand CLI config: install the config, decrypt the secret, and
       # validate -- exactly like the st0x kind, but start no systemd unit. The

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -322,6 +322,17 @@ optional `tokenizer: Option<Arc<dyn Tokenizer>>`, shutdown token).
 
 ## Startup sequencing
 
+Before systemd stops the existing bot, deploy activation validates staged
+config/secrets and uses Turnkey's read-only policy list to verify coverage for
+the exact approval targets startup will grant. Both paths call the same
+deterministic target builder, limited to trading- or rebalancing-enabled symbols
+plus USDC. An allow policy covers a target only when the authenticated API user
+can satisfy its consensus alone and its target condition provably applies.
+Applicable or unprovable deny policies take precedence. Missing or unrecognized
+coverage fails activation without replacing the running process or installed
+config. If stopping the validated service fails, activation also aborts before
+the staged files replace the installed config and secrets.
+
 ```
 Phase 1: connect_http (with RPC probe) | setup_apalis_tables | build CQRS stores
 Phase 2: seed_vault_registry (inline, must complete before downstream wiring)

--- a/rust.nix
+++ b/rust.nix
@@ -183,7 +183,11 @@ in
     // {
       inherit cargoArtifacts;
 
-      cargoExtraArgs = "--bin server --bin validate-config --bin verify-migrations --features wallet-turnkey";
+      cargoExtraArgs = "--bin server --bin validate-config --bin verify-approvals --bin verify-migrations --features wallet-turnkey";
+
+      postInstall = ''
+        test -x $out/bin/verify-approvals
+      '';
 
       meta = {
         description = "st0x liquidity market making server";

--- a/services.nix
+++ b/services.nix
@@ -1,6 +1,7 @@
 { lib }:
 
-# kind = "st0x"    -- full pipeline: agenix decrypt, install config, validate-config,
+# kind = "st0x"    -- full pipeline: stage/decrypt config, validate config and
+#                    Turnkey approval policies, install, verify migrations,
 #                    chown data dirs, write git-rev, marker file, restart unit.
 # kind = "cli"     -- agenix decrypt + install config + validate-config for an
 #                    on-demand CLI (e.g. the `s01` issuer wrapper). No systemd

--- a/src/approval_policy.rs
+++ b/src/approval_policy.rs
@@ -1,0 +1,547 @@
+//! Deploy-time verification that Turnkey policies cover every startup approve.
+
+use std::fmt::{Display, Formatter};
+use std::path::Path;
+
+use st0x_config::Ctx;
+use st0x_evm::USDC_BASE;
+use st0x_evm::turnkey::{
+    TurnkeyPolicy, TurnkeyPolicyClient, TurnkeyPolicyEffect, TurnkeyPolicyError,
+};
+
+use crate::onchain::approvals::{ApprovalTarget, build_approval_targets};
+
+/// Successful result of a deploy-time policy verification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalPolicyVerification {
+    /// The validated wallet backend is not Turnkey, so no Turnkey query is
+    /// applicable.
+    SkippedNonTurnkey,
+    /// Every startup approval target is covered by at least one allow policy.
+    Verified {
+        target_count: usize,
+        policy_count: usize,
+    },
+}
+
+/// Every startup approval target for which no provably matching allow policy
+/// was returned by Turnkey.
+#[derive(Debug)]
+pub struct MissingPolicyCoverage {
+    missing: Vec<ApprovalTarget>,
+}
+
+impl MissingPolicyCoverage {
+    fn new(missing: Vec<ApprovalTarget>) -> Self {
+        Self { missing }
+    }
+}
+
+impl Display for MissingPolicyCoverage {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            formatter,
+            "Turnkey policies do not cover {} startup approval target(s):",
+            self.missing.len()
+        )?;
+
+        for target in &self.missing {
+            let symbol = target
+                .symbol
+                .as_ref()
+                .map_or("USDC", st0x_execution::Symbol::as_str);
+            writeln!(
+                formatter,
+                "- {symbol}: token {}, spender {}, purpose {:?}",
+                target.token, target.spender, target.purpose
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+impl std::error::Error for MissingPolicyCoverage {}
+
+/// Failure from config validation, Turnkey policy listing, or policy coverage.
+#[derive(Debug, thiserror::Error)]
+pub enum ApprovalPolicyVerificationError {
+    #[error(transparent)]
+    Config(#[from] st0x_config::CtxError),
+    #[error(transparent)]
+    Turnkey(#[from] TurnkeyPolicyError),
+    #[error(transparent)]
+    MissingCoverage(#[from] MissingPolicyCoverage),
+}
+
+/// Validates deploy inputs, lists Turnkey policies, and fails unless every
+/// startup MAX approval has a provably matching allow policy.
+pub async fn verify_turnkey_approval_policies(
+    config_path: &Path,
+    secrets_path: &Path,
+) -> Result<ApprovalPolicyVerification, ApprovalPolicyVerificationError> {
+    let Some(inputs) = Ctx::load_turnkey_approval_policy_inputs(config_path, secrets_path)? else {
+        return Ok(ApprovalPolicyVerification::SkippedNonTurnkey);
+    };
+    let targets = build_approval_targets(&inputs.assets, inputs.orderbook, USDC_BASE);
+    let client = TurnkeyPolicyClient::new(inputs.organization_id, &inputs.api_private_key)?;
+    let snapshot = client.list_policies().await?;
+    let missing = missing_policy_coverage(&targets, &snapshot.policies, &snapshot.user_id);
+
+    if !missing.is_empty() {
+        return Err(MissingPolicyCoverage::new(missing).into());
+    }
+
+    Ok(ApprovalPolicyVerification::Verified {
+        target_count: targets.len(),
+        policy_count: snapshot.policies.len(),
+    })
+}
+
+fn missing_policy_coverage(
+    targets: &[ApprovalTarget],
+    policies: &[TurnkeyPolicy],
+    user_id: &str,
+) -> Vec<ApprovalTarget> {
+    targets
+        .iter()
+        .filter(|target| !policies_cover_target(policies, target, user_id))
+        .cloned()
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Applicability {
+    Applies,
+    DoesNotApply,
+    Unknown,
+}
+
+fn policies_cover_target(
+    policies: &[TurnkeyPolicy],
+    target: &ApprovalTarget,
+    user_id: &str,
+) -> bool {
+    let mut has_allow = false;
+
+    for policy in policies {
+        let applicability = policy_applicability(policy, target, user_id);
+
+        match (policy.effect, applicability) {
+            (TurnkeyPolicyEffect::Deny, Applicability::Applies | Applicability::Unknown) => {
+                return false;
+            }
+            (TurnkeyPolicyEffect::Allow, Applicability::Applies) => has_allow = true,
+            _ => {}
+        }
+    }
+
+    has_allow
+}
+
+fn policy_applicability(
+    policy: &TurnkeyPolicy,
+    target: &ApprovalTarget,
+    user_id: &str,
+) -> Applicability {
+    let condition = condition_applicability(policy.condition.as_deref(), target);
+
+    // Consensus identifies who can approve an allowed activity. A matching
+    // deny condition wins independently of which users could approve it.
+    if policy.effect == TurnkeyPolicyEffect::Deny {
+        return condition;
+    }
+
+    conjunction([
+        consensus_applicability(policy.consensus.as_deref(), user_id),
+        condition,
+    ])
+}
+
+fn consensus_applicability(consensus: Option<&str>, user_id: &str) -> Applicability {
+    let Some(consensus) = compact_expression(consensus) else {
+        return Applicability::Applies;
+    };
+
+    let Some(consensus_user_id) = any_approver_user_id(&consensus) else {
+        return Applicability::Unknown;
+    };
+
+    if consensus_user_id == user_id {
+        Applicability::Applies
+    } else {
+        Applicability::DoesNotApply
+    }
+}
+
+fn condition_applicability(condition: Option<&str>, target: &ApprovalTarget) -> Applicability {
+    let Some(condition) = compact_expression(condition) else {
+        return Applicability::Applies;
+    };
+
+    if condition.contains("||") {
+        return Applicability::Unknown;
+    }
+
+    conjunction(
+        condition
+            .split("&&")
+            .map(|term| policy_term_applicability(term, target)),
+    )
+}
+
+fn compact_expression(expression: Option<&str>) -> Option<String> {
+    let expression = expression?;
+    let mut compact = String::with_capacity(expression.len());
+    let mut in_quoted_literal = false;
+    let mut escaped = false;
+
+    for character in expression.chars() {
+        if in_quoted_literal {
+            compact.push(character);
+
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '\'' {
+                in_quoted_literal = false;
+            }
+        } else if character == '\'' {
+            in_quoted_literal = true;
+            compact.push(character);
+        } else if !character.is_ascii_whitespace() {
+            compact.push(character);
+        }
+    }
+
+    (!compact.is_empty()).then_some(compact)
+}
+
+fn conjunction(applicabilities: impl IntoIterator<Item = Applicability>) -> Applicability {
+    applicabilities
+        .into_iter()
+        .fold(Applicability::Applies, |combined, applicability| {
+            match (combined, applicability) {
+                (Applicability::DoesNotApply, _) | (_, Applicability::DoesNotApply) => {
+                    Applicability::DoesNotApply
+                }
+                (Applicability::Unknown, _) | (_, Applicability::Unknown) => Applicability::Unknown,
+                _ => Applicability::Applies,
+            }
+        })
+}
+
+fn any_approver_user_id(consensus: &str) -> Option<&str> {
+    let consensus = trim_grouping_parentheses(consensus);
+
+    consensus
+        .strip_prefix("approvers.any(user,user.id=='")
+        .and_then(|value| value.strip_suffix("')"))
+        .or_else(|| {
+            consensus
+                .strip_prefix("approvers.any(user,'")
+                .and_then(|value| value.strip_suffix("'==user.id)"))
+        })
+}
+
+fn policy_term_applicability(term: &str, target: &ApprovalTarget) -> Applicability {
+    let term = trim_grouping_parentheses(term);
+    let token = format!("{:#x}", target.token);
+
+    if let Some(value) = equality_value(term, "eth.tx.to") {
+        return equality_applicability(value, &token);
+    }
+
+    if let Some(value) = equality_value(term, "eth.tx.data[0..10]") {
+        return equality_applicability(value, "0x095ea7b3");
+    }
+
+    if let Some(value) = equality_value(term, "activity.kind") {
+        return equality_applicability(value, "SIGN_TRANSACTION");
+    }
+
+    if let Some(value) = equality_value(term, "activity.type") {
+        return equality_applicability(value, "ACTIVITY_TYPE_SIGN_TRANSACTION_V2");
+    }
+
+    // ABI-derived fields only have meaning when Turnkey has a matching smart
+    // contract interface. The verifier cannot prove that interface exists, so
+    // these and all other condition shapes remain unknown.
+    Applicability::Unknown
+}
+
+fn equality_applicability(actual: &str, expected: &str) -> Applicability {
+    if actual == expected {
+        Applicability::Applies
+    } else {
+        Applicability::DoesNotApply
+    }
+}
+
+fn equality_value<'a>(term: &'a str, field: &str) -> Option<&'a str> {
+    term.strip_prefix(&format!("{field}=='"))
+        .and_then(|value| value.strip_suffix('\''))
+        .or_else(|| {
+            term.strip_prefix('\'')
+                .and_then(|value| value.strip_suffix(&format!("'=={field}")))
+        })
+}
+
+fn trim_grouping_parentheses(mut term: &str) -> &str {
+    while term.starts_with('(') && term.ends_with(')') {
+        term = &term[1..term.len() - 1];
+    }
+    term
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::Address;
+
+    use st0x_evm::turnkey::{TurnkeyPolicy, TurnkeyPolicyEffect};
+
+    use super::*;
+    use crate::onchain::approvals::{ApprovalPurpose, ApprovalTarget};
+
+    const USER_ID: &str = "user-bot";
+
+    fn target() -> ApprovalTarget {
+        ApprovalTarget {
+            token: "0x1111111111111111111111111111111111111111"
+                .parse()
+                .unwrap(),
+            spender: Address::random(),
+            symbol: Some("AAPL".parse().unwrap()),
+            purpose: ApprovalPurpose::WrapUnderlying,
+        }
+    }
+
+    fn allow(condition: Option<&str>) -> TurnkeyPolicy {
+        TurnkeyPolicy {
+            effect: TurnkeyPolicyEffect::Allow,
+            consensus: Some("approvers.any(user, user.id == 'user-bot')".to_string()),
+            condition: condition.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn exact_token_allow_policy_covers_startup_approve() {
+        let target = target();
+        let policies = [allow(Some(
+            "activity.kind == 'SIGN_TRANSACTION' && \
+             eth.tx.to == '0x1111111111111111111111111111111111111111'",
+        ))];
+
+        assert!(missing_policy_coverage(&[target], &policies, USER_ID).is_empty());
+    }
+
+    #[test]
+    fn deny_and_transfer_only_policies_do_not_cover_approve() {
+        let target = target();
+        let policies = [
+            TurnkeyPolicy {
+                effect: TurnkeyPolicyEffect::Deny,
+                consensus: Some("approvers.any(user, user.id == 'user-bot')".to_string()),
+                condition: Some(
+                    "eth.tx.to == '0x1111111111111111111111111111111111111111'".to_string(),
+                ),
+            },
+            allow(Some(
+                "eth.tx.to == '0x1111111111111111111111111111111111111111' && \
+                 eth.tx.function_name == 'transfer'",
+            )),
+        ];
+
+        assert_eq!(
+            missing_policy_coverage(std::slice::from_ref(&target), &policies, USER_ID),
+            vec![target]
+        );
+    }
+
+    #[test]
+    fn raw_approve_selector_policy_covers_startup_approve() {
+        let target = target();
+        let policies = [allow(Some(
+            "eth.tx.to == '0x1111111111111111111111111111111111111111' && \
+             eth.tx.data[0..10] == '0x095ea7b3'",
+        ))];
+
+        assert!(missing_policy_coverage(&[target], &policies, USER_ID).is_empty());
+    }
+
+    #[test]
+    fn uppercase_address_policy_is_rejected_fail_closed() {
+        let target = target();
+        let policies = [allow(Some(
+            "eth.tx.to == '0x111111111111111111111111111111111111111A'",
+        ))];
+
+        assert_eq!(
+            missing_policy_coverage(std::slice::from_ref(&target), &policies, USER_ID),
+            vec![target]
+        );
+    }
+
+    #[test]
+    fn whitespace_inside_quoted_literal_is_preserved() {
+        let target = target();
+        let policies = [allow(Some(
+            "eth.tx.to == '0x1111111111111111111111111111111111111111 '",
+        ))];
+
+        assert_eq!(
+            missing_policy_coverage(std::slice::from_ref(&target), &policies, USER_ID),
+            vec![target]
+        );
+    }
+
+    #[test]
+    fn unrestricted_allow_policy_covers_every_target() {
+        let target = target();
+
+        assert!(missing_policy_coverage(&[target], &[allow(None)], USER_ID).is_empty());
+    }
+
+    #[test]
+    fn allow_policy_for_another_user_does_not_cover_startup_approve() {
+        let target = target();
+        let policies = [TurnkeyPolicy {
+            effect: TurnkeyPolicyEffect::Allow,
+            consensus: Some("approvers.any(user, user.id == 'user-someone-else')".to_string()),
+            condition: Some(
+                "eth.tx.to == '0x1111111111111111111111111111111111111111'".to_string(),
+            ),
+        }];
+
+        assert_eq!(
+            missing_policy_coverage(std::slice::from_ref(&target), &policies, USER_ID),
+            vec![target]
+        );
+    }
+
+    #[test]
+    fn multi_approver_consensus_fails_closed() {
+        let target = target();
+        let policies = [TurnkeyPolicy {
+            effect: TurnkeyPolicyEffect::Allow,
+            consensus: Some("approvers.count() >= 2".to_string()),
+            condition: Some(
+                "eth.tx.to == '0x1111111111111111111111111111111111111111'".to_string(),
+            ),
+        }];
+
+        assert_eq!(
+            missing_policy_coverage(std::slice::from_ref(&target), &policies, USER_ID),
+            vec![target]
+        );
+    }
+
+    #[test]
+    fn applicable_deny_overrides_matching_allow() {
+        let target = target();
+        let policies = [
+            allow(Some(
+                "eth.tx.to == '0x1111111111111111111111111111111111111111'",
+            )),
+            TurnkeyPolicy {
+                effect: TurnkeyPolicyEffect::Deny,
+                consensus: Some("approvers.any(user, user.id == 'user-bot')".to_string()),
+                condition: Some(
+                    "eth.tx.to == '0x1111111111111111111111111111111111111111'".to_string(),
+                ),
+            },
+        ];
+
+        assert_eq!(
+            missing_policy_coverage(std::slice::from_ref(&target), &policies, USER_ID),
+            vec![target]
+        );
+    }
+
+    #[test]
+    fn unknown_deny_applicability_blocks_matching_allow() {
+        let target = target();
+        let policies = [
+            allow(Some(
+                "eth.tx.to == '0x1111111111111111111111111111111111111111'",
+            )),
+            TurnkeyPolicy {
+                effect: TurnkeyPolicyEffect::Deny,
+                consensus: None,
+                condition: Some("eth.tx.function_name == 'transfer'".to_string()),
+            },
+        ];
+
+        assert_eq!(
+            missing_policy_coverage(std::slice::from_ref(&target), &policies, USER_ID),
+            vec![target]
+        );
+    }
+
+    #[test]
+    fn deny_consensus_does_not_limit_deny_precedence() {
+        let target = target();
+        let policies = [
+            allow(Some(
+                "eth.tx.to == '0x1111111111111111111111111111111111111111'",
+            )),
+            TurnkeyPolicy {
+                effect: TurnkeyPolicyEffect::Deny,
+                consensus: Some("approvers.any(user, user.id == 'user-someone-else')".to_string()),
+                condition: Some(
+                    "eth.tx.to == '0x1111111111111111111111111111111111111111'".to_string(),
+                ),
+            },
+        ];
+
+        assert_eq!(
+            missing_policy_coverage(std::slice::from_ref(&target), &policies, USER_ID),
+            vec![target]
+        );
+    }
+
+    #[test]
+    fn provably_unrelated_deny_does_not_block_matching_allow() {
+        let target = target();
+        let policies = [
+            allow(Some(
+                "eth.tx.to == '0x1111111111111111111111111111111111111111'",
+            )),
+            TurnkeyPolicy {
+                effect: TurnkeyPolicyEffect::Deny,
+                consensus: None,
+                condition: Some(
+                    "eth.tx.to == '0x2222222222222222222222222222222222222222'".to_string(),
+                ),
+            },
+        ];
+
+        assert!(missing_policy_coverage(&[target], &policies, USER_ID).is_empty());
+    }
+
+    #[test]
+    fn abi_derived_function_name_fails_closed_without_interface_proof() {
+        let target = target();
+        let policies = [allow(Some(
+            "eth.tx.to == '0x1111111111111111111111111111111111111111' && \
+             eth.tx.function_name == 'approve'",
+        ))];
+
+        assert_eq!(
+            missing_policy_coverage(std::slice::from_ref(&target), &policies, USER_ID),
+            vec![target]
+        );
+    }
+
+    #[test]
+    fn missing_coverage_error_names_symbol_token_and_spender() {
+        let target = target();
+        let error = MissingPolicyCoverage::new(vec![target.clone()]);
+        let message = error.to_string();
+
+        assert!(message.contains("AAPL"));
+        assert!(message.contains(&target.token.to_string()));
+        assert!(message.contains(&target.spender.to_string()));
+    }
+}

--- a/src/bin/verify-approvals.rs
+++ b/src/bin/verify-approvals.rs
@@ -1,0 +1,37 @@
+//! Pre-deploy Turnkey approval-policy coverage verification binary.
+
+use clap::Parser;
+
+use st0x_config::Env;
+use st0x_hedge::approval_policy::{ApprovalPolicyVerification, verify_turnkey_approval_policies};
+
+#[tokio::main]
+async fn main() -> std::process::ExitCode {
+    let Env { config, secrets } = Env::parse();
+
+    match verify_turnkey_approval_policies(&config, &secrets).await {
+        Ok(ApprovalPolicyVerification::SkippedNonTurnkey) => {
+            eprintln!("Turnkey approval policy verification skipped for non-Turnkey wallet");
+            std::process::ExitCode::SUCCESS
+        }
+        Ok(ApprovalPolicyVerification::Verified {
+            target_count,
+            policy_count,
+        }) => {
+            eprintln!(
+                "Turnkey approval policy verification passed: {target_count} startup targets \
+                 covered by {policy_count} policies"
+            );
+            std::process::ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("Turnkey approval policy verification failed: {error}");
+            let mut source = std::error::Error::source(&error);
+            while let Some(cause) = source {
+                eprintln!("  caused by: {cause}");
+                source = cause.source();
+            }
+            std::process::ExitCode::FAILURE
+        }
+    }
+}

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -986,10 +986,9 @@ fn base_wallet_wrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Addr
 
 /// Grants one-time idempotent MAX ERC20 approvals to the trusted spenders at
 /// startup: each configured equity's underlying -> wrapper vault and wrapped ->
-/// orderbook, plus USDC -> orderbook. Resolves token addresses through a
-/// [`WrapperService`] built from the equity config, and submits through the
-/// base wallet so confirmations and nonce handling match every other on-chain
-/// write.
+/// orderbook, plus USDC -> orderbook. Resolves token addresses from the
+/// configured equity addresses, and submits through the base wallet so
+/// confirmations and nonce handling match every other on-chain write.
 ///
 /// Skips entirely when no wallet is configured -- a standalone bot without a
 /// wallet never wraps or deposits, so it has no allowances to grant.
@@ -1006,22 +1005,7 @@ async fn grant_startup_token_approvals(ctx: &Ctx) -> anyhow::Result<()> {
         Err(error) => return Err(error.into()),
     };
 
-    let wrapper = WrapperService::new(
-        base_wallet.clone(),
-        to_wrapped_equities(&ctx.assets.equities.symbols),
-    );
-
-    let symbols = ctx
-        .assets
-        .equities
-        .symbols
-        .keys()
-        .filter(|symbol| {
-            ctx.assets.is_trading_enabled(symbol) || ctx.assets.is_rebalancing_enabled(symbol)
-        })
-        .cloned();
-
-    let targets = build_approval_targets(&wrapper, symbols, ctx.evm.orderbook, USDC_BASE)?;
+    let targets = build_approval_targets(&ctx.assets, ctx.evm.orderbook, USDC_BASE);
 
     grant_startup_approvals(&base_wallet, &targets).await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(90);
 
 mod alerts;
 pub mod api;
+#[cfg(feature = "wallet-turnkey")]
+pub mod approval_policy;
 #[cfg(any(test, feature = "test-support"))]
 pub mod bindings;
 #[cfg(not(any(test, feature = "test-support")))]

--- a/src/onchain/approvals.rs
+++ b/src/onchain/approvals.rs
@@ -19,9 +19,9 @@
 
 use alloy::primitives::{Address, U256};
 
+use st0x_config::AssetsConfig;
 use st0x_evm::{IERC20, OpenChainErrorRegistry, Wallet};
 use st0x_execution::Symbol;
-use st0x_wrapper::{Wrapper, WrapperError};
 
 /// High watermark above which an existing allowance is treated as "already
 /// effectively unlimited", so the startup grant skips it. A genuine MAX
@@ -98,12 +98,6 @@ impl ApprovalPurpose {
 /// while wrap/deposit would revert with `ERC20InsufficientAllowance`.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum StartupApprovalError {
-    #[error("failed to resolve token addresses for symbol {symbol}")]
-    SymbolResolution {
-        symbol: Symbol,
-        #[source]
-        source: Box<WrapperError>,
-    },
     #[error(
         "failed to read allowance for token {token} spender {spender} \
          (symbol {symbol:?})"
@@ -128,34 +122,28 @@ pub(crate) enum StartupApprovalError {
     },
 }
 
-/// Builds the full list of startup approval targets: for every configured
-/// equity symbol, the two wrap/deposit grants, plus the single USDC grant.
-///
-/// Token addresses are resolved through the [`Wrapper`] trait so the symbol ->
-/// address mapping is owned in one place; the orderbook and USDC addresses come
-/// from the caller (EVM config / raindex constant).
+/// Builds the deterministic list of startup approval targets: for every equity
+/// with trading or rebalancing enabled, the two wrap/deposit grants, plus the
+/// single USDC grant.
 pub(crate) fn build_approval_targets(
-    wrapper: &dyn Wrapper,
-    symbols: impl IntoIterator<Item = Symbol>,
+    assets: &AssetsConfig,
     orderbook: Address,
     usdc: Address,
-) -> Result<Vec<ApprovalTarget>, StartupApprovalError> {
+) -> Vec<ApprovalTarget> {
     let mut targets = Vec::new();
+    let mut enabled_equities = assets
+        .equities
+        .symbols
+        .iter()
+        .filter(|(symbol, _)| {
+            assets.is_trading_enabled(symbol) || assets.is_rebalancing_enabled(symbol)
+        })
+        .collect::<Vec<_>>();
+    enabled_equities.sort_by(|(left, _), (right, _)| left.as_str().cmp(right.as_str()));
 
-    for symbol in symbols {
-        let underlying = wrapper.lookup_underlying(&symbol).map_err(|source| {
-            StartupApprovalError::SymbolResolution {
-                symbol: symbol.clone(),
-                source: Box::new(source),
-            }
-        })?;
-
-        let derivative = wrapper.lookup_derivative(&symbol).map_err(|source| {
-            StartupApprovalError::SymbolResolution {
-                symbol: symbol.clone(),
-                source: Box::new(source),
-            }
-        })?;
+    for (symbol, config) in enabled_equities {
+        let underlying = config.tokenized_equity;
+        let derivative = config.tokenized_equity_derivative;
 
         targets.push(ApprovalTarget {
             token: underlying,
@@ -167,7 +155,7 @@ pub(crate) fn build_approval_targets(
         targets.push(ApprovalTarget {
             token: derivative,
             spender: orderbook,
-            symbol: Some(symbol),
+            symbol: Some(symbol.clone()),
             purpose: ApprovalPurpose::DepositWrappedEquity,
         });
     }
@@ -179,7 +167,7 @@ pub(crate) fn build_approval_targets(
         purpose: ApprovalPurpose::DepositUsdc,
     });
 
-    Ok(targets)
+    targets
 }
 
 /// Grants idempotent MAX approvals for every target, reading each current
@@ -279,123 +267,17 @@ pub(crate) async fn grant_startup_approvals<W: Wallet>(
 #[cfg(test)]
 mod tests {
     use alloy::node_bindings::Anvil;
-    use alloy::primitives::{B256, TxHash, U256};
+    use alloy::primitives::{B256, U256};
     use alloy::providers::{Provider, ProviderBuilder};
-    use async_trait::async_trait;
     use std::collections::HashMap;
 
+    use st0x_config::{AssetsConfig, EquitiesConfig, EquityAssetConfig, OperationMode};
     use st0x_evm::Evm;
     use st0x_evm::local::RawPrivateKeyWallet;
-    use st0x_wrapper::{UnderlyingPerWrapped, UnwrapConfirmation, WrapConfirmation, WrappedEquity};
 
     use super::*;
     use crate::bindings::TestERC20;
     use crate::test_utils::{TestAnvilInstance, spawn_anvil};
-
-    /// Per-symbol wrapper stub: resolves underlying/derivative addresses from a
-    /// configured map and errors on an unconfigured symbol, so the
-    /// target-building path can be exercised with real address resolution.
-    /// `MockWrapper` returns fixed addresses regardless of symbol and has no
-    /// unconfigured-symbol path, so it cannot drive these tests.
-    struct StubWrapper {
-        equities: HashMap<Symbol, WrappedEquity>,
-    }
-
-    impl StubWrapper {
-        fn lookup(&self, symbol: &Symbol) -> Result<&WrappedEquity, WrapperError> {
-            self.equities
-                .get(symbol)
-                .ok_or_else(|| WrapperError::SymbolNotConfigured(symbol.clone()))
-        }
-    }
-
-    #[async_trait]
-    impl Wrapper for StubWrapper {
-        async fn get_ratio_for_symbol(
-            &self,
-            _symbol: &Symbol,
-        ) -> Result<UnderlyingPerWrapped, WrapperError> {
-            unimplemented!("ratio not used by approval target building")
-        }
-
-        fn lookup_underlying(&self, symbol: &Symbol) -> Result<Address, WrapperError> {
-            Ok(self.lookup(symbol)?.underlying)
-        }
-
-        fn lookup_derivative(&self, symbol: &Symbol) -> Result<Address, WrapperError> {
-            Ok(self.lookup(symbol)?.derivative)
-        }
-
-        async fn to_wrapped(
-            &self,
-            _wrapped_token: Address,
-            _underlying_amount: U256,
-            _receiver: Address,
-        ) -> Result<(TxHash, U256), WrapperError> {
-            unimplemented!("wrap not used by approval target building")
-        }
-
-        async fn to_underlying(
-            &self,
-            _wrapped_token: Address,
-            _wrapped_amount: U256,
-            _receiver: Address,
-            _owner: Address,
-        ) -> Result<(TxHash, U256), WrapperError> {
-            unimplemented!("unwrap not used by approval target building")
-        }
-
-        async fn donate(
-            &self,
-            _wrapped_token: Address,
-            _underlying_amount: U256,
-        ) -> Result<TxHash, WrapperError> {
-            unimplemented!("donate not used by approval target building")
-        }
-
-        async fn submit_wrap(
-            &self,
-            _wrapped_token: Address,
-            _underlying_amount: U256,
-            _receiver: Address,
-        ) -> Result<TxHash, WrapperError> {
-            unimplemented!("submit_wrap not used by approval target building")
-        }
-
-        async fn confirm_wrap(
-            &self,
-            _wrapped_token: Address,
-            _tx_hash: TxHash,
-        ) -> Result<WrapConfirmation, WrapperError> {
-            unimplemented!("confirm_wrap not used by approval target building")
-        }
-
-        async fn submit_unwrap(
-            &self,
-            _wrapped_token: Address,
-            _wrapped_amount: U256,
-            _receiver: Address,
-            _owner: Address,
-        ) -> Result<TxHash, WrapperError> {
-            unimplemented!("submit_unwrap not used by approval target building")
-        }
-
-        async fn confirm_unwrap(
-            &self,
-            _wrapped_token: Address,
-            _tx_hash: TxHash,
-        ) -> Result<UnwrapConfirmation, WrapperError> {
-            unimplemented!("confirm_unwrap not used by approval target building")
-        }
-
-        async fn wait_for_block(&self, _block: u64) -> Result<(), WrapperError> {
-            unimplemented!("wait_for_block not used by approval target building")
-        }
-
-        fn owner(&self) -> Address {
-            Address::ZERO
-        }
-    }
 
     /// Watermark sits exactly at `U256::MAX / 2`, the midpoint between a bounded
     /// per-operation allowance and an already-granted MAX approval.
@@ -441,10 +323,38 @@ mod tests {
         );
     }
 
-    fn wrapper_with(symbol: &str, equity: WrappedEquity) -> StubWrapper {
-        let mut equities = HashMap::new();
-        equities.insert(symbol.parse::<Symbol>().unwrap(), equity);
-        StubWrapper { equities }
+    fn equity_asset(
+        underlying: Address,
+        derivative: Address,
+        trading: OperationMode,
+        rebalancing: OperationMode,
+    ) -> EquityAssetConfig {
+        EquityAssetConfig {
+            tokenized_equity: underlying,
+            tokenized_equity_derivative: derivative,
+            pyth_feed_id: None,
+            vault_ids: Vec::new(),
+            trading,
+            rebalancing,
+            wrapped_equity_recovery: OperationMode::Disabled,
+            extended_hours_counter_trading: OperationMode::Disabled,
+            operational_limit: None,
+        }
+    }
+
+    fn assets_with(
+        equities: impl IntoIterator<Item = (&'static str, EquityAssetConfig)>,
+    ) -> AssetsConfig {
+        AssetsConfig {
+            equities: EquitiesConfig {
+                operational_limit: None,
+                symbols: equities
+                    .into_iter()
+                    .map(|(symbol, config)| (symbol.parse().unwrap(), config))
+                    .collect::<HashMap<_, _>>(),
+            },
+            cash: None,
+        }
     }
 
     #[test]
@@ -454,16 +364,17 @@ mod tests {
         let orderbook = Address::random();
         let usdc = Address::random();
 
-        let wrapper = wrapper_with(
+        let assets = assets_with([(
             "AAPL",
-            WrappedEquity {
+            equity_asset(
                 underlying,
                 derivative,
-            },
-        );
+                OperationMode::Enabled,
+                OperationMode::Disabled,
+            ),
+        )]);
 
-        let symbols = vec!["AAPL".parse::<Symbol>().unwrap()];
-        let targets = build_approval_targets(&wrapper, symbols, orderbook, usdc).unwrap();
+        let targets = build_approval_targets(&assets, orderbook, usdc);
 
         assert_eq!(
             targets,
@@ -491,27 +402,51 @@ mod tests {
     }
 
     #[test]
-    fn build_targets_errors_on_unconfigured_symbol() {
-        let wrapper = wrapper_with(
-            "AAPL",
-            WrappedEquity {
-                underlying: Address::random(),
-                derivative: Address::random(),
-            },
-        );
-
-        let symbols = vec!["TSLA".parse::<Symbol>().unwrap()];
-        let error = build_approval_targets(&wrapper, symbols, Address::random(), Address::random())
-            .unwrap_err();
-
-        assert!(
-            matches!(
-                error,
-                StartupApprovalError::SymbolResolution { ref symbol, .. }
-                    if *symbol == "TSLA"
+    fn build_targets_omit_disabled_symbols_and_sort_enabled_symbols() {
+        let aapl_underlying = Address::random();
+        let aapl_derivative = Address::random();
+        let tsla_underlying = Address::random();
+        let tsla_derivative = Address::random();
+        let orderbook = Address::random();
+        let usdc = Address::random();
+        let assets = assets_with([
+            (
+                "TSLA",
+                equity_asset(
+                    tsla_underlying,
+                    tsla_derivative,
+                    OperationMode::Disabled,
+                    OperationMode::Enabled,
+                ),
             ),
-            "expected SymbolResolution for TSLA, got: {error:?}"
-        );
+            (
+                "DISABLED",
+                equity_asset(
+                    Address::random(),
+                    Address::random(),
+                    OperationMode::Disabled,
+                    OperationMode::Disabled,
+                ),
+            ),
+            (
+                "AAPL",
+                equity_asset(
+                    aapl_underlying,
+                    aapl_derivative,
+                    OperationMode::Enabled,
+                    OperationMode::Disabled,
+                ),
+            ),
+        ]);
+
+        let targets = build_approval_targets(&assets, orderbook, usdc);
+
+        assert_eq!(targets.len(), 5);
+        assert_eq!(targets[0].symbol.as_ref().unwrap().as_str(), "AAPL");
+        assert_eq!(targets[1].symbol.as_ref().unwrap().as_str(), "AAPL");
+        assert_eq!(targets[2].symbol.as_ref().unwrap().as_str(), "TSLA");
+        assert_eq!(targets[3].symbol.as_ref().unwrap().as_str(), "TSLA");
+        assert_eq!(targets[4].symbol, None);
     }
 
     /// Spawns anvil, builds a wallet from key[0], and deploys `count`


### PR DESCRIPTION
## What

Closes RAI-1357.

Depends on #1035.

Adds a read-only Turnkey policy preflight that fails deployment before the running bot is stopped unless every startup MAX approval is immediately authorized.

## Why

A config-valid deployment could replace the running bot and then fail during startup when Turnkey policy did not authorize a required token or wrapper approval. The deployment needs to prove policy coverage against the exact startup approval set while the previous process and installed files are still untouched.

## How

- Share one deterministic approval-target builder between server startup and deployment verification, covering enabled trading or rebalancing assets plus USDC.
- Parse and validate the staged candidate config and secrets without logging credentials.
- Query Turnkey `whoami` and policy-list endpoints through an authenticated read-only client.
- Require the authenticated API user to satisfy allow consensus alone; unknown or multi-approver consensus fails closed.
- Apply Turnkey deny precedence with conservative tri-state applicability: applicable or unprovable denies block coverage.
- Trust explicit target addresses, signing activity fields, and the raw ERC-20 `approve` selector; ABI-derived function fields remain unprovable without interface evidence.
- Package `verify-approvals` with a build-time executable assertion and run it before the single stop boundary.
- Structurally assert that candidate config and secrets are installed only after preflight succeeds, with staged secrets removed by an exit trap.

## Testing

- [x] `nix run .#ci` — 3,579 tests passed, with one configured e2e timing retry; Clippy, rustfmt, DTO regeneration, ESLint, and Svelte checks passed
- [x] `nix develop .#ci-backend -c cargo nextest run -p st0x-evm --all-features policy_client_lists_policy_effects_and_conditions --no-fail-fast`
- [x] `nix develop .#ci-backend -c cargo nextest run -p st0x-hedge --features wallet-turnkey approval_policy --no-fail-fast`
- [x] `nix build .#st0x-liquidity`
- [x] `nix build .#st0x-dashboard`
- [x] `nix eval --json .#deploy.nodes --apply builtins.attrNames`
- [x] `./scripts/validate-deploy-migration.sh`
- [x] `nix develop .#ci-hooks -c pre-commit run --all-files`

## Screenshots

N/A

## Anything else

The verifier never signs or submits an activity and tests use mocked Turnkey query endpoints. The conservative parser is intentional because Turnkey does not expose a policy simulation endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment-time verification that Turnkey approval policies cover all required startup approvals, using staged config/secrets and fail-closed coverage checks.
  * Introduced a candidate-config activation flow that validates before stopping and only then installs the approved artifacts.
  * Added a `verify-approvals` command-line tool to check approval-policy coverage.
* **Bug Fixes**
  * Startup ERC-20 allowance/approval targets now consistently derive from the configured assets (enabled trading/rebalancing equities plus USDC).
* **Documentation**
  * Updated sequencing guidance to reflect the new validation and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->