### PR TITLE
fix: surface failed counter-trades

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4102,6 +4102,14 @@ multiple broker-specific contexts.
    reference, spread bps) and per-symbol price charts over time.
 
 4. **Trade History**: Recent trades filterable by venue (onchain/offchain/both).
+   Onchain entries are completed fills. Offchain counter-trade entries include
+   both successful fills and terminal failures; each entry carries its terminal
+   outcome timestamp. Failed entries expose the broker or placement error plus
+   the filled and unfilled portions of that broker order so operators can see
+   partial execution without inspecting logs. Fills beyond the broker-accepted
+   order quantity expose the excess separately rather than clamping it or making
+   history unavailable. Terminal outcomes appear in both initial history and
+   live dashboard updates.
 
 5. **Live Events**: Real-time domain event stream (aggregate type, ID, sequence,
    event type, timestamp). Starts empty, populates via WebSocket.

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -55,6 +55,7 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
     CounterTrading::export_all_to(out_dir)?;
     WalletSettings::export_all_to(out_dir)?;
     Trade::export_all_to(out_dir)?;
+    TradeOutcome::export_all_to(out_dir)?;
     Position::export_all_to(out_dir)?;
     SymbolInventory::export_all_to(out_dir)?;
     InFlightEquity::export_all_to(out_dir)?;

