### PR TITLE
fix: resolve RustSec audit findings

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,6 @@
+[advisories]
+# `sqlx-apalis` includes the MySQL driver in Cargo.lock, but this SQLite-only
+# application never enables or builds that driver.
+# `ark-relations` includes its tracing subscriber in Cargo.lock, but no selected
+# dependency path builds `ark-relations`.
+ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2025-0055"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,6 +143,9 @@ jobs:
               -E "test(compile_fail_tests)"
           '
 
+      - name: Audit Rust dependencies
+        run: nix develop .#ci-backend -c cargo audit
+
       - name: Upload nextest archive
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2137,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4795,9 +4795,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -6709,7 +6709,6 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "reqwest 0.12.28",
- "rsa",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ reqwest = { version = "0.12.4", features = [
   "gzip",
   "blocking",
 ] }
-rsa = { version = "0.9.10", features = ["pem"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.140"
 serial_test = "3.2.0"
@@ -257,7 +256,6 @@ httpmock.workspace = true
 proptest.workspace = true
 rain-math-float.workspace = true
 regex = "1.12.3"
-rsa.workspace = true
 serial_test.workspace = true
 st0x-bridge = { workspace = true, features = ["mock"] }
 st0x-event-sorcery = { workspace = true, features = ["test-support"] }

--- a/flake.nix
+++ b/flake.nix
@@ -540,6 +540,7 @@
             # and they bloat the closure.
             backendInputs = [
               rustToolchain
+              pkgs.cargo-audit
               pkgs.openssl
               pkgs.sqlite
               pkgs.pkg-config
@@ -570,6 +571,7 @@
                     bun
                     sccache
                     sqlx-cli
+                    cargo-audit
                     cargo-nextest
                     ragenixPkg
                     packages.secret


### PR DESCRIPTION
## What

Make RustSec auditing an enforced backend CI check and resolve the currently actionable dependency findings.

## Why

Dependency advisories were not enforced by CI, so a vulnerable or abandoned direct dependency could enter the workspace without blocking review. The workspace also retained an unused direct `rsa` dependency that unnecessarily exposed its advisory surface.

## How

- Remove the unused direct `rsa` workspace and test dependencies.
- Add `cargo-audit` to the Nix backend development/CI environments.
- Run `cargo audit` in the backend CI job.
- Document and narrowly ignore two transitive advisories whose affected code is not built by this SQLite-only application: the MySQL path in `sqlx-apalis` and the unused `ark-relations` tracing path.
- Refresh `Cargo.lock` after removing the direct dependency.

## Testing

- `cargo audit` passes with only the documented transitive ignores.
- `cargo metadata` succeeds.
- GitHub Actions static checks and backend build/test matrix pass.

## Screenshots

Not applicable.

## Anything else

The advisory ignores are scoped in `.cargo/audit.toml` with the reason each affected dependency path is unreachable. CI will continue to fail on every other RustSec advisory.
