### PR TITLE
feat: report return on capital from daily snapshots

### DIFF
--- a/dashboard/src/lib/pnl/report.ts
+++ b/dashboard/src/lib/pnl/report.ts
@@ -226,6 +226,15 @@ export type PnlWindow = {
   symbols: PnlWindowSymbol[]
 }
 
+export type PnlCapitalSummary = {
+  averageDeployedCapitalUsd: string | null
+  annualizedReturnPct: string | null
+  coverageDays: number | null
+  sampleDays: number
+  firstSnapshotDay: string | null
+  lastSnapshotDay: string | null
+}
+
 export type PnlResponse = {
   attributionMethod: string
   asOfRowid?: number
@@ -234,6 +243,7 @@ export type PnlResponse = {
   sampleStats?: PnlSampleStats
   summary: PnlSummary
   costs: PnlCostSummary
+  capital: PnlCapitalSummary
   symbols: PnlSymbolSummary[]
   symbolUniverse?: string[]
   entries: PnlEntry[]

--- a/src/api.rs
+++ b/src/api.rs
@@ -220,6 +220,20 @@ fn pnl_error_response(error: PnlError) -> (StatusCode, String) {
                 "Failed to build PnL report".to_string(),
             )
         }
+        PnlError::PortfolioSnapshot(error) => {
+            error!(%error, "Failed to load portfolio snapshot data for PnL report");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to build PnL report".to_string(),
+            )
+        }
+        PnlError::CapitalFloat(error) => {
+            error!(%error, "Failed to convert a PnL total for capital/return computation");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to build PnL report".to_string(),
+            )
+        }
     }
 }
 