--- a/crates/dto/src/statement.rs
+++ b/crates/dto/src/statement.rs
@@ -28,7 +28,7 @@ use crate::{CurrentState, Position, Trade};
 #[strum(serialize_all = "snake_case")]
 pub enum Statement {
     CurrentState(Box<CurrentState>),
-    TradeFill(Trade),
+    TradeUpdate(Trade),
     PositionUpdate(Position),
     InventorySnapshot(Box<InventorySnapshot>),
     TransferUpdate(TransferOperation),
@@ -101,7 +101,7 @@ mod tests {
             Statement::VARIANTS,
             &[
                 "current_state",
-                "trade_fill",
+                "trade_update",
                 "position_update",
                 "inventory_snapshot",
                 "transfer_update"
@@ -123,18 +123,19 @@ mod tests {
     }
 
     #[test]
-    fn statement_trade_fill_serializes_with_type_tag() {
+    fn statement_trade_update_serializes_with_type_tag() {
         let trade = Trade {
             id: "0x0000000000000000000000000000000000000000000000000000000000000000:0".to_string(),
-            filled_at: Utc::now(),
+            occurred_at: Utc::now(),
             venue: TradingVenue::Raindex,
             direction: Direction::Buy,
             symbol: Symbol::new("AAPL").unwrap(),
             shares: FractionalShares::new(float!(10)),
+            outcome: crate::TradeOutcome::Filled,
         };
-        let msg = Statement::TradeFill(trade);
+        let msg = Statement::TradeUpdate(trade);
         let json = serde_json::to_value(&msg).expect("serialization should succeed");
-        assert_eq!(json["type"], json!("trade_fill"));
+        assert_eq!(json["type"], json!("trade_update"));
         assert_eq!(json["data"]["venue"], json!("raindex"));
         assert_eq!(json["data"]["direction"], json!("buy"));
         assert_eq!(json["data"]["symbol"], json!("AAPL"));

--- a/crates/dto/src/trade.rs
+++ b/crates/dto/src/trade.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
-use st0x_finance::{FractionalShares, Symbol};
+use st0x_finance::{FractionalShares, NonNegative, Symbol};
 
 /// Where a trade was executed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
@@ -118,20 +118,78 @@ pub struct InvalidDirectionError {
     direction_provided: String,
 }
 
-/// A completed trade fill.
+/// Terminal outcome of a dashboard trade entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(
+    tag = "status",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+pub enum TradeOutcome {
+    Filled,
+    Failed {
+        error: String,
+        #[ts(type = "string")]
+        filled_shares: NonNegative<FractionalShares>,
+        #[ts(type = "string")]
+        remaining_shares: NonNegative<FractionalShares>,
+        /// Shares filled beyond the broker-accepted order quantity. This is
+        /// separate from remaining shares so anomalous broker state is never
+        /// clamped away.
+        #[ts(type = "string")]
+        excess_shares: NonNegative<FractionalShares>,
+    },
+}
+
+/// A completed onchain fill or terminal offchain counter-trade.
 #[derive(Debug, Clone, Serialize, TS)]
 #[serde(rename_all = "camelCase")]
 pub struct Trade {
     /// Unique identifier for deduplication on reconnect.
     /// Onchain: `"tx_hash:log_index"`. Offchain: offchain order aggregate ID.
     pub id: String,
-    pub filled_at: DateTime<Utc>,
+    pub occurred_at: DateTime<Utc>,
     pub venue: TradingVenue,
     pub direction: Direction,
     #[ts(type = "string")]
     pub symbol: Symbol,
+    /// Quantity submitted for this counter-trade. Before broker acceptance this
+    /// is the requested quantity; afterward it is the quantity the broker
+    /// accepted. Failed outcomes split this order quantity into filled and
+    /// remaining portions in [`TradeOutcome::Failed`].
     #[ts(type = "string")]
     pub shares: FractionalShares,
+    pub outcome: TradeOutcome,
+}
+
+/// Sorts dashboard trades newest-first with a stable cross-loader tie-breaker.
+pub fn sort_trades_newest_first(trades: &mut [Trade]) {
+    trades.sort_by(|left, right| {
+        right
+            .occurred_at
+            .cmp(&left.occurred_at)
+            .then_with(|| compare_trade_ids(left, right))
+    });
+}
+
+fn compare_trade_ids(left: &Trade, right: &Trade) -> std::cmp::Ordering {
+    if left.venue == TradingVenue::Raindex
+        && right.venue == TradingVenue::Raindex
+        && let (Some((left_hash, left_index)), Some((right_hash, right_index))) = (
+            parse_onchain_trade_id(&left.id),
+            parse_onchain_trade_id(&right.id),
+        )
+        && left_hash == right_hash
+    {
+        return right_index.cmp(&left_index);
+    }
+
+    left.id.cmp(&right.id)
+}
+
+fn parse_onchain_trade_id(id: &str) -> Option<(&str, u64)> {
+    let (tx_hash, log_index) = id.rsplit_once(':')?;
+    Some((tx_hash, log_index.parse().ok()?))
 }
 
 #[cfg(test)]
@@ -158,14 +216,15 @@ mod tests {
     }
 
     #[test]
-    fn trade_serializes_all_fields() {
+    fn filled_trade_serializes_all_fields() {
         let trade = Trade {
             id: "test-order-id".to_string(),
-            filled_at: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            occurred_at: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
             venue: TradingVenue::Alpaca,
             direction: Direction::Sell,
             symbol: Symbol::new("TSLA").unwrap(),
             shares: FractionalShares::new(float!(5.5)),
+            outcome: TradeOutcome::Filled,
         };
         let json = serde_json::to_value(&trade).expect("serialization should succeed");
         assert_eq!(json["id"], json!("test-order-id"));
@@ -173,6 +232,69 @@ mod tests {
         assert_eq!(json["direction"], json!("sell"));
         assert_eq!(json["symbol"], json!("TSLA"));
         assert_eq!(json["shares"], json!("5.5"));
-        assert_eq!(json["filledAt"], json!("2023-11-14T22:13:20Z"));
+        assert_eq!(json["occurredAt"], json!("2023-11-14T22:13:20Z"));
+        assert_eq!(json["outcome"], json!({ "status": "filled" }));
+    }
+
+    #[test]
+    fn failed_trade_serializes_error() {
+        let trade = Trade {
+            id: "failed-order-id".to_string(),
+            occurred_at: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            venue: TradingVenue::Alpaca,
+            direction: Direction::Buy,
+            symbol: Symbol::new("SPCX").unwrap(),
+            shares: FractionalShares::new(float!(1)),
+            outcome: TradeOutcome::Failed {
+                error: "asset is not tradable".to_string(),
+                filled_shares: NonNegative::new(FractionalShares::new(float!(0.25))).unwrap(),
+                remaining_shares: NonNegative::new(FractionalShares::new(float!(0.75))).unwrap(),
+                excess_shares: NonNegative::new(FractionalShares::ZERO).unwrap(),
+            },
+        };
+
+        let json = serde_json::to_value(&trade).expect("serialization should succeed");
+        assert_eq!(
+            json["outcome"],
+            json!({
+                "status": "failed",
+                "error": "asset is not tradable",
+                "filledShares": "0.25",
+                "remainingShares": "0.75",
+                "excessShares": "0"
+            })
+        );
+    }
+
+    #[test]
+    fn newest_first_sort_uses_numeric_log_index_for_tied_onchain_trades() {
+        let timestamp = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
+        let older = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        let trade = |id: &str, occurred_at| Trade {
+            id: id.to_string(),
+            occurred_at,
+            venue: TradingVenue::Raindex,
+            direction: Direction::Buy,
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: FractionalShares::new(float!(1)),
+            outcome: TradeOutcome::Filled,
+        };
+        let tx_hash = "0x0000000000000000000000000000000000000000000000000000000000000000";
+        let mut trades = vec![
+            trade(&format!("{tx_hash}:2"), timestamp),
+            trade("older", older),
+            trade(&format!("{tx_hash}:10"), timestamp),
+        ];
+
+        sort_trades_newest_first(&mut trades);
+
+        assert_eq!(
+            trades.into_iter().map(|trade| trade.id).collect::<Vec<_>>(),
+            [
+                format!("{tx_hash}:10"),
+                format!("{tx_hash}:2"),
+                "older".to_string()
+            ]
+        );
     }
 }

--- a/crates/dto/src/transfer.rs
+++ b/crates/dto/src/transfer.rs
@@ -230,7 +230,7 @@ impl TransferOperation {
     }
 }
 
-/// Warning emitted when transfer data is partially loaded.
+/// Warning emitted when dashboard initial state is partially loaded.
 ///
 /// Variant names encode the category — no separate `TransferCategory`
 /// enum needed. Replay failures carry the dto `Id<Tag>` — the internal
@@ -245,6 +245,7 @@ pub enum TransferWarning {
     MintCategoryUnavailable,
     RedemptionCategoryUnavailable,
     BridgeCategoryUnavailable,
+    TradeHistoryUnavailable,
     MintReplayFailed {
         #[ts(type = "string")]
         id: Id<EquityMintTag>,
@@ -567,6 +568,14 @@ mod tests {
             serialized["status"]["reconcileReason"],
             json!("funds moved manually")
         );
+    }
+
+    #[test]
+    fn transfer_warning_trade_history_unavailable_serializes_with_kind_tag() {
+        let warning = TransferWarning::TradeHistoryUnavailable;
+
+        let serialized = serde_json::to_value(&warning).expect("serialization should succeed");
+        assert_eq!(serialized, json!({"kind": "trade_history_unavailable"}));
     }
 
     #[test]

--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -27,6 +27,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-svelte": "^3.13.1",
         "globals": "^16.5.0",
+        "happy-dom": "^20.10.6",
         "layerchart": "2.0.0-next.48",
         "prettier": "^3.7.4",
         "prettier-plugin-svelte": "^3.4.0",
@@ -267,6 +268,10 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.49.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.49.0", "@typescript-eslint/type-utils": "8.49.0", "@typescript-eslint/utils": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.49.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.49.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.49.0", "@typescript-eslint/types": "8.49.0", "@typescript-eslint/typescript-estree": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA=="],
@@ -322,6 +327,8 @@
     "bits-ui": ["bits-ui@2.14.4", "", { "dependencies": { "@floating-ui/core": "^1.7.1", "@floating-ui/dom": "^1.7.1", "esm-env": "^1.1.2", "runed": "^0.35.1", "svelte-toolbelt": "^0.10.6", "tabbable": "^6.2.0" }, "peerDependencies": { "@internationalized/date": "^3.8.1", "svelte": "^5.33.0" } }, "sha512-W6kenhnbd/YVvur+DKkaVJ6GldE53eLewur5AhUCqslYQ0vjZr8eWlOfwZnMiPB+PF5HMVqf61vXBvmyrAmPWg=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -417,6 +424,8 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.24.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
@@ -474,6 +483,8 @@
     "globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -697,11 +708,15 @@
 
     "vitest": ["vitest@4.0.15", "", { "dependencies": { "@vitest/expect": "4.0.15", "@vitest/mocker": "4.0.15", "@vitest/pretty-format": "4.0.15", "@vitest/runner": "4.0.15", "@vitest/snapshot": "4.0.15", "@vitest/spy": "4.0.15", "@vitest/utils": "4.0.15", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.15", "@vitest/browser-preview": "4.0.15", "@vitest/browser-webdriverio": "4.0.15", "@vitest/ui": "4.0.15", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
     "yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
 

--- a/dashboard/bun.nix
+++ b/dashboard/bun.nix
@@ -481,6 +481,14 @@
     url = "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz";
     hash = "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==";
   };
+  "@types/whatwg-mimetype@3.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz";
+    hash = "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==";
+  };
+  "@types/ws@8.18.1" = fetchurl {
+    url = "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz";
+    hash = "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==";
+  };
   "@typescript-eslint/eslint-plugin@8.49.0" = fetchurl {
     url = "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.49.0.tgz";
     hash = "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==";
@@ -596,6 +604,10 @@
   "brace-expansion@2.0.2" = fetchurl {
     url = "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz";
     hash = "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==";
+  };
+  "buffer-image-size@0.6.4" = fetchurl {
+    url = "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz";
+    hash = "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==";
   };
   "callsites@3.1.0" = fetchurl {
     url = "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz";
@@ -797,6 +809,10 @@
     url = "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz";
     hash = "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==";
   };
+  "entities@7.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz";
+    hash = "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==";
+  };
   "es-module-lexer@1.7.0" = fetchurl {
     url = "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz";
     hash = "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==";
@@ -920,6 +936,10 @@
   "graceful-fs@4.2.11" = fetchurl {
     url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz";
     hash = "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==";
+  };
+  "happy-dom@20.10.6" = fetchurl {
+    url = "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz";
+    hash = "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==";
   };
   "has-flag@4.0.0" = fetchurl {
     url = "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz";
@@ -1433,6 +1453,10 @@
     url = "https://registry.npmjs.org/vitest/-/vitest-4.0.15.tgz";
     hash = "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==";
   };
+  "whatwg-mimetype@3.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz";
+    hash = "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==";
+  };
   "which@2.0.2" = fetchurl {
     url = "https://registry.npmjs.org/which/-/which-2.0.2.tgz";
     hash = "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==";
@@ -1444,6 +1468,10 @@
   "word-wrap@1.2.5" = fetchurl {
     url = "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz";
     hash = "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==";
+  };
+  "ws@8.21.1" = fetchurl {
+    url = "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz";
+    hash = "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==";
   };
   "yaml@1.10.2" = fetchurl {
     url = "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz";

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -36,6 +36,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-svelte": "^3.13.1",
     "globals": "^16.5.0",
+    "happy-dom": "^20.10.6",
     "layerchart": "2.0.0-next.48",
     "prettier": "^3.7.4",
     "prettier-plugin-svelte": "^3.4.0",

--- a/dashboard/src/lib/components/multi-select.svelte
+++ b/dashboard/src/lib/components/multi-select.svelte
@@ -1,18 +1,18 @@
-<script lang="ts">
-  type Option = { value: string; label: string }
+<script lang="ts" generics="Value extends string">
+  type Option = { value: Value; label: string }
 
   interface Props {
     label: string
     options: Option[]
-    selected: Set<string>
-    onchange: (selected: Set<string>) => void
+    selected: Set<Value>
+    onchange: (selected: Set<Value>) => void
   }
 
   let { label, options, selected, onchange }: Props = $props()
 
   let open = $state(false)
 
-  const toggle = (value: string) => {
+  const toggle = (value: Value) => {
     const next = new Set(selected)
     if (next.has(value)) {
       next.delete(value)
@@ -33,7 +33,9 @@
     if (!open) return
 
     document.addEventListener('click', handleClickOutside, true)
-    return () => { document.removeEventListener('click', handleClickOutside, true) }
+    return () => {
+      document.removeEventListener('click', handleClickOutside, true)
+    }
   })
 
   const activeCount = $derived(selected.size)
@@ -50,20 +52,32 @@
 <div class="multi-select-root relative inline-block">
   <button
     class="inline-flex items-center gap-1 rounded border bg-background px-2 py-1 text-xs hover:bg-accent"
-    onclick={() => { open = !open }}
+    onclick={() => {
+      open = !open
+    }}
   >
     <span>{summary}</span>
     <span class="text-[0.6rem] text-muted-foreground">{open ? '\u25B2' : '\u25BC'}</span>
   </button>
 
   {#if open}
-    <div class="absolute left-0 top-full z-20 mt-1 min-w-36 rounded border bg-background py-1 shadow-lg">
+    <div
+      class="absolute left-0 top-full z-20 mt-1 min-w-36 rounded border bg-background py-1 shadow-lg"
+    >
       {#each options as opt (opt.value)}
         <button
           class="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent"
-          onclick={() => { toggle(opt.value); }}
+          onclick={() => {
+            toggle(opt.value)
+          }}
         >
-          <span class="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-sm border {selected.has(opt.value) ? 'bg-primary border-primary text-primary-foreground' : 'border-muted-foreground'}">
+          <span
+            class="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-sm border {selected.has(
+              opt.value
+            )
+              ? 'bg-primary border-primary text-primary-foreground'
+              : 'border-muted-foreground'}"
+          >
             {#if selected.has(opt.value)}
               <span class="text-[0.5rem]">&#10003;</span>
             {/if}

--- a/dashboard/src/lib/components/trade-history-panel.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
   import { createQuery } from '@tanstack/svelte-query'
-  import { onMount } from 'svelte'
+  import { onMount, untrack } from 'svelte'
   import * as Card from '$lib/components/ui/card'
   import * as Table from '$lib/components/ui/table'
   import HoverTooltip from '$lib/components/hover-tooltip.svelte'
   import CliCommandBlock from '$lib/components/cli-command-block.svelte'
   import type { Position } from '$lib/api/Position'
+  import type { Trade } from '$lib/api/Trade'
+  import type { TradingVenue } from '$lib/api/TradingVenue'
+  import TradeOutcomeView from '$lib/components/trade-outcome.svelte'
   import MultiSelect from '$lib/components/multi-select.svelte'
   import { reactive } from '$lib/frp.svelte'
   import {
@@ -18,6 +21,7 @@
   import { formatDecimal } from '$lib/decimal'
   import { equityUsdTooltip } from '$lib/inventory-value'
   import { tradeRecoveryCommands } from '$lib/transfer'
+  import { mergeTradeHistory, type TradeHistoryFilter } from '$lib/trade'
 
   type TradeEvent = {
     step: string
@@ -25,14 +29,7 @@
     payload: Record<string, unknown>
   }
 
-  type TradeEntry = {
-    id: string
-    filledAt: string
-    venue: string
-    direction: string
-    symbol: string
-    shares: string
-  }
+  type TradeEntry = Trade
 
   type TradeResponse = {
     entries: TradeEntry[]
@@ -51,7 +48,7 @@
   const offset = reactive(0)
   const total = reactive(0)
   const hasMore = reactive(false)
-  const selectedVenues = reactive<Set<string>>(new Set(ALL_VENUES))
+  const selectedVenues = reactive<Set<TradingVenue>>(new Set(ALL_VENUES))
   const selectedSymbols = reactive<Set<string>>(new Set())
   const allSymbols = reactive<string[]>([])
   const since = reactive('')
@@ -59,9 +56,14 @@
 
   let sinceInput: HTMLInputElement | undefined
   let untilInput: HTMLInputElement | undefined
+  let historyRequestVersion = 0
 
   const positionsQuery = createQuery<Position[]>(() => ({
     queryKey: ['positions'],
+    enabled: false
+  }))
+  const tradesQuery = createQuery<Trade[]>(() => ({
+    queryKey: ['trades'],
     enabled: false
   }))
 
@@ -100,10 +102,10 @@
   const venueOptions = ALL_VENUES.map((venue) => ({ value: venue, label: venueLabel(venue) }))
   const symbolOptions = $derived(allSymbols.current.map((sym) => ({ value: sym, label: sym })))
 
-  const buildParams = (): URLSearchParams => {
+  const buildParams = (limit = PAGE_SIZE, requestOffset = offset.current): URLSearchParams => {
     const params = new URLSearchParams({
-      limit: String(PAGE_SIZE),
-      offset: String(offset.current)
+      limit: String(limit),
+      offset: String(requestOffset)
     })
 
     if (selectedVenues.current.size > 0 && selectedVenues.current.size < ALL_VENUES.length) {
@@ -120,13 +122,54 @@
     return params
   }
 
+  const historyFilter = (): TradeHistoryFilter => ({
+    venues: selectedVenues.current,
+    symbols: selectedSymbols.current,
+    since: since.current ? toRfc3339(since.current) : null,
+    until: until.current ? toRfc3339(until.current) : null
+  })
+
+  const mergeLiveTrades = (current: TradeEntry[]): TradeEntry[] =>
+    mergeTradeHistory(current, tradesQuery.data ?? [], historyFilter())
+
+  const resetHistoryForFilter = () => {
+    entries.update(() => [])
+    total.update(() => 0)
+    hasMore.update(() => false)
+    loadingMore.update(() => false)
+    error.update(() => null)
+  }
+
+  $effect(() => {
+    const live = tradesQuery.data ?? []
+
+    untrack(() => {
+      const filter = historyFilter()
+      entries.update((current) => {
+        const merged = mergeTradeHistory(current, live, filter)
+        const additions = Math.max(0, merged.length - current.length)
+        if (additions > 0) total.update((currentTotal) => currentTotal + additions)
+        return merged
+      })
+      allSymbols.update((current) =>
+        [...new Set([...current, ...live.map((trade) => trade.symbol)])].sort()
+      )
+    })
+  })
+
   const fetchTrades = async (mode: 'replace' | 'append') => {
     if (selectedVenues.current.size === 0) {
+      historyRequestVersion += 1
       entries.update(() => [])
+      total.update(() => 0)
       hasMore.update(() => false)
+      loading.update(() => false)
+      loadingMore.update(() => false)
+      error.update(() => null)
       return
     }
 
+    const requestVersion = ++historyRequestVersion
     const isLoadMore = mode === 'append'
     if (isLoadMore) {
       loadingMore.update(() => true)
@@ -142,19 +185,26 @@
       })
 
       if (!response.ok) {
-        error.update(() => `HTTP ${String(response.status)}`)
+        if (requestVersion === historyRequestVersion) {
+          error.update(() => `HTTP ${String(response.status)}`)
+        }
         return
       }
 
       const data: TradeResponse = (await response.json()) as TradeResponse
-      total.update(() => data.total)
-      hasMore.update(() => data.hasMore)
+      if (requestVersion !== historyRequestVersion) return
 
-      if (isLoadMore) {
-        entries.update((prev) => [...prev, ...data.entries])
-      } else {
-        entries.update(() => data.entries)
-      }
+      const merged = isLoadMore ? [...entries.current, ...data.entries] : data.entries
+      const nextEntries = mergeLiveTrades(merged)
+      // A replace is an authoritative snapshot: trust the server total and add
+      // back only the live trades the snapshot has not caught up with yet.
+      const liveExtras = Math.max(0, nextEntries.length - merged.length)
+      const reconciledTotal = isLoadMore
+        ? Math.max(total.current, data.total)
+        : data.total + liveExtras
+      total.update(() => reconciledTotal)
+      hasMore.update(() => data.hasMore || nextEntries.length < reconciledTotal)
+      entries.update(() => nextEntries)
 
       // Accumulate symbols across fetches so the dropdown doesn't shrink
       const newSyms = new Set(data.entries.map((trade) => trade.symbol))
@@ -163,10 +213,14 @@
         return [...merged].sort()
       })
     } catch (fetchError) {
-      error.update(() => (fetchError instanceof Error ? fetchError.message : 'Unknown error'))
+      if (requestVersion === historyRequestVersion) {
+        error.update(() => (fetchError instanceof Error ? fetchError.message : 'Unknown error'))
+      }
     } finally {
-      loading.update(() => false)
-      loadingMore.update(() => false)
+      if (requestVersion === historyRequestVersion) {
+        loading.update(() => false)
+        loadingMore.update(() => false)
+      }
     }
   }
 
@@ -187,6 +241,7 @@
     if (sinceInput) sinceInput.value = toDatetimeLocal(sinceDate)
     if (untilInput) untilInput.value = ''
     offset.update(() => 0)
+    resetHistoryForFilter()
     void fetchTrades('replace')
   }
 
@@ -198,6 +253,7 @@
     offset.update(() => 0)
     if (sinceInput) sinceInput.value = ''
     if (untilInput) untilInput.value = ''
+    resetHistoryForFilter()
     void fetchTrades('replace')
   }
 
@@ -207,7 +263,6 @@
       selectedVenues.current.size < ALL_VENUES.length ||
       selectedSymbols.current.size > 0
   )
-
   onMount(() => {
     void fetchTrades('replace')
     const interval = setInterval(() => {
@@ -218,27 +273,31 @@
     }
   })
 
-  const handleVenueChange = (selected: Set<string>) => {
+  const handleVenueChange = (selected: Set<TradingVenue>) => {
     selectedVenues.update(() => selected)
     offset.update(() => 0)
+    resetHistoryForFilter()
     void fetchTrades('replace')
   }
 
   const handleSymbolChange = (selected: Set<string>) => {
     selectedSymbols.update(() => selected)
     offset.update(() => 0)
+    resetHistoryForFilter()
     void fetchTrades('replace')
   }
 
   const handleSinceChange = (event: Event) => {
     since.update(() => (event.target as HTMLInputElement).value)
     offset.update(() => 0)
+    resetHistoryForFilter()
     void fetchTrades('replace')
   }
 
   const handleUntilChange = (event: Event) => {
     until.update(() => (event.target as HTMLInputElement).value)
     offset.update(() => 0)
+    resetHistoryForFilter()
     void fetchTrades('replace')
   }
 
@@ -462,10 +521,11 @@
             <Table.Head class="text-right">Venue</Table.Head>
             <Table.Head class="text-right">Side</Table.Head>
             <Table.Head class="text-center">Size</Table.Head>
+            <Table.Head>Status</Table.Head>
           </Table.Row>
         </Table.Header>
         <Table.Body>
-          {#each entries.current as trade, idx (trade.id + String(idx))}
+          {#each entries.current as trade, idx (trade.id)}
             <Table.Row class={idx % 2 === 0 ? 'bg-muted/40' : ''}>
               <Table.Cell class="w-8 px-1">
                 <button
@@ -488,7 +548,7 @@
                 </button>
               </Table.Cell>
               <Table.Cell class="text-right font-mono text-xs text-muted-foreground">
-                {formatUtc(trade.filledAt)}
+                {formatUtc(trade.occurredAt)}
               </Table.Cell>
               <Table.Cell class="font-mono text-xs font-medium">{trade.symbol}</Table.Cell>
               <Table.Cell class="text-right text-xs font-medium {venueColor(trade.venue)}"
@@ -504,6 +564,9 @@
                     >{fmtSize(trade.shares)}</span
                   >
                 </HoverTooltip>
+              </Table.Cell>
+              <Table.Cell class="max-w-64 text-xs">
+                <TradeOutcomeView outcome={trade.outcome} />
               </Table.Cell>
             </Table.Row>
           {/each}
@@ -603,8 +666,15 @@
           </div>
 
           <div class="flex items-center gap-2 font-mono">
-            <span class="shrink-0 text-muted-foreground">Filled At</span>
-            <span>{formatUtc(trade.filledAt)}</span>
+            <span class="shrink-0 text-muted-foreground">Occurred At</span>
+            <span>{formatUtc(trade.occurredAt)}</span>
+          </div>
+
+          <div class="flex items-start gap-2 font-mono">
+            <span class="shrink-0 text-muted-foreground">Status</span>
+            <div>
+              <TradeOutcomeView outcome={trade.outcome} compact={false} />
+            </div>
           </div>
         </div>
 

--- a/dashboard/src/lib/components/trade-history-panel.test-harness.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.test-harness.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { QueryClientProvider, type QueryClient } from '@tanstack/svelte-query'
+  import TradeHistoryPanel from './trade-history-panel.svelte'
+
+  let { client }: { client: QueryClient } = $props()
+</script>
+
+<QueryClientProvider {client}>
+  <TradeHistoryPanel />
+</QueryClientProvider>

--- a/dashboard/src/lib/components/trade-history-panel.test.ts
+++ b/dashboard/src/lib/components/trade-history-panel.test.ts
@@ -1,0 +1,312 @@
+// @vitest-environment happy-dom
+
+import { QueryClient } from '@tanstack/svelte-query'
+import { mount, tick, unmount } from 'svelte'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Statement } from '$lib/api/Statement'
+import type { Trade } from '$lib/api/Trade'
+import { createWebSocket } from '$lib/websocket'
+import TradeHistoryPanelHarness from './trade-history-panel.test-harness.svelte'
+
+vi.mock('$env/dynamic/public', () => ({ env: {} }))
+
+const staleTrade: Trade = {
+  id: 'counter-trade-1',
+  occurredAt: '2026-01-01T00:00:00Z',
+  venue: 'alpaca',
+  direction: 'buy',
+  symbol: 'SPCX',
+  shares: '1',
+  outcome: { status: 'filled' }
+}
+
+const failedTrade = (id: string, overrides: Partial<Trade> = {}): Trade => ({
+  id,
+  occurredAt: '2026-01-01T00:00:01Z',
+  venue: 'alpaca',
+  direction: 'buy',
+  symbol: 'SPCX',
+  shares: '1',
+  outcome: {
+    status: 'failed',
+    error: 'broker rejected remainder',
+    filledShares: '0.25',
+    remainingShares: '0.75',
+    excessShares: '0'
+  },
+  ...overrides
+})
+
+const setupTestWebSocket = () => {
+  const instances: TestWebSocket[] = []
+
+  class TestWebSocket {
+    onopen: (() => void) | null = null
+    onclose: ((event: CloseEvent) => void) | null = null
+    onmessage: ((event: { data: string }) => void) | null = null
+    onerror: (() => void) | null = null
+
+    constructor(_url: string) {
+      instances.push(this)
+    }
+
+    close() {
+      this.onclose?.({ code: 1000, reason: '' } as CloseEvent)
+    }
+
+    open() {
+      this.onopen?.()
+    }
+
+    receive(statement: Statement) {
+      this.onmessage?.({ data: JSON.stringify(statement) })
+    }
+  }
+
+  vi.stubGlobal('WebSocket', TestWebSocket)
+
+  return () => {
+    const instance = instances.at(-1)
+    if (instance === undefined) throw new Error('WebSocket was not constructed')
+
+    return instance
+  }
+}
+
+const tradeResponse = (entries: Trade[], total: number, hasMore = false): Response =>
+  new Response(JSON.stringify({ entries, total, hasMore }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' }
+  })
+
+const mountPanel = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  })
+  const target = document.createElement('div')
+  document.body.append(target)
+  const component = mount(TradeHistoryPanelHarness, {
+    target,
+    props: { client: queryClient }
+  })
+
+  return { queryClient, target, component }
+}
+
+describe('TradeHistoryPanel', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders initial failures and replaces live rows with an authoritative total', async () => {
+    const socket = setupTestWebSocket()
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        tradeResponse(
+          [
+            staleTrade,
+            failedTrade('initial-failure', {
+              outcome: {
+                status: 'failed',
+                error: 'initial broker failure',
+                filledShares: '0',
+                remainingShares: '1',
+                excessShares: '0'
+              }
+            })
+          ],
+          150,
+          true
+        )
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { queryClient, target, component } = mountPanel()
+
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('initial broker failure')
+      expect(target.textContent).toContain('Failed')
+    })
+
+    const connection = createWebSocket('ws://localhost/api/ws', queryClient)
+    connection.connect()
+    socket().open()
+    for (const trade of [
+      failedTrade('counter-trade-1'),
+      failedTrade('live-failure', {
+        outcome: {
+          status: 'failed',
+          error: 'broker overfilled before rejecting',
+          filledShares: '1',
+          remainingShares: '0',
+          excessShares: '0.5'
+        }
+      })
+    ]) {
+      socket().receive({ type: 'trade_update', data: trade })
+    }
+    await tick()
+
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('broker rejected remainder')
+      expect(target.textContent).toContain('Filled 0.25')
+      expect(target.textContent).toContain('Unfilled 0.75')
+      expect(target.textContent).toContain('broker overfilled before rejecting')
+      expect(target.textContent).toContain('Excess fill 0.5')
+      expect(target.textContent).toContain('3 of 151')
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('limit=100'), expect.any(Object))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    connection.disconnect()
+    await unmount(component)
+    target.remove()
+  })
+
+  it('does not roll back a live total when an older refresh completes', async () => {
+    const socket = setupTestWebSocket()
+    let resolveRefresh: ((response: Response) => void) | undefined
+    const refreshResponse = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve
+    })
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(tradeResponse([staleTrade], 150, true))
+      .mockReturnValueOnce(refreshResponse)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { queryClient, target, component } = mountPanel()
+    await vi.waitFor(() => expect(target.textContent).toContain('1 of 150'))
+
+    const connection = createWebSocket('ws://localhost/api/ws', queryClient)
+    connection.connect()
+    socket().open()
+    socket().receive({
+      type: 'trade_update',
+      data: failedTrade('live-during-refresh')
+    })
+    await vi.waitFor(() => expect(target.textContent).toContain('2 of 151'))
+
+    const refresh = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent.trim() === 'Refresh'
+    )
+    expect(refresh).toBeDefined()
+    refresh?.click()
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    socket().receive({
+      type: 'trade_update',
+      data: failedTrade('newer-than-refresh')
+    })
+    await vi.waitFor(() => expect(target.textContent).toContain('3 of 152'))
+
+    resolveRefresh?.(tradeResponse([staleTrade], 150, true))
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('Refresh')
+      expect(target.textContent).toContain('3 of 152')
+    })
+
+    connection.disconnect()
+    await unmount(component)
+    target.remove()
+  })
+
+  it('adopts the server total on refresh so an inflated count cannot persist', async () => {
+    const socket = setupTestWebSocket()
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(tradeResponse([staleTrade], 3, true))
+      .mockResolvedValueOnce(tradeResponse([failedTrade('live-1'), staleTrade], 2, false))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { queryClient, target, component } = mountPanel()
+    await vi.waitFor(() => expect(target.textContent).toContain('1 of 3'))
+
+    const connection = createWebSocket('ws://localhost/api/ws', queryClient)
+    connection.connect()
+    socket().open()
+    socket().receive({ type: 'trade_update', data: failedTrade('live-1') })
+    await vi.waitFor(() => expect(target.textContent).toContain('2 of 4'))
+
+    const refresh = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent.trim() === 'Refresh'
+    )
+    expect(refresh).toBeDefined()
+    refresh?.click()
+
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('2 of 2')
+      expect(target.textContent).not.toContain('Load older trades')
+    })
+
+    connection.disconnect()
+    await unmount(component)
+    target.remove()
+  })
+
+  it('clears request state when the final venue is deselected', async () => {
+    const pendingResponses: Array<(response: Response) => void> = []
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(tradeResponse([staleTrade], 150, true))
+      .mockImplementation(
+        () =>
+          new Promise<Response>((resolve) => {
+            pendingResponses.push(resolve)
+          })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { target, component } = mountPanel()
+    await vi.waitFor(() => expect(target.textContent).toContain('1 of 150'))
+
+    const loadMore = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent.trim() === 'Load older trades'
+    )
+    expect(loadMore).toBeDefined()
+    loadMore?.click()
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(target.textContent).toContain('Loading...')
+    })
+
+    const venues = [...target.querySelectorAll('button')].find((button) =>
+      button.textContent.includes('Venues')
+    )
+    expect(venues).toBeDefined()
+    venues?.click()
+    await tick()
+
+    for (const label of ['Raindex', 'Alpaca', 'DryRun']) {
+      const option = [...target.querySelectorAll('button')].find((button) =>
+        button.textContent.trim().endsWith(label)
+      )
+      expect(option).toBeDefined()
+      option?.click()
+      await tick()
+    }
+
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('Venues (none)')
+      expect(target.textContent).toContain('No trades yet')
+      expect(target.textContent).toContain('0 of 0')
+      expect(target.textContent).not.toContain('Loading...')
+      expect(fetchMock).toHaveBeenCalledTimes(4)
+    })
+
+    for (const resolve of pendingResponses) {
+      resolve(tradeResponse([failedTrade('stale-completion')], 999, true))
+    }
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('No trades yet')
+      expect(target.textContent).toContain('0 of 0')
+      expect(target.textContent).not.toContain('stale-completion')
+      expect(target.textContent).not.toContain('Load older trades')
+    })
+
+    await unmount(component)
+    target.remove()
+  })
+})

