### PR TITLE
fix: recover exhausted worker circuits (RAI-1051)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -310,6 +310,17 @@ configured `apalis_finished_job_cleanup_interval_secs` cadence so the durable
 queue cannot grow without bound during normal operation or repeated restarts.
 The cadence must be explicitly configured and non-zero.
 
+Supervised apalis workers isolate terminal failures with a local recovering
+circuit. The middleware and durable queue share a four-attempt limit, so a job
+produces one terminal transition after exhausting its bounded retries and
+remains visible as a terminal Jobs row. The first consecutive terminal failure
+then pauses only that worker, sends an operator alert, and records a structured
+circuit transition with the worker name, error, failure count, and cooldown. The
+process and sibling workers remain live. After a five-minute cooldown, the same
+worker resumes without a process restart and records a structured recovery
+transition. A successful job resets the consecutive-failure count. Best-effort
+workers retain and log terminal jobs without pausing.
+
 Deployed systemd services must use bounded restart loops with a restart delay
 long enough to avoid runaway RPC consumption. After the restart limit is hit,
 the service stays stopped until an operator investigates.
@@ -2436,10 +2447,11 @@ misses) so a still-pending tx is never misclassified as dropped.
 **Bound**: Both revert and timeout redrives count against a shared
 `max_burn_revert_redrives` counter persisted in the job payload (durable across
 restarts). Once the bound is reached, the job propagates a
-`BurnRevertLimitReached` error so the circuit opens and the operator is alerted.
-Genuinely ambiguous failures (where the burn may have landed and `is_revert()`
-returns false, e.g. `MessageSentEventNotFound`) are never reclassified and
-always halt for operator review.
+`BurnRevertLimitReached` error so its worker circuit opens and the operator is
+alerted. Genuinely ambiguous failures (where the burn may have landed and
+`is_revert()` returns false, e.g. `MessageSentEventNotFound`) are never
+reclassified and always pause their worker for operator review before automatic
+recovery.
 
 **Alerting**: A Telegram alert fires at the warn threshold (`max / 2 + 1`
 redrives), at the limit, and before any terminal non-redriven error propagates.
@@ -4080,6 +4092,12 @@ requests to the backend.
 The bot raises out-of-band alerts for conditions an operator must react to
 quickly. Alerting is **optional**: when its configuration is absent the bot runs
 normally with no alert channel and the alert monitors are not spawned.
+
+Worker-circuit signals answer two bounded on-call questions. “Which worker
+paused and why?” is answered by the circuit-open transition and its operator
+alert. “Did it recover without a process restart?” is answered by the matching
+structured recovery transition. Worker names and transition names are bounded
+fields; errors remain event details rather than metric labels.
 
 ### Gas balance monitoring
 

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -188,8 +188,7 @@ WorkerBuilder::new(name)
     .data(ctx)
     .concurrency(1)                                          // sequential processing
     .retry(RetryPolicy::retries(3).with_backoff(backoff))    // 1 + 3 = 4 attempts, with backoff
-    .break_circuit_with(fail_stop_config)                    // halt on terminal failure
-    .on_event(|ctx, event| { ... })                          // observability + lifecycle
+    .on_event(recovering_circuit_event)                      // pause, alert, and recover
     .build(work::<MyCtx, MyJob>)
 ```
 
@@ -200,42 +199,33 @@ WorkerBuilder::new(name)
   the next job from starting.
 - **`.retry(RetryPolicy::retries(3).with_backoff(RETRY_BACKOFF))`** — retries
   failed jobs (replaces backon in the handler). `retries(3)` = 4 total attempts.
-  `RETRY_BACKOFF` is a deterministic exponential backoff (1s base, doubles each
-  attempt, capped at 30s) so transient failures (RPC blips, broker rate limits)
-  don't fast-fail into the circuit breaker. No jitter -- single-worker queues
-  don't thunder.
-- **`.break_circuit_with(config)`** — opens the circuit after
-  `failure_threshold` errors, returning `Poll::Pending` from `poll_ready` to
-  block new job pickup. Use `failure_threshold(1)` + very long
-  `recovery_timeout` for fail-stop. Do not install this layer on best-effort
-  workers: in apalis-core 1.0.0-rc.9, an open circuit can return `Poll::Pending`
-  without scheduling a wakeup, so a short `recovery_timeout` does not guarantee
-  the worker will resume.
-- **`.on_event()`** — fires on `Event::Error` (after retries exhaust),
-  `Event::Success`, `Event::Start`, `Event::Stop`. Use for logging AND for
-  calling `ctx.stop()` on terminal failure. The circuit breaker alone only
-  pauses the worker (`Poll::Pending`); `ctx.stop()` is needed to actually make
-  the worker exit.
+  Every queued task carries the same four-attempt durable SQL limit, so one
+  exhausted job produces exactly one terminal worker event. `RETRY_BACKOFF` is a
+  deterministic exponential backoff (1s base, doubles each attempt, capped at
+  30s) so transient failures (RPC blips, broker rate limits) don't fast-fail
+  into the recovering circuit. No jitter -- single-worker queues don't thunder.
+- **`.on_event(recovering_circuit_event)`** — observes terminal `Event::Error`
+  and successful `Event::Success` outcomes. The first consecutive terminal
+  failure opens the local worker circuit, pauses that worker, emits a structured
+  transition, and sends an operator alert. After a five-minute production
+  cooldown, a scheduled task closes the circuit and resumes the same worker
+  without restarting the process. A success resets the consecutive-failure
+  count. Tests use a short cooldown.
 
-### Error propagation: handler failure -> bot shutdown
+Best-effort workers do not install the recovering circuit. Their terminal
+failures are logged and retained in the durable queue, but do not pause the
+worker.
+
+### Error propagation: handler failure -> isolated recovery
 
 1. `work()` returns `Err` -> retry layer retries
-2. Retries exhaust -> error reaches circuit breaker -> circuit opens
-3. Error becomes `Ok(Event::Error)` in apalis `poll_tasks`
-4. `on_event` catches `Event::Error`, fires the shared `failure_notify`
-   (`tokio::sync::Notify`), and calls `ctx.stop()`
-5. Worker exits cleanly (`Ok(())`)
-6. The spawned monitor task's biased `tokio::select!` observes the Notify and
-   returns `Err(MonitorTaskError::TerminalJobFailure)` immediately -- it does
-   not wait for `apalis_monitor.run()` to wind down. The conductor's
-   `wait_for_completion` sees the monitor task exit with that error and shuts
-   the bot down.
-
-**Critical:** the spawned monitor task must select on the shared Notify
-alongside `apalis_monitor.run()` and return the terminal error. Without the
-Notify branch, the conductor would only learn of the failure once apalis
-finished tearing down all workers; without returning the error, the conductor
-would never see the failure at all.
+2. Retries exhaust -> apalis persists the terminal job and emits `Event::Error`
+3. `on_event` opens the local circuit and pauses only that worker
+4. A structured `opened` transition and operator alert identify the worker and
+   failure
+5. The conductor and sibling workers remain running
+6. After the cooldown, the scheduled recovery resumes the worker and emits a
+   structured `recovered` transition
 
 ### Monitor configuration
 
@@ -246,8 +236,9 @@ Monitor::new()
     .run().await
 ```
 
-`should_restart(false)` — terminal job failure is fail-stop. The worker must not
-restart and process the next job with stale state.
+`should_restart(false)` prevents apalis from spawning a replacement worker after
+an unexpected worker exit. Terminal job failures do not exit the worker: the
+recovering event handler owns its pause and resume lifecycle.
 
 ### AccountForDexTrade
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -584,6 +584,7 @@ impl Conductor {
             Err(CtxError::NotRebalancing) => None,
             Err(error) => return Err(error.into()),
         };
+        let notifier = build_operational_notifier(ctx.alerts.as_ref())?;
 
         let PositionAndRebalancing {
             position,
@@ -614,6 +615,7 @@ impl Conductor {
                 vault_registry_projection,
                 schedulers: schedulers.clone(),
                 telemetry: telemetry.clone(),
+                notifier: notifier.clone(),
             },
         )
         .await?;
@@ -699,6 +701,7 @@ impl Conductor {
             wallet_polling,
             tokenizer,
             shutdown_token: shutdown_token.clone(),
+            notifier,
             #[cfg(any(test, feature = "test-support"))]
             failure_injector,
         };
@@ -1149,6 +1152,7 @@ struct RebalancingDeps {
     vault_registry_projection: Arc<Projection<VaultRegistry>>,
     schedulers: RebalancingSchedulers,
     telemetry: TelemetrySender,
+    notifier: Arc<dyn crate::alerts::Notifier>,
 }
 
 /// Position + rebalancing-adjacent infrastructure produced during conductor
@@ -1269,7 +1273,7 @@ impl PositionAndRebalancing {
     }
 }
 
-/// Builds the USDC alerting notifier.
+/// Builds the shared operational alerting notifier.
 ///
 /// Returns `Ok(Arc<NoopNotifier>)` when `[alerts]` is absent — silence is
 /// the correct behaviour for an unconfigured optional channel.
