### PR TITLE
fix: represent unknown block cutoff as null (RAI-1141)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -583,6 +583,10 @@ hedging decisions.
 Phase 2 adds instrumentation for signals not yet captured: chain tip vs backfill
 checkpoint (block lag), poll-cycle duration and skipped ticks, and RPC/broker
 API latency, persisted in a lightweight telemetry store outside the event store.
+An unavailable ingestion cutoff is recorded as unknown rather than synthesized
+as block zero. Its block lag is therefore absent, and the dashboard surfaces the
+latest unknown-cutoff sample as degraded instead of reporting a healthy zero
+lag.
 
 ### Risk Management
 

--- a/dashboard/src/lib/performance/cards.test.ts
+++ b/dashboard/src/lib/performance/cards.test.ts
@@ -234,6 +234,20 @@ describe('blockLagCard', () => {
     expect(card.secondary).toBe('no checkpointed samples yet')
   })
 
+  it('reports degraded when the latest cutoff is unavailable', () => {
+    const card = blockLagCard(
+      infra({
+        currentLagBlocks: null,
+        currentLagSampledAt: '2026-06-01T00:00:30Z'
+      }),
+      freshNow
+    )
+
+    expect(card.status).toBe('warning')
+    expect(card.primary).toBe('—')
+    expect(card.secondary).toContain('cutoff unavailable')
+  })
+
   it('classifies the current lag against the block-lag thresholds', () => {
     const card = blockLagCard(infra({}), freshNow)
 

--- a/dashboard/src/lib/performance/cards.ts
+++ b/dashboard/src/lib/performance/cards.ts
@@ -138,6 +138,15 @@ export const blockLagCard = (
 
   const { currentLagBlocks, currentLagSampledAt, poll } = report.monitor
 
+  if (currentLagBlocks === null && currentLagSampledAt !== null) {
+    return {
+      title: 'Block lag',
+      primary: '—',
+      secondary: 'cutoff unavailable — ingestion paused',
+      status: 'warning'
+    }
+  }
+
   if (currentLagBlocks === null || currentLagSampledAt === null) {
     return {
       title: 'Block lag',

--- a/migrations/20260716151618_make_block_lag_cutoff_nullable.sql
+++ b/migrations/20260716151618_make_block_lag_cutoff_nullable.sql
@@ -1,0 +1,38 @@
+CREATE TABLE block_lag_samples_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sampled_at TEXT NOT NULL,
+    orderbook TEXT NOT NULL,
+    chain_tip INTEGER NOT NULL CHECK (chain_tip >= 0),
+    -- NULL when the configured ingestion cutoff tag is unavailable.
+    cutoff_block INTEGER CHECK (cutoff_block >= 0),
+    -- NULL before the first backfill checkpoint exists.
+    last_processed_block INTEGER CHECK (last_processed_block >= 0),
+    -- cutoff_block - last_processed_block; NULL when either input is unknown.
+    lag_blocks INTEGER CHECK (lag_blocks >= 0)
+);
+
+INSERT INTO block_lag_samples_new (
+    id,
+    sampled_at,
+    orderbook,
+    chain_tip,
+    cutoff_block,
+    last_processed_block,
+    lag_blocks
+)
+SELECT
+    id,
+    sampled_at,
+    orderbook,
+    chain_tip,
+    cutoff_block,
+    last_processed_block,
+    lag_blocks
+FROM block_lag_samples;
+
+DROP TABLE block_lag_samples;
+ALTER TABLE block_lag_samples_new RENAME TO block_lag_samples;
+
+CREATE INDEX idx_block_lag_samples_orderbook_sampled_at
+    ON block_lag_samples (orderbook, sampled_at);
+CREATE INDEX idx_block_lag_samples_sampled_at ON block_lag_samples (sampled_at);

--- a/src/alerts/telegram.rs
+++ b/src/alerts/telegram.rs
@@ -175,7 +175,7 @@ mod tests {
     async fn notify_surfaces_api_error_status() {
         let server = MockServer::start_async().await;
 
-        server
+        let mock = server
             .mock_async(|when, then| {
                 when.method(POST).path("/bot123:abc/sendMessage");
                 then.status(400)
@@ -200,5 +200,7 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST);
         let parsed: Value = serde_json::from_str(&body).unwrap();
         assert_eq!(parsed["description"], json!("Bad Request: chat not found"));
+
+        mock.assert_async().await;
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -2565,7 +2565,7 @@ mod tests {
                 sampled_at: now,
                 orderbook,
                 chain_tip: 120,
-                cutoff_block: 117,
+                cutoff_block: Some(117),
                 last_processed_block: Some(100),
             },
         )

--- a/src/conductor/monitor/order_fills.rs
+++ b/src/conductor/monitor/order_fills.rs
@@ -311,14 +311,14 @@ impl<P: Provider + Clone> OrderFillMonitor<P> {
         // Block-lag telemetry is best-effort: a failed sample must never fail
         // the poll. Lag is measured against the cutoff block -- the real
         // ingestion boundary -- so a caught-up system reads zero rather than a
-        // permanent floor. A null cutoff block records as 0, which saturates
-        // lag to 0.
+        // permanent floor. A null cutoff block remains unknown, so it cannot
+        // synthesize a healthy zero-lag sample while ingestion is paused.
         let sampled_checkpoint = load_backfill_checkpoint(&self.pool, &self.evm_ctx).await?;
         let sample = BlockLagSample {
             sampled_at,
             orderbook: self.evm_ctx.orderbook,
             chain_tip,
-            cutoff_block: cutoff_opt.unwrap_or(0),
+            cutoff_block: cutoff_opt,
             last_processed_block: sampled_checkpoint,
         };
         if let Err(error) = record_block_lag(&self.pool, &sample).await {
@@ -1140,6 +1140,21 @@ mod tests {
                 .unwrap(),
             Some(99),
             "the checkpoint must not move when the cutoff block is momentarily null"
+        );
+        let (cutoff_block, lag_blocks): (Option<i64>, Option<i64>) = sqlx::query_as(
+            "SELECT cutoff_block, lag_blocks FROM block_lag_samples \
+             ORDER BY id DESC LIMIT 1",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            cutoff_block, None,
+            "a null RPC cutoff must remain unknown in telemetry"
+        );
+        assert_eq!(
+            lag_blocks, None,
+            "lag cannot be known without an ingestion cutoff"
         );
 
         // Second tick: cutoff is back -> resume from exactly checkpoint+1.

--- a/src/performance/infra.rs
+++ b/src/performance/infra.rs
@@ -47,9 +47,9 @@ async fn current_lag(
     pool: &SqlitePool,
     orderbook: Address,
 ) -> Result<(Option<i64>, Option<DateTime<Utc>>), PerformanceError> {
-    let latest: Option<(String, i64)> = sqlx::query_as(
-        "SELECT sampled_at, lag_blocks FROM block_lag_samples \
-         WHERE lag_blocks IS NOT NULL AND orderbook = $1 \
+    let latest: Option<(String, Option<i64>, Option<i64>)> = sqlx::query_as(
+        "SELECT sampled_at, cutoff_block, lag_blocks FROM block_lag_samples \
+         WHERE orderbook = $1 \
          ORDER BY sampled_at DESC, id DESC LIMIT 1",
     )
     .bind(orderbook.to_string())
@@ -57,12 +57,18 @@ async fn current_lag(
     .await?;
 
     Ok(match latest {
-        Some((raw_sampled_at, lag_blocks)) => {
+        Some((raw_sampled_at, cutoff_block, lag_blocks)) => {
             // A corrupt timestamp makes the lag value unanchorable in time.
             // Return both fields as null so the TS client treats it as "no
             // sample" rather than showing lag without a timestamp.
             let ts = parse_timestamp(&raw_sampled_at);
-            (ts.map(|_| lag_blocks), ts)
+            match (cutoff_block, lag_blocks, ts) {
+                (None, _, sampled_at) => (None, sampled_at),
+                (Some(_), Some(lag_blocks), Some(sampled_at)) => {
+                    (Some(lag_blocks), Some(sampled_at))
+                }
+                (Some(_), _, _) => (None, None),
+            }
         }
         None => (None, None),
     })
@@ -331,7 +337,7 @@ mod tests {
                 sampled_at: timestamp(seconds),
                 orderbook,
                 chain_tip,
-                cutoff_block: chain_tip.saturating_sub(3),
+                cutoff_block: Some(chain_tip.saturating_sub(3)),
                 last_processed_block: checkpoint,
             },
         )
@@ -368,6 +374,39 @@ mod tests {
                     max_lag_blocks: 2,
                 },
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn latest_unknown_cutoff_supersedes_previous_healthy_lag() {
+        let pool = setup_test_db().await;
+        insert_lag(&pool, 10, 110, Some(100)).await;
+        record_block_lag(
+            &pool,
+            &BlockLagSample {
+                sampled_at: timestamp(20),
+                orderbook: ORDERBOOK,
+                chain_tip: 120,
+                cutoff_block: None,
+                last_processed_block: Some(100),
+            },
+        )
+        .await
+        .unwrap();
+
+        let telemetry = load_monitor_telemetry(&pool, &range(), ORDERBOOK)
+            .await
+            .unwrap();
+
+        assert_eq!(telemetry.current_lag_blocks, None);
+        assert_eq!(telemetry.current_lag_sampled_at, Some(timestamp(20)));
+        assert_eq!(
+            telemetry.block_lag,
+            vec![BlockLagPoint {
+                start: timestamp(0),
+                max_lag_blocks: 7,
+            }],
+            "unknown samples must not fabricate a zero-lag chart point"
         );
     }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -43,7 +43,8 @@ pub(crate) struct BlockLagSample {
     pub(crate) sampled_at: DateTime<Utc>,
     pub(crate) orderbook: Address,
     pub(crate) chain_tip: u64,
-    pub(crate) cutoff_block: u64,
+    /// `None` when the configured ingestion cutoff tag is unavailable.
+    pub(crate) cutoff_block: Option<u64>,
     /// `None` before the first backfill checkpoint exists.
     pub(crate) last_processed_block: Option<u64>,
 }
@@ -57,8 +58,9 @@ impl BlockLagSample {
     /// a load-balanced RPC can briefly report a cutoff block behind the
     /// checkpoint, which is staleness noise, not negative lag.
     fn lag_blocks(&self) -> Option<u64> {
-        self.last_processed_block
-            .map(|checkpoint| self.cutoff_block.saturating_sub(checkpoint))
+        self.cutoff_block
+            .zip(self.last_processed_block)
+            .map(|(cutoff_block, checkpoint)| cutoff_block.saturating_sub(checkpoint))
     }
 }
 
@@ -116,6 +118,7 @@ pub(crate) async fn record_block_lag(
     sample: &BlockLagSample,
 ) -> Result<(), TelemetryError> {
     let lag_blocks = sample.lag_blocks().map(i64::try_from).transpose()?;
+    let cutoff_block = sample.cutoff_block.map(i64::try_from).transpose()?;
     let last_processed_block = sample.last_processed_block.map(i64::try_from).transpose()?;
 
     sqlx::query(
@@ -127,7 +130,7 @@ pub(crate) async fn record_block_lag(
     .bind(sqlite_timestamp(sample.sampled_at))
     .bind(sample.orderbook.to_string())
     .bind(i64::try_from(sample.chain_tip)?)
-    .bind(i64::try_from(sample.cutoff_block)?)
+    .bind(cutoff_block)
     .bind(last_processed_block)
     .bind(lag_blocks)
     .execute(pool)
@@ -496,7 +499,7 @@ mod tests {
             orderbook: address!("0x1111111111111111111111111111111111111111"),
             chain_tip,
             // Cutoff trails the tip by a few blocks in this mock.
-            cutoff_block: chain_tip.saturating_sub(3),
+            cutoff_block: Some(chain_tip.saturating_sub(3)),
             last_processed_block: checkpoint,
         }
     }

--- a/tests/e2e/rebalancing.rs
+++ b/tests/e2e/rebalancing.rs
@@ -570,6 +570,14 @@ async fn equity_imbalance_triggers_redemption() -> anyhow::Result<()> {
         Duration::from_secs(120),
     )
     .await;
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
 
     let expected_positions = [ExpectedPosition::builder()
         .symbol("AAPL")


### PR DESCRIPTION
## What

[RAI-1141](https://linear.app/makeitrain/issue/RAI-1141/make-block-lag-telemetry-record-an-unknown-cutoff-as-null-not-block-0)

- Persist an unavailable ingestion cutoff as `NULL` instead of block zero.
- Keep lag absent when either the cutoff or checkpoint is unknown.
- Surface the latest unknown-cutoff sample as degraded in the dashboard.
- Remove a mock-server leak and a redemption E2E assertion race exposed by full-suite verification.

## Why

Synthesizing block zero made a paused order-fill monitor report a healthy zero lag. Operators need an unavailable cutoff to remain distinguishable from a caught-up monitor.

## How

`BlockLagSample` now models the cutoff as optional, and the read model uses the latest sample even when its lag is absent. A SQLite migration recreates the telemetry table with a nullable cutoff while preserving existing rows and indexes. The dashboard distinguishes an unknown cutoff from the separate no-checkpoint state.

## Testing

- `cargo nextest run -p st0x-hedge`: 2,556 passed, 4 skipped
- Redemption E2E stress run: 5/5 passed with retries disabled
- `cargo clippy -p st0x-hedge --all-targets --all-features`
- Dashboard tests: 244 passed
- Dashboard typecheck and lint
- Pre-commit hooks

## Screenshots

Not applicable.

## Anything else

The unknown-cutoff sample remains timestamped so the dashboard can show a current degraded state, while it is excluded from numeric lag charts.
