### PR TITLE
fix: suppress rebalancing on stale inventory observations

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -1510,6 +1510,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             RebalancingServiceConfig {
                 equity: rebalancing_ctx.equity,
                 usdc: rebalancing_ctx.usdc,
+                inventory_freshness_window: Duration::from_secs(deps.ctx.inventory_poll_interval),
                 transfer_timeout: rebalancing_ctx.transfer_timeout,
                 assets: deps.ctx.assets.clone(),
             },
@@ -3737,6 +3738,7 @@ mod tests {
                     deviation: float!(0.2),
                 },
                 usdc: None,
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: Duration::from_secs(60),
                 assets: AssetsConfig {
                     equities: rebalancing_enabled_equities(&["AAPL"]),
@@ -4004,6 +4006,7 @@ mod tests {
                     deviation: st0x_float_macro::float!(0.2),
                 },
                 usdc: None,
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: Duration::from_secs(60),
                 assets: AssetsConfig {
                     equities: rebalancing_enabled_equities(&["AAPL"]),
@@ -4527,6 +4530,7 @@ mod tests {
                     deviation: st0x_float_macro::float!(0.2),
                 },
                 usdc: None,
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: Duration::from_secs(60),
                 assets: AssetsConfig {
                     // wrapped_equity_recovery ENABLED: recover_mint_state will set
@@ -4621,6 +4625,7 @@ mod tests {
                     deviation: st0x_float_macro::float!(0.2),
                 },
                 usdc: None,
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: Duration::from_secs(60),
                 assets: AssetsConfig {
                     // wrapped_equity_recovery DISABLED: recover_mint_state keeps
@@ -7806,6 +7811,7 @@ mod tests {
                 chrono::Utc::now(),
             )
             .unwrap()
+            .with_rebalancing_sources_observed_at(chrono::Utc::now())
     }
 
     #[tokio::test]
@@ -7854,6 +7860,7 @@ mod tests {
                     target: float!(0.5),
                     deviation: float!(0.2),
                 }),
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: Duration::from_secs(30 * 60),
                 assets: AssetsConfig {
                     equities: rebalancing_enabled_equities(&["AAPL"]),
@@ -7965,6 +7972,7 @@ mod tests {
             RebalancingServiceConfig {
                 equity: threshold,
                 usdc: Some(threshold),
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: Duration::from_secs(30 * 60),
                 assets: AssetsConfig {
                     equities: rebalancing_enabled_equities(&["AAPL"]),
@@ -8086,6 +8094,7 @@ mod tests {
                     target: float!(0.5),
                     deviation: float!(0.2),
                 }),
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: Duration::from_secs(30 * 60),
                 assets: AssetsConfig {
                     equities: rebalancing_enabled_equities(&["AAPL"]),
@@ -8208,7 +8217,8 @@ mod tests {
                 ),
                 chrono::Utc::now(),
             )
-            .unwrap();
+            .unwrap()
+            .with_rebalancing_sources_observed_at(chrono::Utc::now());
 
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(initial_inventory, event_sender));
@@ -8225,6 +8235,7 @@ mod tests {
                     target: float!(0.5),
                     deviation: float!(0.2),
                 }),
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: Duration::from_secs(30 * 60),
                 assets: AssetsConfig {
                     equities: rebalancing_enabled_equities(&["AAPL"]),

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -194,6 +194,7 @@ mod tests {
                 target: float!(0.6),
                 deviation: float!(0.15),
             }),
+            inventory_freshness_window: Duration::from_secs(60),
             transfer_timeout: Duration::from_secs(30 * 60),
             assets: AssetsConfig {
                 equities: rebalancing_enabled_equities(&["AAPL"]),
@@ -392,7 +393,8 @@ mod tests {
                 ),
                 chrono::Utc::now(),
             )
-            .unwrap();
+            .unwrap()
+            .with_rebalancing_sources_observed_at(chrono::Utc::now());
         let inventory = Arc::new(BroadcastingInventory::new(
             initial_inventory,
             event_sender.clone(),

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -203,6 +203,7 @@ fn test_trigger_config() -> RebalancingServiceConfig {
             target: float!(0.5),
             deviation: float!(0.2),
         }),
+        inventory_freshness_window: Duration::from_secs(60),
         transfer_timeout: Duration::from_secs(30 * 60),
         assets: AssetsConfig {
             equities: EquitiesConfig {
@@ -275,7 +276,8 @@ async fn setup_equity_trigger() -> EquityTriggerFixture {
                 FractionalShares::ZERO,
                 FractionalShares::ZERO,
             )
-            .with_usdc(Usdc::new(float!(1000000)), Usdc::new(float!(1000000))),
+            .with_usdc(Usdc::new(float!(1000000)), Usdc::new(float!(1000000)))
+            .with_rebalancing_sources_observed_at(Utc::now()),
         event_sender,
     ));
 
@@ -445,7 +447,8 @@ async fn build_imbalanced_inventory(imbalance: Imbalance<'_>) {
             let taken = std::mem::take(&mut *guard);
             *guard = taken
                 .with_usdc(onchain, offchain)
-                .with_withdrawable_cash_cents(withdrawable_cash_cents);
+                .with_withdrawable_cash_cents(withdrawable_cash_cents)
+                .with_rebalancing_sources_observed_at(Utc::now());
         }
     }
 }
@@ -1738,7 +1741,8 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     let inventory = Arc::new(BroadcastingInventory::new(
         InventoryView::default()
             .with_usdc(Usdc::new(float!(50)), Usdc::new(float!(950)))
-            .with_withdrawable_cash_cents(95_000),
+            .with_withdrawable_cash_cents(95_000)
+            .with_rebalancing_sources_observed_at(Utc::now()),
         event_sender,
     ));
 
@@ -1761,6 +1765,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
             target: float!(0.5),
             deviation: float!(0.2),
         }),
