### PR TITLE
fix: upgrade Turnkey SDK to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7765,9 +7765,9 @@ dependencies = [
 
 [[package]]
 name = "turnkey_api_key_stamper"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ff3d11991690d61cc4c44fb12fa95656bf2a1480be8abbb44d05ee7b75177a"
+checksum = "98a037f2b10b32ddabc83ac250e8a64b08df416b73615eb46bf503e6f3ef06f5"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -7781,9 +7781,9 @@ dependencies = [
 
 [[package]]
 name = "turnkey_client"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9846185545f447fd6ae7b19cc04623b8be9f430e2230950565ad0400b6a62b6"
+checksum = "764836e5d03f4b67127badba0d39bed5d046b50e896ae071b0dd47ce17c790ee"
 dependencies = [
  "mime",
  "prost 0.12.6",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -30,8 +30,8 @@ serde_json = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
-turnkey_api_key_stamper = { version = "0.4.0", optional = true }
-turnkey_client = { version = "0.4.0", optional = true }
+turnkey_api_key_stamper = { version = "0.7.0", optional = true }
+turnkey_client = { version = "0.7.0", optional = true }
 url = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/evm/src/turnkey.rs
+++ b/crates/evm/src/turnkey.rs
@@ -415,6 +415,7 @@ impl TracingTurnkeyClient {
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
+            generate_app_proofs: None,
         };
         let activity = self
             .process_activity(&request, "/public/v1/submit/sign_transaction")
@@ -1099,7 +1100,8 @@ mod tests {
                             "signWith": address.to_string(),
                             "unsignedTransaction": hex::encode(&expected_unsigned_rlp),
                             "type": "TRANSACTION_TYPE_ETHEREUM",
-                        }
+                        },
+                        "generateAppProofs": null
                     })
                     .to_string(),
                 );


### PR DESCRIPTION
## What

Upgrade the Turnkey API key stamper and client dependencies from 0.4.0 to 0.7.0.

## Why

The signing integration needs the current Turnkey request schema and SDK fixes. Keeping the upgrade isolated from the configuration-validation change makes the external-contract delta explicit and independently reviewable.

## How

- Pin `turnkey_api_key_stamper` and `turnkey_client` to 0.7.0.
- Refresh the lockfile.
- Populate the new optional `generate_app_proofs` request field with `None`.
- Update the signed-request fixture to assert the corresponding `generateAppProofs: null` wire payload.

## Testing

- Existing Turnkey signing and request-stamping tests cover the upgraded client.
- The request-body test verifies the exact 0.7.0 JSON shape.
- GitHub Actions static checks and backend build/test matrix pass.

## Screenshots

Not applicable.

## Anything else

No signing semantics change: transaction bytes, organization ID, signer address, and local signature verification remain unchanged. This PR only adapts the integration to the 0.7.0 SDK contract.