@@ -1279,16 +1283,16 @@ impl PositionAndRebalancing {
 /// an operator who configured `[alerts]` believes alerts are active; silently
 /// falling back to Noop would suppress all redrive-limit and terminal-error
 /// pages with no runtime indication.
-fn build_usdc_notifier(
+fn build_operational_notifier(
     alerts: Option<&st0x_config::AlertsCtx>,
 ) -> Result<Arc<dyn crate::alerts::Notifier>, NotifierError> {
     let Some(alerts) = alerts else {
-        debug!("USDC alerting: [alerts] section absent, using NoopNotifier");
+        debug!("Operational alerting: [alerts] section absent, using NoopNotifier");
         return Ok(Arc::new(NoopNotifier));
     };
     let notifier =
         TelegramNotifier::new(&alerts.bot_token, alerts.chat_id, alerts.message_thread_id)?;
-    info!("USDC alerting: Telegram notifier configured");
+    info!("Operational alerting: Telegram notifier configured");
     Ok(Arc::new(notifier))
 }
 
@@ -1471,7 +1475,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         let transfer_usdc_to_market_making_queue =
             deps.schedulers.transfer_usdc_to_market_making.clone();
 
-        let usdc_notifier = build_usdc_notifier(deps.ctx.alerts.as_ref())?;
+        let usdc_notifier = deps.notifier.clone();
 
         let rebalancing_service = Arc::new(RebalancingService::new(
             RebalancingServiceConfig {
@@ -8406,6 +8410,7 @@ mod tests {
                 vault_registry_projection,
                 schedulers: RebalancingSchedulers::new(&apalis_pool),
                 telemetry: TelemetrySender::disabled(),
+                notifier: Arc::new(NoopNotifier),
             },
         )
         .await
@@ -10208,7 +10213,7 @@ mod tests {
         // Monitor returns an error after shutdown signal.
         let monitor = tokio::spawn(async move {
             apalis_token_clone.cancelled().await;
-            Err(MonitorTaskError::TerminalJobFailure)
+            Err(MonitorTaskError::UnexpectedExit { source: None })
         });
 
         let job_cleanup = tokio::spawn(pending::<()>());
@@ -10238,10 +10243,13 @@ mod tests {
     #[test]
     fn check_monitor_drain_result_propagates_monitor_error() {
         let error =
-            check_monitor_drain_result(Ok(Err(MonitorTaskError::TerminalJobFailure))).unwrap_err();
+            check_monitor_drain_result(Ok(Err(MonitorTaskError::UnexpectedExit { source: None })))
+                .unwrap_err();
 
         assert!(
-            error.to_string().contains("Apalis worker failed"),
+            error
+                .to_string()
+                .contains("Apalis monitor exited unexpectedly"),
             "should propagate MonitorTaskError, got: {error}"
         );
     }
@@ -10674,18 +10682,18 @@ mod tests {
         );
     }
 
-    /// When `[alerts]` is absent, `build_usdc_notifier` returns a `NoopNotifier`
+    /// When `[alerts]` is absent, `build_operational_notifier` returns a `NoopNotifier`
     /// that silently discards notifications without error.
     #[tokio::test]
-    async fn build_usdc_notifier_returns_ok_noop_when_alerts_absent() {
-        let notifier = build_usdc_notifier(None).unwrap();
+    async fn build_operational_notifier_returns_ok_noop_when_alerts_absent() {
+        let notifier = build_operational_notifier(None).unwrap();
         notifier
             .notify("test message")
             .await
             .expect("NoopNotifier must not error on notify");
     }
 
-    /// When `[alerts]` IS present, `build_usdc_notifier` constructs a real
+    /// When `[alerts]` IS present, `build_operational_notifier` constructs a real
     /// Telegram notifier and returns `Ok` -- it must NOT fail startup for a
     /// well-formed config, and it must NOT silently fall back to `NoopNotifier`
     /// (which would suppress every redrive-limit and terminal-error page).
@@ -10697,7 +10705,7 @@ mod tests {
     /// `notify()` is deliberately not exercised: the present-branch notifier posts
     /// to the live Telegram API, which a unit test must never reach.
     #[tokio::test]
-    async fn build_usdc_notifier_returns_ok_telegram_when_alerts_present() {
+    async fn build_operational_notifier_returns_ok_telegram_when_alerts_present() {
         let alerts = st0x_config::AlertsCtx {
             chat_id: 123,
             bot_token: "test-bot-token".to_string(),
@@ -10707,7 +10715,7 @@ mod tests {
             message_thread_id: Some(42),
         };
 
-        build_usdc_notifier(Some(&alerts))
+        build_operational_notifier(Some(&alerts))
             .expect("a well-formed [alerts] config must yield a notifier, not a startup error");
     }
 }

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -3,7 +3,6 @@
 use alloy::primitives::{Address, B256};
 use alloy::providers::Provider;
 use apalis::prelude::Monitor;
-use apalis_core::worker::ext::circuit_breaker::config::CircuitBreakerConfig;
 use sqlx::SqlitePool;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
@@ -26,14 +25,13 @@ use super::exit::MonitorTaskError;
 #[cfg(any(test, feature = "test-support"))]
 use super::job::FailureInjector;
 use super::job::{
-    FAIL_STOP_RECOVERY_TIMEOUT, build_best_effort_worker, build_supervised_worker,
-    build_worker_inner,
+    WORKER_CIRCUIT_POLICY, build_best_effort_worker, build_supervised_worker, build_worker_inner,
 };
 use super::monitor::executor_maintenance::ExecutorMaintenance;
 use super::monitor::gas::{GasMonitor, ProviderBalanceReader};
 use super::monitor::inventory::InventoryMonitor;
 use super::monitor::order_fills::OrderFillMonitor;
-use crate::alerts::TelegramNotifier;
+use crate::alerts::{Notifier, TelegramNotifier};
 use crate::inventory::{
     InventoryPollingService, InventorySnapshot, InventorySnapshotId, WalletPollingCtx,
 };
@@ -100,6 +98,7 @@ pub(crate) struct ConductorCtx<Prov, Exec> {
     pub(crate) wallet_polling: Option<WalletPollingCtx>,
     pub(crate) tokenizer: Option<Arc<dyn Tokenizer>>,
     pub(crate) shutdown_token: CancellationToken,
+    pub(crate) notifier: Arc<dyn Notifier>,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) failure_injector: FailureInjector,
 }
@@ -414,6 +413,7 @@ where
         resume_tokenization_ctx,
         apalis_shutdown_token,
         seed_vault_registry_queue,
+        notifier: context.notifier.clone(),
         #[cfg(any(test, feature = "test-support"))]
         failure_injector: context.failure_injector,
     }
@@ -473,6 +473,7 @@ where
     resume_tokenization_ctx: Option<Arc<ResumeTokenizationCtx>>,
     apalis_shutdown_token: CancellationToken,
     seed_vault_registry_queue: SeedVaultRegistryJobQueue,
+    notifier: Arc<dyn Notifier>,
     #[cfg(any(test, feature = "test-support"))]
     failure_injector: FailureInjector,
 }
@@ -520,6 +521,7 @@ where
             resume_tokenization_ctx,
             apalis_shutdown_token,
             seed_vault_registry_queue,
+            notifier,
             #[cfg(any(test, feature = "test-support"))]
             failure_injector,
         } = self;
@@ -556,38 +558,19 @@ where
         let failure_injector_for_transfer_equity_to_hedging = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_resume_tokenization = failure_injector.clone();
-        let failure_notify = Arc::new(tokio::sync::Notify::new());
-        let failure_notify_for_hedge = failure_notify.clone();
-        let failure_notify_for_backfill = failure_notify.clone();
-        let failure_notify_for_poll = failure_notify.clone();
-        let failure_notify_for_reconcile = failure_notify.clone();
-        let failure_notify_for_rejection = failure_notify.clone();
-        let failure_notify_for_equity_rebalancing_check = failure_notify.clone();
-        let failure_notify_for_usdc_rebalancing_check = failure_notify.clone();
-        let failure_notify_for_seed_vault_registry = failure_notify.clone();
-        let failure_notify_for_wrapped_equity_recovery = failure_notify.clone();
-        let failure_notify_for_unwrapped_equity_recovery = failure_notify.clone();
-        let failure_notify_for_check_positions = failure_notify.clone();
-        let failure_notify_for_transfer_usdc_to_hedging = failure_notify.clone();
-        let failure_notify_for_transfer_usdc_to_market_making = failure_notify.clone();
-        let failure_notify_for_select = failure_notify.clone();
-
-        let fail_stop = CircuitBreakerConfig::default()
-            .with_failure_threshold(1)
-            .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
-        let fail_stop_for_hedge = fail_stop.clone();
-        let fail_stop_for_backfill = fail_stop.clone();
-        let fail_stop_for_poll = fail_stop.clone();
-        let fail_stop_for_reconcile = fail_stop.clone();
-        let fail_stop_for_rejection = fail_stop.clone();
-        let fail_stop_for_equity_rebalancing_check = fail_stop.clone();
-        let fail_stop_for_usdc_rebalancing_check = fail_stop.clone();
-        let fail_stop_for_seed_vault_registry = fail_stop.clone();
-        let fail_stop_for_wrapped_equity_recovery = fail_stop.clone();
-        let fail_stop_for_unwrapped_equity_recovery = fail_stop.clone();
-        let fail_stop_for_check_positions = fail_stop.clone();
-        let fail_stop_for_transfer_usdc_to_hedging = fail_stop.clone();
-        let fail_stop_for_transfer_usdc_to_market_making = fail_stop.clone();
+        let notifier_for_hedge = notifier.clone();
+        let notifier_for_backfill = notifier.clone();
+        let notifier_for_poll = notifier.clone();
+        let notifier_for_reconcile = notifier.clone();
+        let notifier_for_rejection = notifier.clone();
+        let notifier_for_equity_rebalancing_check = notifier.clone();
+        let notifier_for_usdc_rebalancing_check = notifier.clone();
+        let notifier_for_seed_vault_registry = notifier.clone();
+        let notifier_for_wrapped_equity_recovery = notifier.clone();
+        let notifier_for_unwrapped_equity_recovery = notifier.clone();
+        let notifier_for_check_positions = notifier.clone();
+        let notifier_for_transfer_usdc_to_hedging = notifier.clone();
+        let notifier_for_transfer_usdc_to_market_making = notifier.clone();
         let accountant_ctx_for_backfill = accountant_ctx.clone();
 
         tokio::spawn(async move {
@@ -599,8 +582,8 @@ where
                         index,
                         job_queue.clone(),
                         accountant_ctx.clone(),
-                        fail_stop.clone(),
-                        failure_notify.clone(),
+                        WORKER_CIRCUIT_POLICY,
+                        notifier.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector.clone(),
                     )
@@ -611,8 +594,8 @@ where
                         index,
                         hedge_queue.clone(),
                         hedge_ctx.clone(),
-                        fail_stop_for_hedge.clone(),
-                        failure_notify_for_hedge.clone(),
+                        WORKER_CIRCUIT_POLICY,
+                        notifier_for_hedge.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_hedge.clone(),
                     )
@@ -623,8 +606,8 @@ where
                         index,
                         backfill_queue.clone(),
                         accountant_ctx_for_backfill.clone(),
-                        fail_stop_for_backfill.clone(),
-                        failure_notify_for_backfill.clone(),
+                        WORKER_CIRCUIT_POLICY,
+                        notifier_for_backfill.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_backfill.clone(),
                     )
@@ -635,8 +618,8 @@ where
                         index,
                         poll_status_queue.clone(),
                         poll_status_ctx.clone(),
-                        fail_stop_for_poll.clone(),
-                        failure_notify_for_poll.clone(),
+                        WORKER_CIRCUIT_POLICY,
+                        notifier_for_poll.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_poll.clone(),
                     )
@@ -647,8 +630,8 @@ where
                         index,
                         reconcile_queue.clone(),
                         reconcile_ctx.clone(),
-                        fail_stop_for_reconcile.clone(),
-                        failure_notify_for_reconcile.clone(),
+                        WORKER_CIRCUIT_POLICY,
+                        notifier_for_reconcile.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_reconcile.clone(),
                     )
@@ -659,8 +642,8 @@ where
                         index,
                         rejection_queue.clone(),
                         rejection_ctx.clone(),
-                        fail_stop_for_rejection.clone(),
-                        failure_notify_for_rejection.clone(),
+                        WORKER_CIRCUIT_POLICY,
+                        notifier_for_rejection.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_rejection.clone(),
                     )