--- a/dashboard/src/lib/components/trade-outcome.svelte
+++ b/dashboard/src/lib/components/trade-outcome.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import type { TradeOutcome } from '$lib/api/TradeOutcome'
+  import { decimalIsZero, formatDecimal } from '$lib/decimal'
+  import {
+    tradeFailureReason,
+    tradeFailureShares,
+    tradeOutcomeClass,
+    tradeOutcomeLabel
+  } from '$lib/trade'
+
+  let { outcome, compact = true }: { outcome: TradeOutcome; compact?: boolean } = $props()
+
+  const failureReason = $derived(tradeFailureReason(outcome))
+  const failureShares = $derived(tradeFailureShares(outcome))
+</script>
+
+<div class="font-medium {tradeOutcomeClass(outcome)}">
+  {tradeOutcomeLabel(outcome)}
+</div>
+{#if failureReason !== null}
+  <div
+    class={compact ? 'truncate text-destructive/80' : 'break-all text-destructive'}
+    title={failureReason}
+  >
+    {failureReason}
+  </div>
+{/if}
+{#if failureShares !== null}
+  <div class="text-muted-foreground">
+    Filled {formatDecimal(failureShares.filled, 9)} · Unfilled {formatDecimal(
+      failureShares.remaining,
+      9
+    )}
+  </div>
+  {#if !decimalIsZero(failureShares.excess)}
+    <div class="text-destructive">
+      Excess fill {formatDecimal(failureShares.excess, 9)}
+    </div>
+  {/if}
+{/if}

--- a/dashboard/src/lib/components/trade-outcome.test.ts
+++ b/dashboard/src/lib/components/trade-outcome.test.ts
@@ -1,0 +1,69 @@
+import { render } from 'svelte/server'
+import { describe, expect, it } from 'vitest'
+import TradeOutcome from './trade-outcome.svelte'
+
+describe('TradeOutcome', () => {
+  it('renders a filled trade without failure details', () => {
+    const { body } = render(TradeOutcome, {
+      props: { outcome: { status: 'filled' } }
+    })
+
+    expect(body).toContain('Filled')
+    expect(body).toContain('text-green-500')
+    expect(body).not.toContain('Unfilled')
+  })
+
+  it('renders a failed counter-trade error and partial-fill quantities', () => {
+    const { body } = render(TradeOutcome, {
+      props: {
+        outcome: {
+          status: 'failed',
+          error: 'broker rejected remainder',
+          filledShares: '0.25',
+          remainingShares: '0.75',
+          excessShares: '0'
+        }
+      }
+    })
+
+    expect(body).toContain('Failed')
+    expect(body).toContain('broker rejected remainder')
+    expect(body).toContain('Filled 0.25')
+    expect(body).toContain('Unfilled 0.75')
+  })
+
+  it('does not render a nonzero partial fill as zero', () => {
+    const { body } = render(TradeOutcome, {
+      props: {
+        outcome: {
+          status: 'failed',
+          error: 'broker rejected remainder',
+          filledShares: '0.0004',
+          remainingShares: '0.9996',
+          excessShares: '0'
+        }
+      }
+    })
+
+    expect(body).toContain('Filled 0.0004')
+    expect(body).not.toContain('Filled 0 ·')
+  })
+
+  it('renders broker fills beyond the accepted order quantity', () => {
+    const { body } = render(TradeOutcome, {
+      props: {
+        outcome: {
+          status: 'failed',
+          error: 'broker overfilled before rejecting',
+          filledShares: '1',
+          remainingShares: '0',
+          excessShares: '0.5'
+        }
+      }
+    })
+
+    expect(body).toContain('Filled 1')
+    expect(body).toContain('Unfilled 0')
+    expect(body).toContain('Excess fill 0.5')
+  })
+})

--- a/dashboard/src/lib/trade.test.ts
+++ b/dashboard/src/lib/trade.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest'
+import type { Trade } from '$lib/api/Trade'
+import {
+  mergeTradeHistory,
+  tradeFailureReason,
+  tradeFailureShares,
+  tradeOutcomeClass,
+  tradeOutcomeLabel
+} from './trade'
+
+describe('trade outcome presentation', () => {
+  it('renders filled outcomes as successful', () => {
+    const outcome = { status: 'filled' } as const
+
+    expect(tradeOutcomeLabel(outcome)).toBe('Filled')
+    expect(tradeOutcomeClass(outcome)).toBe('text-green-500')
+    expect(tradeFailureReason(outcome)).toBeNull()
+  })
+
+  it('renders failed outcomes with their error', () => {
+    const outcome = {
+      status: 'failed',
+      error: 'asset is not tradable',
+      filledShares: '0.25',
+      remainingShares: '0.75',
+      excessShares: '0'
+    } as const
+
+    expect(tradeOutcomeLabel(outcome)).toBe('Failed')
+    expect(tradeOutcomeClass(outcome)).toBe('text-destructive')
+    expect(tradeFailureReason(outcome)).toBe('asset is not tradable')
+    expect(tradeFailureShares(outcome)).toEqual({
+      filled: '0.25',
+      remaining: '0.75',
+      excess: '0'
+    })
+  })
+})
+
+describe('live trade history', () => {
+  const trade = (overrides: Partial<Trade>): Trade => ({
+    id: 'existing',
+    occurredAt: '2026-01-01T00:00:00Z',
+    venue: 'alpaca',
+    direction: 'buy',
+    symbol: 'AAPL',
+    shares: '1',
+    outcome: { status: 'filled' },
+    ...overrides
+  })
+
+  it('merges matching failures into the visible history without duplicates', () => {
+    const stale = trade({})
+    const failure = trade({
+      outcome: {
+        status: 'failed',
+        error: 'broker rejected remainder',
+        filledShares: '0.25',
+        remainingShares: '0.75',
+        excessShares: '0'
+      }
+    })
+
+    expect(
+      mergeTradeHistory([stale], [failure], {
+        venues: new Set(['alpaca']),
+        symbols: new Set(),
+        since: null,
+        until: null
+      })
+    ).toEqual([failure])
+  })
+
+  it('keeps live updates out when they do not match active filters', () => {
+    const failure = trade({ symbol: 'SPCX' })
+
+    expect(
+      mergeTradeHistory([], [failure], {
+        venues: new Set(['alpaca']),
+        symbols: new Set(['AAPL']),
+        since: null,
+        until: null
+      })
+    ).toEqual([])
+  })
+
+  it('applies venue and time filters to live updates', () => {
+    const before = trade({ id: 'before', occurredAt: '2025-12-31T23:59:59Z' })
+    const atStart = trade({ id: 'at-start', occurredAt: '2026-01-01T00:00:00Z' })
+    const atEnd = trade({ id: 'at-end', occurredAt: '2026-01-01T00:01:00Z' })
+    const after = trade({ id: 'after', occurredAt: '2026-01-01T00:01:01Z' })
+    const wrongVenue = trade({ id: 'wrong-venue', venue: 'raindex' })
+
+    expect(
+      mergeTradeHistory([], [before, atStart, atEnd, after, wrongVenue], {
+        venues: new Set(['alpaca']),
+        symbols: new Set(),
+        since: '2026-01-01T00:00:00Z',
+        until: '2026-01-01T00:01:00Z'
+      })
+    ).toEqual([atEnd, atStart])
+  })
+
+  it('sorts merged history newest-first with a stable ID tie-breaker', () => {
+    const older = trade({ id: 'older', occurredAt: '2026-01-01T00:00:00Z' })
+    const sameTimeB = trade({ id: 'b', occurredAt: '2026-01-01T00:01:00Z' })
+    const sameTimeA = trade({ id: 'a', occurredAt: '2026-01-01T00:01:00Z' })
+
+    expect(
+      mergeTradeHistory([older, sameTimeB], [sameTimeA], {
+        venues: new Set(['alpaca']),
+        symbols: new Set(),
+        since: null,
+        until: null
+      })
+    ).toEqual([sameTimeA, sameTimeB, older])
+  })
+
+  it('sorts tied onchain trades by numeric log index', () => {
+    const txHash = `0x${'0'.repeat(64)}`
+    const log2 = trade({ id: `${txHash}:2`, venue: 'raindex' })
+    const log10 = trade({ id: `${txHash}:10`, venue: 'raindex' })
+
+    expect(
+      mergeTradeHistory([log2], [log10], {
+        venues: new Set(['raindex']),
+        symbols: new Set(),
+        since: null,
+        until: null
+      })
+    ).toEqual([log10, log2])
+  })
+})

--- a/dashboard/src/lib/trade.ts
+++ b/dashboard/src/lib/trade.ts
@@ -1,0 +1,93 @@
+import type { Trade } from '$lib/api/Trade'
+import type { TradeOutcome } from '$lib/api/TradeOutcome'
+import type { TradingVenue } from '$lib/api/TradingVenue'
+import { matcher } from '$lib/fp'
+
+const matchOutcome = matcher<TradeOutcome>()('status')
+
+export const tradeOutcomeLabel = (outcome: TradeOutcome): string =>
+  matchOutcome(outcome, {
+    filled: () => 'Filled',
+    failed: () => 'Failed'
+  })
+
+export const tradeOutcomeClass = (outcome: TradeOutcome): string =>
+  matchOutcome(outcome, {
+    filled: () => 'text-green-500',
+    failed: () => 'text-destructive'
+  })
+
+export const tradeFailureReason = (outcome: TradeOutcome): string | null =>
+  matchOutcome(outcome, {
+    filled: () => null,
+    failed: ({ error }) => error
+  })
+
+export const tradeFailureShares = (
+  outcome: TradeOutcome
+): { filled: string; remaining: string; excess: string } | null =>
+  matchOutcome(outcome, {
+    filled: () => null,
+    failed: ({ filledShares, remainingShares, excessShares }) => ({
+      filled: filledShares,
+      remaining: remainingShares,
+      excess: excessShares
+    })
+  })
+
+export type TradeHistoryFilter = {
+  venues: ReadonlySet<TradingVenue>
+  symbols: ReadonlySet<string>
+  since: string | null
+  until: string | null
+}
+
+const matchesHistoryFilter = (trade: Trade, filter: TradeHistoryFilter): boolean => {
+  if (!filter.venues.has(trade.venue)) return false
+  if (filter.symbols.size > 0 && !filter.symbols.has(trade.symbol)) return false
+
+  const occurredAt = Date.parse(trade.occurredAt)
+  if (filter.since !== null && occurredAt < Date.parse(filter.since)) return false
+  if (filter.until !== null && occurredAt > Date.parse(filter.until)) return false
+
+  return true
+}
+
+const parseOnchainTradeId = (id: string): { txHash: string; logIndex: bigint } | null => {
+  const separator = id.lastIndexOf(':')
+  const logIndex = id.slice(separator + 1)
+  if (separator < 0 || !/^\d+$/.test(logIndex)) return null
+
+  return { txHash: id.slice(0, separator), logIndex: BigInt(logIndex) }
+}
+
+const compareStrings = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0
+
+const compareTradeIds = (left: Trade, right: Trade): number => {
+  if (left.venue === 'raindex' && right.venue === 'raindex') {
+    const leftId = parseOnchainTradeId(left.id)
+    const rightId = parseOnchainTradeId(right.id)
+    if (leftId !== null && rightId !== null && leftId.txHash === rightId.txHash) {
+      return leftId.logIndex > rightId.logIndex ? -1 : leftId.logIndex < rightId.logIndex ? 1 : 0
+    }
+  }
+
+  return compareStrings(left.id, right.id)
+}
+
+export const mergeTradeHistory = (
+  current: Trade[],
+  live: Trade[],
+  filter: TradeHistoryFilter
+): Trade[] => {
+  const byId = new Map(current.map((trade) => [trade.id, trade]))
+  for (const trade of live) byId.set(trade.id, trade)
+
+  return [...byId.values()]
+    .filter((trade) => matchesHistoryFilter(trade, filter))
+    .sort(
+      (left, right) =>
+        Date.parse(right.occurredAt) - Date.parse(left.occurredAt) || compareTradeIds(left, right)
+    )
+}

--- a/dashboard/src/lib/websocket/connection.svelte.test.ts
+++ b/dashboard/src/lib/websocket/connection.svelte.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { createWebSocket } from '.'
-import type { QueryClient } from '@tanstack/svelte-query'
+import { QueryClient } from '@tanstack/svelte-query'
 import type { Statement } from '$lib/api/Statement'
 import type { Trade } from '$lib/api/Trade'
 import type { TransferOperation } from '$lib/api/TransferOperation'
@@ -74,24 +74,26 @@ const WS_URL = 'ws://localhost:8001/api/ws'
 
 const makeTrade = (overrides: Partial<Trade> = {}): Trade => ({
   id: 'trade-1',
-  filledAt: '2024-01-01T12:00:00Z',
+  occurredAt: '2024-01-01T12:00:00Z',
   venue: 'raindex',
   direction: 'buy',
   symbol: 'AAPL',
   shares: '10',
+  outcome: { status: 'filled' },
   ...overrides
 })
 
-const makeTransfer = (overrides: Partial<TransferOperation> = {}): TransferOperation => ({
-  kind: 'equity_mint',
-  id: 'transfer-1',
-  symbol: 'AAPL',
-  quantity: '10',
-  status: { status: 'minting' },
-  startedAt: '2024-01-01T12:00:00Z',
-  updatedAt: '2024-01-01T12:00:00Z',
-  ...overrides
-} as TransferOperation)
+const makeTransfer = (overrides: Partial<TransferOperation> = {}): TransferOperation =>
+  ({
+    kind: 'equity_mint',
+    id: 'transfer-1',
+    symbol: 'AAPL',
+    quantity: '10',
+    status: { status: 'minting' },
+    startedAt: '2024-01-01T12:00:00Z',
+    updatedAt: '2024-01-01T12:00:00Z',
+    ...overrides
+  }) as TransferOperation
 
 const setupWebSocketTest = () => {
   const instances: MockWebSocket[] = []
@@ -191,7 +193,8 @@ describe('createWebSocket', () => {
         data: {
           trades: [trade],
           inventory: {
-            perSymbol: [], usdc: {
+            perSymbol: [],
+            usdc: {
               onchainAvailable: '0',
               onchainInflight: '0',
               offchainAvailable: '0',
@@ -209,7 +212,8 @@ describe('createWebSocket', () => {
             usdcTarget: null,
             usdcDeviation: null,
             cashReserved: null,
-            executionThreshold: '$2', assets: [],
+            executionThreshold: '$2',
+            assets: [],
             wallet: null,
             logLevel: 'Debug',
             serverPort: 8001,
@@ -232,16 +236,20 @@ describe('createWebSocket', () => {
       expect(trades).toBeDefined()
       expect(trades).toEqual([trade])
 
-      const active = queryClient.cache.get('["transfers","active"]') as TransferOperation[] | undefined
+      const active = queryClient.cache.get('["transfers","active"]') as
+        | TransferOperation[]
+        | undefined
       expect(active).toBeDefined()
       expect(active).toEqual([activeTransfer])
 
-      const recent = queryClient.cache.get('["transfers","recent"]') as TransferOperation[] | undefined
+      const recent = queryClient.cache.get('["transfers","recent"]') as
+        | TransferOperation[]
+        | undefined
       expect(recent).toBeDefined()
       expect(recent).toEqual([recentTransfer])
     })
 
-    it('prepends fill to trades cache', () => {
+    it('prepends trade updates to the trades cache', () => {
       const { getInstance } = setupWebSocketTest()
       const queryClient = createMockQueryClient()
       const ws = createWebSocket(WS_URL, queryClient)
@@ -250,10 +258,10 @@ describe('createWebSocket', () => {
       getInstance(0).simulateOpen()
 
       // Seed with existing trade
-      queryClient.cache.set('["trades"]', [makeTrade({ symbol: 'TSLA' })])
+      queryClient.cache.set('["trades"]', [makeTrade({ id: 'trade-old', symbol: 'TSLA' })])
 
       const newTrade = makeTrade({ symbol: 'AAPL' })
-      const message: Statement = { type: 'trade_fill', data: newTrade }
+      const message: Statement = { type: 'trade_update', data: newTrade }
 
       getInstance(0).simulateMessage(message)
 
@@ -261,6 +269,33 @@ describe('createWebSocket', () => {
       expect(trades).toHaveLength(2)
       expect(trades[0]?.symbol).toBe('AAPL')
       expect(trades[1]?.symbol).toBe('TSLA')
+    })
+
+    it('replaces a matching initial trade with its live update', () => {
+      const { getInstance } = setupWebSocketTest()
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } }
+      })
+      const ws = createWebSocket(WS_URL, queryClient)
+
+      ws.connect()
+      getInstance(0).simulateOpen()
+
+      queryClient.setQueryData(['trades'], [makeTrade({ symbol: 'STALE' })])
+      const failure = makeTrade({
+        symbol: 'SPCX',
+        outcome: {
+          status: 'failed',
+          error: 'asset is not tradable',
+          filledShares: '0',
+          remainingShares: '10',
+          excessShares: '0'
+        }
+      })
+      getInstance(0).simulateMessage({ type: 'trade_update', data: failure })
+
+      const trades = queryClient.getQueryData<Trade[]>(['trades'])
+      expect(trades).toEqual([failure])
     })
 
     it('limits trades to 100', () => {
@@ -272,12 +307,12 @@ describe('createWebSocket', () => {
       getInstance(0).simulateOpen()
 
       const existing = Array.from({ length: 100 }, (_, idx) =>
-        makeTrade({ symbol: `SYM${String(idx)}` })
+        makeTrade({ id: `trade-${String(idx)}`, symbol: `SYM${String(idx)}` })
       )
       queryClient.cache.set('["trades"]', existing)
 
       const newTrade = makeTrade({ symbol: 'NEW' })
-      getInstance(0).simulateMessage({ type: 'trade_fill', data: newTrade })
+      getInstance(0).simulateMessage({ type: 'trade_update', data: newTrade })
 
       const trades = queryClient.cache.get('["trades"]') as Trade[]
       expect(trades).toHaveLength(100)
@@ -293,17 +328,19 @@ describe('createWebSocket', () => {
       getInstance(0).simulateOpen()
 
       const inventory = {
-        perSymbol: [{
-          symbol: 'AAPL',
-          onchainAvailable: '10',
-          onchainInflight: '0',
-          offchainAvailable: '5',
-          offchainInflight: '0',
-          inflightEquity: {
-            baseWalletUnwrapped: '0',
-            baseWalletWrapped: '0'
+        perSymbol: [
+          {
+            symbol: 'AAPL',
+            onchainAvailable: '10',
+            onchainInflight: '0',
+            offchainAvailable: '5',
+            offchainInflight: '0',
+            inflightEquity: {
+              baseWalletUnwrapped: '0',
+              baseWalletWrapped: '0'
+            }
           }
-        }],
+        ],
         usdc: {
           onchainAvailable: '1000',
           onchainInflight: '0',
@@ -352,7 +389,10 @@ describe('createWebSocket', () => {
       const recent = queryClient.cache.get('["transfers","recent"]') as TransferOperation[]
       expect(recent).toHaveLength(1)
       expect(recent[0]?.id).toBe('mint-1')
-      expect(recent[0]?.status).toEqual({ status: 'completed', completedAt: '2024-01-01T13:00:00Z' })
+      expect(recent[0]?.status).toEqual({
+        status: 'completed',
+        completedAt: '2024-01-01T13:00:00Z'
+      })
     })
 
     it('ignores invalid messages', () => {

--- a/dashboard/src/lib/websocket/connection.svelte.ts
+++ b/dashboard/src/lib/websocket/connection.svelte.ts
@@ -4,7 +4,7 @@ import type { Statement } from '$lib/api/Statement'
 import { isStatement } from '$lib/api/StatementGuard'
 import { matcher } from '$lib/fp'
 import { reactive } from '$lib/frp.svelte'
-import { seedTrades, appendFill } from './trades'
+import { seedTrades, appendTrade } from './trades'
 import { seedInventory, updateSnapshot, upsertPosition } from './inventory'
 import { seedTransfers, upsertTransfer } from './transfers'
 
@@ -38,7 +38,7 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
         seedTransfers(queryClient, data)
       },
 
-      trade_fill: ({ data }) => { appendFill(queryClient, data); },
+      trade_update: ({ data }) => { appendTrade(queryClient, data); },
 
       position_update: ({ data }) => { upsertPosition(queryClient, data); },
 

--- a/dashboard/src/lib/websocket/trades.ts
+++ b/dashboard/src/lib/websocket/trades.ts
@@ -8,8 +8,8 @@ export const seedTrades = (queryClient: QueryClient, state: CurrentState) => {
   queryClient.setQueryData<Trade[]>(['trades'], state.trades)
 }
 
-export const appendFill = (queryClient: QueryClient, trade: Trade) => {
+export const appendTrade = (queryClient: QueryClient, trade: Trade) => {
   queryClient.setQueryData<Trade[]>(['trades'], (old) =>
-    [trade, ...(old ?? [])].slice(0, MAX_TRADES)
+    [trade, ...(old ?? []).filter((existing) => existing.id !== trade.id)].slice(0, MAX_TRADES)
   )
 }

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -131,13 +131,13 @@ const mockApi = () => ({
               decision: null,
               submission: null,
               execution: null,
-              exposureWindow: null,
-            },
+              exposureWindow: null
+            }
           },
           buckets: [],
           cycles: [],
           totalCycles: 0,
-          openExposures: [],
+          openExposures: []
         })
         return
       }
@@ -148,7 +148,7 @@ const mockApi = () => ({
           totalOperations: 0,
           skippedOperations: 0,
           stageSummary: [],
-          attestationTrend: [],
+          attestationTrend: []
         })
         return
       }
@@ -158,7 +158,7 @@ const mockApi = () => ({
           logBuckets: [],
           logTargets: [],
           failureEvents: [],
-          jobQueues: [],
+          jobQueues: []
         })
         return
       }
@@ -168,7 +168,7 @@ const mockApi = () => ({
           operations: [],
           totalOperations: 0,
           skippedOperations: 0,
-          stageSummary: [],
+          stageSummary: []
         })
         return
       }
@@ -179,6 +179,15 @@ const mockApi = () => ({
 })
 
 export default defineConfig({
+  ...(process.env['VITEST'] === 'true'
+    ? {
+        resolve: {
+          // Vitest otherwise resolves Svelte's server entry even when a test
+          // uses a DOM environment, which makes `mount` unavailable.
+          conditions: ['browser']
+        }
+      }
+    : {}),
   plugins: [mockApi(), tailwindcss(), sveltekit()],
   server: {
     proxy: isMockMode()

--- a/src/api.rs
+++ b/src/api.rs
@@ -18,10 +18,11 @@ use tracing::{error, info, warn};
 
 use st0x_config::BrokerCtx;
 use st0x_dto::{
-    EquityTimings, HedgeLatencies, InfraReport, RebalanceTimings, ReliabilityReport, TradingVenue,
+    EquityTimings, HedgeLatencies, InfraReport, RebalanceTimings, ReliabilityReport, Trade,
+    TradeOutcome, TradingVenue, sort_trades_newest_first,
 };
-use st0x_execution::FractionalShares;
 use st0x_execution::alpaca_broker_api::AccountActivitiesQuery;
+use st0x_execution::{FractionalShares, Symbol};
 use st0x_tokenization::IssuerRequestId;
 
 use crate::AppState;
@@ -30,6 +31,8 @@ use crate::dashboard::pnl::{
 };
 use crate::dashboard::transfer_loader::{InvalidTransferKind, TransferKind};
 use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
+use crate::offchain::order::{OffchainOrder, OffchainOrderId, TradeConversionError};
+use crate::onchain_trade::{OnChainTradeEvent, OnChainTradeId, ParseOnChainTradeIdError};
 use crate::performance::equity_timing::load_equity_timings;
 use crate::performance::infra::{load_dependency_stats, load_monitor_telemetry};
 use crate::performance::rebalance::load_rebalance_timings;
@@ -136,21 +139,10 @@ struct StuckTransferInfo {
     reason: StuckReason,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-struct TradeEntry {
-    id: String,
-    filled_at: String,
-    venue: String,
-    direction: String,
-    symbol: String,
-    shares: String,
-}
-
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct TradeResponse {
-    entries: Vec<TradeEntry>,
+    entries: Vec<Trade>,
     total: usize,
     has_more: bool,
 }
@@ -561,40 +553,14 @@ struct TradesQuery {
 async fn trades(
     State(state): State<AppState>,
     Query(query): Query<TradesQuery>,
-) -> Json<TradeResponse> {
+) -> Result<Json<TradeResponse>, StatusCode> {
     let limit = query.limit.unwrap_or(100).min(500);
     let offset = query.offset.unwrap_or(0);
 
-    let since_dt = query.since.as_deref().and_then(|val| {
-        DateTime::parse_from_rfc3339(val)
-            .ok()
-            .map(|dt| dt.with_timezone(&Utc))
-    });
-    let until_dt = query.until.as_deref().and_then(|val| {
-        DateTime::parse_from_rfc3339(val)
-            .ok()
-            .map(|dt| dt.with_timezone(&Utc))
-    });
-
-    let venues = query
-        .venue
-        .as_deref()
-        .filter(|val| !val.is_empty())
-        .map(|val| {
-            val.split(',')
-                .map(|part| part.trim().to_string())
-                .collect::<Vec<_>>()
-        });
-
-    let symbols = query
-        .symbol
-        .as_deref()
-        .filter(|val| !val.is_empty())
-        .map(|val| {
-            val.split(',')
-                .map(|part| part.trim().to_string())
-                .collect::<Vec<_>>()
-        });
+    let since_dt = parse_trade_filter_time(query.since.as_deref(), "since")?;
+    let until_dt = parse_trade_filter_time(query.until.as_deref(), "until")?;
+    let venues = parse_trade_venues(query.venue.as_deref())?;
+    let symbols = parse_trade_symbols(query.symbol.as_deref())?;
 
     let trade_filter = TradeFilter {
         symbols,
@@ -603,33 +569,36 @@ async fn trades(
         until: until_dt,
     };
 
-    let mut all_trades = load_trade_rows(&state.pool, &trade_filter).await;
-    all_trades.sort_by(|lhs, rhs| rhs.filled_at.cmp(&lhs.filled_at));
+    let mut all_trades = load_trade_rows(&state.pool, &trade_filter)
+        .await
+        .inspect_err(|error| warn!(target: "dashboard", ?error, "Failed to load trade history"))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    sort_trades_newest_first(&mut all_trades);
 
     let total = all_trades.len();
-    let end = total.min(offset + limit);
+    let end = total.min(offset.saturating_add(limit));
     let entries = all_trades[offset.min(total)..end].to_vec();
     let has_more = end < total;
 
-    Json(TradeResponse {
+    Ok(Json(TradeResponse {
         entries,
         total,
         has_more,
-    })
+    }))
 }
 
 struct TradeFilter {
-    symbols: Option<Vec<String>>,
-    venues: Option<Vec<String>>,
+    symbols: Option<Vec<Symbol>>,
+    venues: Option<Vec<TradingVenue>>,
     since: Option<DateTime<Utc>>,
     until: Option<DateTime<Utc>>,
 }
 
 impl TradeFilter {
-    fn matches_symbol(&self, symbol: &str) -> bool {
+    fn matches_symbol(&self, symbol: &Symbol) -> bool {
         self.symbols
             .as_ref()
-            .is_none_or(|syms| syms.iter().any(|sym| sym == symbol))
+            .is_none_or(|symbols| symbols.contains(symbol))
     }
 
     fn matches_time(&self, timestamp: DateTime<Utc>) -> bool {
@@ -646,131 +615,246 @@ impl TradeFilter {
         true
     }
 
-    fn matches_venue(&self, venue: &str) -> bool {
+    fn matches_venue(&self, venue: TradingVenue) -> bool {
         self.venues
             .as_ref()
-            .is_none_or(|vals| vals.iter().any(|val| val == venue))
+            .is_none_or(|venues| venues.contains(&venue))
     }
 }
 
-async fn load_trade_rows(pool: &SqlitePool, filter: &TradeFilter) -> Vec<TradeEntry> {
-    let include_onchain = filter.matches_venue("raindex");
-    let include_offchain = filter.matches_venue("alpaca")
-        || filter.matches_venue("dry_run")
-        || filter.venues.is_none();
+fn parse_trade_filter_time(
+    value: Option<&str>,
+    parameter: &'static str,
+) -> Result<Option<DateTime<Utc>>, StatusCode> {
+    value
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            DateTime::parse_from_rfc3339(value)
+                .map(|timestamp| timestamp.with_timezone(&Utc))
+                .inspect_err(|error| {
+                    warn!(target: "dashboard", %error, %parameter, %value, "Invalid trade-history timestamp filter");
+                })
+                .map_err(|_| StatusCode::BAD_REQUEST)
+        })
+        .transpose()
+}
+
+fn parse_trade_venues(value: Option<&str>) -> Result<Option<Vec<TradingVenue>>, StatusCode> {
+    value
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .map(TradingVenue::from_str)
+                .collect::<Result<Vec<_>, _>>()
+                .inspect_err(|error| {
+                    warn!(target: "dashboard", %error, %value, "Invalid trade-history venue filter");
+                })
+                .map_err(|_| StatusCode::BAD_REQUEST)
+        })
+        .transpose()
+}
+
+fn parse_trade_symbols(value: Option<&str>) -> Result<Option<Vec<Symbol>>, StatusCode> {
+    value
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .map(Symbol::from_str)
+                .collect::<Result<Vec<_>, _>>()
+                .inspect_err(|error| {
+                    warn!(target: "dashboard", %error, %value, "Invalid trade-history symbol filter");
+                })
+                .map_err(|_| StatusCode::BAD_REQUEST)
+        })
+        .transpose()
+}
+
+async fn load_trade_rows(
+    pool: &SqlitePool,
+    filter: &TradeFilter,
+) -> Result<Vec<Trade>, TradeHistoryError> {
+    let include_onchain = filter.matches_venue(TradingVenue::Raindex);
+    let include_offchain =
+        filter.matches_venue(TradingVenue::Alpaca) || filter.matches_venue(TradingVenue::DryRun);
 
     let mut trades = Vec::new();
 
     if include_onchain {
-        trades.extend(load_onchain_trade_rows(pool, filter).await);
+        trades.extend(load_onchain_trade_rows(pool, filter).await?);
     }
 
     if include_offchain {
-        trades.extend(load_offchain_trade_rows(pool, filter).await);
+        trades.extend(load_offchain_trade_rows(pool, filter).await?);
     }
 
-    trades
+    Ok(trades)
 }
 
-async fn load_onchain_trade_rows(pool: &SqlitePool, filter: &TradeFilter) -> Vec<TradeEntry> {
-    let rows: Vec<(String, String)> = match sqlx::query_as(
+async fn load_onchain_trade_rows(
+    pool: &SqlitePool,
+    filter: &TradeFilter,
+) -> Result<Vec<Trade>, TradeHistoryError> {
+    let rows: Vec<(String, String)> = sqlx::query_as(
         "SELECT aggregate_id, payload FROM events \
          WHERE event_type = 'OnChainTradeEvent::Filled' \
          ORDER BY rowid DESC",
     )
     .fetch_all(pool)
-    .await
-    {
-        Ok(rows) => rows,
-        Err(error) => {
-            tracing::warn!(target: "dashboard", %error, "Failed to load onchain trades");
-            return Vec::new();
-        }
-    };
+    .await?;
 
-    rows.into_iter()
-        .filter_map(|(aggregate_id, payload_str)| {
-            let payload: serde_json::Value = serde_json::from_str(&payload_str).ok()?;
-            let filled = payload.get("Filled")?;
-
-            let trade_symbol = filled["symbol"].as_str()?;
-            let filled_at_str = filled["block_timestamp"].as_str()?;
-            let filled_at = DateTime::parse_from_rfc3339(filled_at_str)
-                .ok()?
-                .with_timezone(&Utc);
-
-            if !filter.matches_symbol(trade_symbol) || !filter.matches_time(filled_at) {
-                return None;
-            }
-
-            let direction = filled["direction"].as_str()?;
-            let amount = filled["amount"].as_str()?;
-
-            Some(TradeEntry {
-                id: aggregate_id,
-                filled_at: filled_at.to_rfc3339(),
-                venue: "raindex".to_string(),
-                direction: direction.to_string(),
-                symbol: trade_symbol.to_string(),
-                shares: amount.to_string(),
-            })
+    Ok(rows
+        .into_iter()
+        .filter_map(|(aggregate_id, payload)| {
+            parse_onchain_trade_row(aggregate_id, &payload, filter)
+                .inspect_err(|error| {
+                    warn!(
+                        target: "dashboard",
+                        %error,
+                        "Skipping unparseable onchain trade history row"
+                    );
+                })
+                .ok()
+                .flatten()
         })
-        .collect()
+        .collect())
 }
 
-async fn load_offchain_trade_rows(pool: &SqlitePool, filter: &TradeFilter) -> Vec<TradeEntry> {
-    let rows: Vec<(String, String)> = match sqlx::query_as(
+fn parse_onchain_trade_row(
+    aggregate_id: String,
+    payload: &str,
+    filter: &TradeFilter,
+) -> Result<Option<Trade>, TradeHistoryError> {
+    let result = (|| -> Result<Trade, OnchainTradeRowError> {
+        let id = OnChainTradeId::from_str(&aggregate_id)?;
+        let event: OnChainTradeEvent = serde_json::from_str(payload)?;
+        let OnChainTradeEvent::Filled {
+            symbol,
+            amount,
+            direction,
+            block_timestamp,
+            ..
+        } = event
+        else {
+            return Err(OnchainTradeRowError::UnexpectedEvent);
+        };
+
+        Ok(Trade {
+            id: id.to_string(),
+            occurred_at: block_timestamp,
+            venue: TradingVenue::Raindex,
+            direction,
+            symbol,
+            shares: FractionalShares::new(amount),
+            outcome: TradeOutcome::Filled,
+        })
+    })()
+    .map_err(|source| TradeHistoryError::InvalidOnchainRow {
+        aggregate_id,
+        source,
+    })?;
+
+    if !filter.matches_symbol(&result.symbol) || !filter.matches_time(result.occurred_at) {
+        return Ok(None);
+    }
+
+    Ok(Some(result))
+}
+
+async fn load_offchain_trade_rows(
+    pool: &SqlitePool,
+    filter: &TradeFilter,
+) -> Result<Vec<Trade>, TradeHistoryError> {
+    let rows: Vec<(String, String)> = sqlx::query_as(
         "SELECT view_id, payload FROM offchain_order_view \
-         WHERE status = 'Filled'",
+         WHERE status IN ('Filled', 'Failed')",
     )
     .fetch_all(pool)
-    .await
-    {
-        Ok(rows) => rows,
-        Err(error) => {
-            tracing::warn!(target: "dashboard", %error, "Failed to load offchain trades");
-            return Vec::new();
-        }
-    };
+    .await?;
 
-    rows.into_iter()
-        .filter_map(|(view_id, payload_str)| {
-            let payload: serde_json::Value = serde_json::from_str(&payload_str).ok()?;
-            let filled = payload.get("Live")?.get("Filled")?;
-
-            let trade_symbol = filled["symbol"].as_str()?;
-            let filled_at_str = filled["filled_at"].as_str()?;
-            let filled_at = DateTime::parse_from_rfc3339(filled_at_str)
-                .ok()?
-                .with_timezone(&Utc);
-
-            if !filter.matches_symbol(trade_symbol) || !filter.matches_time(filled_at) {
-                return None;
-            }
-
-            let executor = filled["executor"].as_str().unwrap_or("AlpacaBrokerApi");
-            let venue = match executor {
-                "DryRun" => "dry_run",
-                _ => "alpaca",
-            };
-
-            if !filter.matches_venue(venue) {
-                return None;
-            }
-
-            let direction = filled["direction"].as_str()?;
-            let shares = filled["shares"].as_str()?;
-
-            Some(TradeEntry {
-                id: view_id,
-                filled_at: filled_at.to_rfc3339(),
-                venue: venue.to_string(),
-                direction: direction.to_string(),
-                symbol: trade_symbol.to_string(),
-                shares: shares.to_string(),
-            })
+    Ok(rows
+        .into_iter()
+        .filter_map(|(view_id, payload)| {
+            parse_offchain_trade_row(view_id, &payload, filter)
+                .inspect_err(|error| {
+                    warn!(
+                        target: "dashboard",
+                        %error,
+                        "Skipping unparseable offchain trade history row"
+                    );
+                })
+                .ok()
+                .flatten()
         })
-        .collect()
+        .collect())
+}
+
+#[derive(Deserialize)]
+enum OffchainOrderProjectionPayload {
+    Live(OffchainOrder),
+}
+
+#[derive(Debug, thiserror::Error)]
+enum OffchainTradeRowError {
+    #[error("invalid offchain order projection payload: {0}")]
+    Payload(#[from] serde_json::Error),
+    #[error("invalid offchain order id: {0}")]
+    Id(#[from] uuid::Error),
+    #[error("offchain order cannot be represented in trade history: {0}")]
+    Conversion(#[from] TradeConversionError),
+}
+
+#[derive(Debug, thiserror::Error)]
+enum OnchainTradeRowError {
+    #[error("invalid onchain trade id: {0}")]
+    Id(#[from] ParseOnChainTradeIdError),
+    #[error("invalid onchain trade event payload: {0}")]
+    Payload(#[from] serde_json::Error),
+    #[error("query returned a non-fill onchain event")]
+    UnexpectedEvent,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum TradeHistoryError {
+    #[error("failed to query trade history: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("failed to parse onchain trade history row {aggregate_id}: {source}")]
+    InvalidOnchainRow {
+        aggregate_id: String,
+        #[source]
+        source: OnchainTradeRowError,
+    },
+    #[error("failed to parse offchain trade history row {view_id}: {source}")]
+    InvalidOffchainRow {
+        view_id: String,
+        #[source]
+        source: OffchainTradeRowError,
+    },
+}
+
+fn parse_offchain_trade_row(
+    view_id: String,
+    payload: &str,
+    filter: &TradeFilter,
+) -> Result<Option<Trade>, TradeHistoryError> {
+    let result = (|| -> Result<Trade, OffchainTradeRowError> {
+        let OffchainOrderProjectionPayload::Live(order) = serde_json::from_str(payload)?;
+        let id = OffchainOrderId::from_str(&view_id)?;
+        Ok(order.try_into_trade(&id)?)
+    })()
+    .map_err(|source| TradeHistoryError::InvalidOffchainRow { view_id, source })?;
+
+    if !filter.matches_symbol(&result.symbol)
+        || !filter.matches_time(result.occurred_at)
+        || !filter.matches_venue(result.venue)
+    {
+        return Ok(None);
+    }
+
+    Ok(Some(result))
 }
 
 #[derive(Deserialize, Default)]
@@ -1772,7 +1856,7 @@ mod tests {
     use st0x_event_sorcery::ReactorHarness;
     use st0x_execution::{
         AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode,
-        DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS, TimeInForce,
+        DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS, Symbol, TimeInForce,
     };
     use st0x_float_macro::float;
     use st0x_tokenization::{
@@ -1860,6 +1944,249 @@ mod tests {
         assert_eq!(parsed.submitted_at.as_deref(), Some("2026-01-01T00:00:01Z"));
         assert_eq!(parsed.shares_filled.as_deref(), Some("0.5"));
         assert_eq!(parsed.avg_price.as_deref(), Some("195.25"));
+    }
+
+    #[tokio::test]
+    async fn offchain_trade_history_includes_failed_orders() {
+        let state = empty_app_state(create_test_ctx_with_order_owner(Address::ZERO)).await;
+        let pool = state.pool.clone();
+        let payload = r#"{"Live":{"Failed":{"symbol":"SPCX","shares":"1","direction":"Buy","executor":"AlpacaBrokerApi","retained_fill":{"Priced":{"shares_filled":"0.25","avg_price":"25","partially_filled_at":"2026-01-01T00:00:00Z"}},"executor_order_id":"broker-order","error":"asset is not tradable","placed_at":"2026-01-01T00:00:00Z","failed_at":"2026-01-01T00:00:01Z"}}}"#;
+        let view_id = "00000000-0000-0000-0000-000000000141";
+        sqlx::query("INSERT INTO offchain_order_view (view_id, version, payload) VALUES (?, 1, ?)")
+            .bind(view_id)
+            .bind(payload)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let entries = load_offchain_trade_rows(
+            &pool,
+            &TradeFilter {
+                symbols: None,
+                venues: None,
+                since: None,
+                until: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, view_id);
+        assert_eq!(entries[0].symbol, Symbol::new("SPCX").unwrap());
+        match &entries[0].outcome {
+            TradeOutcome::Failed {
+                error,
+                filled_shares,
+                remaining_shares,
+                excess_shares,
+            } => {
+                assert_eq!(error, "asset is not tradable");
+                assert!(
+                    filled_shares
+                        .inner()
+                        .inner()
+                        .eq(st0x_float_macro::float!(0.25))
+                        .unwrap()
+                );
+                assert!(
+                    remaining_shares
+                        .inner()
+                        .inner()
+                        .eq(st0x_float_macro::float!(0.75))
+                        .unwrap()
+                );
+                assert!(excess_shares.inner().inner().is_zero().unwrap());
+            }
+            TradeOutcome::Filled => panic!("failed projection must remain failed"),
+        }
+
+        let response = build_app(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/trades")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value =
+            serde_json::from_str(&body_to_string(response).await).unwrap();
+        assert_eq!(body["entries"][0]["occurredAt"], "2026-01-01T00:00:01Z");
+        assert_eq!(body["entries"][0]["outcome"]["status"], "failed");
+        assert_eq!(
+            body["entries"][0]["outcome"]["error"],
+            "asset is not tradable"
+        );
+        assert_eq!(body["entries"][0]["outcome"]["filledShares"], "0.25");
+        assert_eq!(body["entries"][0]["outcome"]["remainingShares"], "0.75");
+    }
+
+    #[tokio::test]
+    async fn offchain_trade_history_skips_malformed_rows() {
+        let state = empty_app_state(create_test_ctx_with_order_owner(Address::ZERO)).await;
+        let pool = state.pool.clone();
+        let malformed_payload = r#"{"Live":{"Failed":{"symbol":"SPCX"}}}"#;
+        let malformed_view_id = "00000000-0000-0000-0000-000000000142";
+        sqlx::query("INSERT INTO offchain_order_view (view_id, version, payload) VALUES (?, 1, ?)")
+            .bind(malformed_view_id)
+            .bind(malformed_payload)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let valid_payload = r#"{"Live":{"Failed":{"symbol":"SPCX","shares":"1","direction":"Buy","executor":"AlpacaBrokerApi","retained_fill":{"Priced":{"shares_filled":"0.25","avg_price":"25","partially_filled_at":"2026-01-01T00:00:00Z"}},"executor_order_id":"broker-order","error":"asset is not tradable","placed_at":"2026-01-01T00:00:00Z","failed_at":"2026-01-01T00:00:01Z"}}}"#;
+        let valid_view_id = "00000000-0000-0000-0000-000000000143";
+        sqlx::query("INSERT INTO offchain_order_view (view_id, version, payload) VALUES (?, 1, ?)")
+            .bind(valid_view_id)
+            .bind(valid_payload)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let entries = load_offchain_trade_rows(
+            &pool,
+            &TradeFilter {
+                symbols: None,
+                venues: None,
+                since: None,
+                until: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, valid_view_id);
+
+        let response = build_app(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/trades")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value =
+            serde_json::from_str(&body_to_string(response).await).unwrap();
+        assert_eq!(body["total"], 1);
+        assert_eq!(body["entries"][0]["id"], valid_view_id);
+    }
+
+    #[test]
+    fn onchain_trade_history_rejects_malformed_aggregate_ids() {
+        let error = parse_onchain_trade_row(
+            "not-an-onchain-trade-id".to_string(),
+            "{}",
+            &TradeFilter {
+                symbols: None,
+                venues: None,
+                since: None,
+                until: None,
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("not-an-onchain-trade-id"));
+        assert!(matches!(
+            error,
+            TradeHistoryError::InvalidOnchainRow {
+                source: OnchainTradeRowError::Id(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn failed_offchain_trade_history_respects_all_filters() {
+        let payload = r#"{"Live":{"Failed":{"symbol":"SPCX","shares":"1","direction":"Buy","executor":"AlpacaBrokerApi","retained_fill":null,"executor_order_id":null,"error":"asset is not tradable","placed_at":"2026-01-01T00:00:00Z","failed_at":"2026-01-01T00:00:01Z"}}}"#;
+        let view_id = "00000000-0000-0000-0000-000000000143";
+        let parse = |filter: TradeFilter| {
+            parse_offchain_trade_row(view_id.to_string(), payload, &filter)
+                .expect("valid failed trade should parse")
+        };
+
+        assert!(
+            parse(TradeFilter {
+                symbols: Some(vec![Symbol::new("SPCX").unwrap()]),
+                venues: Some(vec![TradingVenue::Alpaca]),
+                since: Some("2026-01-01T00:00:01Z".parse().unwrap()),
+                until: Some("2026-01-01T00:00:01Z".parse().unwrap()),
+            })
+            .is_some()
+        );
+
+        for filter in [
+            TradeFilter {
+                symbols: Some(vec![Symbol::new("AAPL").unwrap()]),
+                venues: None,
+                since: None,
+                until: None,
+            },
+            TradeFilter {
+                symbols: None,
+                venues: Some(vec![TradingVenue::DryRun]),
+                since: None,
+                until: None,
+            },
+            TradeFilter {
+                symbols: None,
+                venues: None,
+                since: Some("2026-01-01T00:00:02Z".parse().unwrap()),
+                until: None,
+            },
+            TradeFilter {
+                symbols: None,
+                venues: None,
+                since: None,
+                until: Some("2026-01-01T00:00:00Z".parse().unwrap()),
+            },
+        ] {
+            assert!(parse(filter).is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn trade_history_rejects_invalid_filters() {
+        let state = empty_app_state(create_test_ctx_with_order_owner(Address::ZERO)).await;
+        let app = build_app(state);
+
+        for uri in [
+            "/trades?venue=unknown",
+            "/trades?symbol=%20",
+            "/trades?since=not-a-timestamp",
+            "/trades?until=not-a-timestamp",
+        ] {
+            let response = app
+                .clone()
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "URI: {uri}");
+        }
+    }
+
+    #[tokio::test]
+    async fn trade_history_saturates_an_overflowing_page_end() {
+        let state = empty_app_state(create_test_ctx_with_order_owner(Address::ZERO)).await;
+        let response = build_app(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/trades?offset={}", usize::MAX))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value =
+            serde_json::from_str(&body_to_string(response).await).unwrap();
+        assert_eq!(body["entries"], serde_json::json!([]));
+        assert_eq!(body["total"], 0);
+        assert_eq!(body["hasMore"], false);
     }
 
     #[tokio::test]

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -160,11 +160,57 @@ pub(crate) async fn setup_apalis_tables(
     Ok(())
 }
 
+/// Builds the vault registry store and runs the seeding logic inline so
+/// downstream wiring (RaindexService, trade accounting, inventory polling)
+/// starts with a populated registry. The returned queue and ctx are
+/// registered as an apalis worker by the caller so the queue retries on
+/// failure if seeding is re-triggered later (e.g. from a recovery flow).
+async fn setup_vault_registry(
+    pool: &SqlitePool,
+    apalis_pool: &apalis_sqlite::SqlitePool,
+    ctx: &Ctx,
+) -> anyhow::Result<(
+    Arc<Store<VaultRegistry>>,
+    Arc<Projection<VaultRegistry>>,
+    SeedVaultRegistryJobQueue,
+    Arc<SeedVaultRegistryCtx>,
+)> {
+    let (vault_registry, vault_registry_projection) =
+        StoreBuilder::<VaultRegistry>::new(pool.clone())
+            .build(())
+            .await?;
+
+    let seed_vault_registry_queue = SeedVaultRegistryJobQueue::new(apalis_pool);
+    let seed_vault_registry_ctx = Arc::new(
+        SeedVaultRegistryCtx::from_config(vault_registry.clone(), ctx).map_err(|err| *err)?,
+    );
+
+    crate::conductor::job::Job::perform(&SeedVaultRegistry, &seed_vault_registry_ctx).await?;
+
+    Ok((
+        vault_registry,
+        vault_registry_projection,
+        seed_vault_registry_queue,
+        seed_vault_registry_ctx,
+    ))
+}
+
+async fn setup_onchain_trade_store(
+    pool: &SqlitePool,
+    broadcaster: Arc<Broadcaster>,
+) -> anyhow::Result<Arc<Store<OnChainTrade>>> {
+    Ok(StoreBuilder::<OnChainTrade>::new(pool.clone())
+        .with(broadcaster)
+        .build(())
+        .await?)
+}
+
 async fn setup_offchain_order_store<E>(
     pool: &SqlitePool,
     executor: &E,
     position: &Arc<Store<Position>>,
     position_projection: &Arc<Projection<Position>>,
+    broadcaster: Arc<Broadcaster>,
 ) -> anyhow::Result<(Arc<Store<OffchainOrder>>, Arc<Projection<OffchainOrder>>)>
 where
     E: Executor + Clone + Send + Sync + 'static,
@@ -180,6 +226,7 @@ where
     let order_placer: Arc<dyn OrderPlacer> = Arc::new(ExecutorOrderPlacer(executor.clone()));
     let (offchain_order, offchain_order_projection) =
         StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .with(broadcaster)
             .with(Arc::new(RetryOnBusy {
                 inner: HedgeLatencyProjection::new(pool.clone()),
             }))
@@ -549,27 +596,16 @@ impl Conductor {
         let job_queue = DexTradeAccountingJobQueue::new(&apalis_pool);
         let backfill_queue = BackfillJobQueue::new(&apalis_pool);
         let schedulers = RebalancingSchedulers::new(&apalis_pool);
+        let broadcaster = Arc::new(Broadcaster::new(event_sender.clone(), pool.clone()));
 
-        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
-            .build(())
-            .await?;
+        let onchain_trade = setup_onchain_trade_store(&pool, broadcaster.clone()).await?;
 
-        let (vault_registry, vault_registry_projection) =
-            StoreBuilder::<VaultRegistry>::new(pool.clone())
-                .build(())
-                .await?;
-
-        let seed_vault_registry_queue = SeedVaultRegistryJobQueue::new(&apalis_pool);
-        let seed_vault_registry_ctx = Arc::new(
-            SeedVaultRegistryCtx::from_config(vault_registry.clone(), &ctx).map_err(|err| *err)?,
-        );
-
-        // Run the seeding logic inline at startup so downstream wiring
-        // (RaindexService, trade accounting, inventory polling) starts
-        // with a populated registry. The same code path is registered
-        // below as an apalis worker so the queue retries on failure if
-        // seeding is re-triggered later (e.g. from a recovery flow).
-        crate::conductor::job::Job::perform(&SeedVaultRegistry, &seed_vault_registry_ctx).await?;
+        let (
+            vault_registry,
+            vault_registry_projection,
+            seed_vault_registry_queue,
+            seed_vault_registry_ctx,
+        ) = setup_vault_registry(&pool, &apalis_pool, &ctx).await?;
 
         // Grant one-time idempotent MAX approvals to the trusted spenders (our
         // ERC-4626 wrapper vaults and the Raindex orderbook) before any worker
@@ -618,7 +654,7 @@ impl Conductor {
                 apalis_pool: apalis_pool.clone(),
                 ctx: ctx.clone(),
                 inventory: inventory.clone(),
-                event_sender,
+                event_sender: event_sender.clone(),
                 vault_registry: vault_registry.clone(),
                 vault_registry_projection,
                 schedulers: schedulers.clone(),
@@ -653,8 +689,14 @@ impl Conductor {
             service.enqueue_recovery_for_current_wallet_balances().await;
         }
 
-        let (offchain_order, offchain_order_projection) =
-            setup_offchain_order_store(&pool, &executor, &position, &position_projection).await?;
+        let (offchain_order, offchain_order_projection) = setup_offchain_order_store(
+            &pool,
+            &executor,
+            &position,
+            &position_projection,
+            broadcaster,
+        )
+        .await?;
 
         let frameworks = CqrsFrameworks {
             onchain_trade,
@@ -3618,7 +3660,7 @@ mod tests {
     use st0x_evm::local::RawPrivateKeyWallet;
     use st0x_execution::{
         Direction, EquityPosition, ExecutorOrderId, Inventory as ExecutionInventory, MarketOrder,
-        MockExecutor, Positive, Symbol,
+        MockExecutor, Positive, SupportedExecutor, Symbol,
     };
     use st0x_finance::{Usd, Usdc};
     use st0x_float_macro::float;
@@ -3799,6 +3841,101 @@ mod tests {
     fn test_broadcaster(pool: &SqlitePool) -> (Arc<Broadcaster>, broadcast::Receiver<Statement>) {
         let (sender, receiver) = broadcast::channel(16);
         (Arc::new(Broadcaster::new(sender, pool.clone())), receiver)
+    }
+
+    #[tokio::test]
+    async fn onchain_trade_store_broadcasts_filled_trades() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let (broadcaster, mut receiver) = test_broadcaster(&pool);
+        let store = setup_onchain_trade_store(&pool, broadcaster).await.unwrap();
+        let id = crate::onchain_trade::OnChainTradeId {
+            tx_hash: TxHash::ZERO,
+            log_index: 0,
+        };
+
+        store
+            .send(
+                &id,
+                crate::onchain_trade::OnChainTradeCommand::Witness {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: float!(1),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_number: 1,
+                    block_timestamp: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let message = tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("wired store should broadcast the onchain fill")
+            .expect("dashboard receiver should remain connected");
+        assert!(matches!(
+            message,
+            Statement::TradeUpdate(st0x_dto::Trade {
+                venue: st0x_dto::TradingVenue::Raindex,
+                outcome: st0x_dto::TradeOutcome::Filled,
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn offchain_order_store_broadcasts_failed_counter_trades() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (broadcaster, mut receiver) = test_broadcaster(&pool);
+        let (offchain_order, _) = setup_offchain_order_store(
+            &pool,
+            &MockExecutor::new(),
+            &position,
+            &position_projection,
+            broadcaster,
+        )
+        .await
+        .unwrap();
+        let id = OffchainOrderId::new();
+
+        offchain_order
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("SPCX").unwrap(),
+                    shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                    direction: Direction::Buy,
+                    executor: SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        offchain_order
+            .send(
+                &id,
+                OffchainOrderCommand::MarkPlacementFailed {
+                    error: "asset is not tradable".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let message = tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("wired store should broadcast the terminal failure")
+            .expect("dashboard receiver should remain connected");
+        assert!(matches!(
+            message,
+            Statement::TradeUpdate(st0x_dto::Trade {
+                outcome: st0x_dto::TradeOutcome::Failed { error, .. },
+                ..
+            }) if error == "asset is not tradable"
+        ));
     }
 
     async fn insert_finished_job(apalis_pool: &apalis_sqlite::SqlitePool, id: &str) {

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -6,7 +6,7 @@ use sqlx::SqlitePool;
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
 
-use st0x_dto::{Statement, Trade, TradingVenue};
+use st0x_dto::{Statement, Trade, TradeOutcome, TradingVenue};
 use st0x_event_sorcery::{EntityList, Never, Reactor, deps, load_entity};
 
 use crate::equity_redemption::EquityRedemption;
@@ -40,9 +40,9 @@ impl Broadcaster {
         Self { sender, pool }
     }
 
-    fn broadcast_fill(&self, trade: Trade) {
-        if let Err(error) = self.sender.send(Statement::TradeFill(trade)) {
-            debug!(target: "dashboard", %error, "Failed to broadcast trade fill (no receivers)");
+    fn broadcast_trade(&self, trade: Trade) {
+        if let Err(error) = self.sender.send(Statement::TradeUpdate(trade)) {
+            debug!(target: "dashboard", %error, "Failed to broadcast trade update (no receivers)");
         }
     }
 
@@ -73,17 +73,18 @@ impl Reactor for Broadcaster {
                     symbol,
                     amount,
                     direction,
-                    filled_at,
+                    block_timestamp,
                     ..
-                } = &event
+                } = event
                 {
-                    self.broadcast_fill(Trade {
+                    self.broadcast_trade(Trade {
                         id: id.to_string(),
-                        filled_at: *filled_at,
+                        occurred_at: block_timestamp,
                         venue: TradingVenue::Raindex,
-                        direction: *direction,
-                        symbol: symbol.clone(),
-                        shares: st0x_finance::FractionalShares::new(*amount),
+                        direction,
+                        symbol,
+                        shares: st0x_finance::FractionalShares::new(amount),
+                        outcome: TradeOutcome::Filled,
                     });
                 }
             })
@@ -114,14 +115,14 @@ impl Reactor for Broadcaster {
             .on(|id, event| async move {
                 use OffchainOrderEvent::*;
                 match event {
-                    Filled { .. } => {
+                    Filled { .. } | Failed { .. } => {
                         match load_entity::<OffchainOrder>(&self.pool, &id).await {
-                            Ok(Some(order)) => match order.try_to_trade(&id) {
-                                Ok(trade) => self.broadcast_fill(trade),
+                            Ok(Some(order)) => match order.try_into_trade(&id) {
+                                Ok(trade) => self.broadcast_trade(trade),
                                 Err(error) => warn!(
                                     target: "dashboard",
                                     %id, %error,
-                                    "OffchainOrder not in Filled state after Filled event"
+                                    "OffchainOrder not terminal after terminal event"
                                 ),
                             },
                             Ok(None) => warn!(
@@ -132,7 +133,7 @@ impl Reactor for Broadcaster {
                             Err(error) => warn!(
                                 target: "dashboard",
                                 %id, ?error,
-                                "Failed to load OffchainOrder for fill broadcast"
+                                "Failed to load OffchainOrder for terminal broadcast"
                             ),
                         }
                     }
@@ -141,7 +142,6 @@ impl Reactor for Broadcaster {
                     | Accepted { .. }
                     | PartiallyFilled { .. }
                     | CancelRequested { .. }
-                    | Failed { .. }
                     | Cancelled { .. } => {}
                 }
             })
@@ -211,6 +211,7 @@ mod tests {
         let harness = ReactorHarness::new(broadcaster);
 
         let now = chrono::Utc::now();
+        let ingested_at = now + chrono::Duration::seconds(1);
         let id = crate::onchain_trade::OnChainTradeId {
             tx_hash: alloy::primitives::TxHash::ZERO,
             log_index: 0,
@@ -226,7 +227,7 @@ mod tests {
                     price_usdc: st0x_float_macro::float!(150),
                     block_number: 12345,
                     block_timestamp: now,
-                    filled_at: now,
+                    filled_at: ingested_at,
                 },
             )
             .await
@@ -235,12 +236,13 @@ mod tests {
         let msg = receiver.recv().await.expect("should receive fill");
 
         match msg {
-            Statement::TradeFill(trade) => {
+            Statement::TradeUpdate(trade) => {
                 assert!(matches!(trade.venue, TradingVenue::Raindex));
                 assert!(matches!(trade.direction, st0x_dto::Direction::Buy));
                 assert_eq!(trade.symbol, Symbol::new("AAPL").unwrap());
+                assert_eq!(trade.occurred_at, now);
             }
-            other => panic!("expected TradeFill message, got {other:?}"),
+            other => panic!("expected TradeUpdate message, got {other:?}"),
         }
     }
 
@@ -311,12 +313,121 @@ mod tests {
         let msg = receiver.recv().await.expect("should receive fill");
 
         match msg {
-            Statement::TradeFill(trade) => {
+            Statement::TradeUpdate(trade) => {
                 assert!(matches!(trade.venue, TradingVenue::Alpaca));
                 assert!(matches!(trade.direction, st0x_dto::Direction::Sell));
                 assert_eq!(trade.symbol, Symbol::new("TSLA").unwrap());
             }
-            other => panic!("expected TradeFill message, got {other:?}"),
+            other => panic!("expected TradeUpdate message, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn offchain_order_failed_broadcasts_failure() {
+        let pool = setup_test_db().await;
+        let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .build(crate::offchain::order::noop_order_placer())
+            .await
+            .unwrap();
+        let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
+        let harness = ReactorHarness::new(broadcaster);
+
+        let id = crate::offchain::order::OffchainOrderId::new();
+        let now = chrono::Utc::now();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("SPCX").unwrap(),
+                    shares: st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
+                        st0x_float_macro::float!(1),
+                    ))
+                    .unwrap(),
+                    direction: st0x_execution::Direction::Buy,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: st0x_execution::ExecutorOrderId::new("partial-failure"),
+                    placed_shares: st0x_execution::Positive::new(
+                        st0x_execution::FractionalShares::new(st0x_float_macro::float!(1)),
+                    )
+                    .unwrap(),
+                    submitted_at: now,
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: st0x_execution::FractionalShares::new(st0x_float_macro::float!(
+                        0.25
+                    )),
+                    avg_price: st0x_finance::Usd::new(st0x_float_macro::float!(25)),
+                    partially_filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkFailed {
+                    error: "asset is not tradable".to_string(),
+                    failed_at: now,
+                },
+            )
+            .await
+            .unwrap();
+
+        let failed = OffchainOrderEvent::Failed {
+            error: "asset is not tradable".to_string(),
+            failed_at: now,
+        };
+        harness.receive::<OffchainOrder>(id, failed).await.unwrap();
+
+        let message = receiver.recv().await.expect("should receive failure");
+        match message {
+            Statement::TradeUpdate(trade) => match trade.outcome {
+                st0x_dto::TradeOutcome::Failed {
+                    error,
+                    filled_shares,
+                    remaining_shares,
+                    excess_shares,
+                } => {
+                    assert_eq!(error, "asset is not tradable");
+                    assert!(
+                        filled_shares
+                            .inner()
+                            .inner()
+                            .eq(st0x_float_macro::float!(0.25))
+                            .unwrap()
+                    );
+                    assert!(
+                        remaining_shares
+                            .inner()
+                            .inner()
+                            .eq(st0x_float_macro::float!(0.75))
+                            .unwrap()
+                    );
+                    assert!(excess_shares.inner().inner().is_zero().unwrap());
+                }
+                st0x_dto::TradeOutcome::Filled => {
+                    panic!("failed order must broadcast a failure outcome")
+                }
+            },
+            other => panic!("expected TradeUpdate message, got {other:?}"),
         }
     }
 

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -12,7 +12,7 @@ use tokio::sync::broadcast;
 use tracing::{info, trace, warn};
 
 use st0x_config::{ExecutionThreshold, OperationMode};
-use st0x_dto::{CurrentState, Statement};
+use st0x_dto::{CurrentState, Statement, TransferWarning};
 use st0x_event_sorcery::{load_all_ids, load_entity};
 use st0x_finance::Positive;
 
@@ -86,7 +86,19 @@ async fn drain_client_messages(stream: &mut futures_util::stream::SplitStream<We
 async fn send_initial_state(sink: &mut SplitSink<WebSocket, Message>, state: &AppState) -> bool {
     let inventory_dto = state.inventory.read().await.to_dto();
     let transfers = transfer_loader::load_transfers(&state.pool).await;
-    let trades = trade_loader::load_trades(&state.pool).await;
+    let mut warnings = transfers.warnings;
+    let trades = match trade_loader::load_trades(&state.pool).await {
+        Ok(trades) => trades,
+        Err(error) => {
+            warn!(
+                target: "dashboard",
+                %error,
+                "Failed to load initial trade history; sending empty trade list"
+            );
+            warnings.push(TransferWarning::TradeHistoryUnavailable);
+            Vec::new()
+        }
+    };
     let positions = load_positions(&state.pool).await;
 
     let initial = Statement::CurrentState(Box::new(CurrentState {
@@ -96,7 +108,7 @@ async fn send_initial_state(sink: &mut SplitSink<WebSocket, Message>, state: &Ap
         settings: state.settings.clone(),
         active_transfers: transfers.active,
         recent_transfers: transfers.recent,
-        warnings: transfers.warnings,
+        warnings,
     }));
 
     match send_json(sink, &initial).await {
@@ -312,18 +324,26 @@ mod tests {
 
     use st0x_config::{EquityAssetConfig, create_test_ctx_with_order_owner};
     use st0x_dto::{Direction, Trade, TradingVenue};
+    use st0x_event_sorcery::StoreBuilder;
+    use st0x_execution::{ClientOrderId, FractionalShares, Positive, SupportedExecutor, Symbol};
+    use st0x_float_macro::float;
 
     use super::*;
     use crate::inventory::{self, BroadcastingInventory};
+    use crate::offchain::order::{
+        CounterTradeOrderKind, OffchainOrder, OffchainOrderCommand, OffchainOrderId,
+        noop_order_placer,
+    };
 
     fn dummy_fill(symbol: &str) -> Statement {
-        Statement::TradeFill(Trade {
+        Statement::TradeUpdate(Trade {
             id: format!("test-fill-{symbol}"),
-            filled_at: chrono::Utc::now(),
+            occurred_at: chrono::Utc::now(),
             venue: TradingVenue::Raindex,
             direction: Direction::Buy,
             symbol: st0x_finance::Symbol::new(symbol).unwrap(),
             shares: st0x_finance::FractionalShares::new(st0x_float_macro::float!(1)),
+            outcome: st0x_dto::TradeOutcome::Filled,
         })
     }
 
@@ -472,7 +492,10 @@ mod tests {
     }
 
     async fn start_test_server() -> TestServer {
-        let state = create_test_state().await;
+        start_test_server_with_state(create_test_state().await).await
+    }
+
+    async fn start_test_server_with_state(state: AppState) -> TestServer {
         let event_sender = state.event_sender.clone();
         let inventory = Arc::clone(&state.inventory);
 
@@ -549,6 +572,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn websocket_initial_state_includes_failed_counter_trades() {
+        let state = create_test_state().await;
+        let (store, _) = StoreBuilder::<OffchainOrder>::new(state.pool.clone())
+            .build(noop_order_placer())
+            .await
+            .unwrap();
+        let id = OffchainOrderId::new();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("SPCX").unwrap(),
+                    shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                    direction: Direction::Buy,
+                    executor: SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkPlacementFailed {
+                    error: "asset is not tradable".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut server = start_test_server_with_state(state).await;
+        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
+        let (mut client, _) = connect_async(&url).await.unwrap();
+        let message = client.next().await.unwrap().unwrap().into_text().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+        let trade = &parsed["data"]["trades"][0];
+
+        assert_eq!(trade["id"], id.to_string());
+        assert!(trade["occurredAt"].as_str().is_some());
+        assert_eq!(trade["outcome"]["status"], "failed");
+        assert_eq!(trade["outcome"]["error"], "asset is not tradable");
+        assert_eq!(trade["outcome"]["filledShares"], "0");
+        assert_eq!(trade["outcome"]["remainingShares"], "1");
+        assert_eq!(trade["outcome"]["excessShares"], "0");
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn multiple_concurrent_clients_receive_initial_message() {
         let mut server = start_test_server().await;
         let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
@@ -619,8 +692,8 @@ mod tests {
 
             assert_eq!(
                 parsed["type"],
-                "trade_fill",
-                "client{} should receive trade_fill message",
+                "trade_update",
+                "client{} should receive trade_update message",
                 i + 1
             );
             assert_eq!(parsed["data"]["symbol"], "AAPL");
@@ -661,7 +734,7 @@ mod tests {
         let text = msg.into_text().expect("expected text");
         let parsed: serde_json::Value = serde_json::from_str(&text).expect("invalid JSON");
 
-        assert_eq!(parsed["type"], "trade_fill");
+        assert_eq!(parsed["type"], "trade_update");
         assert_eq!(parsed["data"]["symbol"], "TSLA");
 
         server.shutdown().await;

--- a/src/dashboard/trade_loader.rs
+++ b/src/dashboard/trade_loader.rs
@@ -1,13 +1,13 @@
-//! Loads filled trades from the event store for the initial dashboard state.
+//! Loads terminal trade outcomes from the event store for dashboard history.
 
 use futures_util::{StreamExt, stream};
 use sqlx::SqlitePool;
 use tracing::warn;
 
-use st0x_dto::Trade;
-use st0x_event_sorcery::{load_all_ids, load_entity};
+use st0x_dto::{Trade, sort_trades_newest_first};
+use st0x_event_sorcery::{LoadAllIdsError, SendError, load_all_ids, load_entity};
 
-use crate::offchain::order::OffchainOrder;
+use crate::offchain::order::{OffchainOrder, TradeConversionError};
 use crate::onchain_trade::OnChainTrade;
 
 const MAX_TRADES: usize = 100;
@@ -15,65 +15,124 @@ const MAX_TRADES: usize = 100;
 /// Load recent filled trades from both onchain and offchain sources.
 ///
 /// Returns up to [`MAX_TRADES`] trades sorted by fill time (newest first).
-pub(crate) async fn load_trades(pool: &SqlitePool) -> Vec<Trade> {
+pub(crate) async fn load_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHistoryError> {
     let mut trades: Vec<Trade> = load_onchain_trades(pool)
-        .await
+        .await?
         .into_iter()
-        .chain(load_offchain_trades(pool).await)
+        .chain(load_offchain_trades(pool).await?)
         .collect();
 
-    trades.sort_by(|lhs, rhs| rhs.filled_at.cmp(&lhs.filled_at));
+    sort_trades_newest_first(&mut trades);
     trades.truncate(MAX_TRADES);
 
-    trades
+    Ok(trades)
 }
 
-async fn load_onchain_trades(pool: &SqlitePool) -> Vec<Trade> {
+async fn load_onchain_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHistoryError> {
     let ids = load_all_ids::<OnChainTrade>(pool)
         .await
-        .inspect_err(|error| warn!(?error, "Failed to load OnChainTrade IDs for trade history"))
-        .unwrap_or_default();
+        .map_err(TradeHistoryError::OnchainIds)?;
 
-    stream::iter(ids)
+    Ok(stream::iter(ids)
         .filter_map(|id| async move {
-            match load_entity::<OnChainTrade>(pool, &id).await {
-                Ok(Some(entity)) => Some(entity.to_trade(&id)),
+            let entity = match load_entity::<OnChainTrade>(pool, &id).await {
+                Ok(Some(entity)) => entity,
                 Ok(None) => {
-                    warn!(?id, "OnChainTrade replayed to empty state");
-                    None
+                    let error = TradeHistoryError::OnchainMissing { id: id.to_string() };
+                    warn!(target: "dashboard", %error, "Skipping unloadable onchain trade");
+                    return None;
                 }
-                Err(error) => {
-                    warn!(?error, ?id, "Failed to load OnChainTrade");
-                    None
+                Err(source) => {
+                    let error = TradeHistoryError::OnchainReplay {
+                        id: id.to_string(),
+                        source,
+                    };
+                    warn!(target: "dashboard", %error, "Skipping unloadable onchain trade");
+                    return None;
                 }
-            }
+            };
+
+            Some(entity.into_trade(&id))
         })
         .collect()
-        .await
+        .await)
 }
 
-async fn load_offchain_trades(pool: &SqlitePool) -> Vec<Trade> {
+async fn load_offchain_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHistoryError> {
     let ids = load_all_ids::<OffchainOrder>(pool)
         .await
-        .inspect_err(|error| warn!(?error, "Failed to load OffchainOrder IDs for trade history"))
-        .unwrap_or_default();
+        .map_err(TradeHistoryError::OffchainIds)?;
 
-    stream::iter(ids)
+    Ok(stream::iter(ids)
         .filter_map(|id| async move {
-            match load_entity::<OffchainOrder>(pool, &id).await {
-                Ok(Some(order)) => order.try_to_trade(&id).ok(),
+            let order = match load_entity::<OffchainOrder>(pool, &id).await {
+                Ok(Some(order)) => order,
                 Ok(None) => {
-                    warn!(?id, "OffchainOrder replayed to empty state");
-                    None
+                    let error = TradeHistoryError::OffchainMissing { id: id.to_string() };
+                    warn!(target: "dashboard", %error, "Skipping unloadable offchain trade");
+                    return None;
                 }
-                Err(error) => {
-                    warn!(?error, ?id, "Failed to load OffchainOrder");
+                Err(source) => {
+                    let error = TradeHistoryError::OffchainReplay {
+                        id: id.to_string(),
+                        source,
+                    };
+                    warn!(target: "dashboard", %error, "Skipping unloadable offchain trade");
+                    return None;
+                }
+            };
+
+            match order.try_into_trade(&id) {
+                Ok(trade) => Some(trade),
+                Err(
+                    TradeConversionError::Pending
+                    | TradeConversionError::Submitted
+                    | TradeConversionError::PartiallyFilled
+                    | TradeConversionError::Cancelling
+                    | TradeConversionError::Cancelled,
+                ) => None,
+                Err(source) => {
+                    let error = TradeHistoryError::OffchainConversion {
+                        id: id.to_string(),
+                        source,
+                    };
+                    warn!(target: "dashboard", %error, "Skipping unrepresentable offchain trade");
                     None
                 }
             }
         })
         .collect()
-        .await
+        .await)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum TradeHistoryError {
+    #[error("failed to load onchain trade IDs: {0}")]
+    OnchainIds(#[source] LoadAllIdsError),
+    #[error("failed to load offchain trade IDs: {0}")]
+    OffchainIds(#[source] LoadAllIdsError),
+    #[error("failed to replay onchain trade {id}: {source}")]
+    OnchainReplay {
+        id: String,
+        #[source]
+        source: SendError<OnChainTrade>,
+    },
+    #[error("onchain trade {id} replayed to empty state")]
+    OnchainMissing { id: String },
+    #[error("failed to replay offchain trade {id}: {source}")]
+    OffchainReplay {
+        id: String,
+        #[source]
+        source: SendError<OffchainOrder>,
+    },
+    #[error("offchain trade {id} replayed to empty state")]
+    OffchainMissing { id: String },
+    #[error("offchain trade {id} cannot be represented in history: {source}")]
+    OffchainConversion {
+        id: String,
+        #[source]
+        source: TradeConversionError,
+    },
 }
 
 #[cfg(test)]
@@ -91,7 +150,7 @@ mod tests {
     #[tokio::test]
     async fn load_trades_empty_database() {
         let pool = setup_test_db().await;
-        let trades = load_trades(&pool).await;
+        let trades = load_trades(&pool).await.unwrap();
         assert!(trades.is_empty());
     }
 
@@ -125,7 +184,7 @@ mod tests {
             .await
             .unwrap();
 
-        let trades = load_trades(&pool).await;
+        let trades = load_trades(&pool).await.unwrap();
         assert_eq!(trades.len(), 1);
         assert_eq!(trades[0].symbol, Symbol::new("AAPL").unwrap());
         assert!(matches!(trades[0].venue, st0x_dto::TradingVenue::Raindex));
@@ -184,7 +243,7 @@ mod tests {
             .await
             .unwrap();
 
-        let trades = load_trades(&pool).await;
+        let trades = load_trades(&pool).await.unwrap();
         assert_eq!(trades.len(), 1);
         assert_eq!(trades[0].symbol, Symbol::new("TSLA").unwrap());
         assert!(matches!(trades[0].venue, st0x_dto::TradingVenue::Alpaca));
@@ -210,17 +269,22 @@ mod tests {
             tx_hash: alloy::primitives::TxHash::ZERO,
             log_index: 1,
         };
+        let tied_id = OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 2,
+        };
 
         store
             .send(
                 &older_id,
-                OnChainTradeCommand::Witness {
+                OnChainTradeCommand::WitnessAt {
                     symbol: Symbol::new("AAPL").unwrap(),
                     amount: float!(10),
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_number: 1,
-                    block_timestamp: now,
+                    block_timestamp: now - chrono::Duration::seconds(1),
+                    filled_at: now,
                 },
             )
             .await
@@ -229,26 +293,97 @@ mod tests {
         store
             .send(
                 &newer_id,
-                OnChainTradeCommand::Witness {
+                OnChainTradeCommand::WitnessAt {
                     symbol: Symbol::new("TSLA").unwrap(),
                     amount: float!(5),
                     direction: Direction::Sell,
                     price_usdc: float!(200),
                     block_number: 2,
                     block_timestamp: now,
+                    filled_at: now,
                 },
             )
             .await
             .unwrap();
 
-        let trades = load_trades(&pool).await;
-        assert_eq!(trades.len(), 2);
-        assert!(
-            trades[0].filled_at >= trades[1].filled_at,
-            "trades should be sorted newest first: {:?} >= {:?}",
-            trades[0].filled_at,
-            trades[1].filled_at
-        );
+        store
+            .send(
+                &tied_id,
+                OnChainTradeCommand::WitnessAt {
+                    symbol: Symbol::new("NVDA").unwrap(),
+                    amount: float!(3),
+                    direction: Direction::Buy,
+                    price_usdc: float!(300),
+                    block_number: 2,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+
+        let trades = load_trades(&pool).await.unwrap();
+        assert_eq!(trades.len(), 3);
+        assert_eq!(trades[0].id, tied_id.to_string());
+        assert_eq!(trades[1].id, newer_id.to_string());
+        assert_eq!(trades[2].id, older_id.to_string());
+    }
+
+    #[tokio::test]
+    async fn load_trades_skips_rows_that_fail_to_replay() {
+        let pool = setup_test_db().await;
+
+        let store = st0x_event_sorcery::StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let now = Utc::now();
+
+        let corrupt_id = OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 0,
+        };
+        let intact_id = OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 1,
+        };
+
+        for (id, symbol) in [(&corrupt_id, "AAPL"), (&intact_id, "TSLA")] {
+            store
+                .send(
+                    id,
+                    OnChainTradeCommand::WitnessAt {
+                        symbol: Symbol::new(symbol).unwrap(),
+                        amount: float!(1),
+                        direction: Direction::Buy,
+                        price_usdc: float!(100),
+                        block_number: 1,
+                        block_timestamp: now,
+                        filled_at: now,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        // Simulates a legacy row whose persisted payload no longer
+        // deserializes under the current event shapes.
+        sqlx::query("UPDATE events SET payload = '{\"bogus\":true}' WHERE aggregate_id = ?")
+            .bind(corrupt_id.to_string())
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM snapshots WHERE aggregate_id = ?")
+            .bind(corrupt_id.to_string())
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let trades = load_trades(&pool).await.unwrap();
+
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].id, intact_id.to_string());
     }
 
     #[tokio::test]
@@ -283,12 +418,12 @@ mod tests {
                 .unwrap();
         }
 
-        let trades = load_trades(&pool).await;
+        let trades = load_trades(&pool).await.unwrap();
         assert_eq!(trades.len(), MAX_TRADES, "should be capped at {MAX_TRADES}");
     }
 
     #[tokio::test]
-    async fn load_trades_excludes_unfilled_offchain_orders() {
+    async fn load_trades_includes_failed_offchain_orders() {
         let pool = setup_test_db().await;
 
         let (store, _projection) =
@@ -314,7 +449,58 @@ mod tests {
             .await
             .unwrap();
 
-        let trades = load_trades(&pool).await;
-        assert!(trades.is_empty(), "unfilled orders should not appear");
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkPlacementFailed {
+                    error: "asset is not tradable".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let trades = load_trades(&pool).await.unwrap();
+        assert_eq!(trades.len(), 1, "failed orders should appear");
+        assert!(matches!(
+            &trades[0].outcome,
+            st0x_dto::TradeOutcome::Failed {
+                error,
+                filled_shares,
+                remaining_shares,
+                excess_shares,
+            } if error == "asset is not tradable"
+                && filled_shares.inner().inner().eq(float!(0)).unwrap()
+                && remaining_shares.inner().inner().eq(float!(10)).unwrap()
+                && excess_shares.inner().inner().is_zero().unwrap()
+        ));
+    }
+
+    #[tokio::test]
+    async fn load_trades_excludes_pending_offchain_orders() {
+        let pool = setup_test_db().await;
+        let (store, _projection) =
+            st0x_event_sorcery::StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(crate::offchain::order::noop_order_placer())
+                .await
+                .unwrap();
+        let id = OffchainOrderId::new();
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("NVDA").unwrap(),
+                    shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
+                    direction: Direction::Buy,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+
+        let trades = load_trades(&pool).await.unwrap();
+        assert!(trades.is_empty(), "pending orders should not appear");
     }
 }

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -33,20 +33,21 @@ pub(crate) use reconcile_fill::{ReconcileOrderFill, ReconcileOrderFillJobQueue};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use metrics::{counter, histogram};
+use rain_math_float::FloatError;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
-use st0x_dto::{Direction, Trade, TradingVenue};
+use st0x_dto::{Direction, Trade, TradeOutcome, TradingVenue};
 use st0x_event_sorcery::{DomainEvent, EventSourced, SendError, Store, Table};
 use st0x_execution::{
     AlpacaBrokerApiError, CancellationOutcome, ClientOrderId, ExecutionError, Executor,
     ExecutorOrderId, FractionalShares, LimitOrder, MarketOrder, MarketSession, OrderState,
     PersistenceError, Positive, SupportedExecutor, Symbol,
 };
-use st0x_finance::Usd;
+use st0x_finance::{NonNegative, NotNonNegative, Usd};
 
 use crate::conductor::job::QueuePushError;
 use crate::onchain::OnChainError;
@@ -1393,47 +1394,90 @@ fn evolve_cancelled(
 }
 
 impl OffchainOrder {
-    /// Renders this order as a dashboard [`Trade`]. Only the `Filled` state
-    /// has the executed price and fill timestamp needed for a Trade; every
-    /// other state returns [`NotFilled`] so callers must acknowledge the
-    /// conversion can fail. Callers that want a silently-discarded `Option`
-    /// can write `.ok()`.
-    pub(crate) fn try_to_trade(&self, id: &OffchainOrderId) -> Result<Trade, NotFilled> {
-        use OffchainOrder::{Cancelled, Cancelling, Failed, PartiallyFilled, Pending, Submitted};
-        let Self::Filled {
-            symbol,
-            shares,
-            direction,
-            executor,
-            filled_at,
-            ..
-        } = self
-        else {
-            return Err(match self {
-                Pending { .. } => NotFilled { state: "Pending" },
-                Submitted { .. } => NotFilled { state: "Submitted" },
-                PartiallyFilled { .. } => NotFilled {
-                    state: "PartiallyFilled",
-                },
-                Cancelling { .. } => NotFilled {
-                    state: "Cancelling",
-                },
-                Failed { .. } => NotFilled { state: "Failed" },
-                Cancelled { .. } => NotFilled { state: "Cancelled" },
-                Self::Filled { .. } => unreachable!(),
-            });
+    /// Renders a terminal fill or failure as a dashboard [`Trade`].
+    pub(crate) fn try_into_trade(
+        self,
+        id: &OffchainOrderId,
+    ) -> Result<Trade, TradeConversionError> {
+        let (symbol, shares, direction, executor, occurred_at, outcome) = match self {
+            Self::Filled {
+                symbol,
+                shares,
+                direction,
+                executor,
+                filled_at,
+                ..
+            } => (
+                symbol,
+                shares,
+                direction,
+                executor,
+                filled_at,
+                TradeOutcome::Filled,
+            ),
+            Self::Failed {
+                symbol,
+                shares,
+                direction,
+                executor,
+                retained_fill,
+                error,
+                failed_at,
+                ..
+            } => {
+                let filled_shares =
+                    retained_fill.map_or(FractionalShares::ZERO, RetainedFill::shares_filled);
+                let accepted_shares = shares.inner();
+                let (filled_portion, remaining_shares, excess_shares) =
+                    if filled_shares.inner().gt(accepted_shares.inner())? {
+                        (
+                            accepted_shares,
+                            FractionalShares::ZERO,
+                            (filled_shares - accepted_shares)?,
+                        )
+                    } else {
+                        (
+                            filled_shares,
+                            (accepted_shares - filled_shares)?,
+                            FractionalShares::ZERO,
+                        )
+                    };
+                let filled_shares = NonNegative::new(filled_portion)?;
+                let remaining_shares = NonNegative::new(remaining_shares)?;
+                let excess_shares = NonNegative::new(excess_shares)?;
+
+                (
+                    symbol,
+                    shares,
+                    direction,
+                    executor,
+                    failed_at,
+                    TradeOutcome::Failed {
+                        error,
+                        filled_shares,
+                        remaining_shares,
+                        excess_shares,
+                    },
+                )
+            }
+            Self::Pending { .. } => return Err(TradeConversionError::Pending),
+            Self::Submitted { .. } => return Err(TradeConversionError::Submitted),
+            Self::PartiallyFilled { .. } => return Err(TradeConversionError::PartiallyFilled),
+            Self::Cancelling { .. } => return Err(TradeConversionError::Cancelling),
+            Self::Cancelled { .. } => return Err(TradeConversionError::Cancelled),
         };
 
         Ok(Trade {
             id: id.to_string(),
-            filled_at: *filled_at,
+            occurred_at,
             venue: match executor {
                 SupportedExecutor::AlpacaBrokerApi => TradingVenue::Alpaca,
                 SupportedExecutor::DryRun => TradingVenue::DryRun,
             },
-            direction: *direction,
-            symbol: symbol.clone(),
-            shares: FractionalShares::new(shares.inner().inner()),
+            direction,
+            symbol,
+            shares: shares.inner(),
+            outcome,
         })
     }
 
@@ -2463,14 +2507,24 @@ impl OffchainOrderId {
     }
 }
 
-/// Returned by [`OffchainOrder::try_to_trade`] when the order isn't in the
-/// `Filled` state. `state` is the variant name as a `&'static str` so
-/// diagnostics get the specific state without dragging the variant's data
-/// (which would include opaque error strings on `Failed`).
+/// Returned by [`OffchainOrder::try_into_trade`] when the order cannot be
+/// rendered as a dashboard trade.
 #[derive(Debug, thiserror::Error)]
-#[error("OffchainOrder cannot be rendered as a Trade: current state is {state}")]
-pub(crate) struct NotFilled {
-    pub(crate) state: &'static str,
+pub(crate) enum TradeConversionError {
+    #[error("pending OffchainOrder cannot be rendered as a Trade")]
+    Pending,
+    #[error("submitted OffchainOrder cannot be rendered as a Trade")]
+    Submitted,
+    #[error("partially filled OffchainOrder cannot be rendered as a Trade")]
+    PartiallyFilled,
+    #[error("cancelling OffchainOrder cannot be rendered as a Trade")]
+    Cancelling,
+    #[error("cancelled OffchainOrder cannot be rendered as a Trade")]
+    Cancelled,
+    #[error("failed to calculate the remaining counter-trade shares: {0}")]
+    Arithmetic(#[from] FloatError),
+    #[error("failed counter-trade shares cannot be negative: {0}")]
+    NegativeShares(#[from] NotNonNegative<FractionalShares>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
@@ -2758,6 +2812,83 @@ mod tests {
             broker_timestamp, fill_time,
             "finalization must stamp the broker fill time, not the failure time"
         );
+    }
+
+    #[test]
+    fn failed_trade_reports_filled_and_remaining_shares() {
+        let fill_time = "2026-01-05T14:30:00Z".parse::<DateTime<Utc>>().unwrap();
+        let failure_time = "2026-01-06T14:32:01Z".parse::<DateTime<Utc>>().unwrap();
+        let order = OffchainOrder::Failed {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(2))).unwrap(),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            retained_fill: Some(RetainedFill::priced(
+                FractionalShares::new(float!(0.5)),
+                Usd::new(float!(195.25)),
+                fill_time,
+            )),
+            executor_order_id: Some(ExecutorOrderId::new("failed-with-fill")),
+            error: "broker rejected remainder".to_string(),
+            placed_at: fill_time,
+            failed_at: failure_time,
+        };
+
+        let trade = order
+            .try_into_trade(&OffchainOrderId::new())
+            .expect("valid terminal failure should convert");
+        assert_eq!(trade.occurred_at, failure_time);
+        assert!(trade.shares.inner().eq(float!(2)).unwrap());
+        match trade.outcome {
+            TradeOutcome::Failed {
+                error,
+                filled_shares,
+                remaining_shares,
+                excess_shares,
+            } => {
+                assert_eq!(error, "broker rejected remainder");
+                assert!(filled_shares.inner().inner().eq(float!(0.5)).unwrap());
+                assert!(remaining_shares.inner().inner().eq(float!(1.5)).unwrap());
+                assert!(excess_shares.inner().inner().is_zero().unwrap());
+            }
+            TradeOutcome::Filled => panic!("failed order must retain its failure outcome"),
+        }
+    }
+
+    #[test]
+    fn failed_trade_reports_retained_fill_larger_than_order_as_excess() {
+        let failed_at = Utc::now();
+        let order = OffchainOrder::Failed {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            retained_fill: Some(RetainedFill::priced(
+                FractionalShares::new(float!(1.5)),
+                Usd::new(float!(195.25)),
+                failed_at,
+            )),
+            executor_order_id: Some(ExecutorOrderId::new("invalid-retained-fill")),
+            error: "broker reported an impossible fill".to_string(),
+            placed_at: failed_at,
+            failed_at,
+        };
+
+        let trade = order
+            .try_into_trade(&OffchainOrderId::new())
+            .expect("overfilled terminal failures must remain visible");
+        let TradeOutcome::Failed {
+            filled_shares,
+            remaining_shares,
+            excess_shares,
+            ..
+        } = trade.outcome
+        else {
+            panic!("failed order must retain its failure outcome");
+        };
+        assert!(filled_shares.inner().inner().eq(float!(1)).unwrap());
+        assert!(remaining_shares.inner().inner().is_zero().unwrap());
+        assert!(excess_shares.inner().inner().eq(float!(0.5)).unwrap());
     }
 
     #[test]

--- a/src/onchain_trade.rs
+++ b/src/onchain_trade.rs
@@ -15,7 +15,7 @@ use rain_math_float::Float;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use st0x_dto::{Direction, Trade, TradingVenue};
+use st0x_dto::{Direction, Trade, TradeOutcome, TradingVenue};
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
 use st0x_execution::Symbol;
 use st0x_finance::FractionalShares;
@@ -264,14 +264,15 @@ impl OnChainTrade {
         self.acknowledged_at.is_some()
     }
 
-    pub(crate) fn to_trade(&self, id: &OnChainTradeId) -> Trade {
+    pub(crate) fn into_trade(self, id: &OnChainTradeId) -> Trade {
         Trade {
             id: id.to_string(),
-            filled_at: self.filled_at,
+            occurred_at: self.block_timestamp,
             venue: TradingVenue::Raindex,
             direction: self.direction,
-            symbol: self.symbol.clone(),
+            symbol: self.symbol,
             shares: FractionalShares::new(self.amount),
+            outcome: TradeOutcome::Filled,
         }
     }
 }


### PR DESCRIPTION
## What

- Fixes [RAI-1418](https://linear.app/makeitrain/issue/RAI-1418/dashboard-does-not-surface-failed-counter-trades).
- Surfaces failed counter-trades in both initial dashboard history and live updates.
- Shows the terminal error and the filled, unfilled, and excess portions of failed broker orders.

## Why

Failed hedges were only visible through logs or direct database queries. That made it too easy to miss unhedged exposure from the dashboard's main operational view.

## How

- Adds a typed terminal outcome to the trade DTO and uses the terminal outcome timestamp for ordering.
- Converts failed offchain orders into trade entries without hiding partial fills or clamping broker overfill anomalies.
- Makes the history loaders and `/trades` endpoint fail closed on malformed persisted data or invalid filters.
- Broadcasts terminal offchain outcomes and reconciles live updates with paginated history without duplicate rows, stale responses, or count rollbacks.
- Keeps initial and live history ordering aligned, including numeric Raindex log-index tie breaks.
- Renders failed outcomes and their quantities in the trade-history table and detail view.

## Testing

- `cargo check --workspace` and `cargo check --workspace --all-features`
- `cargo nextest run --workspace --all-features`: 3,621 passed, 6 skipped
- `cargo clippy --workspace --all-targets --all-features`
- `cargo fmt -- --check`, Nix formatting, and changed-file pre-commit hooks
- Dashboard lint, `svelte-check`, and Vitest: 258 passed
- `nix build .#st0x-dashboard`
- 7 full review-loop iterations, plus focused review-feedback verification and clean re-reviews

## Screenshots

Not included. The dashboard change is covered by mounted Svelte component tests.

## Anything else

The trade WebSocket statement changes from `trade_fill` to `trade_update` because it now carries both fills and failures. Rolling-version compatibility is tracked separately from this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trade History now shows both completed and failed trades, including outcome status plus failure reasons and filled, unfilled, and excess quantities.
  * The history table and detail view now include an explicit trade status (“Filled” / “Failed”) and use the trade occurrence time.
  * Live updates continue to reconcile correctly with the current filtered/paginated history.

* **Bug Fixes**
  * Invalid trade-history filters now produce clear client-facing errors.
  * Terminal outcomes now reliably appear in both the initial dashboard state and subsequent live updates without stale or duplicated rows.

* **Documentation**
  * Updated Trade History panel documentation to clarify on-chain vs counter-trade failure representation and quantity accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->