### PR TITLE
fix: dead-letter terminal equity transfer jobs (RAI-1110)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1562,6 +1562,14 @@ Four transfer jobs exist:
 | TransferUsdcToMarketMaking   | USDC   | Convert USD->USDC, withdraw, bridge via CCTP, deposit to vault |
 | TransferUsdcToHedging        | USDC   | Withdraw from vault, bridge via CCTP, deposit USDC to Alpaca   |
 
+Equity-transfer workers dead-letter a job that exhausts its retries: the Jobs
+row is recorded as terminal and retained as the durable ownership record, while
+the worker and conductor continue processing unrelated jobs. On startup, any
+equity-transfer row owns recovery of its aggregate: a non-terminal row is
+requeued, while a terminal row remains dead-lettered instead of being
+resurrected through generic tokenization recovery. A poison mint or redemption
+row therefore cannot put the bot into a process restart loop.
+
 The trigger enqueues at most one transfer per scope at a time, guarded both by
 an in-memory in-progress set and by a Jobs-table dedupe (the in-memory guard
 resets on restart; a non-terminal job row suppresses a duplicate enqueue). The

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -87,7 +87,8 @@ use crate::position::{Position, PositionCommand, PositionError, PositionEvent, T
 use crate::rebalancing::equity::{
     CrossVenueEquityTransfer, EquityTransferServices, ResumeTokenizationAggregate,
     ResumeTokenizationCtx, ResumeTokenizationJobQueue, ResumeTokenizationTarget,
-    TransferEquityToHedgingCtx, TransferEquityToMarketMakingCtx,
+    TransferEquityToHedging, TransferEquityToHedgingCtx, TransferEquityToMarketMaking,
+    TransferEquityToMarketMakingCtx,
 };
 use crate::rebalancing::trigger::GuardState;
 use crate::rebalancing::usdc::{
@@ -1029,16 +1030,14 @@ fn spawn_finished_job_cleanup(
         loop {
             interval.tick().await;
 
-            // USDC transfer-job rows are the durable startup re-arm
-            // idempotency + redrive-budget signal. Pruning them while the
-            // aggregate is still mid-flight (e.g. `BridgingSubmitting`) resets
-            // the redrive bound to a fresh budget on restart and silences the
-            // stranded-transfer operator alert. Transfer jobs are low-volume,
-            // so retaining their finished rows is cheap; exclude both transfer
-            // job types from cleanup.
+            // Transfer-job rows are the durable startup ownership signal.
+            // USDC rows additionally preserve the redrive budget. Equity rows
+            // prevent generic tokenization recovery from racing a requeued
+            // transfer job or resurrecting a terminal dead letter. Transfer
+            // jobs are low-volume, so retaining their finished rows is cheap.
             let cleanup_result = sqlx_apalis::query(
                 "DELETE FROM Jobs \
-                 WHERE job_type NOT IN (?, ?) \
+                 WHERE job_type NOT IN (?, ?, ?, ?) \
                  AND ( \
                      status = ? \
                      OR status = ? \
@@ -1047,6 +1046,8 @@ fn spawn_finished_job_cleanup(
             )
             .bind(std::any::type_name::<TransferUsdcToHedging>())
             .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+            .bind(std::any::type_name::<TransferEquityToHedging>())
+            .bind(std::any::type_name::<TransferEquityToMarketMaking>())
             .bind(Status::Done.to_string())
             .bind(Status::Killed.to_string())
             .bind(Status::Failed.to_string())
@@ -1820,6 +1821,8 @@ async fn recover_interrupted_tokenization_aggregates(
 
     let interrupted_mints = interrupted_mint_ids(pool).await?;
     let interrupted_redemptions = interrupted_redemption_ids(pool).await?;
+    let transfer_mints = load_transfer_jobs::<TransferEquityToMarketMaking>(pool).await?;
+    let transfer_redemptions = load_transfer_jobs::<TransferEquityToHedging>(pool).await?;
 
     for mint_id in &interrupted_mints {
         let Some(mint) = mint_store.load(mint_id).await? else {
@@ -1843,7 +1846,12 @@ async fn recover_interrupted_tokenization_aggregates(
         // If cancel_all_pending silently failed above, a stale Pending row for
         // this aggregate may still exist. The duplicate Pending row is tolerated
         // because resume_mint is idempotent.
-        if !is_pre_wrap_held_for_recovery(&mint, &rebalancing_service.equity_in_progress) {
+        let owned_by_transfer_job = transfer_mints
+            .iter()
+            .any(|job| job.issuer_request_id == *mint_id);
+        if !owned_by_transfer_job
+            && !is_pre_wrap_held_for_recovery(&mint, &rebalancing_service.equity_in_progress)
+        {
             resume_queue
                 .push(ResumeTokenizationAggregate {
                     target: ResumeTokenizationTarget::Mint(mint_id.clone()),
@@ -1863,19 +1871,52 @@ async fn recover_interrupted_tokenization_aggregates(
             .recover_redemption_state(redemption_id, &redemption)
             .await?;
 
-        // If cancel_all_pending silently failed above, a stale Pending row for
-        // this aggregate may still exist. The duplicate Pending row is tolerated
-        // because resume_redemption is idempotent.
-        resume_queue
-            .push(ResumeTokenizationAggregate {
-                target: ResumeTokenizationTarget::Redemption(redemption_id.clone()),
-            })
-            .await?;
+        let owned_by_transfer_job = transfer_redemptions
+            .iter()
+            .any(|job| job.aggregate_id == *redemption_id);
+        if !owned_by_transfer_job {
+            // If cancel_all_pending silently failed above, a stale Pending row for
+            // this aggregate may still exist. The duplicate Pending row is tolerated
+            // because resume_redemption is idempotent.
+            resume_queue
+                .push(ResumeTokenizationAggregate {
+                    target: ResumeTokenizationTarget::Redemption(redemption_id.clone()),
+                })
+                .await?;
+        }
     }
 
     recover_stuck_redemptions(pool, inventory).await?;
 
     Ok(())
+}
+
+/// Loads every durable row for a transfer-job type, including terminal rows.
+///
+/// A non-terminal row is the sole owner that restart recovery must re-drive.
+/// A terminal row is a dead letter and must remain terminal across restarts.
+/// Treating both as ownership prevents the generic tokenization queue from
+/// racing the transfer queue or silently resetting an exhausted retry budget.
+async fn load_transfer_jobs<Task>(pool: &SqlitePool) -> anyhow::Result<Vec<Task>>
+where
+    Task: serde::de::DeserializeOwned + 'static,
+{
+    let payloads: Vec<Vec<u8>> = sqlx::query_scalar("SELECT job FROM Jobs WHERE job_type = ?")
+        .bind(std::any::type_name::<Task>())
+        .fetch_all(pool)
+        .await?;
+
+    payloads
+        .into_iter()
+        .map(|payload| {
+            serde_json::from_slice(&payload).with_context(|| {
+                format!(
+                    "failed to deserialize durable {} transfer job",
+                    std::any::type_name::<Task>()
+                )
+            })
+        })
+        .collect()
 }
 
 /// Returns `true` when `mint` is a pre-wrap post-receipt state
@@ -4070,6 +4111,161 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn transfer_jobs_own_interrupted_aggregate_resume_on_restart() {
+        let InterruptedAggregateFixture {
+            pool,
+            apalis_pool,
+            services,
+            mint_id,
+            redemption_id,
+            tokenizer: _,
+            rebalancing_service,
+            inventory,
+            mut resume_queue,
+        } = seed_interrupted_aggregates_and_build_service(
+            4,
+            "transfer-owned-mint",
+            "transfer-owned-redemption",
+        )
+        .await;
+
+        let mut transfer_queue =
+            crate::rebalancing::equity::TransferEquityToMarketMakingJobQueue::new(&apalis_pool);
+        transfer_queue
+            .push(TransferEquityToMarketMaking {
+                issuer_request_id: mint_id.clone(),
+                symbol: Symbol::new("AAPL").unwrap(),
+                quantity: FractionalShares::new(float!(1)),
+                generation: 1,
+            })
+            .await
+            .unwrap();
+        let mut redemption_queue =
+            crate::rebalancing::equity::TransferEquityToHedgingJobQueue::new(&apalis_pool);
+        redemption_queue
+            .push(TransferEquityToHedging {
+                aggregate_id: redemption_id,
+                symbol: Symbol::new("AAPL").unwrap(),
+                quantity: FractionalShares::new(float!(1)),
+            })
+            .await
+            .unwrap();
+
+        recover_interrupted_tokenization_aggregates(
+            &pool,
+            &rebalancing_service,
+            inventory.as_ref(),
+            Arc::new(test_store::<TokenizedEquityMint>(
+                pool.clone(),
+                services.clone(),
+            )),
+            Arc::new(test_store::<EquityRedemption>(pool.clone(), services)),
+            &mut resume_queue,
+        )
+        .await
+        .unwrap();
+
+        let payloads: Vec<Vec<u8>> = sqlx_apalis::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<ResumeTokenizationAggregate>())
+        .fetch_all(&apalis_pool)
+        .await
+        .unwrap();
+        let targets: Vec<_> = payloads
+            .iter()
+            .map(|payload| {
+                serde_json::from_slice::<ResumeTokenizationAggregate>(payload)
+                    .unwrap()
+                    .target
+            })
+            .collect();
+
+        assert!(
+            targets.is_empty(),
+            "live transfer jobs must exclusively own mint and redemption resume; generic jobs found: {targets:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_transfer_job_remains_dead_lettered_on_restart() {
+        let InterruptedAggregateFixture {
+            pool,
+            apalis_pool,
+            services,
+            mint_id,
+            redemption_id,
+            tokenizer: _,
+            rebalancing_service,
+            inventory,
+            mut resume_queue,
+        } = seed_interrupted_aggregates_and_build_service(
+            5,
+            "dead-lettered-mint",
+            "dead-lettered-redemption",
+        )
+        .await;
+
+        let mut transfer_queue =
+            crate::rebalancing::equity::TransferEquityToMarketMakingJobQueue::new(&apalis_pool);
+        transfer_queue
+            .push(TransferEquityToMarketMaking {
+                issuer_request_id: mint_id.clone(),
+                symbol: Symbol::new("AAPL").unwrap(),
+                quantity: FractionalShares::new(float!(1)),
+                generation: 1,
+            })
+            .await
+            .unwrap();
+        let mut redemption_queue =
+            crate::rebalancing::equity::TransferEquityToHedgingJobQueue::new(&apalis_pool);
+        redemption_queue
+            .push(TransferEquityToHedging {
+                aggregate_id: redemption_id,
+                symbol: Symbol::new("AAPL").unwrap(),
+                quantity: FractionalShares::new(float!(1)),
+            })
+            .await
+            .unwrap();
+        sqlx_apalis::query(
+            "UPDATE Jobs SET status = ?, attempts = max_attempts \
+             WHERE job_type IN (?, ?)",
+        )
+        .bind(Status::Failed.to_string())
+        .bind(std::any::type_name::<TransferEquityToMarketMaking>())
+        .bind(std::any::type_name::<TransferEquityToHedging>())
+        .execute(&apalis_pool)
+        .await
+        .unwrap();
+
+        recover_interrupted_tokenization_aggregates(
+            &pool,
+            &rebalancing_service,
+            inventory.as_ref(),
+            Arc::new(test_store::<TokenizedEquityMint>(
+                pool.clone(),
+                services.clone(),
+            )),
+            Arc::new(test_store::<EquityRedemption>(pool.clone(), services)),
+            &mut resume_queue,
+        )
+        .await
+        .unwrap();
+
+        let payloads: Vec<Vec<u8>> = sqlx_apalis::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<ResumeTokenizationAggregate>())
+        .fetch_all(&apalis_pool)
+        .await
+        .unwrap();
+        assert!(
+            payloads.is_empty(),
+            "dead-lettered mint and redemption transfers must not be resurrected through the generic resume queue"
+        );
+    }
+
     /// Extension of the above: a crash mid-job leaves a `Running` row (not
     /// `Pending`). `cancel_all_pending` alone cannot clean it up; the orphan
     /// must be promoted to `Pending` first and then cancelled. Without the
@@ -4518,10 +4714,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn spawn_finished_job_cleanup_retains_usdc_transfer_rows() {
+    async fn spawn_finished_job_cleanup_retains_transfer_rows() {
         let (pool, apalis_pool) = setup_test_pools().await;
         let hedging_type = std::any::type_name::<TransferUsdcToHedging>();
         let market_making_type = std::any::type_name::<TransferUsdcToMarketMaking>();
+        let equity_to_hedging_type = std::any::type_name::<TransferEquityToHedging>();
+        let equity_to_market_making_type = std::any::type_name::<TransferEquityToMarketMaking>();
 
         // Non-transfer finished rows must be pruned (Done and exhausted Failed).
         insert_job_row(&apalis_pool, "other-done", "test", Status::Done, 1, 25).await;
@@ -4547,12 +4745,30 @@ mod tests {
             25,
         )
         .await;
+        insert_job_row(
+            &apalis_pool,
+            "equity-to-hedging-done",
+            equity_to_hedging_type,
+            Status::Done,
+            1,
+            25,
+        )
+        .await;
+        insert_job_row(
+            &apalis_pool,
+            "equity-to-market-making-failed",
+            equity_to_market_making_type,
+            Status::Failed,
+            25,
+            25,
+        )
+        .await;
 
         let handle =
             spawn_finished_job_cleanup(pool.clone(), apalis_pool.clone(), Duration::from_secs(60));
 
-        // The two non-transfer finished rows are pruned; the two transfer rows remain.
-        wait_for_job_count(&apalis_pool, 2).await;
+        // The two non-transfer finished rows are pruned; all transfer rows remain.
+        wait_for_job_count(&apalis_pool, 4).await;
         handle.abort();
 
         let mut remaining: Vec<String> = sqlx_apalis::query_scalar("SELECT job_type FROM Jobs")
@@ -4560,11 +4776,16 @@ mod tests {
             .await
             .unwrap();
         remaining.sort();
-        let mut expected = vec![hedging_type.to_string(), market_making_type.to_string()];
+        let mut expected = vec![
+            hedging_type.to_string(),
+            market_making_type.to_string(),
+            equity_to_hedging_type.to_string(),
+            equity_to_market_making_type.to_string(),
+        ];
         expected.sort();
         assert_eq!(
             remaining, expected,
-            "USDC transfer finished rows must survive cleanup regardless of Done/Failed status"
+            "transfer finished rows must survive cleanup regardless of direction or Done/Failed status"
         );
     }
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -570,8 +570,6 @@ where
         let failure_notify_for_check_positions = failure_notify.clone();
         let failure_notify_for_transfer_usdc_to_hedging = failure_notify.clone();
         let failure_notify_for_transfer_usdc_to_market_making = failure_notify.clone();
-        let failure_notify_for_transfer_equity_to_market_making = failure_notify.clone();
-        let failure_notify_for_transfer_equity_to_hedging = failure_notify.clone();
         let failure_notify_for_select = failure_notify.clone();
 
         let fail_stop = CircuitBreakerConfig::default()
@@ -590,8 +588,6 @@ where
         let fail_stop_for_check_positions = fail_stop.clone();
         let fail_stop_for_transfer_usdc_to_hedging = fail_stop.clone();
         let fail_stop_for_transfer_usdc_to_market_making = fail_stop.clone();
-        let fail_stop_for_transfer_equity_to_market_making = fail_stop.clone();
-        let fail_stop_for_transfer_equity_to_hedging = fail_stop.clone();
         let accountant_ctx_for_backfill = accountant_ctx.clone();
 
         tokio::spawn(async move {
@@ -772,8 +768,6 @@ where
                 apalis_monitor,
                 transfer_equity_to_market_making_ctx,
                 transfer_equity_to_market_making_queue,
-                FailStopCircuit(fail_stop_for_transfer_equity_to_market_making),
-                failure_notify_for_transfer_equity_to_market_making,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_transfer_equity_to_market_making,
             );
@@ -782,8 +776,6 @@ where
                 apalis_monitor,
                 transfer_equity_to_hedging_ctx,
                 transfer_equity_to_hedging_queue,
-                FailStopCircuit(fail_stop_for_transfer_equity_to_hedging),
-                failure_notify_for_transfer_equity_to_hedging,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_transfer_equity_to_hedging,
             );
@@ -1011,12 +1003,12 @@ fn register_transfer_usdc_to_market_making_worker(
 /// Conditionally registers the `TransferEquityToMarketMaking` worker. Same
 /// pattern as the USDC transfer workers: the ctx is `None` when rebalancing
 /// is disabled, in which case the queue exists but no worker consumes it.
+/// Terminal per-transfer failures remain dead-lettered in apalis without
+/// stopping this worker or the conductor.
 fn register_transfer_equity_to_market_making_worker(
     monitor: Monitor,
     transfer_ctx: Option<Arc<TransferEquityToMarketMakingCtx>>,
     transfer_queue: TransferEquityToMarketMakingJobQueue,
-    FailStopCircuit(fail_stop): FailStopCircuit,
-    failure_notify: Arc<tokio::sync::Notify>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
     let Some(transfer_ctx) = transfer_ctx else {
@@ -1028,13 +1020,11 @@ fn register_transfer_equity_to_market_making_worker(
     };
 
     monitor.register(move |index| {
-        build_supervised_worker!(
+        build_best_effort_worker!(
             ::<TransferEquityToMarketMakingCtx, TransferEquityToMarketMaking>,
             index,
             transfer_queue.clone(),
             transfer_ctx.clone(),
-            fail_stop.clone(),
-            failure_notify.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector.clone(),
         )
@@ -1047,8 +1037,6 @@ fn register_transfer_equity_to_hedging_worker(
     monitor: Monitor,
     transfer_ctx: Option<Arc<TransferEquityToHedgingCtx>>,
     transfer_queue: TransferEquityToHedgingJobQueue,
-    FailStopCircuit(fail_stop): FailStopCircuit,
-    failure_notify: Arc<tokio::sync::Notify>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
     let Some(transfer_ctx) = transfer_ctx else {
@@ -1060,13 +1048,11 @@ fn register_transfer_equity_to_hedging_worker(
     };
 
     monitor.register(move |index| {
-        build_supervised_worker!(
+        build_best_effort_worker!(
             ::<TransferEquityToHedgingCtx, TransferEquityToHedging>,
             index,
             transfer_queue.clone(),
             transfer_ctx.clone(),
-            fail_stop.clone(),
-            failure_notify.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector.clone(),
         )
@@ -1101,4 +1087,245 @@ fn register_resume_tokenization_worker(
             failure_injector.clone(),
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::RwLock;
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use st0x_config::EquitiesConfig;
+    use st0x_event_sorcery::test_store;
+    use st0x_execution::{FractionalShares, Symbol};
+    use st0x_float_macro::float;
+    use st0x_raindex::Raindex;
+    use st0x_tokenization::IssuerRequestId;
+    use st0x_tokenization::mock::MockTokenizer;
+    use st0x_wrapper::{MockWrapper, Wrapper};
+
+    use super::*;
+    use crate::equity_redemption::RedemptionAggregateId;
+    use crate::onchain::mock::MockRaindex;
+    use crate::rebalancing::equity::{
+        EquityTransferServices, MintError, MintTransferError, RedemptionError,
+        ResumeEquityToHedging, ResumeEquityToMarketMaking,
+    };
+    use crate::test_utils::{setup_test_apalis_pool, setup_test_pools};
+    use crate::vault_lookup::MockVaultLookup;
+
+    struct PoisonThenHealthyRedemptionResume {
+        poison_id: RedemptionAggregateId,
+        healthy_completed: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl ResumeEquityToHedging for PoisonThenHealthyRedemptionResume {
+        async fn resume_equity_to_hedging(
+            &self,
+            aggregate_id: &RedemptionAggregateId,
+            _symbol: &Symbol,
+            _quantity: FractionalShares,
+        ) -> Result<(), RedemptionError> {
+            if aggregate_id == &self.poison_id {
+                return Err(RedemptionError::EntityNotFound {
+                    aggregate_id: aggregate_id.clone(),
+                });
+            }
+
+            self.healthy_completed.notify_waiters();
+            Ok(())
+        }
+    }
+
+    struct PoisonThenHealthyMintResume {
+        poison_id: IssuerRequestId,
+        healthy_completed: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl ResumeEquityToMarketMaking for PoisonThenHealthyMintResume {
+        async fn resume_equity_to_market_making(
+            &self,
+            issuer_request_id: &IssuerRequestId,
+            _symbol: &Symbol,
+            _quantity: FractionalShares,
+        ) -> Result<(), MintTransferError> {
+            if issuer_request_id == &self.poison_id {
+                return Err(MintTransferError::PreReceipt(MintError::EntityNotFound {
+                    issuer_request_id: issuer_request_id.clone(),
+                    expected_state: "healthy test mint",
+                }));
+            }
+
+            self.healthy_completed.notify_waiters();
+            Ok(())
+        }
+    }
+
+    async fn wait_for_terminal_job<Task: 'static>(apalis_pool: &apalis_sqlite::SqlitePool) {
+        tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                let terminal_count: i64 = sqlx_apalis::query_scalar(
+                    "SELECT COUNT(*) FROM Jobs \
+                     WHERE job_type = ? AND status IN ('Failed', 'Killed') \
+                     AND attempts >= max_attempts",
+                )
+                .bind(std::any::type_name::<Task>())
+                .fetch_one(apalis_pool)
+                .await
+                .unwrap();
+                if terminal_count == 1 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("the poison job must reach a visible terminal state");
+    }
+
+    fn mint_transfer_ctx(
+        transfer: Arc<dyn ResumeEquityToMarketMaking>,
+        cqrs_pool: sqlx::SqlitePool,
+    ) -> Arc<TransferEquityToMarketMakingCtx> {
+        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+        let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
+        let services = EquityTransferServices {
+            raindex,
+            vault_lookup: Arc::new(MockVaultLookup::new()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper,
+        };
+
+        Arc::new(TransferEquityToMarketMakingCtx {
+            transfer,
+            equity_in_progress: Arc::new(RwLock::new(HashMap::new())),
+            mint_store: Arc::new(test_store(cqrs_pool, services)),
+            equities_config: EquitiesConfig::default(),
+        })
+    }
+
+    #[tokio::test]
+    async fn terminal_equity_transfer_is_dead_lettered_without_stopping_worker() {
+        let apalis_pool = setup_test_apalis_pool().await;
+        let mut queue = TransferEquityToHedgingJobQueue::new(&apalis_pool);
+        let poison_id = RedemptionAggregateId::generate();
+        let healthy_id = RedemptionAggregateId::generate();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        queue
+            .push(TransferEquityToHedging {
+                aggregate_id: poison_id.clone(),
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(float!(1)),
+            })
+            .await
+            .unwrap();
+        let mut push_queue = queue.clone();
+
+        let healthy_completed = Arc::new(tokio::sync::Notify::new());
+        let transfer_ctx = Arc::new(TransferEquityToHedgingCtx {
+            transfer: Arc::new(PoisonThenHealthyRedemptionResume {
+                poison_id,
+                healthy_completed: healthy_completed.clone(),
+            }),
+        });
+        let monitor = register_transfer_equity_to_hedging_worker(
+            Monitor::new().should_restart(|_ctx, _error, _attempt| false),
+            Some(transfer_ctx),
+            queue,
+            FailureInjector::new(),
+        );
+        let monitor_handle = tokio::spawn(async move { monitor.run().await });
+
+        wait_for_terminal_job::<TransferEquityToHedging>(&apalis_pool).await;
+
+        push_queue
+            .push(TransferEquityToHedging {
+                aggregate_id: healthy_id,
+                symbol,
+                quantity: FractionalShares::new(float!(1)),
+            })
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(15), healthy_completed.notified())
+            .await
+            .expect("the worker must process a healthy sibling after dead-lettering a poison job");
+
+        let terminal_count: i64 = sqlx_apalis::query_scalar(
+            "SELECT COUNT(*) FROM Jobs \
+             WHERE job_type = ? AND status IN ('Failed', 'Killed') AND attempts >= max_attempts",
+        )
+        .bind(std::any::type_name::<TransferEquityToHedging>())
+        .fetch_one(&apalis_pool)
+        .await
+        .unwrap();
+        assert_eq!(terminal_count, 1, "the poison job must remain visible");
+
+        assert!(
+            !monitor_handle.is_finished(),
+            "a terminal equity-transfer job must not stop the conductor monitor",
+        );
+        monitor_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn terminal_equity_mint_is_dead_lettered_without_stopping_worker() {
+        let (cqrs_pool, apalis_pool) = setup_test_pools().await;
+        let mut queue = TransferEquityToMarketMakingJobQueue::new(&apalis_pool);
+        let poison_id = IssuerRequestId::generate();
+        let healthy_id = IssuerRequestId::generate();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        queue
+            .push(TransferEquityToMarketMaking {
+                issuer_request_id: poison_id.clone(),
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(float!(1)),
+                generation: 0,
+            })
+            .await
+            .unwrap();
+        let mut push_queue = queue.clone();
+
+        let healthy_completed = Arc::new(tokio::sync::Notify::new());
+        let transfer_ctx = mint_transfer_ctx(
+            Arc::new(PoisonThenHealthyMintResume {
+                poison_id,
+                healthy_completed: healthy_completed.clone(),
+            }),
+            cqrs_pool,
+        );
+        let monitor = register_transfer_equity_to_market_making_worker(
+            Monitor::new().should_restart(|_ctx, _error, _attempt| false),
+            Some(transfer_ctx),
+            queue,
+            FailureInjector::new(),
+        );
+        let monitor_handle = tokio::spawn(async move { monitor.run().await });
+
+        wait_for_terminal_job::<TransferEquityToMarketMaking>(&apalis_pool).await;
+        push_queue
+            .push(TransferEquityToMarketMaking {
+                issuer_request_id: healthy_id,
+                symbol,
+                quantity: FractionalShares::new(float!(1)),
+                generation: 0,
+            })
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(15), healthy_completed.notified())
+            .await
+            .expect("the mint worker must process a healthy sibling after a poison job");
+        assert!(
+            !monitor_handle.is_finished(),
+            "a terminal equity-mint job must not stop the conductor monitor",
+        );
+        monitor_handle.abort();
+    }
 }

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -376,9 +376,10 @@ pub(crate) use build_supervised_worker;
 /// worker idle after retries are exhausted because `poll_ready` returns
 /// `Pending` without scheduling a wakeup when the circuit is open.
 ///
-/// Use for background recovery workers (e.g. `ResumeTokenizationAggregate`)
-/// where a persistently failing individual job must not block processing of
-/// sibling jobs or bring down hedging and fill detection.
+/// Use for jobs whose exhausted item is a visible dead letter rather than a
+/// process-level fault, including equity transfers and background tokenization
+/// recovery. A persistently failing individual job must not block sibling jobs
+/// or bring down hedging and fill detection.
 macro_rules! build_best_effort_worker {
     (
         ::<$ctx_type:ty, $job:ty>,
@@ -689,10 +690,10 @@ pub(crate) fn on_terminal_failure(
 /// On-event handler for workers where terminal failure must not crash the
 /// conductor. Logs the error at `error!` level but does NOT call
 /// `failure_notify.notify_waiters()` and does NOT call `ctx.stop()`.
-/// Used for best-effort background workers (e.g. `ResumeTokenizationAggregate`)
-/// where a persistently failing individual job should not bring down hedging
-/// and fill detection. See [`build_best_effort_worker!`] for why these workers
-/// do not install Apalis' circuit-breaker layer.
+/// Used for dead-lettering per-item workers (equity transfers and background
+/// tokenization recovery) where a persistently failing individual job should
+/// not bring down hedging and fill detection. See [`build_best_effort_worker!`]
+/// for why these workers do not install Apalis' circuit-breaker layer.
 ///
 /// Structural invariant: unlike [`on_terminal_failure`], this function takes
 /// no `Notify` argument and therefore can never call `notify_waiters()` or

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -13,7 +13,9 @@ mod job;
 mod resume_job;
 
 #[cfg(test)]
-pub(crate) use job::TransferEquityToMarketMakingJobError;
+pub(crate) use job::{
+    ResumeEquityToHedging, ResumeEquityToMarketMaking, TransferEquityToMarketMakingJobError,
+};
 pub(crate) use job::{
     TransferEquityToHedging, TransferEquityToHedgingCtx, TransferEquityToHedgingJobQueue,
     TransferEquityToMarketMaking, TransferEquityToMarketMakingCtx,

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -851,6 +851,8 @@ async fn assert_equity_redeem_rebalancing<P: Provider>(
     Ok(())
 }
 
+/// Reads the CQRS snapshot rather than the events table because inventory
+/// events may be compacted immediately after the first poll.
 pub(crate) async fn assert_initial_base_wallet_unwrapped_and_wrapped_equity_snapshot(
     bot: &mut JoinHandle<anyhow::Result<()>>,
     db_path: &std::path::Path,
@@ -865,32 +867,22 @@ pub(crate) async fn assert_initial_base_wallet_unwrapped_and_wrapped_equity_snap
              {expected_unwrapped_balance} and wrapped {expected_wrapped_balance}"
     );
 
-    let parse_snapshot_balance = |events: &[crate::assert::StoredEvent],
-                                  event_type: &str,
-                                  payload_key: &str|
-     -> anyhow::Result<Option<FractionalShares>> {
-        events
-            .iter()
-            .rev()
-            .find(|event| event.event_type == event_type)
-            .and_then(|event| {
-                event
-                    .payload
-                    .get(payload_key)
-                    .and_then(|value| value.get("balances"))
-                    .and_then(|balances| balances.get(symbol))
-                    .and_then(|value| value.as_str())
-            })
-            .map(|balance_str| {
-                balance_str.parse::<FractionalShares>().map_err(|error| {
-                    anyhow::anyhow!(
-                        "Failed to parse {event_type} balance '{balance_str}' for {symbol}: \
-                         {error}"
-                    )
+    let parse_snapshot_balance =
+        |snapshot: &serde_json::Value, field: &str| -> anyhow::Result<Option<FractionalShares>> {
+            snapshot
+                .get("Live")
+                .and_then(|live| live.get(field))
+                .and_then(|balances| balances.get(symbol))
+                .and_then(|value| value.as_str())
+                .map(|balance_str| {
+                    balance_str.parse::<FractionalShares>().map_err(|error| {
+                        anyhow::anyhow!(
+                            "Failed to parse {field} balance '{balance_str}' for {symbol}: {error}"
+                        )
+                    })
                 })
-            })
-            .transpose()
-    };
+                .transpose()
+        };
 
     loop {
         sleep_or_crash(bot, &context).await;
@@ -903,22 +895,23 @@ pub(crate) async fn assert_initial_base_wallet_unwrapped_and_wrapped_equity_snap
             continue;
         };
 
-        let events = fetch_events_by_type(&pool, "InventorySnapshot").await;
+        let snapshot_payload: Result<Option<String>, sqlx::Error> = sqlx::query_scalar(
+            "SELECT payload FROM snapshots \
+             WHERE aggregate_type = 'InventorySnapshot' LIMIT 1",
+        )
+        .fetch_optional(&pool)
+        .await;
         pool.close().await;
 
-        let (unwrapped_snapshot_balance, wrapped_snapshot_balance) = match events {
-            Ok(events) => (
-                parse_snapshot_balance(
-                    &events,
-                    "InventorySnapshotEvent::BaseWalletUnwrappedEquity",
-                    "BaseWalletUnwrappedEquity",
-                )?,
-                parse_snapshot_balance(
-                    &events,
-                    "InventorySnapshotEvent::BaseWalletWrappedEquity",
-                    "BaseWalletWrappedEquity",
-                )?,
-            ),
+        let (unwrapped_snapshot_balance, wrapped_snapshot_balance) = match snapshot_payload {
+            Ok(Some(payload)) => {
+                let snapshot: serde_json::Value = serde_json::from_str(&payload)?;
+                (
+                    parse_snapshot_balance(&snapshot, "base_wallet_unwrapped_equity")?,
+                    parse_snapshot_balance(&snapshot, "base_wallet_wrapped_equity")?,
+                )
+            }
+            Ok(None) => (None, None),
             Err(error) => {
                 assert!(
                     tokio::time::Instant::now() < deadline,


### PR DESCRIPTION
## Stack Context

Stacked directly on #1041 (both based off master for a fast hotfix merge); the rest of the Liquidity Bot Improvements stack resyncs after these merge.

Depends on #1041.

## What

- Dead-letter terminal equity mint and redemption transfer jobs without stopping their workers or the conductor.
- Retain durable equity transfer rows and make them the sole owner of interrupted aggregate recovery.
- Keep terminal transfer rows dead-lettered across restarts instead of resurrecting them.
- Make the initial equity-balance E2E assertion read the compacted CQRS snapshot.

## Why

A terminal Alpaca mint or redemption failure must remain observable without crashing or restart-looping the bot. Startup must also avoid scheduling both the transfer job and a generic aggregate resume, which can drive the same onchain deposit twice.

## How

Equity transfer registrations use the existing best-effort worker policy. Finished-job cleanup retains all transfer ownership rows, and startup recovery excludes aggregates already owned by any durable equity transfer row, including terminal rows.

## Testing

- cargo nextest run -p st0x-hedge --retries 0 --flaky-result fail: 2562 passed, 4 skipped
- Focused worker dead-letter and restart ownership regression tests
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets --all-features
- cargo fmt --all -- --check
