### PR TITLE
fix: preserve dashboard trade protocol compatibility

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4111,6 +4111,20 @@ multiple broker-specific contexts.
    history unavailable. Terminal outcomes appear in both initial history and
    live dashboard updates.
 
+   Dashboard trade messages remain compatible during rolling deploys. The
+   canonical protocol sends every terminal outcome as `trade_update`. Filled
+   outcomes also carry the legacy `filledAt` timestamp field and are broadcast
+   as a legacy `trade_fill`, so an older dashboard connected to a newer backend
+   continues to receive fills. Snapshot, HTTP, and live protocols default to
+   legacy filled-only behavior; a newer dashboard opts into terminal outcomes
+   with `trade_protocol=terminal_outcomes_v1`. Old backends ignore that query
+   parameter. A newer dashboard accepts legacy `trade_fill` messages and legacy
+   snapshot/HTTP trade rows, normalizing them to a filled outcome before merging
+   by trade ID. Failed outcomes are sent only through the canonical protocol.
+   Trade ordering compares the complete RFC 3339 timestamp, including
+   sub-millisecond precision, then uses the same stable trade-ID tie-breaker for
+   initial history and live updates.
+
 5. **Live Events**: Real-time domain event stream (aggregate type, ID, sequence,
    event type, timestamp). Starts empty, populates via WebSocket.
 

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -55,6 +55,7 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
     CounterTrading::export_all_to(out_dir)?;
     WalletSettings::export_all_to(out_dir)?;
     Trade::export_all_to(out_dir)?;
+    LegacyTrade::export_all_to(out_dir)?;
     TradeOutcome::export_all_to(out_dir)?;
     Position::export_all_to(out_dir)?;
     SymbolInventory::export_all_to(out_dir)?;

--- a/crates/dto/src/statement.rs
+++ b/crates/dto/src/statement.rs
@@ -10,7 +10,7 @@ use ts_rs::TS;
 
 use crate::inventory::InventorySnapshot;
 use crate::transfer::TransferOperation;
-use crate::{CurrentState, Position, Trade};
+use crate::{CurrentState, LegacyTrade, Position, Trade};
 
 /// Server-to-client WebSocket statements.
 ///
@@ -29,6 +29,7 @@ use crate::{CurrentState, Position, Trade};
 pub enum Statement {
     CurrentState(Box<CurrentState>),
     TradeUpdate(Trade),
+    TradeFill(LegacyTrade),
     PositionUpdate(Position),
     InventorySnapshot(Box<InventorySnapshot>),
     TransferUpdate(TransferOperation),
@@ -102,6 +103,7 @@ mod tests {
             &[
                 "current_state",
                 "trade_update",
+                "trade_fill",
                 "position_update",
                 "inventory_snapshot",
                 "transfer_update"

--- a/crates/dto/src/trade.rs
+++ b/crates/dto/src/trade.rs
@@ -1,7 +1,8 @@
 //! Trade fill DTOs for completed onchain and offchain trades.
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Serialize, Serializer};
 use ts_rs::TS;
 
 use st0x_finance::{FractionalShares, NonNegative, Symbol};
@@ -142,12 +143,12 @@ pub enum TradeOutcome {
 }
 
 /// A completed onchain fill or terminal offchain counter-trade.
-#[derive(Debug, Clone, Serialize, TS)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, TS)]
 pub struct Trade {
     /// Unique identifier for deduplication on reconnect.
     /// Onchain: `"tx_hash:log_index"`. Offchain: offchain order aggregate ID.
     pub id: String,
+    #[ts(rename = "occurredAt")]
     pub occurred_at: DateTime<Utc>,
     pub venue: TradingVenue,
     pub direction: Direction,
@@ -160,6 +161,61 @@ pub struct Trade {
     #[ts(type = "string")]
     pub shares: FractionalShares,
     pub outcome: TradeOutcome,
+}
+
+impl Serialize for Trade {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let is_filled = matches!(self.outcome, TradeOutcome::Filled);
+        let mut trade = serializer.serialize_struct("Trade", 7 + usize::from(is_filled))?;
+        trade.serialize_field("id", &self.id)?;
+        trade.serialize_field("occurredAt", &self.occurred_at)?;
+        if is_filled {
+            trade.serialize_field("filledAt", &self.occurred_at)?;
+        }
+        trade.serialize_field("venue", &self.venue)?;
+        trade.serialize_field("direction", &self.direction)?;
+        trade.serialize_field("symbol", &self.symbol)?;
+        trade.serialize_field("shares", &self.shares)?;
+        trade.serialize_field("outcome", &self.outcome)?;
+        trade.end()
+    }
+}
+
+/// Filled-trade wire shape consumed by dashboard versions before terminal
+/// outcomes were added to [`Trade`].
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyTrade {
+    pub id: String,
+    pub filled_at: DateTime<Utc>,
+    pub venue: TradingVenue,
+    pub direction: Direction,
+    #[ts(type = "string")]
+    pub symbol: Symbol,
+    #[ts(type = "string")]
+    pub shares: FractionalShares,
+}
+
+impl Trade {
+    /// Returns the pre-terminal-outcome representation for filled trades.
+    #[must_use]
+    pub fn legacy_fill(&self) -> Option<LegacyTrade> {
+        if !matches!(self.outcome, TradeOutcome::Filled) {
+            return None;
+        }
+
+        Some(LegacyTrade {
+            id: self.id.clone(),
+            filled_at: self.occurred_at,
+            venue: self.venue,
+            direction: self.direction,
+            symbol: self.symbol.clone(),
+            shares: self.shares,
+        })
+    }
 }
 
 /// Sorts dashboard trades newest-first with a stable cross-loader tie-breaker.
@@ -233,6 +289,7 @@ mod tests {
         assert_eq!(json["symbol"], json!("TSLA"));
         assert_eq!(json["shares"], json!("5.5"));
         assert_eq!(json["occurredAt"], json!("2023-11-14T22:13:20Z"));
+        assert_eq!(json["filledAt"], json!("2023-11-14T22:13:20Z"));
         assert_eq!(json["outcome"], json!({ "status": "filled" }));
     }
 
@@ -263,6 +320,10 @@ mod tests {
                 "remainingShares": "0.75",
                 "excessShares": "0"
             })
+        );
+        assert!(
+            json.get("filledAt").is_none(),
+            "failed outcomes must not masquerade as legacy fills"
         );
     }
 