+        inventory_freshness_window: Duration::from_secs(60),
         transfer_timeout: Duration::from_secs(30 * 60),
         assets,
     };
@@ -1869,7 +1874,8 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
     let inventory = Arc::new(BroadcastingInventory::new(
         InventoryView::default()
             .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(900)))
-            .with_withdrawable_cash_cents(90_000),
+            .with_withdrawable_cash_cents(90_000)
+            .with_rebalancing_sources_observed_at(Utc::now()),
         event_sender,
     ));
 
@@ -1891,6 +1897,7 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
             target: float!(0.5),
             deviation: float!(0.2),
         }),
+        inventory_freshness_window: Duration::from_secs(60),
         transfer_timeout: Duration::from_secs(30 * 60),
         assets,
     };
@@ -1984,6 +1991,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
                 target: float!(0.5),
                 deviation: float!(0.4),
             }),
+            inventory_freshness_window: Duration::from_secs(60),
             transfer_timeout: Duration::from_secs(30 * 60),
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),
@@ -2045,6 +2053,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
                 target: float!(0.5),
                 deviation: float!(0.1),
             }),
+            inventory_freshness_window: Duration::from_secs(60),
             transfer_timeout: Duration::from_secs(30 * 60),
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -17,7 +17,7 @@ use st0x_finance::{Usd, Usdc};
 use st0x_tokenization::IssuerRequestId;
 use st0x_wrapper::{RatioError, UnderlyingPerWrapped};
 
-use super::snapshot::InventorySnapshotEvent;
+use super::snapshot::{InventoryObservationSource, InventorySnapshotEvent};
 use super::venue_balance::{InventoryError, VenueBalance};
 use crate::equity_redemption::RedemptionAggregateId;
 use crate::usdc_rebalance::UsdcRebalanceId;
@@ -33,6 +33,53 @@ pub(crate) enum InventoryViewError {
     Float(#[from] FloatError),
     #[error("failed to convert USD balance cents {0} to USDC")]
     UsdBalanceConversion(i64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InventoryFreshnessRequirement {
+    Equity,
+    Usdc,
+}
+
+impl InventoryFreshnessRequirement {
+    const fn sources(self) -> &'static [InventoryObservationSource] {
+        match self {
+            Self::Equity => &[
+                InventoryObservationSource::InflightEquity,
+                InventoryObservationSource::OnchainEquity,
+                InventoryObservationSource::OffchainInventory,
+            ],
+            Self::Usdc => &[
+                InventoryObservationSource::OnchainUsdc,
+                InventoryObservationSource::OffchainInventory,
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum InventorySourceFreshnessError {
+    #[error("inventory source {observation_source:?} has never been observed")]
+    Missing {
+        observation_source: InventoryObservationSource,
+    },
+    #[error(
+        "inventory source {observation_source:?} was last observed at {observed_at}, older than the {max_age:?} freshness window at {checked_at}"
+    )]
+    Stale {
+        observation_source: InventoryObservationSource,
+        observed_at: DateTime<Utc>,
+        checked_at: DateTime<Utc>,
+        max_age: std::time::Duration,
+    },
+    #[error(
+        "inventory source {observation_source:?} was observed at future time {observed_at}, after freshness check time {checked_at}"
+    )]
+    Future {
+        observation_source: InventoryObservationSource,
+        observed_at: DateTime<Utc>,
+        checked_at: DateTime<Utc>,
+    },
 }
 
 /// Why an equity imbalance check failed.
@@ -621,9 +668,69 @@ pub(crate) struct InventoryView {
     /// Latest absolute equity snapshot timestamp by symbol for the offchain venue.
     #[serde(default)]
     offchain_equity_snapshot_watermarks: HashMap<Symbol, DateTime<Utc>>,
+    #[serde(default)]
+    source_observed_at: BTreeMap<InventoryObservationSource, DateTime<Utc>>,
 }
 
 impl InventoryView {
+    pub(crate) fn require_fresh_sources(
+        &self,
+        requirement: InventoryFreshnessRequirement,
+        checked_at: DateTime<Utc>,
+        max_age: std::time::Duration,
+    ) -> Result<(), InventorySourceFreshnessError> {
+        for &observation_source in requirement.sources() {
+            let Some(&observed_at) = self.source_observed_at.get(&observation_source) else {
+                return Err(InventorySourceFreshnessError::Missing { observation_source });
+            };
+
+            if observed_at > checked_at {
+                return Err(InventorySourceFreshnessError::Future {
+                    observation_source,
+                    observed_at,
+                    checked_at,
+                });
+            }
+
+            let age = (checked_at - observed_at)
+                .to_std()
+                .unwrap_or(std::time::Duration::MAX);
+            if age > max_age {
+                return Err(InventorySourceFreshnessError::Stale {
+                    observation_source,
+                    observed_at,
+                    checked_at,
+                    max_age,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn reset_for_snapshot_recovery(self) -> Self {
+        Self {
+            source_observed_at: self.source_observed_at,
+            ..Self::default()
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_rebalancing_sources_observed_at(
+        mut self,
+        observed_at: DateTime<Utc>,
+    ) -> Self {
+        for source in [
+            InventoryObservationSource::InflightEquity,
+            InventoryObservationSource::OnchainEquity,
+            InventoryObservationSource::OnchainUsdc,
+            InventoryObservationSource::OffchainInventory,
+        ] {
+            self = self.record_source_observation(source, observed_at, observed_at);
+        }
+        self
+    }
+
     /// Checks a single equity for imbalance against the threshold.
     ///
     /// The onchain balance is converted from wrapped to unwrapped-equivalent using
@@ -859,6 +966,7 @@ impl Default for InventoryView {
             previous_inflight_redemption_symbols: HashSet::new(),
             onchain_equity_snapshot_watermarks: HashMap::new(),
             offchain_equity_snapshot_watermarks: HashMap::new(),
+            source_observed_at: BTreeMap::new(),
         }
     }
 }
@@ -1031,6 +1139,7 @@ impl InventoryView {
             previous_inflight_redemption_symbols: self.previous_inflight_redemption_symbols,
             onchain_equity_snapshot_watermarks: self.onchain_equity_snapshot_watermarks,
             offchain_equity_snapshot_watermarks: self.offchain_equity_snapshot_watermarks,
+            source_observed_at: self.source_observed_at,
         })
     }
 
@@ -1058,6 +1167,7 @@ impl InventoryView {
             previous_inflight_redemption_symbols: self.previous_inflight_redemption_symbols,
             onchain_equity_snapshot_watermarks: self.onchain_equity_snapshot_watermarks,
             offchain_equity_snapshot_watermarks: self.offchain_equity_snapshot_watermarks,
+            source_observed_at: self.source_observed_at,
         })
     }
 
@@ -1297,6 +1407,7 @@ impl InventoryView {
             previous_inflight_redemption_symbols: self.previous_inflight_redemption_symbols,
             onchain_equity_snapshot_watermarks: self.onchain_equity_snapshot_watermarks,
             offchain_equity_snapshot_watermarks: self.offchain_equity_snapshot_watermarks,
+            source_observed_at: self.source_observed_at,
         })
     }
 
@@ -1325,6 +1436,7 @@ impl InventoryView {
             previous_inflight_redemption_symbols: self.previous_inflight_redemption_symbols,
             onchain_equity_snapshot_watermarks: self.onchain_equity_snapshot_watermarks,
             offchain_equity_snapshot_watermarks: self.offchain_equity_snapshot_watermarks,
+            source_observed_at: self.source_observed_at,
         })
     }
 
