### PR TITLE
fix: retry busy read-model reactors (RAI-1325)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,8 +2615,8 @@ dependencies = [
 
 [[package]]
 name = "event-sorcery"
-version = "0.1.0"
-source = "git+https://github.com/ST0x-Technology/event-sorcery.git?tag=0.1.1#d0ad3f66bb5a1da23161d898027bff1abb9dabd6"
+version = "0.2.0"
+source = "git+https://github.com/ST0x-Technology/event-sorcery.git?tag=v0.2.0#8a57fca95f2bb090e9bd4cab4ba6f9b1e22fffc1"
 dependencies = [
  "async-trait",
  "cqrs-es 0.5.0",
@@ -3391,7 +3391,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -4786,7 +4786,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4823,7 +4823,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -6102,8 +6102,8 @@ dependencies = [
 
 [[package]]
 name = "sqlite-es"
-version = "0.1.0"
-source = "git+https://github.com/ST0x-Technology/event-sorcery.git?tag=0.1.1#d0ad3f66bb5a1da23161d898027bff1abb9dabd6"
+version = "0.2.0"
+source = "git+https://github.com/ST0x-Technology/event-sorcery.git?tag=v0.2.0#8a57fca95f2bb090e9bd4cab4ba6f9b1e22fffc1"
 dependencies = [
  "chrono",
  "cqrs-es 0.5.0",
@@ -7085,7 +7085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8228,7 +8228,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,14 +140,9 @@ uuid = { version = "1.11", features = ["serde", "v4", "v5"] }
 # newer crates require >=0.2.122).
 wasm-bindgen = "=0.2.122"
 
-[workspace.dependencies.sqlite-es]
-git = "https://github.com/ST0x-Technology/event-sorcery.git"
-tag = "0.1.1"
-package = "sqlite-es"
-
 [workspace.dependencies.st0x-event-sorcery]
 git = "https://github.com/ST0x-Technology/event-sorcery.git"
-tag = "0.1.1"
+tag = "v0.2.0"
 package = "event-sorcery"
 
 [package]

--- a/SPEC.md
+++ b/SPEC.md
@@ -512,11 +512,19 @@ migration files in `migrations/`.
 
 The dashboard exposes a Performance tab measuring the _technological_ health of
 the system (latency and reliability), complementing the P&L tab's economic view.
-All phase-1 metrics are maintained by a forward-only reactor that subscribes to
-live CQRS events and writes into bespoke read-model tables (`hedge_fill`,
-`hedge_cycle`, `hedge_attribution_state`). The read model reflects activity
-since deployment only -- there is no historical backfill from pre-existing
-events in the event store. No new write paths touch the trading path.
+The hedge-latency metrics are maintained by a forward-only reactor that
+subscribes to live CQRS events and writes into bespoke read-model tables
+(`hedge_fill`, `hedge_cycle`, `hedge_submission`, and
+`hedge_attribution_reset`). That read model reflects activity since deployment
+only -- there is no historical backfill from pre-existing events in the event
+store. The USDC/equity stage-timing and lifecycle-failure reactors maintain
+their own bespoke tables with startup catch-up from the event store.
+
+All four bespoke reactors are idempotent, database-only units and retry
+transient SQLite busy/locked failures with bounded exponential backoff. A retry
+re-runs the complete event reaction: multi-statement reactions therefore execute
+in one transaction, and every insert is conflict-safe under redelivery. No new
+write paths touch the trading path.
 
 #### Hedge latency pipeline
 

--- a/rust.nix
+++ b/rust.nix
@@ -47,8 +47,8 @@ let
     outputHashes = {
       "git+https://github.com/rainlanguage/rain.error#3d2ed70fb2f7c6156706846e10f163d1e493a8d3" =
         "sha256-dDsvRkrGXhfoFunvk6fwP+12fSsjiWYoxz/CzVVGpHA=";
-      "git+https://github.com/ST0x-Technology/event-sorcery.git?rev=1557172049c8a43add209a86c7d809e89a5fbc82#1557172049c8a43add209a86c7d809e89a5fbc82" =
-        "sha256-GkQaR+cp09NJBarrz8VeJV/6DVFz+EhMsu2y8jP0Uck=";
+      "git+https://github.com/ST0x-Technology/event-sorcery.git?tag=v0.2.0#8a57fca95f2bb090e9bd4cab4ba6f9b1e22fffc1" =
+        "sha256-1vsayhfS3kghmwlKvdNYRklk85VKG6DiuS8Qpn75/wE=";
       "git+https://github.com/rainlanguage/rain.wasm?rev=06990d85a0b7c55378a1c8cca4dd9e2bc34a596a#06990d85a0b7c55378a1c8cca4dd9e2bc34a596a" =
         "sha256-MkuPc9mWAmry5Yzjph4/IbaIvjevFUerji1lipLUK4g=";
     };
@@ -85,12 +85,12 @@ let
 
   # sqlite-es uses sqlx::migrate!("../../migrations") which resolves inside
   # the vendor dir. Fetch migrations from event-sorcery at the same commit
-  # as Cargo.lock specifies for sqlite-es.
+  # as Cargo.lock specifies for event-sorcery.
   cargoLock = builtins.fromTOML (builtins.readFile ./Cargo.lock);
-  sqliteEsPackage = builtins.head (
-    builtins.filter (p: p.name or "" == "sqlite-es") cargoLock.package
+  eventSorceryPackage = builtins.head (
+    builtins.filter (p: p.name or "" == "event-sorcery") cargoLock.package
   );
-  sqliteEsRev = builtins.head (builtins.match ".*#([a-f0-9]+)" sqliteEsPackage.source);
+  eventSorceryRev = builtins.head (builtins.match ".*#([a-f0-9]+)" eventSorceryPackage.source);
 
   # Issuance vendor override (above) reuses the rev Cargo.lock locks for the
   # st0x-issuance-* crates, so the rev can never drift from the Cargo.toml pins.
@@ -103,7 +103,7 @@ let
   sqliteEsMigrations =
     builtins.fetchGit {
       url = "https://github.com/ST0x-Technology/event-sorcery";
-      rev = sqliteEsRev;
+      rev = eventSorceryRev;
     }
     + "/migrations";
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -36,8 +36,8 @@ use st0x_config::{
 };
 use st0x_dto::Statement;
 use st0x_event_sorcery::{
-    AggregateError, EventSourced, LifecycleError, Projection, SendError, Store, StoreBuilder,
-    compact_events, incremental_vacuum, load_all_ids, load_entity,
+    AggregateError, EventSourced, LifecycleError, Projection, RetryOnBusy, SendError, Store,
+    StoreBuilder, compact_events, incremental_vacuum, load_all_ids, load_entity,
 };
 use st0x_evm::{OpenChainErrorRegistry, USDC_BASE, Wallet};
 use st0x_execution::{
@@ -179,8 +179,12 @@ where
     let order_placer: Arc<dyn OrderPlacer> = Arc::new(ExecutorOrderPlacer(executor.clone()));
     let (offchain_order, offchain_order_projection) =
         StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
-            .with(Arc::new(LifecycleFailureProjection::new(pool.clone())))
+            .with(Arc::new(RetryOnBusy {
+                inner: HedgeLatencyProjection::new(pool.clone()),
+            }))
+            .with(Arc::new(RetryOnBusy {
+                inner: LifecycleFailureProjection::new(pool.clone()),
+            }))
             .build(order_placer.clone())
             .await?;
 
@@ -1491,10 +1495,10 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         .await?;
 
         let broadcaster = Arc::new(Broadcaster::new(deps.event_sender, deps.pool.clone()));
-        let hedge_latency = Arc::new(HedgeLatencyProjection::new(deps.pool.clone()));
-        let rebalance_timing = Arc::new(RebalanceTimingProjection::new(deps.pool.clone()));
-        let equity_timing = Arc::new(EquityTimingProjection::new(deps.pool.clone()));
-        let lifecycle_failure = Arc::new(LifecycleFailureProjection::new(deps.pool.clone()));
+        let hedge_latency = HedgeLatencyProjection::new(deps.pool.clone());
+        let rebalance_timing = RebalanceTimingProjection::new(deps.pool.clone());
+        let equity_timing = EquityTimingProjection::new(deps.pool.clone());
+        let lifecycle_failure = LifecycleFailureProjection::new(deps.pool.clone());
         catch_up_stage_timing_projections(&rebalance_timing, &equity_timing).await?;
 
         let manifest = QueryManifest::new(
@@ -2161,7 +2165,9 @@ async fn build_position_cqrs(
 ) -> anyhow::Result<(Arc<Store<Position>>, Arc<Projection<Position>>)> {
     let (store, projection) = StoreBuilder::<Position>::new(pool.clone())
         .with(broadcaster)
-        .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
+        .with(Arc::new(RetryOnBusy {
+            inner: HedgeLatencyProjection::new(pool.clone()),
+        }))
         .build(())
         .await?;
 

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -16,7 +16,7 @@
 use sqlx::SqlitePool;
 use std::sync::Arc;
 
-use st0x_event_sorcery::{Projection, Store, StoreBuilder};
+use st0x_event_sorcery::{Projection, RetryOnBusy, Store, StoreBuilder};
 
 use crate::dashboard::Broadcaster;
 use crate::equity_redemption::EquityRedemption;
@@ -38,10 +38,10 @@ use crate::usdc_rebalance::UsdcRebalance;
 pub(super) struct QueryManifest {
     rebalancing_service: Arc<RebalancingService>,
     broadcaster: Arc<Broadcaster>,
-    hedge_latency: Arc<HedgeLatencyProjection>,
-    rebalance_timing: Arc<RebalanceTimingProjection>,
-    equity_timing: Arc<EquityTimingProjection>,
-    lifecycle_failure: Arc<LifecycleFailureProjection>,
+    hedge_latency: Arc<RetryOnBusy<HedgeLatencyProjection>>,
+    rebalance_timing: Arc<RetryOnBusy<RebalanceTimingProjection>>,
+    equity_timing: Arc<RetryOnBusy<EquityTimingProjection>>,
+    lifecycle_failure: Arc<RetryOnBusy<LifecycleFailureProjection>>,
 }
 
 /// Built CQRS frameworks from the wiring process.
@@ -62,18 +62,26 @@ impl QueryManifest {
     pub(super) fn new(
         rebalancing_service: Arc<RebalancingService>,
         broadcaster: Arc<Broadcaster>,
-        hedge_latency: Arc<HedgeLatencyProjection>,
-        rebalance_timing: Arc<RebalanceTimingProjection>,
-        equity_timing: Arc<EquityTimingProjection>,
-        lifecycle_failure: Arc<LifecycleFailureProjection>,
+        hedge_latency: HedgeLatencyProjection,
+        rebalance_timing: RebalanceTimingProjection,
+        equity_timing: EquityTimingProjection,
+        lifecycle_failure: LifecycleFailureProjection,
     ) -> Self {
         Self {
             rebalancing_service,
             broadcaster,
-            hedge_latency,
-            rebalance_timing,
-            equity_timing,
-            lifecycle_failure,
+            hedge_latency: Arc::new(RetryOnBusy {
+                inner: hedge_latency,
+            }),
+            rebalance_timing: Arc::new(RetryOnBusy {
+                inner: rebalance_timing,
+            }),
+            equity_timing: Arc::new(RetryOnBusy {
+                inner: equity_timing,
+            }),
+            lifecycle_failure: Arc::new(RetryOnBusy {
+                inner: lifecycle_failure,
+            }),
         }
     }
 
@@ -220,10 +228,10 @@ mod tests {
         ));
 
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
-        let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
-        let rebalance_timing = Arc::new(RebalanceTimingProjection::new(pool.clone()));
-        let equity_timing = Arc::new(EquityTimingProjection::new(pool.clone()));
-        let lifecycle_failure = Arc::new(LifecycleFailureProjection::new(pool.clone()));
+        let hedge_latency = HedgeLatencyProjection::new(pool.clone());
+        let rebalance_timing = RebalanceTimingProjection::new(pool.clone());
+        let equity_timing = EquityTimingProjection::new(pool.clone());
+        let lifecycle_failure = LifecycleFailureProjection::new(pool.clone());
         let manifest = QueryManifest::new(
             rebalancing_service,
             broadcaster,
@@ -282,10 +290,10 @@ mod tests {
             Arc::new(crate::alerts::NoopNotifier),
         ));
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
-        let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
-        let rebalance_timing = Arc::new(RebalanceTimingProjection::new(pool.clone()));
-        let equity_timing = Arc::new(EquityTimingProjection::new(pool.clone()));
-        let lifecycle_failure = Arc::new(LifecycleFailureProjection::new(pool.clone()));
+        let hedge_latency = HedgeLatencyProjection::new(pool.clone());
+        let rebalance_timing = RebalanceTimingProjection::new(pool.clone());
+        let equity_timing = EquityTimingProjection::new(pool.clone());
+        let lifecycle_failure = LifecycleFailureProjection::new(pool.clone());
         let manifest = QueryManifest::new(
             rebalancing_service,
             broadcaster,
@@ -400,10 +408,10 @@ mod tests {
             Arc::new(crate::alerts::NoopNotifier),
         ));
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
-        let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
-        let rebalance_timing = Arc::new(RebalanceTimingProjection::new(pool.clone()));
-        let equity_timing = Arc::new(EquityTimingProjection::new(pool.clone()));
-        let lifecycle_failure = Arc::new(LifecycleFailureProjection::new(pool.clone()));
+        let hedge_latency = HedgeLatencyProjection::new(pool.clone());
+        let rebalance_timing = RebalanceTimingProjection::new(pool.clone());
+        let equity_timing = EquityTimingProjection::new(pool.clone());
+        let lifecycle_failure = LifecycleFailureProjection::new(pool.clone());
         let manifest = QueryManifest::new(
             rebalancing_service.clone(),
             broadcaster,

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -20,10 +20,11 @@
 //! tables, so the read model survives a restart with no in-memory state.
 //!
 //! Forward-only: the reactor processes only events emitted after construction.
-//! There is NO startup backfill of pre-existing history. A crash between an
-//! event being persisted and this reactor's tables being updated can drop that
-//! single event from the read model -- accepted as best-effort, matching the
-//! `Broadcaster` reactor's guarantees.
+//! There is NO startup backfill of pre-existing history. Transient SQLite
+//! busy/locked failures are retried because each database-only reaction is
+//! idempotent; a crash between an event being persisted and this reactor's
+//! tables being updated can still drop that single event from the read model --
+//! accepted as best-effort, matching the `Broadcaster` reactor's guarantees.
 //!
 //! The implementation splits into a write side ([`projection`]) that reacts to
 //! events and a read side ([`report`]) that loads and assembles the report. The
@@ -38,7 +39,7 @@ use chrono::Duration;
 use chrono::{DateTime, Utc};
 #[cfg(any(test, feature = "test-support"))]
 use rain_math_float::Float;
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 #[cfg(any(test, feature = "test-support"))]
 use std::sync::Arc;
 use tracing::warn;
@@ -46,7 +47,7 @@ use tracing::warn;
 #[cfg(any(test, feature = "test-support"))]
 use st0x_config::ExecutionThreshold;
 #[cfg(any(test, feature = "test-support"))]
-use st0x_event_sorcery::StoreBuilder;
+use st0x_event_sorcery::{RetryOnBusy, StoreBuilder};
 use st0x_execution::Symbol;
 #[cfg(any(test, feature = "test-support"))]
 use st0x_execution::{
@@ -167,14 +168,18 @@ pub async fn seed_simulated_hedge_latency_history(
     sqlx::migrate!().set_ignore_missing(true).run(pool).await?;
 
     let (position, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
-        .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
+        .with(Arc::new(RetryOnBusy {
+            inner: HedgeLatencyProjection::new(pool.clone()),
+        }))
         .build(())
         .await?;
 
     let order_placer: Arc<dyn OrderPlacer> = Arc::new(FixtureOrderPlacer);
     let (offchain_order, _offchain_order_projection) =
         StoreBuilder::<OffchainOrder>::new(pool.clone())
-            .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
+            .with(Arc::new(RetryOnBusy {
+                inner: HedgeLatencyProjection::new(pool.clone()),
+            }))
             .build(order_placer)
             .await?;
 
@@ -394,6 +399,17 @@ async fn uncovered_fills(
     pool: &SqlitePool,
     symbol: &Symbol,
 ) -> Result<Vec<UncoveredFill>, PerformanceError> {
+    let mut connection = pool.acquire().await?;
+    uncovered_fills_on_connection(&mut connection, symbol).await
+}
+
+/// Connection-scoped form used by placement so its attribution snapshot and
+/// cycle insert share one transaction. The report path delegates here through
+/// an acquired pool connection to keep the attribution algorithm single-sourced.
+async fn uncovered_fills_on_connection(
+    connection: &mut SqliteConnection,
+    symbol: &Symbol,
+) -> Result<Vec<UncoveredFill>, PerformanceError> {
     let symbol_text = symbol.to_string();
 
     // MAX over zero matching rows yields a single NULL row, so the aggregate is
@@ -401,7 +417,7 @@ async fn uncovered_fills(
     let (latest_reset,): (Option<String>,) =
         sqlx::query_as("SELECT MAX(adjusted_at) FROM hedge_attribution_reset WHERE symbol = ?")
             .bind(&symbol_text)
-            .fetch_one(pool)
+            .fetch_one(&mut *connection)
             .await?;
 
     let latest_reset_at = latest_reset
@@ -412,7 +428,7 @@ async fn uncovered_fills(
         "SELECT block_timestamp, seen_at FROM hedge_fill WHERE symbol = ? ORDER BY id",
     )
     .bind(&symbol_text)
-    .fetch_all(pool)
+    .fetch_all(&mut *connection)
     .await?;
 
     // Parse, reset-filter, and collect in a single pass. Malformed rows are
@@ -441,7 +457,7 @@ async fn uncovered_fills(
          FROM hedge_cycle WHERE symbol = ? ORDER BY placed_at, offchain_order_id",
     )
     .bind(&symbol_text)
-    .fetch_all(pool)
+    .fetch_all(&mut *connection)
     .await?;
 
     for (placed_at, covered_count, filled_at, failed_at) in cycle_rows {

--- a/src/performance/equity_timing/mod.rs
+++ b/src/performance/equity_timing/mod.rs
@@ -38,7 +38,7 @@ use st0x_dto::{
     EquityOperationKind, EquityOperationTiming, EquityStageName, EquityStageStats,
     EquityStageTiming, RebalanceTimingStatus, StageOutcome,
 };
-use st0x_event_sorcery::{EntityList, EventSourced, Reactor, deps};
+use st0x_event_sorcery::{EntityList, EventSourced, IdempotentReactor, Reactor, deps};
 use st0x_execution::Symbol;
 use st0x_finance::FractionalShares;
 use st0x_tokenization::IssuerRequestId;
@@ -564,6 +564,8 @@ impl Reactor for EquityTimingProjection {
             .await
     }
 }
+
+impl IdempotentReactor for EquityTimingProjection {}
 
 /// Accumulated per-operation timing state, persisted as JSON.
 ///

--- a/src/performance/projection.rs
+++ b/src/performance/projection.rs
@@ -11,7 +11,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
-use st0x_event_sorcery::{EntityList, Reactor, deps};
+use st0x_event_sorcery::{EntityList, IdempotentReactor, Reactor, deps};
 use thiserror::Error;
 use tracing::{debug, warn};
 
@@ -20,7 +20,7 @@ use st0x_execution::Symbol;
 use crate::offchain::order::{OffchainOrder, OffchainOrderEvent, OffchainOrderId};
 use crate::position::{Position, PositionEvent, TradeId};
 
-use super::{PerformanceError, covered_fills, uncovered_fills};
+use super::{PerformanceError, covered_fills, uncovered_fills_on_connection};
 
 /// Reactor maintaining the hedge-latency read model from live events.
 pub(crate) struct HedgeLatencyProjection {
@@ -102,11 +102,22 @@ impl HedgeLatencyProjection {
         symbol: &Symbol,
         adjusted_at: DateTime<Utc>,
     ) -> Result<(), ProjectionError> {
-        sqlx::query("INSERT INTO hedge_attribution_reset (symbol, adjusted_at) VALUES (?, ?)")
-            .bind(symbol.to_string())
-            .bind(adjusted_at.to_rfc3339())
-            .execute(&self.pool)
-            .await?;
+        let symbol = symbol.to_string();
+        let adjusted_at = adjusted_at.to_rfc3339();
+        sqlx::query(
+            "INSERT INTO hedge_attribution_reset (symbol, adjusted_at) \
+             SELECT ?, ? \
+             WHERE NOT EXISTS (\
+                 SELECT 1 FROM hedge_attribution_reset \
+                 WHERE symbol = ? AND adjusted_at = ?\
+             )",
+        )
+        .bind(&symbol)
+        .bind(&adjusted_at)
+        .bind(&symbol)
+        .bind(&adjusted_at)
+        .execute(&self.pool)
+        .await?;
 
         Ok(())
     }
@@ -155,11 +166,12 @@ impl HedgeLatencyProjection {
         offchain_order_id: OffchainOrderId,
         placed_at: DateTime<Utc>,
     ) -> Result<(), ProjectionError> {
-        // Snapshot the current uncovered set as this placement's covered batch.
-        // The per-aggregate serial-delivery invariant means no concurrent writer
-        // mutates hedge_fill or hedge_attribution_reset between this read and the
-        // INSERT, and ON CONFLICT DO NOTHING keeps redelivery idempotent.
-        let batch = uncovered_fills(&self.pool, symbol).await?;
+        // Snapshot the current uncovered set and insert the corresponding cycle
+        // in one transaction. A retry therefore re-runs the complete reaction
+        // against a fresh snapshot, while ON CONFLICT keeps redelivery
+        // idempotent.
+        let mut tx = self.pool.begin().await?;
+        let batch = uncovered_fills_on_connection(&mut tx, symbol).await?;
         let covered = covered_fills(&batch);
 
         let (earliest_block_ts, latest_seen_at) = covered.as_ref().map_or((None, None), |cov| {
@@ -183,8 +195,10 @@ impl HedgeLatencyProjection {
         .bind(count)
         .bind(earliest_block_ts)
         .bind(latest_seen_at)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
+
+        tx.commit().await?;
 
         Ok(())
     }
@@ -372,6 +386,8 @@ impl Reactor for HedgeLatencyProjection {
             .await
     }
 }
+
+impl IdempotentReactor for HedgeLatencyProjection {}
 
 #[cfg(test)]
 mod tests {
@@ -800,6 +816,34 @@ mod tests {
         assert_eq!(covered.count, 1);
         assert_eq!(covered.earliest_block_timestamp, timestamp(0));
         assert!(after[0].open_exposure.is_none());
+    }
+
+    #[tokio::test]
+    async fn duplicate_manual_adjustment_is_idempotent() {
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(HedgeLatencyProjection::new(pool.clone()));
+        let adjustment = PositionEvent::ManualPositionAdjusted {
+            previous_net: FractionalShares::new(float!(1)),
+            target_net: FractionalShares::new(float!(0)),
+            reason: "manual reset".to_string(),
+            price_usdc: None,
+            adjusted_at: timestamp(5),
+        };
+
+        harness
+            .receive::<Position>(symbol(), adjustment.clone())
+            .await
+            .unwrap();
+        harness
+            .receive::<Position>(symbol(), adjustment)
+            .await
+            .unwrap();
+
+        let reset_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM hedge_attribution_reset")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(reset_count, 1);
     }
 
     /// A manual adjustment writes a durable reset boundary; fills observed after

--- a/src/performance/rebalance.rs
+++ b/src/performance/rebalance.rs
@@ -44,7 +44,7 @@ use st0x_dto::{
     AttestationSample, RebalanceOperationTiming, RebalanceStageName, RebalanceStageStats,
     RebalanceStageTiming, RebalanceTimingStatus, RebalanceTimings, StageOutcome,
 };
-use st0x_event_sorcery::{EntityList, EventSourced, Reactor, deps};
+use st0x_event_sorcery::{EntityList, EventSourced, IdempotentReactor, Reactor, deps};
 use st0x_finance::Usdc;
 
 use super::{PerformanceError, ReportRange, latency_stats};
@@ -445,6 +445,8 @@ impl Reactor for RebalanceTimingProjection {
             .await
     }
 }
+
+impl IdempotentReactor for RebalanceTimingProjection {}
 
 /// Accumulated per-operation timing state, persisted as JSON.
 ///

--- a/src/performance/reliability.rs
+++ b/src/performance/reliability.rs
@@ -49,7 +49,7 @@ use st0x_dto::{
     LogVolumeBucket,
 };
 
-use st0x_event_sorcery::{EntityList, EventSourced, Reactor, deps};
+use st0x_event_sorcery::{EntityList, EventSourced, IdempotentReactor, Reactor, deps};
 
 use super::{PerformanceError, ReportRange};
 use crate::equity_redemption::{EquityRedemption, EquityRedemptionEvent};
@@ -429,6 +429,8 @@ impl Reactor for LifecycleFailureProjection {
     }
 }
 
+impl IdempotentReactor for LifecycleFailureProjection {}
+
 /// Failure signal carried by an `OffchainOrder` event, if any.
 fn offchain_order_failure(event: &OffchainOrderEvent) -> Option<(FailureEventType, DateTime<Utc>)> {
     match event {
@@ -696,19 +698,20 @@ fn count(value: i64) -> Result<usize, PerformanceError> {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::time::Duration;
 
     use alloy::primitives::TxHash;
     use chrono::TimeZone;
     use serde_json::json;
     use uuid::Uuid;
 
-    use st0x_event_sorcery::{DomainEvent, ReactorHarness};
+    use st0x_event_sorcery::{DomainEvent, ReactorHarness, RetryOnBusy};
     use st0x_execution::Symbol;
     use st0x_float_macro::float;
 
     use crate::equity_redemption::DetectionFailure;
     use crate::offchain::order::OffchainOrderId;
-    use crate::test_utils::setup_test_db;
+    use crate::test_utils::{setup_file_backed_test_db, setup_test_db};
     use crate::usdc_rebalance::UsdcRebalanceId;
 
     use super::*;
@@ -828,6 +831,38 @@ mod tests {
             error: "rejected".to_string(),
             failed_at: timestamp(failed_offset),
         }
+    }
+
+    #[tokio::test]
+    async fn lifecycle_failure_reactor_survives_transient_sqlite_busy() {
+        let (pool, _apalis_pool, _database_path, _database_guard) =
+            setup_file_backed_test_db(Duration::from_millis(1)).await;
+        let mut blocker = pool.acquire().await.unwrap();
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *blocker)
+            .await
+            .unwrap();
+        let release_blocker = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(35)).await;
+            sqlx::query("COMMIT").execute(&mut *blocker).await.unwrap();
+        });
+
+        let harness = ReactorHarness::new(RetryOnBusy {
+            inner: LifecycleFailureProjection::new(pool.clone()),
+        });
+        let order_id = OffchainOrderId::new();
+        let result = harness
+            .receive::<OffchainOrder>(order_id, offchain_order_failed(100))
+            .await;
+
+        release_blocker.await.unwrap();
+        result.unwrap();
+        let failures = load_failure_events(&pool, &range()).await.unwrap();
+        assert_eq!(failures.len(), 1);
+        assert_eq!(
+            failures[0].event_type,
+            FailureEventType::OffchainOrderFailed
+        );
     }
 
     #[tokio::test]

--- a/src/performance/simulated_transfers.rs
+++ b/src/performance/simulated_transfers.rs
@@ -30,7 +30,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use st0x_event_sorcery::{Store, StoreBuilder};
+use st0x_event_sorcery::{RetryOnBusy, Store, StoreBuilder};
 use st0x_evm::IERC20;
 use st0x_execution::{AlpacaTransferId, ClientOrderId, FractionalShares, Symbol};
 use st0x_finance::Usdc;
@@ -244,7 +244,9 @@ pub async fn seed_simulated_mint_history(
     services.tokenizer = Arc::new(FixtureTokenizer::new(Address::ZERO, 0));
 
     let mint = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-        .with(Arc::new(EquityTimingProjection::new(pool.clone())))
+        .with(Arc::new(RetryOnBusy {
+            inner: EquityTimingProjection::new(pool.clone()),
+        }))
         .build(services)
         .await?;
 
@@ -336,7 +338,9 @@ pub async fn seed_simulated_usdc_rebalance_history(
     // `Materialized = Table`, which returns a `(Store, Projection)` pair) --
     // the reactor is wired into the store's dispatch either way.
     let rebalance = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-        .with(Arc::new(RebalanceTimingProjection::new(pool.clone())))
+        .with(Arc::new(RetryOnBusy {
+            inner: RebalanceTimingProjection::new(pool.clone()),
+        }))
         .build(())
         .await?;
 
@@ -1047,7 +1051,9 @@ pub async fn seed_simulated_equity_redemption_history(
         };
 
         let redemption = StoreBuilder::<EquityRedemption>::new(pool.clone())
-            .with(Arc::new(EquityTimingProjection::new(pool.clone())))
+            .with(Arc::new(RetryOnBusy {
+                inner: EquityTimingProjection::new(pool.clone()),
+            }))
             .build(services)
             .await?;
 


### PR DESCRIPTION
## Stack Context

Based directly on master for a fast hotfix merge; #1043 stacks on top. The rest of the Liquidity Bot Improvements stack remains on #1040 and will resync after this merges.

## What

[RAI-1325](https://linear.app/makeitrain/issue/RAI-1325/wire-the-4-read-model-reactors-to-retryonbusy-once-event-sorcery-rai)

- Pin event-sorcery at the v0.2.0 release tag (RetryOnBusy, per-aggregate command serialization, bounded per-aggregate lock table) and update the crane source hash.
- Mark all four bespoke performance reactors idempotent and wrap every production and simulation registration in RetryOnBusy.
- Make hedge-cycle attribution read and insertion transactional.
- Make manual attribution resets replay-safe.
- Add SQLite lock-contention and duplicate-delivery regression tests.

## Why

Transient SQLite busy errors currently drop performance read-model reactions. Retrying is safe only when the complete reaction is database-only, atomic, and idempotent under redelivery.

## How

The four reactors now opt into the event-sorcery IdempotentReactor contract after auditing their side effects and write shapes. QueryManifest owns the RetryOnBusy wrappers so registrations cannot accidentally bypass them. Hedge placement computes its uncovered-fill snapshot and records the cycle in one transaction, while manual resets use a conflict-safe conditional insert.

## Testing

- cargo nextest run -p st0x-hedge --lib on the master base with the v0.2.0 pin: 2,489 passed
- cargo check --workspace --all-targets
- nix build .#st0x-liquidity (verifies the v0.2.0 vendor hash and migrations copy end to end)
- Pre-commit hooks

## Screenshots

Not applicable.

## Anything else

The hedge-latency model remains forward-only. The stage-timing and lifecycle-failure models keep their startup catch-up behavior.