@@ -295,6 +356,33 @@ mod tests {
                 format!("{tx_hash}:2"),
                 "older".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn newest_first_sort_preserves_sub_millisecond_precision_and_fallback_ties() {
+        let earlier = DateTime::from_timestamp(1_700_000_000, 123_456_788).unwrap();
+        let later = DateTime::from_timestamp(1_700_000_000, 123_456_789).unwrap();
+        let trade = |id: &str, occurred_at| Trade {
+            id: id.to_string(),
+            occurred_at,
+            venue: TradingVenue::Alpaca,
+            direction: Direction::Buy,
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: FractionalShares::new(float!(1)),
+            outcome: TradeOutcome::Filled,
+        };
+        let mut trades = vec![
+            trade("z-tied", earlier),
+            trade("later", later),
+            trade("a-tied", earlier),
+        ];
+
+        sort_trades_newest_first(&mut trades);
+
+        assert_eq!(
+            trades.into_iter().map(|trade| trade.id).collect::<Vec<_>>(),
+            ["later", "a-tied", "z-tied"]
         );
     }
 }

--- a/dashboard/src/lib/components/trade-history-panel.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.svelte
@@ -6,6 +6,7 @@
   import HoverTooltip from '$lib/components/hover-tooltip.svelte'
   import CliCommandBlock from '$lib/components/cli-command-block.svelte'
   import type { Position } from '$lib/api/Position'
+  import type { LegacyTrade } from '$lib/api/LegacyTrade'
   import type { Trade } from '$lib/api/Trade'
   import type { TradingVenue } from '$lib/api/TradingVenue'
   import TradeOutcomeView from '$lib/components/trade-outcome.svelte'
@@ -21,7 +22,7 @@
   import { formatDecimal } from '$lib/decimal'
   import { equityUsdTooltip } from '$lib/inventory-value'
   import { tradeRecoveryCommands } from '$lib/transfer'
-  import { mergeTradeHistory, type TradeHistoryFilter } from '$lib/trade'
+  import { mergeTradeHistory, normalizeTrade, type TradeHistoryFilter } from '$lib/trade'
 
   type TradeEvent = {
     step: string
@@ -32,7 +33,7 @@
   type TradeEntry = Trade
 
   type TradeResponse = {
-    entries: TradeEntry[]
+    entries: Array<TradeEntry | LegacyTrade>
     total: number
     hasMore: boolean
   }
@@ -105,7 +106,8 @@
   const buildParams = (limit = PAGE_SIZE, requestOffset = offset.current): URLSearchParams => {
     const params = new URLSearchParams({
       limit: String(limit),
-      offset: String(requestOffset)
+      offset: String(requestOffset),
+      trade_protocol: 'terminal_outcomes_v1'
     })
 
     if (selectedVenues.current.size > 0 && selectedVenues.current.size < ALL_VENUES.length) {
@@ -191,7 +193,8 @@
         return
       }
 
-      const data: TradeResponse = (await response.json()) as TradeResponse
+      const wireData: TradeResponse = (await response.json()) as TradeResponse
+      const data = { ...wireData, entries: wireData.entries.map(normalizeTrade) }
       if (requestVersion !== historyRequestVersion) return
 
       const merged = isLoadMore ? [...entries.current, ...data.entries] : data.entries

--- a/dashboard/src/lib/components/trade-history-panel.test.ts
+++ b/dashboard/src/lib/components/trade-history-panel.test.ts
@@ -3,6 +3,7 @@
 import { QueryClient } from '@tanstack/svelte-query'
 import { mount, tick, unmount } from 'svelte'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { LegacyTrade } from '$lib/api/LegacyTrade'
 import type { Statement } from '$lib/api/Statement'
 import type { Trade } from '$lib/api/Trade'
 import { createWebSocket } from '$lib/websocket'
@@ -73,7 +74,7 @@ const setupTestWebSocket = () => {
   }
 }
 
-const tradeResponse = (entries: Trade[], total: number, hasMore = false): Response =>
+const tradeResponse = (entries: Array<Trade | LegacyTrade>, total: number, hasMore = false): Response =>
   new Response(JSON.stringify({ entries, total, hasMore }), {
     status: 200,
     headers: { 'content-type': 'application/json' }
@@ -96,6 +97,29 @@ const mountPanel = () => {
 describe('TradeHistoryPanel', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('normalizes legacy REST fills from an old server', async () => {
+    const legacyTrade: LegacyTrade = {
+      id: 'legacy-rest-fill',
+      filledAt: '2026-01-01T00:00:00.123456789Z',
+      venue: 'alpaca',
+      direction: 'sell',
+      symbol: 'TSLA',
+      shares: '2'
+    }
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(tradeResponse([legacyTrade], 1))))
+
+    const { target, component } = mountPanel()
+
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('TSLA')
+      expect(target.textContent).toContain('Filled')
+      expect(target.textContent).toContain('1 of 1')
+    })
+
+    await unmount(component)
+    target.remove()
   })
 
   it('renders initial failures and replaces live rows with an authoritative total', async () => {
@@ -158,6 +182,10 @@ describe('TradeHistoryPanel', () => {
     })
 
     expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('limit=100'), expect.any(Object))
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('trade_protocol=terminal_outcomes_v1'),
+      expect.any(Object)
+    )
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
     connection.disconnect()

--- a/dashboard/src/lib/trade.test.ts
+++ b/dashboard/src/lib/trade.test.ts
@@ -130,4 +130,18 @@ describe('live trade history', () => {
       })
     ).toEqual([log10, log2])
   })
