### PR TITLE
feat: ingest persisted bot gas costs into PnL

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -542,6 +542,14 @@ migration files in `migrations/`.
 
 - Calculate profit/loss for each trade pair using actual executed amounts
 - Generate running totals and performance reports over time
+- Include bot-paid gas only from immutable receipt-cost events with a verified
+  payer, strictly positive gas and valuation inputs, and a persisted ETH/USD
+  valuation source
+- Apply the report's `asOfRowid` boundary to bot-gas events exactly as it is
+  applied to other CQRS facts, so later receipt ingestion cannot change a
+  historical report
+- Treat an identical receipt-cost retry as idempotent and reject conflicting
+  facts for the same chain and transaction hash
 - Track inventory positions across both venues
 - Push aggregated metrics to external logging system using structured logging
 - Identify unprofitable trades for strategy optimization

--- a/adrs/0015-bot-gas-pnl-requires-explicit-receipt-cost-ledger.md
+++ b/adrs/0015-bot-gas-pnl-requires-explicit-receipt-cost-ledger.md
@@ -1,0 +1,111 @@
+# ADR 0015: Bot gas PnL requires an explicit receipt cost ledger
+
+- **Status:** Proposed
+- **Date:** 2026-07-16
+- **Linear:** RAI-1406 (parent RAI-1402 -- Extended-hours PnL leaks)
+
+## Context
+
+The `/pnl` endpoint currently reports bot gas as `not_ingested`. RAI-1406 asks
+to include bot gas so net PnL is no longer an upper bound.
+
+The existing persisted data is not enough to do that safely:
+
+- `OnChainTradeEvent::Enriched` records `gas_used`, `effective_gas_price`, and a
+  Pyth equity reference price for the transaction that produced a Raindex fill.
+- A Raindex fill transaction can be submitted by a taker or solver. The existing
+  enrichment does not persist the receipt `from` address or a gas-payer
+  classification, so it cannot prove the bot paid that gas.
+- The enrichment's Pyth price is the traded equity's reference price, not
+  ETH/USD. It cannot value native gas in USD.
+- Rebalancing, wrapping, vault operations, and CCTP burns/mints are the paths
+  where the bot normally pays gas, but their terminal events mostly persist tx
+  hashes and economic CCTP/tokenization fees, not normalized gas-cost facts.
+
+Counting existing receipt gas as bot gas would silently overstate costs whenever
+the fill transaction was paid by someone else, and valuing gas without a
+persisted ETH/USD source would make the PnL report non-reproducible.
+
+## Decision
+
+Do not derive bot gas costs directly from `OnChainTradeEvent::Enriched`.
+
+Bot gas must enter PnL through a dedicated persisted receipt-cost ledger. Each
+recorded cost fact must include:
+
+- transaction hash and chain;
+- receipt `from` address;
+- bot gas-payer classification;
+- gas used and effective gas price;
+- native token cost in wei;
+- ETH/USD price used for valuation, including source and timestamp/block;
+- USD cost;
+- operation category, such as vault deposit, vault withdraw, wrap, unwrap, CCTP
+  burn, CCTP mint, or bot-paid order-management transaction;
+- optional symbol when the gas can be directly attributed to an equity.
+
+The `/pnl` report should include only ledger rows classified as bot-paid. Rows
+without payer classification or USD valuation remain excluded and should
+increment missing-cost diagnostics rather than silently entering PnL.
+
+## Consequences
+
+### Positive
+
+- Prevents solver/taker-paid Raindex fill gas from being charged to the bot.
+- Makes PnL reproducible from persisted facts instead of live RPC or live price
+  lookups at report time.
+- Gives reviewers a clear checklist for the eventual implementation: receipt
+  ingestion, payer classification, ETH/USD valuation, and PnL cost inclusion.
+
+### Negative / costs
+
+- RAI-1406 is not completed by simply reading the existing `OnChainTrade`
+  enrichment stream.
+- A complete implementation needs new persisted cost facts and instrumentation
+  around every bot-signed onchain transaction path.
+- ETH/USD valuation needs an explicit source decision. The current equity Pyth
+  feed configuration is insufficient.
+
+### Neutral
+
+- Existing CCTP `fee_collected` and tokenization fees remain included as they
+  are today. Those are economic protocol/provider fees, not native gas costs.
+- Existing PnL still reports bot gas as excluded until the ledger is implemented
+  and populated.
+
+## Alternatives considered
+
+### Count all enriched Raindex fill gas as bot gas
+
+Rejected. The transaction can be paid by the taker/solver, and the existing
+event lacks `from` or any payer classification. This would corrupt PnL by
+charging the bot for costs it did not pay.
+
+### Fetch receipts and ETH/USD live inside `/pnl`
+
+Rejected. The endpoint supports `asOfRowid` snapshot semantics for persisted
+SQLite events. Live receipt and price lookups would make historical PnL depend
+on current RPC availability and mutable external data.
+
+### Use current Pyth equity enrichment as the USD valuation source
+
+Rejected. That price is for the traded equity, not ETH/USD. Gas is paid in the
+chain's native token and needs a native-token/USD valuation.
+
+### Attach gas fields ad hoc to each existing aggregate event
+
+Rejected as the primary model. It would duplicate valuation and classification
+logic across mint, redemption, USDC rebalancing, wrapper recovery, and future
+order-management events. A single receipt-cost ledger keeps PnL ingestion
+uniform.
+
+## Follow-ups
+
+- Add a receipt-cost aggregate or append-only ledger table with the fields in
+  this ADR.
+- Pick and document the ETH/USD valuation source and failure mode.
+- Emit receipt-cost facts from every bot-signed transaction path.
+- Update `/pnl` to load those facts as `bot_gas` cost entries, mark coverage as
+  `included` when rows exist, and keep unclassified/unvalued receipts out of net
+  PnL.

