### PR TITLE
fix: make terminal trade broadcasts durable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,8 +286,8 @@ create and migrate the local database before any cargo commands.
 **Verifying a migration against real data**: `sqlx db reset -y` only proves a
 migration applies to an empty schema, not that it behaves correctly against real
 prod/staging data or that legacy events still deserialize under current code.
-While developing a migration, run `nix run .#prod-verify-migrations` (or
-`.#staging-verify-migrations`) -- it takes a _consistent_ server-side
+While developing a migration, run `nix run .#prodVerifyMigrations` (or
+`.#stagingVerifyMigrations`) -- it takes a _consistent_ server-side
 `VACUUM INTO` snapshot of the live database (`<env>-db-snapshot` in
 `infra/default.nix`; a plain `scp` of a live WAL-mode SQLite file can race the
 bot's writes and download a torn/corrupt copy, so never `scp` the `.db` file

--- a/SPEC.md
+++ b/SPEC.md
@@ -4125,6 +4125,23 @@ multiple broker-specific contexts.
    sub-millisecond precision, then uses the same stable trade-ID tie-breaker for
    initial history and live updates.
 
+   Terminal trade live updates are delivered through a persistent delivery
+   ledger and job queue, not directly from the CQRS reactor. The ledger is keyed
+   by trade ID. The reactor attempts to register the outcome and idempotently
+   enqueue its delivery job. A supervised handoff monitor retains and retries an
+   outcome when that durable insertion fails while the process remains alive;
+   startup also reconciles the complete authoritative trade history into the
+   ledger and queue, closing the remaining process-crash window between event
+   persistence and job insertion. Before workers start, unfinished and
+   retry-exhausted delivery jobs become pending again. A job records
+   `delivered_at` only after publishing; failure to read or update that durable
+   state uses the standard supervised-worker retry policy, and exhaustion is a
+   fail-stop condition reported through the conductor monitor. Re-delivery is
+   permitted: the dashboard merges trade updates by trade ID, making a retry or
+   crash replay idempotent from the operator's point of view. Publishing with no
+   connected WebSocket receivers is successful because the next connection
+   obtains the same terminal outcome from its initial-state snapshot.
+
 5. **Live Events**: Real-time domain event stream (aggregate type, ID, sequence,
    event type, timestamp). Starts empty, populates via WebSocket.
 

--- a/crates/dto/src/trade.rs
+++ b/crates/dto/src/trade.rs
@@ -143,7 +143,8 @@ pub enum TradeOutcome {
 }
 
 /// A completed onchain fill or terminal offchain counter-trade.
-#[derive(Debug, Clone, TS)]
+#[derive(Debug, Clone, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 pub struct Trade {
     /// Unique identifier for deduplication on reconnect.
     /// Onchain: `"tx_hash:log_index"`. Offchain: offchain order aggregate ID.
@@ -291,6 +292,30 @@ mod tests {
         assert_eq!(json["occurredAt"], json!("2023-11-14T22:13:20Z"));
         assert_eq!(json["filledAt"], json!("2023-11-14T22:13:20Z"));
         assert_eq!(json["outcome"], json!({ "status": "filled" }));
+    }
+
+    #[test]
+    fn trade_roundtrips_through_persistent_job_payload() {
+        let trade = Trade {
+            id: "durable-order-id".to_string(),
+            occurred_at: DateTime::from_timestamp(1_700_000_000, 123_456_789).unwrap(),
+            venue: TradingVenue::Alpaca,
+            direction: Direction::Sell,
+            symbol: Symbol::new("TSLA").unwrap(),
+            shares: FractionalShares::new(float!(5.5)),
+            outcome: TradeOutcome::Filled,
+        };
+
+        let payload = serde_json::to_vec(&trade).unwrap();
+        let restored: Trade = serde_json::from_slice(&payload).unwrap();
+
+        assert_eq!(restored.id, trade.id);
+        assert_eq!(restored.occurred_at, trade.occurred_at);
+        assert_eq!(restored.venue, trade.venue);
+        assert_eq!(restored.direction, trade.direction);
+        assert_eq!(restored.symbol, trade.symbol);
+        assert_eq!(restored.shares, trade.shares);
+        assert_eq!(restored.outcome, trade.outcome);
     }
 
     #[test]

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -270,6 +270,37 @@ the job needs: config, symbol cache, configured Pyth feed IDs (`PythFeedIds`),
 EVM provider, orderbook address, CQRS frameworks, vault registry, executor,
 database pool, and job queue. Wrapped in `Arc` and injected via apalis `Data`.
 
+### DeliverDashboardTrade
+
+Defined in `src/dashboard/event.rs`. The dashboard CQRS reactor enqueues this
+job for each terminal trade outcome instead of publishing the update inline. The
+serialized `Trade` payload is the replay record. A separate
+`dashboard_trade_delivery` ledger, keyed by trade ID, records whether the live
+update completed. The reactor registers the ledger row before its idempotent
+queue insertion. If either insertion fails after the terminal event commits, a
+supervised handoff monitor retains the outcome in a bounded in-memory queue and
+retries it with exponential backoff a fixed number of times. An outcome that
+exhausts its immediate retries is not lost: the monitor schedules a periodic
+authoritative reconciliation that rebuilds every undelivered terminal trade from
+the event log, so one poison handoff cannot block later outcomes. A handoff
+whose trade can never be represented (a deterministic conversion failure) stops
+the monitor through the supervisor instead of retrying forever. Startup
+reconstructs every terminal trade from the event log, creates any ledger rows or
+jobs missing after a crash, and resets `Running`/`Queued`/`Failed`/`Killed` jobs
+to `Pending` before workers start. This closes both the event-to-job handoff
+window and the dequeue-to-publish restart window.
+
+The worker checks the ledger before publishing and records `delivered_at`
+afterward. A database failure in either step is retryable; a crash after publish
+but before the update commits can replay the message safely. Retry exhaustion
+notifies the conductor monitor and is logged as an undelivered terminal update.
+
+The Tokio broadcast channel reports an error when it has no receivers. That is
+not a delivery failure here: a later WebSocket connection loads terminal trades
+from the authoritative snapshot, so zero connected clients completes the job.
+Replaying a publish is safe because the dashboard replaces an existing trade
+with the same trade ID; a completed ledger row prevents unnecessary replays.
+
 ### CheckPositions
 
 Defined in `src/position_check.rs`. A durable, self-rescheduling apalis job that

--- a/migrations/20260720175533_dashboard_trade_delivery_ledger.sql
+++ b/migrations/20260720175533_dashboard_trade_delivery_ledger.sql
@@ -1,0 +1,4 @@
+CREATE TABLE dashboard_trade_delivery (
+    trade_id TEXT PRIMARY KEY NOT NULL,
+    delivered_at TEXT
+) STRICT;

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -55,7 +55,7 @@ use st0x_wrapper::WrapperService;
 use crate::alerts::{NoopNotifier, NotifierError, TelegramNotifier};
 use crate::conductor::exit::{ConductorExit, MonitorTaskError};
 use crate::conductor::monitor::order_fills::{CutoffProbe, probe_cutoff_block_support};
-use crate::dashboard::Broadcaster;
+use crate::dashboard::{Broadcaster, DashboardTradeDelivery};
 use crate::equity_redemption::{
     EquityRedemption, interrupted_redemption_ids, symbols_with_stuck_redemptions,
 };
@@ -595,10 +595,11 @@ impl Conductor {
         setup_apalis_tables(&apalis_pool).await?;
         let job_queue = DexTradeAccountingJobQueue::new(&apalis_pool);
         let backfill_queue = BackfillJobQueue::new(&apalis_pool);
+        let dashboard_delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, event_sender);
         let schedulers = RebalancingSchedulers::new(&apalis_pool);
-        let broadcaster = Arc::new(Broadcaster::new(event_sender.clone(), pool.clone()));
 
-        let onchain_trade = setup_onchain_trade_store(&pool, broadcaster.clone()).await?;
+        let onchain_trade =
+            setup_onchain_trade_store(&pool, dashboard_delivery.broadcaster.clone()).await?;
 
         let (
             vault_registry,
@@ -654,7 +655,7 @@ impl Conductor {
                 apalis_pool: apalis_pool.clone(),
                 ctx: ctx.clone(),
                 inventory: inventory.clone(),
-                event_sender: event_sender.clone(),
+                broadcaster: dashboard_delivery.broadcaster.clone(),
                 vault_registry: vault_registry.clone(),
                 vault_registry_projection,
                 schedulers: schedulers.clone(),
@@ -694,9 +695,11 @@ impl Conductor {
             &executor,
             &position,
             &position_projection,
-            broadcaster,
+            dashboard_delivery.broadcaster.clone(),
         )
         .await?;
+
+        dashboard_delivery.reconcile().await?;
 
         let frameworks = CqrsFrameworks {
             onchain_trade,
@@ -761,29 +764,19 @@ impl Conductor {
         // rebalancing service to rebuild tracking during recheck recovery.
         let recovery_rebalancing_service = rebalancing_service.clone();
 
-        // Build ResumeTokenizationCtx only when BOTH the queue and the
-        // recovery_transfer are present (rebalancing enabled). zip() makes the
-        // dual-Some requirement explicit: if either is None the ctx is None,
-        // and the compiler flags any mismatch if one arm is accidentally set
-        // without the other.
-        let resume_tokenization_ctx = resume_tokenization_queue
-            .as_ref()
-            .zip(recovery_transfer.as_ref())
-            .map(|(_, transfer)| {
-                Arc::new(ResumeTokenizationCtx {
-                    transfer: transfer.clone(),
-                })
-            });
-
-        // Provide a fallback empty queue when rebalancing is disabled, so the
-        // builder always receives a concrete queue (it is never consumed).
-        let resume_tokenization_queue = resume_tokenization_queue
-            .unwrap_or_else(|| ResumeTokenizationJobQueue::new(&apalis_pool));
+        let (resume_tokenization_queue, resume_tokenization_ctx) = resolve_resume_tokenization(
+            resume_tokenization_queue,
+            recovery_transfer.as_ref(),
+            &apalis_pool,
+        );
 
         let mut conductor = builder::spawn()
             .context(conductor_ctx)
             .job_queue(job_queue)
             .backfill_queue(backfill_queue)
+            .dashboard_trade_delivery_queue(dashboard_delivery.queue)
+            .dashboard_trade_delivery_ctx(dashboard_delivery.ctx)
+            .dashboard_trade_handoff_monitor(dashboard_delivery.handoff_monitor)
             .hedge_queue(hedge_queue)
             .poll_status_queue(poll_status_queue)
             .reconcile_queue(reconcile_queue)
@@ -1225,7 +1218,7 @@ struct RebalancingDeps {
     apalis_pool: apalis_sqlite::SqlitePool,
     ctx: Ctx,
     inventory: Arc<BroadcastingInventory>,
-    event_sender: broadcast::Sender<Statement>,
+    broadcaster: Arc<Broadcaster>,
     vault_registry: Arc<Store<VaultRegistry>>,
     vault_registry_projection: Arc<Projection<VaultRegistry>>,
     schedulers: RebalancingSchedulers,
@@ -1313,11 +1306,10 @@ impl PositionAndRebalancing {
             let RebalancingDeps {
                 pool,
                 inventory,
-                event_sender,
+                broadcaster,
                 ..
             } = deps;
 
-            let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
             let (position, position_projection) = build_position_cqrs(&pool, broadcaster).await?;
 
             // Without the service, the projection is the only subscriber
@@ -1488,16 +1480,45 @@ async fn revoke_stale_orderbook_allowances<Chain: Wallet + Clone>(
     }
 }
 
-/// Builds the CQRS frameworks behind the query manifest: the dashboard
-/// broadcaster and the four query projections, with the stage-timing read
-/// models caught up to the event log before their reactors go live.
+/// Resolves the resume-tokenization wiring.
+///
+/// The ctx is built only when BOTH the queue and the recovery transfer are
+/// present (rebalancing enabled). `zip()` makes the dual-Some requirement
+/// explicit: if either is None the ctx is None, and the compiler flags any
+/// mismatch if one arm is accidentally set without the other. The queue falls
+/// back to an empty one when rebalancing is disabled, so the builder always
+/// receives a concrete queue (it is never consumed).
+fn resolve_resume_tokenization(
+    queue: Option<ResumeTokenizationJobQueue>,
+    recovery_transfer: Option<&Arc<CrossVenueEquityTransfer>>,
+    apalis_pool: &apalis_sqlite::SqlitePool,
+) -> (
+    ResumeTokenizationJobQueue,
+    Option<Arc<ResumeTokenizationCtx>>,
+) {
+    let ctx = queue.as_ref().zip(recovery_transfer).map(|(_, transfer)| {
+        Arc::new(ResumeTokenizationCtx {
+            transfer: transfer.clone(),
+        })
+    });
+
+    (
+        queue.unwrap_or_else(|| ResumeTokenizationJobQueue::new(apalis_pool)),
+        ctx,
+    )
+}
+
+/// Builds the CQRS frameworks behind the query manifest: the four query
+/// projections, with the stage-timing read models caught up to the event log
+/// before their reactors go live. The broadcaster is passed in rather than
+/// built here so every aggregate shares the one wired to the durable
+/// dashboard-trade delivery queue.
 async fn build_query_frameworks(
     pool: &SqlitePool,
-    event_sender: broadcast::Sender<Statement>,
+    broadcaster: Arc<Broadcaster>,
     rebalancing_service: Arc<RebalancingService>,
     equity_transfer_services: EquityTransferServices,
 ) -> anyhow::Result<BuiltFrameworks> {
-    let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
     let hedge_latency = HedgeLatencyProjection::new(pool.clone());
     let rebalance_timing = RebalanceTimingProjection::new(pool.clone());
     let equity_timing = EquityTimingProjection::new(pool.clone());
@@ -1606,11 +1627,15 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
 
         let built = build_query_frameworks(
             &deps.pool,
-            deps.event_sender,
+            deps.broadcaster,
             rebalancing_service.clone(),
             equity_transfer_services,
         )
         .await?;
+
+        rebalancing_service
+            .recover_pending_offchain_order_symbols(&built.position_projection)
+            .await?;
 
         rebalancing_service
             .set_stores(
@@ -3675,6 +3700,7 @@ mod tests {
         ClearConfigV2, ClearV3, EvaluableV4, IOV2, OrderV4, TakeOrderConfigV4, TakeOrderV3,
     };
     use crate::conductor::builder::CqrsFrameworks;
+    use crate::dashboard::{DashboardTradeDeliveryCtx, DashboardTradeDeliveryJobQueue};
     use crate::equity_redemption::{EquityRedemptionCommand, redemption_aggregate_id};
     use crate::inventory::view::Operator;
     use crate::inventory::{ImbalanceThreshold, Inventory, InventoryView, Venue};
@@ -3838,15 +3864,24 @@ mod tests {
         }
     }
 
-    fn test_broadcaster(pool: &SqlitePool) -> (Arc<Broadcaster>, broadcast::Receiver<Statement>) {
+    fn test_broadcaster(
+        pool: &SqlitePool,
+        apalis_pool: &apalis_sqlite::SqlitePool,
+    ) -> (
+        Arc<Broadcaster>,
+        broadcast::Receiver<Statement>,
+        DashboardTradeDeliveryJobQueue,
+        Arc<DashboardTradeDeliveryCtx>,
+    ) {
         let (sender, receiver) = broadcast::channel(16);
-        (Arc::new(Broadcaster::new(sender, pool.clone())), receiver)
+        let delivery = DashboardTradeDelivery::new(apalis_pool, pool, sender);
+        (delivery.broadcaster, receiver, delivery.queue, delivery.ctx)
     }
 
     #[tokio::test]
-    async fn onchain_trade_store_broadcasts_filled_trades() {
-        let pool = crate::test_utils::setup_test_db().await;
-        let (broadcaster, mut receiver) = test_broadcaster(&pool);
+    async fn onchain_trade_store_enqueues_terminal_dashboard_delivery() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (broadcaster, _receiver, queue, _delivery_ctx) = test_broadcaster(&pool, &apalis_pool);
         let store = setup_onchain_trade_store(&pool, broadcaster).await.unwrap();
         let id = crate::onchain_trade::OnChainTradeId {
             tx_hash: TxHash::ZERO,
@@ -3868,28 +3903,25 @@ mod tests {
             .await
             .unwrap();
 
-        let message = tokio::time::timeout(Duration::from_secs(1), receiver.recv())
-            .await
-            .expect("wired store should broadcast the onchain fill")
-            .expect("dashboard receiver should remain connected");
-        assert!(matches!(
-            message,
-            Statement::TradeUpdate(st0x_dto::Trade {
-                venue: st0x_dto::TradingVenue::Raindex,
-                outcome: st0x_dto::TradeOutcome::Filled,
-                ..
-            })
-        ));
+        let pending: i64 = sqlx_apalis::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<crate::dashboard::DeliverDashboardTrade>())
+        .fetch_one(queue.pool())
+        .await
+        .unwrap();
+        assert_eq!(pending, 1, "production store wiring must enqueue the fill");
     }
 
     #[tokio::test]
     async fn offchain_order_store_broadcasts_failed_counter_trades() {
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
             .build(())
             .await
             .unwrap();
-        let (broadcaster, mut receiver) = test_broadcaster(&pool);
+        let (broadcaster, mut receiver, queue, delivery_ctx) =
+            test_broadcaster(&pool, &apalis_pool);
         let (offchain_order, _) = setup_offchain_order_store(
             &pool,
             &MockExecutor::new(),
@@ -3915,6 +3947,7 @@ mod tests {
             )
             .await
             .unwrap();
+
         offchain_order
             .send(
                 &id,
@@ -3922,6 +3955,19 @@ mod tests {
                     error: "asset is not tradable".to_string(),
                 },
             )
+            .await
+            .unwrap();
+
+        let payload: Vec<u8> = sqlx_apalis::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ? LIMIT 1",
+        )
+        .bind(std::any::type_name::<crate::dashboard::DeliverDashboardTrade>())
+        .fetch_one(queue.pool())
+        .await
+        .unwrap();
+        let job: crate::dashboard::DeliverDashboardTrade =
+            serde_json::from_slice(&payload).unwrap();
+        crate::conductor::job::Job::perform(&job, &delivery_ctx)
             .await
             .unwrap();
 
@@ -8454,12 +8500,13 @@ mod tests {
 
     #[tokio::test]
     async fn restart_hydrates_position_view_from_persisted_events() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let symbol = Symbol::new("AAPL").unwrap();
 
         // First "session": create position store, execute commands.
         {
-            let (broadcaster, _receiver) = test_broadcaster(&pool);
+            let (broadcaster, _receiver, _queue, _delivery_ctx) =
+                test_broadcaster(&pool, &apalis_pool);
             let (position_store, position_projection) =
                 build_position_cqrs(&pool, broadcaster).await.unwrap();
 
@@ -8495,7 +8542,8 @@ mod tests {
 
         // Second "session": create NEW position store against the same pool.
         {
-            let (broadcaster, _receiver) = test_broadcaster(&pool);
+            let (broadcaster, _receiver, _queue, _delivery_ctx) =
+                test_broadcaster(&pool, &apalis_pool);
             let (_position_store, position_projection) =
                 build_position_cqrs(&pool, broadcaster).await.unwrap();
 
@@ -8520,9 +8568,10 @@ mod tests {
 
     #[tokio::test]
     async fn standalone_position_cqrs_broadcasts_live_position_updates() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let (broadcaster, mut receiver) = test_broadcaster(&pool);
+        let (broadcaster, mut receiver, _queue, _delivery_ctx) =
+            test_broadcaster(&pool, &apalis_pool);
         let (position_store, _position_projection) =
             build_position_cqrs(&pool, broadcaster).await.unwrap();
 
@@ -8581,6 +8630,7 @@ mod tests {
                 .build(())
                 .await
                 .unwrap();
+        let dashboard_delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, event_sender);
 
         let position_and_rebalancing = PositionAndRebalancing::setup(
             None,
@@ -8589,7 +8639,7 @@ mod tests {
                 apalis_pool: apalis_pool.clone(),
                 ctx: ctx.clone(),
                 inventory,
-                event_sender,
+                broadcaster: dashboard_delivery.broadcaster,
                 vault_registry,
                 vault_registry_projection,
                 schedulers: RebalancingSchedulers::new(&apalis_pool),

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -34,6 +34,10 @@ use super::monitor::gas::{GasMonitor, ProviderBalanceReader};
 use super::monitor::inventory::InventoryMonitor;
 use super::monitor::order_fills::OrderFillMonitor;
 use crate::alerts::TelegramNotifier;
+use crate::dashboard::{
+    DashboardTradeDeliveryCtx, DashboardTradeDeliveryJobQueue, DashboardTradeHandoffMonitor,
+    DeliverDashboardTrade,
+};
 use crate::inventory::{
     BroadcastingInventory, InventoryDivergenceRecoveryCtx, InventoryPollingService,
     InventorySnapshot, InventorySnapshotId, WalletPollingCtx,
@@ -156,6 +160,9 @@ pub(crate) fn spawn<Prov, Exec>(
     context: ConductorCtx<Prov, Exec>,
     job_queue: DexTradeAccountingJobQueue,
     backfill_queue: BackfillJobQueue,
+    dashboard_trade_delivery_queue: DashboardTradeDeliveryJobQueue,
+    dashboard_trade_delivery_ctx: Arc<DashboardTradeDeliveryCtx>,
+    dashboard_trade_handoff_monitor: DashboardTradeHandoffMonitor,
     hedge_queue: HedgeJobQueue,
     poll_status_queue: PollOrderStatusJobQueue,
     reconcile_queue: ReconcileOrderFillJobQueue,
@@ -373,7 +380,11 @@ where
         .with_base_restart_delay(std::time::Duration::from_secs(1))
         .with_dead_tasks_threshold(Some(0.0))
         .with_task("order-fill-monitor", order_fill_monitor)
-        .with_task("inventory-monitor", inventory_monitor);
+        .with_task("inventory-monitor", inventory_monitor)
+        .with_task(
+            "dashboard-trade-handoff-monitor",
+            dashboard_trade_handoff_monitor,
+        );
 
     log_optional_task_status("executor maintenance", maintenance_interval.is_some());
 
@@ -404,6 +415,8 @@ where
         job_queue,
         hedge_queue,
         backfill_queue,
+        dashboard_trade_delivery_queue,
+        dashboard_trade_delivery_ctx,
         poll_status_queue,
         reconcile_queue,
         rejection_queue,
@@ -463,6 +476,8 @@ where
     job_queue: DexTradeAccountingJobQueue,
     hedge_queue: HedgeJobQueue,
     backfill_queue: BackfillJobQueue,
+    dashboard_trade_delivery_queue: DashboardTradeDeliveryJobQueue,
+    dashboard_trade_delivery_ctx: Arc<DashboardTradeDeliveryCtx>,
     poll_status_queue: PollOrderStatusJobQueue,
     reconcile_queue: ReconcileOrderFillJobQueue,
     rejection_queue: HandleOrderRejectionJobQueue,
@@ -510,6 +525,8 @@ where
             job_queue,
             hedge_queue,
             backfill_queue,
+            dashboard_trade_delivery_queue,
+            dashboard_trade_delivery_ctx,
             poll_status_queue,
             reconcile_queue,
             rejection_queue,
@@ -541,6 +558,8 @@ where
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_backfill = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_dashboard_trade_delivery = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_poll = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_reconcile = failure_injector.clone();
@@ -571,6 +590,7 @@ where
         let failure_notify = Arc::new(tokio::sync::Notify::new());
         let failure_notify_for_hedge = failure_notify.clone();
         let failure_notify_for_backfill = failure_notify.clone();
+        let failure_notify_for_dashboard_trade_delivery = failure_notify.clone();
         let failure_notify_for_poll = failure_notify.clone();
         let failure_notify_for_reconcile = failure_notify.clone();
         let failure_notify_for_rejection = failure_notify.clone();
@@ -589,6 +609,7 @@ where
             .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
         let fail_stop_for_hedge = fail_stop.clone();
         let fail_stop_for_backfill = fail_stop.clone();
+        let fail_stop_for_dashboard_trade_delivery = fail_stop.clone();
         let fail_stop_for_poll = fail_stop.clone();
         let fail_stop_for_reconcile = fail_stop.clone();
         let fail_stop_for_rejection = fail_stop.clone();
@@ -615,6 +636,18 @@ where
                         failure_notify.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector.clone(),
+                    )
+                })
+                .register(move |index| {
+                    build_supervised_worker!(
+                        ::<DashboardTradeDeliveryCtx, DeliverDashboardTrade>,
+                        index,
+                        dashboard_trade_delivery_queue.clone(),
+                        dashboard_trade_delivery_ctx.clone(),
+                        fail_stop_for_dashboard_trade_delivery.clone(),
+                        failure_notify_for_dashboard_trade_delivery.clone(),
+                        #[cfg(any(test, feature = "test-support"))]
+                        failure_injector_for_dashboard_trade_delivery.clone(),
                     )
                 })
                 .register(move |index| {

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -131,6 +131,18 @@ impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static> JobQueu
         Ok(TaskSink::push(&mut self.0, task).await?)
     }
 
+    /// Enqueues at most one row for a stable domain identity.
+    pub(crate) async fn push_idempotent(
+        &mut self,
+        idempotency_key: &str,
+        task: Task,
+    ) -> Result<(), QueuePushError> {
+        let task = TaskBuilder::<Task, SqliteContext, _>::new(task)
+            .with_idempotency_key(idempotency_key)
+            .build();
+        Ok(TaskSink::push_task(&mut self.0, task).await?)
+    }
+
     /// Schedules a task to run after `delay` from now. Used by self-rescheduling
     /// jobs (e.g. status pollers waiting for a broker to fill an order) to
     /// avoid burning the retry budget on a successful poll that simply hasn't
@@ -465,6 +477,7 @@ pub enum JobKind {
     TransferEquityToMarketMaking,
     TransferEquityToHedging,
     ResumeTokenizationAggregate,
+    DashboardTradeDelivery,
 }
 
 /// Job execution error. Wraps the concrete `Job::Error` type at
@@ -506,6 +519,7 @@ pub struct FailureInjector {
     transfer_equity_to_market_making: Arc<Mutex<InjectionState>>,
     transfer_equity_to_hedging: Arc<Mutex<InjectionState>>,
     resume_tokenization_aggregate: Arc<Mutex<InjectionState>>,
+    dashboard_trade_delivery: Arc<Mutex<InjectionState>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -545,6 +559,7 @@ impl FailureInjector {
             transfer_equity_to_market_making: Arc::new(Mutex::new(InjectionState::Idle)),
             transfer_equity_to_hedging: Arc::new(Mutex::new(InjectionState::Idle)),
             resume_tokenization_aggregate: Arc::new(Mutex::new(InjectionState::Idle)),
+            dashboard_trade_delivery: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
@@ -596,6 +611,7 @@ impl FailureInjector {
             JobKind::TransferEquityToMarketMaking => &self.transfer_equity_to_market_making,
             JobKind::TransferEquityToHedging => &self.transfer_equity_to_hedging,
             JobKind::ResumeTokenizationAggregate => &self.resume_tokenization_aggregate,
+            JobKind::DashboardTradeDelivery => &self.dashboard_trade_delivery,
         };
 
         match mutex.lock() {

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -227,7 +227,9 @@ mod tests {
             Arc::new(crate::alerts::NoopNotifier),
         ));
 
-        let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
+        let broadcaster =
+            crate::dashboard::DashboardTradeDelivery::new(&apalis_pool, &pool, event_sender)
+                .broadcaster;
         let hedge_latency = HedgeLatencyProjection::new(pool.clone());
         let rebalance_timing = RebalanceTimingProjection::new(pool.clone());
         let equity_timing = EquityTimingProjection::new(pool.clone());
@@ -289,7 +291,9 @@ mod tests {
             RebalancingSchedulers::new(&apalis_pool),
             Arc::new(crate::alerts::NoopNotifier),
         ));
-        let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
+        let broadcaster =
+            crate::dashboard::DashboardTradeDelivery::new(&apalis_pool, &pool, event_sender)
+                .broadcaster;
         let hedge_latency = HedgeLatencyProjection::new(pool.clone());
         let rebalance_timing = RebalanceTimingProjection::new(pool.clone());
         let equity_timing = EquityTimingProjection::new(pool.clone());
@@ -407,7 +411,9 @@ mod tests {
             RebalancingSchedulers::new(&apalis_pool),
             Arc::new(crate::alerts::NoopNotifier),
         ));
-        let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
+        let broadcaster =
+            crate::dashboard::DashboardTradeDelivery::new(&apalis_pool, &pool, event_sender)
+                .broadcaster;
         let hedge_latency = HedgeLatencyProjection::new(pool.clone());
         let rebalance_timing = RebalanceTimingProjection::new(pool.clone());
         let equity_timing = EquityTimingProjection::new(pool.clone());

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -1,16 +1,30 @@
 //! Reactor that broadcasts aggregate events to WebSocket dashboard
 //! clients as [`Trade`] fills and [`TransferOperation`] updates.
 
+use anyhow::Context;
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
-use tokio::sync::broadcast;
-use tracing::{debug, warn};
+use std::collections::VecDeque;
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use task_supervisor::{SupervisedTask, TaskResult};
+#[cfg(test)]
+use tokio::sync::Notify;
+use tokio::sync::{Mutex, broadcast, mpsc};
+use tokio::time::{Instant, interval, sleep_until};
+use tracing::{debug, info, warn};
 
 use st0x_dto::{Statement, Trade, TradeOutcome, TradingVenue};
-use st0x_event_sorcery::{EntityList, Never, Reactor, deps, load_entity};
+use st0x_event_sorcery::{EntityList, Reactor, SendError, deps, load_entity};
 
+use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::equity_redemption::EquityRedemption;
-use crate::offchain::order::{OffchainOrder, OffchainOrderEvent};
+use crate::offchain::order::{
+    OffchainOrder, OffchainOrderEvent, OffchainOrderId, TradeConversionError,
+};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeEvent};
 use crate::position::{Position, PositionEvent};
 use crate::tokenized_equity_mint::TokenizedEquityMint;
@@ -28,29 +42,699 @@ deps!(
     ]
 );
 
-/// Reactor that broadcasts notifications and trade fills to connected
-/// WebSocket clients.
-pub(crate) struct Broadcaster {
-    sender: broadcast::Sender<Statement>,
-    pool: SqlitePool,
+pub(crate) type DashboardTradeDeliveryJobQueue = JobQueue<DeliverDashboardTrade>;
+
+const HANDOFF_RETRY_INITIAL_DELAY: Duration = Duration::from_secs(1);
+const HANDOFF_RETRY_MAX_DELAY: Duration = Duration::from_secs(30);
+const HANDOFF_RETRY_MAX_ATTEMPTS: usize = 3;
+const HANDOFF_RETRY_QUEUE_CAPACITY: usize = 64;
+const HANDOFF_RECONCILIATION_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Runtime dependencies shared by terminal-trade reactors and their worker.
+pub(crate) struct DashboardTradeDelivery {
+    pub(crate) queue: DashboardTradeDeliveryJobQueue,
+    pub(crate) ctx: Arc<DashboardTradeDeliveryCtx>,
+    pub(crate) broadcaster: Arc<Broadcaster>,
+    pub(crate) handoff_monitor: DashboardTradeHandoffMonitor,
+    #[cfg(test)]
+    store: Arc<DashboardTradeDeliveryStore>,
+    enqueuer: Arc<DashboardTradeEnqueuer>,
 }
 
-impl Broadcaster {
-    pub(crate) fn new(sender: broadcast::Sender<Statement>, pool: SqlitePool) -> Self {
-        Self { sender, pool }
+impl DashboardTradeDelivery {
+    pub(crate) fn new(
+        apalis_pool: &apalis_sqlite::SqlitePool,
+        pool: &SqlitePool,
+        sender: broadcast::Sender<Statement>,
+    ) -> Self {
+        let queue = DashboardTradeDeliveryJobQueue::new(apalis_pool);
+        let store = Arc::new(DashboardTradeDeliveryStore::new(pool.clone()));
+        let enqueuer = Arc::new(DashboardTradeEnqueuer::new(queue.clone(), store.clone()));
+        #[cfg(test)]
+        let test_store = store.clone();
+        let (handoff_retry_sender, handoff_retry_receiver) =
+            mpsc::channel(HANDOFF_RETRY_QUEUE_CAPACITY);
+        let ctx = Arc::new(DashboardTradeDeliveryCtx::with_store(sender.clone(), store));
+        let broadcaster = Arc::new(Broadcaster::new(
+            sender,
+            pool.clone(),
+            enqueuer.clone(),
+            handoff_retry_sender,
+        ));
+        let handoff_monitor = DashboardTradeHandoffMonitor::new(
+            handoff_retry_receiver,
+            enqueuer.clone(),
+            pool.clone(),
+        );
+
+        Self {
+            queue,
+            ctx,
+            broadcaster,
+            handoff_monitor,
+            #[cfg(test)]
+            store: test_store,
+            enqueuer,
+        }
     }
 
-    fn broadcast_trade(&self, trade: Trade) {
+    /// Reconstructs missing delivery records from authoritative trade history
+    /// and makes every undelivered row runnable before workers start.
+    pub(crate) async fn reconcile(&self) -> anyhow::Result<usize> {
+        let exhausted: i64 = sqlx_apalis::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE job_type = ? AND status IN ('Failed', 'Killed')",
+        )
+        .bind(std::any::type_name::<DeliverDashboardTrade>())
+        .fetch_one(self.queue.pool())
+        .await
+        .context("failed to count exhausted dashboard trade delivery jobs")?;
+
+        if exhausted > 0 {
+            warn!(
+                target: "dashboard",
+                exhausted,
+                "Re-driving dashboard trade deliveries that previously exhausted their retry \
+                 budget; a repeat of this warning across restarts indicates a poison delivery",
+            );
+        }
+
+        let reset = sqlx_apalis::query(
+            "UPDATE Jobs SET status = 'Pending', attempts = 0, run_at = strftime('%s', 'now'), \
+             last_result = NULL, \
+             lock_at = NULL, lock_by = NULL, done_at = NULL \
+             WHERE job_type = ? AND status IN ('Running', 'Queued', 'Failed', 'Killed')",
+        )
+        .bind(std::any::type_name::<DeliverDashboardTrade>())
+        .execute(self.queue.pool())
+        .await
+        .context("failed to reset unfinished dashboard trade delivery jobs")?
+        .rows_affected();
+
+        let undelivered = self.enqueuer.reconcile_undelivered().await?;
+
+        if reset > 0 || undelivered > 0 {
+            info!(
+                target: "dashboard",
+                reset,
+                undelivered,
+                "Reconciled durable dashboard trade deliveries",
+            );
+        }
+
+        Ok(undelivered)
+    }
+}
+
+impl DashboardTradeEnqueuer {
+    async fn reconcile_undelivered(&self) -> anyhow::Result<usize> {
+        let trades = crate::dashboard::trade_loader::load_all_trades(&self.store.pool)
+            .await
+            .context("failed to reconstruct terminal trades for delivery reconciliation")?;
+        let mut undelivered = 0;
+
+        for trade in trades {
+            self.store.register(&trade.id).await?;
+            if self.store.is_delivered(&trade.id).await? {
+                continue;
+            }
+
+            self.enqueue_reconciled(trade).await?;
+            undelivered += 1;
+        }
+
+        Ok(undelivered)
+    }
+}
+
+struct DashboardTradeEnqueuer {
+    queue: DashboardTradeDeliveryJobQueue,
+    store: Arc<DashboardTradeDeliveryStore>,
+}
+
+impl DashboardTradeEnqueuer {
+    fn new(queue: DashboardTradeDeliveryJobQueue, store: Arc<DashboardTradeDeliveryStore>) -> Self {
+        Self { queue, store }
+    }
+
+    async fn enqueue(&self, trade: Trade) -> Result<(), DashboardTradePersistenceError> {
+        self.store.register(&trade.id).await?;
+        self.enqueue_registered(trade).await
+    }
+
+    async fn enqueue_registered(&self, trade: Trade) -> Result<(), DashboardTradePersistenceError> {
+        let idempotency_key = trade.id.clone();
+        let mut queue = self.queue.clone();
+        queue
+            .push_idempotent(&idempotency_key, DeliverDashboardTrade::new(trade))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn enqueue_reconciled(&self, trade: Trade) -> Result<(), DashboardTradePersistenceError> {
+        let idempotency_key = trade.id.clone();
+        let payload = serde_json::to_vec(&DeliverDashboardTrade::new(trade.clone()))?;
+        self.enqueue_registered(trade).await?;
+
+        // The delivery ledger is authoritative and this refresh only runs for
+        // undelivered trades, so it must also reclaim a `Done` job row: a
+        // crash between publishing and `mark_delivered` leaves the job `Done`
+        // while the ledger still shows undelivered, and the idempotency-key
+        // unique index blocks inserting a replacement row.
+        sqlx_apalis::query(
+            "UPDATE Jobs SET job = ?, status = 'Pending', attempts = 0, \
+             run_at = strftime('%s', 'now'), last_result = NULL, \
+             lock_at = NULL, lock_by = NULL, done_at = NULL \
+             WHERE job_type = ? AND idempotency_key = ?",
+        )
+        .bind(payload)
+        .bind(std::any::type_name::<DeliverDashboardTrade>())
+        .bind(idempotency_key)
+        .execute(self.queue.pool())
+        .await?;
+
+        Ok(())
+    }
+}
+
+/// Retries terminal event-to-job handoffs that fail after the CQRS event has
+/// committed, without waiting for a process restart.
+#[derive(Clone, Debug)]
+pub(crate) enum DashboardTradeHandoff {
+    Trade(Box<Trade>),
+    ReloadOffchainOrder(OffchainOrderId),
+}
+
+struct ScheduledDashboardTradeHandoff {
+    handoff: DashboardTradeHandoff,
+    next_attempt: Instant,
+    retry_delay: Duration,
+    attempt: usize,
+}
+
+impl ScheduledDashboardTradeHandoff {
+    fn new(handoff: DashboardTradeHandoff) -> Self {
+        Self {
+            handoff,
+            next_attempt: Instant::now(),
+            retry_delay: HANDOFF_RETRY_INITIAL_DELAY,
+            attempt: 1,
+        }
+    }
+
+    fn reschedule(mut self) -> Self {
+        self.next_attempt = Instant::now() + self.retry_delay;
+        self.retry_delay = self
+            .retry_delay
+            .saturating_mul(2)
+            .min(HANDOFF_RETRY_MAX_DELAY);
+        self.attempt = self.attempt.saturating_add(1);
+        self
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DashboardTradeHandoffMonitor {
+    receiver: Arc<Mutex<mpsc::Receiver<DashboardTradeHandoff>>>,
+    enqueuer: Arc<DashboardTradeEnqueuer>,
+    pool: SqlitePool,
+    reconciliation_interval: Duration,
+    #[cfg(test)]
+    exhaustion_notify: Arc<Notify>,
+}
+
+impl DashboardTradeHandoffMonitor {
+    fn new(
+        receiver: mpsc::Receiver<DashboardTradeHandoff>,
+        enqueuer: Arc<DashboardTradeEnqueuer>,
+        pool: SqlitePool,
+    ) -> Self {
+        Self {
+            receiver: Arc::new(Mutex::new(receiver)),
+            enqueuer,
+            pool,
+            reconciliation_interval: HANDOFF_RECONCILIATION_INTERVAL,
+            #[cfg(test)]
+            exhaustion_notify: Arc::new(Notify::new()),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_reconciliation_interval(mut self, reconciliation_interval: Duration) -> Self {
+        self.reconciliation_interval = reconciliation_interval;
+        self
+    }
+
+    #[cfg(test)]
+    fn exhaustion_notification(&self) -> Arc<Notify> {
+        self.exhaustion_notify.clone()
+    }
+
+    async fn receive(&self) -> Option<DashboardTradeHandoff> {
+        self.receiver.lock().await.recv().await
+    }
+
+    async fn persist_once(
+        &self,
+        handoff: &DashboardTradeHandoff,
+    ) -> Result<(), DashboardTradeHandoffAttemptError> {
+        let trade = match handoff {
+            DashboardTradeHandoff::Trade(trade) => trade.as_ref().clone(),
+            DashboardTradeHandoff::ReloadOffchainOrder(id) => {
+                let order = load_entity::<OffchainOrder>(&self.pool, id)
+                    .await
+                    .map_err(|source| DashboardTradeHandoffAttemptError::Replay {
+                        id: *id,
+                        source,
+                    })?
+                    .ok_or(DashboardTradeHandoffAttemptError::Missing { id: *id })?;
+
+                match order.try_into_trade(id) {
+                    Ok(trade) => trade,
+                    // A cancellation racing an earlier terminal handoff is
+                    // benign: the rest of the system treats cancelled orders
+                    // as "nothing to deliver", so the handoff completes as a
+                    // no-op instead of fail-stopping the monitor.
+                    Err(TradeConversionError::Cancelled) => {
+                        warn!(
+                            target: "dashboard",
+                            %id,
+                            "Offchain order was cancelled after its terminal handoff; \
+                             skipping dashboard delivery",
+                        );
+                        return Ok(());
+                    }
+                    Err(source) => {
+                        return Err(DashboardTradeHandoffAttemptError::Conversion {
+                            id: *id,
+                            source,
+                        });
+                    }
+                }
+            }
+        };
+
+        self.enqueuer.enqueue(trade).await?;
+        Ok(())
+    }
+
+    async fn attempt(
+        &self,
+        scheduled: ScheduledDashboardTradeHandoff,
+        pending: &mut VecDeque<ScheduledDashboardTradeHandoff>,
+    ) -> Result<bool, DashboardTradeHandoffMonitorError> {
+        let mut exhausted = false;
+        if let Err(error) = self.persist_once(&scheduled.handoff).await {
+            warn!(
+                target: "dashboard",
+                handoff = ?scheduled.handoff,
+                ?error,
+                attempt = scheduled.attempt,
+                retry_delay_ms = scheduled.retry_delay.as_millis(),
+                "Dashboard trade handoff attempt failed",
+            );
+            if error.is_retryable() {
+                if scheduled.attempt < HANDOFF_RETRY_MAX_ATTEMPTS {
+                    pending.push_back(scheduled.reschedule());
+                } else {
+                    exhausted = true;
+                    #[cfg(test)]
+                    self.exhaustion_notify.notify_one();
+                    warn!(
+                        target: "dashboard",
+                        handoff = ?scheduled.handoff,
+                        attempts = scheduled.attempt,
+                        "Dashboard trade handoff exhausted immediate retries; periodic authoritative reconciliation will recover it",
+                    );
+                }
+            } else {
+                return Err(DashboardTradeHandoffMonitorError::DeterministicConversion(
+                    error,
+                ));
+            }
+        }
+
+        Ok(exhausted)
+    }
+
+    fn take_ready(
+        pending: &mut VecDeque<ScheduledDashboardTradeHandoff>,
+    ) -> Option<ScheduledDashboardTradeHandoff> {
+        let now = Instant::now();
+        let index = pending
+            .iter()
+            .position(|scheduled| scheduled.next_attempt <= now)?;
+        pending.remove(index)
+    }
+
+    fn next_attempt(pending: &VecDeque<ScheduledDashboardTradeHandoff>) -> Option<Instant> {
+        pending.iter().map(|scheduled| scheduled.next_attempt).min()
+    }
+
+    /// A reconciliation pass runs many SQLite statements, so write contention
+    /// alone can fail it. Absorb that failure and leave `needed` set so the
+    /// next tick retries: terminating the monitor would discard the in-memory
+    /// pending queue and leave those handoffs waiting on the very pass that
+    /// just failed.
+    async fn reconcile_after_exhaustion(&self, needed: &mut bool) {
+        match self.enqueuer.reconcile_undelivered().await {
+            Ok(_) => *needed = false,
+            Err(error) => warn!(
+                target: "dashboard",
+                ?error,
+                "Dashboard trade handoff reconciliation failed; retrying on the next tick",
+            ),
+        }
+    }
+}
+
+impl SupervisedTask for DashboardTradeHandoffMonitor {
+    async fn run(&mut self) -> TaskResult {
+        info!(target: "dashboard", "Dashboard trade handoff monitor started");
+        let mut pending = VecDeque::with_capacity(HANDOFF_RETRY_QUEUE_CAPACITY);
+        let mut reconciliation = interval(self.reconciliation_interval);
+        reconciliation.tick().await;
+        let mut reconciliation_needed = false;
+
+        loop {
+            if let Some(scheduled) = Self::take_ready(&mut pending) {
+                if self.attempt(scheduled, &mut pending).await? {
+                    if !reconciliation_needed {
+                        reconciliation.reset();
+                    }
+                    reconciliation_needed = true;
+                }
+                continue;
+            }
+
+            // At least one arm is always live: an empty queue enables the
+            // receive arm, and a full queue implies a scheduled retry, which
+            // enables the sleep arm.
+            let next_attempt = Self::next_attempt(&pending);
+            tokio::select! {
+                handoff = self.receive(), if pending.len() < HANDOFF_RETRY_QUEUE_CAPACITY => {
+                    let handoff = handoff.ok_or(DashboardTradeHandoffMonitorError::QueueClosed)?;
+                    pending.push_back(ScheduledDashboardTradeHandoff::new(handoff));
+                }
+                () = sleep_until(next_attempt.unwrap_or_else(Instant::now)), if next_attempt.is_some() => {}
+                _ = reconciliation.tick(), if reconciliation_needed => {
+                    self.reconcile_after_exhaustion(&mut reconciliation_needed).await;
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum DashboardTradeHandoffMonitorError {
+    #[error("dashboard trade handoff retry queue closed unexpectedly")]
+    QueueClosed,
+    #[error("dashboard trade cannot be represented for durable delivery: {0}")]
+    DeterministicConversion(#[source] DashboardTradeHandoffAttemptError),
+}
+
+#[derive(Debug, thiserror::Error)]
+enum DashboardTradeHandoffAttemptError {
+    #[error(transparent)]
+    Persistence(#[from] DashboardTradePersistenceError),
+    #[error("failed to replay terminal offchain order {id}: {source}")]
+    Replay {
+        id: OffchainOrderId,
+        #[source]
+        source: SendError<OffchainOrder>,
+    },
+    #[error("terminal offchain order {id} replayed to empty state")]
+    Missing { id: OffchainOrderId },
+    #[error("terminal offchain order {id} cannot be represented for delivery: {source}")]
+    Conversion {
+        id: OffchainOrderId,
+        #[source]
+        source: TradeConversionError,
+    },
+}
+
+impl DashboardTradeHandoffAttemptError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::Persistence(_) | Self::Replay { .. } | Self::Missing { .. } => true,
+            Self::Conversion { source, .. } => matches!(
+                source,
+                TradeConversionError::Pending
+                    | TradeConversionError::Submitted
+                    | TradeConversionError::PartiallyFilled
+                    | TradeConversionError::Cancelling
+            ),
+        }
+    }
+}
+
+/// Persistent delivery job for one terminal dashboard trade outcome.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct DeliverDashboardTrade {
+    trade: Trade,
+}
+
+impl DeliverDashboardTrade {
+    fn new(trade: Trade) -> Self {
+        Self { trade }
+    }
+}
+
+struct DashboardTradeDeliveryStore {
+    pool: SqlitePool,
+    #[cfg(test)]
+    completion_failures_remaining: AtomicUsize,
+    #[cfg(test)]
+    registration_failures_remaining: AtomicUsize,
+}
+
+impl DashboardTradeDeliveryStore {
+    fn new(pool: SqlitePool) -> Self {
+        Self {
+            pool,
+            #[cfg(test)]
+            completion_failures_remaining: AtomicUsize::new(0),
+            #[cfg(test)]
+            registration_failures_remaining: AtomicUsize::new(0),
+        }
+    }
+
+    async fn register(&self, trade_id: &str) -> Result<(), DashboardTradeDeliveryError> {
+        #[cfg(test)]
+        if consume_failure(&self.registration_failures_remaining) {
+            return Err(DashboardTradeDeliveryError::Injected);
+        }
+
+        sqlx::query(
+            "INSERT INTO dashboard_trade_delivery (trade_id) VALUES (?) \
+             ON CONFLICT(trade_id) DO NOTHING",
+        )
+        .bind(trade_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn is_delivered(&self, trade_id: &str) -> Result<bool, DashboardTradeDeliveryError> {
+        let delivered: Option<bool> = sqlx::query_scalar(
+            "SELECT delivered_at IS NOT NULL FROM dashboard_trade_delivery WHERE trade_id = ?",
+        )
+        .bind(trade_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        delivered.ok_or_else(|| DashboardTradeDeliveryError::MissingRecord {
+            trade_id: trade_id.to_owned(),
+        })
+    }
+
+    async fn mark_delivered(&self, trade_id: &str) -> Result<(), DashboardTradeDeliveryError> {
+        #[cfg(test)]
+        if consume_failure(&self.completion_failures_remaining) {
+            return Err(DashboardTradeDeliveryError::Injected);
+        }
+
+        sqlx::query("UPDATE dashboard_trade_delivery SET delivered_at = ? WHERE trade_id = ?")
+            .bind(chrono::Utc::now())
+            .bind(trade_id)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn fail_next_completion(&self, count: usize) {
+        self.completion_failures_remaining
+            .store(count, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn fail_next_registration(&self, count: usize) {
+        self.registration_failures_remaining
+            .store(count, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+fn consume_failure(failures_remaining: &AtomicUsize) -> bool {
+    failures_remaining
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+            remaining.checked_sub(1)
+        })
+        .is_ok()
+}
+
+/// Shared live-stream publisher used by the dashboard delivery worker.
+pub(crate) struct DashboardTradeDeliveryCtx {
+    sender: broadcast::Sender<Statement>,
+    store: Arc<DashboardTradeDeliveryStore>,
+}
+
+impl DashboardTradeDeliveryCtx {
+    #[cfg(test)]
+    pub(crate) fn new(sender: broadcast::Sender<Statement>, pool: SqlitePool) -> Self {
+        Self::with_store(sender, Arc::new(DashboardTradeDeliveryStore::new(pool)))
+    }
+
+    fn with_store(
+        sender: broadcast::Sender<Statement>,
+        store: Arc<DashboardTradeDeliveryStore>,
+    ) -> Self {
+        Self { sender, store }
+    }
+
+    #[cfg(test)]
+    fn fail_next(&self, count: usize) {
+        self.store.fail_next_completion(count);
+    }
+
+    fn publish(&self, trade: Trade) {
         let legacy_fill = trade.legacy_fill();
         if let Err(error) = self.sender.send(Statement::TradeUpdate(trade)) {
-            debug!(target: "dashboard", %error, "Failed to broadcast trade update (no receivers)");
+            debug!(target: "dashboard", %error, "No dashboard receivers for trade update");
         }
 
         if let Some(legacy_fill) = legacy_fill
             && let Err(error) = self.sender.send(Statement::TradeFill(legacy_fill))
         {
-            debug!(target: "dashboard", %error, "Failed to broadcast legacy trade fill (no receivers)");
+            debug!(target: "dashboard", %error, "No dashboard receivers for legacy trade fill");
         }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DashboardTradeDeliveryError {
+    #[error("dashboard trade delivery database operation failed: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("dashboard trade delivery record is missing for {trade_id}")]
+    MissingRecord { trade_id: String },
+    #[cfg(test)]
+    #[error("injected dashboard trade delivery failure")]
+    Injected,
+}
+
+impl Job<DashboardTradeDeliveryCtx> for DeliverDashboardTrade {
+    type Output = ();
+    type Error = DashboardTradeDeliveryError;
+
+    const WORKER_NAME: &'static str = "dashboard-trade-delivery-worker";
+    const TERMINAL_FAILURE_MSG: &'static str =
+        "Dashboard trade delivery failed after retries; terminal update remains undelivered";
+
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::DashboardTradeDelivery;
+
+    fn label(&self) -> Label {
+        Label::new(format!("DeliverDashboardTrade:{}", self.trade.id))
+    }
+
+    async fn perform(&self, ctx: &DashboardTradeDeliveryCtx) -> Result<Self::Output, Self::Error> {
+        if ctx.store.is_delivered(&self.trade.id).await? {
+            debug!(
+                target: "dashboard",
+                trade_id = %self.trade.id,
+                "Skipping dashboard trade delivery; ledger already records completion",
+            );
+            return Ok(());
+        }
+
+        ctx.publish(self.trade.clone());
+        ctx.store.mark_delivered(&self.trade.id).await
+    }
+}
+
+/// Reactor that broadcasts notifications and trade fills to connected
+/// WebSocket clients.
+pub(crate) struct Broadcaster {
+    sender: broadcast::Sender<Statement>,
+    pool: SqlitePool,
+    trade_enqueuer: Arc<DashboardTradeEnqueuer>,
+    handoff_retry_sender: mpsc::Sender<DashboardTradeHandoff>,
+}
+
+impl Broadcaster {
+    fn new(
+        sender: broadcast::Sender<Statement>,
+        pool: SqlitePool,
+        trade_enqueuer: Arc<DashboardTradeEnqueuer>,
+        handoff_retry_sender: mpsc::Sender<DashboardTradeHandoff>,
+    ) -> Self {
+        Self {
+            sender,
+            pool,
+            trade_enqueuer,
+            handoff_retry_sender,
+        }
+    }
+
+    async fn enqueue_trade(&self, trade: Trade) -> Result<(), DashboardTradeEnqueueError> {
+        if let Err(error) = self.trade_enqueuer.enqueue(trade.clone()).await {
+            warn!(
+                target: "dashboard",
+                trade_id = %trade.id,
+                ?error,
+                "Durable dashboard trade handoff failed; queued for in-process retry",
+            );
+            self.handoff_retry_sender
+                .send(DashboardTradeHandoff::Trade(Box::new(trade)))
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn enqueue_offchain_trade(
+        &self,
+        id: OffchainOrderId,
+    ) -> Result<(), DashboardTradeEnqueueError> {
+        match load_entity::<OffchainOrder>(&self.pool, &id).await {
+            Ok(Some(order)) => match order.try_into_trade(&id) {
+                Ok(trade) => return self.enqueue_trade(trade).await,
+                Err(error) => warn!(
+                    target: "dashboard",
+                    %id, %error,
+                    "Failed to convert terminal OffchainOrder; queued for reload retry"
+                ),
+            },
+            Ok(None) => warn!(
+                target: "dashboard",
+                %id,
+                "Terminal OffchainOrder replayed to empty state; queued for reload retry"
+            ),
+            Err(error) => warn!(
+                target: "dashboard",
+                %id, ?error,
+                "Failed to load terminal OffchainOrder; queued for reload retry"
+            ),
+        }
+
+        self.handoff_retry_sender
+            .send(DashboardTradeHandoff::ReloadOffchainOrder(id))
+            .await?;
+        Ok(())
     }
 
     fn broadcast_position(&self, position: st0x_dto::Position) {
@@ -66,9 +750,27 @@ impl Broadcaster {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+enum DashboardTradePersistenceError {
+    #[error(transparent)]
+    Delivery(#[from] DashboardTradeDeliveryError),
+    #[error(transparent)]
+    Queue(#[from] QueuePushError),
+    #[error("failed to serialize dashboard trade delivery job: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("failed to refresh dashboard trade delivery job: {0}")]
+    Refresh(#[from] apalis_sqlite::SqlxError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DashboardTradeEnqueueError {
+    #[error("dashboard trade handoff retry queue closed before retaining the outcome: {0}")]
+    RetryQueue(#[from] mpsc::error::SendError<DashboardTradeHandoff>),
+}
+
 #[async_trait]
 impl Reactor for Broadcaster {
-    type Error = Never;
+    type Error = DashboardTradeEnqueueError;
 
     async fn react(
         &self,
@@ -84,7 +786,7 @@ impl Reactor for Broadcaster {
                     ..
                 } = event
                 {
-                    self.broadcast_trade(Trade {
+                    self.enqueue_trade(Trade {
                         id: id.to_string(),
                         occurred_at: block_timestamp,
                         venue: TradingVenue::Raindex,
@@ -92,8 +794,11 @@ impl Reactor for Broadcaster {
                         symbol,
                         shares: st0x_finance::FractionalShares::new(amount),
                         outcome: TradeOutcome::Filled,
-                    });
+                    })
+                    .await?;
                 }
+
+                Ok(())
             })
 
             .on(|id, event| async move {
@@ -103,7 +808,7 @@ impl Reactor for Broadcaster {
                         | PositionEvent::OffChainOrderFilled { .. }
                         | PositionEvent::ManualPositionAdjusted { .. }
                 ) {
-                    return;
+                    return Ok(());
                 }
 
                 match load_entity::<Position>(&self.pool, &id).await {
@@ -117,32 +822,15 @@ impl Reactor for Broadcaster {
                     Ok(None) => warn!(target: "dashboard", %id, "Position not found after event"),
                     Err(error) => warn!(target: "dashboard", %id, ?error, "Failed to load position for broadcast"),
                 }
+
+                Ok(())
             })
 
             .on(|id, event| async move {
                 use OffchainOrderEvent::*;
                 match event {
                     Filled { .. } | Failed { .. } => {
-                        match load_entity::<OffchainOrder>(&self.pool, &id).await {
-                            Ok(Some(order)) => match order.try_into_trade(&id) {
-                                Ok(trade) => self.broadcast_trade(trade),
-                                Err(error) => warn!(
-                                    target: "dashboard",
-                                    %id, %error,
-                                    "OffchainOrder not terminal after terminal event"
-                                ),
-                            },
-                            Ok(None) => warn!(
-                                target: "dashboard",
-                                %id,
-                                "OffchainOrder replayed to empty state"
-                            ),
-                            Err(error) => warn!(
-                                target: "dashboard",
-                                %id, ?error,
-                                "Failed to load OffchainOrder for terminal broadcast"
-                            ),
-                        }
+                        self.enqueue_offchain_trade(id).await?;
                     }
                     Placed { .. }
                     | Submitted { .. }
@@ -151,6 +839,8 @@ impl Reactor for Broadcaster {
                     | CancelRequested { .. }
                     | Cancelled { .. } => {}
                 }
+
+                Ok(())
             })
 
             .on(|id, _event| async move {
@@ -159,6 +849,7 @@ impl Reactor for Broadcaster {
                     Ok(None) => warn!(target: "dashboard", %id, "Mint entity not found for transfer broadcast"),
                     Err(error) => warn!(target: "dashboard", %id, ?error, "Failed to load mint for broadcast"),
                 }
+                Ok(())
             })
 
             .on(|id, _event| async move {
@@ -167,6 +858,7 @@ impl Reactor for Broadcaster {
                     Ok(None) => warn!(target: "dashboard", %id, "Redemption entity not found for broadcast"),
                     Err(error) => warn!(target: "dashboard", %id, ?error, "Failed to load redemption for broadcast"),
                 }
+                Ok(())
             })
 
             .on(|id, _event| async move {
@@ -175,35 +867,221 @@ impl Reactor for Broadcaster {
                     Ok(None) => warn!(target: "dashboard", %id, "USDC rebalance entity not found for broadcast"),
                     Err(error) => warn!(target: "dashboard", %id, ?error, "Failed to load rebalance for broadcast"),
                 }
+                Ok(())
             })
             .exhaustive()
-            .await;
-
-        Ok(())
+            .await
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use apalis::prelude::Monitor;
+    use apalis_core::worker::ext::circuit_breaker::config::CircuitBreakerConfig;
+    use std::sync::Arc;
+    use std::time::Duration;
+
     use st0x_event_sorcery::{ReactorHarness, StoreBuilder};
     use st0x_execution::Symbol;
 
     use super::*;
+    use crate::conductor::job::{
+        FAIL_STOP_RECOVERY_TIMEOUT, FailureInjector, build_supervised_worker, build_worker_inner,
+    };
     use crate::offchain::order::{OffchainOrderCommand, OffchainOrderEvent};
     use crate::position::{PositionCommand, PositionEvent, TradeId};
-    use crate::test_utils::setup_test_db;
+    use crate::test_utils::setup_test_pools;
 
-    fn test_broadcaster(pool: SqlitePool) -> (Broadcaster, broadcast::Receiver<Statement>) {
+    fn test_broadcaster(
+        pool: &SqlitePool,
+        apalis_pool: &apalis_sqlite::SqlitePool,
+    ) -> (
+        Arc<Broadcaster>,
+        broadcast::Receiver<Statement>,
+        DashboardTradeDeliveryJobQueue,
+        Arc<DashboardTradeDeliveryCtx>,
+    ) {
         let (sender, receiver) = broadcast::channel(16);
-        let broadcaster = Broadcaster::new(sender, pool);
-        (broadcaster, receiver)
+        let delivery = DashboardTradeDelivery::new(apalis_pool, pool, sender);
+        (delivery.broadcaster, receiver, delivery.queue, delivery.ctx)
+    }
+
+    async fn perform_pending_delivery(
+        queue: &DashboardTradeDeliveryJobQueue,
+        ctx: &DashboardTradeDeliveryCtx,
+    ) {
+        let payload: Vec<u8> = sqlx_apalis::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ? LIMIT 1",
+        )
+        .bind(std::any::type_name::<DeliverDashboardTrade>())
+        .fetch_one(queue.pool())
+        .await
+        .unwrap();
+        let job: DeliverDashboardTrade = serde_json::from_slice(&payload).unwrap();
+        job.perform(ctx).await.unwrap();
+    }
+
+    fn test_trade() -> Trade {
+        Trade {
+            id: "terminal-trade-1".to_string(),
+            occurred_at: chrono::Utc::now(),
+            venue: TradingVenue::Alpaca,
+            direction: st0x_execution::Direction::Sell,
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: st0x_finance::FractionalShares::new(st0x_float_macro::float!(1)),
+            outcome: TradeOutcome::Filled,
+        }
+    }
+
+    async fn persist_failed_offchain_order(pool: SqlitePool, id: OffchainOrderId) {
+        let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool)
+            .build(crate::offchain::order::noop_order_placer())
+            .await
+            .unwrap();
+        let shares = st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
+            st0x_float_macro::float!(1),
+        ))
+        .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    shares,
+                    direction: st0x_execution::Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: st0x_execution::ExecutorOrderId::new("broker-order"),
+                    placed_shares: shares,
+                    submitted_at: chrono::Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkFailed {
+                    error: "broker unavailable".to_string(),
+                    failed_at: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn persist_cancelled_offchain_order(pool: SqlitePool, id: OffchainOrderId) {
+        let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool)
+            .build(crate::offchain::order::noop_order_placer())
+            .await
+            .unwrap();
+        let shares = st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
+            st0x_float_macro::float!(1),
+        ))
+        .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    shares,
+                    direction: st0x_execution::Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: st0x_execution::ExecutorOrderId::new("broker-order"),
+                    placed_shares: shares,
+                    submitted_at: chrono::Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: crate::offchain::order::CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::ConfirmCancellation {
+                    cancelled_at: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn enqueue_test_delivery(
+        queue: &mut DashboardTradeDeliveryJobQueue,
+        ctx: &DashboardTradeDeliveryCtx,
+        trade: Trade,
+    ) {
+        ctx.store.register(&trade.id).await.unwrap();
+        let idempotency_key = trade.id.clone();
+        queue
+            .push_idempotent(&idempotency_key, DeliverDashboardTrade::new(trade))
+            .await
+            .unwrap();
+    }
+
+    fn spawn_delivery_worker(
+        queue: DashboardTradeDeliveryJobQueue,
+        ctx: Arc<DashboardTradeDeliveryCtx>,
+        failure_notify: Arc<tokio::sync::Notify>,
+    ) -> tokio::task::JoinHandle<()> {
+        let fail_stop = CircuitBreakerConfig::default()
+            .with_failure_threshold(1)
+            .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
+
+        tokio::spawn(async move {
+            let monitor = Monitor::new()
+                .should_restart(|_ctx, _error, _attempt| false)
+                .register(move |index| {
+                    build_supervised_worker!(
+                        ::<DashboardTradeDeliveryCtx, DeliverDashboardTrade>,
+                        index,
+                        queue.clone(),
+                        ctx.clone(),
+                        fail_stop.clone(),
+                        failure_notify.clone(),
+                        FailureInjector::new(),
+                    )
+                });
+            let _ = monitor.run().await;
+        })
     }
 
     #[tokio::test]
     async fn no_broadcast_without_events() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (sender, mut receiver) = broadcast::channel(16);
-        let _broadcaster = Broadcaster::new(sender, pool);
+        let _delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
 
         let result =
             tokio::time::timeout(std::time::Duration::from_millis(10), receiver.recv()).await;
@@ -212,9 +1090,684 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn terminal_trade_reactor_persists_delivery_job() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        let harness = ReactorHarness::new(delivery.broadcaster);
+        let now = chrono::Utc::now();
+
+        harness
+            .receive::<OnChainTrade>(
+                crate::onchain_trade::OnChainTradeId {
+                    tx_hash: alloy::primitives::TxHash::ZERO,
+                    log_index: 0,
+                },
+                OnChainTradeEvent::Filled {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: st0x_float_macro::float!(10),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+
+        let pending: i64 = sqlx_apalis::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<DeliverDashboardTrade>())
+        .fetch_one(delivery.queue.pool())
+        .await
+        .unwrap();
+
+        assert_eq!(pending, 1, "terminal outcome must be durably enqueued");
+    }
+
+    #[tokio::test]
+    async fn failed_reactor_handoff_retries_without_restart() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        delivery.store.fail_next_registration(1);
+        let harness = ReactorHarness::new(delivery.broadcaster.clone());
+        let mut handoff_monitor = delivery.handoff_monitor.clone();
+        let monitor = tokio::spawn(async move { handoff_monitor.run().await });
+        let now = chrono::Utc::now();
+
+        harness
+            .receive::<OnChainTrade>(
+                crate::onchain_trade::OnChainTradeId {
+                    tx_hash: alloy::primitives::TxHash::ZERO,
+                    log_index: 9,
+                },
+                OnChainTradeEvent::Filled {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: st0x_float_macro::float!(1),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .expect("the failed durable handoff should be staged for retry");
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let pending: i64 = sqlx_apalis::query_scalar(
+                    "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+                )
+                .bind(std::any::type_name::<DeliverDashboardTrade>())
+                .fetch_one(delivery.queue.pool())
+                .await
+                .unwrap();
+                if pending == 1 {
+                    break;
+                }
+
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the in-process handoff monitor should persist the delivery job");
+        monitor.abort();
+    }
+
+    #[tokio::test]
+    async fn failed_offchain_reload_retries_without_restart() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        let harness = ReactorHarness::new(delivery.broadcaster.clone());
+        let mut handoff_monitor = delivery.handoff_monitor.clone();
+        let monitor = tokio::spawn(async move { handoff_monitor.run().await });
+        let id = crate::offchain::order::OffchainOrderId::new();
+        let now = chrono::Utc::now();
+
+        harness
+            .receive::<OffchainOrder>(
+                id,
+                OffchainOrderEvent::Failed {
+                    error: "broker unavailable".to_string(),
+                    failed_at: now,
+                },
+            )
+            .await
+            .expect("a failed reload should be staged for retry");
+
+        let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool)
+            .build(crate::offchain::order::noop_order_placer())
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    shares: st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
+                        st0x_float_macro::float!(1),
+                    ))
+                    .unwrap(),
+                    direction: st0x_execution::Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkPlacementFailed {
+                    error: "broker unavailable".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let pending: i64 = sqlx_apalis::query_scalar(
+                    "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+                )
+                .bind(std::any::type_name::<DeliverDashboardTrade>())
+                .fetch_one(delivery.queue.pool())
+                .await
+                .unwrap();
+                if pending == 1 {
+                    break;
+                }
+
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the handoff monitor should reload and enqueue the terminal order");
+        monitor.abort();
+    }
+
+    #[tokio::test]
+    async fn exhausted_handoff_is_recovered_by_periodic_authoritative_reconciliation() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        let mut handoff_monitor = delivery
+            .handoff_monitor
+            .clone()
+            .with_reconciliation_interval(Duration::from_secs(1));
+        let exhausted = handoff_monitor.exhaustion_notification();
+        let monitor = tokio::spawn(async move { handoff_monitor.run().await });
+        let id = OffchainOrderId::new();
+
+        delivery
+            .broadcaster
+            .handoff_retry_sender
+            .send(DashboardTradeHandoff::ReloadOffchainOrder(id))
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(4), exhausted.notified())
+            .await
+            .expect("the missing handoff must exhaust its immediate retry budget");
+
+        persist_failed_offchain_order(pool, id).await;
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let pending: i64 = sqlx_apalis::query_scalar(
+                    "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+                )
+                .bind(std::any::type_name::<DeliverDashboardTrade>())
+                .fetch_one(delivery.queue.pool())
+                .await
+                .unwrap();
+                if pending == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the running monitor must recover exhausted work from authoritative history");
+        monitor.abort();
+    }
+
+    #[tokio::test]
+    async fn failed_reconciliation_pass_keeps_the_monitor_running() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        let mut handoff_monitor = delivery
+            .handoff_monitor
+            .clone()
+            .with_reconciliation_interval(Duration::from_millis(100));
+        let exhausted = handoff_monitor.exhaustion_notification();
+        let monitor = tokio::spawn(async move { handoff_monitor.run().await });
+
+        delivery
+            .broadcaster
+            .handoff_retry_sender
+            .send(DashboardTradeHandoff::ReloadOffchainOrder(
+                OffchainOrderId::new(),
+            ))
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(4), exhausted.notified())
+            .await
+            .expect("the missing handoff must exhaust its immediate retry budget");
+
+        // Closing the pool makes every reconciliation pass fail. The monitor
+        // must absorb those failures rather than terminate and hand its whole
+        // pending queue back to the pass that is failing.
+        pool.close().await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        assert!(
+            !monitor.is_finished(),
+            "a failing reconciliation pass must not terminate the handoff monitor"
+        );
+        monitor.abort();
+    }
+
+    #[tokio::test]
+    async fn cancelled_offchain_order_handoff_is_a_noop() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let id = OffchainOrderId::new();
+        persist_cancelled_offchain_order(pool.clone(), id).await;
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        let mut handoff_monitor = delivery.handoff_monitor.clone();
+        let monitor = tokio::spawn(async move { handoff_monitor.run().await });
+
+        delivery
+            .broadcaster
+            .handoff_retry_sender
+            .send(DashboardTradeHandoff::ReloadOffchainOrder(id))
+            .await
+            .unwrap();
+        delivery
+            .broadcaster
+            .handoff_retry_sender
+            .send(DashboardTradeHandoff::Trade(Box::new(test_trade())))
+            .await
+            .unwrap();
+
+        // The handoffs are processed in order, so once the trade job lands the
+        // monitor has survived the cancelled handoff, and exactly one job
+        // proves the cancellation delivered nothing.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let jobs: i64 =
+                    sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                        .bind(std::any::type_name::<DeliverDashboardTrade>())
+                        .fetch_one(delivery.queue.pool())
+                        .await
+                        .unwrap();
+                if jobs == 1 {
+                    break;
+                }
+
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("a cancelled handoff must not stop the monitor or deliver anything");
+        monitor.abort();
+    }
+
+    #[tokio::test]
+    async fn poison_handoff_does_not_block_later_terminal_trade() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        let mut handoff_monitor = delivery.handoff_monitor.clone();
+        let monitor = tokio::spawn(async move { handoff_monitor.run().await });
+
+        for _ in 0..HANDOFF_RETRY_QUEUE_CAPACITY {
+            delivery
+                .broadcaster
+                .handoff_retry_sender
+                .send(DashboardTradeHandoff::ReloadOffchainOrder(
+                    OffchainOrderId::new(),
+                ))
+                .await
+                .unwrap();
+        }
+        delivery
+            .broadcaster
+            .handoff_retry_sender
+            .send(DashboardTradeHandoff::Trade(Box::new(test_trade())))
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let pending: i64 = sqlx_apalis::query_scalar(
+                    "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+                )
+                .bind(std::any::type_name::<DeliverDashboardTrade>())
+                .fetch_one(delivery.queue.pool())
+                .await
+                .unwrap();
+                if pending == 1 {
+                    break;
+                }
+
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("poison handoffs must be bounded and must not block a later trade");
+        monitor.abort();
+    }
+
+    #[tokio::test]
+    async fn startup_reconciliation_recovers_terminal_trade_without_job() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let id = crate::onchain_trade::OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 7,
+        };
+        let now = chrono::Utc::now();
+        store
+            .send(
+                &id,
+                crate::onchain_trade::OnChainTradeCommand::WitnessAt {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: st0x_float_macro::float!(1),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+
+        assert_eq!(delivery.reconcile().await.unwrap(), 1);
+        let pending: i64 = sqlx_apalis::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<DeliverDashboardTrade>())
+        .fetch_one(&apalis_pool)
+        .await
+        .unwrap();
+        assert_eq!(pending, 1, "reconciliation must recreate the missing job");
+    }
+
+    #[tokio::test]
+    async fn startup_reconciliation_reclaims_done_job_with_undelivered_ledger() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let id = crate::onchain_trade::OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 9,
+        };
+        let now = chrono::Utc::now();
+        store
+            .send(
+                &id,
+                crate::onchain_trade::OnChainTradeCommand::WitnessAt {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: st0x_float_macro::float!(1),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        assert_eq!(delivery.reconcile().await.unwrap(), 1);
+
+        // Simulates the crash window between publishing and `mark_delivered`:
+        // apalis records the job `Done` while the ledger row stays
+        // undelivered. The idempotency-key unique index spans terminal rows,
+        // so only the refresh UPDATE can make this trade runnable again.
+        sqlx_apalis::query(
+            "UPDATE Jobs SET status = 'Done', done_at = strftime('%s', 'now') WHERE job_type = ?",
+        )
+        .bind(std::any::type_name::<DeliverDashboardTrade>())
+        .execute(&apalis_pool)
+        .await
+        .unwrap();
+
+        assert_eq!(delivery.reconcile().await.unwrap(), 1);
+        let pending: i64 = sqlx_apalis::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<DeliverDashboardTrade>())
+        .fetch_one(&apalis_pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            pending, 1,
+            "a Done job whose ledger row is undelivered must be made runnable again"
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_reconciliation_skips_delivered_trade() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let id = crate::onchain_trade::OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 8,
+        };
+        let now = chrono::Utc::now();
+        store
+            .send(
+                &id,
+                crate::onchain_trade::OnChainTradeCommand::WitnessAt {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: st0x_float_macro::float!(1),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        delivery.store.register(&id.to_string()).await.unwrap();
+        delivery
+            .store
+            .mark_delivered(&id.to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(delivery.reconcile().await.unwrap(), 0);
+        let pending: i64 = sqlx_apalis::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<DeliverDashboardTrade>())
+        .fetch_one(&apalis_pool)
+        .await
+        .unwrap();
+        assert_eq!(pending, 0, "delivered history must not be enqueued again");
+    }
+
+    #[tokio::test]
+    async fn startup_reconciliation_refreshes_stale_offchain_job_payload() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .build(crate::offchain::order::noop_order_placer())
+            .await
+            .unwrap();
+        let id = crate::offchain::order::OffchainOrderId::new();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    shares: st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
+                        st0x_float_macro::float!(1),
+                    ))
+                    .unwrap(),
+                    direction: st0x_execution::Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkPlacementFailed {
+                    error: "broker unavailable".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        let mut queue = delivery.queue.clone();
+        let mut stale_trade = test_trade();
+        stale_trade.id = id.to_string();
+        enqueue_test_delivery(&mut queue, &delivery.ctx, stale_trade).await;
+        assert_eq!(delivery.reconcile().await.unwrap(), 1);
+
+        let payload: Vec<u8> = sqlx_apalis::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<DeliverDashboardTrade>())
+        .fetch_one(&apalis_pool)
+        .await
+        .unwrap();
+        let job: DeliverDashboardTrade = serde_json::from_slice(&payload).unwrap();
+        assert!(matches!(
+            job.trade.outcome,
+            TradeOutcome::Failed { error, .. } if error == "broker unavailable"
+        ));
+    }
+
+    #[tokio::test]
+    async fn transient_delivery_failure_is_retried() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let mut queue = DashboardTradeDeliveryJobQueue::new(&apalis_pool);
+        let (sender, mut receiver) = broadcast::channel(16);
+        let ctx = Arc::new(DashboardTradeDeliveryCtx::new(sender, pool));
+        enqueue_test_delivery(&mut queue, &ctx, test_trade()).await;
+        ctx.fail_next(1);
+        let monitor =
+            spawn_delivery_worker(queue, ctx.clone(), Arc::new(tokio::sync::Notify::new()));
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while !ctx.store.is_delivered("terminal-trade-1").await.unwrap() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("delivery should retry and persist completion");
+        monitor.abort();
+
+        let statements: Vec<_> = std::iter::from_fn(|| receiver.try_recv().ok()).collect();
+        assert_eq!(
+            statements
+                .iter()
+                .filter(|statement| matches!(statement, Statement::TradeUpdate(_)))
+                .count(),
+            2,
+            "the first publish must be replayed when completion persistence fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn orphaned_delivery_replays_after_restart() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (sender, mut receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        let mut queue = delivery.queue.clone();
+        enqueue_test_delivery(&mut queue, &delivery.ctx, test_trade()).await;
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Running' WHERE job_type = ?")
+            .bind(std::any::type_name::<DeliverDashboardTrade>())
+            .execute(&apalis_pool)
+            .await
+            .unwrap();
+
+        delivery.reconcile().await.unwrap();
+
+        let monitor = spawn_delivery_worker(
+            delivery.queue,
+            delivery.ctx,
+            Arc::new(tokio::sync::Notify::new()),
+        );
+        let statement = tokio::time::timeout(Duration::from_secs(10), receiver.recv())
+            .await
+            .expect("restarted worker should replay the orphaned delivery")
+            .expect("dashboard receiver should stay connected");
+        monitor.abort();
+
+        assert!(matches!(statement, Statement::TradeUpdate(_)));
+    }
+
+    #[tokio::test]
+    async fn exhausted_delivery_is_redriven_once_by_startup_reconciliation() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        let mut queue = delivery.queue.clone();
+        enqueue_test_delivery(&mut queue, &delivery.ctx, test_trade()).await;
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Killed', attempts = 5 WHERE job_type = ?")
+            .bind(std::any::type_name::<DeliverDashboardTrade>())
+            .execute(&apalis_pool)
+            .await
+            .unwrap();
+
+        delivery.reconcile().await.unwrap();
+        delivery.reconcile().await.unwrap();
+
+        let (jobs, pending, attempts): (i64, i64, i64) = sqlx_apalis::query_as(
+            "SELECT COUNT(*), SUM(status = 'Pending'), SUM(attempts) FROM Jobs \
+             WHERE job_type = ?",
+        )
+        .bind(std::any::type_name::<DeliverDashboardTrade>())
+        .fetch_one(&apalis_pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            jobs, 1,
+            "reconciliation must not duplicate the delivery job"
+        );
+        assert_eq!(
+            pending, 1,
+            "the exhausted delivery must become runnable again"
+        );
+        assert_eq!(
+            attempts, 0,
+            "a restart must restore the delivery retry budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn delivery_without_connected_receivers_succeeds() {
+        let (pool, _apalis_pool) = setup_test_pools().await;
+        let (sender, receiver) = broadcast::channel(16);
+        drop(receiver);
+        let ctx = DashboardTradeDeliveryCtx::new(sender, pool);
+        let trade = test_trade();
+        ctx.store.register(&trade.id).await.unwrap();
+
+        DeliverDashboardTrade::new(trade)
+            .perform(&ctx)
+            .await
+            .expect("snapshot recovery makes zero live receivers a successful delivery");
+        assert!(ctx.store.is_delivered("terminal-trade-1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn exhausted_delivery_retries_notify_fail_stop_monitor() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let mut queue = DashboardTradeDeliveryJobQueue::new(&apalis_pool);
+        let (sender, _receiver) = broadcast::channel(16);
+        let ctx = Arc::new(DashboardTradeDeliveryCtx::new(sender, pool));
+        enqueue_test_delivery(&mut queue, &ctx, test_trade()).await;
+        ctx.fail_next(usize::MAX);
+        let failure_notify = Arc::new(tokio::sync::Notify::new());
+        let terminal_failure = failure_notify.notified();
+        let monitor = spawn_delivery_worker(queue, ctx, failure_notify.clone());
+
+        tokio::time::timeout(Duration::from_secs(15), terminal_failure)
+            .await
+            .expect("retry exhaustion should notify the conductor fail-stop path");
+        monitor.abort();
+    }
+
+    #[tokio::test]
     async fn onchain_trade_filled_broadcasts_fill() {
-        let pool = setup_test_db().await;
-        let (broadcaster, mut receiver) = test_broadcaster(pool);
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (broadcaster, mut receiver, queue, delivery_ctx) =
+            test_broadcaster(&pool, &apalis_pool);
         let harness = ReactorHarness::new(broadcaster);
 
         let now = chrono::Utc::now();
@@ -240,6 +1793,8 @@ mod tests {
             .await
             .unwrap();
 
+        perform_pending_delivery(&queue, &delivery_ctx).await;
+
         let msg = receiver.recv().await.expect("should receive fill");
 
         match msg {
@@ -264,12 +1819,13 @@ mod tests {
 
     #[tokio::test]
     async fn offchain_order_filled_broadcasts_fill() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
             .build(crate::offchain::order::noop_order_placer())
             .await
             .unwrap();
-        let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
+        let (broadcaster, mut receiver, queue, delivery_ctx) =
+            test_broadcaster(&pool, &apalis_pool);
         let harness = ReactorHarness::new(broadcaster);
 
         let now = chrono::Utc::now();
@@ -326,6 +1882,8 @@ mod tests {
 
         harness.receive::<OffchainOrder>(id, filled).await.unwrap();
 
+        perform_pending_delivery(&queue, &delivery_ctx).await;
+
         let msg = receiver.recv().await.expect("should receive fill");
 
         match msg {
@@ -349,12 +1907,13 @@ mod tests {
 
     #[tokio::test]
     async fn offchain_order_failed_broadcasts_failure() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
             .build(crate::offchain::order::noop_order_placer())
             .await
             .unwrap();
-        let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
+        let (broadcaster, mut receiver, queue, delivery_ctx) =
+            test_broadcaster(&pool, &apalis_pool);
         let harness = ReactorHarness::new(broadcaster);
 
         let id = crate::offchain::order::OffchainOrderId::new();
@@ -422,6 +1981,8 @@ mod tests {
         };
         harness.receive::<OffchainOrder>(id, failed).await.unwrap();
 
+        perform_pending_delivery(&queue, &delivery_ctx).await;
+
         let message = receiver.recv().await.expect("should receive failure");
         match message {
             Statement::TradeUpdate(trade) => match trade.outcome {
@@ -465,12 +2026,13 @@ mod tests {
 
     #[tokio::test]
     async fn position_update_broadcasts_net_position() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (store, _projection) = StoreBuilder::<Position>::new(pool.clone())
             .build(())
             .await
             .unwrap();
-        let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
+        let (broadcaster, mut receiver, _queue, _delivery_ctx) =
+            test_broadcaster(&pool, &apalis_pool);
         let harness = ReactorHarness::new(broadcaster);
 
         let symbol = Symbol::new("AAPL").unwrap();
@@ -539,12 +2101,13 @@ mod tests {
 
     #[tokio::test]
     async fn manual_position_adjustment_broadcasts_adjusted_net() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (store, _projection) = StoreBuilder::<Position>::new(pool.clone())
             .build(())
             .await
             .unwrap();
-        let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
+        let (broadcaster, mut receiver, _queue, _delivery_ctx) =
+            test_broadcaster(&pool, &apalis_pool);
         let harness = ReactorHarness::new(broadcaster);
 
         let symbol = Symbol::new("AAPL").unwrap();

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -24,7 +24,10 @@ mod event;
 pub(crate) mod pnl;
 mod trade_loader;
 pub(crate) mod transfer_loader;
-pub(crate) use event::Broadcaster;
+pub(crate) use event::{
+    Broadcaster, DashboardTradeDelivery, DashboardTradeDeliveryCtx, DashboardTradeDeliveryJobQueue,
+    DashboardTradeHandoffMonitor, DeliverDashboardTrade,
+};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/dashboard/trade_loader.rs
+++ b/src/dashboard/trade_loader.rs
@@ -16,6 +16,15 @@ const MAX_TRADES: usize = 100;
 ///
 /// Returns up to [`MAX_TRADES`] trades sorted by fill time (newest first).
 pub(crate) async fn load_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHistoryError> {
+    let mut trades = load_all_trades(pool).await?;
+
+    trades.truncate(MAX_TRADES);
+
+    Ok(trades)
+}
+
+/// Loads every terminal trade for delivery-ledger reconciliation.
+pub(crate) async fn load_all_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHistoryError> {
     let mut trades: Vec<Trade> = load_onchain_trades(pool)
         .await?
         .into_iter()
@@ -23,7 +32,6 @@ pub(crate) async fn load_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHi
         .collect();
 
     sort_trades_newest_first(&mut trades);
-    trades.truncate(MAX_TRADES);
 
     Ok(trades)
 }


### PR DESCRIPTION
## What

[RAI-1431](https://linear.app/makeitrain/issue/RAI-1431/make-terminal-trade-broadcasts-durable-and-replayable)

Makes terminal dashboard trade delivery durable and replayable across transient failures and process restarts.

## Why

- The domain event could persist while the in-process broadcast failed. Active dashboard sessions then missed a terminal trade until a reload.
- A restart could make that live-stream gap permanent.

## How

- Persists terminal deliveries in an idempotent ledger and Apalis job queue keyed by trade ID.
- Retries failed reactor handoffs in-process from a bounded queue (64 entries, 3 attempts with exponential backoff).
- An exhausted or poison handoff cannot block later trades: a periodic authoritative reconciliation rebuilds every undelivered terminal trade from the event log, and refreshes stale job payloads in place.
- A handoff whose trade can never convert fail-stops the monitor through the supervisor instead of retrying forever.
- Reconciles missing, in-flight, failed, and exhausted deliveries at startup.
- Publishes the canonical and legacy events before marking delivery complete, while the dashboard deduplicates retries by trade ID.
- Wires both production trade stores through the durable broadcaster.

## Testing

- Replayed all 11,358 persisted aggregates from a consistent production snapshot through the exact migration tree with zero failures.
- Added coverage for transient failures, restart recovery, exhausted jobs and handoffs, poison-handoff isolation, deterministic conversion failures, duplicate delivery, stale payload refresh, and both trade stores.
- `cargo nextest run -p st0x-hedge dashboard::event` is green on every branch of the stack; full CI runs remotely.

## Screenshots

Not applicable.

## Anything else

- Stacked on #1056.
- The bounded-queue and periodic-reconciliation hardening moved down from #1063 into this PR, so the delivery mechanism lives in one place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable live dashboard updates for completed trades, including retry and restart recovery.
  * Added reconciliation to restore undelivered trade updates after interruptions.
  * Expanded trade history loading before applying display limits.
* **Bug Fixes**
  * Trade payloads can now be safely saved and restored without losing field names or timestamp precision.
* **Documentation**
  * Documented dashboard trade delivery and updated migration verification commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->