+
+  it('preserves sub-millisecond RFC 3339 ordering', () => {
+    const earlier = trade({ id: 'a-earlier', occurredAt: '2026-01-01T00:00:00.123456788Z' })
+    const later = trade({ id: 'z-later', occurredAt: '2026-01-01T00:00:00.123456789Z' })
+
+    expect(
+      mergeTradeHistory([earlier], [later], {
+        venues: new Set(['alpaca']),
+        symbols: new Set(),
+        since: null,
+        until: null
+      })
+    ).toEqual([later, earlier])
+  })
 })

--- a/dashboard/src/lib/trade.ts
+++ b/dashboard/src/lib/trade.ts
@@ -1,9 +1,24 @@
 import type { Trade } from '$lib/api/Trade'
 import type { TradeOutcome } from '$lib/api/TradeOutcome'
 import type { TradingVenue } from '$lib/api/TradingVenue'
+import type { LegacyTrade } from '$lib/api/LegacyTrade'
 import { matcher } from '$lib/fp'
 
 const matchOutcome = matcher<TradeOutcome>()('status')
+
+export const normalizeTrade = (trade: Trade | LegacyTrade): Trade => {
+  if ('occurredAt' in trade) return trade
+
+  return {
+    id: trade.id,
+    occurredAt: trade.filledAt,
+    venue: trade.venue,
+    direction: trade.direction,
+    symbol: trade.symbol,
+    shares: trade.shares,
+    outcome: { status: 'filled' }
+  }
+}
 
 export const tradeOutcomeLabel = (outcome: TradeOutcome): string =>
   matchOutcome(outcome, {
@@ -64,6 +79,39 @@ const parseOnchainTradeId = (id: string): { txHash: string; logIndex: bigint } |
 const compareStrings = (left: string, right: string): number =>
   left < right ? -1 : left > right ? 1 : 0
 
+type UtcTimestampParts = {
+  wholeSeconds: number
+  fraction: string
+}
+
+const parseUtcTimestamp = (timestamp: string): UtcTimestampParts | null => {
+  const match = /^(.*:\d{2})(?:\.(\d+))?Z$/.exec(timestamp)
+  if (match === null) return null
+
+  const [, wholeTimestamp, fraction = ''] = match
+  if (wholeTimestamp === undefined) return null
+
+  const wholeSeconds = Date.parse(`${wholeTimestamp}Z`)
+  return Number.isNaN(wholeSeconds) ? null : { wholeSeconds, fraction }
+}
+
+const compareRfc3339Timestamps = (left: string, right: string): number => {
+  const leftParts = parseUtcTimestamp(left)
+  const rightParts = parseUtcTimestamp(right)
+  if (leftParts !== null && rightParts !== null) {
+    const secondsComparison = leftParts.wholeSeconds - rightParts.wholeSeconds
+    if (secondsComparison !== 0) return secondsComparison
+
+    const precision = Math.max(leftParts.fraction.length, rightParts.fraction.length)
+    return compareStrings(
+      leftParts.fraction.padEnd(precision, '0'),
+      rightParts.fraction.padEnd(precision, '0')
+    )
+  }
+
+  return Date.parse(left) - Date.parse(right)
+}
+
 const compareTradeIds = (left: Trade, right: Trade): number => {
   if (left.venue === 'raindex' && right.venue === 'raindex') {
     const leftId = parseOnchainTradeId(left.id)
@@ -76,6 +124,9 @@ const compareTradeIds = (left: Trade, right: Trade): number => {
   return compareStrings(left.id, right.id)
 }
 
+export const compareTradesNewestFirst = (left: Trade, right: Trade): number =>
+  compareRfc3339Timestamps(right.occurredAt, left.occurredAt) || compareTradeIds(left, right)
+
 export const mergeTradeHistory = (
   current: Trade[],
   live: Trade[],
@@ -86,8 +137,5 @@ export const mergeTradeHistory = (
 
   return [...byId.values()]
     .filter((trade) => matchesHistoryFilter(trade, filter))
-    .sort(
-      (left, right) =>
-        Date.parse(right.occurredAt) - Date.parse(left.occurredAt) || compareTradeIds(left, right)
-    )
+    .sort(compareTradesNewestFirst)
 }

--- a/dashboard/src/lib/websocket/connection.svelte.test.ts
+++ b/dashboard/src/lib/websocket/connection.svelte.test.ts
@@ -271,6 +271,96 @@ describe('createWebSocket', () => {
       expect(trades[1]?.symbol).toBe('TSLA')
     })
 
+    it('normalizes legacy fills from an old server snapshot', () => {
+      const { getInstance } = setupWebSocketTest()
+      const queryClient = createMockQueryClient()
+      const ws = createWebSocket(WS_URL, queryClient)
+
+      ws.connect()
+      getInstance(0).simulateOpen()
+      getInstance(0).simulateRawMessage(
+        JSON.stringify({
+          type: 'current_state',
+          data: {
+            trades: [
+              {
+                id: 'legacy-snapshot',
+                filledAt: '2024-01-01T12:00:00.123456789Z',
+                venue: 'alpaca',
+                direction: 'sell',
+                symbol: 'TSLA',
+                shares: '2'
+              }
+            ],
+            inventory: {
+              perSymbol: [],
+              usdc: {
+                onchainAvailable: '0',
+                onchainInflight: '0',
+                offchainAvailable: '0',
+                offchainInflight: '0',
+                offchainGross: null,
+                withdrawableCash: null,
+                alpacaUsdc: null,
+                inflightCash: { ethereumWallet: null, baseWallet: null }
+              }
+            },
+            positions: [],
+            settings: {},
+            activeTransfers: [],
+            recentTransfers: [],
+            warnings: []
+          }
+        })
+      )
+
+      expect(queryClient.cache.get('["trades"]')).toEqual([
+        {
+          id: 'legacy-snapshot',
+          occurredAt: '2024-01-01T12:00:00.123456789Z',
+          venue: 'alpaca',
+          direction: 'sell',
+          symbol: 'TSLA',
+          shares: '2',
+          outcome: { status: 'filled' }
+        }
+      ])
+    })
+
+    it('accepts legacy live fills from an old server', () => {
+      const { getInstance } = setupWebSocketTest()
+      const queryClient = createMockQueryClient()
+      const ws = createWebSocket(WS_URL, queryClient)
+
+      ws.connect()
+      getInstance(0).simulateOpen()
+      getInstance(0).simulateRawMessage(
+        JSON.stringify({
+          type: 'trade_fill',
+          data: {
+            id: 'legacy-live',
+            filledAt: '2024-01-01T12:00:00.123456789Z',
+            venue: 'raindex',
+            direction: 'buy',
+            symbol: 'AAPL',
+            shares: '1'
+          }
+        })
+      )
+
+      expect(queryClient.cache.get('["trades"]')).toEqual([
+        {
+          id: 'legacy-live',
+          occurredAt: '2024-01-01T12:00:00.123456789Z',
+          venue: 'raindex',
+          direction: 'buy',
+          symbol: 'AAPL',
+          shares: '1',
+          outcome: { status: 'filled' }
+        }
+      ])
+    })
+
     it('replaces a matching initial trade with its live update', () => {
       const { getInstance } = setupWebSocketTest()
       const queryClient = new QueryClient({
@@ -311,7 +401,10 @@ describe('createWebSocket', () => {
       )
       queryClient.cache.set('["trades"]', existing)
 
-      const newTrade = makeTrade({ symbol: 'NEW' })
+      const newTrade = makeTrade({
+        symbol: 'NEW',
+        occurredAt: '2024-01-01T12:00:01Z'
+      })
       getInstance(0).simulateMessage({ type: 'trade_update', data: newTrade })
 
       const trades = queryClient.cache.get('["trades"]') as Trade[]

--- a/dashboard/src/lib/websocket/connection.svelte.ts
+++ b/dashboard/src/lib/websocket/connection.svelte.ts
@@ -16,6 +16,12 @@ type ConnectionEvent = 'connect' | 'open' | 'close' | 'error' | 'disconnect'
 const RECONNECT_DELAY_MS = 1000
 const MAX_RECONNECT_DELAY_MS = 10000
 
+const withTradeProtocol = (url: string): string => {
+  const protocolUrl = new URL(url)
+  protocolUrl.searchParams.set('trade_protocol', 'terminal_outcomes_v1')
+  return protocolUrl.toString()
+}
+
 const getReconnectDelay = (attempts: number): number =>
   Math.min(RECONNECT_DELAY_MS * Math.pow(2, attempts), MAX_RECONNECT_DELAY_MS)
 
@@ -25,6 +31,7 @@ export type ErrorContext = {
 }
 
 export const createWebSocket = (url: string, queryClient: QueryClient) => {
+  const protocolUrl = withTradeProtocol(url)
   let socket: WebSocket | null = null
   let reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null
   const reconnectAttempts = reactive(0)
@@ -40,6 +47,8 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
 
       trade_update: ({ data }) => { appendTrade(queryClient, data); },
 
+      trade_fill: ({ data }) => { appendTrade(queryClient, data); },
+
       position_update: ({ data }) => { upsertPosition(queryClient, data); },
 
       inventory_snapshot: ({ data }) => { updateSnapshot(queryClient, data); },
@@ -49,10 +58,10 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
   }
 
   const createSocket = () => {
-    socket = new WebSocket(url)
+    socket = new WebSocket(protocolUrl)
 
     socket.onopen = () => {
-      if (import.meta.env.DEV) console.log(`[ws] connected to ${url}`)
+      if (import.meta.env.DEV) console.log(`[ws] connected to ${protocolUrl}`)
       fsm.send('open')
     }
 

--- a/dashboard/src/lib/websocket/trades.ts
+++ b/dashboard/src/lib/websocket/trades.ts
@@ -1,15 +1,22 @@
 import type { QueryClient } from '@tanstack/svelte-query'
 import type { CurrentState } from '$lib/api/CurrentState'
+import type { LegacyTrade } from '$lib/api/LegacyTrade'
 import type { Trade } from '$lib/api/Trade'
+import { compareTradesNewestFirst, normalizeTrade } from '$lib/trade'
 
 const MAX_TRADES = 100
 
 export const seedTrades = (queryClient: QueryClient, state: CurrentState) => {
-  queryClient.setQueryData<Trade[]>(['trades'], state.trades)
+  queryClient.setQueryData<Trade[]>(
+    ['trades'],
+    state.trades.map(normalizeTrade).sort(compareTradesNewestFirst)
+  )
 }
 
-export const appendTrade = (queryClient: QueryClient, trade: Trade) => {
-  queryClient.setQueryData<Trade[]>(['trades'], (old) =>
-    [trade, ...(old ?? []).filter((existing) => existing.id !== trade.id)].slice(0, MAX_TRADES)
-  )
+export const appendTrade = (queryClient: QueryClient, wireTrade: Trade | LegacyTrade) => {
+  const trade = normalizeTrade(wireTrade)
+  queryClient.setQueryData<Trade[]>(['trades'], (old) => {
+    const merged = [trade, ...(old ?? []).filter((existing) => existing.id !== trade.id)]
+    return merged.sort(compareTradesNewestFirst).slice(0, MAX_TRADES)
+  })
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -26,6 +26,7 @@ use st0x_execution::{FractionalShares, Symbol};
 use st0x_tokenization::IssuerRequestId;
 
 use crate::AppState;
+use crate::dashboard::TradeProtocol;
 use crate::dashboard::pnl::{
     PnlError, PnlQuery, PnlResponse, build_pnl_report, validate_pnl_snapshot_rowid,
 };
@@ -545,6 +546,8 @@ struct TradesQuery {
     venue: Option<String>,
     since: Option<String>,
     until: Option<String>,
+    #[serde(default)]
+    trade_protocol: TradeProtocol,
 }
 
 /// Paginated trade history from both onchain and offchain fills.
@@ -573,6 +576,9 @@ async fn trades(
         .await
         .inspect_err(|error| warn!(target: "dashboard", ?error, "Failed to load trade history"))
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    if query.trade_protocol == TradeProtocol::LegacyFills {
+        all_trades.retain(|trade| matches!(trade.outcome, TradeOutcome::Filled));
+    }
     sort_trades_newest_first(&mut all_trades);
 
     let total = all_trades.len();
@@ -1958,6 +1964,14 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
+        let filled_view_id = "00000000-0000-0000-0000-000000000140";
+        let filled_payload = r#"{"Live":{"Filled":{"symbol":"AAPL","shares":"2","direction":"Sell","executor":"AlpacaBrokerApi","executor_order_id":"broker-fill","price":"100","placed_at":"2026-01-01T00:00:00Z","submitted_at":"2026-01-01T00:00:00Z","filled_at":"2026-01-01T00:00:00.123456789Z"}}}"#;
+        sqlx::query("INSERT INTO offchain_order_view (view_id, version, payload) VALUES (?, 1, ?)")
+            .bind(filled_view_id)
+            .bind(filled_payload)
+            .execute(&pool)
+            .await
+            .unwrap();
 
         let entries = load_offchain_trade_rows(
             &pool,
@@ -1971,10 +1985,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].id, view_id);
-        assert_eq!(entries[0].symbol, Symbol::new("SPCX").unwrap());
-        match &entries[0].outcome {
+        assert_eq!(entries.len(), 2);
+        let failed = entries
+            .iter()
+            .find(|trade| trade.id == view_id)
+            .expect("failed trade should be loaded");
+        assert_eq!(failed.symbol, Symbol::new("SPCX").unwrap());
+        match &failed.outcome {
             TradeOutcome::Failed {
                 error,
                 filled_shares,
@@ -2001,10 +2018,38 @@ mod tests {
             TradeOutcome::Filled => panic!("failed projection must remain failed"),
         }
 
-        let response = build_app(state)
+        let legacy_response = build_app(state.clone())
             .oneshot(
                 Request::builder()
                     .uri("/trades")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(legacy_response.status(), StatusCode::OK);
+        let legacy_body: serde_json::Value =
+            serde_json::from_str(&body_to_string(legacy_response).await).unwrap();
+        assert_eq!(legacy_body["total"], 1);
+        assert_eq!(legacy_body["entries"][0]["id"], filled_view_id);
+        assert_eq!(
+            legacy_body["entries"][0]["filledAt"],
+            "2026-01-01T00:00:00.123456789Z"
+        );
+        assert_eq!(legacy_body["entries"][0]["outcome"]["status"], "filled");
+        assert!(
+            legacy_body["entries"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|trade| trade["id"] != view_id),
+            "legacy clients must not receive failed trades"
+        );
+
+        let response = build_app(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/trades?trade_protocol=terminal_outcomes_v1")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -2062,7 +2107,7 @@ mod tests {
         let response = build_app(state)
             .oneshot(
                 Request::builder()
-                    .uri("/trades")
+                    .uri("/trades?trade_protocol=terminal_outcomes_v1")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -41,8 +41,15 @@ impl Broadcaster {
     }
 
     fn broadcast_trade(&self, trade: Trade) {
+        let legacy_fill = trade.legacy_fill();
         if let Err(error) = self.sender.send(Statement::TradeUpdate(trade)) {
             debug!(target: "dashboard", %error, "Failed to broadcast trade update (no receivers)");
+        }
+
+        if let Some(legacy_fill) = legacy_fill
+            && let Err(error) = self.sender.send(Statement::TradeFill(legacy_fill))
+        {
+            debug!(target: "dashboard", %error, "Failed to broadcast legacy trade fill (no receivers)");
         }
     }
 
@@ -244,6 +251,15 @@ mod tests {
             }
             other => panic!("expected TradeUpdate message, got {other:?}"),
         }
+
+        let legacy = receiver.recv().await.expect("should receive legacy fill");
+        let legacy = serde_json::to_value(legacy).expect("legacy fill should serialize");
+        assert_eq!(legacy["type"], "trade_fill");
+        assert_eq!(
+            legacy["data"]["filledAt"],
+            serde_json::to_value(now).expect("timestamp should serialize")
+        );
+        assert!(legacy["data"].get("outcome").is_none());
     }
 
     #[tokio::test]
@@ -320,6 +336,15 @@ mod tests {
             }
             other => panic!("expected TradeUpdate message, got {other:?}"),
         }
+
+        let legacy = receiver.recv().await.expect("should receive legacy fill");
+        let legacy = serde_json::to_value(legacy).expect("legacy fill should serialize");
+        assert_eq!(legacy["type"], "trade_fill");
+        assert_eq!(
+            legacy["data"]["filledAt"],
+            serde_json::to_value(now).expect("timestamp should serialize")
+        );
+        assert!(legacy["data"].get("outcome").is_none());
     }
 
     #[tokio::test]
@@ -429,6 +454,13 @@ mod tests {
             },
             other => panic!("expected TradeUpdate message, got {other:?}"),
         }
+
+        let unexpected =
+            tokio::time::timeout(std::time::Duration::from_millis(10), receiver.recv()).await;
+        assert!(
+            unexpected.is_err(),
+            "failed outcomes must not be broadcast as legacy fills"
+        );
     }
 
     #[tokio::test]

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -1,18 +1,19 @@
 //! WebSocket-based dashboard for real-time server state streaming.
 
 use axum::Router;
-use axum::extract::State;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Query, State};
 use axum::response::IntoResponse;
 use axum::routing::get;
 use futures_util::sink::SinkExt;
 use futures_util::stream::{SplitSink, StreamExt};
+use serde::Deserialize;
 use sqlx::SqlitePool;
 use tokio::sync::broadcast;
 use tracing::{info, trace, warn};
 
 use st0x_config::{ExecutionThreshold, OperationMode};
-use st0x_dto::{CurrentState, Statement, TransferWarning};
+use st0x_dto::{CurrentState, Statement, Trade, TradeOutcome, TransferWarning};
 use st0x_event_sorcery::{load_all_ids, load_entity};
 use st0x_finance::Positive;
 
@@ -25,8 +26,61 @@ mod trade_loader;
 pub(crate) mod transfer_loader;
 pub(crate) use event::Broadcaster;
 
-async fn ws_endpoint(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| handle_socket(socket, state))
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TradeProtocol {
+    #[default]
+    LegacyFills,
+    TerminalOutcomesV1,
+}
+
+impl TradeProtocol {
+    fn includes_trade(self, trade: &Trade) -> bool {
+        match self {
+            Self::LegacyFills => match trade.outcome {
+                TradeOutcome::Filled => true,
+                TradeOutcome::Failed { .. } => false,
+            },
+            Self::TerminalOutcomesV1 => match trade.outcome {
+                TradeOutcome::Filled | TradeOutcome::Failed { .. } => true,
+            },
+        }
+    }
+
+    fn includes_statement(self, statement: &Statement) -> bool {
+        match self {
+            Self::LegacyFills => match statement {
+                Statement::TradeUpdate(_) => false,
+                Statement::CurrentState(_)
+                | Statement::TradeFill(_)
+                | Statement::PositionUpdate(_)
+                | Statement::InventorySnapshot(_)
+                | Statement::TransferUpdate(_) => true,
+            },
+            Self::TerminalOutcomesV1 => match statement {
+                Statement::TradeFill(_) => false,
+                Statement::CurrentState(_)
+                | Statement::TradeUpdate(_)
+                | Statement::PositionUpdate(_)
+                | Statement::InventorySnapshot(_)
+                | Statement::TransferUpdate(_) => true,
+            },
+        }
+    }
+}
+
+#[derive(Default, Deserialize)]
+struct WebSocketQuery {
+    #[serde(default)]
+    trade_protocol: TradeProtocol,
+}
+
+async fn ws_endpoint(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+    Query(query): Query<WebSocketQuery>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_socket(socket, state, query.trade_protocol))
 }
 
 /// Outcome of attempting to send a serialized message over the socket.
@@ -53,16 +107,16 @@ async fn send_json(sink: &mut SplitSink<WebSocket, Message>, value: &Statement) 
     SendOutcome::Sent
 }
 
-async fn handle_socket(socket: WebSocket, state: AppState) {
+async fn handle_socket(socket: WebSocket, state: AppState, trade_protocol: TradeProtocol) {
     let mut receiver = state.event_sender.subscribe();
     let (mut sink, mut stream) = socket.split();
 
-    if !send_initial_state(&mut sink, &state).await {
+    if !send_initial_state(&mut sink, &state, trade_protocol).await {
         return;
     }
 
     tokio::select! {
-        () = stream_broadcasts(&mut sink, &mut receiver) => {}
+        () = stream_broadcasts(&mut sink, &mut receiver, trade_protocol) => {}
         () = drain_client_messages(&mut stream) => {}
     }
 }
@@ -83,11 +137,15 @@ async fn drain_client_messages(stream: &mut futures_util::stream::SplitStream<We
     }
 }
 
-async fn send_initial_state(sink: &mut SplitSink<WebSocket, Message>, state: &AppState) -> bool {
+async fn send_initial_state(
+    sink: &mut SplitSink<WebSocket, Message>,
+    state: &AppState,
+    trade_protocol: TradeProtocol,
+) -> bool {
     let inventory_dto = state.inventory.read().await.to_dto();
     let transfers = transfer_loader::load_transfers(&state.pool).await;
     let mut warnings = transfers.warnings;
-    let trades = match trade_loader::load_trades(&state.pool).await {
+    let mut trades = match trade_loader::load_trades(&state.pool).await {
         Ok(trades) => trades,
         Err(error) => {
             warn!(
@@ -99,6 +157,7 @@ async fn send_initial_state(sink: &mut SplitSink<WebSocket, Message>, state: &Ap
             Vec::new()
         }
     };
+    trades.retain(|trade| trade_protocol.includes_trade(trade));
     let positions = load_positions(&state.pool).await;
 
     let initial = Statement::CurrentState(Box::new(CurrentState {
@@ -123,10 +182,14 @@ async fn send_initial_state(sink: &mut SplitSink<WebSocket, Message>, state: &Ap
 async fn stream_broadcasts(
     sink: &mut SplitSink<WebSocket, Message>,
     receiver: &mut broadcast::Receiver<Statement>,
+    trade_protocol: TradeProtocol,
 ) {
     loop {
         match receiver.recv().await {
             Ok(msg) => {
+                if !trade_protocol.includes_statement(&msg) {
+                    continue;
+                }
                 trace!(target: "dashboard", ?msg, "Broadcasting to dashboard client");
                 match send_json(sink, &msg).await {
                     SendOutcome::Sent => {}
@@ -325,7 +388,10 @@ mod tests {
     use st0x_config::{EquityAssetConfig, create_test_ctx_with_order_owner};
     use st0x_dto::{Direction, Trade, TradingVenue};
     use st0x_event_sorcery::StoreBuilder;
-    use st0x_execution::{ClientOrderId, FractionalShares, Positive, SupportedExecutor, Symbol};
+    use st0x_execution::{
+        ClientOrderId, ExecutorOrderId, FractionalShares, MarketSession, Positive,
+        SupportedExecutor, Symbol, Usd,
+    };
     use st0x_float_macro::float;
 
     use super::*;
@@ -345,6 +411,24 @@ mod tests {
             shares: st0x_finance::FractionalShares::new(st0x_float_macro::float!(1)),
             outcome: st0x_dto::TradeOutcome::Filled,
         })
+    }
+
+    #[test]
+    fn trade_protocol_routes_only_its_trade_statement_version() {
+        let Statement::TradeUpdate(trade) = dummy_fill("AAPL") else {
+            panic!("dummy fill should be a trade update")
+        };
+        let legacy_fill = Statement::TradeFill(
+            trade
+                .legacy_fill()
+                .expect("filled trade should have a legacy representation"),
+        );
+        let trade_update = Statement::TradeUpdate(trade);
+
+        assert!(TradeProtocol::LegacyFills.includes_statement(&legacy_fill));
+        assert!(!TradeProtocol::LegacyFills.includes_statement(&trade_update));
+        assert!(TradeProtocol::TerminalOutcomesV1.includes_statement(&trade_update));
+        assert!(!TradeProtocol::TerminalOutcomesV1.includes_statement(&legacy_fill));
     }
 
     fn empty_settings() -> st0x_dto::Settings {
@@ -593,6 +677,44 @@ mod tests {
             )
             .await
             .unwrap();
+        let filled_id = OffchainOrderId::new();
+        store
+            .send(
+                &filled_id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    shares: Positive::new(FractionalShares::new(float!(2))).unwrap(),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(filled_id.as_uuid()),
+                    kind: CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &filled_id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("broker-fill"),
+                    placed_shares: Positive::new(FractionalShares::new(float!(2))).unwrap(),
+                    submitted_at: chrono::Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &filled_id,
+                OffchainOrderCommand::CompleteFill {
+                    price: Usd::new(float!(100)),
+                    filled_at: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
         store
             .send(
                 &id,
@@ -604,7 +726,26 @@ mod tests {
             .unwrap();
 
         let mut server = start_test_server_with_state(state).await;
-        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
+        let legacy_url = format!("ws://127.0.0.1:{}/api/ws", server.port);
+        let (mut legacy_client, _) = connect_async(&legacy_url).await.unwrap();
+        let legacy_message = legacy_client
+            .next()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_text()
+            .unwrap();
+        let legacy_state: serde_json::Value = serde_json::from_str(&legacy_message).unwrap();
+        assert_eq!(legacy_state["data"]["trades"].as_array().unwrap().len(), 1);
+        let legacy_trade = &legacy_state["data"]["trades"][0];
+        assert_eq!(legacy_trade["id"], filled_id.to_string());
+        assert!(legacy_trade["filledAt"].as_str().is_some());
+        assert_eq!(legacy_trade["outcome"]["status"], "filled");
+
+        let url = format!(
+            "ws://127.0.0.1:{}/api/ws?trade_protocol=terminal_outcomes_v1",
+            server.port
+        );
         let (mut client, _) = connect_async(&url).await.unwrap();
         let message = client.next().await.unwrap().unwrap().into_text().unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
@@ -617,6 +758,46 @@ mod tests {
         assert_eq!(trade["outcome"]["filledShares"], "0");
         assert_eq!(trade["outcome"]["remainingShares"], "1");
         assert_eq!(trade["outcome"]["excessShares"], "0");
+
+        let live_trade = Trade {
+            id: "live-fill".to_string(),
+            occurred_at: chrono::Utc::now(),
+            venue: TradingVenue::Raindex,
+            direction: Direction::Buy,
+            symbol: Symbol::new("TSLA").unwrap(),
+            shares: FractionalShares::new(float!(1)),
+            outcome: TradeOutcome::Filled,
+        };
+        server
+            .event_sender
+            .send(Statement::TradeUpdate(live_trade.clone()))
+            .unwrap();
+        server
+            .event_sender
+            .send(Statement::TradeFill(live_trade.legacy_fill().unwrap()))
+            .unwrap();
+
+        let legacy_live: serde_json::Value = serde_json::from_str(
+            &legacy_client
+                .next()
+                .await
+                .unwrap()
+                .unwrap()
+                .into_text()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(legacy_live["type"], "trade_fill");
+        assert_eq!(legacy_live["data"]["id"], "live-fill");
+        assert!(legacy_live["data"]["filledAt"].as_str().is_some());
+        assert!(legacy_live["data"].get("outcome").is_none());
+
+        let canonical_live: serde_json::Value =
+            serde_json::from_str(&client.next().await.unwrap().unwrap().into_text().unwrap())
+                .unwrap();
+        assert_eq!(canonical_live["type"], "trade_update");
+        assert_eq!(canonical_live["data"]["id"], "live-fill");
+        assert_eq!(canonical_live["data"]["outcome"]["status"], "filled");
 
         server.shutdown().await;
     }
@@ -663,7 +844,10 @@ mod tests {
     #[tokio::test]
     async fn broadcast_message_reaches_connected_clients() {
         let mut server = start_test_server().await;
-        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
+        let url = format!(
+            "ws://127.0.0.1:{}/api/ws?trade_protocol=terminal_outcomes_v1",
+            server.port
+        );
 
         let (mut client1, _) = connect_async(&url)
             .await
@@ -705,7 +889,10 @@ mod tests {
     #[tokio::test]
     async fn client_disconnect_does_not_affect_other_clients() {
         let mut server = start_test_server().await;
-        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
+        let url = format!(
+            "ws://127.0.0.1:{}/api/ws?trade_protocol=terminal_outcomes_v1",
+            server.port
+        );
 
         let (mut client1, _) = connect_async(&url)
             .await
@@ -743,7 +930,10 @@ mod tests {
     #[tokio::test]
     async fn new_client_receives_initial_not_previous_broadcasts() {
         let mut server = start_test_server().await;
-        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
+        let url = format!(
+            "ws://127.0.0.1:{}/api/ws?trade_protocol=terminal_outcomes_v1",
+            server.port
+        );
 
         let (mut client1, _) = connect_async(&url)
             .await


### PR DESCRIPTION
## What

[RAI-1429](https://linear.app/makeitrain/issue/RAI-1429/preserve-dashboard-trade-protocol-compatibility-across-rolling-deploys)

Keeps trade history working across mixed backend/dashboard versions while failed counter-trades roll out.

## Why

RAI-1418 expands the trade payload from fills to terminal outcomes. Without an explicit compatibility contract, an old dashboard can render failures as fills, while a new dashboard can lose fills when connected to an old backend.

## How

- Defaults REST and WebSocket clients to the legacy filled-only protocol.
- Lets the new dashboard opt into `terminal_outcomes_v1`.
- Emits canonical `trade_update` messages plus legacy `trade_fill` messages for fills.
- Normalizes legacy REST, snapshot, and live rows in the new dashboard.
- Uses full RFC 3339 precision and the same deterministic ID tie-breaker in backend and frontend ordering.

## Testing

- Added mixed-version REST and WebSocket snapshot/live coverage in both directions.
- Added sub-millisecond and exact-tie ordering coverage.
- `cargo nextest run -p st0x-dto`
- Focused `st0x-hedge` compatibility tests
- Focused dashboard Vitest suite
- `cargo clippy -p st0x-hedge --all-targets --all-features`
- `bun run check`
- `bun run lint`

## Screenshots

N/A - protocol compatibility only.

## Anything else

Stacked on #1053.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for terminal trade outcomes (including filled and failed) with protocol-aware REST and WebSocket trade messaging.
  - Introduced an opt-in query parameter to enable terminal-outcome trade protocol in newer dashboards.
  - Legacy dashboards continue to receive filled trades in the legacy trade-fill format.

- **Bug Fixes**
  - Trade history normalization now correctly maps legacy payloads to the modern UI.
  - Ordering now preserves sub-millisecond timestamps with stable tie-breaking.
  - Duplicate trades are de-duplicated while maintaining newest-first ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->