--- a/adrs/0016-store-bot-gas-costs-in-the-event-stream.md
+++ b/adrs/0016-store-bot-gas-costs-in-the-event-stream.md
@@ -1,0 +1,95 @@
+# ADR 0016: Store bot-gas costs in the event stream
+
+- **Status:** Proposed
+- **Date:** 2026-07-23
+- **Amends:** ADR 0015
+- **Linear:** RAI-1406 (parent RAI-1402 -- Extended-hours PnL leaks)
+
+## Context
+
+The PnL API supports historical reports through `asOfRowid`. That value is a row
+ID from the shared CQRS `events` table: a report at row 100 must use only facts
+known by event 100.
+
+ADR 0015 requires bot-paid gas to be persisted as immutable receipt-cost facts.
+The first implementation put those facts in a separate `bot_gas_cost` table.
+That table has its own row IDs, so an event row ID cannot bound it. Loading all
+gas rows makes an old report change when gas is recorded later; comparing the
+two tables' unrelated row IDs would also be incorrect.
+
+## Decision
+
+Persist each bot-paid receipt cost as a CQRS event in the shared `events` table.
+The aggregate is identified by chain and transaction hash and accepts one
+recording:
+
+- recording the same fact again is idempotent and emits no new event;
+- recording different facts for the same receipt fails with a typed conflict
+  error;
+- invalid or non-positive financial values fail before event persistence.
+
+PnL reads bot-gas cost events with the same `rowid <= asOfRowid` boundary used
+for its other event-backed facts. The event row ID is therefore the shared
+immutable ingestion cursor; no comparison between independent table row IDs is
+needed.
+
+The initial implementation reads the event payloads directly. If query volume
+later requires a projection, each projected row must retain its source event row
+ID and PnL must continue filtering on that value.
+
+## Consequences
+
+### Positive
+
+- Historical PnL reports remain stable when later gas costs are recorded.
+- Bot-gas costs reuse the API's existing snapshot contract instead of adding a
+  second cursor.
+- Aggregate state makes identical retries idempotent and conflicting retries
+  explicit.
+- Receipt costs are append-only facts rather than mutable rows.
+
+### Negative / costs
+
+- Bot-gas recording needs a CQRS aggregate and one shared framework instance in
+  the server wiring.
+- PnL must deserialize the bot-gas event payload.
+- Direct SQL insertion into a standalone bot-gas ledger is no longer the source
+  of truth.
+
+### Neutral
+
+- ADR 0015's required receipt, payer, valuation, category, and symbol fields do
+  not change.
+- The public `asOfRowid` API does not change.
+
+## Alternatives considered
+
+### Keep a separate table and compare its row ID with `asOfRowid`
+
+Rejected. SQLite row IDs from different tables are unrelated and do not express
+which fact was known first.
+
+### Return a composite event-and-gas snapshot token
+
+Rejected for now. It would change the public PnL API and require clients to
+store a new token when the existing event stream already provides a shared
+ordering.
+
+### Attach the latest event row ID to each gas row
+
+Rejected. A gas row recorded after event 100 could still receive watermark 100,
+making it incorrectly visible in a historical report at event 100. Advancing the
+watermark safely would require an event, which is the chosen design.
+
+### Exclude bot gas from historical reports
+
+Rejected. A report would have different cost coverage depending on whether it
+requested the current or a historical snapshot.
+
+## Follow-ups
+
+- Model and test the bot-gas receipt-cost aggregate.
+- Route recording through the aggregate's single server-side CQRS framework.
+- Load bot-gas events through the existing PnL event snapshot boundary.
+- Remove the standalone mutable bot-gas ledger table from the proposed
+  implementation.

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -124,3 +124,5 @@ decision.
 | [0009](0009-record-overfill-as-acceptance.md)                           | Record a broker over-fill as an acceptance, not a failure                            | Accepted |
 | [0010](0010-bounded-pending-ack-set-for-cross-process-exactly-once.md)  | Bounded pending-acknowledgement set for cross-process exactly-once                   | Accepted |
 | [0014](0014-runtime-stuck-pending-recovery-and-serialized-placement.md) | Recover stuck Pending placements at runtime, and serialize broker-placement attempts | Accepted |
+| [0015](0015-bot-gas-pnl-requires-explicit-receipt-cost-ledger.md)       | Require an explicit receipt cost ledger for bot gas PnL                              | Proposed |
+| [0016](0016-store-bot-gas-costs-in-the-event-stream.md)                 | Store bot-gas costs in the event stream                                              | Proposed |