@@ -671,8 +654,8 @@ where
                         index,
                         seed_vault_registry_queue.clone(),
                         seed_vault_registry_ctx.clone(),
-                        fail_stop_for_seed_vault_registry.clone(),
-                        failure_notify_for_seed_vault_registry.clone(),
+                        WORKER_CIRCUIT_POLICY,
+                        notifier_for_seed_vault_registry.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_seed_vault_registry.clone(),
                     )
@@ -683,8 +666,8 @@ where
                         index,
                         check_positions_queue.clone(),
                         check_positions_ctx.clone(),
-                        fail_stop_for_check_positions.clone(),
-                        failure_notify_for_check_positions.clone(),
+                        WORKER_CIRCUIT_POLICY,
+                        notifier_for_check_positions.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_check_positions.clone(),
                     )
@@ -702,8 +685,8 @@ where
                             index,
                             equity_queue.clone(),
                             equity_service.clone(),
-                            fail_stop_for_equity_rebalancing_check.clone(),
-                            failure_notify_for_equity_rebalancing_check.clone(),
+                            WORKER_CIRCUIT_POLICY,
+                            notifier_for_equity_rebalancing_check.clone(),
                             #[cfg(any(test, feature = "test-support"))]
                             failure_injector_for_equity_rebalancing_check.clone(),
                         )
@@ -714,8 +697,8 @@ where
                             index,
                             usdc_queue.clone(),
                             usdc_service.clone(),
-                            fail_stop_for_usdc_rebalancing_check.clone(),
-                            failure_notify_for_usdc_rebalancing_check.clone(),
+                            WORKER_CIRCUIT_POLICY,
+                            notifier_for_usdc_rebalancing_check.clone(),
                             #[cfg(any(test, feature = "test-support"))]
                             failure_injector_for_usdc_rebalancing_check.clone(),
                         )
@@ -728,8 +711,7 @@ where
                 apalis_monitor,
                 wrapped_equity_recovery_ctx,
                 wrapped_equity_recovery_queue,
-                FailStopCircuit(fail_stop_for_wrapped_equity_recovery),
-                failure_notify_for_wrapped_equity_recovery,
+                notifier_for_wrapped_equity_recovery,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_wrapped_equity_recovery,
             );
@@ -738,8 +720,7 @@ where
                 apalis_monitor,
                 unwrapped_equity_recovery_ctx,
                 unwrapped_equity_recovery_queue,
-                FailStopCircuit(fail_stop_for_unwrapped_equity_recovery),
-                failure_notify_for_unwrapped_equity_recovery,
+                notifier_for_unwrapped_equity_recovery,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_unwrapped_equity_recovery,
             );
@@ -748,8 +729,7 @@ where
                 apalis_monitor,
                 transfer_usdc_to_hedging_ctx,
                 transfer_usdc_to_hedging_queue,
-                FailStopCircuit(fail_stop_for_transfer_usdc_to_hedging),
-                failure_notify_for_transfer_usdc_to_hedging,
+                notifier_for_transfer_usdc_to_hedging,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_transfer_usdc_to_hedging,
             );
@@ -758,8 +738,7 @@ where
                 apalis_monitor,
                 transfer_usdc_to_market_making_ctx,
                 transfer_usdc_to_market_making_queue,
-                FailStopCircuit(fail_stop_for_transfer_usdc_to_market_making),
-                failure_notify_for_transfer_usdc_to_market_making,
+                notifier_for_transfer_usdc_to_market_making,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_transfer_usdc_to_market_making,
             );
@@ -788,8 +767,6 @@ where
                 failure_injector_for_resume_tokenization,
             );
 
-            let is_draining = apalis_shutdown_token.clone();
-
             let shutdown_signal = async {
                 apalis_shutdown_token.cancelled().await;
                 Ok(())
@@ -800,19 +777,11 @@ where
             // gap where apalis reports Ok(()) for both clean drain and timeout,
             // making the two cases indistinguishable.
 
-            tokio::select! {
-                biased;
-                // During drain, suppress terminal job failures — let remaining
-                // workers finish instead of short-circuiting the drain.
-                () = failure_notify_for_select.notified(),
-                    if !is_draining.is_cancelled() =>
-                {
-                    Err(MonitorTaskError::TerminalJobFailure)
-                }
-                result = apalis_monitor.run_with_signal(shutdown_signal) => match result {
-                    Ok(()) => Ok(()),
-                    Err(source) => Err(MonitorTaskError::UnexpectedExit { source: Some(source) }),
-                },
+            match apalis_monitor.run_with_signal(shutdown_signal).await {
+                Ok(()) => Ok(()),
+                Err(source) => Err(MonitorTaskError::UnexpectedExit {
+                    source: Some(source),
+                }),
             }
         })
     }
@@ -860,14 +829,6 @@ fn log_optional_task_status(task_name: &str, is_configured: bool) {
     }
 }
 
-/// A circuit-breaker config for a FAIL-STOP worker (threshold 1, ~1yr timeout):
-/// a single terminal failure opens the circuit and latches the worker idle,
-/// tripping the conductor-wide fail-stop. A distinct type from
-/// [`BestEffortCircuit`] so the two policies cannot be cross-assigned at a
-/// worker-registration site -- passing the wrong one would be a compile error
-/// rather than a silent freeze.
-struct FailStopCircuit(CircuitBreakerConfig);
-
 /// Conditionally registers the wrapped-equity recovery worker against the
 /// apalis monitor. Extracted because this is the only `Option`-gated worker
 /// registration and inlining the let-else + debug log keeps
