### PR TITLE
fix: reconstruct resumed USDC reservation (RAI-1324)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2133,6 +2133,16 @@ action that already succeeded. Each phase records its intent (and the relevant
 chain head) before the action, so resume can scan the chain to adopt an
 already-submitted action instead of re-issuing it:
 
+- Startup recovery of a pre-burn Alpaca-to-Base transfer in
+  `ConversionComplete`, `Withdrawing`, `WithdrawalComplete`, or
+  `BridgingSubmitting` restores its exact Hedging source reservation before the
+  worker re-enters the transfer manager. The durable guard is latched
+  immediately, but the worker delayed-redrives until a fresh post-startup,
+  reserve-adjusted offchain cash observation has replaced available inventory.
+  Recovery then replacement-sets inflight to the aggregate amount and restores
+  the aggregate as the active owner. Repeating the observation or resuming the
+  same aggregate is idempotent; multiple reservation owners or an existing
+  different inventory owner fail closed without overwriting financial state.
 - `WithdrawalSubmitting` / `BridgingSubmitting`: scan the source chain for an
   already-submitted withdrawal / burn (`find_recent_withdrawal` /
   `find_recent_burn`) from the captured head and adopt it rather than

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -1618,6 +1618,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
 
         let transfer_usdc_to_market_making_ctx = Arc::new(TransferUsdcToMarketMakingCtx {
             transfer: usdc_handles.resume_alpaca_to_base,
+            resume_preparation: rebalancing_service.clone(),
             job_queue: transfer_usdc_to_market_making_queue,
             max_burn_revert_redrives: rebalancing_ctx.max_burn_revert_redrives,
             notifier: usdc_notifier.clone(),

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -233,8 +233,9 @@ where
     .with_configured_vaults(configured_equity_vaults, configured_usdc_vaults);
 
     if let Some(rebalancing_service) = &rebalancing_service {
-        polling_service =
-            polling_service.with_pending_request_ownership(rebalancing_service.clone());
+        polling_service = polling_service
+            .with_pending_request_ownership(rebalancing_service.clone())
+            .with_fresh_offchain_usd_observer(rebalancing_service.clone());
     }
 
     let polling_service = Arc::new(polling_service);

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -13,8 +13,8 @@ pub(crate) use broadcasting::BroadcastingInventory;
 #[cfg(test)]
 pub(crate) use polling::PollerError;
 pub(crate) use polling::{
-    InventoryPollingService, PendingRequestOwnership, PendingRequestOwnershipSnapshot, Poller,
-    WalletPollingCtx,
+    FreshOffchainUsdObserver, InventoryPollingService, PendingRequestOwnership,
+    PendingRequestOwnershipSnapshot, Poller, WalletPollingCtx,
 };
 pub(crate) use projection::InventoryProjection;
 pub(crate) use snapshot::{InventorySnapshot, InventorySnapshotId};

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -9,7 +9,7 @@
 use alloy::primitives::{Address, B256, TxHash};
 use alloy::providers::RootProvider;
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use futures_util::future::try_join_all;
 use rain_math_float::FloatError;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -50,6 +50,18 @@ pub(crate) trait PendingRequestOwnership: Send + Sync {
     async fn pending_request_ownership(&self) -> PendingRequestOwnershipSnapshot;
 }
 
+/// Consumer for a freshly fetched, reserve-adjusted offchain cash balance.
+/// Unlike snapshot reactors, this callback runs even when the aggregate
+/// deduplicates an unchanged balance.
+#[async_trait]
+pub(crate) trait FreshOffchainUsdObserver: Send + Sync {
+    async fn observe_fresh_offchain_usd(
+        &self,
+        available: Usdc,
+        observed_at: DateTime<Utc>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
+}
+
 /// Error type for inventory polling operations.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum InventoryPollingError<ExecutorError> {
@@ -78,6 +90,8 @@ pub(crate) enum InventoryPollingError<ExecutorError> {
     SharesConversion(#[from] SharesConversionError),
     #[error(transparent)]
     Reserve(#[from] ReserveError),
+    #[error("fresh offchain USD observer failed: {0}")]
+    FreshOffchainUsdObserver(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Errors that can occur when computing available cash after subtracting
@@ -92,6 +106,8 @@ pub(crate) enum ReserveError {
     CentsConversion(#[from] UsdToCentsError),
     #[error("failed to convert broker cents {cents} to Usd")]
     BrokerCentsConversion { cents: i64 },
+    #[error("failed to convert available broker cents {cents} to Usdc")]
+    AvailableUsdcConversion { cents: i64 },
 }
 
 pub(crate) struct WalletPollingCtx {
@@ -120,6 +136,7 @@ where
     wallet_polling: Option<WalletPollingCtx>,
     tokenizer: Option<Arc<dyn Tokenizer>>,
     pending_request_ownership: Option<Arc<dyn PendingRequestOwnership>>,
+    fresh_offchain_usd_observer: Option<Arc<dyn FreshOffchainUsdObserver>>,
     external_pending_warnings: Mutex<HashSet<TokenizationRequestId>>,
     unconfigured_symbol_warnings: Mutex<HashSet<Symbol>>,
     retired_equity_vault_warnings: Mutex<HashSet<(Address, B256)>>,
@@ -157,6 +174,7 @@ where
             wallet_polling,
             tokenizer,
             pending_request_ownership: None,
+            fresh_offchain_usd_observer: None,
             external_pending_warnings: Mutex::new(HashSet::new()),
             unconfigured_symbol_warnings: Mutex::new(HashSet::new()),
             retired_equity_vault_warnings: Mutex::new(HashSet::new()),
@@ -191,6 +209,14 @@ where
         pending_request_ownership: Arc<dyn PendingRequestOwnership>,
     ) -> Self {
         self.pending_request_ownership = Some(pending_request_ownership);
+        self
+    }
+
+    pub(crate) fn with_fresh_offchain_usd_observer(
+        mut self,
+        observer: Arc<dyn FreshOffchainUsdObserver>,
+    ) -> Self {
+        self.fresh_offchain_usd_observer = Some(observer);
         self
     }
 
@@ -540,6 +566,18 @@ where
                 },
             )
             .await?;
+
+        if let Some(observer) = &self.fresh_offchain_usd_observer {
+            let available = Usdc::from_cents(available_usd_cents).ok_or(
+                ReserveError::AvailableUsdcConversion {
+                    cents: available_usd_cents,
+                },
+            )?;
+            observer
+                .observe_fresh_offchain_usd(available, Utc::now())
+                .await
+                .map_err(InventoryPollingError::FreshOffchainUsdObserver)?;
+        }
 
         self.snapshot
             .send(
@@ -996,6 +1034,21 @@ mod tests {
     impl PendingRequestOwnership for TestPendingRequestOwnership {
         async fn pending_request_ownership(&self) -> PendingRequestOwnershipSnapshot {
             self.0.clone()
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingFreshOffchainUsdObserver(Mutex<Vec<Usdc>>);
+
+    #[async_trait]
+    impl FreshOffchainUsdObserver for RecordingFreshOffchainUsdObserver {
+        async fn observe_fresh_offchain_usd(
+            &self,
+            available: Usdc,
+            _observed_at: DateTime<Utc>,
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            self.0.lock().unwrap().push(available);
+            Ok(())
         }
     }
 
@@ -1457,6 +1510,56 @@ mod tests {
         assert_eq!(
             *usd_balance_cents, 25_000_000,
             "Cash balance mismatch: expected $250,000.00"
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_offchain_usd_observer_runs_when_snapshot_deduplicates_balance() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(provider.clone());
+        let (orderbook, order_owner) = test_addresses();
+        let observer = Arc::new(RecordingFreshOffchainUsdObserver::default());
+        let executor = MockExecutor::new().with_inventory(Inventory {
+            positions: vec![],
+            usd_balance_cents: 25_000_000,
+            cash_buying_power_cents: Some(25_000_000),
+            alpaca_usdc: None,
+            cash_withdrawable_cents: None,
+        });
+        let service = InventoryPollingService::new(
+            raindex_service,
+            executor,
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            order_owner,
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            None,
+            Usd::ZERO,
+        )
+        .with_fresh_offchain_usd_observer(observer.clone());
+
+        service.poll_and_record().await.unwrap();
+        service.poll_and_record().await.unwrap();
+
+        let observations = observer.0.lock().unwrap().clone();
+        assert_eq!(
+            observations.as_slice(),
+            &[Usdc::new(float!(250000)), Usdc::new(float!(250000))],
+            "each successful broker fetch must cross the recovery freshness barrier",
+        );
+        let snapshot_events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        assert_eq!(
+            snapshot_events
+                .iter()
+                .filter(|event| matches!(event, InventorySnapshotEvent::OffchainUsd { .. }))
+                .count(),
+            1,
+            "the recovery callback must not disable persisted snapshot deduplication",
         );
     }
 

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -413,6 +413,24 @@ where
         })
     }
 
+    /// Atomically replace a venue with a fresh available balance and an exact
+    /// recovered source reservation.
+    ///
+    /// This is narrower than [`Self::force_on_snapshot`]: it is used only when
+    /// durable transfer state proves the reservation amount, so recovery keeps
+    /// that inflight amount while replacing potentially stale available state.
+    pub(crate) fn restore_reservation(
+        venue: Venue,
+        available: T,
+        inflight: T,
+    ) -> Box<dyn FnOnce(Self) -> Result<Self, InventoryError<T>> + Send> {
+        Box::new(move |inventory| {
+            let balance = VenueBalance::new(available, T::ZERO).set_inflight(inflight)?;
+
+            Ok(inventory.set_venue(venue, Some(balance)))
+        })
+    }
+
     /// Apply a fetched venue snapshot.
     ///
     /// Skips if ANY venue has inflight operations, because we cannot
@@ -1311,7 +1329,6 @@ impl InventoryView {
     }
 
     /// Returns the aggregate ID of the in-flight USDC rebalance, if any.
-    #[cfg(test)]
     pub(crate) fn active_usdc_rebalance(&self) -> Option<&UsdcRebalanceId> {
         self.active_usdc_rebalance.as_ref()
     }
@@ -2756,6 +2773,20 @@ mod tests {
 
         let onchain = result.onchain.unwrap();
         assert_eq!(onchain.total().unwrap(), shares(999));
+    }
+
+    #[test]
+    fn restore_reservation_replaces_stale_available_and_existing_inflight() {
+        let inventory = make_inventory(50, 0, 100, 20);
+
+        let restored =
+            Inventory::restore_reservation(Venue::Hedging, shares(75), shares(30))(inventory)
+                .unwrap();
+
+        let offchain = restored.offchain.unwrap();
+        assert_eq!(offchain.available(), shares(75));
+        assert_eq!(offchain.inflight(), shares(30));
+        assert_eq!(restored.onchain, Some(venue(50, 0)));
     }
 
     #[test]

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -40,8 +40,9 @@ use crate::inventory::projection::InventoryProjectionError;
 use crate::inventory::snapshot::{InventorySnapshot, InventorySnapshotEvent};
 use crate::inventory::view::InFlightEquityLocation;
 use crate::inventory::{
-    BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, InventoryViewError,
-    Operator, PendingRequestOwnership, PendingRequestOwnershipSnapshot, TransferOp, Venue,
+    BroadcastingInventory, FreshOffchainUsdObserver, ImbalanceThreshold, Inventory, InventoryView,
+    InventoryViewError, Operator, PendingRequestOwnership, PendingRequestOwnershipSnapshot,
+    TransferOp, Venue,
 };
 use crate::position::{Position, PositionEvent};
 use crate::rebalancing::equity::{
@@ -49,6 +50,7 @@ use crate::rebalancing::equity::{
     TransferEquityToMarketMakingJobQueue,
 };
 use crate::rebalancing::usdc::{
+    AlpacaToBaseResumePreparation, AlpacaToBaseResumePreparationError, PrepareAlpacaToBaseResume,
     TransferUsdcToHedging, TransferUsdcToHedgingJobQueue, TransferUsdcToMarketMaking,
     TransferUsdcToMarketMakingJobQueue,
 };
@@ -60,8 +62,8 @@ use crate::unwrapped_equity_recovery::{
     UnwrappedEquityRecoveryJob, UnwrappedEquityRecoveryJobQueue,
 };
 use crate::usdc_rebalance::{
-    InterruptedUsdcRebalances, RebalanceDirection, UsdcRebalance, UsdcRebalanceEvent,
-    UsdcRebalanceId, interrupted_usdc_rebalance_ids,
+    AlpacaToBaseReservationRecovery, InterruptedUsdcRebalances, RebalanceDirection, UsdcRebalance,
+    UsdcRebalanceEvent, UsdcRebalanceId, interrupted_usdc_rebalance_ids,
 };
 use crate::vault_registry::{VaultRegistry, VaultRegistryId};
 use crate::wrapped_equity_recovery::aggregate::WrappedEquityRecoveryId;
@@ -137,6 +139,21 @@ pub(crate) enum RebalancingServiceError {
     ApalisSqlx(#[from] sqlx_apalis::Error),
     #[error("failed to re-arm a stranded USDC transfer job at startup: {0}")]
     RearmEnqueue(#[from] QueuePushError),
+    #[error("multiple Alpaca-to-Base source reservations require recovery: {ids:?}")]
+    MultipleAlpacaToBaseReservationRecoveries { ids: Vec<UsdcRebalanceId> },
+    #[error("cannot restore Alpaca-to-Base rebalance {recovered}: inventory is owned by {active}")]
+    ConflictingActiveUsdcRebalance {
+        recovered: UsdcRebalanceId,
+        active: UsdcRebalanceId,
+    },
+    #[error(
+        "recovered Alpaca-to-Base reservation for {id} is {reserved}, but Initiated carries {initiated}"
+    )]
+    RecoveredReservationAmountMismatch {
+        id: UsdcRebalanceId,
+        reserved: Usdc,
+        initiated: Usdc,
+    },
 }
 
 /// Why loading a token address from the vault registry failed.
@@ -509,6 +526,9 @@ pub(crate) struct RebalancingService {
     /// Tracks USDC rebalance lifecycle data needed to settle inventory on
     /// terminal events with the actual amount received.
     usdc_tracking: Arc<RwLock<HashMap<UsdcRebalanceId, usdc::UsdcRebalanceTracking>>>,
+    /// Startup-only barrier that prevents a recovered Alpaca-to-Base worker
+    /// from resuming until its exact source reservation is reconstructed.
+    alpaca_to_base_resume_gate: Arc<RwLock<Option<AlpacaToBaseResumeGate>>>,
     suppressed_inflight_symbols: Arc<RwLock<HashMap<Symbol, DateTime<Utc>>>>,
     timed_out_mints: Arc<RwLock<HashMap<IssuerRequestId, DateTime<Utc>>>>,
     timed_out_redemptions: Arc<RwLock<HashMap<RedemptionAggregateId, DateTime<Utc>>>>,
@@ -536,6 +556,27 @@ pub(crate) struct RebalancingService {
     mint_store: RwLock<Option<Arc<Store<TokenizedEquityMint>>>>,
     redemption_store: RwLock<Option<Arc<Store<EquityRedemption>>>>,
     usdc_store: RwLock<Option<Arc<Store<UsdcRebalance>>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AlpacaToBaseResumeGate {
+    AwaitingFreshHedgingSnapshot {
+        id: UsdcRebalanceId,
+        recovery: AlpacaToBaseReservationRecovery,
+    },
+    ReservationRestored {
+        id: UsdcRebalanceId,
+        amount: Usdc,
+    },
+}
+
+impl AlpacaToBaseResumeGate {
+    fn id(&self) -> &UsdcRebalanceId {
+        match self {
+            Self::AwaitingFreshHedgingSnapshot { id, .. }
+            | Self::ReservationRestored { id, .. } => id,
+        }
+    }
 }
 
 type EquityInventoryUpdate = Box<
@@ -650,6 +691,7 @@ impl RebalancingService {
             mint_tracking: Arc::new(RwLock::new(HashMap::new())),
             redemption_tracking: Arc::new(RwLock::new(HashMap::new())),
             usdc_tracking: Arc::new(RwLock::new(HashMap::new())),
+            alpaca_to_base_resume_gate: Arc::new(RwLock::new(None)),
             suppressed_inflight_symbols: Arc::new(RwLock::new(HashMap::new())),
             timed_out_mints: Arc::new(RwLock::new(HashMap::new())),
             timed_out_redemptions: Arc::new(RwLock::new(HashMap::new())),
@@ -1037,6 +1079,11 @@ impl RebalancingService {
                         "USDC transfer timed out; clearing trigger guard and inventory inflight"
                     );
 
+                    let mut resume_gate = self.alpaca_to_base_resume_gate.write().await;
+                    if resume_gate.as_ref().is_some_and(|gate| gate.id() == &id) {
+                        *resume_gate = None;
+                    }
+                    drop(resume_gate);
                     self.clear_usdc_in_progress();
                 }
                 UsdcTimeoutCleanup::PreservedPostBurn { tracking, elapsed } => {
@@ -1678,8 +1725,11 @@ impl RebalancingService {
     ) -> Result<(), RebalancingServiceError> {
         use InventorySnapshotEvent::*;
         use RebalancingServiceError::{
-            ApalisSqlx, EquityTrigger, Float, MissingUsdcBridgedAmount, MissingUsdcTrackingContext,
-            Projection, RearmEnqueue, SettledUsdcExceedsInitiatedAmount, SharesConversion, Sqlx,
+            ApalisSqlx, ConflictingActiveUsdcRebalance, EquityTrigger, Float,
+            MissingUsdcBridgedAmount, MissingUsdcTrackingContext,
+            MultipleAlpacaToBaseReservationRecoveries, Projection, RearmEnqueue,
+            RecoveredReservationAmountMismatch, SettledUsdcExceedsInitiatedAmount,
+            SharesConversion, Sqlx,
         };
 
         self.expire_stuck_operations_with_logging().await;
@@ -1693,6 +1743,9 @@ impl RebalancingService {
             | MissingUsdcTrackingContext { .. }
             | MissingUsdcBridgedAmount { .. }
             | SettledUsdcExceedsInitiatedAmount { .. }
+            | MultipleAlpacaToBaseReservationRecoveries { .. }
+            | ConflictingActiveUsdcRebalance { .. }
+            | RecoveredReservationAmountMismatch { .. }
             | Sqlx(_)
             | ApalisSqlx(_)
             | RearmEnqueue(_)) => {
@@ -2026,6 +2079,107 @@ impl RebalancingService {
             })
             .await;
         }
+    }
+}
+
+#[async_trait]
+impl PrepareAlpacaToBaseResume for RebalancingService {
+    async fn prepare_alpaca_to_base_resume(
+        &self,
+        id: &UsdcRebalanceId,
+    ) -> Result<AlpacaToBaseResumePreparation, AlpacaToBaseResumePreparationError> {
+        match self.alpaca_to_base_resume_gate.read().await.as_ref() {
+            Some(AlpacaToBaseResumeGate::AwaitingFreshHedgingSnapshot {
+                id: recovered_id, ..
+            }) if recovered_id == id => {
+                Ok(AlpacaToBaseResumePreparation::AwaitingFreshHedgingSnapshot)
+            }
+            Some(AlpacaToBaseResumeGate::ReservationRestored {
+                id: recovered_id, ..
+            }) if recovered_id == id => Ok(AlpacaToBaseResumePreparation::Ready),
+            Some(gate) => Err(
+                AlpacaToBaseResumePreparationError::ConflictingRecoveryOwner {
+                    requested: id.clone(),
+                    owner: gate.id().clone(),
+                },
+            ),
+            None => Ok(AlpacaToBaseResumePreparation::Ready),
+        }
+    }
+}
+
+#[async_trait]
+impl FreshOffchainUsdObserver for RebalancingService {
+    async fn observe_fresh_offchain_usd(
+        &self,
+        available: Usdc,
+        observed_at: DateTime<Utc>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let event_sync_guard = self.usdc_event_sync.lock().await;
+        let awaiting = match self.alpaca_to_base_resume_gate.read().await.as_ref() {
+            Some(AlpacaToBaseResumeGate::AwaitingFreshHedgingSnapshot { id, recovery }) => {
+                Some((id.clone(), *recovery))
+            }
+            Some(AlpacaToBaseResumeGate::ReservationRestored { .. }) | None => None,
+        };
+
+        let Some((id, recovery)) = awaiting else {
+            return Ok(());
+        };
+
+        let mut inventory = self.inventory.write().await;
+        if let Some(active) = inventory.active_usdc_rebalance()
+            && active != &id
+        {
+            return Err(Box::new(
+                RebalancingServiceError::ConflictingActiveUsdcRebalance {
+                    recovered: id,
+                    active: active.clone(),
+                },
+            ));
+        }
+
+        *inventory = inventory
+            .clone()
+            .update_usdc(
+                Inventory::restore_reservation(Venue::Hedging, available, recovery.amount),
+                observed_at,
+            )?
+            .set_active_usdc_rebalance(id.clone());
+        drop(inventory);
+
+        let stage = match recovery.stage {
+            crate::usdc_rebalance::AlpacaToBaseReservationStage::ConversionComplete => {
+                usdc::UsdcRebalanceStage::ConversionConfirmed
+            }
+            crate::usdc_rebalance::AlpacaToBaseReservationStage::Withdrawing => {
+                usdc::UsdcRebalanceStage::Initiated
+            }
+            crate::usdc_rebalance::AlpacaToBaseReservationStage::WithdrawalComplete => {
+                usdc::UsdcRebalanceStage::WithdrawalConfirmed
+            }
+            crate::usdc_rebalance::AlpacaToBaseReservationStage::BridgingSubmitting => {
+                usdc::UsdcRebalanceStage::BridgingInitiated
+            }
+        };
+        self.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: recovery.amount,
+                bridged_amount_received: None,
+                stage,
+                last_progress_at: recovery.last_progress_at,
+            },
+        );
+        *self.alpaca_to_base_resume_gate.write().await =
+            Some(AlpacaToBaseResumeGate::ReservationRestored {
+                id,
+                amount: recovery.amount,
+            });
+        drop(event_sync_guard);
+
+        Ok(())
     }
 }
 
@@ -3631,7 +3785,7 @@ impl RebalancingService {
     /// each post-burn resumable aggregate with no blocking job row, this
     /// re-enqueues a transfer job keyed by the existing id. The live/row-existence
     /// checks make this idempotent with apalis's own re-pick of still-owned rows.
-    /// See ADR 2.
+    /// See ADR 0003 and ADR 0015.
     pub(crate) async fn recover_usdc_guard(
         &self,
         pool: &SqlitePool,
@@ -3644,6 +3798,7 @@ impl RebalancingService {
 
         let mut held_ids = Vec::new();
         let mut held_tracking = Vec::new();
+        let mut reservation_recoveries = Vec::new();
         // Guard-holding aggregates with no tracking seed AND no re-arm path
         // (e.g. WithdrawalSubmitting{AlpacaToBase}): the sweep never selects
         // them, so there is no automated recovery. The operator must be paged
@@ -3654,6 +3809,10 @@ impl RebalancingService {
         for id in candidate_ids {
             match usdc_store.load(&id).await {
                 Ok(Some(entity)) => {
+                    if let Some(recovery) = entity.alpaca_to_base_reservation_recovery() {
+                        reservation_recoveries.push((id.clone(), recovery));
+                    }
+
                     if entity.holds_rebalance_guard() {
                         held_ids.push(id.clone());
 
@@ -3757,11 +3916,11 @@ impl RebalancingService {
                         // is_resumable_mid_flight_data: resume_alpaca_to_base returns
                         // ResumeDirectionMismatch for that state so it must not be re-armed.
                         //
-                        // IMPORTANT: These states must NOT get a tracking seed (only
-                        // DepositFailed, ConversionFailed, and BridgingFailed{burn_tx=Some}
-                        // get tracking seeds). Adding tracking here would wedge the
-                        // DepositConfirmed path which requires bridged_amount_received
-                        // that the seed cannot supply.
+                        // Alpaca-to-Base pre-burn states receive their tracking
+                        // and exact source reservation only after the fresh
+                        // offchain inventory observer runs. Base-to-Alpaca and
+                        // post-burn states remain guard-only here because their
+                        // full inventory effect cannot be reconstructed safely.
                         //
                         // This re-arm runs BEFORE the apalis monitor spawns (see
                         // conductor.rs startup order), so there is no live-worker race.
@@ -3882,6 +4041,27 @@ impl RebalancingService {
                 }
             }
         }
+
+        if reservation_recoveries.len() > 1 {
+            return Err(
+                RebalancingServiceError::MultipleAlpacaToBaseReservationRecoveries {
+                    ids: reservation_recoveries
+                        .into_iter()
+                        .map(|(id, _)| id)
+                        .collect(),
+                },
+            );
+        }
+
+        *self.alpaca_to_base_resume_gate.write().await = reservation_recoveries
+            .into_iter()
+            .next()
+            .map(
+                |(id, recovery)| AlpacaToBaseResumeGate::AwaitingFreshHedgingSnapshot {
+                    id,
+                    recovery,
+                },
+            );
 
         // Re-arm a transfer job for each post-burn resumable aggregate that has
         // no job row at all -- the strand that a failed redrive enqueue (or a
@@ -12726,6 +12906,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn timed_out_recovered_conversion_retires_resume_gate() {
+        let now = Utc::now();
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(400);
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(100), usdc(900))
+            .update_usdc(
+                Inventory::transfer(Venue::Hedging, TransferOp::Start, amount),
+                now,
+            )
+            .unwrap()
+            .set_active_usdc_rebalance(id.clone());
+        let trigger = make_trigger_with_inventory_config(
+            inventory,
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: amount,
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::ConversionConfirmed,
+                last_progress_at: now - ChronoDuration::minutes(31),
+            },
+        );
+        *trigger.alpaca_to_base_resume_gate.write().await =
+            Some(AlpacaToBaseResumeGate::ReservationRestored {
+                id: id.clone(),
+                amount,
+            });
+
+        trigger.expire_stuck_usdc_rebalances(now).await.unwrap();
+
+        assert!(
+            trigger.alpaca_to_base_resume_gate.read().await.is_none(),
+            "timeout cleanup must retire the restart-only gate with its recovered owner",
+        );
+        assert!(!trigger.usdc_in_progress.load(Ordering::SeqCst));
+        assert_eq!(
+            trigger.inventory.read().await.usdc_inflight(Venue::Hedging),
+            Some(Usdc::ZERO),
+        );
+    }
+
+    #[tokio::test]
     async fn in_flight_hedging_transfer_blocks_market_making_enqueue() {
         let service = make_trigger_with_inventory(InventoryView::default()).await;
 
@@ -16434,6 +16663,34 @@ mod tests {
             .unwrap();
     }
 
+    async fn seed_conversion_complete_alpaca_to_base(
+        store: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        requested: Usdc,
+        received: Usdc,
+    ) {
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::InitiateConversion {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount: requested,
+                    order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                UsdcRebalanceCommand::ConfirmConversion {
+                    conversion: ConversionAmounts::new(requested, received),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
     async fn make_trigger_with_timed_out_alpaca_to_base_tracking(
         pool: &SqlitePool,
         store: Arc<Store<UsdcRebalance>>,
@@ -16503,6 +16760,52 @@ mod tests {
         service.recover_usdc_guard(&pool, &store).await.unwrap();
 
         assert_eq!(
+            service.prepare_alpaca_to_base_resume(&id).await.unwrap(),
+            AlpacaToBaseResumePreparation::AwaitingFreshHedgingSnapshot,
+            "the recovered job must remain gated until a fresh hedging snapshot arrives",
+        );
+
+        service
+            .observe_fresh_offchain_usd(usdc(500), Utc::now())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            service.prepare_alpaca_to_base_resume(&id).await.unwrap(),
+            AlpacaToBaseResumePreparation::Ready,
+            "the fresh snapshot must release the resume gate after restoring inventory",
+        );
+        {
+            let inventory = service.inventory.read().await;
+            assert_eq!(
+                inventory.usdc_available(Venue::Hedging),
+                Some(usdc(500)),
+                "snapshot-reconciled available cash must not be debited a second time",
+            );
+            assert_eq!(
+                inventory.usdc_inflight(Venue::Hedging),
+                Some(amount),
+                "recovery must restore the exact durable source reservation",
+            );
+            assert_eq!(
+                inventory.active_usdc_rebalance(),
+                Some(&id),
+                "recovery must restore active aggregate ownership together with inflight",
+            );
+            drop(inventory);
+        }
+
+        service
+            .observe_fresh_offchain_usd(usdc(500), Utc::now())
+            .await
+            .unwrap();
+        assert_eq!(
+            service.inventory.read().await.usdc_inflight(Venue::Hedging),
+            Some(amount),
+            "observing the same recovery twice must replace, never add, inflight",
+        );
+
+        assert_eq!(
             count_pending_transfer_usdc_to_market_making_jobs(&service).await,
             1,
             "a Withdrawing{{AlpacaToBase}} with no job row must be re-armed as a market-making job",
@@ -16515,6 +16818,241 @@ mod tests {
         assert!(
             service.usdc_in_progress.load(Ordering::SeqCst),
             "usdc_in_progress must be latched after re-arming a Withdrawing{{AlpacaToBase}} job",
+        );
+    }
+
+    #[tokio::test]
+    async fn recovered_conversion_complete_initiated_event_does_not_debit_snapshot_twice() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let requested = usdc(400);
+        let received = usdc(390);
+
+        seed_conversion_complete_alpaca_to_base(&store, &id, requested, received).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+        service
+            .observe_fresh_offchain_usd(usdc(500), Utc::now())
+            .await
+            .unwrap();
+
+        service
+            .on_usdc_rebalance(
+                id.clone(),
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount: received,
+                    withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+                    initiated_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let inventory = service.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_available(Venue::Hedging),
+            Some(usdc(500)),
+            "the fresh broker snapshot already reflects conversion, so Initiated must not debit it again",
+        );
+        assert_eq!(
+            inventory.usdc_inflight(Venue::Hedging),
+            Some(received),
+            "the restored reservation must remain exact after the durable Initiated event",
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
+    async fn recovered_reservation_rejects_a_different_initiated_amount() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let reserved = usdc(400);
+        let initiated = usdc(399);
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        *service.alpaca_to_base_resume_gate.write().await =
+            Some(AlpacaToBaseResumeGate::ReservationRestored {
+                id: id.clone(),
+                amount: reserved,
+            });
+
+        let error = service
+            .on_usdc_rebalance(
+                id.clone(),
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount: initiated,
+                    withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+                    initiated_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RebalancingServiceError::RecoveredReservationAmountMismatch {
+                id: mismatched_id,
+                reserved: mismatched_reserved,
+                initiated: mismatched_initiated,
+            } if mismatched_id == id
+                && mismatched_reserved == reserved
+                && mismatched_initiated == initiated
+        ));
+    }
+
+    #[tokio::test]
+    async fn recovered_reservation_does_not_overwrite_conflicting_inventory_owner() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let recovered_id = UsdcRebalanceId(Uuid::new_v4());
+        let active_id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc(400);
+
+        seed_withdrawing_alpaca_to_base(&store, &recovered_id, amount).await;
+
+        let inventory = InventoryView::default().set_active_usdc_rebalance(active_id.clone());
+        let service = make_trigger_with_inventory(inventory).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        let error = service
+            .observe_fresh_offchain_usd(usdc(500), Utc::now())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<RebalancingServiceError>(),
+            Some(RebalancingServiceError::ConflictingActiveUsdcRebalance {
+                recovered,
+                active,
+            }) if recovered == &recovered_id && active == &active_id
+        ));
+        assert_eq!(
+            service
+                .prepare_alpaca_to_base_resume(&recovered_id)
+                .await
+                .unwrap(),
+            AlpacaToBaseResumePreparation::AwaitingFreshHedgingSnapshot,
+            "a conflicting owner must leave the recovered transfer gated",
+        );
+        assert_eq!(
+            service.inventory.read().await.active_usdc_rebalance(),
+            Some(&active_id),
+            "recovery must never overwrite a different aggregate's ownership",
+        );
+    }
+
+    #[tokio::test]
+    async fn recovered_reservation_rejects_a_different_job_owner() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let recovered_id = UsdcRebalanceId(Uuid::new_v4());
+        let different_id = UsdcRebalanceId(Uuid::new_v4());
+
+        seed_withdrawing_alpaca_to_base(&store, &recovered_id, usdc(400)).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        let error = service
+            .prepare_alpaca_to_base_resume(&different_id)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            AlpacaToBaseResumePreparationError::ConflictingRecoveryOwner {
+                requested,
+                owner,
+            } if requested == different_id && owner == recovered_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn recovery_rejects_multiple_alpaca_to_base_reservation_owners() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let first = UsdcRebalanceId(Uuid::new_v4());
+        let second = UsdcRebalanceId(Uuid::new_v4());
+
+        seed_withdrawing_alpaca_to_base(&store, &first, usdc(300)).await;
+        seed_withdrawing_alpaca_to_base(&store, &second, usdc(400)).await;
+
+        let service = make_trigger_with_inventory(InventoryView::default()).await;
+        let error = service.recover_usdc_guard(&pool, &store).await.unwrap_err();
+
+        let RebalancingServiceError::MultipleAlpacaToBaseReservationRecoveries { ids } = error
+        else {
+            panic!("expected multiple-recovery-owner error, got {error:?}");
+        };
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&first));
+        assert!(ids.contains(&second));
+        assert!(service.alpaca_to_base_resume_gate.read().await.is_none());
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&service).await,
+            0,
+            "ambiguous ownership must fail before any resume job is enqueued",
+        );
+    }
+
+    #[tokio::test]
+    async fn recovered_reservation_settles_terminal_success_without_inflight_underflow() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated = usdc(400);
+        let received = usdc(398);
+
+        seed_withdrawing_alpaca_to_base(&store, &id, initiated).await;
+
+        let service =
+            make_trigger_with_inventory(InventoryView::default().with_usdc(usdc(100), usdc(900)))
+                .await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+        service
+            .observe_fresh_offchain_usd(usdc(500), Utc::now())
+            .await
+            .unwrap();
+
+        service
+            .on_usdc_rebalance(
+                id.clone(),
+                make_usdc_bridged_with_amounts(received, usdc(2)),
+            )
+            .await
+            .unwrap();
+        service
+            .on_usdc_rebalance(
+                id.clone(),
+                make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase),
+            )
+            .await
+            .unwrap();
+
+        let inventory = service.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_available(Venue::Hedging),
+            Some(usdc(500)),
+            "terminal settlement must not debit the already-reconciled source snapshot",
+        );
+        assert_eq!(
+            inventory.usdc_inflight(Venue::Hedging),
+            Some(Usdc::ZERO),
+            "terminal settlement must release the exact reconstructed inflight",
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(498)),
+            "the destination must receive the actual bridged amount",
+        );
+        assert_eq!(inventory.active_usdc_rebalance(), None);
+        drop(inventory);
+        assert!(!service.usdc_in_progress.load(Ordering::SeqCst));
+        assert!(
+            service.alpaca_to_base_resume_gate.read().await.is_none(),
+            "terminal cleanup must retire the restart-only resume gate",
         );
     }
 
@@ -16955,6 +17493,27 @@ mod tests {
 
         let service = make_trigger_with_inventory(InventoryView::default()).await;
         service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert_eq!(
+            service.prepare_alpaca_to_base_resume(&id).await.unwrap(),
+            AlpacaToBaseResumePreparation::AwaitingFreshHedgingSnapshot,
+        );
+        service
+            .observe_fresh_offchain_usd(usdc(700), Utc::now())
+            .await
+            .unwrap();
+        assert_eq!(
+            service.inventory.read().await.usdc_inflight(Venue::Hedging),
+            Some(amount),
+            "BridgingSubmitting recovery must restore its source reservation before burn resume",
+        );
+        assert!(matches!(
+            service.usdc_tracking.read().await.get(&id),
+            Some(usdc::UsdcRebalanceTracking {
+                stage: usdc::UsdcRebalanceStage::BridgingInitiated,
+                ..
+            })
+        ));
 
         assert_eq!(
             count_pending_transfer_usdc_to_market_making_jobs(&service).await,

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -610,6 +610,11 @@ impl RebalancingService {
         }
         if is_clearable_terminal {
             self.usdc_tracking.write().await.remove(&id);
+            let mut resume_gate = self.alpaca_to_base_resume_gate.write().await;
+            if resume_gate.as_ref().is_some_and(|gate| gate.id() == &id) {
+                *resume_gate = None;
+            }
+            drop(resume_gate);
             self.clear_usdc_in_progress();
             debug!(target: "rebalance", "Cleared USDC in-progress flag after rebalance terminal event");
         } else if terminal_action == UsdcTerminalAction::PreservePostBurn {
@@ -697,10 +702,10 @@ impl RebalancingService {
         // while an AlpacaToBase pre-withdrawal `ConversionFailed` clears.
         // Terminal successes fall through to `false` and settle normally.
         //
-        // When in-memory tracking is absent -- e.g. an apalis job that resumes
-        // after a restart, where `recover_usdc_guard` reasserts the guard but
-        // does not rebuild tracking -- we must NOT speculatively clear the guard
-        // on a failure that could be post-burn. So:
+        // When in-memory tracking is absent -- e.g. a post-burn apalis resume,
+        // for which startup recovery deliberately remains guard-only -- we must
+        // NOT speculatively clear the guard on a failure that could be
+        // post-burn. So:
         //   - `DepositFailed` is only reachable from `DepositInitiated`
         //     (post-mint), hence unconditionally post-burn.
         //   - `ConversionFailed` defaults to preserve when tracking is absent
@@ -910,6 +915,30 @@ impl RebalancingService {
                     id: id.clone(),
                     event: UsdcTrackingEvent::Initiated,
                 })?;
+        let restored_amount = self
+            .alpaca_to_base_resume_gate
+            .read()
+            .await
+            .as_ref()
+            .and_then(|gate| match gate {
+                super::AlpacaToBaseResumeGate::ReservationRestored {
+                    id: recovered_id,
+                    amount,
+                } if recovered_id == id => Some(*amount),
+                super::AlpacaToBaseResumeGate::AwaitingFreshHedgingSnapshot { .. }
+                | super::AlpacaToBaseResumeGate::ReservationRestored { .. } => None,
+            });
+        if let Some(reserved) = restored_amount
+            && reserved != amount
+        {
+            return Err(
+                RebalancingServiceError::RecoveredReservationAmountMismatch {
+                    id: id.clone(),
+                    reserved,
+                    initiated: amount,
+                },
+            );
+        }
         let mut tracking = self.usdc_tracking.write().await;
         if let Some(existing) = tracking.get_mut(id) {
             let tracking_entry = UsdcRebalanceTracking {
@@ -920,7 +949,7 @@ impl RebalancingService {
                 last_progress_at,
             };
 
-            if existing.source_transfer_started() {
+            if existing.source_transfer_started() || restored_amount.is_some() {
                 *existing = tracking_entry;
                 return Ok(());
             }
@@ -950,6 +979,14 @@ impl RebalancingService {
             stage,
             last_progress_at,
         };
+
+        if restored_amount.is_some() {
+            self.usdc_tracking
+                .write()
+                .await
+                .insert(id.clone(), tracking_entry);
+            return Ok(());
+        }
 
         let update = Inventory::transfer(tracking_entry.source_venue(), TransferOp::Start, amount);
 

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -70,6 +70,10 @@ const SETTLEMENT_REDRIVE_DELAY: Duration = Duration::from_secs(30);
 /// (Ethereum block timing) so the two can evolve independently.
 const WITHDRAWAL_POLL_REDRIVE_DELAY: Duration = Duration::from_secs(30);
 
+/// Delay before retrying a recovered Alpaca-to-Base job whose source
+/// reservation is still waiting for a fresh hedging inventory observation.
+const INVENTORY_RECOVERY_REDRIVE_DELAY: Duration = Duration::from_secs(30);
+
 /// Duration after which repeated `WithdrawalPollInconclusive` redrives page
 /// the operator via the notifier. The deadline is durable: it is derived from
 /// `Withdrawing.initiated_at` (stored in the CQRS aggregate, survives restarts)
@@ -151,6 +155,50 @@ pub(crate) trait ResumeAlpacaToBase: Send + Sync + 'static {
         id: &UsdcRebalanceId,
         amount: Usdc,
     ) -> Result<(), UsdcTransferError>;
+}
+
+/// Whether a recovered Alpaca-to-Base transfer can safely enter its durable
+/// aggregate resume path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AlpacaToBaseResumePreparation {
+    Ready,
+    AwaitingFreshHedgingSnapshot,
+}
+
+/// Why a recovered Alpaca-to-Base job cannot enter its aggregate resume path.
+#[derive(Debug, Error)]
+pub(crate) enum AlpacaToBaseResumePreparationError {
+    #[error(
+        "Alpaca-to-Base job {requested} cannot resume while recovered reservation owner {owner} is active"
+    )]
+    ConflictingRecoveryOwner {
+        requested: UsdcRebalanceId,
+        owner: UsdcRebalanceId,
+    },
+}
+
+/// Restores restart-only source inventory ownership before the transfer
+/// manager resumes. Fresh transfers return [`AlpacaToBaseResumePreparation::Ready`].
+#[async_trait]
+pub(crate) trait PrepareAlpacaToBaseResume: Send + Sync + 'static {
+    async fn prepare_alpaca_to_base_resume(
+        &self,
+        id: &UsdcRebalanceId,
+    ) -> Result<AlpacaToBaseResumePreparation, AlpacaToBaseResumePreparationError>;
+}
+
+#[cfg(test)]
+struct ReadyAlpacaToBaseResume;
+
+#[cfg(test)]
+#[async_trait]
+impl PrepareAlpacaToBaseResume for ReadyAlpacaToBaseResume {
+    async fn prepare_alpaca_to_base_resume(
+        &self,
+        _id: &UsdcRebalanceId,
+    ) -> Result<AlpacaToBaseResumePreparation, AlpacaToBaseResumePreparationError> {
+        Ok(AlpacaToBaseResumePreparation::Ready)
+    }
 }
 
 #[async_trait]
@@ -653,6 +701,7 @@ impl TransferUsdcToHedging {
 /// [`TransferUsdcToHedgingCtx`].
 pub(crate) struct TransferUsdcToMarketMakingCtx {
     pub(crate) transfer: Arc<dyn ResumeAlpacaToBase>,
+    pub(crate) resume_preparation: Arc<dyn PrepareAlpacaToBaseResume>,
     pub(crate) job_queue: TransferUsdcToMarketMakingJobQueue,
     /// Maximum consecutive revert-class burn failures before circuit opens.
     pub(crate) max_burn_revert_redrives: u32,
@@ -667,6 +716,8 @@ pub(crate) struct TransferUsdcToMarketMakingCtx {
 pub(crate) enum TransferUsdcToMarketMakingJobError {
     #[error(transparent)]
     Transfer(#[from] UsdcTransferError),
+    #[error(transparent)]
+    ResumePreparation(#[from] AlpacaToBaseResumePreparationError),
     #[error(
         "Alpaca->Base transfer {id} burn revert redrive limit reached; \
          aggregate stalled at BridgingSubmitting, operator action required"
@@ -708,6 +759,25 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
         &self,
         ctx: &TransferUsdcToMarketMakingCtx,
     ) -> Result<Self::Output, Self::Error> {
+        if ctx
+            .resume_preparation
+            .prepare_alpaca_to_base_resume(&self.id)
+            .await?
+            == AlpacaToBaseResumePreparation::AwaitingFreshHedgingSnapshot
+        {
+            warn!(
+                target: "rebalance",
+                id = %self.id,
+                delay = ?INVENTORY_RECOVERY_REDRIVE_DELAY,
+                "Waiting for fresh hedging inventory before resuming recovered Alpaca->Base transfer"
+            );
+            ctx.job_queue
+                .clone()
+                .push_with_delay(self.clone(), INVENTORY_RECOVERY_REDRIVE_DELAY)
+                .await?;
+            return Ok(());
+        }
+
         // No per-attempt timeout here unlike the hedging direction. The
         // AlpacaToBase resume can pass through a long-running broker Converting
         // leg with no safe re-entry path if interrupted (unlike BaseToAlpaca
@@ -1506,10 +1576,64 @@ mod tests {
     ) -> TransferUsdcToMarketMakingCtx {
         TransferUsdcToMarketMakingCtx {
             transfer,
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(pool),
             max_burn_revert_redrives: 5,
             notifier: Arc::new(NoopNotifier),
         }
+    }
+
+    struct AwaitingAlpacaToBaseResume;
+
+    #[async_trait]
+    impl PrepareAlpacaToBaseResume for AwaitingAlpacaToBaseResume {
+        async fn prepare_alpaca_to_base_resume(
+            &self,
+            _id: &UsdcRebalanceId,
+        ) -> Result<AlpacaToBaseResumePreparation, AlpacaToBaseResumePreparationError> {
+            Ok(AlpacaToBaseResumePreparation::AwaitingFreshHedgingSnapshot)
+        }
+    }
+
+    #[tokio::test]
+    async fn market_making_job_waits_for_recovered_source_reservation() {
+        let pool = setup_queue_pool().await;
+        let transfer = Arc::new(RecordingResume {
+            fail: false,
+            captured: std::sync::Mutex::new(None),
+        });
+        let mut ctx = market_making_ctx(transfer.clone(), &pool);
+        ctx.resume_preparation = Arc::new(AwaitingAlpacaToBaseResume);
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let before = Utc::now().timestamp();
+        job.perform(&ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert!(
+            transfer.captured.lock().unwrap().is_none(),
+            "the transfer manager must not run before recovery restores source inventory"
+        );
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "the gated job must enqueue one delayed replacement"
+        );
+        let (_, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        assert!(
+            run_at
+                >= before + i64::try_from(INVENTORY_RECOVERY_REDRIVE_DELAY.as_secs()).unwrap() - 5
+                && run_at
+                    <= after
+                        + i64::try_from(INVENTORY_RECOVERY_REDRIVE_DELAY.as_secs()).unwrap()
+                        + 5,
+            "recovery redrive must be delayed by ~{INVENTORY_RECOVERY_REDRIVE_DELAY:?}: \
+             run_at={run_at} before={before} after={after}"
+        );
     }
 
     #[tokio::test]
@@ -1562,6 +1686,7 @@ mod tests {
         let notifier = Arc::new(CapturingNotifier::default());
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(InconclusiveAlpacaToBase::before_deadline()),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 5,
             notifier: notifier.clone(),
@@ -1625,6 +1750,7 @@ mod tests {
         let notifier = Arc::new(CapturingNotifier::default());
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(InconclusiveAlpacaToBase::future_initiated_at()),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 5,
             notifier: notifier.clone(),
@@ -1675,6 +1801,7 @@ mod tests {
         let notifier = Arc::new(CapturingNotifier::default());
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(InconclusiveAlpacaToBase::after_deadline()),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 5,
             notifier: notifier.clone(),
@@ -1748,6 +1875,7 @@ mod tests {
         let notifier = Arc::new(CapturingNotifier::default());
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(InconclusiveAlpacaToBase::at_deadline()),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 5,
             notifier: notifier.clone(),
@@ -1978,6 +2106,7 @@ mod tests {
         let notifier = Arc::new(CapturingNotifier::default());
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(TerminalAlpacaToBase(outcome)),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 5,
             notifier: notifier.clone(),
@@ -3157,6 +3286,7 @@ mod tests {
         let pool = setup_queue_pool().await;
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(BurnRevertAlpacaToBase),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 3,
             notifier: Arc::new(NoopNotifier),
@@ -3192,6 +3322,7 @@ mod tests {
         let notifier = Arc::new(CapturingNotifier::default());
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(BurnRevertAlpacaToBase),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 5,
             notifier: notifier.clone(),
@@ -3236,6 +3367,7 @@ mod tests {
         let notifier = Arc::new(CapturingNotifier::default());
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(BurnRevertAlpacaToBase),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 3,
             notifier: notifier.clone(),
@@ -3280,6 +3412,7 @@ mod tests {
         let notifier = Arc::new(CapturingNotifier::default());
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(BurnRevertAlpacaToBase),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 3,
             notifier: notifier.clone(),
@@ -3334,6 +3467,7 @@ mod tests {
 
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(NonRevertAlpacaToBase),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 5,
             notifier: notifier.clone(),
@@ -3402,6 +3536,7 @@ mod tests {
         let notifier = Arc::new(CapturingNotifier::default());
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(TerminalAlpacaToBase(TerminalOutcome::DeadlineElapsed)),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 5,
             notifier: notifier.clone(),
@@ -3521,6 +3656,7 @@ mod tests {
         let notifier = Arc::new(CapturingNotifier::default());
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(MintPathRevertAlpacaToBase),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 5,
             notifier: notifier.clone(),
@@ -3562,6 +3698,7 @@ mod tests {
         let notifier = Arc::new(CapturingNotifier::default());
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(TerminalAlpacaToBase(TerminalOutcome::AmbientBalance)),
+            resume_preparation: Arc::new(ReadyAlpacaToBaseResume),
             job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
             max_burn_revert_redrives: 5,
             notifier: notifier.clone(),

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -9,6 +9,7 @@ mod job;
 mod manager;
 
 pub(crate) use job::{
+    AlpacaToBaseResumePreparation, AlpacaToBaseResumePreparationError, PrepareAlpacaToBaseResume,
     ResumeAlpacaToBase, ResumeBaseToAlpaca, TransferUsdcToHedging, TransferUsdcToHedgingCtx,
     TransferUsdcToHedgingJobQueue, TransferUsdcToMarketMaking, TransferUsdcToMarketMakingCtx,
     TransferUsdcToMarketMakingJobQueue,

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -138,6 +138,24 @@ pub(crate) struct ConversionAmounts {
     pub(crate) received_amount: Usdc,
 }
 
+/// Durable Alpaca-to-Base pre-burn state needed to reconstruct the source
+/// inventory reservation after a process restart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AlpacaToBaseReservationRecovery {
+    pub(crate) amount: Usdc,
+    pub(crate) stage: AlpacaToBaseReservationStage,
+    pub(crate) last_progress_at: DateTime<Utc>,
+}
+
+/// The durable lifecycle point represented by a recovered source reservation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AlpacaToBaseReservationStage {
+    ConversionComplete,
+    Withdrawing,
+    WithdrawalComplete,
+    BridgingSubmitting,
+}
+
 impl ConversionAmounts {
     pub(crate) const fn new(source_amount: Usdc, received_amount: Usdc) -> Self {
         Self {
@@ -1536,6 +1554,80 @@ impl UsdcRebalance {
             | Self::BridgingFailed { .. }
             | Self::Reconciled { .. } => None,
         }
+    }
+
+    /// Returns the exact source reservation that an Alpaca-to-Base pre-burn
+    /// aggregate must regain after restart, or `None` when the aggregate is not
+    /// in a recoverable source-reservation state.
+    pub(crate) fn alpaca_to_base_reservation_recovery(
+        &self,
+    ) -> Option<AlpacaToBaseReservationRecovery> {
+        let (amount, stage, last_progress_at) = match self {
+            Self::ConversionComplete {
+                direction: RebalanceDirection::AlpacaToBase,
+                conversion,
+                converted_at,
+                ..
+            } => (
+                conversion.received_amount,
+                AlpacaToBaseReservationStage::ConversionComplete,
+                *converted_at,
+            ),
+            Self::Withdrawing {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                initiated_at,
+                ..
+            } => (
+                *amount,
+                AlpacaToBaseReservationStage::Withdrawing,
+                *initiated_at,
+            ),
+            Self::WithdrawalComplete {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                confirmed_at,
+                ..
+            } => (
+                *amount,
+                AlpacaToBaseReservationStage::WithdrawalComplete,
+                *confirmed_at,
+            ),
+            Self::BridgingSubmitting {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                initiated_at,
+                pending_burn_tx: None,
+                ..
+            } => (
+                *amount,
+                AlpacaToBaseReservationStage::BridgingSubmitting,
+                *initiated_at,
+            ),
+            Self::Converting { .. }
+            | Self::ConversionComplete { .. }
+            | Self::ConversionFailed { .. }
+            | Self::WithdrawalSubmitting { .. }
+            | Self::Withdrawing { .. }
+            | Self::WithdrawalComplete { .. }
+            | Self::WithdrawalFailed { .. }
+            | Self::BridgingSubmitting { .. }
+            | Self::Bridging { .. }
+            | Self::AwaitingAttestation { .. }
+            | Self::Attested { .. }
+            | Self::Bridged { .. }
+            | Self::BridgingFailed { .. }
+            | Self::DepositInitiated { .. }
+            | Self::DepositConfirmed { .. }
+            | Self::DepositFailed { .. }
+            | Self::Reconciled { .. } => return None,
+        };
+
+        Some(AlpacaToBaseReservationRecovery {
+            amount,
+            stage,
+            last_progress_at,
+        })
     }
 }
 
@@ -5211,6 +5303,26 @@ mod tests {
             failed_at: now,
         };
         assert_eq!(deposit_failed.direction(), RebalanceDirection::AlpacaToBase);
+    }
+
+    /// A recorded burn is no longer safely reconstructable from the fresh
+    /// offchain source balance and must retain guard-only recovery.
+    #[test]
+    fn reservation_recovery_rejects_bridging_submitting_with_pending_burn() {
+        let state = UsdcRebalance::BridgingSubmitting {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: Usdc::new(float!(321)),
+            from_block: 100,
+            initiated_at: Utc::now(),
+            burn_amount: Some(Usdc::new(float!(320))),
+            pending_burn_tx: Some(fixed_bytes!(
+                "0x0000000000000000000000000000000000000000000000000000000000000002"
+            )),
+        };
+
+        let None = state.alpaca_to_base_reservation_recovery() else {
+            panic!("a recorded burn must retain guard-only recovery");
+        };
     }
 
     /// `amount()` must return the persisted EFFECTIVE amount: the conversion


### PR DESCRIPTION
## What

[RAI-1324](https://linear.app/makeitrain/issue/RAI-1324)

Implement ADR 0015 by reconstructing the exact pre-burn Alpaca-to-Base USDC source reservation before a resumed transfer re-enters the transfer manager.

## Why

Startup recovery already re-armed resumable USDC jobs, but their in-memory Hedging reservation and ownership were lost across restart. Resuming against a fresh broker snapshot could debit the source twice, conflict with another owner, or settle with an inflight underflow.

## How

- Derive a typed reservation-recovery context from supported Alpaca-to-Base aggregate states.
- Wait for a fresh Hedging inventory observation before releasing the resume gate.
- Restore the exact owner, tracking context, available balance, and inflight amount with replacement semantics rather than an additive debit.
- Fail closed on conflicting owners, mismatched amounts, multiple recovery candidates, source-observation failures, and recorded burn submissions.
- Retire stale resume gates after timeout so later recovery can proceed.

## Testing

Added focused coverage for:

- fresh snapshot callbacks even when the snapshot value is deduplicated;
- replacement of stale available/inflight inventory;
- timeout cleanup of the recovered resume gate;
- no second debit after `ConversionComplete` recovery;
- owner and amount conflicts;
- multiple reservation candidates;
- terminal settlement without inflight underflow;
- transfer-job blocking until reservation recovery completes; and
- exclusion of `BridgingSubmitting` with a recorded burn transaction.

Verification:

- `cargo fmt --all -- --check`
- GitHub Actions backend build and partitioned test matrix

## Screenshots

Not applicable.

## Anything else

ADR 0015 is Accepted and supersedes the earlier guard-only recovery decision in ADR 0003. Recovery beyond the burn-submission boundary remains fail-closed and requires separate transaction and destination-settlement evidence.