@@ -1864,20 +1878,26 @@ pub(crate) fn routes() -> Router<AppState> {
 mod tests {
     use std::sync::Arc;
 
-    use alloy::primitives::Address;
+    use alloy::primitives::{Address, TxHash};
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
+    use chrono::{NaiveDate, TimeZone};
+    use chrono_tz::America::New_York;
     use httpmock::Method::GET;
     use tokio::sync::broadcast;
     use tower::ServiceExt;
     use uuid::uuid;
 
-    use st0x_config::{BrokerCtx, Ctx, RestApiCtx, create_test_ctx_with_order_owner};
-    use st0x_event_sorcery::ReactorHarness;
+    use st0x_config::{
+        BrokerCtx, Ctx, ExecutionThreshold, RestApiCtx, create_test_ctx_with_order_owner,
+    };
+    use st0x_event_sorcery::{ReactorHarness, StoreBuilder};
     use st0x_execution::{
         AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode,
-        DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS, Symbol, TimeInForce,
+        DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS, Direction, ExecutorOrderId, Positive,
+        SupportedExecutor, Symbol, TimeInForce,
     };
+    use st0x_finance::Usd;
     use st0x_float_macro::float;
     use st0x_tokenization::{
         MintVerificationError, TokenizerError, issuer_request_id, tokenization_request_id,
@@ -1885,10 +1905,17 @@ mod tests {
 
     use super::*;
     use crate::dashboard;
-    use crate::inventory::{self, BroadcastingInventory};
+    use crate::inventory::{
+        self, BroadcastingInventory, PortfolioAsset, PortfolioBalanceRow, PortfolioLocation,
+    };
     use crate::offchain::order::{OffchainOrder, OffchainOrderEvent, OffchainOrderId};
     use crate::performance::equity_timing::EquityTimingProjection;
     use crate::performance::reliability::LifecycleFailureProjection;
+    use crate::portfolio_snapshot::{
+        PortfolioBalanceRowWithMark, PortfolioSnapshot, PortfolioSnapshotCommand,
+        PortfolioSnapshotId, PortfolioSnapshotProjection, et_day,
+    };
+    use crate::position::{Position, PositionCommand, TradeId};
     use crate::tokenized_equity_mint::TokenizedEquityMint;
 
     async fn empty_app_state(ctx: Ctx) -> AppState {
@@ -2789,6 +2816,228 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         account_activity_mock.assert_calls(0);
+    }
+
+    fn portfolio_snapshot_usdc_row(
+        amount: i64,
+        captured_at: chrono::DateTime<Utc>,
+    ) -> PortfolioBalanceRowWithMark {
+        PortfolioBalanceRowWithMark {
+            row: PortfolioBalanceRow {
+                location: PortfolioLocation::MarketMaking,
+                asset: PortfolioAsset::Usdc,
+                available: float!(&amount.to_string()),
+                inflight: float!(0),
+            },
+            usd_mark: Some(float!(1)),
+            mark_captured_at: Some(captured_at),
+        }
+    }
+
+    /// Seeds a real onchain-sell/offchain-buy hedge pair for `RKLB` through
+    /// the `Position` aggregate's own commands (`Store::send`, never a raw
+    /// `events` INSERT -- direct writes to that table are forbidden, see
+    /// docs/cqrs.md). Onchain sell at 10, offchain buy at 8: a 2-per-share
+    /// realized spread, matching this test's `grossRealizedPnlUsd` assertion.
+    async fn seed_position_pnl_fill(pool: &SqlitePool, symbol: &Symbol) {
+        let (position, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let threshold = ExecutionThreshold::whole_share();
+        let block_timestamp = Utc.with_ymd_and_hms(2026, 3, 8, 14, 0, 0).unwrap();
+        let broker_timestamp = Utc.with_ymd_and_hms(2026, 3, 8, 14, 1, 0).unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let one_share = Positive::new(FractionalShares::new(float!(1))).unwrap();
+
+        position
+            .send(
+                symbol,
+                PositionCommand::AcknowledgeOnChainFillAt {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: TradeId {
+                        tx_hash: TxHash::with_last_byte(1),
+                        log_index: 0,
+                    },
+                    amount: FractionalShares::new(float!(1)),
+                    direction: Direction::Sell,
+                    price_usdc: float!(10),
+                    block_timestamp,
+                    seen_at: block_timestamp,
+                },
+            )
+            .await
+            .unwrap();
+
+        position
+            .send(
+                symbol,
+                PositionCommand::PlaceOffChainOrderAt {
+                    offchain_order_id,
+                    shares: one_share,
+                    direction: Direction::Buy,
+                    executor: SupportedExecutor::DryRun,
+                    threshold,
+                    placed_at: block_timestamp,
+                },
+            )
+            .await
+            .unwrap();
+
+        position
+            .send(
+                symbol,
+                PositionCommand::CompleteOffChainOrder {
+                    offchain_order_id,
+                    shares_filled: one_share,
+                    direction: Direction::Buy,
+                    executor_order_id: ExecutorOrderId::new("test-fill"),
+                    price: Usd::new(float!(8)),
+                    broker_timestamp,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    /// End-to-end `/pnl` coverage for capital/return-on-capital figures: three
+    /// portfolio_snapshot days are captured through the real
+    /// aggregate (`Store::send`, never raw SQL), each `captured_at` built
+    /// from the actual "just after ET midnight" local time (mirroring
+    /// `write.rs`'s `CAPTURE_BUFFER` scheme) across the actual 2026 US DST
+    /// spring-forward Sunday (March 8) -- so the UTC offset genuinely shifts
+    /// between the March 8 and March 9 captures -- and each row's aggregate
+    /// id is derived through the same DST-aware [`et_day`] the production
+    /// job uses, not assumed from the loop variable. The response is
+    /// asserted at the JSON boundary so camelCase field naming is verified
+    /// too.
+    #[tokio::test]
+    async fn pnl_endpoint_reports_capital_from_persisted_portfolio_snapshots() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let state = empty_app_state(ctx).await;
+
+        let portfolio_snapshot_store = StoreBuilder::<PortfolioSnapshot>::new(state.pool.clone())
+            .with(Arc::new(PortfolioSnapshotProjection::new(
+                state.pool.clone(),
+            )))
+            .build(())
+            .await
+            .unwrap();
+
+        for (year, month, day, amount) in
+            [(2026, 3, 7, 1000), (2026, 3, 8, 2000), (2026, 3, 9, 3000)]
+        {
+            let captured_at = New_York
+                .with_ymd_and_hms(year, month, day, 0, 5, 0)
+                .single()
+                .unwrap()
+                .with_timezone(&Utc);
+            let target_et_day = et_day(captured_at);
+            assert_eq!(
+                target_et_day,
+                NaiveDate::from_ymd_opt(year, month, day).unwrap(),
+                "captured_at should round-trip to the same calendar day it was built from, \
+                 proving et_day resolves the correct EST/EDT offset either side of the \
+                 spring-forward transition"
+            );
+            portfolio_snapshot_store
+                .send(
+                    &PortfolioSnapshotId(target_et_day),
+                    PortfolioSnapshotCommand::Capture {
+                        captured_at,
+                        rows: vec![portfolio_snapshot_usdc_row(amount, captured_at)],
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        seed_position_pnl_fill(&state.pool, &Symbol::new("RKLB").unwrap()).await;
+
+        let app = build_app(state);
+
+        let inclusive_range = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/pnl?fromDate=2026-03-07&toDate=2026-03-09")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(inclusive_range.status(), StatusCode::OK);
+        let body = body_to_string(inclusive_range).await;
+        let report: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(report["capital"]["sampleDays"], serde_json::json!(3));
+        assert_eq!(report["capital"]["coverageDays"], serde_json::json!(3));
+        assert_eq!(
+            report["capital"]["averageDeployedCapitalUsd"],
+            serde_json::json!("2000")
+        );
+        assert_eq!(
+            report["capital"]["firstSnapshotDay"],
+            serde_json::json!("2026-03-07")
+        );
+        assert_eq!(
+            report["capital"]["lastSnapshotDay"],
+            serde_json::json!("2026-03-09")
+        );
+        assert_eq!(
+            report["summary"]["gross_realized_pnl_usd"],
+            serde_json::Value::Null
+        );
+        assert_eq!(
+            report["summary"]["grossRealizedPnlUsd"],
+            serde_json::json!("2")
+        );
+
+        let no_bounds = app
+            .clone()
+            .oneshot(Request::builder().uri("/pnl").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(no_bounds.status(), StatusCode::OK);
+        let body = body_to_string(no_bounds).await;
+        let report: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(report["capital"]["sampleDays"], serde_json::json!(3));
+        assert_eq!(
+            report["capital"]["averageDeployedCapitalUsd"],
+            serde_json::json!("2000")
+        );
+
+        let dst_day_only = app
+            .oneshot(
+                Request::builder()
+                    .uri("/pnl?fromDate=2026-03-08&toDate=2026-03-08")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(dst_day_only.status(), StatusCode::OK);
+        let body = body_to_string(dst_day_only).await;
+        let report: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(report["capital"]["sampleDays"], serde_json::json!(1));
+        assert_eq!(report["capital"]["coverageDays"], serde_json::json!(1));
+        assert_eq!(
+            report["capital"]["averageDeployedCapitalUsd"],
+            serde_json::json!("2000")
+        );
+        assert_eq!(
+            report["capital"]["annualizedReturnPct"],
+            serde_json::Value::Null
+        );
+        assert_eq!(
+            report["capital"]["firstSnapshotDay"],
+            serde_json::json!("2026-03-08")
+        );
+        assert_eq!(
+            report["capital"]["lastSnapshotDay"],
+            serde_json::json!("2026-03-08")
+        );
     }
 
     fn write_test_logs(dir: &std::path::Path, filename: &str, content: &str) {

--- a/src/dashboard/pnl/builder.rs
+++ b/src/dashboard/pnl/builder.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
+use num_decimal::Num;
+
 use st0x_execution::alpaca_broker_api::AccountActivity;
 use st0x_finance::Symbol;
 
@@ -18,7 +20,7 @@ use super::replay::{
     parse_onchain_fill, reset_symbol_costs, summary_from_entries, summary_to_dto,
     symbol_summary_to_dto, with_direct_symbol_costs, with_replay_exposure,
 };
-use super::response::{PnlCostEntry, PnlResponse};
+use super::response::{PnlCapitalSummary, PnlCostEntry, PnlResponse};
 use super::samples::{build_available_range, build_sample_stats, parse_position_view};
 use super::sessions::{
     date_key, matches_cost_date_filter, matches_cost_symbol_filter, matches_date_filter,
@@ -78,6 +80,11 @@ fn remove_tokenization_fee_overlaps(
         .collect()
 }
 
+/// Builds the `/pnl` response from already-loaded rows. Returns the DTO
+/// alongside the internal numeric net realized PnL total for the queried
+/// range. Callers needing that total for the capital/return-on-capital
+/// computation read it from here rather than re-parsing
+/// `PnlResponse.summary.net_realized_pnl_usd`'s formatted string.
 pub(crate) fn build_pnl_response_from_rows(
     event_rows: Vec<PositionEventRow>,
     position_rows: &[PositionViewRow],
@@ -86,7 +93,7 @@ pub(crate) fn build_pnl_response_from_rows(
     query: &PnlQuery,
     symbols: &BTreeSet<String>,
     mut warnings: Vec<String>,
-) -> Result<PnlResponse, PnlError> {
+) -> Result<(PnlResponse, Num), PnlError> {
     let event_rows = if symbols.is_empty() {
         event_rows
     } else {
@@ -222,7 +229,7 @@ pub(crate) fn build_pnl_response_from_rows(
     );
     let filtered = summary_from_entries(&filtered_entries);
     let replay_summary = summary_to_dto(&full_total);
-    let summary = with_costs(
+    let (summary, net_realized_pnl_usd) = with_costs(
         with_replay_exposure(filtered.summary, replay_summary),
         &cost_summary,
     )?;
@@ -244,20 +251,24 @@ pub(crate) fn build_pnl_response_from_rows(
         .map(PnlCostEntry::from)
         .collect();
 
-    Ok(PnlResponse {
-        attribution_method: ATTRIBUTION_METHOD,
-        as_of_rowid: query.as_of_rowid.unwrap_or(0),
-        warnings,
-        available_range,
-        sample_stats,
-        summary,
-        costs: cost_summary,
-        symbols: symbols_with_costs,
-        symbol_universe,
-        entries: page_entries,
-        cost_entries,
-        total,
-        has_more: end < total,
-        windows,
-    })
+    Ok((
+        PnlResponse {
+            attribution_method: ATTRIBUTION_METHOD,
+            as_of_rowid: query.as_of_rowid.unwrap_or(0),
+            warnings,
+            available_range,
+            sample_stats,
+            summary,
+            costs: cost_summary,
+            capital: PnlCapitalSummary::default(),
+            symbols: symbols_with_costs,
+            symbol_universe,
+            entries: page_entries,
+            cost_entries,
+            total,
+            has_more: end < total,
+            windows,
+        },
+        net_realized_pnl_usd,
+    ))
 }

--- a/src/dashboard/pnl/costs.rs
+++ b/src/dashboard/pnl/costs.rs
@@ -369,10 +369,14 @@ pub(crate) fn summarize_cost_entries(
     cost_summary_to_dto(&summary, entries.len())
 }
 
+/// Applies tracked costs/revenue to `summary`'s gross PnL, returning both the
+/// updated DTO and the internal numeric net realized PnL total -- callers
+/// needing that total (e.g. the capital/return-on-capital computation) read
+/// it from here directly rather than re-parsing the DTO's formatted string.
 pub(crate) fn with_costs(
     summary: PnlSummary,
     costs: &PnlCostSummary,
-) -> Result<PnlSummary, PnlError> {
+) -> Result<(PnlSummary, Num), PnlError> {
     let gross = parse_internal_decimal("summary.totalPnlUsd", &summary.total_pnl_usd)?;
     let tracked_costs =
         parse_internal_decimal("costs.totalTrackedCostsUsd", &costs.total_tracked_costs_usd)?;
@@ -382,13 +386,16 @@ pub(crate) fn with_costs(
     )?;
     let net = &(&gross - &tracked_costs) + &tracked_revenue;
 
-    Ok(PnlSummary {
-        gross_realized_pnl_usd: fmt_decimal(&gross),
-        tracked_costs_usd: fmt_decimal(&tracked_costs),
-        tracked_revenue_usd: fmt_decimal(&tracked_revenue),
-        net_realized_pnl_usd: fmt_decimal(&net),
-        ..summary
-    })
+    Ok((
+        PnlSummary {
+            gross_realized_pnl_usd: fmt_decimal(&gross),
+            tracked_costs_usd: fmt_decimal(&tracked_costs),
+            tracked_revenue_usd: fmt_decimal(&tracked_revenue),
+            net_realized_pnl_usd: fmt_decimal(&net),
+            ..summary
+        },
+        net,
+    ))
 }
 
 fn cost_entry(

--- a/src/dashboard/pnl/mod.rs
+++ b/src/dashboard/pnl/mod.rs
@@ -29,11 +29,24 @@ const ATTRIBUTION_WARNING: &str = "PnL source: realized gross replay from persis
      execution timestamp and replayed through per-symbol FIFO inventory lots for accounting and \
      attribution; explicit offchain_order_id -> onchain_trade_ids parentage is not currently \
      persisted.";
-const BASELINE_WARNING: &str = "Displayed PnL is realized by lot close date from persisted fills. Baseline drift, percentage \
-     return, and true period/NAV PnL require a persisted portfolio state vector, price vector, and \
-     cash-flow events; those are not currently persisted, so baseline drift and percentage return \
-     are not reported. Reconciliation diagnostics compare the replay against the current \
-     position_view, not a historical position_view snapshot.";
+// Percentage return is now sometimes available (see `capital`, backed by
+// persisted daily portfolio snapshots), so the unconditional "not currently
+// persisted" claim about it was split out into CAPITAL_AVAILABLE_NOTE /
+// CAPITAL_UNAVAILABLE_NOTE in source.rs, appended per-query.
+const BASELINE_WARNING: &str = "Displayed PnL is realized by lot close date from persisted fills. Baseline drift and true \
+     period/NAV PnL require a persisted portfolio state vector, price vector, and cash-flow \
+     events; those are not currently persisted, so baseline drift and true period/NAV PnL are not \
+     reported. Reconciliation diagnostics compare the replay against the current position_view, \
+     not a historical position_view snapshot.";
+const CAPITAL_AVAILABLE_NOTE: &str = "Average deployed capital is computed from persisted daily portfolio snapshots (see `capital`); \
+     annualized return on capital is computed only when the sample and full-range coverage \
+     requirements are met. Days with a missing or stale USD mark are excluded from the sample and \
+     named in the warnings above.";
+const CAPITAL_UNAVAILABLE_NOTE: &str = "Average deployed capital and annualized return on capital are not available for this query; \
+     see the warnings above for why (no snapshot coverage in range, every sampled day excluded, or \
+     average deployed capital is zero).";
+const SYMBOL_FILTERED_CAPITAL_WARNING: &str = "Capital and return on capital are not computed for symbol-filtered queries: a symbol-scoped \
+     slice of whole-portfolio capital is not a meaningful denominator.";
 const COST_WARNING: &str = "Tracked costs and revenues are built bottom-up by economic bucket. On-chain netting and raw \
      directional drift have no direct bot-paid execution cost. USD and USDC are treated as \
      equivalent reporting currency, so USD/USDC conversion basis is not modeled as PnL; only \

--- a/src/dashboard/pnl/query.rs
+++ b/src/dashboard/pnl/query.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use std::collections::BTreeSet;
 
 use super::parsing::is_safe_symbol;
+use crate::portfolio_snapshot::EtDayRange;
 
 const ALPACA_ACTIVITY_FETCH_PADDING_DAYS: i64 = 7;
 
@@ -63,6 +64,10 @@ pub(crate) enum PnlError {
     InvalidSymbolFilter { value: String },
     #[error("failed to load PnL rows: {0}")]
     Database(#[from] sqlx::Error),
+    #[error("failed to load portfolio snapshot data for capital/return computation: {0}")]
+    PortfolioSnapshot(#[from] crate::portfolio_snapshot::ReadError),
+    #[error("failed to convert a PnL total for capital/return computation: {0}")]
+    CapitalFloat(#[from] rain_math_float::FloatError),
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -125,6 +130,31 @@ impl PnlQuery {
                 })
             })
             .transpose()
+    }
+
+    /// The query's `fromDate`/`toDate` bounds as independent, optionally-open
+    /// ET-day bounds (inclusive), reusing [`parse_query_date`] -- no new
+    /// query params. Each side is `None` when that bound is not set; no
+    /// sentinel dates stand in for "unbounded". Using `0001-01-01` or
+    /// `9999-12-31` to widen a missing side would make the sentinel
+    /// indistinguishable from the same literal date supplied by a client.
+    /// Downstream query building (`load_portfolio_days`) branches on each
+    /// side's presence directly instead.
+    pub(crate) fn et_day_range(&self) -> Result<EtDayRange, PnlError> {
+        let from = self
+            .from_date
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| parse_query_date(value, "fromDate"))
+            .transpose()?;
+        let to = self
+            .to_date
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| parse_query_date(value, "toDate"))
+            .transpose()?;
+
+        Ok(EtDayRange { from, to })
     }
 
     pub(crate) fn symbol_filter(

--- a/src/dashboard/pnl/response.rs
+++ b/src/dashboard/pnl/response.rs
@@ -57,6 +57,7 @@ pub(crate) struct PnlResponse {
     pub(crate) sample_stats: PnlSampleStats,
     pub(crate) summary: PnlSummary,
     pub(crate) costs: PnlCostSummary,
+    pub(crate) capital: PnlCapitalSummary,
     pub(crate) symbols: Vec<PnlSymbolSummary>,
     pub(crate) symbol_universe: Vec<Symbol>,
     pub(crate) entries: Vec<PnlEntry>,
@@ -64,6 +65,22 @@ pub(crate) struct PnlResponse {
     pub(crate) total: usize,
     pub(crate) has_more: bool,
     pub(crate) windows: Vec<PnlWindow>,
+}
+
+/// Capital and return-on-capital figures derived from persisted daily
+/// portfolio snapshots. Every field is `None`/empty when capital could not be
+/// computed for the query (see the accompanying `warnings` entries for why --
+/// symbol-filtered queries, no snapshot coverage in range, missing/stale marks,
+/// or zero average deployed capital).
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PnlCapitalSummary {
+    pub(crate) average_deployed_capital_usd: Option<String>,
+    pub(crate) annualized_return_pct: Option<String>,
+    pub(crate) coverage_days: Option<i64>,
+    pub(crate) sample_days: usize,
+    pub(crate) first_snapshot_day: Option<String>,
+    pub(crate) last_snapshot_day: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/dashboard/pnl/source.rs
+++ b/src/dashboard/pnl/source.rs
@@ -1,15 +1,22 @@
 //! SQLite and broker-backed source loading for backend PnL reports.
+use rain_math_float::Float;
 use sqlx::{QueryBuilder, Sqlite, SqlitePool, Transaction};
 use std::collections::BTreeSet;
 
 use st0x_execution::alpaca_broker_api::AccountActivity;
+use st0x_float_serde::format_float;
+
+use crate::portfolio_snapshot::{capital_summary, load_portfolio_days};
 
 use super::builder::build_pnl_response_from_rows;
-use super::parsing::parse_payload_string;
+use super::parsing::{fmt_decimal, parse_payload_string};
 use super::query::{PnlError, PnlQuery};
-use super::response::PnlResponse;
+use super::response::{PnlCapitalSummary, PnlResponse};
 use super::state::{CostEventRow, PositionEventRow, PositionViewRow};
-use super::{ATTRIBUTION_WARNING, BASELINE_WARNING, COST_WARNING};
+use super::{
+    ATTRIBUTION_WARNING, BASELINE_WARNING, CAPITAL_AVAILABLE_NOTE, CAPITAL_UNAVAILABLE_NOTE,
+    COST_WARNING, SYMBOL_FILTERED_CAPITAL_WARNING,
+};
 
 pub(crate) async fn build_pnl_report(
     pool: &SqlitePool,
@@ -23,18 +30,18 @@ pub(crate) async fn build_pnl_report(
     ];
     let symbols = query.symbol_filter(&mut warnings)?;
     let mut tx = pool.begin().await?;
-    let as_of_rowid = effective_as_of_rowid(&mut tx, query).await?;
+    let resolved_rowid = effective_as_of_rowid(&mut tx, query).await?;
     let effective_query = PnlQuery {
-        as_of_rowid: Some(as_of_rowid),
+        as_of_rowid: Some(resolved_rowid.resolved),
         ..query.clone()
     };
 
-    let event_rows = load_position_events(&mut tx, &symbols, as_of_rowid).await?;
+    let event_rows = load_position_events(&mut tx, &symbols, resolved_rowid.resolved).await?;
     let position_rows = load_position_view(&mut tx).await?;
-    let cost_rows = load_cost_events(&mut tx, as_of_rowid).await?;
+    let cost_rows = load_cost_events(&mut tx, resolved_rowid.resolved).await?;
     tx.commit().await?;
 
-    build_pnl_response_from_rows(
+    let (mut response, net_realized_pnl_usd) = build_pnl_response_from_rows(
         event_rows,
         &position_rows,
         &cost_rows,
@@ -42,7 +49,94 @@ pub(crate) async fn build_pnl_report(
         &effective_query,
         &symbols,
         warnings,
+    )?;
+
+    apply_capital_summary(
+        pool,
+        query,
+        &resolved_rowid,
+        &symbols,
+        &fmt_decimal(&net_realized_pnl_usd),
+        &mut response,
     )
+    .await?;
+
+    Ok(response)
+}
+
+/// Populates `response.capital` and its accompanying warnings. Symbol-filtered
+/// queries omit capital entirely because a symbol-scoped slice of
+/// whole-portfolio capital is not a meaningful denominator. `symbols` is the
+/// same parsed filter set the PnL body itself was scoped by
+/// (`query.symbol_filter`), not the raw `query.symbol` string, so an
+/// empty/whitespace-only `symbol=` param (which `symbol_filter` treats as no
+/// filter at all) does not suppress capital while the PnL stays
+/// whole-portfolio. Capital is never watermarked to `as_of_rowid` -- it always
+/// reflects the live `portfolio_snapshot` table, so a non-current
+/// `as_of_rowid` gets an explicit caveat rather than a different figure.
+async fn apply_capital_summary(
+    pool: &SqlitePool,
+    query: &PnlQuery,
+    resolved_rowid: &ResolvedRowid,
+    symbols: &BTreeSet<String>,
+    net_realized_pnl_usd_decimal: &str,
+    response: &mut PnlResponse,
+) -> Result<(), PnlError> {
+    if resolved_rowid.resolved != resolved_rowid.max {
+        response.warnings.push(format!(
+            "Capital and return-on-capital figures reflect the current portfolio snapshot \
+             table, not a historical view as of rowid {}: daily snapshots are not watermarked \
+             to event rowids.",
+            resolved_rowid.resolved
+        ));
+        // A past as_of_rowid asks for a historical view the snapshot table
+        // cannot provide. Leave response.capital at its default (both fields
+        // None) rather than silently substituting the live snapshot's current
+        // capital for a requested historical one.
+        return Ok(());
+    }
+
+    if !symbols.is_empty() {
+        response
+            .warnings
+            .push(SYMBOL_FILTERED_CAPITAL_WARNING.to_owned());
+        response.warnings.push(CAPITAL_UNAVAILABLE_NOTE.to_owned());
+        return Ok(());
+    }
+
+    let et_day_range = query.et_day_range()?;
+    let days = load_portfolio_days(pool, et_day_range).await?;
+    let net_realized_pnl_usd = Float::parse(net_realized_pnl_usd_decimal.to_owned())?;
+    let capital = capital_summary(&days, net_realized_pnl_usd, et_day_range)?;
+
+    response.warnings.extend(capital.warnings);
+    response.warnings.push(
+        if capital.average_deployed_capital_usd.is_some() {
+            CAPITAL_AVAILABLE_NOTE
+        } else {
+            CAPITAL_UNAVAILABLE_NOTE
+        }
+        .to_owned(),
+    );
+
+    response.capital = PnlCapitalSummary {
+        average_deployed_capital_usd: capital
+            .average_deployed_capital_usd
+            .as_ref()
+            .map(format_float)
+            .transpose()?,
+        annualized_return_pct: capital
+            .annualized_return_pct
+            .as_ref()
+            .map(format_float)
+            .transpose()?,
+        coverage_days: capital.coverage_days,
+        sample_days: capital.sample_days,
+        first_snapshot_day: capital.first_snapshot_day.map(|day| day.to_string()),
+        last_snapshot_day: capital.last_snapshot_day.map(|day| day.to_string()),
+    };
+
+    Ok(())
 }
 
 pub(crate) async fn validate_pnl_snapshot_rowid(
@@ -60,17 +154,34 @@ pub(crate) async fn validate_pnl_snapshot_rowid(
     check_as_of_rowid(as_of_rowid, max_rowid)
 }
 
+/// The effective `as_of_rowid` alongside the current max event rowid, so
+/// callers can tell whether the resolved value is the live head (needed for
+/// the capital as-of-rowid caveat). A named pair rather than a bare
+/// `(i64, i64)` prevents the two rowids from being transposed at a call site.
+struct ResolvedRowid {
+    resolved: i64,
+    max: i64,
+}
+
+/// Resolves the effective `as_of_rowid`.
 async fn effective_as_of_rowid(
     tx: &mut Transaction<'_, Sqlite>,
     query: &PnlQuery,
-) -> Result<i64, PnlError> {
+) -> Result<ResolvedRowid, PnlError> {
+    let max_rowid = max_event_rowid(tx).await?;
+
     if let Some(as_of_rowid) = query.as_of_rowid {
-        let max_rowid = max_event_rowid(tx).await?;
         check_as_of_rowid(as_of_rowid, max_rowid)?;
-        return Ok(as_of_rowid);
+        return Ok(ResolvedRowid {
+            resolved: as_of_rowid,
+            max: max_rowid,
+        });
     }
 
-    max_event_rowid(tx).await
+    Ok(ResolvedRowid {
+        resolved: max_rowid,
+        max: max_rowid,
+    })
 }
 
 fn check_as_of_rowid(as_of_rowid: i64, max_rowid: i64) -> Result<(), PnlError> {

--- a/src/dashboard/pnl/tests.rs
+++ b/src/dashboard/pnl/tests.rs
@@ -15,9 +15,10 @@ use super::query::{PnlCounterTradingFilter, PnlError, PnlMarketSessionFilter, Pn
 use super::response::{PnlResponse, PnlSymbolSummary, PnlWindow, PnlWindowSymbol};
 use super::state::{CostEventRow, Direction, PnlBucket, PositionEventRow, PositionViewRow, Venue};
 use super::{
-    ATTRIBUTION_WARNING, BASELINE_WARNING, COST_WARNING, build_pnl_report,
-    validate_pnl_snapshot_rowid,
+    ATTRIBUTION_WARNING, BASELINE_WARNING, CAPITAL_AVAILABLE_NOTE, CAPITAL_UNAVAILABLE_NOTE,
+    COST_WARNING, SYMBOL_FILTERED_CAPITAL_WARNING, build_pnl_report, validate_pnl_snapshot_rowid,
 };
+use crate::portfolio_snapshot::EtDayRange;
 
 fn event(rowid: i64, symbol: &str, event_type: &str, payload: Value) -> PositionEventRow {
     PositionEventRow {
@@ -188,6 +189,54 @@ fn query_normalizes_zero_limit_to_one() {
     };
 
     assert_eq!(query.normalized_limit(), 1);
+}
+
+#[test]
+fn et_day_range_returns_both_bounds_open_when_neither_set() {
+    let query = PnlQuery::default();
+
+    assert_eq!(query.et_day_range().unwrap(), EtDayRange::default());
+}
+
+#[test]
+fn et_day_range_returns_inclusive_bounds_when_both_set() {
+    let query = PnlQuery {
+        from_date: Some("2026-05-10".to_owned()),
+        to_date: Some("2026-05-15".to_owned()),
+        ..PnlQuery::default()
+    };
+
+    assert_eq!(
+        query.et_day_range().unwrap(),
+        EtDayRange {
+            from: Some(NaiveDate::from_ymd_opt(2026, 5, 10).unwrap()),
+            to: Some(NaiveDate::from_ymd_opt(2026, 5, 15).unwrap()),
+        }
+    );
+}
+
+#[test]
+fn et_day_range_leaves_upper_bound_open_when_only_from_date_set() {
+    let query = PnlQuery {
+        from_date: Some("2026-05-10".to_owned()),
+        ..PnlQuery::default()
+    };
+
+    let EtDayRange { from, to } = query.et_day_range().unwrap();
+    assert_eq!(from, Some(NaiveDate::from_ymd_opt(2026, 5, 10).unwrap()));
+    assert_eq!(to, None);
+}
+
+#[test]
+fn et_day_range_leaves_lower_bound_open_when_only_to_date_set() {
+    let query = PnlQuery {
+        to_date: Some("2026-05-15".to_owned()),
+        ..PnlQuery::default()
+    };
+
+    let EtDayRange { from, to } = query.et_day_range().unwrap();
+    assert_eq!(from, None);
+    assert_eq!(to, Some(NaiveDate::from_ymd_opt(2026, 5, 15).unwrap()));
 }
 
 #[test]
@@ -541,6 +590,7 @@ fn report_with_result(
             COST_WARNING.to_owned(),
         ],
     )
+    .map(|(response, _net_realized_pnl_usd)| response)
 }
 
 async fn pnl_test_pool(
@@ -576,6 +626,25 @@ async fn pnl_test_pool_with_costs(
         .execute(&pool)
         .await
         .unwrap();
+    // Empty by default: build_pnl_report's capital computation reads this
+    // table unconditionally, so it must exist even when a test doesn't
+    // seed any snapshot rows (capital is then omitted with a warning).
+    sqlx::query(
+        "CREATE TABLE portfolio_snapshot ( \
+           et_day TEXT NOT NULL, \
+           captured_at TEXT NOT NULL, \
+           location TEXT NOT NULL, \
+           asset TEXT NOT NULL, \
+           available_balance TEXT NOT NULL, \
+           inflight_balance TEXT NOT NULL, \
+           usd_mark TEXT, \
+           mark_captured_at TEXT, \
+           PRIMARY KEY (et_day, location, asset) \
+         )",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
 
     for row in events {
         sqlx::query(
@@ -630,6 +699,7 @@ fn report_result(events: Vec<PositionEventRow>) -> Result<PnlResponse, PnlError>
             COST_WARNING.to_owned(),
         ],
     )
+    .map(|(response, _net_realized_pnl_usd)| response)
 }
 
 fn report(events: Vec<PositionEventRow>) -> PnlResponse {
@@ -2453,4 +2523,207 @@ fn summarizes_offchain_origin_diagnostics_without_raw_per_fill_warnings() {
     );
     assert_eq!(report.summary.total_pnl_usd, "0");
     assert_eq!(report.summary.open_long_shares, "1");
+}
+
+async fn insert_portfolio_snapshot_row(
+    pool: &SqlitePool,
+    et_day: &str,
+    location: &str,
+    asset: &str,
+    available: &str,
+    usd_mark: Option<&str>,
+    mark_captured_at: Option<&str>,
+) {
+    sqlx::query(
+        "INSERT INTO portfolio_snapshot \
+         (et_day, captured_at, location, asset, available_balance, inflight_balance, \
+          usd_mark, mark_captured_at) \
+         VALUES (?, ?, ?, ?, ?, '0', ?, ?)",
+    )
+    .bind(et_day)
+    .bind(format!("{et_day}T04:05:00+00:00"))
+    .bind(location)
+    .bind(asset)
+    .bind(available)
+    .bind(usd_mark)
+    .bind(mark_captured_at)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn build_pnl_report_populates_capital_when_snapshots_exist() {
+    let pool = pnl_test_pool(Vec::new(), position_rows()).await;
+    insert_portfolio_snapshot_row(
+        &pool,
+        "2026-05-15",
+        "market_making",
+        "USDC",
+        "1000",
+        Some("1"),
+        Some("2026-05-15T04:05:00+00:00"),
+    )
+    .await;
+
+    let report = build_pnl_report(&pool, &query(), Vec::new()).await.unwrap();
+
+    assert_eq!(
+        report.capital.average_deployed_capital_usd,
+        Some("1000".to_owned())
+    );
+    assert_eq!(report.capital.annualized_return_pct, None);
+    assert_eq!(report.capital.sample_days, 1);
+    assert_eq!(report.capital.coverage_days, Some(1));
+    assert_eq!(
+        report.capital.first_snapshot_day,
+        Some("2026-05-15".to_owned())
+    );
+    assert!(report.warnings.contains(&CAPITAL_AVAILABLE_NOTE.to_owned()));
+    assert!(CAPITAL_AVAILABLE_NOTE.contains("annualized return on capital is computed only when"));
+    assert!(
+        !report
+            .warnings
+            .contains(&CAPITAL_UNAVAILABLE_NOTE.to_owned())
+    );
+}
+
+#[tokio::test]
+async fn build_pnl_report_omits_capital_with_warning_when_no_snapshots_exist() {
+    let pool = pnl_test_pool(Vec::new(), position_rows()).await;
+
+    let report = build_pnl_report(&pool, &query(), Vec::new()).await.unwrap();
+
+    assert_eq!(report.capital.average_deployed_capital_usd, None);
+    assert_eq!(report.capital.annualized_return_pct, None);
+    assert_eq!(report.capital.sample_days, 0);
+    assert!(
+        report
+            .warnings
+            .contains(&CAPITAL_UNAVAILABLE_NOTE.to_owned())
+    );
+    assert!(!report.warnings.contains(&CAPITAL_AVAILABLE_NOTE.to_owned()));
+    assert!(report.warnings.contains(&BASELINE_WARNING.to_owned()));
+}
+
+#[tokio::test]
+async fn build_pnl_report_symbol_filtered_query_omits_capital_with_warning() {
+    let pool = pnl_test_pool(Vec::new(), position_rows()).await;
+    insert_portfolio_snapshot_row(
+        &pool,
+        "2026-05-15",
+        "market_making",
+        "USDC",
+        "1000",
+        Some("1"),
+        Some("2026-05-15T04:05:00+00:00"),
+    )
+    .await;
+
+    let report = build_pnl_report(
+        &pool,
+        &PnlQuery {
+            symbol: Some("RKLB".to_owned()),
+            ..query()
+        },
+        Vec::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(report.capital.average_deployed_capital_usd, None);
+    assert!(
+        report
+            .warnings
+            .contains(&SYMBOL_FILTERED_CAPITAL_WARNING.to_owned())
+    );
+    assert!(
+        report
+            .warnings
+            .contains(&CAPITAL_UNAVAILABLE_NOTE.to_owned())
+    );
+}
+
+/// An empty/whitespace-only `symbol=` param is treated as "no filter" by
+/// `PnlQuery::symbol_filter`, so capital must stay whole-portfolio rather than
+/// being suppressed as if a real symbol filter were present.
+#[tokio::test]
+async fn build_pnl_report_empty_symbol_param_preserves_capital() {
+    let pool = pnl_test_pool(Vec::new(), position_rows()).await;
+    insert_portfolio_snapshot_row(
+        &pool,
+        "2026-05-15",
+        "market_making",
+        "USDC",
+        "1000",
+        Some("1"),
+        Some("2026-05-15T04:05:00+00:00"),
+    )
+    .await;
+
+    let report = build_pnl_report(
+        &pool,
+        &PnlQuery {
+            symbol: Some("   ".to_owned()),
+            ..query()
+        },
+        Vec::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        report.capital.average_deployed_capital_usd,
+        Some("1000".to_owned())
+    );
+    assert!(
+        !report
+            .warnings
+            .contains(&SYMBOL_FILTERED_CAPITAL_WARNING.to_owned())
+    );
+}
+
+#[tokio::test]
+async fn build_pnl_report_as_of_rowid_non_current_omits_capital_with_warning() {
+    let pool = pnl_test_pool(
+        vec![
+            onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
+            offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
+        ],
+        position_rows(),
+    )
+    .await;
+    insert_portfolio_snapshot_row(
+        &pool,
+        "2026-05-15",
+        "market_making",
+        "USDC",
+        "1000",
+        Some("1"),
+        Some("2026-05-15T04:05:00+00:00"),
+    )
+    .await;
+
+    let report = build_pnl_report(
+        &pool,
+        &PnlQuery {
+            as_of_rowid: Some(1),
+            ..query()
+        },
+        Vec::new(),
+    )
+    .await
+    .unwrap();
+
+    // Capital is never watermarked to as_of_rowid. A historical rowid cannot
+    // yield a historical capital figure, so both fields stay None rather than
+    // silently substituting the live snapshot table's current capital.
+    assert_eq!(report.capital.average_deployed_capital_usd, None);
+    assert_eq!(report.capital.annualized_return_pct, None);
+    assert!(
+        report
+            .warnings
+            .iter()
+            .any(|warning| { warning.contains("not a historical view as of rowid 1") })
+    );
 }

--- a/src/portfolio_snapshot/mod.rs
+++ b/src/portfolio_snapshot/mod.rs
@@ -22,7 +22,8 @@
 //! The write side splits into [`write`] (the self-rescheduling job that
 //! resolves USD marks and issues the `Capture` command) and [`projection`]
 //! (the reactor that maintains the flat read-model table from the retained
-//! `Captured` events).
+//! `Captured` events). The [`read`] module computes the capital and return
+//! figures exposed by `/pnl` from that read model.
 
 use std::fmt;
 use std::str::FromStr;
@@ -40,13 +41,20 @@ use crate::inventory::PortfolioBalanceRow;
 use crate::position::option_float_eq;
 
 pub(crate) mod projection;
+pub(crate) mod read;
 pub(crate) mod write;
 
 pub(crate) use projection::PortfolioSnapshotProjection;
+pub(crate) use read::{EtDayRange, ReadError, capital_summary, load_portfolio_days};
 pub(crate) use write::{
     PortfolioSnapshotCtx, PortfolioSnapshotJob, PortfolioSnapshotJobQueue,
     bootstrap_portfolio_snapshot,
 };
+// Only consumed by api.rs's `#[cfg(test)]` DST-boundary /pnl test, which
+// derives the same day a real capture would rather than assuming it;
+// `cfg(test)` only because that test module is not part of the e2e binary.
+#[cfg(test)]
+pub(crate) use write::et_day;
 
 /// Typed identifier for [`PortfolioSnapshot`] aggregates: one instance per
 /// Eastern Time calendar day. Using the day itself as the id gives

--- a/src/portfolio_snapshot/read.rs
+++ b/src/portfolio_snapshot/read.rs
@@ -1,0 +1,1251 @@
+//! Capital and return-on-capital computation for `/pnl`, reading only the
+//! reactor-maintained `portfolio_snapshot` table (see SPEC.md "Portfolio
+//! Capital and Return Tracking"). Never folds the `events` table: capital is
+//! not watermarked to any `as_of_rowid` and always reflects the live snapshot
+//! table.
+//!
+//! Inclusion is decided per ET day, never per row: a day is included in the
+//! capital sample only when every nonzero balance that counts toward capital
+//! has a known, fresh USD mark. Cash and positive equity count at every
+//! location, including the current Alpaca position at the Hedging venue. A
+//! negative equity position does not count because the collateral or margin
+//! supporting shorts is not modeled. Per-row exclusion of a row that does
+//! count would understate capital and mechanically inflate the reported
+//! return -- the dangerous direction for a financial metric to be wrong in --
+//! so a single bad counted row excludes the whole day instead.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, NaiveDate, Utc};
+use rain_math_float::Float;
+use sqlx::{QueryBuilder, Sqlite, SqlitePool};
+use thiserror::Error;
+
+use st0x_execution::{EmptySymbolError, HasZero, Symbol};
+use st0x_float_macro::float;
+use st0x_float_serde::parse_float_string_or_hex;
+
+use super::write::et_day as et_day_of;
+use crate::inventory::{PortfolioAsset, PortfolioLocation};
+
+/// Balances marked more than this many days before their `et_day` exclude
+/// the whole day from the capital sample. Only equity marks are
+/// staleness-checked -- USDC's mark is a fixed par assumption captured fresh
+/// at capture time.
+const MARK_STALENESS_THRESHOLD_DAYS: i64 = 7;
+
+/// Minimum included snapshot days, spanning at least this many calendar
+/// days, before an annualized return is computed. A single day's return
+/// extrapolated by 365x is exactly the misleading-financial-number failure
+/// mode the project's fail-fast rules exist to prevent.
+const MIN_SAMPLE_DAYS_FOR_ANNUALIZATION: usize = 2;
+const MIN_COVERAGE_DAYS_FOR_ANNUALIZATION: i64 = 2;
+
+const DAYS_PER_YEAR: Float = float!(365);
+const PERCENT: Float = float!(100);
+
+/// Errors loading and interpreting persisted `portfolio_snapshot` rows.
+#[derive(Debug, Error)]
+pub(crate) enum ReadError {
+    #[error("failed to load portfolio snapshot rows: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("failed to parse a persisted portfolio snapshot balance: {0}")]
+    Float(#[from] rain_math_float::FloatError),
+    #[error("failed to parse persisted portfolio snapshot et_day '{value}': {source}")]
+    InvalidEtDay {
+        value: String,
+        #[source]
+        source: chrono::ParseError,
+    },
+    #[error("failed to parse persisted portfolio snapshot asset '{value}': {source}")]
+    InvalidAsset {
+        value: String,
+        #[source]
+        source: EmptySymbolError,
+    },
+    #[error("failed to parse persisted portfolio snapshot location: '{value}'")]
+    InvalidLocation { value: String },
+    #[error("failed to parse persisted portfolio snapshot mark_captured_at '{value}': {source}")]
+    InvalidMarkTimestamp {
+        value: String,
+        #[source]
+        source: chrono::ParseError,
+    },
+    #[error("sample day count {sample_days} does not fit in i64 for the coverage-gap check")]
+    SampleDaysOverflow { sample_days: usize },
+}
+
+/// Why a day was excluded from the capital sample.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum DayExclusionReason {
+    MissingMark(PortfolioAsset),
+    StaleMark(PortfolioAsset, DateTime<Utc>),
+}
+
+/// A day's deployed capital, or the reason it could not be computed. Mutually
+/// exclusive by construction -- a day is never both a computed total and an
+/// exclusion reason at once, so the two are no longer independent `Option`s
+/// that could (invalidly) both be `Some` or both be `None`.
+#[derive(Debug, Clone)]
+pub(crate) enum DayCapital {
+    Included(Float),
+    Excluded(DayExclusionReason),
+}
+
+impl PartialEq for DayCapital {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Included(left), Self::Included(right)) => left.eq(*right).unwrap_or(false),
+            (Self::Excluded(left), Self::Excluded(right)) => left == right,
+            (Self::Included(_), Self::Excluded(_)) | (Self::Excluded(_), Self::Included(_)) => {
+                false
+            }
+        }
+    }
+}
+
+/// One ET day's deployed capital, or the reason it could not be computed.
+#[derive(Debug, Clone)]
+pub(crate) struct PortfolioDay {
+    pub(crate) et_day: NaiveDate,
+    pub(crate) capital: DayCapital,
+}
+
+/// An inclusive, independently-optional ET-day range: each side is `None`
+/// when that bound is unset (open), never a sentinel date. A named struct
+/// rather than a bare `(Option<NaiveDate>, Option<NaiveDate>)` tuple so
+/// `from` and `to` cannot be transposed at a call site -- the same swap risk
+/// `ResolvedRowid` (`src/dashboard/pnl/source.rs`) exists to prevent for a
+/// pair of same-typed rowids.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct EtDayRange {
+    pub(crate) from: Option<NaiveDate>,
+    pub(crate) to: Option<NaiveDate>,
+}
+
+/// Capital and return-on-capital figures for `/pnl`, computed over a set of
+/// [`PortfolioDay`]s with the guards described below.
+#[derive(Debug, Clone)]
+pub(crate) struct CapitalSummary {
+    pub(crate) average_deployed_capital_usd: Option<Float>,
+    pub(crate) annualized_return_pct: Option<Float>,
+    pub(crate) coverage_days: Option<i64>,
+    pub(crate) sample_days: usize,
+    pub(crate) first_snapshot_day: Option<NaiveDate>,
+    pub(crate) last_snapshot_day: Option<NaiveDate>,
+    pub(crate) warnings: Vec<String>,
+}
+
+/// A single `(location, asset)` balance row loaded from `portfolio_snapshot`
+/// for one ET day, before day-level inclusion is decided.
+struct RawBalanceRow {
+    asset: PortfolioAsset,
+    available: Float,
+    inflight: Float,
+    usd_mark: Option<Float>,
+    mark_captured_at: Option<DateTime<Utc>>,
+}
+
+/// Loads every `portfolio_snapshot` row in `et_day_range` (inclusive both
+/// ends; each side `None` leaves that end of the range open), grouped and
+/// evaluated per ET day.
+pub(crate) async fn load_portfolio_days(
+    pool: &SqlitePool,
+    et_day_range: EtDayRange,
+) -> Result<Vec<PortfolioDay>, ReadError> {
+    let mut query = QueryBuilder::<Sqlite>::new(
+        "SELECT et_day, location, asset, available_balance, inflight_balance, usd_mark, \
+         mark_captured_at \
+         FROM portfolio_snapshot",
+    );
+    let EtDayRange { from, to } = et_day_range;
+    let has_condition = from.is_some();
+    if let Some(from) = from {
+        query.push(" WHERE et_day >= ");
+        query.push_bind(from.to_string());
+    }
+    if let Some(to) = to {
+        query.push(if has_condition {
+            " AND et_day <= "
+        } else {
+            " WHERE et_day <= "
+        });
+        query.push_bind(to.to_string());
+    }
+    query.push(" ORDER BY et_day ASC, asset ASC");
+
+    let rows = query
+        .build_query_as::<(
+            String,
+            String,
+            String,
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+        )>()
+        .fetch_all(pool)
+        .await?;
+
+    let mut by_day: BTreeMap<NaiveDate, Vec<RawBalanceRow>> = BTreeMap::new();
+    for (et_day, location, asset, available, inflight, usd_mark, mark_captured_at) in rows {
+        let et_day = parse_et_day(&et_day)?;
+        parse_portfolio_location(&location)?;
+        let asset = parse_portfolio_asset(&asset)?;
+        let available = parse_float_string_or_hex(&available)?;
+        let inflight = parse_float_string_or_hex(&inflight)?;
+        let usd_mark = usd_mark
+            .as_deref()
+            .map(parse_float_string_or_hex)
+            .transpose()?;
+        let mark_captured_at = mark_captured_at
+            .as_deref()
+            .map(parse_mark_captured_at)
+            .transpose()?;
+
+        by_day.entry(et_day).or_default().push(RawBalanceRow {
+            asset,
+            available,
+            inflight,
+            usd_mark,
+            mark_captured_at,
+        });
+    }
+
+    by_day
+        .into_iter()
+        .map(|(et_day, rows)| evaluate_day(et_day, rows))
+        .collect()
+}
+
+/// Computes [`CapitalSummary`] from already-loaded [`PortfolioDay`]s and the
+/// range's numeric net realized PnL accumulator, not a re-parsed response
+/// string.
+///
+/// `query_et_day_range` has the same `(from, to)` bounds that scope
+/// `net_realized_pnl_usd`: the PnL numerator is computed over the caller's
+/// whole query range, not over snapshot coverage, so annualizing by
+/// `365 / coverage_days` is only valid when snapshot coverage fully spans that
+/// range. See [`coverage_spans_query_range`].
+pub(crate) fn capital_summary(
+    days: &[PortfolioDay],
+    net_realized_pnl_usd: Float,
+    query_et_day_range: EtDayRange,
+) -> Result<CapitalSummary, ReadError> {
+    let mut warnings = exclusion_warnings(days);
+
+    let included: Vec<(NaiveDate, Float)> = days
+        .iter()
+        .filter_map(|day| match day.capital {
+            DayCapital::Included(total) => Some((day.et_day, total)),
+            DayCapital::Excluded(_) => None,
+        })
+        .collect();
+    let sample_days = included.len();
+
+    if sample_days == 0 {
+        return Ok(CapitalSummary {
+            average_deployed_capital_usd: None,
+            annualized_return_pct: None,
+            coverage_days: None,
+            sample_days: 0,
+            first_snapshot_day: None,
+            last_snapshot_day: None,
+            warnings,
+        });
+    }
+
+    let first_snapshot_day = included[0].0;
+    let last_snapshot_day = included[included.len() - 1].0;
+    let coverage_days = (last_snapshot_day - first_snapshot_day).num_days() + 1;
+    // Converts sample_days (bounded by however many portfolio_snapshot rows
+    // were actually loaded, realistically tiny) to i64 rather than
+    // converting coverage_days (a calendar-day span with no such bound) to
+    // usize: the smaller-magnitude direction is the one that can fail fast
+    // without ever plausibly doing so, instead of silently defaulting.
+    let sample_days_i64 = i64::try_from(sample_days)
+        .map_err(|_conversion_error| ReadError::SampleDaysOverflow { sample_days })?;
+    if sample_days_i64 < coverage_days {
+        warnings.push(format!(
+            "Portfolio snapshot coverage has gaps: {sample_days} captured day(s) out of \
+             {coverage_days} calendar day(s) in range"
+        ));
+    }
+
+    let mut total = Float::zero()?;
+    for (_, day_total) in &included {
+        total = (total + *day_total)?;
+    }
+    let sample_days_float = Float::parse(sample_days.to_string())?;
+    let average = (total / sample_days_float)?;
+
+    if average.is_zero()? {
+        warnings.push(format!(
+            "Average deployed capital over {sample_days} sampled day(s) is zero; return on \
+             capital cannot be computed"
+        ));
+        return Ok(CapitalSummary {
+            average_deployed_capital_usd: None,
+            annualized_return_pct: None,
+            coverage_days: Some(coverage_days),
+            sample_days,
+            first_snapshot_day: Some(first_snapshot_day),
+            last_snapshot_day: Some(last_snapshot_day),
+            warnings,
+        });
+    }
+
+    let meets_sample_and_coverage_minimums = sample_days >= MIN_SAMPLE_DAYS_FOR_ANNUALIZATION
+        && coverage_days >= MIN_COVERAGE_DAYS_FOR_ANNUALIZATION;
+
+    let annualized_return_pct = if !meets_sample_and_coverage_minimums {
+        warnings.push(format!(
+            "Annualized return on capital requires at least \
+             {MIN_SAMPLE_DAYS_FOR_ANNUALIZATION} included snapshot days spanning at least \
+             {MIN_COVERAGE_DAYS_FOR_ANNUALIZATION} calendar days; only {sample_days} day(s) \
+             covering {coverage_days} calendar day(s) are available"
+        ));
+        None
+    } else if !coverage_spans_query_range(first_snapshot_day, last_snapshot_day, query_et_day_range)
+    {
+        warnings.push(
+            "Snapshot coverage does not span the full query range; annualized return omitted \
+             to avoid conflating a partial-coverage denominator with full-range realized PnL"
+                .to_owned(),
+        );
+        None
+    } else {
+        let coverage_days_float = Float::parse(coverage_days.to_string())?;
+        let annual_factor = (DAYS_PER_YEAR / coverage_days_float)?;
+        let period_return = (net_realized_pnl_usd / average)?;
+        Some(((period_return * annual_factor)? * PERCENT)?)
+    };
+
+    Ok(CapitalSummary {
+        average_deployed_capital_usd: Some(average),
+        annualized_return_pct,
+        coverage_days: Some(coverage_days),
+        sample_days,
+        first_snapshot_day: Some(first_snapshot_day),
+        last_snapshot_day: Some(last_snapshot_day),
+        warnings,
+    })
+}
+
+/// Whether `[first_snapshot_day, last_snapshot_day]` fully covers
+/// `query_et_day_range`: the realized-PnL numerator passed into
+/// [`capital_summary`] is scoped to the caller's query range, not to
+/// snapshot coverage, so annualizing by `365 / coverage_days` is only valid
+/// when the two line up. An unbounded query side (`None`, "load every
+/// captured day") can never be proven spanned by a finite snapshot range --
+/// `portfolio_snapshot` does not backfill history -- so it conservatively
+/// counts as not spanning rather than assuming the coverage happens to reach
+/// back to the true start of history.
+fn coverage_spans_query_range(
+    first_snapshot_day: NaiveDate,
+    last_snapshot_day: NaiveDate,
+    query_et_day_range: EtDayRange,
+) -> bool {
+    let EtDayRange {
+        from: query_from,
+        to: query_to,
+    } = query_et_day_range;
+    query_from.is_some_and(|from| first_snapshot_day <= from)
+        && query_to.is_some_and(|to| last_snapshot_day >= to)
+}
+
+fn exclusion_warnings(days: &[PortfolioDay]) -> Vec<String> {
+    days.iter()
+        .filter_map(|day| match &day.capital {
+            DayCapital::Included(_) => None,
+            DayCapital::Excluded(reason) => Some(describe_exclusion(day.et_day, reason)),
+        })
+        .collect()
+}
+
+fn describe_exclusion(et_day: NaiveDate, reason: &DayExclusionReason) -> String {
+    match reason {
+        DayExclusionReason::MissingMark(asset) => format!(
+            "Portfolio capital sample excludes {et_day}: no USD mark observed yet for {asset}"
+        ),
+        DayExclusionReason::StaleMark(asset, mark_captured_at) => format!(
+            "Portfolio capital sample excludes {et_day}: USD mark for {asset} is stale \
+             (last observed {mark_captured_at})"
+        ),
+    }
+}
+
+fn evaluate_day(et_day: NaiveDate, rows: Vec<RawBalanceRow>) -> Result<PortfolioDay, ReadError> {
+    let mut total = Float::zero()?;
+
+    for row in rows {
+        let balance = (row.available + row.inflight)?;
+        if balance.is_zero()? {
+            continue;
+        }
+
+        // Deployed capital = cash everywhere + positive equity holdings
+        // everywhere (SPEC.md "Portfolio Capital and Return Tracking"). The
+        // Hedging venue contains the broker's one current equity position;
+        // counter-trades consume or replenish that inventory rather than
+        // creating a separate hedge leg. A negative broker position does not
+        // contribute under this long-inventory definition because the margin
+        // supporting shorts is not modeled. Skip it before mark validation:
+        // a row that cannot contribute must not gate the whole day.
+        if matches!(&row.asset, PortfolioAsset::Equity(_)) && balance.is_negative()? {
+            continue;
+        }
+
+        let Some(mark) = row.usd_mark else {
+            return Ok(PortfolioDay {
+                et_day,
+                capital: DayCapital::Excluded(DayExclusionReason::MissingMark(row.asset)),
+            });
+        };
+
+        // write.rs always sets usd_mark and mark_captured_at together, so a
+        // mark without a timestamp should never occur in practice. Treat it
+        // the same as a missing mark rather than fabricating a timestamp for
+        // StaleMark.
+        let Some(mark_captured_at) = row.mark_captured_at else {
+            return Ok(PortfolioDay {
+                et_day,
+                capital: DayCapital::Excluded(DayExclusionReason::MissingMark(row.asset)),
+            });
+        };
+
+        if is_stale_mark(&row.asset, mark_captured_at, et_day) {
+            return Ok(PortfolioDay {
+                et_day,
+                capital: DayCapital::Excluded(DayExclusionReason::StaleMark(
+                    row.asset,
+                    mark_captured_at,
+                )),
+            });
+        }
+
+        total = (total + (balance * mark)?)?;
+    }
+
+    Ok(PortfolioDay {
+        et_day,
+        capital: DayCapital::Included(total),
+    })
+}
+
+fn is_stale_mark(
+    asset: &PortfolioAsset,
+    mark_captured_at: DateTime<Utc>,
+    et_day: NaiveDate,
+) -> bool {
+    if !matches!(asset, PortfolioAsset::Equity(_)) {
+        return false;
+    }
+
+    // Both sides must be the same calendar basis: `et_day` is already an ET
+    // calendar day (see this module's callers), so `mark_captured_at` -- a
+    // stored UTC timestamp -- is converted through the same ET-day helper
+    // the rest of this module relies on, rather than `.date_naive()` (the
+    // UTC calendar date). ET trails UTC by 4-5 hours, so a mark timestamped
+    // in the ~20:00-23:59 ET window has a UTC date one day ahead of its true
+    // ET day; comparing that raw UTC date against `et_day` would understate
+    // the mark's age by a day and let a genuinely stale mark pass the gate.
+    let mark_et_day = et_day_of(mark_captured_at);
+    let age_days = (et_day - mark_et_day).num_days();
+    age_days > MARK_STALENESS_THRESHOLD_DAYS
+}
+
+fn parse_et_day(value: &str) -> Result<NaiveDate, ReadError> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").map_err(|source| ReadError::InvalidEtDay {
+        value: value.to_owned(),
+        source,
+    })
+}
+
+/// Inverse of `PortfolioLocation`'s `Display` impl (`src/inventory/view.rs`),
+/// which is what `PortfolioSnapshotProjection` persists into the `location`
+/// column (`row.row.location.to_string()`).
+fn parse_portfolio_location(value: &str) -> Result<PortfolioLocation, ReadError> {
+    match value {
+        "market_making" => Ok(PortfolioLocation::MarketMaking),
+        "hedging" => Ok(PortfolioLocation::Hedging),
+        "ethereum_wallet" => Ok(PortfolioLocation::EthereumWallet),
+        "base_wallet_unwrapped" => Ok(PortfolioLocation::BaseWalletUnwrapped),
+        "base_wallet_wrapped" => Ok(PortfolioLocation::BaseWalletWrapped),
+        _ => Err(ReadError::InvalidLocation {
+            value: value.to_owned(),
+        }),
+    }
+}
+
+fn parse_portfolio_asset(value: &str) -> Result<PortfolioAsset, ReadError> {
+    if value == "USDC" {
+        return Ok(PortfolioAsset::Usdc);
+    }
+
+    Symbol::new(value)
+        .map(PortfolioAsset::Equity)
+        .map_err(|source| ReadError::InvalidAsset {
+            value: value.to_owned(),
+            source,
+        })
+}
+
+fn parse_mark_captured_at(value: &str) -> Result<DateTime<Utc>, ReadError> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|parsed| parsed.with_timezone(&Utc))
+        .map_err(|source| ReadError::InvalidMarkTimestamp {
+            value: value.to_owned(),
+            source,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{Days, TimeZone};
+
+    use crate::test_utils::setup_test_db;
+
+    use super::*;
+
+    fn usd(value: i64) -> Float {
+        float!(&value.to_string())
+    }
+
+    async fn insert_row(
+        pool: &SqlitePool,
+        et_day: &str,
+        location: &str,
+        asset: &str,
+        available: &str,
+        usd_mark: Option<&str>,
+        mark_captured_at: Option<&str>,
+    ) {
+        sqlx::query(
+            "INSERT INTO portfolio_snapshot \
+             (et_day, captured_at, location, asset, available_balance, inflight_balance, \
+              usd_mark, mark_captured_at) \
+             VALUES (?, ?, ?, ?, ?, '0', ?, ?)",
+        )
+        .bind(et_day)
+        .bind(format!("{et_day}T04:05:00+00:00"))
+        .bind(location)
+        .bind(asset)
+        .bind(available)
+        .bind(usd_mark)
+        .bind(mark_captured_at)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn load_portfolio_days_sums_all_rows_for_a_fully_marked_day() {
+        let pool = setup_test_db().await;
+        insert_row(
+            &pool,
+            "2026-07-18",
+            "market_making",
+            "USDC",
+            "1000",
+            Some("1"),
+            Some("2026-07-18T04:05:00+00:00"),
+        )
+        .await;
+        insert_row(
+            &pool,
+            "2026-07-18",
+            "market_making",
+            "AAPL",
+            "2",
+            Some("50"),
+            Some("2026-07-18T04:05:00+00:00"),
+        )
+        .await;
+
+        let days = load_portfolio_days(&pool, EtDayRange::default())
+            .await
+            .unwrap();
+
+        assert_eq!(days.len(), 1);
+        assert_eq!(
+            days[0].et_day,
+            NaiveDate::from_ymd_opt(2026, 7, 18).unwrap()
+        );
+        match &days[0].capital {
+            DayCapital::Included(total_usd) => assert!(total_usd.eq(usd(1100)).unwrap()),
+            DayCapital::Excluded(reason) => panic!("expected day to be included, got {reason:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn load_portfolio_days_excludes_whole_day_on_missing_mark() {
+        let pool = setup_test_db().await;
+        insert_row(
+            &pool,
+            "2026-07-18",
+            "market_making",
+            "USDC",
+            "1000",
+            Some("1"),
+            Some("2026-07-18T04:05:00+00:00"),
+        )
+        .await;
+        insert_row(
+            &pool,
+            "2026-07-18",
+            "market_making",
+            "AAPL",
+            "2",
+            None,
+            None,
+        )
+        .await;
+
+        let days = load_portfolio_days(&pool, EtDayRange::default())
+            .await
+            .unwrap();
+
+        assert_eq!(days.len(), 1);
+        assert_eq!(
+            days[0].capital,
+            DayCapital::Excluded(DayExclusionReason::MissingMark(PortfolioAsset::Equity(
+                Symbol::new("AAPL").unwrap()
+            )))
+        );
+    }
+
+    #[tokio::test]
+    async fn load_portfolio_days_excludes_whole_day_on_stale_mark() {
+        let pool = setup_test_db().await;
+        insert_row(
+            &pool,
+            "2026-07-18",
+            "market_making",
+            "AAPL",
+            "2",
+            Some("50"),
+            Some("2026-07-01T04:05:00+00:00"),
+        )
+        .await;
+
+        let days = load_portfolio_days(&pool, EtDayRange::default())
+            .await
+            .unwrap();
+
+        assert_eq!(days.len(), 1);
+        let expected_captured_at = Utc.with_ymd_and_hms(2026, 7, 1, 4, 5, 0).unwrap();
+        assert_eq!(
+            days[0].capital,
+            DayCapital::Excluded(DayExclusionReason::StaleMark(
+                PortfolioAsset::Equity(Symbol::new("AAPL").unwrap()),
+                expected_captured_at
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn load_portfolio_days_zero_balance_row_with_no_mark_does_not_exclude_day() {
+        let pool = setup_test_db().await;
+        insert_row(
+            &pool,
+            "2026-07-18",
+            "market_making",
+            "USDC",
+            "1000",
+            Some("1"),
+            Some("2026-07-18T04:05:00+00:00"),
+        )
+        .await;
+        insert_row(&pool, "2026-07-18", "hedging", "AAPL", "0", None, None).await;
+
+        let days = load_portfolio_days(&pool, EtDayRange::default())
+            .await
+            .unwrap();
+
+        assert_eq!(days.len(), 1);
+        match &days[0].capital {
+            DayCapital::Included(total_usd) => assert!(total_usd.eq(usd(1000)).unwrap()),
+            DayCapital::Excluded(reason) => panic!("expected day to be included, got {reason:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn load_portfolio_days_respects_et_day_range_bounds() {
+        let pool = setup_test_db().await;
+        insert_row(
+            &pool,
+            "2026-07-17",
+            "market_making",
+            "USDC",
+            "1000",
+            Some("1"),
+            Some("2026-07-17T04:05:00+00:00"),
+        )
+        .await;
+        insert_row(
+            &pool,
+            "2026-07-18",
+            "market_making",
+            "USDC",
+            "2000",
+            Some("1"),
+            Some("2026-07-18T04:05:00+00:00"),
+        )
+        .await;
+        insert_row(
+            &pool,
+            "2026-07-19",
+            "market_making",
+            "USDC",
+            "3000",
+            Some("1"),
+            Some("2026-07-19T04:05:00+00:00"),
+        )
+        .await;
+
+        let range = EtDayRange {
+            from: Some(NaiveDate::from_ymd_opt(2026, 7, 18).unwrap()),
+            to: Some(NaiveDate::from_ymd_opt(2026, 7, 18).unwrap()),
+        };
+        let days = load_portfolio_days(&pool, range).await.unwrap();
+
+        assert_eq!(days.len(), 1);
+        assert_eq!(
+            days[0].et_day,
+            NaiveDate::from_ymd_opt(2026, 7, 18).unwrap()
+        );
+    }
+
+    /// An open-ended range (only `from` set) must include every day at or
+    /// after it, with no upper bound.
+    #[tokio::test]
+    async fn load_portfolio_days_respects_open_ended_lower_bound() {
+        let pool = setup_test_db().await;
+        insert_row(
+            &pool,
+            "2026-07-17",
+            "market_making",
+            "USDC",
+            "1000",
+            Some("1"),
+            Some("2026-07-17T04:05:00+00:00"),
+        )
+        .await;
+        insert_row(
+            &pool,
+            "2026-07-19",
+            "market_making",
+            "USDC",
+            "3000",
+            Some("1"),
+            Some("2026-07-19T04:05:00+00:00"),
+        )
+        .await;
+
+        let range = EtDayRange {
+            from: Some(NaiveDate::from_ymd_opt(2026, 7, 18).unwrap()),
+            to: None,
+        };
+        let days = load_portfolio_days(&pool, range).await.unwrap();
+
+        assert_eq!(days.len(), 1);
+        assert_eq!(
+            days[0].et_day,
+            NaiveDate::from_ymd_opt(2026, 7, 19).unwrap()
+        );
+    }
+
+    /// Positive equity inventory counts at both venues: the Hedging row is
+    /// the broker's current holding, not a distinct short leg paired with the
+    /// MarketMaking balance.
+    #[tokio::test]
+    async fn deployed_capital_includes_positive_equity_at_both_venues() {
+        let pool = setup_test_db().await;
+        insert_row(
+            &pool,
+            "2026-07-18",
+            "market_making",
+            "USDC",
+            "5000",
+            Some("1"),
+            Some("2026-07-18T04:05:00+00:00"),
+        )
+        .await;
+        insert_row(
+            &pool,
+            "2026-07-18",
+            "hedging",
+            "USDC",
+            "2000",
+            Some("1"),
+            Some("2026-07-18T04:05:00+00:00"),
+        )
+        .await;
+        insert_row(
+            &pool,
+            "2026-07-18",
+            "market_making",
+            "AAPL",
+            "10",
+            Some("150"),
+            Some("2026-07-18T04:05:00+00:00"),
+        )
+        .await;
+        // The broker's current positive AAPL inventory.
+        insert_row(
+            &pool,
+            "2026-07-18",
+            "hedging",
+            "AAPL",
+            "10",
+            Some("150"),
+            Some("2026-07-18T04:05:00+00:00"),
+        )
+        .await;
+
+        let days = load_portfolio_days(&pool, EtDayRange::default())
+            .await
+            .unwrap();
+
+        assert_eq!(days.len(), 1);
+        match &days[0].capital {
+            DayCapital::Included(total_usd) => assert!(
+                total_usd.eq(usd(10000)).unwrap(),
+                "expected cash (5000 + 2000) + equity at both venues \
+                 (10 * 150 + 10 * 150 = 3000) = 10000, got {total_usd:?}"
+            ),
+            DayCapital::Excluded(reason) => panic!("expected day to be included, got {reason:?}"),
+        }
+    }
+
+    /// A positive Hedging-venue equity row is real broker inventory and
+    /// contributes to deployed capital even when no MarketMaking row exists.
+    #[tokio::test]
+    async fn positive_hedging_equity_row_alone_contributes_to_capital() {
+        let pool = setup_test_db().await;
+        insert_row(
+            &pool,
+            "2026-07-18",
+            "hedging",
+            "AAPL",
+            "10",
+            Some("150"),
+            Some("2026-07-18T04:05:00+00:00"),
+        )
+        .await;
+
+        let days = load_portfolio_days(&pool, EtDayRange::default())
+            .await
+            .unwrap();
+
+        assert_eq!(days.len(), 1);
+        match &days[0].capital {
+            DayCapital::Included(total_usd) => assert!(
+                total_usd.eq(usd(1500)).unwrap(),
+                "the broker's 10 positive AAPL shares at 150 must contribute 1500"
+            ),
+            DayCapital::Excluded(reason) => panic!("expected day to be included, got {reason:?}"),
+        }
+    }
+
+    /// Reallocating the same equity inventory between venues must not change
+    /// deployed capital. A counter-trade moves the holdings in opposite
+    /// directions while preserving their combined quantity.
+    #[tokio::test]
+    async fn equity_capital_is_invariant_to_venue_allocation() {
+        let pool = setup_test_db().await;
+        for (et_day, market_making, hedging) in
+            [("2026-07-18", "60", "40"), ("2026-07-19", "50", "50")]
+        {
+            for (location, available) in [("market_making", market_making), ("hedging", hedging)] {
+                insert_row(
+                    &pool,
+                    et_day,
+                    location,
+                    "AAPL",
+                    available,
+                    Some("100"),
+                    Some(&format!("{et_day}T04:05:00+00:00")),
+                )
+                .await;
+            }
+        }
+
+        let days = load_portfolio_days(&pool, EtDayRange::default())
+            .await
+            .unwrap();
+
+        assert_eq!(days.len(), 2);
+        for day in days {
+            match day.capital {
+                DayCapital::Included(total_usd) => assert!(
+                    total_usd.eq(usd(10000)).unwrap(),
+                    "100 total AAPL shares at 100 must contribute 10000 regardless of venue"
+                ),
+                DayCapital::Excluded(reason) => {
+                    panic!("expected day to be included, got {reason:?}")
+                }
+            }
+        }
+    }
+
+    /// A negative broker position is not positive equity inventory. Its
+    /// margin requirement is not modeled, so it contributes nothing and does
+    /// not require a mark.
+    #[tokio::test]
+    async fn negative_hedging_equity_does_not_contribute_or_gate_the_day() {
+        let pool = setup_test_db().await;
+        insert_row(&pool, "2026-07-18", "hedging", "AAPL", "-10", None, None).await;
+
+        let days = load_portfolio_days(&pool, EtDayRange::default())
+            .await
+            .unwrap();
+
+        assert_eq!(days.len(), 1);
+        match &days[0].capital {
+            DayCapital::Included(total_usd) => assert!(total_usd.eq(usd(0)).unwrap()),
+            DayCapital::Excluded(reason) => panic!("expected day to be included, got {reason:?}"),
+        }
+    }
+
+    /// USDC (cash) contributes to capital at EVERY location, including both
+    /// venues and every wallet-transit point -- only equity's Hedging leg is
+    /// special-cased.
+    #[tokio::test]
+    async fn usdc_contributes_to_capital_at_every_location() {
+        let pool = setup_test_db().await;
+        for (location, available) in [
+            ("market_making", "1000"),
+            ("hedging", "2000"),
+            ("ethereum_wallet", "300"),
+            ("base_wallet_unwrapped", "40"),
+        ] {
+            insert_row(
+                &pool,
+                "2026-07-18",
+                location,
+                "USDC",
+                available,
+                Some("1"),
+                Some("2026-07-18T04:05:00+00:00"),
+            )
+            .await;
+        }
+
+        let days = load_portfolio_days(&pool, EtDayRange::default())
+            .await
+            .unwrap();
+
+        assert_eq!(days.len(), 1);
+        match &days[0].capital {
+            DayCapital::Included(total_usd) => {
+                assert!(total_usd.eq(usd(3340)).unwrap(), "got {total_usd:?}");
+            }
+            DayCapital::Excluded(reason) => panic!("expected day to be included, got {reason:?}"),
+        }
+    }
+
+    fn included_day(day: NaiveDate, total: i64) -> PortfolioDay {
+        PortfolioDay {
+            et_day: day,
+            capital: DayCapital::Included(usd(total)),
+        }
+    }
+
+    fn day(offset: u64) -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 7, 14)
+            .unwrap()
+            .checked_add_days(Days::new(offset))
+            .unwrap()
+    }
+
+    #[test]
+    fn capital_summary_hand_computed_two_day_average_and_annualized_return() {
+        let days = vec![included_day(day(0), 1000), included_day(day(1), 2000)];
+        let query_range = EtDayRange {
+            from: Some(day(0)),
+            to: Some(day(1)),
+        };
+
+        let summary = capital_summary(&days, usd(30), query_range).unwrap();
+
+        assert_eq!(summary.sample_days, 2);
+        assert_eq!(summary.coverage_days, Some(2));
+        assert_eq!(summary.first_snapshot_day, Some(day(0)));
+        assert_eq!(summary.last_snapshot_day, Some(day(1)));
+        assert!(
+            summary
+                .average_deployed_capital_usd
+                .unwrap()
+                .eq(usd(1500))
+                .unwrap()
+        );
+        assert!(summary.annualized_return_pct.unwrap().eq(usd(365)).unwrap());
+        assert!(summary.warnings.is_empty());
+    }
+
+    #[test]
+    fn capital_summary_hand_computed_five_day_average_and_annualized_return() {
+        let totals = [800, 900, 1000, 1100, 1200];
+        let days: Vec<_> = totals
+            .iter()
+            .enumerate()
+            .map(|(offset, total)| included_day(day(offset as u64), *total))
+            .collect();
+        let query_range = EtDayRange {
+            from: Some(day(0)),
+            to: Some(day(4)),
+        };
+
+        let summary = capital_summary(&days, usd(50), query_range).unwrap();
+
+        assert_eq!(summary.sample_days, 5);
+        assert_eq!(summary.coverage_days, Some(5));
+        assert!(
+            summary
+                .average_deployed_capital_usd
+                .unwrap()
+                .eq(usd(1000))
+                .unwrap()
+        );
+        assert!(summary.annualized_return_pct.unwrap().eq(usd(365)).unwrap());
+    }
+
+    /// `capital_summary` itself emits no warning for the zero-snapshot-rows
+    /// case; `CAPITAL_UNAVAILABLE_NOTE` is added one layer up, by
+    /// `apply_capital_summary` (`src/dashboard/pnl/source.rs`), which this
+    /// test does not exercise.
+    #[test]
+    fn capital_summary_zero_included_days_returns_none_without_a_warning() {
+        let summary = capital_summary(&[], usd(0), EtDayRange::default()).unwrap();
+
+        assert!(summary.average_deployed_capital_usd.is_none());
+        assert!(summary.annualized_return_pct.is_none());
+        assert_eq!(summary.coverage_days, None);
+        assert_eq!(summary.sample_days, 0);
+        assert_eq!(summary.first_snapshot_day, None);
+        assert_eq!(summary.last_snapshot_day, None);
+        assert_eq!(summary.warnings, Vec::<String>::new());
+    }
+
+    #[test]
+    fn capital_summary_single_included_day_reports_average_but_no_annualized_figure() {
+        let days = vec![included_day(day(0), 1000)];
+
+        let summary = capital_summary(&days, usd(10), EtDayRange::default()).unwrap();
+
+        assert_eq!(summary.sample_days, 1);
+        assert_eq!(summary.coverage_days, Some(1));
+        assert!(
+            summary
+                .average_deployed_capital_usd
+                .unwrap()
+                .eq(usd(1000))
+                .unwrap()
+        );
+        assert!(summary.annualized_return_pct.is_none());
+        assert_eq!(summary.warnings.len(), 1);
+        assert!(summary.warnings[0].contains("Annualized return on capital requires"));
+    }
+
+    #[test]
+    fn capital_summary_average_capital_zero_returns_none_without_dividing() {
+        let days = vec![included_day(day(0), 0), included_day(day(1), 0)];
+
+        let summary = capital_summary(&days, usd(10), EtDayRange::default()).unwrap();
+
+        assert!(summary.average_deployed_capital_usd.is_none());
+        assert!(summary.annualized_return_pct.is_none());
+        assert_eq!(summary.coverage_days, Some(2));
+        assert_eq!(summary.sample_days, 2);
+        assert_eq!(summary.warnings.len(), 1);
+        assert!(summary.warnings[0].contains("is zero"));
+    }
+
+    #[test]
+    fn capital_summary_missing_mark_and_stale_mark_produce_distinct_warnings() {
+        let stale_at = Utc.with_ymd_and_hms(2026, 7, 1, 4, 5, 0).unwrap();
+        let days = vec![
+            PortfolioDay {
+                et_day: day(0),
+                capital: DayCapital::Excluded(DayExclusionReason::MissingMark(
+                    PortfolioAsset::Equity(Symbol::new("AAPL").unwrap()),
+                )),
+            },
+            PortfolioDay {
+                et_day: day(1),
+                capital: DayCapital::Excluded(DayExclusionReason::StaleMark(
+                    PortfolioAsset::Equity(Symbol::new("TSLA").unwrap()),
+                    stale_at,
+                )),
+            },
+        ];
+
+        let summary = capital_summary(&days, usd(0), EtDayRange::default()).unwrap();
+
+        assert_eq!(summary.sample_days, 0);
+        assert_eq!(summary.warnings.len(), 2);
+        assert!(summary.warnings[0].contains("no USD mark observed yet for AAPL"));
+        assert!(summary.warnings[1].contains("USD mark for TSLA is stale"));
+    }
+
+    #[test]
+    fn capital_summary_gap_in_coverage_adds_warning_but_still_annualizes() {
+        let days = vec![included_day(day(0), 1000), included_day(day(4), 2000)];
+        let query_range = EtDayRange {
+            from: Some(day(0)),
+            to: Some(day(4)),
+        };
+
+        let summary = capital_summary(&days, usd(30), query_range).unwrap();
+
+        assert_eq!(summary.sample_days, 2);
+        assert_eq!(summary.coverage_days, Some(5));
+        assert!(
+            summary
+                .average_deployed_capital_usd
+                .unwrap()
+                .eq(usd(1500))
+                .unwrap()
+        );
+        assert!(summary.annualized_return_pct.unwrap().eq(usd(146)).unwrap());
+        assert!(
+            summary
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("coverage has gaps"))
+        );
+    }
+
+    /// The realized-PnL numerator is scoped to the caller's whole query
+    /// range, not to snapshot coverage: when the query range extends beyond
+    /// what was actually captured, annualizing by `365 / coverage_days`
+    /// would conflate a wider-period PnL figure with a narrower capital
+    /// sample. Average capital is still reported honestly.
+    #[test]
+    fn capital_summary_omits_annualized_when_query_range_exceeds_snapshot_coverage() {
+        let days = vec![included_day(day(0), 1000), included_day(day(1), 2000)];
+        // Query spans a month before the earliest captured day: realized PnL
+        // over that whole month must not be annualized against the 2-day
+        // coverage denominator.
+        let query_range = EtDayRange {
+            from: Some(day(0).checked_sub_days(Days::new(30)).unwrap()),
+            to: Some(day(1)),
+        };
+
+        let summary = capital_summary(&days, usd(30), query_range).unwrap();
+
+        assert!(
+            summary
+                .average_deployed_capital_usd
+                .unwrap()
+                .eq(usd(1500))
+                .unwrap(),
+            "average deployed capital must still be reported"
+        );
+        assert!(summary.annualized_return_pct.is_none());
+        assert!(
+            summary
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("does not span the full query range"))
+        );
+    }
+
+    /// The mirror case: when snapshot coverage fully spans the query range,
+    /// annualization proceeds as usual.
+    #[test]
+    fn capital_summary_annualizes_when_coverage_fully_spans_query_range() {
+        let days = vec![included_day(day(0), 1000), included_day(day(1), 2000)];
+        let query_range = EtDayRange {
+            from: Some(day(0)),
+            to: Some(day(1)),
+        };
+
+        let summary = capital_summary(&days, usd(30), query_range).unwrap();
+
+        assert!(summary.annualized_return_pct.unwrap().eq(usd(365)).unwrap());
+    }
+
+    /// Boundary of `is_stale_mark`: exactly `MARK_STALENESS_THRESHOLD_DAYS`
+    /// old must stay fresh (included); one day older must flip to stale
+    /// (excluded).
+    #[tokio::test]
+    async fn load_portfolio_days_mark_staleness_boundary() {
+        let pool = setup_test_db().await;
+        let et_day_value = "2026-07-18";
+        let fresh_mark = "2026-07-11T04:05:00+00:00"; // exactly 7 days old
+        let stale_mark = "2026-07-10T04:05:00+00:00"; // 8 days old
+
+        insert_row(
+            &pool,
+            et_day_value,
+            "market_making",
+            "AAPL",
+            "2",
+            Some("50"),
+            Some(fresh_mark),
+        )
+        .await;
+
+        let days = load_portfolio_days(&pool, EtDayRange::default())
+            .await
+            .unwrap();
+        assert_eq!(days.len(), 1);
+        match &days[0].capital {
+            DayCapital::Included(_) => {}
+            DayCapital::Excluded(reason) => {
+                panic!("expected exactly-7-day-old mark to stay fresh, got {reason:?}")
+            }
+        }
+
+        sqlx::query("DELETE FROM portfolio_snapshot WHERE et_day = ?")
+            .bind(et_day_value)
+            .execute(&pool)
+            .await
+            .unwrap();
+        insert_row(
+            &pool,
+            et_day_value,
+            "market_making",
+            "AAPL",
+            "2",
+            Some("50"),
+            Some(stale_mark),
+        )
+        .await;
+
+        let days = load_portfolio_days(&pool, EtDayRange::default())
+            .await
+            .unwrap();
+        assert_eq!(days.len(), 1);
+        match &days[0].capital {
+            DayCapital::Excluded(DayExclusionReason::StaleMark(..)) => {}
+            other => panic!("expected an 8-day-old mark to be excluded as stale, got {other:?}"),
+        }
+    }
+
+    /// A mark timestamped in the evening ET window has a UTC calendar date
+    /// one day ahead of its true ET calendar day. Comparing that raw UTC
+    /// date against `et_day` (as `.date_naive()` did before this fix) would
+    /// shrink the computed age by a day, letting a mark that is genuinely 8
+    /// ET-calendar-days old pass as only 7 days old (still fresh). This test
+    /// would fail under that UTC/ET mismatch.
+    #[test]
+    fn is_stale_mark_uses_et_calendar_day_not_utc_calendar_day() {
+        let et_day = NaiveDate::from_ymd_opt(2026, 7, 18).unwrap();
+        let asset = PortfolioAsset::Equity(Symbol::new("AAPL").unwrap());
+
+        // 2026-07-10T23:00:00 EDT (UTC-4) = 2026-07-11T03:00:00Z: the UTC
+        // calendar date (07-11) is 7 days before et_day, but the true ET
+        // calendar day (07-10) is 8 days before -- past the threshold.
+        let mark_captured_at = Utc.with_ymd_and_hms(2026, 7, 11, 3, 0, 0).unwrap();
+
+        assert!(
+            is_stale_mark(&asset, mark_captured_at, et_day),
+            "a mark whose true ET day is 8 days before et_day must be stale, even though its \
+             UTC calendar date is only 7 days before et_day"
+        );
+    }
+}


### PR DESCRIPTION
## What

[RAI-1457](https://linear.app/makeitrain/issue/RAI-1457/persist-daily-portfolio-snapshots-so-pnl-can-report-return-on-capital), part 2 of 2.

- Add a `capital` block to `/pnl`.
- Report average deployed capital, annualized return, coverage, and sample dates.
- Add the matching `PnlCapitalSummary` TypeScript type.
- Count positive Alpaca equity as deployed inventory.

## Why

- Realized profit and loss is not a return metric without the capital used to earn it.
- Venue allocation must not change the denominator when a counter-trade moves inventory between Alpaca and Raindex.

## How

- Deployed capital sums cash everywhere and positive equity everywhere.
- Negative broker equity contributes zero because short margin is not modeled.
- One missing or stale mark excludes the whole day.
- Annualization requires at least two sample days and full query-range coverage.
- Symbol filters and historical `as_of_rowid` queries omit capital with an explicit warning.
- The report passes its numeric net profit directly into the return calculation.

## Testing

- 22 capital read-model tests pass, including venue-allocation invariance.
- 84 `/pnl` tests and the persisted-snapshot endpoint test pass.
- Workspace check, Clippy, formatting, nixfmt, and changed-file hooks pass.

## Screenshots

None, this PR changes the API response only.

## Anything else

- The snapshot table is live and is not watermarked to historical event row IDs.
- A negative broker position needs a new margin model if Alpaca short-selling is added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PnL reports now include average deployed capital, coverage and sample days, snapshot date range, and annualized return on capital when sufficient data is available.
  * Capital metrics are calculated from persisted portfolio snapshots, including support for date ranges and daylight-saving-time transitions.
* **Bug Fixes**
  * Improved handling of missing or outdated price marks, historical report views, and symbol-filtered queries with clear availability warnings.
  * PnL failures now return consistent server-error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->