@@ -876,8 +837,7 @@ fn register_wrapped_equity_recovery_worker(
     monitor: Monitor,
     recovery_ctx: Option<Arc<WrappedEquityRecoveryCtx>>,
     recovery_queue: WrappedEquityRecoveryJobQueue,
-    FailStopCircuit(fail_stop): FailStopCircuit,
-    failure_notify: Arc<tokio::sync::Notify>,
+    notifier: Arc<dyn Notifier>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
     let Some(recovery_ctx) = recovery_ctx else {
@@ -894,8 +854,8 @@ fn register_wrapped_equity_recovery_worker(
             index,
             recovery_queue.clone(),
             recovery_ctx.clone(),
-            fail_stop.clone(),
-            failure_notify.clone(),
+            WORKER_CIRCUIT_POLICY,
+            notifier.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector.clone(),
         )
@@ -908,8 +868,7 @@ fn register_unwrapped_equity_recovery_worker(
     monitor: Monitor,
     recovery_ctx: Option<Arc<UnwrappedEquityRecoveryCtx>>,
     recovery_queue: UnwrappedEquityRecoveryJobQueue,
-    FailStopCircuit(fail_stop): FailStopCircuit,
-    failure_notify: Arc<tokio::sync::Notify>,
+    notifier: Arc<dyn Notifier>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
     let Some(recovery_ctx) = recovery_ctx else {
@@ -926,8 +885,8 @@ fn register_unwrapped_equity_recovery_worker(
             index,
             recovery_queue.clone(),
             recovery_ctx.clone(),
-            fail_stop.clone(),
-            failure_notify.clone(),
+            WORKER_CIRCUIT_POLICY,
+            notifier.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector.clone(),
         )
@@ -942,8 +901,7 @@ fn register_transfer_usdc_to_hedging_worker(
     monitor: Monitor,
     transfer_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
     transfer_queue: TransferUsdcToHedgingJobQueue,
-    FailStopCircuit(fail_stop): FailStopCircuit,
-    failure_notify: Arc<tokio::sync::Notify>,
+    notifier: Arc<dyn Notifier>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
     let Some(transfer_ctx) = transfer_ctx else {
@@ -960,8 +918,8 @@ fn register_transfer_usdc_to_hedging_worker(
             index,
             transfer_queue.clone(),
             transfer_ctx.clone(),
-            fail_stop.clone(),
-            failure_notify.clone(),
+            WORKER_CIRCUIT_POLICY,
+            notifier.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector.clone(),
         )
@@ -974,8 +932,7 @@ fn register_transfer_usdc_to_market_making_worker(
     monitor: Monitor,
     transfer_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
     transfer_queue: TransferUsdcToMarketMakingJobQueue,
-    FailStopCircuit(fail_stop): FailStopCircuit,
-    failure_notify: Arc<tokio::sync::Notify>,
+    notifier: Arc<dyn Notifier>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
     let Some(transfer_ctx) = transfer_ctx else {
@@ -992,8 +949,8 @@ fn register_transfer_usdc_to_market_making_worker(
             index,
             transfer_queue.clone(),
             transfer_ctx.clone(),
-            fail_stop.clone(),
-            failure_notify.clone(),
+            WORKER_CIRCUIT_POLICY,
+            notifier.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector.clone(),
         )

--- a/src/conductor/exit.rs
+++ b/src/conductor/exit.rs
@@ -10,8 +10,6 @@ use tracing::{error, info};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum MonitorTaskError {
-    #[error("Apalis worker failed after retries")]
-    TerminalJobFailure,
     #[error("Apalis monitor exited unexpectedly")]
     UnexpectedExit {
         #[source]
@@ -127,16 +125,6 @@ mod tests {
     #[tokio::test]
     async fn monitor_inner_ok_returns_ok() {
         ConductorExit::Monitor(Ok(Ok(()))).handle().unwrap();
-    }
-
-    #[tokio::test]
-    async fn monitor_inner_terminal_job_failure_returns_monitor_variant() {
-        assert!(matches!(
-            ConductorExit::Monitor(Ok(Err(MonitorTaskError::TerminalJobFailure)))
-                .handle()
-                .unwrap_err(),
-            ConductorExitError::Monitor(MonitorTaskError::TerminalJobFailure)
-        ));
     }
 
     #[tokio::test]

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -11,21 +11,232 @@ use apalis_core::backend::TaskSinkError;
 use apalis_core::backend::poll_strategy::{BackoffConfig, IntervalStrategy, StrategyBuilder};
 use apalis_core::worker::context::WorkerContext;
 use apalis_core::worker::event::Event;
-use apalis_sqlite::{Config, SqliteContext, SqlitePool, SqliteStorage, SqlxError};
+use apalis_sqlite::{Config, SqliteContext, SqlitePool, SqliteStorage, SqlxError, TaskBuilderExt};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::fmt;
+use std::num::NonZeroU32;
 use std::sync::Arc;
-#[cfg(any(test, feature = "test-support"))]
 use std::sync::Mutex;
-use std::time::Duration;
-use tracing::{debug, error, warn};
+use std::time::{Duration, Instant};
+use tracing::{debug, error, info, warn};
 
-/// Recovery timeout for the fail-stop circuit breaker. Effectively
-/// infinite for any plausible bot uptime; chosen to be finite so
-/// `last_failure + recovery_timeout` cannot overflow if apalis
-/// changes its check from `elapsed() >=` to addition.
-pub(crate) const FAIL_STOP_RECOVERY_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24 * 365);
+use crate::alerts::Notifier;
+
+/// Production policy for workers whose terminal systemic failures must pause
+/// new work and recover without restarting the process.
+#[cfg(not(any(test, feature = "test-support")))]
+pub(crate) const WORKER_CIRCUIT_POLICY: WorkerCircuitPolicy = WorkerCircuitPolicy::new(
+    NonZeroU32::MIN,
+    Duration::from_secs(5 * 60),
+    Duration::from_secs(60 * 60),
+);
+
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) const WORKER_CIRCUIT_POLICY: WorkerCircuitPolicy = WorkerCircuitPolicy::new(
+    NonZeroU32::MIN,
+    Duration::from_millis(10),
+    Duration::from_secs(60 * 60),
+);
+
+pub(crate) const JOB_RETRIES: usize = 3;
+const JOB_MAX_ATTEMPTS: u32 = 4;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct WorkerCircuitPolicy {
+    failure_threshold: NonZeroU32,
+    recovery_timeout: Duration,
+    realert_interval: Duration,
+}
+
+impl WorkerCircuitPolicy {
+    pub(crate) const fn new(
+        failure_threshold: NonZeroU32,
+        recovery_timeout: Duration,
+        realert_interval: Duration,
+    ) -> Self {
+        Self {
+            failure_threshold,
+            recovery_timeout,
+            realert_interval,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkerCircuitState {
+    Closed { consecutive_failures: u32 },
+    Open,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum WorkerCircuitTransition {
+    Opened,
+    Recovered,
+}
+
+impl fmt::Display for WorkerCircuitTransition {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Opened => formatter.write_str("opened"),
+            Self::Recovered => formatter.write_str("recovered"),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct RecoveringWorkerCircuit {
+    policy: WorkerCircuitPolicy,
+    state: Arc<Mutex<WorkerCircuitState>>,
+    last_alerted: Arc<Mutex<Option<Instant>>>,
+    notifier: Arc<dyn Notifier>,
+}
+
+impl RecoveringWorkerCircuit {
+    pub(crate) fn new(policy: WorkerCircuitPolicy, notifier: Arc<dyn Notifier>) -> Self {
+        Self {
+            policy,
+            state: Arc::new(Mutex::new(WorkerCircuitState::Closed {
+                consecutive_failures: 0,
+            })),
+            last_alerted: Arc::new(Mutex::new(None)),
+            notifier,
+        }
+    }
+
+    fn record_success(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if matches!(*state, WorkerCircuitState::Closed { .. }) {
+            *state = WorkerCircuitState::Closed {
+                consecutive_failures: 0,
+            };
+        }
+    }
+
+    fn record_failure(&self) -> Option<u32> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let WorkerCircuitState::Closed {
+            consecutive_failures,
+        } = *state
+        else {
+            return None;
+        };
+
+        let consecutive_failures = consecutive_failures.saturating_add(1);
+        if consecutive_failures < self.policy.failure_threshold.get() {
+            *state = WorkerCircuitState::Closed {
+                consecutive_failures,
+            };
+            return None;
+        }
+
+        *state = WorkerCircuitState::Open;
+        drop(state);
+        Some(consecutive_failures)
+    }
+
+    fn schedule_recovery(&self, worker: WorkerContext) {
+        let recovery_timeout = self.policy.recovery_timeout;
+        let state = self.state.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(recovery_timeout).await;
+            *state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = WorkerCircuitState::Closed {
+                consecutive_failures: 0,
+            };
+
+            match worker.resume() {
+                Ok(()) => info!(
+                    worker = %worker.name(),
+                    worker_circuit_transition = %WorkerCircuitTransition::Recovered,
+                    "Worker circuit recovered after cooldown"
+                ),
+                Err(_) if worker.is_running() => info!(
+                    worker = %worker.name(),
+                    worker_circuit_transition = %WorkerCircuitTransition::Recovered,
+                    "Worker circuit was already resumed after cooldown"
+                ),
+                Err(error) => warn!(
+                    worker = %worker.name(),
+                    ?error,
+                    "Worker circuit cooldown elapsed but the worker could not resume"
+                ),
+            }
+        });
+    }
+
+    fn should_alert(&self, now: Instant) -> bool {
+        let mut last_alerted = self
+            .last_alerted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if last_alerted
+            .is_some_and(|last| now.saturating_duration_since(last) < self.policy.realert_interval)
+        {
+            return false;
+        }
+
+        *last_alerted = Some(now);
+        true
+    }
+
+    fn alert(&self, worker_name: String, error_msg: &'static str) {
+        let notifier = self.notifier.clone();
+        tokio::spawn(async move {
+            let message = format!("{error_msg}: worker {worker_name} paused for recovery");
+            if let Err(error) = notifier.notify(&message).await {
+                warn!(
+                    worker = %worker_name,
+                    ?error,
+                    "Failed to deliver worker circuit-open alert"
+                );
+            }
+        });
+    }
+}
+
+pub(crate) fn on_recovering_circuit_event(
+    circuit: RecoveringWorkerCircuit,
+    error_msg: &'static str,
+) -> impl Fn(&WorkerContext, &Event) + Send + Sync + 'static {
+    move |ctx, event| match event {
+        Event::Success => circuit.record_success(),
+        Event::Error(error) => {
+            let Some(consecutive_failures) = circuit.record_failure() else {
+                return;
+            };
+
+            if let Err(pause_error) = ctx.pause() {
+                error!(
+                    worker = %ctx.name(),
+                    ?pause_error,
+                    "Worker circuit opened but the worker could not pause"
+                );
+            }
+
+            error!(
+                worker = %ctx.name(),
+                worker_circuit_transition = %WorkerCircuitTransition::Opened,
+                consecutive_failures,
+                recovery_timeout_seconds = circuit.policy.recovery_timeout.as_secs(),
+                %error,
+                "{error_msg}"
+            );
+            if circuit.should_alert(Instant::now()) {
+                circuit.alert(ctx.name().clone(), error_msg);
+            }
+            circuit.schedule_recovery(ctx.clone());
+        }
+        _ => {}
+    }
+}
 
 /// Deterministic exponential backoff for the apalis retry layer.
 /// Doubles the delay each attempt up to `max`, with no jitter (unnecessary
@@ -128,7 +339,10 @@ impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static> JobQueu
     }
 
     pub(crate) async fn push(&mut self, task: Task) -> Result<(), QueuePushError> {
-        Ok(TaskSink::push(&mut self.0, task).await?)
+        let task = TaskBuilder::<Task, SqliteContext, _>::new(task)
+            .max_attempts(JOB_MAX_ATTEMPTS)
+            .build();
+        Ok(TaskSink::push_task(&mut self.0, task).await?)
     }
 
     /// Schedules a task to run after `delay` from now. Used by self-rescheduling
@@ -142,6 +356,7 @@ impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static> JobQueu
         delay: Duration,
     ) -> Result<(), QueuePushError> {
         let scheduled = TaskBuilder::<Task, SqliteContext, _>::new(task)
+            .max_attempts(JOB_MAX_ATTEMPTS)
             .run_after(delay)
             .build();
         Ok(TaskSink::push_task(&mut self.0, scheduled).await?)
@@ -282,22 +497,19 @@ where
 /// modules.
 ///
 /// `$on_event:expr` must be a value of type
-/// `impl Fn(&WorkerContext, &Event) + Send + Sync + 'static`, produced by
-/// [`on_terminal_failure`].
+/// `impl Fn(&WorkerContext, &Event) + Send + Sync + 'static`.
 macro_rules! build_worker_inner {
     (
         ::<$ctx_type:ty, $job:ty>,
         $index:expr,
         $queue:expr,
         $ctx:expr,
-        $circuit:expr,
         $on_event:expr
         $(, $failure_injector:expr)? $(,)?
     ) => {{
         use ::apalis::layers::WorkerBuilderExt;
         use ::apalis::layers::retry::RetryPolicy;
         use ::apalis::prelude::WorkerBuilder;
-        use ::apalis_core::worker::ext::circuit_breaker::CircuitBreaker;
         use ::apalis_core::worker::ext::event_listener::EventListenerExt;
 
         let builder = WorkerBuilder::new(format!(
@@ -318,10 +530,9 @@ macro_rules! build_worker_inner {
         builder
             .concurrency(1)
             .retry(
-                RetryPolicy::retries(3)
+                RetryPolicy::retries($crate::conductor::job::JOB_RETRIES)
                     .with_backoff($crate::conductor::job::RETRY_BACKOFF.clone()),
             )
-            .break_circuit_with($circuit)
             .on_event($on_event)
             .build($crate::conductor::job::work::<$ctx_type, $job>)
     }};
@@ -333,7 +544,7 @@ pub(crate) use build_worker_inner;
 ///
 /// Mirrors the `work::<Ctx, Job>` turbofish style: pass the same two
 /// types and the macro expands to a fully-wired worker (queue backend,
-/// retry policy, fail-stop circuit breaker, terminal-failure notifier,
+/// retry policy, recovering worker circuit, terminal-failure notifier,
 /// `.build(work::<Ctx, Job>)`).
 ///
 /// A macro because `.build()` returns a deeply-nested
@@ -347,8 +558,8 @@ macro_rules! build_supervised_worker {
         $index:expr,
         $queue:expr,
         $ctx:expr,
-        $fail_stop:expr,
-        $failure_notify:expr
+        $circuit_policy:expr,
+        $notifier:expr
         $(, $failure_injector:expr)? $(,)?
     ) => {{
         build_worker_inner!(
@@ -356,9 +567,11 @@ macro_rules! build_supervised_worker {
             $index,
             $queue,
             $ctx,
-            $fail_stop,
-            $crate::conductor::job::on_terminal_failure(
-                $failure_notify,
+            $crate::conductor::job::on_recovering_circuit_event(
+                $crate::conductor::job::RecoveringWorkerCircuit::new(
+                    $circuit_policy,
+                    $notifier,
+                ),
                 <$job as $crate::conductor::job::Job<$ctx_type>>::TERMINAL_FAILURE_MSG,
             )
             $(, $failure_injector)?
@@ -371,7 +584,7 @@ pub(crate) use build_supervised_worker;
 /// Builds a best-effort `Worker` for a `Job<Ctx>` impl.
 ///
 /// A terminal job failure is logged at `error!` level but does NOT trip the
-/// conductor-wide fail-stop, does NOT stop the worker, and does NOT install an
+/// recovering worker circuit, does NOT pause the worker, and does NOT install a
 /// Apalis circuit breaker. The circuit breaker can latch a single-concurrency
 /// worker idle after retries are exhausted because `poll_ready` returns
 /// `Pending` without scheduling a wakeup when the circuit is open.
@@ -411,7 +624,7 @@ macro_rules! build_best_effort_worker {
         builder
             .concurrency(1)
             .retry(
-                RetryPolicy::retries(3)
+                RetryPolicy::retries($crate::conductor::job::JOB_RETRIES)
                     .with_backoff($crate::conductor::job::RETRY_BACKOFF.clone()),
             )
             .on_event($crate::conductor::job::on_terminal_failure_log_only(
@@ -671,22 +884,6 @@ where
     })
 }
 
-/// On-event handler shared by every supervised worker: when apalis
-/// reports a terminal job failure (retries exhausted), notify the
-/// monitor task and stop the worker.
-pub(crate) fn on_terminal_failure(
-    failure_notify: Arc<tokio::sync::Notify>,
-    error_msg: &'static str,
-) -> impl Fn(&WorkerContext, &Event) + Send + Sync + 'static {
-    move |ctx, event| {
-        if let Event::Error(err) = event {
-            error!(%err, worker = %ctx.name(), "{error_msg}");
-            failure_notify.notify_waiters();
-            let _ = ctx.stop();
-        }
-    }
-}
-
 /// On-event handler for workers where terminal failure must not crash the
 /// conductor. Logs the error at `error!` level but does NOT call
 /// `failure_notify.notify_waiters()` and does NOT call `ctx.stop()`.
@@ -695,9 +892,8 @@ pub(crate) fn on_terminal_failure(
 /// not bring down hedging and fill detection. See [`build_best_effort_worker!`]
 /// for why these workers do not install Apalis' circuit-breaker layer.
 ///
-/// Structural invariant: unlike [`on_terminal_failure`], this function takes
-/// no `Notify` argument and therefore can never call `notify_waiters()` or
-/// `ctx.stop()`, regardless of how it is called.
+/// Structural invariant: this function takes no circuit policy or notifier and
+/// therefore cannot pause the worker or page for a systemic failure.
 pub(crate) fn on_terminal_failure_log_only(
     error_msg: &'static str,
 ) -> impl Fn(&WorkerContext, &Event) + Send + Sync + 'static {
@@ -711,7 +907,6 @@ pub(crate) fn on_terminal_failure_log_only(
 #[cfg(test)]
 mod tests {
     use apalis::prelude::{Monitor, Status};
-    use apalis_core::worker::ext::circuit_breaker::config::CircuitBreakerConfig;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
@@ -756,6 +951,11 @@ mod tests {
             "workers run with concurrency(1), so the SQLite fetch buffer must \
              not reserve extra rows as Queued before a handler can execute them",
         );
+    }
+
+    #[test]
+    fn durable_attempt_limit_matches_middleware_retry_budget() {
+        assert_eq!(usize::try_from(JOB_MAX_ATTEMPTS).unwrap(), JOB_RETRIES + 1,);
     }
 
     #[test]
@@ -937,33 +1137,162 @@ mod tests {
     #[error("test job deliberately failed")]
     struct TestJobError;
 
-    /// A job that fails after all retries must halt further processing --
-    /// the worker must not pick up the next job with stale state.
+    fn test_error_event() -> Event {
+        let error: apalis_core::error::BoxDynError = Box::new(TestJobError);
+        Event::Error(Arc::new(error))
+    }
+
+    #[test]
+    fn worker_circuit_suppresses_alerts_until_realert_interval_elapses() {
+        let circuit = RecoveringWorkerCircuit::new(
+            WorkerCircuitPolicy::new(
+                NonZeroU32::MIN,
+                Duration::from_millis(10),
+                Duration::from_secs(60 * 60),
+            ),
+            Arc::new(crate::alerts::CapturingNotifier::default()),
+        );
+        let first_alert = Instant::now();
+
+        assert!(circuit.should_alert(first_alert));
+        assert!(!circuit.should_alert(first_alert + Duration::from_secs(5 * 60)));
+        assert!(circuit.should_alert(first_alert + Duration::from_secs(60 * 60)));
+    }
+
     #[tokio::test]
-    async fn job_failure_after_retries_halts_processing() {
+    #[tracing_test::traced_test]
+    async fn worker_circuit_alerts_and_recovers_without_process_restart() {
+        let notifier = Arc::new(crate::alerts::CapturingNotifier::default());
+        let circuit = RecoveringWorkerCircuit::new(
+            WorkerCircuitPolicy::new(
+                NonZeroU32::MIN,
+                Duration::from_millis(10),
+                Duration::from_secs(60 * 60),
+            ),
+            notifier.clone(),
+        );
+        let on_event = on_recovering_circuit_event(circuit, "Test worker circuit opened");
+        let mut worker = WorkerContext::new::<()>("recovering-test-worker");
+        worker.start().unwrap();
+
+        on_event(&worker, &test_error_event());
+
+        assert!(
+            worker.is_paused(),
+            "the first systemic failure must fail fast"
+        );
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !worker.is_running() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the worker must resume after the finite recovery timeout");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while notifier.messages().is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("opening the circuit must emit an operator alert");
+
+        assert!(
+            notifier.messages()[0].contains("recovering-test-worker"),
+            "the alert must identify the affected worker"
+        );
+        assert!(logs_contain("worker_circuit_transition=opened"));
+        assert!(logs_contain("worker_circuit_transition=recovered"));
+    }
+
+    #[tokio::test]
+    async fn worker_circuit_recovers_when_pause_reports_already_paused() {
+        let notifier = Arc::new(crate::alerts::CapturingNotifier::default());
+        let circuit = RecoveringWorkerCircuit::new(
+            WorkerCircuitPolicy::new(
+                NonZeroU32::MIN,
+                Duration::from_millis(10),
+                Duration::from_secs(60 * 60),
+            ),
+            notifier.clone(),
+        );
+        let on_event = on_recovering_circuit_event(circuit, "Test worker circuit opened");
+        let mut worker = WorkerContext::new::<()>("already-paused-test-worker");
+        worker.start().unwrap();
+        worker.pause().unwrap();
+
+        on_event(&worker, &test_error_event());
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !worker.is_running() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("pause failure must not prevent circuit recovery");
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while notifier.messages().is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("pause failure must not suppress the circuit alert");
+    }
+
+    #[tokio::test]
+    async fn worker_circuit_counts_consecutive_not_lifetime_failures() {
+        let notifier = Arc::new(crate::alerts::CapturingNotifier::default());
+        let circuit = RecoveringWorkerCircuit::new(
+            WorkerCircuitPolicy::new(
+                NonZeroU32::new(2).unwrap(),
+                Duration::from_millis(10),
+                Duration::from_secs(60 * 60),
+            ),
+            notifier,
+        );
+        let on_event = on_recovering_circuit_event(circuit, "Test worker circuit opened");
+        let mut worker = WorkerContext::new::<()>("consecutive-test-worker");
+        worker.start().unwrap();
+
+        on_event(&worker, &test_error_event());
+        assert!(worker.is_running());
+        on_event(&worker, &Event::Success);
+        on_event(&worker, &test_error_event());
+        assert!(
+            worker.is_running(),
+            "a success must reset failures accumulated while closed"
+        );
+        on_event(&worker, &test_error_event());
+        assert!(
+            worker.is_paused(),
+            "two consecutive failures must open the circuit"
+        );
+    }
+
+    /// A terminal systemic failure pauses the worker, alerts, and then resumes
+    /// sibling processing after the configured cooldown.
+    #[tokio::test]
+    async fn supervised_worker_recovers_after_terminal_failure() {
         let apalis_pool = setup_test_apalis_pool().await;
 
         let mut queue: JobQueue<TestJob> = JobQueue::new(&apalis_pool);
         queue.push(TestJob { should_fail: true }).await.unwrap();
         let mut push_queue = queue.clone();
 
-        let failure_notify = Arc::new(tokio::sync::Notify::new());
+        let notifier = Arc::new(crate::alerts::CapturingNotifier::default());
         let failing_job_started = Arc::new(tokio::sync::Notify::new());
+        let success_notify = Arc::new(tokio::sync::Notify::new());
         let ctx = Arc::new(TestCtx {
             success_count: AtomicUsize::new(0),
-            success_notify: Arc::new(tokio::sync::Notify::new()),
+            success_notify: success_notify.clone(),
             failing_job_started: failing_job_started.clone(),
         });
         let ctx_for_assert = ctx.clone();
 
-        let fail_stop = CircuitBreakerConfig::default()
-            .with_failure_threshold(1)
-            .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
-
-        let failing_job_started_wait = failing_job_started.notified();
+        let success_wait = success_notify.notified();
 
         let monitor_handle = tokio::spawn({
-            let failure_notify = failure_notify.clone();
+            let notifier = notifier.clone();
             let monitor = Monitor::new()
                 .should_restart(|_ctx, _error, _attempt| false)
                 .register(move |index| {
@@ -972,8 +1301,12 @@ mod tests {
                         index,
                         queue.clone(),
                         ctx.clone(),
-                        fail_stop.clone(),
-                        failure_notify.clone(),
+                        WorkerCircuitPolicy::new(
+                            NonZeroU32::MIN,
+                            Duration::from_millis(10),
+                            Duration::from_secs(60 * 60),
+                        ),
+                        notifier.clone(),
                         FailureInjector::new(),
                     )
                 });
@@ -983,86 +1316,31 @@ mod tests {
             }
         });
 
-        if tokio::time::timeout(Duration::from_secs(10), failing_job_started_wait)
-            .await
-            .is_err()
-        {
-            panic!(
-                "failing job should start before sibling is enqueued; job rows: {:?}",
-                job_rows_for_assertion(&apalis_pool).await
-            );
-        }
+        wait_for_terminal_test_job(&apalis_pool).await;
 
         push_queue
             .push(TestJob { should_fail: false })
             .await
             .unwrap();
 
-        wait_for_fail_stop_without_processing_sibling(
-            &apalis_pool,
-            &failure_notify,
-            monitor_handle,
-        )
-        .await;
+        tokio::time::timeout(Duration::from_secs(15), success_wait)
+            .await
+            .expect("the worker must resume and process the healthy sibling");
 
         assert_eq!(
             ctx_for_assert.success_count.load(Ordering::SeqCst),
-            0,
-            "The second job should NOT have been processed after a prior \
-             job failed all retries; job rows: {:?}",
+            1,
+            "the healthy sibling must complete after circuit recovery; job rows: {:?}",
             job_rows_for_assertion(&apalis_pool).await
         );
-    }
-
-    async fn wait_for_fail_stop_without_processing_sibling(
-        apalis_pool: &apalis_sqlite::SqlitePool,
-        failure_notify: &Arc<tokio::sync::Notify>,
-        monitor_handle: tokio::task::JoinHandle<()>,
-    ) {
-        let terminal = tokio::time::timeout(Duration::from_secs(30), async {
-            loop {
-                let rows = job_rows_for_assertion(apalis_pool).await;
-                if rows
-                    .iter()
-                    .any(|(_, status, _, _, _)| status == &Status::Done.to_string())
-                {
-                    panic!(
-                        "pre-queued sibling job must not reach Done while the failing job \
-                         is still retrying or before the worker halts; job rows: {rows:?}"
-                    );
-                }
-
-                if monitor_handle.is_finished() {
-                    return;
-                }
-
-                tokio::select! {
-                    () = failure_notify.notified() => {
-                        // Terminal failure fired stop; give the monitor a moment to exit.
-                        for _ in 0..100 {
-                            if monitor_handle.is_finished() {
-                                return;
-                            }
-                            tokio::time::sleep(Duration::from_millis(10)).await;
-                        }
-                        return;
-                    }
-                    () = tokio::time::sleep(Duration::from_millis(10)) => {}
-                }
-            }
-        })
-        .await;
-
-        assert!(
-            terminal.is_ok(),
-            "failing job should reach terminal state and halt the worker; job rows at timeout: {:?}",
-            job_rows_for_assertion(apalis_pool).await
+        let job_rows = job_rows_for_assertion(&apalis_pool).await;
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "one exhausted job must page exactly once; job rows: {job_rows:?}"
         );
-
-        let join_result = tokio::time::timeout(Duration::from_secs(5), monitor_handle)
-            .await
-            .expect("Monitor should exit within 5s after terminal job failure");
-        join_result.expect("Monitor task should not panic");
+        assert!(!monitor_handle.is_finished(), "the monitor must stay alive");
+        monitor_handle.abort();
     }
 
     async fn insert_job(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,16 @@ pub use position::Position;
 pub fn check_positions_job_type() -> &'static str {
     std::any::type_name::<position_check::CheckPositions>()
 }
+/// Returns the apalis job type identifier for the `PollOrderStatus` job.
+#[cfg(any(test, feature = "test-support"))]
+pub fn poll_order_status_job_type() -> &'static str {
+    std::any::type_name::<offchain::order::poll_status::PollOrderStatus>()
+}
+/// Returns the apalis job type identifier for the `AccountForDexTrade` job.
+#[cfg(any(test, feature = "test-support"))]
+pub fn account_for_dex_trade_job_type() -> &'static str {
+    std::any::type_name::<trading::onchain::trade_accountant::AccountForDexTrade>()
+}
 #[cfg(any(test, feature = "test-support"))]
 pub use conductor::job::{FailureInjector, JobKind};
 #[cfg(any(test, feature = "test-support"))]

--- a/src/onchain/trade.rs
+++ b/src/onchain/trade.rs
@@ -273,7 +273,7 @@ pub(crate) const INVENTORY_TOKEN_DECIMALS_MAX_RETRIES: usize = 3;
 /// code, or returns malformed data) is a genuine defect in that token and
 /// must not surface as an opaque `OnChainError::Evm`: `perform()` doesn't
 /// catch that variant, so apalis retries would exhaust and trip the
-/// conductor-wide fail-stop over a single misbehaving third-party token.
+/// worker circuit over a single misbehaving third-party token.
 ///
 /// But `EvmError::Contract` is *also* produced for pure transport failures
 /// (connection reset, timeout) when no revert data could be decoded --
@@ -488,7 +488,7 @@ impl OnchainTrade {
         // extreme raw amount from a misbehaving venue). Reclassified into
         // `InvalidInventoryAmount` rather than the top-level
         // `OnChainError::FloatConversion` `?` would otherwise resolve to, so
-        // `perform()` can skip this fill instead of fail-stopping.
+        // `perform()` can skip this fill instead of opening the worker circuit.
         //
         // Unlike the ClearV3/TakeOrderV3 path's `Float::from_raw` above,
         // `OperatorDeposit`/`OperatorWithdraw` amounts are raw fixed-decimal
@@ -507,7 +507,7 @@ impl OnchainTrade {
         // (`try_from_order_and_fill_details` above, which calls it directly
         // and leaves its Float-conversion failures uncaught by `perform()` --
         // there they come from the bot's own trusted order config, so such a
-        // failure indicates a real bug worth fail-stopping on). Here the
+        // failure indicates a real bug worth opening the worker circuit on). Here the
         // amounts are externally supplied, so reclassify only the
         // Float-conversion failures into the caught `InvalidInventoryAmount`
         // variant; everything else (e.g. `InvalidSymbolConfiguration`) passes
@@ -691,7 +691,7 @@ struct InventoryRecoveryConfig<'config> {
 
 /// Reclassifies a Float-conversion failure surfaced by the shared
 /// `TradeDetails::try_from_io` into [`TradeValidationError::InvalidInventoryAmount`]
-/// so `perform()` can skip the fill instead of fail-stopping. Only called
+/// so `perform()` can skip the fill instead of opening the worker circuit. Only called
 /// from [`OnchainTrade::try_from_inventory_trade`] -- the ClearV3/TakeOrderV3
 /// path calls `try_from_io` directly and leaves these variants uncaught,
 /// since a Float-conversion failure there comes from the bot's own trusted
@@ -985,7 +985,7 @@ pub(crate) enum TradeValidationError {
     /// Unlike ClearV3/TakeOrderV3, whose token addresses come from the bot's
     /// own trusted order config, these addresses come from any `OPERATOR_ROLE`
     /// holder on the shared inventory -- a non-standard or misconfigured
-    /// third-party token must not trip the conductor-wide fail-stop.
+    /// third-party token must not open the worker circuit.
     #[error("Failed to introspect InventoryTrade token {token}: {source}")]
     TokenIntrospectionFailed {
         token: Address,
@@ -997,7 +997,7 @@ pub(crate) enum TradeValidationError {
     /// model as `TokenIntrospectionFailed`: `OperatorDeposit`/
     /// `OperatorWithdraw` amounts come from any `OPERATOR_ROLE` holder, not
     /// the bot's own trusted order config, so a malformed or extreme
-    /// amount/decimals pair must not trip the conductor-wide fail-stop.
+    /// amount/decimals pair must not open the worker circuit.
     #[error("Failed to convert InventoryTrade amount: {0}")]
     InvalidInventoryAmount(#[source] FloatError),
     /// An `InventoryTrade` leg's token address does not match the configured
@@ -1005,7 +1005,7 @@ pub(crate) enum TradeValidationError {
     /// ClearV3/TakeOrderV3, whose token addresses come from the bot's own
     /// trusted order config, these addresses come from any `OPERATOR_ROLE`
     /// holder on the shared inventory -- a spoofed or misconfigured token
-    /// must not trip the conductor-wide fail-stop.
+    /// must not open the worker circuit.
     #[error(
         "InventoryTrade token {token} claims symbol '{claimed_symbol}' but does not match \
          the configured canonical address for that symbol"
@@ -2429,7 +2429,7 @@ mod tests {
     /// A genuine revert (malformed/malicious token) on `decimals()` must
     /// still be classified as `TokenIntrospectionFailed` so the fill is
     /// caught and skipped, rather than retried forever and eventually
-    /// tripping the conductor-wide fail-stop.
+    /// opening the worker circuit.
     #[tokio::test]
     async fn fetch_inventory_token_decimals_classifies_genuine_revert_as_token_introspection_failed()
      {

--- a/src/rebalancing/equity/resume_job.rs
+++ b/src/rebalancing/equity/resume_job.rs
@@ -11,7 +11,7 @@
 //!
 //! Transient errors propagate as `Err` so apalis retries up to three times.
 //! If all retries are exhausted the terminal failure is logged at `error!` but
-//! does NOT trip the conductor-wide fail-stop, so hedging and fill detection
+//! does NOT open a recovering worker circuit, so hedging and fill detection
 //! continue running. Aggregates already in a terminal state return `Ok(())`
 //! (idempotent).
 

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -274,7 +274,7 @@ impl<
     /// USDC is already burned, so the aggregate is moved to `BridgingFailed`
     /// via `FailBridging` -- surfacing a durable terminal state for operator
     /// reconciliation rather than wedging the rebalance in a non-terminal state
-    /// while the worker exhausts retries and fail-stops.
+    /// while the worker exhausts retries and opens its recovering circuit.
     async fn poll_cctp_attestation(
         &self,
         id: &UsdcRebalanceId,

--- a/src/trading/onchain/skipped_fill.rs
+++ b/src/trading/onchain/skipped_fill.rs
@@ -1,7 +1,7 @@
 //! Durable record of on-chain fills the accountant skipped instead of hedging.
 //!
 //! [`AccountForDexTrade`] swallows unpriceable fills and non-hedgeable pairs so a
-//! single anomalous (or crafted) fill cannot trip the conductor-wide fail-stop.
+//! single anomalous (or crafted) fill cannot open the worker circuit.
 //! Persisting them here means a skipped fill survives log rotation and can be
 //! reconciled by hand, rather than being visible only in an `error!` line.
 //!

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -170,8 +170,8 @@ where
                 // An unpriceable fill (non-zero equity moved at a non-positive
                 // USDC/share price) is anomalous and possibly adversarial. Surface
                 // it loudly and skip THIS fill only -- propagating the error would
-                // exhaust the worker retries and trip the conductor-wide fail-stop,
-                // letting one crafted on-chain fill take the whole bot down.
+                // exhaust the worker retries and pause this supervised worker
+                // while its recovering circuit is open.
                 error!(
                     target: "hedge",
                     event_type = trade_event.event.kind(),
@@ -197,7 +197,7 @@ where
                 // holder on the shared inventory (Bebop hook, univ4 hook, or a
                 // future venue), not the bot's own trusted order config. A
                 // non-standard token there must not be allowed to exhaust
-                // worker retries and trip the conductor-wide fail-stop --
+                // worker retries and open its recovering circuit --
                 // skip THIS fill only, same as an unpriceable fill.
                 error!(
                     target: "hedge",
@@ -225,8 +225,8 @@ where
                 // the resolved equity). Same threat model as
                 // TokenIntrospectionFailed: any OPERATOR_ROLE holder can
                 // supply this token, so a spoofed/misconfigured one must not
-                // exhaust worker retries and trip the conductor-wide
-                // fail-stop -- skip THIS fill only.
+                // exhaust worker retries and pause this supervised worker
+                // while its recovering circuit is open -- skip THIS fill only.
                 error!(
                     target: "hedge",
                     event_type = trade_event.event.kind(),
@@ -252,7 +252,7 @@ where
                 // OPERATOR_ROLE holder on the shared inventory, same threat
                 // model as TokenIntrospectionFailed above: a malformed or
                 // extreme amount must not exhaust worker retries and trip
-                // the conductor-wide fail-stop -- skip THIS fill only.
+                // the worker circuit -- skip THIS fill only.
                 error!(
                     target: "hedge",
                     event_type = trade_event.event.kind(),
@@ -325,7 +325,7 @@ where
 /// Best-effort durable record of a skipped fill for manual reconciliation. A
 /// persistence failure is logged but never propagated: the whole point of the
 /// skip is to not fail the job, so a write hiccup must not resurrect the
-/// fail-stop it exists to avoid.
+/// worker circuit it exists to avoid.
 async fn persist_skipped_fill(
     pool: &SqlitePool,
     trade_event: &EmittedOnChain<RaindexTradeEvent>,
@@ -698,8 +698,8 @@ mod tests {
     /// A fill whose USDC/share price is non-positive (zero USDC against non-zero
     /// equity) is anomalous and possibly adversarial. `perform` must surface it
     /// and skip THIS fill only -- returning Ok(()) -- rather than propagating the
-    /// error, which would exhaust the worker retries and trip the conductor-wide
-    /// fail-stop, letting one crafted fill take the whole bot down.
+    /// error, which would exhaust the worker retries and pause this supervised
+    /// worker while its recovering circuit is open.
     #[tokio::test]
     async fn perform_skips_unpriceable_fill() {
         let (pool, apalis_pool) = setup_test_pools().await;
@@ -840,7 +840,7 @@ mod tests {
     /// An `InventoryTrade` whose two vault deltas are the same non-USDC token
     /// (a non-hedgeable pair) must be routed through `try_from_inventory_trade`
     /// and skipped gracefully -- exercising the InventoryTrade accounting arm
-    /// end to end without tripping the fail-stop.
+    /// end to end without opening the worker circuit.
     #[tokio::test]
     async fn perform_skips_inventory_trade_with_non_hedgeable_pair() {
         let (pool, apalis_pool) = setup_test_pools().await;
@@ -1000,7 +1000,7 @@ mod tests {
         .await;
 
         // Should succeed (skip) rather than error -- a spoofed token address
-        // must not trip the fail-stop.
+        // must not open the worker circuit.
         job.perform(&accountant_ctx).await.unwrap();
 
         let recorded = sqlx::query!(
@@ -1019,7 +1019,7 @@ mod tests {
     /// introspection (a non-standard or reverting ERC20 -- these addresses
     /// come from any OPERATOR_ROLE holder, not the bot's own trusted order
     /// config) must be classified as `TokenIntrospectionFailed` and skipped
-    /// gracefully through `perform()` rather than tripping the fail-stop.
+    /// gracefully through `perform()` rather than opening the worker circuit.
     #[tokio::test]
     async fn perform_skips_inventory_trade_with_unintrospectable_token() {
         let (pool, apalis_pool) = setup_test_pools().await;
@@ -1097,7 +1097,7 @@ mod tests {
         .await;
 
         // Should succeed (skip) rather than error, so a misbehaving
-        // third-party token cannot exhaust retries and trip the fail-stop.
+        // third-party token cannot exhaust retries and open the worker circuit.
         job.perform(&accountant_ctx).await.unwrap();
 
         let recorded = sqlx::query!(
@@ -1116,7 +1116,7 @@ mod tests {
     /// represented as a `rain_math_float` value (here `U256::MAX`, which
     /// deterministically overflows `Float::from_fixed_decimal` regardless of
     /// decimals) must be classified as `InvalidInventoryAmount` and skipped
-    /// gracefully through `perform()` rather than tripping the fail-stop.
+    /// gracefully through `perform()` rather than opening the worker circuit.
     #[tokio::test]
     async fn perform_skips_inventory_trade_with_invalid_amount() {
         let (pool, apalis_pool) = setup_test_pools().await;
@@ -1184,7 +1184,7 @@ mod tests {
         .await;
 
         // Should succeed (skip) rather than error, so a malformed external
-        // amount cannot exhaust retries and trip the fail-stop.
+        // amount cannot exhaust retries and open the worker circuit.
         job.perform(&accountant_ctx).await.unwrap();
 
         let recorded = sqlx::query!(

--- a/src/vault_registry.rs
+++ b/src/vault_registry.rs
@@ -733,13 +733,20 @@ impl Job<SeedVaultRegistryCtx> for SeedVaultRegistry {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{address, b256};
+    use apalis::layers::WorkerBuilderExt;
+    use apalis::layers::retry::RetryPolicy;
+    use apalis::prelude::{Monitor, WorkerBuilder};
+    use apalis_core::worker::event::Event;
+    use apalis_core::worker::ext::event_listener::EventListenerExt;
     use async_trait::async_trait;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     use st0x_event_sorcery::{EntityList, Reactor, StoreBuilder, TestHarness, deps, replay};
 
     use super::*;
+    use crate::conductor::job::{FailureInjector, JobQueue, work};
     use crate::test_utils::{setup_test_db, setup_test_pools};
 
     const TEST_ORDERBOOK: Address = address!("0x1234567890123456789012345678901234567890");
@@ -1744,18 +1751,6 @@ mod tests {
     // happened.
     #[tokio::test]
     async fn enqueued_job_retries_on_aggregate_command_failure() {
-        use apalis::layers::WorkerBuilderExt;
-        use apalis::layers::retry::RetryPolicy;
-        use apalis::prelude::{Monitor, WorkerBuilder};
-        use apalis_core::worker::event::Event;
-        use apalis_core::worker::ext::circuit_breaker::{
-            CircuitBreaker, config::CircuitBreakerConfig,
-        };
-        use apalis_core::worker::ext::event_listener::EventListenerExt;
-        use std::time::Duration;
-
-        use crate::conductor::job::{FAIL_STOP_RECOVERY_TIMEOUT, FailureInjector, JobQueue, work};
-
         let (pool, apalis_pool) = setup_test_pools().await;
 
         let ctx = ctx_with_seeded_assets();
@@ -1775,17 +1770,12 @@ mod tests {
             let monitor = Monitor::new()
                 .should_restart(|_ctx, _error, _attempt| false)
                 .register(move |index| {
-                    let fail_stop = CircuitBreakerConfig::default()
-                        .with_failure_threshold(1)
-                        .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
-
                     WorkerBuilder::new(format!("seed-vault-registry-test-{index}"))
                         .backend(queue_for_worker.clone().into_storage())
                         .data(ctx_for_worker.clone())
                         .data(injector_for_worker.clone())
                         .concurrency(1)
                         .retry(RetryPolicy::retries(3))
-                        .break_circuit_with(fail_stop)
                         .on_event(|ctx, event| {
                             if let Event::Error(_) = event {
                                 let _ = ctx.stop();

--- a/tests/e2e/chaos_alpaca.rs
+++ b/tests/e2e/chaos_alpaca.rs
@@ -19,7 +19,10 @@ use st0x_float_macro::float;
 
 use crate::chaos::LatencyProxy;
 use crate::hedging::assertions::*;
-use crate::poll::{connect_db, fetch_events_by_type, poll_for_events_with_timeout, spawn_bot};
+use crate::poll::{
+    connect_db, fetch_events_by_type, poll_for_events_with_timeout, poll_for_terminal_job,
+    spawn_bot,
+};
 
 /// Response arrives before the client times out -- no transport failure.
 /// Held 5s below the timeout (not 1s) so CI scheduling jitter cannot push the
@@ -533,20 +536,19 @@ fn alpaca_client_timeout_constants_bracket_placement_delay_boundaries() {
 }
 
 /// Top-level hypothesis: a broker outage while a hedge sits `Submitted`
-/// must end in a loud halt -- never a silently un-polled order -- and a
-/// restart with the broker restored must resume polling to exactly one
-/// filled broker order.
+/// must leave a loud terminal job -- never a silently un-polled order -- while
+/// isolating the failure to its worker. A restart with the broker restored must
+/// resume polling to exactly one filled broker order.
 ///
 /// Scenario: the broker mock holds the order "new" indefinitely, the
 /// proxy is severed while the order awaits its fill, and `PollOrderStatus`
 /// exhausts its retry budget against the refused connections. The
-/// fail-stop circuit breaker then halts the bot (the deliberate
-/// fail-stop posture: a one-sided trade must page an operator, not
-/// accumulate silent exposure). On restart with the broker back,
+/// recovering worker circuit then pauses that worker and pages the operator
+/// without stopping the process. On restart with the broker back,
 /// `recover_submitted_offchain_orders` re-enqueues the poll and the
 /// order completes.
 #[test_log::test(tokio::test)]
-async fn broker_outage_with_submitted_order_halts_bot_and_restart_recovers() -> anyhow::Result<()> {
+async fn broker_outage_with_submitted_order_isolated_and_restart_recovers() -> anyhow::Result<()> {
     let equity_symbol = "AAPL";
     let onchain_price = float!(155.00);
     let broker_fill_price = float!(150.25);
@@ -589,18 +591,19 @@ async fn broker_outage_with_submitted_order_halts_bot_and_restart_recovers() -> 
 
     latency.sever();
 
-    // PollOrderStatus exhausts its retries against refused connections;
-    // the fail-stop breaker must halt the bot loudly.
-    let join_result = tokio::time::timeout(Duration::from_secs(60), &mut bot)
-        .await
-        .expect("Bot must halt within 60s of the broker going dark with an order in flight");
-    let error = join_result
-        .expect("Bot task must fail, not panic")
-        .expect_err("Bot must fail-stop, not keep running with an un-pollable order");
-    let chain = format!("{error:#}");
+    // PollOrderStatus exhausts its retries against refused connections. The
+    // terminal queue row remains visible while the bot and sibling workers stay
+    // alive.
+    poll_for_terminal_job(
+        &mut bot,
+        &infra.db_path,
+        st0x_hedge::poll_order_status_job_type(),
+        Duration::from_secs(60),
+    )
+    .await;
     assert!(
-        chain.contains("Apalis worker failed after retries"),
-        "Bot error chain should contain the terminal job failure, got: {chain}",
+        !bot.is_finished(),
+        "a terminal status-poll job must not stop the bot",
     );
 
     // Broker comes back; let the order fill on the next poll.
@@ -608,6 +611,14 @@ async fn broker_outage_with_submitted_order_halts_bot_and_restart_recovers() -> 
         .broker_service
         .set_symbol_fill_delay(Symbol::new(equity_symbol)?, 0);
     latency.restore().await?;
+    bot.abort();
+    let cancellation_error = bot
+        .await
+        .expect_err("aborted bot task must return an error");
+    assert!(
+        cancellation_error.is_cancelled(),
+        "the first bot must finish cancellation before its replacement starts",
+    );
 
     let ctx2 = build_ctx()
         .chain(&infra.base_chain)

--- a/tests/e2e/hedging.rs
+++ b/tests/e2e/hedging.rs
@@ -24,7 +24,7 @@ use st0x_hedge::FailureInjector;
 use self::assertions::*;
 use crate::assert::{assert_broker_state, assert_cqrs_state};
 use crate::base_chain::{self, DeployableERC20, IERC20, USDC_BASE};
-use crate::poll::poll_for_all_jobs_done;
+use crate::poll::{poll_for_all_jobs_done, poll_for_terminal_job};
 
 #[test_log::test(tokio::test)]
 async fn e2e_hedging_via_launch() -> anyhow::Result<()> {
@@ -1491,17 +1491,11 @@ async fn duplicate_event_delivery() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// RAI-199: when a job fails terminally, the bot must halt -- not
-/// silently continue processing subsequent events with stale state.
-///
-/// This is a stopgap: a single worker failure brings down the whole
-/// system. Future work (tracked in Linear) will add system-level
-/// invariant enforcement infrastructure and robust auto-recovery so
-/// individual worker failures are isolated and state inconsistencies
-/// are made impossible, rather than relying on a full halt.
+/// A terminal job failure pauses only its worker, preserves the exhausted job
+/// for diagnosis, and resumes processing after the cooldown.
 #[cfg(feature = "test-support")]
 #[test_log::test(tokio::test)]
-async fn job_failure_halts_bot() -> anyhow::Result<()> {
+async fn job_failure_recovers_worker_without_stopping_bot() -> anyhow::Result<()> {
     let onchain_price = float!(155.00);
     let broker_fill_price = float!(150.25);
     let sell_amount = float!(10.75);
@@ -1553,29 +1547,46 @@ async fn job_failure_halts_bot() -> anyhow::Result<()> {
         .call()
         .await?;
 
-    // The bot should exit -- the injected failure should halt processing
-    let join_result = tokio::time::timeout(Duration::from_secs(30), &mut bot)
-        .await
-        .expect("Bot should exit within 30s after terminal job failure");
-    let inner_result = join_result.expect("Bot task should fail, not panic");
-    let error = inner_result
-        .expect_err("Bot should fail after terminal job failure, not exit successfully");
-    let chain = format!("{error:#}");
-    assert!(
-        chain.contains("Apalis worker failed after retries"),
-        "Bot error chain should contain TerminalJobFailure, got: {chain}"
-    );
-
-    // The second trade's onchain event should NOT have been processed
+    // The failed job remains visible after exhausting retries.
+    poll_for_terminal_job(
+        &mut bot,
+        &infra.db_path,
+        st0x_hedge::account_for_dex_trade_job_type(),
+        Duration::from_secs(30),
+    )
+    .await;
     let pool = connect_db(&infra.db_path).await?;
-    let events_after = count_events(&pool, "OnChainTrade").await?;
-    pool.close().await;
 
     assert_eq!(
-        events_before, events_after,
-        "No new OnChainTrade events should be persisted after terminal failure"
+        events_before,
+        count_events(&pool, "OnChainTrade").await?,
+        "the failed trade must not be accounted"
+    );
+    assert!(
+        !bot.is_finished(),
+        "a terminal job failure must not stop the bot"
     );
 
+    // The worker resumes after its test cooldown and processes the next trade.
+    infra
+        .base_chain
+        .take_order()
+        .symbol("AAPL")
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_events(&mut bot, &infra.db_path, "OffchainOrderEvent::Filled", 2).await;
+    assert_eq!(
+        events_before * 2,
+        count_events(&pool, "OnChainTrade").await?,
+        "the recovered worker must persist the same event sequence for the next trade"
+    );
+
+    pool.close().await;
+    bot.abort();
     Ok(())
 }
 

--- a/tests/e2e/poll.rs
+++ b/tests/e2e/poll.rs
@@ -518,6 +518,51 @@ pub async fn poll_for_running_job(
     }
 }
 
+/// Polls until a job of the given concrete type reaches an apalis terminal
+/// state, panicking if the bot dies or the timeout passes first.
+pub async fn poll_for_terminal_job(
+    bot: &mut JoinHandle<anyhow::Result<()>>,
+    db_path: &std::path::Path,
+    job_type: &str,
+    timeout: Duration,
+) {
+    let connect_opts = SqliteConnectOptions::new().filename(db_path);
+    let deadline = tokio::time::Instant::now() + timeout;
+    let context = format!("terminal {job_type} job");
+
+    loop {
+        sleep_or_crash(bot, &context).await;
+
+        let Ok(pool) = SqlitePool::connect_with(connect_opts.clone()).await else {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timed out after {timeout:?} waiting for {context} (database not ready)",
+            );
+            continue;
+        };
+
+        let terminal: Result<(i64,), _> = sqlx::query_as(
+            "SELECT COUNT(*) FROM Jobs \
+             WHERE job_type = ? AND (status = 'Killed' \
+             OR (status = 'Failed' AND attempts >= max_attempts))",
+        )
+        .bind(job_type)
+        .fetch_one(&pool)
+        .await;
+
+        pool.close().await;
+
+        if matches!(terminal, Ok((count,)) if count >= 1) {
+            return;
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out after {timeout:?} waiting for {context}",
+        );
+    }
+}
+
 /// Polls until the backfill checkpoint has advanced to at least
 /// `block`, panicking if the bot dies or the timeout passes first. Once
 /// the checkpoint passes a fill's block, the fill's accounting job row


### PR DESCRIPTION
## What

[RAI-1051](https://linear.app/makeitrain/issue/RAI-1051)

Recover supervised durable-job workers automatically after terminal retry exhaustion, while isolating the failed worker from unrelated trading and rebalancing jobs.

## Why

A single terminal worker failure previously stopped the entire bot and required a process restart. One exhausted job should open a bounded circuit for its own worker, alert operators once, and recover without interrupting independent financial workflows.

## How

- Track terminal failures with a per-worker recovery circuit.
- Open the circuit after retry exhaustion and schedule a cooldown.
- Stop and restart only the affected worker.
- Reset the circuit after successful work.
- Align persisted job attempts with retry-middleware accounting.
- Emit one operator alert when the circuit opens and log its scheduled recovery.
- Leave explicitly best-effort workers outside supervision.

## Testing

- `nix run .#ci`
- 3,562 tests passed; one restart E2E used its configured retry.
- Clippy and formatting passed.
- Generated DTO and Bun inputs passed.
- Dashboard lint and Svelte checks passed with zero warnings or errors.

## Screenshots

Not applicable.

## Anything else

The production recovery cooldown is five minutes. Tests use a short deterministic cooldown.