@@ -1675,7 +1787,10 @@ impl InventoryView {
                 mints, redemptions, ..
             } => self.apply_inflight_snapshot(mints, redemptions, fetched_at, now),
 
-            SourceObserved { .. } => Ok(self),
+            SourceObserved {
+                source,
+                observed_at,
+            } => Ok(self.record_source_observation(*source, *observed_at, now)),
         }
     }
 
@@ -1835,8 +1950,28 @@ impl InventoryView {
                 fetched_at,
             } => self.apply_inflight_snapshot(mints, redemptions, *fetched_at, now),
 
-            SourceObserved { .. } => Ok(self),
+            SourceObserved {
+                source,
+                observed_at,
+            } => Ok(self.record_source_observation(*source, *observed_at, now)),
         }
+    }
+
+    fn record_source_observation(
+        mut self,
+        source: InventoryObservationSource,
+        observed_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Self {
+        let should_record = self
+            .source_observed_at
+            .get(&source)
+            .is_none_or(|existing| observed_at > *existing);
+        if should_record {
+            self.source_observed_at.insert(source, observed_at);
+            self.last_updated = now;
+        }
+        self
     }
 }
 
@@ -1883,6 +2018,125 @@ mod tests {
             target: Float::parse(target.to_string()).unwrap(),
             deviation: Float::parse(deviation.to_string()).unwrap(),
         }
+    }
+
+    #[test]
+    fn equity_freshness_accepts_all_required_source_observations() {
+        let now = Utc::now();
+        let view = [
+            InventoryObservationSource::InflightEquity,
+            InventoryObservationSource::OnchainEquity,
+            InventoryObservationSource::OffchainInventory,
+        ]
+        .into_iter()
+        .fold(InventoryView::default(), |view, source| {
+            view.apply_snapshot_event(
+                &InventorySnapshotEvent::SourceObserved {
+                    source,
+                    observed_at: now,
+                },
+                now,
+            )
+            .unwrap()
+        });
+
+        view.require_fresh_sources(
+            InventoryFreshnessRequirement::Equity,
+            now,
+            std::time::Duration::from_secs(60),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn usdc_freshness_fails_closed_when_a_source_is_missing() {
+        let now = Utc::now();
+
+        let result = InventoryView::default().require_fresh_sources(
+            InventoryFreshnessRequirement::Usdc,
+            now,
+            std::time::Duration::from_secs(60),
+        );
+
+        assert_eq!(
+            result,
+            Err(InventorySourceFreshnessError::Missing {
+                observation_source: InventoryObservationSource::OnchainUsdc,
+            })
+        );
+    }
+
+    #[test]
+    fn usdc_freshness_rejects_an_observation_older_than_the_window() {
+        let now = Utc::now();
+        let stale_at = now - Duration::seconds(61);
+        let view = [
+            (InventoryObservationSource::OnchainUsdc, stale_at),
+            (InventoryObservationSource::OffchainInventory, now),
+        ]
+        .into_iter()
+        .fold(InventoryView::default(), |view, (source, observed_at)| {
+            view.apply_snapshot_event(
+                &InventorySnapshotEvent::SourceObserved {
+                    source,
+                    observed_at,
+                },
+                now,
+            )
+            .unwrap()
+        });
+
+        let result = view.require_fresh_sources(
+            InventoryFreshnessRequirement::Usdc,
+            now,
+            std::time::Duration::from_secs(60),
+        );
+
+        assert_eq!(
+            result,
+            Err(InventorySourceFreshnessError::Stale {
+                observation_source: InventoryObservationSource::OnchainUsdc,
+                observed_at: stale_at,
+                checked_at: now,
+                max_age: std::time::Duration::from_secs(60),
+            })
+        );
+    }
+
+    #[test]
+    fn usdc_freshness_rejects_an_observation_from_the_future() {
+        let now = Utc::now();
+        let future_at = now + Duration::milliseconds(1);
+        let view = [
+            (InventoryObservationSource::OnchainUsdc, future_at),
+            (InventoryObservationSource::OffchainInventory, now),
+        ]
+        .into_iter()
+        .fold(InventoryView::default(), |view, (source, observed_at)| {
+            view.apply_snapshot_event(
+                &InventorySnapshotEvent::SourceObserved {
+                    source,
+                    observed_at,
+                },
+                now,
+            )
+            .unwrap()
+        });
+
+        let result = view.require_fresh_sources(
+            InventoryFreshnessRequirement::Usdc,
+            now,
+            std::time::Duration::from_secs(60),
+        );
+
+        assert_eq!(
+            result,
+            Err(InventorySourceFreshnessError::Future {
+                observation_source: InventoryObservationSource::OnchainUsdc,
+                observed_at: future_at,
+                checked_at: now,
+            })
+        );
     }
 
     #[test]
@@ -1947,6 +2201,7 @@ mod tests {
             previous_inflight_redemption_symbols: HashSet::new(),
             onchain_equity_snapshot_watermarks: HashMap::new(),
             offchain_equity_snapshot_watermarks: HashMap::new(),
+            source_observed_at: BTreeMap::new(),
         }
     }
 
@@ -1978,6 +2233,7 @@ mod tests {
             previous_inflight_redemption_symbols: HashSet::new(),
             onchain_equity_snapshot_watermarks: HashMap::new(),
             offchain_equity_snapshot_watermarks: HashMap::new(),
+            source_observed_at: BTreeMap::new(),
         }
     }
 