--- a/src/api.rs
+++ b/src/api.rs
@@ -204,6 +204,7 @@ fn pnl_error_response(error: PnlError) -> (StatusCode, String) {
         | PnlError::InvalidSnapshotRowid { .. }
         | PnlError::InvalidSymbolFilter { .. } => (StatusCode::BAD_REQUEST, error.to_string()),
         PnlError::InvalidPayload { .. }
+        | PnlError::InvalidBotGasReceiptCost { .. }
         | PnlError::MalformedPayload { .. }
         | PnlError::InvalidFinancialField { .. }
         | PnlError::InvalidInternalDecimal { .. } => {

--- a/src/bot_gas.rs
+++ b/src/bot_gas.rs
@@ -1,0 +1,622 @@
+//! Bot-paid gas cost ledger.
+use alloy::primitives::{Address, TxHash, U256};
+use alloy::rpc::types::TransactionReceipt;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use num_decimal::Num;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use st0x_event_sorcery::{DomainEvent, EventSourced, Nil, SendError, Store};
+use st0x_finance::Symbol;
+
+const WEI_PER_ETH: &str = "1000000000000000000";
+
+#[derive(Debug, thiserror::Error)]
+pub enum BotGasCostError {
+    #[error("receipt payer {receipt_from} does not match bot wallet {bot_wallet}")]
+    NonBotPayer {
+        receipt_from: Address,
+        bot_wallet: Address,
+    },
+    #[error("native gas cost overflow for receipt {tx_hash}")]
+    NativeCostOverflow { tx_hash: TxHash },
+    #[error("failed to parse decimal {field}")]
+    Decimal {
+        field: &'static str,
+        #[source]
+        source: num_decimal::ParseNumError,
+    },
+    #[error(transparent)]
+    InvalidReceiptCost(#[from] BotGasReceiptCostError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BotGasChain {
+    Base,
+    Ethereum,
+}
+
+impl BotGasChain {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Base => "base",
+            Self::Ethereum => "ethereum",
+        }
+    }
+}
+
+impl fmt::Display for BotGasChain {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("expected bot gas chain 'base' or 'ethereum'")]
+pub struct ParseBotGasChainError;
+
+impl FromStr for BotGasChain {
+    type Err = ParseBotGasChainError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "base" => Ok(Self::Base),
+            "ethereum" => Ok(Self::Ethereum),
+            _ => Err(ParseBotGasChainError),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BotGasOperationCategory {
+    VaultDeposit,
+    VaultWithdraw,
+    Wrap,
+    Unwrap,
+    CctpBurn,
+    CctpMint,
+    WalletTransfer,
+}
+
+impl BotGasOperationCategory {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::VaultDeposit => "vault_deposit",
+            Self::VaultWithdraw => "vault_withdraw",
+            Self::Wrap => "wrap",
+            Self::Unwrap => "unwrap",
+            Self::CctpBurn => "cctp_burn",
+            Self::CctpMint => "cctp_mint",
+            Self::WalletTransfer => "wallet_transfer",
+        }
+    }
+}
+
+impl fmt::Display for BotGasOperationCategory {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EthUsdPrice {
+    pub price: Num,
+    pub source: String,
+    pub observed_at: DateTime<Utc>,
+    pub block_number: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BotGasReceiptCost {
+    pub chain: BotGasChain,
+    pub tx_hash: TxHash,
+    pub receipt_from: Address,
+    pub gas_used: u64,
+    pub effective_gas_price_wei: u128,
+    pub native_cost_wei: U256,
+    #[serde(serialize_with = "serialize_num", deserialize_with = "deserialize_num")]
+    pub eth_usd_price: Num,
+    pub eth_usd_price_source: String,
+    pub eth_usd_price_at: DateTime<Utc>,
+    pub eth_usd_price_block_number: Option<u64>,
+    #[serde(serialize_with = "serialize_num", deserialize_with = "deserialize_num")]
+    pub usd_cost: Num,
+    pub operation_category: BotGasOperationCategory,
+    pub symbol: Option<Symbol>,
+    pub occurred_at: DateTime<Utc>,
+}
+
+fn serialize_num<S>(value: &Num, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&value.to_string())
+}
+
+fn deserialize_num<'de, D>(deserializer: D) -> Result<Num, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    Num::from_str(&value).map_err(serde::de::Error::custom)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BotGasReceiptCostId {
+    pub chain: BotGasChain,
+    pub tx_hash: TxHash,
+}
+
+impl fmt::Display for BotGasReceiptCostId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}:{}", self.chain, self.tx_hash)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseBotGasReceiptCostIdError {
+    #[error("bot gas receipt cost id is missing the chain/hash delimiter")]
+    MissingDelimiter,
+    #[error(transparent)]
+    Chain(#[from] ParseBotGasChainError),
+    #[error(transparent)]
+    TransactionHash(#[from] alloy::hex::FromHexError),
+}
+
+impl FromStr for BotGasReceiptCostId {
+    type Err = ParseBotGasReceiptCostIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (chain, tx_hash) = value
+            .split_once(':')
+            .ok_or(ParseBotGasReceiptCostIdError::MissingDelimiter)?;
+
+        Ok(Self {
+            chain: chain.parse()?,
+            tx_hash: tx_hash.parse()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+pub enum BotGasReceiptCostError {
+    #[error("receipt gas used must be positive")]
+    ZeroGasUsed,
+    #[error("receipt effective gas price must be positive")]
+    ZeroEffectiveGasPrice,
+    #[error("receipt native gas cost must be positive")]
+    ZeroNativeCost,
+    #[error("ETH/USD valuation must be positive")]
+    NonPositiveEthUsdPrice,
+    #[error("receipt USD cost must be positive")]
+    NonPositiveUsdCost,
+    #[error("receipt cost conflicts with the immutable fact already recorded")]
+    ConflictingReceiptCost,
+}
+
+impl BotGasReceiptCost {
+    pub fn from_receipt(
+        receipt: &TransactionReceipt,
+        bot_wallet: Address,
+        chain: BotGasChain,
+        operation_category: BotGasOperationCategory,
+        symbol: Option<Symbol>,
+        eth_usd_price: EthUsdPrice,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<Self, BotGasCostError> {
+        if receipt.from != bot_wallet {
+            return Err(BotGasCostError::NonBotPayer {
+                receipt_from: receipt.from,
+                bot_wallet,
+            });
+        }
+        if receipt.gas_used == 0 {
+            return Err(BotGasReceiptCostError::ZeroGasUsed.into());
+        }
+        if receipt.effective_gas_price == 0 {
+            return Err(BotGasReceiptCostError::ZeroEffectiveGasPrice.into());
+        }
+        if !eth_usd_price.price.is_positive() {
+            return Err(BotGasReceiptCostError::NonPositiveEthUsdPrice.into());
+        }
+
+        let effective_gas_price_wei = receipt.effective_gas_price;
+        let native_cost_wei = U256::from(receipt.gas_used)
+            .checked_mul(U256::from(effective_gas_price_wei))
+            .ok_or(BotGasCostError::NativeCostOverflow {
+                tx_hash: receipt.transaction_hash,
+            })?;
+        let usd_cost = native_cost_usd(native_cost_wei, &eth_usd_price.price)?;
+
+        let cost = Self {
+            chain,
+            tx_hash: receipt.transaction_hash,
+            receipt_from: receipt.from,
+            gas_used: receipt.gas_used,
+            effective_gas_price_wei,
+            native_cost_wei,
+            eth_usd_price: eth_usd_price.price,
+            eth_usd_price_source: eth_usd_price.source,
+            eth_usd_price_at: eth_usd_price.observed_at,
+            eth_usd_price_block_number: eth_usd_price.block_number,
+            usd_cost,
+            operation_category,
+            symbol,
+            occurred_at,
+        };
+        cost.validate()?;
+
+        Ok(cost)
+    }
+
+    pub fn id(&self) -> BotGasReceiptCostId {
+        BotGasReceiptCostId {
+            chain: self.chain,
+            tx_hash: self.tx_hash,
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), BotGasReceiptCostError> {
+        if self.gas_used == 0 {
+            return Err(BotGasReceiptCostError::ZeroGasUsed);
+        }
+        if self.effective_gas_price_wei == 0 {
+            return Err(BotGasReceiptCostError::ZeroEffectiveGasPrice);
+        }
+        if self.native_cost_wei.is_zero() {
+            return Err(BotGasReceiptCostError::ZeroNativeCost);
+        }
+        if !self.eth_usd_price.is_positive() {
+            return Err(BotGasReceiptCostError::NonPositiveEthUsdPrice);
+        }
+        if !self.usd_cost.is_positive() {
+            return Err(BotGasReceiptCostError::NonPositiveUsdCost);
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BotGasReceiptCostCommand {
+    Record { cost: BotGasReceiptCost },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BotGasReceiptCostEvent {
+    Recorded { cost: BotGasReceiptCost },
+}
+
+impl DomainEvent for BotGasReceiptCostEvent {
+    fn event_type(&self) -> String {
+        match self {
+            Self::Recorded { .. } => "BotGasReceiptCostEvent::Recorded".to_owned(),
+        }
+    }
+
+    fn event_version(&self) -> String {
+        "1.0".to_owned()
+    }
+}
+
+#[async_trait]
+impl EventSourced for BotGasReceiptCost {
+    type Id = BotGasReceiptCostId;
+    type Event = BotGasReceiptCostEvent;
+    type Command = BotGasReceiptCostCommand;
+    type Error = BotGasReceiptCostError;
+    type Services = ();
+    type Materialized = Nil;
+
+    const AGGREGATE_TYPE: &'static str = "BotGasReceiptCost";
+    const PROJECTION: Nil = Nil;
+    const SCHEMA_VERSION: u64 = 1;
+
+    fn originate(event: &Self::Event) -> Option<Self> {
+        match event {
+            BotGasReceiptCostEvent::Recorded { cost } => Some(cost.clone()),
+        }
+    }
+
+    fn evolve(_entity: &Self, _event: &Self::Event) -> Result<Option<Self>, Self::Error> {
+        Ok(None)
+    }
+
+    async fn initialize(
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        match command {
+            BotGasReceiptCostCommand::Record { cost } => {
+                cost.validate()?;
+                Ok(vec![BotGasReceiptCostEvent::Recorded { cost }])
+            }
+        }
+    }
+
+    async fn transition(
+        &self,
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        match command {
+            BotGasReceiptCostCommand::Record { cost } if self == &cost => Ok(Vec::new()),
+            BotGasReceiptCostCommand::Record { .. } => {
+                Err(BotGasReceiptCostError::ConflictingReceiptCost)
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct BotGasCostLedger {
+    store: Arc<Store<BotGasReceiptCost>>,
+}
+
+impl BotGasCostLedger {
+    pub fn new(store: Arc<Store<BotGasReceiptCost>>) -> Self {
+        Self { store }
+    }
+
+    pub async fn record(
+        &self,
+        cost: &BotGasReceiptCost,
+    ) -> Result<(), SendError<BotGasReceiptCost>> {
+        self.store
+            .send(
+                &cost.id(),
+                BotGasReceiptCostCommand::Record { cost: cost.clone() },
+            )
+            .await
+    }
+}
+
+fn parse_num(field: &'static str, value: &str) -> Result<Num, BotGasCostError> {
+    Num::from_str(value).map_err(|source| BotGasCostError::Decimal { field, source })
+}
+
+fn native_cost_usd(native_cost_wei: U256, eth_usd_price: &Num) -> Result<Num, BotGasCostError> {
+    let native_cost_wei = parse_num("native_cost_wei", &native_cost_wei.to_string())?;
+    let wei_per_eth = parse_num("wei_per_eth", WEI_PER_ETH)?;
+
+    Ok(&(&native_cost_wei / &wei_per_eth) * eth_usd_price)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy::primitives::Bloom;
+    use alloy::primitives::{Address, TxHash};
+    use alloy::rpc::types::TransactionReceipt;
+    use chrono::TimeZone;
+
+    use st0x_event_sorcery::{LifecycleError, TestHarness};
+
+    use super::*;
+
+    fn receipt(from: Address) -> TransactionReceipt {
+        TransactionReceipt {
+            inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom {
+                receipt: Receipt {
+                    status: true.into(),
+                    cumulative_gas_used: 0,
+                    logs: vec![],
+                },
+                logs_bloom: Bloom::default(),
+            }),
+            transaction_hash: TxHash::repeat_byte(0x11),
+            transaction_index: Some(0),
+            block_hash: None,
+            block_number: Some(123),
+            to: Some(Address::ZERO),
+            contract_address: None,
+            from,
+            gas_used: 21_000,
+            effective_gas_price: 1_000_000_000,
+            blob_gas_used: None,
+            blob_gas_price: None,
+        }
+    }
+
+    fn price() -> EthUsdPrice {
+        EthUsdPrice {
+            price: Num::from_str("2000").unwrap(),
+            source: "eth_usd_valuation_feed".to_owned(),
+            observed_at: Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap(),
+            block_number: Some(123),
+        }
+    }
+
+    #[test]
+    fn receipt_cost_values_native_gas_in_usd() {
+        let bot = Address::repeat_byte(0x01);
+        let cost = BotGasReceiptCost::from_receipt(
+            &receipt(bot),
+            bot,
+            BotGasChain::Base,
+            BotGasOperationCategory::VaultDeposit,
+            None,
+            price(),
+            Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 1).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(cost.native_cost_wei, U256::from(21_000_000_000_000u128));
+        assert_eq!(cost.usd_cost.to_string(), "0.042");
+    }
+
+    #[test]
+    fn receipt_cost_rejects_non_bot_payer() {
+        let error = BotGasReceiptCost::from_receipt(
+            &receipt(Address::repeat_byte(0x02)),
+            Address::repeat_byte(0x01),
+            BotGasChain::Base,
+            BotGasOperationCategory::VaultDeposit,
+            None,
+            price(),
+            Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 1).unwrap(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, BotGasCostError::NonBotPayer { .. }));
+    }
+
+    #[test]
+    fn receipt_cost_rejects_zero_gas_used() {
+        let bot = Address::repeat_byte(0x01);
+        let mut receipt = receipt(bot);
+        receipt.gas_used = 0;
+
+        let error = BotGasReceiptCost::from_receipt(
+            &receipt,
+            bot,
+            BotGasChain::Base,
+            BotGasOperationCategory::VaultDeposit,
+            None,
+            price(),
+            Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 1).unwrap(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            BotGasCostError::InvalidReceiptCost(BotGasReceiptCostError::ZeroGasUsed)
+        ));
+    }
+
+    #[test]
+    fn receipt_cost_rejects_zero_effective_gas_price() {
+        let bot = Address::repeat_byte(0x01);
+        let mut receipt = receipt(bot);
+        receipt.effective_gas_price = 0;
+
+        let error = BotGasReceiptCost::from_receipt(
+            &receipt,
+            bot,
+            BotGasChain::Base,
+            BotGasOperationCategory::VaultDeposit,
+            None,
+            price(),
+            Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 1).unwrap(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            BotGasCostError::InvalidReceiptCost(BotGasReceiptCostError::ZeroEffectiveGasPrice)
+        ));
+    }
+
+    #[test]
+    fn receipt_cost_rejects_non_positive_eth_usd_price() {
+        let bot = Address::repeat_byte(0x01);
+        for value in ["0", "-1"] {
+            let mut price = price();
+            price.price = Num::from_str(value).unwrap();
+
+            let error = BotGasReceiptCost::from_receipt(
+                &receipt(bot),
+                bot,
+                BotGasChain::Base,
+                BotGasOperationCategory::VaultDeposit,
+                None,
+                price,
+                Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 1).unwrap(),
+            )
+            .unwrap_err();
+
+            assert!(
+                matches!(
+                    error,
+                    BotGasCostError::InvalidReceiptCost(
+                        BotGasReceiptCostError::NonPositiveEthUsdPrice
+                    )
+                ),
+                "ETH/USD price {value} must be rejected"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn identical_receipt_cost_retry_is_idempotent() {
+        let bot = Address::repeat_byte(0x01);
+        let cost = BotGasReceiptCost::from_receipt(
+            &receipt(bot),
+            bot,
+            BotGasChain::Base,
+            BotGasOperationCategory::VaultDeposit,
+            None,
+            price(),
+            Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 1).unwrap(),
+        )
+        .unwrap();
+
+        TestHarness::<BotGasReceiptCost>::with(())
+            .given(vec![BotGasReceiptCostEvent::Recorded {
+                cost: cost.clone(),
+            }])
+            .when(BotGasReceiptCostCommand::Record { cost })
+            .await
+            .then_expect_events(&[]);
+    }
+
+    #[tokio::test]
+    async fn conflicting_receipt_cost_retry_is_rejected() {
+        let bot = Address::repeat_byte(0x01);
+        let cost = BotGasReceiptCost::from_receipt(
+            &receipt(bot),
+            bot,
+            BotGasChain::Base,
+            BotGasOperationCategory::VaultDeposit,
+            None,
+            price(),
+            Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 1).unwrap(),
+        )
+        .unwrap();
+        let mut conflicting = cost.clone();
+        conflicting.eth_usd_price = Num::from_str("2100").unwrap();
+
+        let error = TestHarness::<BotGasReceiptCost>::with(())
+            .given(vec![BotGasReceiptCostEvent::Recorded { cost }])
+            .when(BotGasReceiptCostCommand::Record { cost: conflicting })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(BotGasReceiptCostError::ConflictingReceiptCost)
+        ));
+    }
+
+    #[tokio::test]
+    async fn direct_recording_rejects_non_positive_receipt_cost() {
+        let bot = Address::repeat_byte(0x01);
+        let mut cost = BotGasReceiptCost::from_receipt(
+            &receipt(bot),
+            bot,
+            BotGasChain::Base,
+            BotGasOperationCategory::VaultDeposit,
+            None,
+            price(),
+            Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 1).unwrap(),
+        )
+        .unwrap();
+        cost.usd_cost = Num::from_str("0").unwrap();
+
+        let error = TestHarness::<BotGasReceiptCost>::with(())
+            .given_no_previous_events()
+            .when(BotGasReceiptCostCommand::Record { cost })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(BotGasReceiptCostError::NonPositiveUsdCost)
+        ));
+    }
+}

--- a/src/dashboard/pnl/builder.rs
+++ b/src/dashboard/pnl/builder.rs
@@ -12,8 +12,7 @@ use super::costs::{
     build_cost_entries, summarize_cost_entries, with_costs,
 };
 use super::diagnostics::append_replay_diagnostics;
-use super::parsing::fmt_decimal;
-use super::parsing::{is_safe_symbol, ordered_position_events};
+use super::parsing::{fmt_decimal, is_safe_symbol, ordered_position_events};
 use super::query::{PnlError, PnlQuery};
 use super::replay::{
     add_summary, apply_manual_position_adjustment, apply_offchain_fill, apply_offchain_placement,
@@ -26,7 +25,9 @@ use super::samples::{build_available_range, build_sample_stats, parse_position_v
 use super::sessions::{
     date_key, et_day_key, matches_cost_date_filter, matches_cost_symbol_filter, matches_date_filter,
 };
-use super::state::{CostEventRow, PositionEventRow, PositionViewRow, SummaryAcc, SymbolBook};
+use super::state::{
+    BotGasCostRow, CostEventRow, PositionEventRow, PositionViewRow, SummaryAcc, SymbolBook,
+};
 use super::windows::build_windows;
 
 fn tokenization_fee_overlap_key(entry: &CostEntryInternal) -> Option<(Symbol, String, String)> {
@@ -87,6 +88,7 @@ pub(crate) fn build_pnl_response_from_rows(
     event_rows: Vec<PositionEventRow>,
     position_rows: &[PositionViewRow],
     cost_rows: &[CostEventRow],
+    bot_gas_rows: &[BotGasCostRow],
     alpaca_activities: &[AccountActivity],
     query: &PnlQuery,
     symbols: &BTreeSet<String>,
@@ -193,6 +195,9 @@ pub(crate) fn build_pnl_response_from_rows(
     let page_entries = filtered_entries[start..end].to_vec();
 
     let mut cost_replay = build_cost_entries(cost_rows, &mut warnings)?;
+    cost_replay
+        .entries
+        .extend(build_bot_gas_cost_entries(bot_gas_rows, &mut warnings)?);
     let alpaca_entries = build_alpaca_activity_cost_entries(alpaca_activities, &mut warnings)?;
     let alpaca_entries =
         remove_tokenization_fee_overlaps(&cost_replay.entries, alpaca_entries, &mut warnings);
@@ -289,4 +294,53 @@ pub(crate) fn build_pnl_response_from_rows(
         },
         daily_net_realized_pnl_usd,
     ))
+}
+
+fn build_bot_gas_cost_entries(
+    rows: &[BotGasCostRow],
+    warnings: &mut Vec<String>,
+) -> Result<Vec<CostEntryInternal>, PnlError> {
+    rows.iter()
+        .filter_map(|row| {
+            let symbol = match row.symbol.as_deref() {
+                Some(symbol) if is_safe_symbol(symbol) => {
+                    if let Ok(symbol) = Symbol::new(symbol.to_owned()) {
+                        Some(symbol)
+                    } else {
+                        warnings.push(format!(
+                            "Skipped invalid bot gas symbol in backend PnL response: {symbol}"
+                        ));
+                        return None;
+                    }
+                }
+                Some(symbol) => {
+                    warnings.push(format!(
+                        "Skipped unsafe bot gas symbol in backend PnL response: {symbol}"
+                    ));
+                    return None;
+                }
+                None => None,
+            };
+            let amount_usd = match super::parsing::parse_internal_decimal(
+                "bot_gas_cost.usd_cost",
+                &row.usd_cost,
+            ) {
+                Ok(amount_usd) => amount_usd,
+                Err(error) => return Some(Err(error)),
+            };
+
+            Some(Ok(CostEntryInternal {
+                category: CostCategory::BotGas,
+                accounting_bucket: super::costs::AccountingBucket::Generic,
+                effect: AccountingEffect::Cost,
+                amount_usd,
+                occurred_at: row.occurred_at.clone(),
+                aggregate_type: "BotGasCost".to_owned(),
+                aggregate_id: format!("{}:{}", row.chain, row.tx_hash),
+                event_rowid: row.rowid,
+                symbol,
+                detail: format!("Bot-paid {} gas on {}", row.operation_category, row.chain),
+            }))
+        })
+        .collect()
 }

--- a/src/dashboard/pnl/costs.rs
+++ b/src/dashboard/pnl/costs.rs
@@ -38,6 +38,7 @@ fn malformed_cost_payload(row: &CostEventRow, reason: &'static str) -> PnlError 
 pub(crate) enum CostCategory {
     TokenizationFee,
     CctpFee,
+    BotGas,
     BrokerFee,
     MarginInterest,
     DividendIncome,
@@ -49,6 +50,7 @@ impl CostCategory {
         match self {
             Self::TokenizationFee => "tokenization_fee",
             Self::CctpFee => "cctp_fee",
+            Self::BotGas => "bot_gas",
             Self::BrokerFee => "broker_fee",
             Self::MarginInterest => "margin_interest",
             Self::DividendIncome => "dividend_income",
@@ -175,6 +177,7 @@ fn add_cost(
     match category {
         CostCategory::TokenizationFee => summary.tokenization_fees_usd += &signed_amount,
         CostCategory::CctpFee => summary.cctp_fees_usd += &signed_amount,
+        CostCategory::BotGas => summary.bot_gas_usd += amount,
         CostCategory::BrokerFee => {
             summary.broker_fees_usd += &signed_amount;
             summary.broker_fee_entry_count += 1;
@@ -331,9 +334,9 @@ fn cost_summary_to_dto(summary: &CostSummaryAcc, cost_entry_count: usize) -> Pnl
                 "Bot gas",
                 AccountingBucket::Generic,
                 AccountingEffect::Cost,
-                "not_ingested",
+                included_when_observed(usize::from(!summary.bot_gas_usd.is_zero())),
                 &summary.bot_gas_usd,
-                "Requires tx receipt ingestion, gas-payer classification, and ETH/USD valuation.",
+                "Read from persisted bot-paid transaction receipts after gas-payer classification and ETH/USD valuation.",
             ),
             coverage(
                 "Wallet transfer fees",

--- a/src/dashboard/pnl/query.rs
+++ b/src/dashboard/pnl/query.rs
@@ -31,6 +31,12 @@ pub(crate) enum PnlError {
         #[source]
         source: serde_json::Error,
     },
+    #[error("invalid bot gas receipt cost at event row {rowid}")]
+    InvalidBotGasReceiptCost {
+        rowid: i64,
+        #[source]
+        source: crate::bot_gas::BotGasReceiptCostError,
+    },
     #[error(
         "malformed persisted PnL payload at row {rowid} ({aggregate_type}/{event_type}): {reason}"
     )]

--- a/src/dashboard/pnl/source.rs
+++ b/src/dashboard/pnl/source.rs
@@ -8,13 +8,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use st0x_execution::alpaca_broker_api::AccountActivity;
 use st0x_float_serde::format_float;
 
+use crate::bot_gas::BotGasReceiptCostEvent;
 use crate::portfolio_snapshot::{CAPTURE_BUFFER, EtDayRange, capital_summary, load_portfolio_days};
 
 use super::builder::build_pnl_response_from_rows;
 use super::parsing::{fmt_decimal, parse_payload_string};
 use super::query::{PnlError, PnlQuery};
 use super::response::{PnlCapitalSummary, PnlResponse};
-use super::state::{CostEventRow, PositionEventRow, PositionViewRow};
+use super::state::{BotGasCostRow, CostEventRow, PositionEventRow, PositionViewRow};
 use super::{
     ATTRIBUTION_WARNING, BASELINE_WARNING, CAPITAL_AVAILABLE_NOTE, CAPITAL_UNAVAILABLE_NOTE,
     COST_WARNING, SYMBOL_FILTERED_CAPITAL_WARNING,
@@ -42,12 +43,14 @@ pub(crate) async fn build_pnl_report(
     let event_rows = load_position_events(&mut tx, &symbols, resolved_rowid.resolved).await?;
     let position_rows = load_position_view(&mut tx).await?;
     let cost_rows = load_cost_events(&mut tx, resolved_rowid.resolved).await?;
+    let bot_gas_rows = load_bot_gas_costs(&mut tx, resolved_rowid.resolved).await?;
     tx.commit().await?;
 
     let (mut response, daily_net_realized_pnl_usd) = build_pnl_response_from_rows(
         event_rows,
         &position_rows,
         &cost_rows,
+        &bot_gas_rows,
         &alpaca_activities,
         &effective_query,
         &symbols,
@@ -390,4 +393,47 @@ async fn load_cost_events(
     }
 
     Ok(events)
+}
+
+async fn load_bot_gas_costs(
+    tx: &mut Transaction<'_, Sqlite>,
+    as_of_rowid: i64,
+) -> Result<Vec<BotGasCostRow>, PnlError> {
+    let rows = sqlx::query_as::<_, (i64, String)>(
+        "SELECT rowid, payload \
+         FROM events \
+         WHERE aggregate_type = 'BotGasReceiptCost' \
+           AND event_type = 'BotGasReceiptCostEvent::Recorded' \
+           AND rowid <= ? \
+         ORDER BY rowid ASC",
+    )
+    .bind(as_of_rowid)
+    .fetch_all(&mut **tx)
+    .await?;
+
+    let mut costs = Vec::with_capacity(rows.len());
+    for (rowid, payload) in rows {
+        let event = parse_payload_string(&payload)
+            .and_then(serde_json::from_value::<BotGasReceiptCostEvent>)
+            .map_err(|source| PnlError::InvalidPayload {
+                rowid,
+                aggregate_type: "BotGasReceiptCost".to_owned(),
+                event_type: "BotGasReceiptCostEvent::Recorded".to_owned(),
+                source,
+            })?;
+        let BotGasReceiptCostEvent::Recorded { cost } = event;
+        cost.validate()
+            .map_err(|source| PnlError::InvalidBotGasReceiptCost { rowid, source })?;
+        costs.push(BotGasCostRow {
+            rowid,
+            chain: cost.chain.to_string(),
+            tx_hash: cost.tx_hash.to_string(),
+            usd_cost: cost.usd_cost.to_string(),
+            operation_category: cost.operation_category.to_string(),
+            symbol: cost.symbol.map(|symbol| symbol.to_string()),
+            occurred_at: cost.occurred_at.to_rfc3339(),
+        });
+    }
+
+    Ok(costs)
 }

--- a/src/dashboard/pnl/state.rs
+++ b/src/dashboard/pnl/state.rs
@@ -164,6 +164,17 @@ pub(crate) struct CostEventRow {
     pub(crate) payload: Value,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct BotGasCostRow {
+    pub(crate) rowid: i64,
+    pub(crate) chain: String,
+    pub(crate) tx_hash: String,
+    pub(crate) usd_cost: String,
+    pub(crate) operation_category: String,
+    pub(crate) symbol: Option<String>,
+    pub(crate) occurred_at: String,
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SampleStatsAcc {
     pub(crate) first_at: Option<String>,

--- a/src/dashboard/pnl/tests.rs
+++ b/src/dashboard/pnl/tests.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::str::FromStr;
 
+use alloy::primitives::{Address, TxHash, U256};
 use chrono::{NaiveDate, TimeZone, Utc};
 use num_decimal::Num;
 use serde_json::Value;
@@ -8,15 +9,21 @@ use sqlx::SqlitePool;
 use sqlx::sqlite::SqlitePoolOptions;
 
 use st0x_execution::alpaca_broker_api::AccountActivity;
+use st0x_finance::Symbol;
 
 use super::builder::build_pnl_response_from_rows;
 use super::parsing::{fmt_decimal, parse_payload_string, parse_timestamp};
 use super::query::{PnlCounterTradingFilter, PnlError, PnlMarketSessionFilter, PnlQuery};
 use super::response::{PnlResponse, PnlSymbolSummary, PnlWindow, PnlWindowSymbol};
-use super::state::{CostEventRow, Direction, PnlBucket, PositionEventRow, PositionViewRow, Venue};
+use super::state::{
+    BotGasCostRow, CostEventRow, Direction, PnlBucket, PositionEventRow, PositionViewRow, Venue,
+};
 use super::{
     ATTRIBUTION_WARNING, BASELINE_WARNING, CAPITAL_AVAILABLE_NOTE, CAPITAL_UNAVAILABLE_NOTE,
     COST_WARNING, SYMBOL_FILTERED_CAPITAL_WARNING, build_pnl_report, validate_pnl_snapshot_rowid,
+};
+use crate::bot_gas::{
+    BotGasChain, BotGasOperationCategory, BotGasReceiptCost, BotGasReceiptCostEvent,
 };
 use crate::portfolio_snapshot::EtDayRange;
 
@@ -483,6 +490,34 @@ fn usdc_bridged(rowid: i64, aggregate_id: &str, fee: &str, timestamp: &str) -> C
     )
 }
 
+fn bot_gas_recorded(rowid: i64) -> CostEventRow {
+    let tx_hash = TxHash::repeat_byte(0xab);
+    let cost = BotGasReceiptCost {
+        chain: BotGasChain::Base,
+        tx_hash,
+        receipt_from: Address::repeat_byte(0x11),
+        gas_used: 21_000,
+        effective_gas_price_wei: 1_000_000_000,
+        native_cost_wei: U256::from(21_000_000_000_000u128),
+        eth_usd_price: Num::from_str("2000").unwrap(),
+        eth_usd_price_source: "eth_usd_valuation_feed".to_owned(),
+        eth_usd_price_at: Utc.with_ymd_and_hms(2026, 5, 15, 14, 0, 0).unwrap(),
+        eth_usd_price_block_number: Some(123),
+        usd_cost: Num::from_str("0.042").unwrap(),
+        operation_category: BotGasOperationCategory::VaultDeposit,
+        symbol: Some(Symbol::new("RKLB").unwrap()),
+        occurred_at: Utc.with_ymd_and_hms(2026, 5, 15, 14, 0, 1).unwrap(),
+    };
+
+    cost_event(
+        rowid,
+        "BotGasReceiptCost",
+        &format!("base:{tx_hash}"),
+        "BotGasReceiptCostEvent::Recorded",
+        serde_json::to_value(BotGasReceiptCostEvent::Recorded { cost }).unwrap(),
+    )
+}
+
 fn account_activity(
     id: &str,
     activity_type: &str,
@@ -555,6 +590,7 @@ fn report_with_result(
         events: Vec<PositionEventRow>,
         position_rows: Vec<PositionViewRow>,
         cost_rows: Vec<CostEventRow>,
+        bot_gas_rows: Vec<BotGasCostRow>,
         alpaca_activities: Vec<AccountActivity>,
         query: PnlQuery,
         symbols: BTreeSet<String>,
@@ -564,6 +600,7 @@ fn report_with_result(
         events,
         position_rows,
         cost_rows,
+        bot_gas_rows: Vec::new(),
         alpaca_activities,
         query,
         symbols,
@@ -572,6 +609,7 @@ fn report_with_result(
         events,
         position_rows,
         cost_rows,
+        bot_gas_rows,
         alpaca_activities,
         query,
         symbols,
@@ -581,6 +619,7 @@ fn report_with_result(
         events,
         &position_rows,
         &cost_rows,
+        &bot_gas_rows,
         &alpaca_activities,
         &query,
         &symbols,
@@ -689,6 +728,7 @@ fn report_result(events: Vec<PositionEventRow>) -> Result<PnlResponse, PnlError>
     build_pnl_response_from_rows(
         events,
         &position_rows(),
+        &Vec::new(),
         &Vec::new(),
         &Vec::new(),
         &query(),
@@ -1013,6 +1053,84 @@ async fn source_loader_includes_persisted_cost_events() {
     assert_eq!(report.costs.tokenization_fees_usd, "0.25");
     assert_eq!(report.cost_entries.len(), 1);
     assert_eq!(report.cost_entries[0].aggregate_type, "TokenizedEquityMint");
+}
+
+#[tokio::test]
+async fn source_loader_includes_persisted_bot_gas_costs() {
+    let pool = pnl_test_pool_with_costs(
+        vec![
+            onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
+            offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
+        ],
+        position_rows(),
+        vec![bot_gas_recorded(3)],
+    )
+    .await;
+
+    let report = build_pnl_report(&pool, &query(), Vec::new(), Utc::now())
+        .await
+        .unwrap();
+
+    assert_eq!(report.summary.gross_realized_pnl_usd, "2");
+    assert_eq!(report.summary.tracked_costs_usd, "0.042");
+    assert_eq!(report.summary.net_realized_pnl_usd, "1.958");
+    assert_eq!(report.costs.bot_gas_usd, "0.042");
+    assert_eq!(cost_coverage_status(&report, "Bot gas"), "included");
+    assert_eq!(report.cost_entries.len(), 1);
+    assert_eq!(report.cost_entries[0].category, "bot_gas");
+    assert_eq!(
+        report.cost_entries[0].symbol.as_ref().map(Symbol::as_str),
+        Some("RKLB")
+    );
+}
+
+#[tokio::test]
+async fn source_loader_excludes_bot_gas_recorded_after_snapshot() {
+    let pool = pnl_test_pool_with_costs(
+        vec![
+            onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
+            offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
+        ],
+        position_rows(),
+        vec![bot_gas_recorded(3)],
+    )
+    .await;
+
+    let report = build_pnl_report(
+        &pool,
+        &PnlQuery {
+            as_of_rowid: Some(2),
+            ..query()
+        },
+        Vec::new(),
+        Utc::now(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(report.as_of_rowid, 2);
+    assert_eq!(report.costs.bot_gas_usd, "0");
+    assert_eq!(cost_coverage_status(&report, "Bot gas"), "not_ingested");
+    assert!(report.cost_entries.is_empty());
+}
+
+#[tokio::test]
+async fn source_loader_rejects_non_positive_persisted_bot_gas_cost() {
+    let mut bot_gas = bot_gas_recorded(1);
+    bot_gas.payload["Recorded"]["cost"]["usd_cost"] = serde_json::json!("0");
+    let pool = pnl_test_pool_with_costs(Vec::new(), position_rows(), vec![bot_gas]).await;
+
+    let error = build_pnl_report(&pool, &query(), Vec::new(), Utc::now())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        PnlError::InvalidBotGasReceiptCost {
+            source: crate::bot_gas::BotGasReceiptCostError::NonPositiveUsdCost,
+            ..
+        }
+    ));
 }
 
 #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod api;
 pub mod bindings;
 #[cfg(not(any(test, feature = "test-support")))]
 pub(crate) mod bindings;
+pub mod bot_gas;
 pub mod cli;
 mod conductor;
 pub(crate) mod dashboard;


### PR DESCRIPTION
## What

- Implements the persisted-ledger foundation for [RAI-1406](https://linear.app/makeitrain/issue/RAI-1406/ingest-bot-gas-costs-into-the-pnl-report).
- Adds `BotGasReceiptCost` and `BotGasCostLedger`, an event-sourced aggregate keyed by `(chain, tx_hash)`, recorded into the shared CQRS `events` table.
- Loads persisted bot-paid rows into `/pnl` as `bot_gas` costs and deducts them from net profit and loss (PnL).

## Why

- `/pnl` currently treats bot gas as `not_ingested`, so net PnL remains an upper bound.
- Raindex fill gas cannot prove that the bot paid it, and its equity price cannot value ETH gas.
- The report needs persisted payer classification and ETH/USD valuation to stay reproducible.

## How

- `BotGasReceiptCost::from_receipt` verifies `receipt.from`, computes the wei cost, and applies an explicit ETH/USD price.
- `BotGasCostLedger::record` persists the receipt, valuation source, operation category, optional symbol, and USD cost idempotently.
- `/pnl` reads only rows classified as `bot_paid`. It applies the existing date and symbol cost filters.
- ADR 0015 records why live report-time lookups and existing Raindex enrichment are unsafe.
- ADR 0016 amends ADR 0015: receipt costs persist as CQRS events in the shared `events` table, not a separate table, so `/pnl` can bound them with the same `asOfRowid` cursor it already uses for other facts.

## Testing

- `cargo check -p st0x-hedge`
- `cargo nextest run -p st0x-hedge bot_gas source_loader_includes_persisted_bot_gas_costs`
- `cargo nextest run -p st0x-hedge dashboard::pnl`
- `cargo clippy -p st0x-hedge --all-targets --all-features`
- `DATABASE_URL=sqlite://.tmp/rai1406-bot-gas-<timestamp>.sqlite sqlx database setup`

## Screenshots

N/A (backend).

## Anything else

- This PR does not populate the ledger from bot-signed transaction paths yet.
- Bot gas stays `not_ingested` until a producer records a non-zero bot-paid row with ETH/USD valuation.
- `/pnl` performs no live receipt or price lookup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persisted bot-paid gas receipt costs to PnL reporting.
  * Bot gas costs include verified payer information, ETH/USD valuation, operation category, and optional asset attribution.
  * Historical reports respect snapshot boundaries, preventing later-recorded costs from changing past results.
  * Duplicate receipt records are handled idempotently, while conflicting or invalid records are rejected.

* **Documentation**
  * Added architecture and specification documentation for bot gas cost recording and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