@@ -3358,6 +3614,7 @@ mod tests {
             previous_inflight_redemption_symbols: HashSet::new(),
             onchain_equity_snapshot_watermarks: HashMap::new(),
             offchain_equity_snapshot_watermarks: HashMap::new(),
+            source_observed_at: BTreeMap::new(),
         };
 
         let dto = view.to_dto();
@@ -3411,6 +3668,7 @@ mod tests {
             previous_inflight_redemption_symbols: HashSet::new(),
             onchain_equity_snapshot_watermarks: HashMap::new(),
             offchain_equity_snapshot_watermarks: HashMap::new(),
+            source_observed_at: BTreeMap::new(),
         };
 
         let dto = view.to_dto();

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -1957,6 +1957,7 @@ mod tests {
                     deviation: float!(0.2),
                 },
                 usdc: None,
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: Duration::from_secs(1800),
                 assets: AssetsConfig {
                     equities: EquitiesConfig::default(),
@@ -2105,6 +2106,7 @@ mod tests {
                     deviation: float!(0.2),
                 },
                 usdc: None,
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: Duration::from_secs(1800),
                 assets: AssetsConfig {
                     equities: EquitiesConfig::default(),
@@ -2431,6 +2433,7 @@ mod tests {
                     deviation: float!(0.2),
                 },
                 usdc: None,
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: Duration::from_secs(1800),
                 assets: AssetsConfig {
                     equities: EquitiesConfig::default(),

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -154,6 +154,7 @@ mod tests {
     use httpmock::MockServer;
     use serde_json::json;
     use std::collections::HashMap;
+    use std::time::Duration;
     use uuid::Uuid;
 
     use st0x_config::{AssetsConfig, EquitiesConfig, OperationMode, RebalancingCtx};
@@ -238,6 +239,7 @@ mod tests {
         let trigger_config = RebalancingServiceConfig {
             equity: ctx.equity,
             usdc: ctx.usdc,
+            inventory_freshness_window: Duration::from_secs(60),
             transfer_timeout: ctx.transfer_timeout,
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),
@@ -256,6 +258,7 @@ mod tests {
         let trigger_config = RebalancingServiceConfig {
             equity: ctx.equity,
             usdc: ctx.usdc,
+            inventory_freshness_window: Duration::from_secs(60),
             transfer_timeout: ctx.transfer_timeout,
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -37,8 +37,12 @@ use crate::equity_redemption::{
     EquityRedemption, EquityRedemptionCommand, EquityRedemptionEvent, RedemptionAggregateId,
 };
 use crate::inventory::projection::InventoryProjectionError;
-use crate::inventory::snapshot::{InventorySnapshot, InventorySnapshotEvent};
-use crate::inventory::view::InFlightEquityLocation;
+use crate::inventory::snapshot::{
+    InventoryObservationSource, InventorySnapshot, InventorySnapshotEvent,
+};
+use crate::inventory::view::{
+    InFlightEquityLocation, InventoryFreshnessRequirement, InventorySourceFreshnessError,
+};
 use crate::inventory::{
     BroadcastingInventory, FreshOffchainUsdObserver, ImbalanceThreshold, Inventory, InventoryView,
     InventoryViewError, Operator, PendingRequestOwnership, PendingRequestOwnershipSnapshot,
@@ -170,6 +174,7 @@ pub(crate) enum TokenAddressError {
 pub(crate) struct RebalancingServiceConfig {
     pub(crate) equity: ImbalanceThreshold,
     pub(crate) usdc: Option<ImbalanceThreshold>,
+    pub(crate) inventory_freshness_window: Duration,
     pub(crate) transfer_timeout: Duration,
     pub(crate) assets: AssetsConfig,
 }
@@ -1691,7 +1696,8 @@ impl RebalancingService {
             | EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
-            | BaseWalletWrappedEquity { .. } => inventory.clone().apply_snapshot_event(&event, now),
+            | BaseWalletWrappedEquity { .. }
+            | SourceObserved { .. } => inventory.clone().apply_snapshot_event(&event, now),
 
             InflightEquity { .. } => {
                 if let Some((mints, redemptions)) = &filtered_inflight {
@@ -1702,8 +1708,6 @@ impl RebalancingService {
                     Ok(inventory.clone())
                 }
             }
-
-            SourceObserved { .. } => Ok(inventory.clone()),
         }?;
 
         *inventory = updated;
@@ -1784,7 +1788,8 @@ impl RebalancingService {
             _ => None,
         };
         let mut inventory = self.inventory.write().await;
-        *inventory = InventoryView::default();
+        let current_inventory = std::mem::take(&mut *inventory);
+        *inventory = current_inventory.reset_for_snapshot_recovery();
 
         let updated = match &event {
             OnchainUsdc { usdc_balance, .. } => inventory.clone().update_usdc(
@@ -1823,7 +1828,7 @@ impl RebalancingService {
                 }
             }
 
-            SourceObserved { .. } => Ok(inventory.clone()),
+            SourceObserved { .. } => inventory.clone().apply_snapshot_event(&event, now),
         }?;
 
         *inventory = updated;
@@ -2034,8 +2039,40 @@ impl RebalancingService {
             // Inflight snapshots don't trigger rebalancing -- they
             // indicate transfers already in progress, not new balances
             // to rebalance.
-            | InflightEquity { .. }
-            | SourceObserved { .. } => {}
+            | InflightEquity { .. } => {}
+            // A successful source observation re-drives checks that may have
+            // failed closed while this source was missing or stale.
+            SourceObserved { source, .. } => match source {
+                InventoryObservationSource::InflightEquity
+                | InventoryObservationSource::OnchainEquity => {
+                    self.enqueue_enabled_equity_checks().await;
+                }
+                InventoryObservationSource::OnchainUsdc => {
+                    self.enqueue_usdc_check_if_enabled().await;
+                }
+                InventoryObservationSource::OffchainInventory => {
+                    self.enqueue_enabled_equity_checks().await;
+                    self.enqueue_usdc_check_if_enabled().await;
+                }
+                InventoryObservationSource::EthereumWalletUsdc
+                | InventoryObservationSource::BaseWalletUsdc
+                | InventoryObservationSource::BaseWalletUnwrappedEquity
+                | InventoryObservationSource::BaseWalletWrappedEquity => {}
+            },
+        }
+    }
+
+    async fn enqueue_enabled_equity_checks(&self) {
+        for symbol in self.config.assets.equities.symbols.keys() {
+            if self.config.is_equity_rebalancing_enabled(symbol) {
+                self.equity_scheduler.enqueue_check(symbol.clone()).await;
+            }
+        }
+    }
+
+    async fn enqueue_usdc_check_if_enabled(&self) {
+        if self.usdc_rebalancing_params().is_some() {
+            self.usdc_scheduler.enqueue_check().await;
         }
     }
 
@@ -2337,7 +2374,16 @@ impl Reactor for RebalancingService {
                     return Ok(());
                 }
 
-                inventory_result?;
+                if let Err(error) = inventory_result {
+                    warn!(
+                        target: "rebalance",
+                        %symbol,
+                        ?error,
+                        "Inventory update failed for onchain fill; relying on independent absolute snapshots"
+                    );
+                    return Ok(());
+                }
+
                 self.equity_scheduler.enqueue_check(symbol).await;
                 self.usdc_scheduler.enqueue_check().await;
                 Ok::<(), RebalancingServiceError>(())
@@ -2738,6 +2784,19 @@ impl RebalancingService {
             return Ok(());
         }
 
+        if let Err(freshness_error) = self
+            .require_fresh_inventory_sources(InventoryFreshnessRequirement::Equity)
+            .await
+        {
+            warn!(
+                target: "rebalance",
+                %symbol,
+                ?freshness_error,
+                "Skipped equity trigger: required inventory source is not fresh"
+            );
+            return Ok(());
+        }
+
         // Dividend freeze guard: do not start a rebalancing flow for an asset
         // issuance has frozen. The check goes before claiming the in-progress
         // guard or building the operation so a frozen asset is skipped cheaply.
@@ -2878,6 +2937,18 @@ impl RebalancingService {
             return;
         };
 
+        if let Err(freshness_error) = self
+            .require_fresh_inventory_sources(InventoryFreshnessRequirement::Usdc)
+            .await
+        {
+            warn!(
+                target: "rebalance",
+                ?freshness_error,
+                "Skipped USDC trigger: required inventory source is not fresh"
+            );
+            return;
+        }
+
         let Some(guard) = self.try_claim_usdc_guard() else {
             debug!(target: "rebalance", "Skipped USDC trigger: already in progress");
             return;
@@ -2909,6 +2980,17 @@ impl RebalancingService {
 
         debug!(target: "rebalance", ?operation, "Triggered USDC rebalancing");
         guard.defuse();
+    }
+
+    async fn require_fresh_inventory_sources(
+        &self,
+        requirement: InventoryFreshnessRequirement,
+    ) -> Result<(), InventorySourceFreshnessError> {
+        self.inventory.read().await.require_fresh_sources(
+            requirement,
+            Utc::now(),
+            self.config.inventory_freshness_window,
+        )
     }
 
     /// Returns the oldest non-terminal USDC transfer job in *either* direction
@@ -4991,10 +5073,16 @@ impl RebalancingService {
             self.apply_equity_update(&symbol, update).await?;
         }
 
-        // When a new redemption transfer starts, clear the previous poll
-        // marker so the next inflight poll won't incorrectly zero the new
-        // inflight if Alpaca hasn't reflected the request yet.
-        if matches!(event, EquityRedemptionEvent::VaultWithdrawPending { .. }) {
+        // Clear the previous poll marker whenever the locally tracked balance
+        // must outlive the provider's view. A new transfer may not be visible
+        // yet; a rejected or undetected transfer is no longer visible but its
+        // assets remain stranded in the redemption wallet.
+        if matches!(
+            event,
+            EquityRedemptionEvent::VaultWithdrawPending { .. }
+                | EquityRedemptionEvent::DetectionFailed { .. }
+                | EquityRedemptionEvent::RedemptionRejected { .. }
+        ) {
             let mut inventory = self.inventory.write().await;
             *inventory = inventory
                 .clone()
@@ -5167,7 +5255,7 @@ mod tests {
         DetectionFailure, EquityRedemptionCommand, redemption_aggregate_id,
     };
     use crate::inventory::snapshot::{
-        InventorySnapshot, InventorySnapshotEvent, InventorySnapshotId,
+        InventoryObservationSource, InventorySnapshot, InventorySnapshotEvent, InventorySnapshotId,
     };
     use crate::inventory::view::{InFlightEquityLocation, Operator};
     use crate::inventory::{InventoryError, InventoryView, TransferOp, Venue};
@@ -5245,6 +5333,7 @@ mod tests {
                 target: float!(0.5),
                 deviation: float!(0.2),
             }),
+            inventory_freshness_window: Duration::from_secs(60),
             transfer_timeout: Duration::from_secs(30 * 60),
             assets: AssetsConfig {
                 equities: rebalancing_enabled_equities(&["AAPL", "TSLA", "GOOG", "RKLB"]),
@@ -7173,6 +7262,7 @@ mod tests {
             RebalancingServiceConfig {
                 equity: test_config().equity,
                 usdc: None,
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: test_config().transfer_timeout,
                 assets: AssetsConfig {
                     equities: EquitiesConfig::default(),
@@ -7547,6 +7637,12 @@ mod tests {
     const TEST_ORDER_OWNER: Address = address!("0x0000000000000000000000000000000000000002");
     const TEST_TOKEN: Address = address!("0x1234567890123456789012345678901234567890");
 
+    #[derive(Debug, Clone, Copy)]
+    enum TestInventoryFreshness {
+        Fresh,
+        Unobserved,
+    }
+
     async fn seed_vault_registry(pool: &SqlitePool, symbol: &Symbol) {
         let store = test_store::<VaultRegistry>(pool.clone(), ());
         let vault_registry_id = VaultRegistryId {
@@ -7587,7 +7683,28 @@ mod tests {
         config: RebalancingServiceConfig,
         notifier: Arc<dyn crate::alerts::Notifier>,
     ) -> Arc<RebalancingService> {
+        make_trigger_with_inventory_config_notifier_and_freshness(
+            inventory,
+            config,
+            notifier,
+            TestInventoryFreshness::Fresh,
+        )
+        .await
+    }
+
+    async fn make_trigger_with_inventory_config_notifier_and_freshness(
+        inventory: InventoryView,
+        config: RebalancingServiceConfig,
+        notifier: Arc<dyn crate::alerts::Notifier>,
+        freshness: TestInventoryFreshness,
+    ) -> Arc<RebalancingService> {
         let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = match freshness {
+            TestInventoryFreshness::Fresh => {
+                inventory.with_rebalancing_sources_observed_at(Utc::now())
+            }
+            TestInventoryFreshness::Unobserved => inventory,
+        };
         let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
@@ -7624,6 +7741,28 @@ mod tests {
         .fetch_one(service.transfer_usdc_to_hedging_queue.pool())
         .await
         .expect("count pending TransferUsdcToHedging jobs")
+    }
+
+    async fn count_pending_equity_check_jobs(service: &RebalancingService) -> i64 {
+        let job_type = std::any::type_name::<EquityRebalancingCheck>();
+        sqlx_apalis::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(job_type)
+        .fetch_one(service.equity_scheduler.queue().pool())
+        .await
+        .expect("count pending EquityRebalancingCheck jobs")
+    }
+
+    async fn count_pending_usdc_check_jobs(service: &RebalancingService) -> i64 {
+        let job_type = std::any::type_name::<UsdcRebalancingCheck>();
+        sqlx_apalis::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(job_type)
+        .fetch_one(service.usdc_scheduler.queue().pool())
+        .await
+        .expect("count pending UsdcRebalancingCheck jobs")
     }
 
     async fn count_pending_transfer_usdc_to_market_making_jobs(
@@ -7825,7 +7964,30 @@ mod tests {
         wrapper: Arc<MockWrapper>,
         config: RebalancingServiceConfig,
     ) -> Arc<RebalancingService> {
+        make_trigger_with_inventory_registry_wrapper_and_freshness(
+            inventory,
+            symbol,
+            wrapper,
+            config,
+            TestInventoryFreshness::Fresh,
+        )
+        .await
+    }
+
+    async fn make_trigger_with_inventory_registry_wrapper_and_freshness(
+        inventory: InventoryView,
+        symbol: &Symbol,
+        wrapper: Arc<MockWrapper>,
+        config: RebalancingServiceConfig,
+        freshness: TestInventoryFreshness,
+    ) -> Arc<RebalancingService> {
         let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = match freshness {
+            TestInventoryFreshness::Fresh => {
+                inventory.with_rebalancing_sources_observed_at(Utc::now())
+            }
+            TestInventoryFreshness::Unobserved => inventory,
+        };
         let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
@@ -7897,7 +8059,9 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
-            InventoryView::default().with_usdc(usdc(1_000_000), usdc(1_000_000)),
+            InventoryView::default()
+                .with_usdc(usdc(1_000_000), usdc(1_000_000))
+                .with_rebalancing_sources_observed_at(Utc::now()),
             event_sender,
         ));
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
@@ -8009,6 +8173,32 @@ mod tests {
             0,
             "Expected no equity redemption job enqueued"
         );
+    }
+
+    #[tokio::test]
+    async fn onchain_fill_already_reflected_by_snapshot_does_not_fail_reactor() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(0))
+            .with_usdc(usdc(0), usdc(0));
+        let trigger = make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_onchain_fill(shares(10), Direction::Buy),
+            )
+            .await
+            .expect("a fill already reflected by absolute snapshots must not poison the reactor");
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.equity_available(&symbol, Venue::MarketMaking),
+            Some(shares(0)),
+            "the two fill legs remain atomic when the cash leg is already reflected"
+        );
+        assert_eq!(inventory.usdc_available(Venue::MarketMaking), Some(usdc(0)));
+        drop(inventory);
     }
 
     #[tokio::test]
@@ -11212,6 +11402,114 @@ mod tests {
             0,
             "64% ratio within 50% +/- 30% threshold"
         );
+    }
+
+    #[tokio::test]
+    async fn source_recovery_markers_are_applied_and_reenqueue_checks() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(500), usdc(500));
+        let reactor = make_trigger_with_inventory_registry_wrapper_and_freshness(
+            inventory,
+            &symbol,
+            Arc::new(MockWrapper::new()),
+            test_config(),
+            TestInventoryFreshness::Unobserved,
+        )
+        .await;
+        let trigger = reactor.clone();
+        let id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+
+        apply_and_dispatch_snapshot(
+            reactor.clone(),
+            id,
+            InventorySnapshotEvent::SourceObserved {
+                source: InventoryObservationSource::OffchainInventory,
+                observed_at: Utc::now(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let enabled_equity_count = i64::try_from(
+            trigger
+                .config
+                .assets
+                .equities
+                .symbols
+                .keys()
+                .filter(|symbol| trigger.config.is_equity_rebalancing_enabled(symbol))
+                .count(),
+        )
+        .expect("enabled equity count fits in i64");
+        assert_eq!(
+            count_pending_equity_check_jobs(&trigger).await,
+            enabled_equity_count
+        );
+        assert_eq!(count_pending_usdc_check_jobs(&trigger).await, 1);
+
+        apply_and_dispatch_snapshot(
+            reactor,
+            InventorySnapshotId {
+                orderbook: TEST_ORDERBOOK,
+                owner: TEST_ORDER_OWNER,
+            },
+            InventorySnapshotEvent::SourceObserved {
+                source: InventoryObservationSource::OnchainUsdc,
+                observed_at: Utc::now(),
+            },
+        )
+        .await
+        .unwrap();
+
+        trigger
+            .inventory
+            .read()
+            .await
+            .require_fresh_sources(
+                InventoryFreshnessRequirement::Usdc,
+                Utc::now(),
+                Duration::from_secs(60),
+            )
+            .unwrap();
+        assert_eq!(
+            count_pending_equity_check_jobs(&trigger).await,
+            enabled_equity_count
+        );
+        assert_eq!(count_pending_usdc_check_jobs(&trigger).await, 2);
+    }
+
+    #[tokio::test]
+    async fn snapshot_recovery_preserves_fresh_source_observations() {
+        let trigger =
+            make_trigger_with_inventory(InventoryView::default().with_usdc(usdc(500), usdc(500)))
+                .await;
+
+        trigger
+            .on_snapshot_recovery(
+                RebalancingServiceError::Inventory(InventoryViewError::UsdBalanceConversion(-1)),
+                InventorySnapshotEvent::OnchainUsdc {
+                    usdc_balance: usdc(600),
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        trigger
+            .inventory
+            .read()
+            .await
+            .require_fresh_sources(
+                InventoryFreshnessRequirement::Usdc,
+                Utc::now(),
+                Duration::from_secs(60),
+            )
+            .unwrap();
     }
 
     #[tokio::test]
@@ -19032,6 +19330,7 @@ mod tests {
                     deviation: float!(0.2),
                 },
                 usdc: None,
+                inventory_freshness_window: Duration::from_secs(60),
                 transfer_timeout: Duration::from_secs(30 * 60),
                 assets: AssetsConfig {
                     equities: EquitiesConfig::default(),
@@ -19655,7 +19954,7 @@ mod tests {
         // Empty inventory - simulates startup state before polling completes
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
-            InventoryView::default(),
+            InventoryView::default().with_rebalancing_sources_observed_at(Utc::now()),
             event_sender,
         ));
 
@@ -19728,7 +20027,7 @@ mod tests {
         let symbol = Symbol::new("RKLB").unwrap();
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
-            InventoryView::default(),
+            InventoryView::default().with_rebalancing_sources_observed_at(Utc::now()),
             event_sender,
         ));
         seed_vault_registry(&pool, &symbol).await;
@@ -19807,7 +20106,7 @@ mod tests {
         let symbol = Symbol::new("RKLB").unwrap();
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
-            InventoryView::default(),
+            InventoryView::default().with_rebalancing_sources_observed_at(Utc::now()),
             event_sender,
         ));
         seed_vault_registry(&pool, &symbol).await;
@@ -19870,7 +20169,7 @@ mod tests {
         let symbol = Symbol::new("RKLB").unwrap();
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
-            InventoryView::default(),
+            InventoryView::default().with_rebalancing_sources_observed_at(Utc::now()),
             event_sender,
         ));
         seed_vault_registry(&pool, &symbol).await;
@@ -20249,7 +20548,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn redemption_rejected_preserves_inflight_via_absent_skip() {
+    async fn redemption_rejected_preserves_inflight_after_provider_stops_reporting_request() {
         let symbol = Symbol::new("AAPL").unwrap();
         // 80 onchain, 20 offchain = imbalanced
         let inventory = InventoryView::default()
@@ -20281,18 +20580,30 @@ mod tests {
             .await
             .unwrap();
 
-        // RedemptionRejected: terminal failure, no inventory update
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+        apply_and_dispatch_snapshot(
+            reactor.clone(),
+            snapshot_id.clone(),
+            InventorySnapshotEvent::InflightEquity {
+                mints: BTreeMap::new(),
+                redemptions: BTreeMap::from([(symbol.clone(), shares(10))]),
+                fetched_at: Utc::now(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // RedemptionRejected: terminal failure, no inventory update.
         harness
             .receive::<EquityRedemption>(id.clone(), make_redemption_rejected())
             .await
             .unwrap();
 
-        // Empty InflightEquity snapshot: symbol absent from maps, so inflight
-        // is preserved (poll never zeros absent symbols).
-        let snapshot_id = InventorySnapshotId {
-            orderbook: TEST_ORDERBOOK,
-            owner: TEST_ORDER_OWNER,
-        };
+        // The provider stops reporting the rejected request. Its absence must
+        // not clear assets that remain stranded in the redemption wallet.
         apply_and_dispatch_snapshot(
             reactor.clone(),
             snapshot_id,
@@ -20312,8 +20623,7 @@ mod tests {
                 .await
                 .symbols_with_inflight()
                 .contains(&symbol),
-            "Inflight should be preserved after RedemptionRejected \
-             (symbol absent from poll maps)"
+            "Inflight should be preserved after the provider stops reporting a rejected request"
         );
     }
 
@@ -22152,6 +22462,74 @@ mod tests {
             panic!("Expected exactly one mint job, got {dispatched:?}");
         };
         assert_eq!(job.symbol, symbol);
+    }
+
+    #[tokio::test]
+    async fn equity_check_fails_closed_when_a_required_source_was_never_observed() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(80))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000));
+        let trigger = make_trigger_with_inventory_registry_wrapper_and_freshness(
+            inventory,
+            &symbol,
+            Arc::new(MockWrapper::new()),
+            test_config(),
+            TestInventoryFreshness::Unobserved,
+        )
+        .await;
+
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+
+        assert_eq!(count_pending_equity_mint_jobs(&trigger).await, 0);
+        assert_eq!(count_pending_equity_redemption_jobs(&trigger).await, 0);
+    }
+
+    #[tokio::test]
+    async fn usdc_check_fails_closed_when_a_required_source_was_never_observed() {
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(100), usdc(900))
+            .with_withdrawable_cash_cents(90_000);
+        let trigger = make_trigger_with_inventory_config_notifier_and_freshness(
+            inventory,
+            test_config(),
+            Arc::new(NoopNotifier),
+            TestInventoryFreshness::Unobserved,
+        )
+        .await;
+
+        trigger.check_and_trigger_usdc().await;
+
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&trigger).await,
+            0
+        );
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&trigger).await,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn equity_check_fails_closed_when_required_sources_are_stale() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(80))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000))
+            .with_rebalancing_sources_observed_at(Utc::now() - ChronoDuration::seconds(61));
+        let trigger = make_trigger_with_inventory_registry_wrapper_and_freshness(
+            inventory,
+            &symbol,
+            Arc::new(MockWrapper::new()),
+            test_config(),
+            TestInventoryFreshness::Unobserved,
+        )
+        .await;
+
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+
+        assert_eq!(count_pending_equity_mint_jobs(&trigger).await, 0);
+        assert_eq!(count_pending_equity_redemption_jobs(&trigger).await, 0);
     }
 
     /// A crash between `queue.push` and the first persisted mint event leaves

--- a/tests/e2e/hedging.rs
+++ b/tests/e2e/hedging.rs
@@ -124,6 +124,7 @@ async fn direct_high_precision_sell_price_still_hedges() -> anyhow::Result<()> {
         .await?;
 
     poll_for_events(&mut bot, &infra.db_path, "OffchainOrderEvent::Filled", 1).await;
+    poll_for_hedged_position(&mut bot, &infra.db_path, "AAPL").await;
 
     let pool = connect_db(&infra.db_path).await?;
 


### PR DESCRIPTION
## What

[RAI-703](https://linear.app/makeitrain/issue/RAI-703)

Fail closed before dispatching equity or USDC rebalancing when any required inventory source lacks a fresh successful observation.

## Why

A complete aggregate snapshot can still contain stale venue data. Rebalancing from a missing, old, or future-dated observation can size transfers and hedges against inventory that no longer exists, creating avoidable exposure. The trigger must distinguish snapshot availability from per-source freshness.

## How

- Persist and restore the latest successful observation timestamp for every inventory source.
- Define the required source set independently for equity and USDC checks.
- Gate check enqueueing on every required source being present and inside the configured freshness window.
- Treat missing, stale, and future timestamps as typed fail-closed errors.
- Re-enqueue checks when a recovering source records a fresh observation.
- Preserve freshness markers across snapshot recovery.

## Testing

Added coverage for:

- complete required-source sets;
- missing observations;
- observations older than the freshness window;
- future-dated observations;
- source recovery re-enqueueing checks;
- snapshot recovery preserving freshness markers; and
- equity and USDC trigger suppression while required sources are stale.

GitHub Actions static checks and backend build/test matrix pass.

## Screenshots

Not applicable.

## Anything else

This PR consumes the independent source-observation markers introduced by #1039. It does not change inventory quantities; it only prevents automated financial actions until their inputs are demonstrably fresh.
