### PR TITLE
fix: validate dashboard trade payloads at runtime

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4125,6 +4125,19 @@ multiple broker-specific contexts.
    sub-millisecond precision, then uses the same stable trade-ID tie-breaker for
    initial history and live updates.
 
+   Every dashboard transport validates trade payloads at runtime before they
+   enter client state. Snapshot, live WebSocket, and paginated HTTP paths use
+   the same validation rules for the canonical and legacy wire shapes:
+   timestamps must be valid UTC RFC 3339 values, venues/directions/outcomes must
+   be known variants, the total share quantity must be positive, and outcome
+   quantities must be non-negative decimal strings. An invalid payload is
+   reported visibly and leaves the last known-good trade state unchanged. The
+   remaining domains from an otherwise valid snapshot still refresh. An invalid
+   WebSocket payload closes the connection, shows the reconnect banner, and
+   retries with bounded exponential backoff. The Rust trade DTO encodes the
+   positive total-quantity invariant so an invalid trade cannot be constructed
+   or deserialized at the server boundary.
+
    Terminal trade live updates are delivered through a persistent delivery
    ledger and job queue, not directly from the CQRS reactor. The ledger is keyed
    by trade ID. The reactor attempts to register the outcome and idempotently

--- a/crates/dto/src/statement.rs
+++ b/crates/dto/src/statement.rs
@@ -48,13 +48,11 @@ impl Statement {
     /// TypeScript-side compile error if the tags ever drift from the
     /// generated `Statement` type definition.
     ///
-    /// The generated `isStatement` performs tag-only validation: it checks
-    /// that the `type` field is a known `Statement` variant, but does not
-    /// validate the shape of `data`. This is intentional — the TypeScript
-    /// type system enforces payload shape after the type guard narrows to
-    /// `Statement`, so per-variant structural checks would be redundant.
-    /// Callers must not assume `data` is well-formed until they pattern-match
-    /// on `type`.
+    /// The generated `isStatement` validates only the envelope tag. Transport
+    /// handlers must still pass external `data` through the feature-specific
+    /// runtime validator before storing it. For example, every dashboard trade
+    /// path uses the shared trade-payload parser for structural and financial
+    /// validation after matching the statement variant.
     #[must_use]
     pub fn guard_ts() -> String {
         let tags = Self::VARIANTS
@@ -90,7 +88,7 @@ mod tests {
     use chrono::Utc;
     use serde_json::json;
 
-    use st0x_finance::{FractionalShares, Symbol};
+    use st0x_finance::{FractionalShares, Positive, Symbol};
     use st0x_float_macro::float;
 
     use super::*;
@@ -132,7 +130,7 @@ mod tests {
             venue: TradingVenue::Raindex,
             direction: Direction::Buy,
             symbol: Symbol::new("AAPL").unwrap(),
-            shares: FractionalShares::new(float!(10)),
+            shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
             outcome: crate::TradeOutcome::Filled,
         };
         let msg = Statement::TradeUpdate(trade);

--- a/crates/dto/src/trade.rs
+++ b/crates/dto/src/trade.rs
@@ -5,7 +5,7 @@ use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize, Serializer};
 use ts_rs::TS;
 
-use st0x_finance::{FractionalShares, NonNegative, Symbol};
+use st0x_finance::{FractionalShares, NonNegative, Positive, Symbol};
 
 /// Where a trade was executed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
@@ -160,7 +160,7 @@ pub struct Trade {
     /// accepted. Failed outcomes split this order quantity into filled and
     /// remaining portions in [`TradeOutcome::Failed`].
     #[ts(type = "string")]
-    pub shares: FractionalShares,
+    pub shares: Positive<FractionalShares>,
     pub outcome: TradeOutcome,
 }
 
@@ -197,7 +197,7 @@ pub struct LegacyTrade {
     #[ts(type = "string")]
     pub symbol: Symbol,
     #[ts(type = "string")]
-    pub shares: FractionalShares,
+    pub shares: Positive<FractionalShares>,
 }
 
 impl Trade {
@@ -258,6 +258,10 @@ mod tests {
 
     use super::*;
 
+    fn positive_shares(value: &str) -> Positive<FractionalShares> {
+        Positive::new(FractionalShares::from_str(value).unwrap()).unwrap()
+    }
+
     #[test]
     fn direction_from_str_accepts_both_wire_forms() {
         assert_eq!(Direction::from_str("BUY").unwrap(), Direction::Buy);
@@ -280,7 +284,7 @@ mod tests {
             venue: TradingVenue::Alpaca,
             direction: Direction::Sell,
             symbol: Symbol::new("TSLA").unwrap(),
-            shares: FractionalShares::new(float!(5.5)),
+            shares: positive_shares("5.5"),
             outcome: TradeOutcome::Filled,
         };
         let json = serde_json::to_value(&trade).expect("serialization should succeed");
@@ -302,7 +306,7 @@ mod tests {
             venue: TradingVenue::Alpaca,
             direction: Direction::Sell,
             symbol: Symbol::new("TSLA").unwrap(),
-            shares: FractionalShares::new(float!(5.5)),
+            shares: positive_shares("5.5"),
             outcome: TradeOutcome::Filled,
         };
 
@@ -319,6 +323,30 @@ mod tests {
     }
 
     #[test]
+    fn trade_deserialization_rejects_non_positive_total_quantity() {
+        let valid = json!({
+            "id": "order-1",
+            "occurredAt": "2026-07-20T12:00:00Z",
+            "venue": "alpaca",
+            "direction": "buy",
+            "symbol": "AAPL",
+            "shares": "1",
+            "outcome": { "status": "filled" }
+        });
+
+        for invalid_shares in ["0", "-1"] {
+            let mut invalid = valid.clone();
+            invalid["shares"] = json!(invalid_shares);
+
+            let error = serde_json::from_value::<Trade>(invalid).unwrap_err();
+            assert!(
+                error.to_string().contains("value must be positive"),
+                "unexpected error for {invalid_shares}: {error}"
+            );
+        }
+    }
+
+    #[test]
     fn failed_trade_serializes_error() {
         let trade = Trade {
             id: "failed-order-id".to_string(),
@@ -326,7 +354,7 @@ mod tests {
             venue: TradingVenue::Alpaca,
             direction: Direction::Buy,
             symbol: Symbol::new("SPCX").unwrap(),
-            shares: FractionalShares::new(float!(1)),
+            shares: positive_shares("1"),
             outcome: TradeOutcome::Failed {
                 error: "asset is not tradable".to_string(),
                 filled_shares: NonNegative::new(FractionalShares::new(float!(0.25))).unwrap(),
@@ -362,7 +390,7 @@ mod tests {
             venue: TradingVenue::Raindex,
             direction: Direction::Buy,
             symbol: Symbol::new("AAPL").unwrap(),
-            shares: FractionalShares::new(float!(1)),
+            shares: positive_shares("1"),
             outcome: TradeOutcome::Filled,
         };
         let tx_hash = "0x0000000000000000000000000000000000000000000000000000000000000000";
@@ -394,7 +422,7 @@ mod tests {
             venue: TradingVenue::Alpaca,
             direction: Direction::Buy,
             symbol: Symbol::new("AAPL").unwrap(),
-            shares: FractionalShares::new(float!(1)),
+            shares: positive_shares("1"),
             outcome: TradeOutcome::Filled,
         };
         let mut trades = vec![

--- a/dashboard/src/lib/components/trade-history-panel.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.svelte
@@ -6,7 +6,6 @@
   import HoverTooltip from '$lib/components/hover-tooltip.svelte'
   import CliCommandBlock from '$lib/components/cli-command-block.svelte'
   import type { Position } from '$lib/api/Position'
-  import type { LegacyTrade } from '$lib/api/LegacyTrade'
   import type { Trade } from '$lib/api/Trade'
   import type { TradingVenue } from '$lib/api/TradingVenue'
   import TradeOutcomeView from '$lib/components/trade-outcome.svelte'
@@ -23,6 +22,7 @@
   import { equityUsdTooltip } from '$lib/inventory-value'
   import { tradeRecoveryCommands } from '$lib/transfer'
   import { mergeTradeHistory, normalizeTrade, type TradeHistoryFilter } from '$lib/trade'
+  import { parseTradeResponse } from '$lib/trade-payload'
 
   type TradeEvent = {
     step: string
@@ -31,12 +31,6 @@
   }
 
   type TradeEntry = Trade
-
-  type TradeResponse = {
-    entries: Array<TradeEntry | LegacyTrade>
-    total: number
-    hasMore: boolean
-  }
 
   const PAGE_SIZE = 100
   const POLL_INTERVAL_MS = 10_000
@@ -159,7 +153,10 @@
     })
   })
 
-  const fetchTrades = async (mode: 'replace' | 'append') => {
+  const fetchTrades = async (
+    mode: 'replace' | 'append',
+    requestOffset = offset.current
+  ) => {
     if (selectedVenues.current.size === 0) {
       historyRequestVersion += 1
       entries.update(() => [])
@@ -182,7 +179,7 @@
 
     try {
       const baseUrl = getApiBaseUrl()
-      const response = await fetch(`${baseUrl}/trades?${buildParams().toString()}`, {
+      const response = await fetch(`${baseUrl}/trades?${buildParams(PAGE_SIZE, requestOffset).toString()}`, {
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
       })
 
@@ -193,7 +190,7 @@
         return
       }
 
-      const wireData: TradeResponse = (await response.json()) as TradeResponse
+      const wireData = parseTradeResponse(await response.json())
       const data = { ...wireData, entries: wireData.entries.map(normalizeTrade) }
       if (requestVersion !== historyRequestVersion) return
 
@@ -205,6 +202,7 @@
       const reconciledTotal = isLoadMore
         ? Math.max(total.current, data.total)
         : data.total + liveExtras
+      if (isLoadMore) offset.update(() => requestOffset)
       total.update(() => reconciledTotal)
       hasMore.update(() => data.hasMore || nextEntries.length < reconciledTotal)
       entries.update(() => nextEntries)
@@ -233,8 +231,7 @@
   }
 
   const loadMore = () => {
-    offset.update((current) => current + PAGE_SIZE)
-    void fetchTrades('append')
+    void fetchTrades('append', offset.current + PAGE_SIZE)
   }
 
   const applyPreset = (minutes: number) => () => {
@@ -269,7 +266,7 @@
   onMount(() => {
     void fetchTrades('replace')
     const interval = setInterval(() => {
-      if (offset.current === 0) void fetchTrades('replace')
+      if (offset.current === 0 && !loadingMore.current) void fetchTrades('replace')
     }, POLL_INTERVAL_MS)
     return () => {
       clearInterval(interval)
@@ -509,12 +506,16 @@
 
   <Card.Content class="relative min-h-0 flex-1 overflow-auto px-6 pt-2">
     {#if error.current}
-      <div class="flex h-full items-center justify-center text-destructive">
+      <div
+        class="mb-2 rounded border border-destructive/40 bg-destructive/10 px-3 py-2 text-destructive"
+      >
         Failed to load trades: {error.current}
       </div>
-    {:else if entries.current.length === 0 && !loading.current}
+    {/if}
+
+    {#if entries.current.length === 0 && !loading.current && error.current === null}
       <div class="flex h-full items-center justify-center text-muted-foreground">No trades yet</div>
-    {:else}
+    {:else if entries.current.length > 0}
       <Table.Root>
         <Table.Header>
           <Table.Row>

--- a/dashboard/src/lib/components/trade-history-panel.test.ts
+++ b/dashboard/src/lib/components/trade-history-panel.test.ts
@@ -96,6 +96,7 @@ const mountPanel = () => {
 
 describe('TradeHistoryPanel', () => {
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
 
@@ -270,6 +271,121 @@ describe('TradeHistoryPanel', () => {
     })
 
     connection.disconnect()
+    await unmount(component)
+    target.remove()
+  })
+
+  it('reports an invalid refresh without replacing known-good history', async () => {
+    const invalidResponse = new Response(
+      JSON.stringify({
+        entries: [failedTrade('invalid', { shares: '0' })],
+        total: 1,
+        hasMore: false
+      }),
+      {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      }
+    )
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(tradeResponse([staleTrade], 1))
+      .mockResolvedValueOnce(invalidResponse)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { target, component } = mountPanel()
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('SPCX')
+      expect(target.textContent).toContain('1 of 1')
+    })
+
+    const refresh = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent.trim() === 'Refresh'
+    )
+    expect(refresh).toBeDefined()
+    refresh?.click()
+
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain(
+        'Failed to load trades: Invalid trade payload at entries[0].shares'
+      )
+      expect(target.textContent).toContain('SPCX')
+      expect(target.textContent).toContain('1 of 1')
+    })
+
+    await unmount(component)
+    target.remove()
+  })
+
+  it('retries the same page after a failed append', async () => {
+    const fetchMock = vi
+      .fn<(url: string, init?: RequestInit) => Promise<Response>>()
+      .mockResolvedValueOnce(tradeResponse([staleTrade], 201, true))
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+      .mockResolvedValueOnce(tradeResponse([failedTrade('older-trade')], 201, true))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { target, component } = mountPanel()
+    await vi.waitFor(() => expect(target.textContent).toContain('1 of 201'))
+
+    const findLoadMore = (): HTMLButtonElement | undefined =>
+      [...target.querySelectorAll('button')].find(
+        (button) => button.textContent.trim() === 'Load older trades'
+      )
+
+    findLoadMore()?.click()
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('Failed to load trades: HTTP 500')
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    findLoadMore()?.click()
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('2 of 201')
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+    })
+
+    const requestedUrls = fetchMock.mock.calls.map(([url]) => url)
+    expect(requestedUrls[1]).toContain('offset=100')
+    expect(requestedUrls[2]).toContain('offset=100')
+
+    await unmount(component)
+    target.remove()
+  })
+
+  it('does not let polling supersede an in-flight page load', async () => {
+    let poll: (() => void) | undefined
+    vi.spyOn(globalThis, 'setInterval').mockImplementation((handler) => {
+      poll = handler as () => void
+      return {} as ReturnType<typeof setInterval>
+    })
+    let resolveOlder: ((response: Response) => void) | undefined
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(tradeResponse([staleTrade], 201, true))
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveOlder = resolve
+          })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { target, component } = mountPanel()
+    await vi.waitFor(() => expect(target.textContent).toContain('1 of 201'))
+
+    const loadMore = [...target.querySelectorAll('button')].find(
+      (button) => button.textContent.trim() === 'Load older trades'
+    )
+    loadMore?.click()
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    poll?.()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    resolveOlder?.(tradeResponse([failedTrade('older-trade')], 201, true))
+    await vi.waitFor(() => expect(target.textContent).toContain('2 of 201'))
+
     await unmount(component)
     target.remove()
   })

--- a/dashboard/src/lib/trade-payload.test.ts
+++ b/dashboard/src/lib/trade-payload.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseCanonicalTrade,
+  parseTrade,
+  parseTradeEntries,
+  parseTradeResponse
+} from './trade-payload'
+
+const validTrade = (overrides: Record<string, unknown> = {}): unknown => ({
+  id: 'counter-trade-1',
+  occurredAt: '2026-07-20T12:00:00.123456789Z',
+  venue: 'alpaca',
+  direction: 'sell',
+  symbol: 'AAPL',
+  shares: '1.25',
+  outcome: { status: 'filled' },
+  ...overrides
+})
+
+describe('trade payload validation', () => {
+  it('accepts canonical and legacy trade entries', () => {
+    expect(parseTrade(validTrade())).toEqual(validTrade())
+    expect(
+      parseTrade({
+        id: 'legacy-fill-1',
+        filledAt: '2026-07-20T12:00:00Z',
+        venue: 'raindex',
+        direction: 'buy',
+        symbol: 'TSLA',
+        shares: '2'
+      })
+    ).toEqual({
+      id: 'legacy-fill-1',
+      filledAt: '2026-07-20T12:00:00Z',
+      venue: 'raindex',
+      direction: 'buy',
+      symbol: 'TSLA',
+      shares: '2'
+    })
+  })
+
+  it.each([
+    ['timestamp', { occurredAt: '2026-02-30T12:00:00Z' }, 'occurredAt'],
+    ['venue', { venue: 'unknown' }, 'venue'],
+    ['direction', { direction: 'hold' }, 'direction'],
+    ['symbol', { symbol: '   ' }, 'symbol'],
+    ['zero total shares', { shares: '0' }, 'shares'],
+    ['negative total shares', { shares: '-0.1' }, 'shares'],
+    ['non-numeric total shares', { shares: 'many' }, 'shares'],
+    ['non-decimal total shares', { shares: '0x10' }, 'shares'],
+    ['outcome variant', { outcome: { status: 'pending' } }, 'outcome.status'],
+    [
+      'negative filled shares',
+      {
+        outcome: {
+          status: 'failed',
+          error: 'rejected',
+          filledShares: '-1',
+          remainingShares: '2',
+          excessShares: '0'
+        }
+      },
+      'outcome.filledShares'
+    ],
+    [
+      'missing failure quantity',
+      {
+        outcome: {
+          status: 'failed',
+          error: 'rejected',
+          filledShares: '0',
+          remainingShares: '1'
+        }
+      },
+      'outcome.excessShares'
+    ]
+  ])('rejects an invalid %s', (_case, overrides, path) => {
+    expect(() => parseTrade(validTrade(overrides))).toThrow(`Invalid trade payload at ${path}`)
+  })
+
+  it('identifies the invalid entry in a snapshot', () => {
+    expect(() => parseTradeEntries([validTrade(), validTrade({ shares: '0' })])).toThrow(
+      'Invalid trade payload at trades[1].shares'
+    )
+  })
+
+  it('requires the canonical outcome shape for a live trade update', () => {
+    const missingOutcome = validTrade() as Record<string, unknown>
+    delete missingOutcome['outcome']
+
+    expect(() => parseCanonicalTrade(missingOutcome)).toThrow('Invalid trade payload at outcome')
+  })
+
+  it('does not reinterpret a malformed canonical snapshot row as legacy', () => {
+    const missingTimestamp = validTrade({
+      occurredAt: undefined,
+      filledAt: '2026-07-20T12:00:00Z'
+    })
+
+    expect(() => parseTrade(missingTimestamp)).toThrow('Invalid trade payload at occurredAt')
+  })
+
+  it('validates paginated history metadata and entries', () => {
+    expect(
+      parseTradeResponse({
+        entries: [validTrade()],
+        total: 1,
+        hasMore: false
+      })
+    ).toEqual({
+      entries: [validTrade()],
+      total: 1,
+      hasMore: false
+    })
+
+    expect(() =>
+      parseTradeResponse({
+        entries: [validTrade({ shares: '0' })],
+        total: 1,
+        hasMore: false
+      })
+    ).toThrow('Invalid trade payload at entries[0].shares')
+    expect(() =>
+      parseTradeResponse({
+        entries: [validTrade()],
+        total: -1,
+        hasMore: false
+      })
+    ).toThrow('Invalid trade payload at total')
+  })
+})

--- a/dashboard/src/lib/trade-payload.ts
+++ b/dashboard/src/lib/trade-payload.ts
@@ -1,0 +1,201 @@
+import Decimal from 'decimal.js'
+import type { Direction } from '$lib/api/Direction'
+import type { LegacyTrade } from '$lib/api/LegacyTrade'
+import type { Trade } from '$lib/api/Trade'
+import type { TradeOutcome } from '$lib/api/TradeOutcome'
+import type { TradingVenue } from '$lib/api/TradingVenue'
+import { tryCatch } from '$lib/fp'
+
+type JsonRecord = Record<string, unknown>
+type CommonTradeFields = Pick<Trade, 'id' | 'venue' | 'direction' | 'symbol' | 'shares'>
+
+const DECIMAL_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/
+
+export type TradeResponse = {
+  entries: Array<Trade | LegacyTrade>
+  total: number
+  hasMore: boolean
+}
+
+export class TradePayloadError extends Error {
+  constructor(path: string, expected: string) {
+    super(`Invalid trade payload at ${path}: expected ${expected}`)
+    this.name = 'TradePayloadError'
+  }
+}
+
+const fieldPath = (path: string, field: string): string =>
+  path === '' ? field : `${path}.${field}`
+
+const invalid = (path: string, expected: string): never => {
+  throw new TradePayloadError(path, expected)
+}
+
+const parseRecord = (value: unknown, path: string): JsonRecord => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return invalid(path, 'an object')
+  }
+
+  return value as JsonRecord
+}
+
+const parseString = (value: unknown, path: string): string => {
+  if (typeof value !== 'string') return invalid(path, 'a string')
+  return value
+}
+
+const parseNonEmptyString = (value: unknown, path: string): string => {
+  const parsed = parseString(value, path)
+  return parsed.length === 0 ? invalid(path, 'a non-empty string') : parsed
+}
+
+const parseSymbol = (value: unknown, path: string): string => {
+  const parsed = parseString(value, path)
+  return parsed.length > 0 && parsed.trim() === parsed
+    ? parsed
+    : invalid(path, 'a non-empty trimmed symbol')
+}
+
+const parseDecimal = (
+  value: unknown,
+  path: string,
+  minimum: 'positive' | 'non-negative'
+): string => {
+  const parsed = parseString(value, path)
+  if (!DECIMAL_PATTERN.test(parsed)) return invalid(path, `a ${minimum} decimal string`)
+
+  const decimal = tryCatch(() => new Decimal(parsed))
+  if (decimal.tag === 'err') return invalid(path, `a ${minimum} decimal string`)
+
+  const valid =
+    decimal.value.isFinite() &&
+    (minimum === 'positive'
+      ? decimal.value.greaterThan(0)
+      : decimal.value.greaterThanOrEqualTo(0))
+  if (valid) return parsed
+
+  return invalid(path, `a ${minimum} decimal string`)
+}
+
+const daysInMonth = (year: number, month: number): number => {
+  if (month === 2) {
+    const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+    return leapYear ? 29 : 28
+  }
+
+  return [4, 6, 9, 11].includes(month) ? 30 : 31
+}
+
+const parseTimestamp = (value: unknown, path: string): string => {
+  const parsed = parseString(value, path)
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?Z$/.exec(parsed)
+  if (match === null) return invalid(path, 'a UTC RFC 3339 timestamp')
+
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText] = match
+  const year = Number(yearText)
+  const month = Number(monthText)
+  const day = Number(dayText)
+  const hour = Number(hourText)
+  const minute = Number(minuteText)
+  const second = Number(secondText)
+  const valid =
+    month >= 1 &&
+    month <= 12 &&
+    day >= 1 &&
+    day <= daysInMonth(year, month) &&
+    hour <= 23 &&
+    minute <= 59 &&
+    second <= 59
+
+  return valid ? parsed : invalid(path, 'a UTC RFC 3339 timestamp')
+}
+
+const parseVenue = (value: unknown, path: string): TradingVenue => {
+  if (value === 'raindex' || value === 'alpaca' || value === 'dry_run') return value
+  return invalid(path, 'a known trading venue')
+}
+
+const parseDirection = (value: unknown, path: string): Direction => {
+  if (value === 'buy' || value === 'sell') return value
+  return invalid(path, 'a known trade direction')
+}
+
+const parseOutcome = (value: unknown, path: string): TradeOutcome => {
+  const outcome = parseRecord(value, path)
+  const statusPath = fieldPath(path, 'status')
+  if (outcome['status'] === 'filled') return { status: 'filled' }
+  if (outcome['status'] !== 'failed') return invalid(statusPath, 'a known terminal outcome')
+
+  return {
+    status: 'failed',
+    error: parseString(outcome['error'], fieldPath(path, 'error')),
+    filledShares: parseDecimal(
+      outcome['filledShares'],
+      fieldPath(path, 'filledShares'),
+      'non-negative'
+    ),
+    remainingShares: parseDecimal(
+      outcome['remainingShares'],
+      fieldPath(path, 'remainingShares'),
+      'non-negative'
+    ),
+    excessShares: parseDecimal(
+      outcome['excessShares'],
+      fieldPath(path, 'excessShares'),
+      'non-negative'
+    )
+  }
+}
+
+const parseCommonTradeFields = (trade: JsonRecord, path: string): CommonTradeFields => ({
+  id: parseNonEmptyString(trade['id'], fieldPath(path, 'id')),
+  venue: parseVenue(trade['venue'], fieldPath(path, 'venue')),
+  direction: parseDirection(trade['direction'], fieldPath(path, 'direction')),
+  symbol: parseSymbol(trade['symbol'], fieldPath(path, 'symbol')),
+  shares: parseDecimal(trade['shares'], fieldPath(path, 'shares'), 'positive')
+})
+
+export const parseCanonicalTrade = (value: unknown, path = ''): Trade => {
+  const trade = parseRecord(value, path === '' ? 'trade' : path)
+  return {
+    ...parseCommonTradeFields(trade, path),
+    occurredAt: parseTimestamp(trade['occurredAt'], fieldPath(path, 'occurredAt')),
+    outcome: parseOutcome(trade['outcome'], fieldPath(path, 'outcome'))
+  }
+}
+
+export const parseLegacyTrade = (value: unknown, path = ''): LegacyTrade => {
+  const trade = parseRecord(value, path === '' ? 'trade' : path)
+  return {
+    ...parseCommonTradeFields(trade, path),
+    filledAt: parseTimestamp(trade['filledAt'], fieldPath(path, 'filledAt'))
+  }
+}
+
+export const parseTrade = (value: unknown, path = ''): Trade | LegacyTrade => {
+  const trade = parseRecord(value, path === '' ? 'trade' : path)
+  return 'occurredAt' in trade || 'outcome' in trade
+    ? parseCanonicalTrade(trade, path)
+    : parseLegacyTrade(trade, path)
+}
+
+export const parseTradeEntries = (value: unknown, path = 'trades'): Array<Trade | LegacyTrade> => {
+  if (!Array.isArray(value)) return invalid(path, 'an array')
+  return value.map((trade, index) => parseTrade(trade, `${path}[${String(index)}]`))
+}
+
+export const parseTradeResponse = (value: unknown): TradeResponse => {
+  const response = parseRecord(value, 'response')
+  const total = response['total']
+  if (typeof total !== 'number' || !Number.isSafeInteger(total) || total < 0) {
+    return invalid('total', 'a non-negative integer')
+  }
+  const hasMore = response['hasMore']
+  if (typeof hasMore !== 'boolean') return invalid('hasMore', 'a boolean')
+
+  return {
+    entries: parseTradeEntries(response['entries'], 'entries'),
+    total,
+    hasMore
+  }
+}

--- a/dashboard/src/lib/websocket/connection.svelte.test.ts
+++ b/dashboard/src/lib/websocket/connection.svelte.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { createWebSocket } from '.'
 import { QueryClient } from '@tanstack/svelte-query'
+import type { CurrentState } from '$lib/api/CurrentState'
 import type { Statement } from '$lib/api/Statement'
 import type { Trade } from '$lib/api/Trade'
 import type { TransferOperation } from '$lib/api/TransferOperation'
@@ -94,6 +95,49 @@ const makeTransfer = (overrides: Partial<TransferOperation> = {}): TransferOpera
     updatedAt: '2024-01-01T12:00:00Z',
     ...overrides
   }) as TransferOperation
+
+const makeCurrentState = (overrides: Partial<CurrentState> = {}): CurrentState => ({
+  trades: [makeTrade()],
+  inventory: {
+    perSymbol: [],
+    usdc: {
+      onchainAvailable: '0',
+      onchainInflight: '0',
+      offchainAvailable: '0',
+      offchainInflight: '0',
+      offchainGross: null,
+      withdrawableCash: null,
+      alpacaUsdc: null,
+      inflightCash: {
+        ethereumWallet: null,
+        baseWallet: null
+      }
+    }
+  },
+  positions: [],
+  settings: {
+    equityTarget: 0.5,
+    equityDeviation: 0.2,
+    usdcTarget: null,
+    usdcDeviation: null,
+    cashReserved: null,
+    executionThreshold: '$2',
+    assets: [],
+    wallet: null,
+    logLevel: 'Debug',
+    serverPort: 8001,
+    orderbook: '0x0',
+    deploymentBlock: 0,
+    tradingMode: 'standalone',
+    broker: 'dry_run',
+    orderPollingInterval: 5,
+    inventoryPollInterval: 15
+  },
+  activeTransfers: [],
+  recentTransfers: [],
+  warnings: [],
+  ...overrides
+})
 
 const setupWebSocketTest = () => {
   const instances: MockWebSocket[] = []
@@ -190,44 +234,11 @@ describe('createWebSocket', () => {
 
       const message: Statement = {
         type: 'current_state',
-        data: {
+        data: makeCurrentState({
           trades: [trade],
-          inventory: {
-            perSymbol: [],
-            usdc: {
-              onchainAvailable: '0',
-              onchainInflight: '0',
-              offchainAvailable: '0',
-              offchainInflight: '0',
-              offchainGross: null,
-              withdrawableCash: null,
-              alpacaUsdc: null,
-              inflightCash: { ethereumWallet: null, baseWallet: null }
-            }
-          },
-          positions: [],
-          settings: {
-            equityTarget: 0.5,
-            equityDeviation: 0.2,
-            usdcTarget: null,
-            usdcDeviation: null,
-            cashReserved: null,
-            executionThreshold: '$2',
-            assets: [],
-            wallet: null,
-            logLevel: 'Debug',
-            serverPort: 8001,
-            orderbook: '0x0',
-            deploymentBlock: 0,
-            tradingMode: 'standalone',
-            broker: 'dry_run',
-            orderPollingInterval: 5,
-            inventoryPollInterval: 15
-          },
           activeTransfers: [activeTransfer],
-          recentTransfers: [recentTransfer],
-          warnings: []
-        }
+          recentTransfers: [recentTransfer]
+        })
       }
 
       getInstance(0).simulateMessage(message)
@@ -359,6 +370,72 @@ describe('createWebSocket', () => {
           outcome: { status: 'filled' }
         }
       ])
+    })
+
+    it.each([
+      [
+        'initial snapshot',
+        {
+          type: 'current_state',
+          data: { trades: [makeTrade({ shares: '0' })] }
+        }
+      ],
+      [
+        'live update',
+        {
+          type: 'trade_update',
+          data: makeTrade({ shares: '0' })
+        }
+      ]
+    ])('rejects an invalid trade from %s without replacing the cache', (_case, message) => {
+      const { getInstance } = setupWebSocketTest()
+      const queryClient = createMockQueryClient()
+      const knownGood = makeTrade({ id: 'known-good' })
+      queryClient.cache.set('["trades"]', [knownGood])
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      const ws = createWebSocket(WS_URL, queryClient)
+
+      ws.connect()
+      getInstance(0).simulateOpen()
+      getInstance(0).simulateRawMessage(JSON.stringify(message))
+
+      expect(queryClient.cache.get('["trades"]')).toEqual([knownGood])
+      expect(ws.state).toBe('error')
+      expect(ws.error?.message).toContain('Invalid trade payload')
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to parse WebSocket message:',
+        expect.objectContaining({ message: expect.stringContaining('shares') }),
+        'Raw data:',
+        JSON.stringify(message)
+      )
+    })
+
+    it('seeds non-trade snapshot domains when a snapshot trade is invalid', () => {
+      const { getInstance } = setupWebSocketTest()
+      const queryClient = createMockQueryClient()
+      const knownGood = makeTrade({ id: 'known-good' })
+      const activeTransfer = makeTransfer({ id: 'fresh-transfer' })
+      const state = makeCurrentState({
+        trades: [makeTrade({ shares: '0' })],
+        activeTransfers: [activeTransfer]
+      })
+      queryClient.cache.set('["trades"]', [knownGood])
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      const ws = createWebSocket(WS_URL, queryClient)
+
+      ws.connect()
+      getInstance(0).simulateOpen()
+      getInstance(0).simulateRawMessage(
+        JSON.stringify({
+          type: 'current_state',
+          data: state
+        })
+      )
+
+      expect(queryClient.cache.get('["trades"]')).toEqual([knownGood])
+      expect(queryClient.cache.get('["inventory"]')).toEqual(state.inventory)
+      expect(queryClient.cache.get('["transfers","active"]')).toEqual([activeTransfer])
+      expect(ws.state).toBe('error')
     })
 
     it('replaces a matching initial trade with its live update', () => {
@@ -514,6 +591,7 @@ describe('createWebSocket', () => {
       expect(ws.state).toBe('error')
       expect(ws.error).not.toBeNull()
       expect(ws.error?.attempts).toBe(1)
+      expect(ws.error?.message).toBe('WebSocket connection error')
     })
 
     it('reconnects after delay', () => {
@@ -544,7 +622,38 @@ describe('createWebSocket', () => {
       getInstance(1).simulateOpen()
 
       expect(ws.state).toBe('connected')
+      expect(ws.error).not.toBeNull()
+
+      getInstance(1).simulateMessage({ type: 'trade_update', data: makeTrade() })
+
       expect(ws.error).toBeNull()
+    })
+
+    it('backs off repeated invalid messages until a valid message arrives', () => {
+      const { instances, getInstance } = setupWebSocketTest()
+      const queryClient = createMockQueryClient()
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      const ws = createWebSocket(WS_URL, queryClient)
+
+      ws.connect()
+      getInstance(0).simulateOpen()
+      getInstance(0).simulateRawMessage('{"not":"valid"}')
+
+      expect(ws.error?.attempts).toBe(1)
+      expect(ws.error?.nextRetryMs).toBe(1000)
+
+      vi.advanceTimersByTime(1000)
+      getInstance(1).simulateOpen()
+      getInstance(1).simulateRawMessage('{"not":"valid"}')
+
+      expect(ws.error?.attempts).toBe(2)
+      expect(ws.error?.nextRetryMs).toBe(2000)
+
+      vi.advanceTimersByTime(1000)
+      expect(instances).toHaveLength(2)
+      vi.advanceTimersByTime(1000)
+      expect(instances).toHaveLength(3)
+      expect(consoleError).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/dashboard/src/lib/websocket/connection.svelte.ts
+++ b/dashboard/src/lib/websocket/connection.svelte.ts
@@ -2,8 +2,9 @@ import { FiniteStateMachine } from 'runed'
 import type { QueryClient } from '@tanstack/svelte-query'
 import type { Statement } from '$lib/api/Statement'
 import { isStatement } from '$lib/api/StatementGuard'
-import { matcher } from '$lib/fp'
+import { matcher, tryCatch } from '$lib/fp'
 import { reactive } from '$lib/frp.svelte'
+import { parseCanonicalTrade, parseLegacyTrade, parseTradeEntries } from '$lib/trade-payload'
 import { seedTrades, appendTrade } from './trades'
 import { seedInventory, updateSnapshot, upsertPosition } from './inventory'
 import { seedTransfers, upsertTransfer } from './transfers'
@@ -28,32 +29,49 @@ const getReconnectDelay = (attempts: number): number =>
 export type ErrorContext = {
   attempts: number
   nextRetryMs: number
+  message: string
 }
 
 export const createWebSocket = (url: string, queryClient: QueryClient) => {
   const protocolUrl = withTradeProtocol(url)
   let socket: WebSocket | null = null
   let reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null
+  let failureMessage = 'WebSocket connection error'
   const reconnectAttempts = reactive(0)
   const error = reactive<ErrorContext | null>(null)
+
+  const markHealthy = () => {
+    reconnectAttempts.update(() => 0)
+    error.update(() => null)
+  }
 
   const handleMessage = (msg: Statement) => {
     matchMessage(msg, {
       current_state: ({ data }) => {
-        seedTrades(queryClient, data)
         seedInventory(queryClient, data)
         seedTransfers(queryClient, data)
+        seedTrades(queryClient, parseTradeEntries(data.trades))
       },
 
-      trade_update: ({ data }) => { appendTrade(queryClient, data); },
+      trade_update: ({ data }) => {
+        appendTrade(queryClient, parseCanonicalTrade(data))
+      },
 
-      trade_fill: ({ data }) => { appendTrade(queryClient, data); },
+      trade_fill: ({ data }) => {
+        appendTrade(queryClient, parseLegacyTrade(data))
+      },
 
-      position_update: ({ data }) => { upsertPosition(queryClient, data); },
+      position_update: ({ data }) => {
+        upsertPosition(queryClient, data)
+      },
 
-      inventory_snapshot: ({ data }) => { updateSnapshot(queryClient, data); },
+      inventory_snapshot: ({ data }) => {
+        updateSnapshot(queryClient, data)
+      },
 
-      transfer_update: ({ data }) => { upsertTransfer(queryClient, data); }
+      transfer_update: ({ data }) => {
+        upsertTransfer(queryClient, data)
+      }
     })
   }
 
@@ -66,30 +84,49 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
     }
 
     socket.onmessage = (event) => {
-      try {
-        const parsed: unknown = JSON.parse(event.data as string)
-
-        if (!isStatement(parsed)) {
-          console.error('Invalid Statement structure:', parsed)
-          return
-        }
-
-        const { type } = parsed
-        if (import.meta.env.DEV) console.log(`[ws] received "${type}"`, parsed)
-
-        handleMessage(parsed)
-      } catch (parseError) {
-        console.error('Failed to parse WebSocket message:', parseError, 'Raw data:', event.data)
+      const parsed = tryCatch((): unknown => JSON.parse(event.data as string))
+      if (parsed.tag === 'err') {
+        failureMessage = 'Rejected malformed WebSocket message'
+        console.error('Failed to parse WebSocket message:', parsed.error, 'Raw data:', event.data)
+        fsm.send('error')
+        return
       }
+
+      if (!isStatement(parsed.value)) {
+        failureMessage = 'Rejected invalid WebSocket message'
+        console.error('Invalid Statement structure:', parsed.value)
+        fsm.send('error')
+        return
+      }
+
+      const statement = parsed.value
+      const { type } = statement
+      if (import.meta.env.DEV) console.log(`[ws] received "${type}"`, statement)
+
+      const handled = tryCatch(() => handleMessage(statement))
+      if (handled.tag === 'ok') {
+        markHealthy()
+        return
+      }
+
+      failureMessage =
+        handled.error instanceof Error
+          ? handled.error.message
+          : 'Rejected invalid WebSocket message'
+      console.error('Failed to parse WebSocket message:', handled.error, 'Raw data:', event.data)
+      fsm.send('error')
     }
 
     socket.onclose = (event) => {
-      if (import.meta.env.DEV) console.log(`[ws] closed (code=${String(event.code)}, reason="${event.reason}")`)
+      if (import.meta.env.DEV)
+        console.log(`[ws] closed (code=${String(event.code)}, reason="${event.reason}")`)
+      failureMessage = 'WebSocket connection closed'
       socket = null
       fsm.send('close')
     }
 
     socket.onerror = () => {
+      failureMessage = 'WebSocket connection error'
       fsm.send('error')
     }
   }
@@ -115,8 +152,12 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
   const scheduleReconnect = () => {
     cancelReconnect()
     const delay = getReconnectDelay(reconnectAttempts.current)
-    error.update(() => ({ attempts: reconnectAttempts.current + 1, nextRetryMs: delay }))
-    reconnectAttempts.update(attempts => attempts + 1)
+    error.update(() => ({
+      attempts: reconnectAttempts.current + 1,
+      nextRetryMs: delay,
+      message: failureMessage
+    }))
+    reconnectAttempts.update((attempts) => attempts + 1)
     reconnectTimeoutId = setTimeout(() => fsm.send('connect'), delay)
   }
 
@@ -144,11 +185,7 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
     connected: {
       close: 'error',
       error: 'error',
-      disconnect: 'disconnected',
-      _enter: () => {
-        reconnectAttempts.update(() => 0)
-        error.update(() => null)
-      }
+      disconnect: 'disconnected'
     },
 
     error: {

--- a/dashboard/src/lib/websocket/trades.ts
+++ b/dashboard/src/lib/websocket/trades.ts
@@ -1,15 +1,14 @@
 import type { QueryClient } from '@tanstack/svelte-query'
-import type { CurrentState } from '$lib/api/CurrentState'
 import type { LegacyTrade } from '$lib/api/LegacyTrade'
 import type { Trade } from '$lib/api/Trade'
 import { compareTradesNewestFirst, normalizeTrade } from '$lib/trade'
 
 const MAX_TRADES = 100
 
-export const seedTrades = (queryClient: QueryClient, state: CurrentState) => {
+export const seedTrades = (queryClient: QueryClient, wireTrades: Array<Trade | LegacyTrade>) => {
   queryClient.setQueryData<Trade[]>(
     ['trades'],
-    state.trades.map(normalizeTrade).sort(compareTradesNewestFirst)
+    wireTrades.map(normalizeTrade).sort(compareTradesNewestFirst)
   )
 }
 

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -72,7 +72,7 @@
       class="mx-2 mt-2 rounded-md border border-destructive bg-destructive/10
         px-4 py-2 text-sm text-destructive md:mx-4"
     >
-      Connection error. Reconnecting in {countdown}s (attempt {errorContext.attempts})...
+      {errorContext.message}. Reconnecting in {countdown}s (attempt {errorContext.attempts})...
     </div>
   {/if}
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -21,8 +21,9 @@ use st0x_dto::{
     EquityTimings, HedgeLatencies, InfraReport, RebalanceTimings, ReliabilityReport, Trade,
     TradeOutcome, TradingVenue, sort_trades_newest_first,
 };
+use st0x_execution::Symbol;
 use st0x_execution::alpaca_broker_api::AccountActivitiesQuery;
-use st0x_execution::{FractionalShares, Symbol};
+use st0x_finance::{FractionalShares, NotPositive, Positive};
 use st0x_tokenization::IssuerRequestId;
 
 use crate::AppState;
@@ -754,7 +755,7 @@ fn parse_onchain_trade_row(
             venue: TradingVenue::Raindex,
             direction,
             symbol,
-            shares: FractionalShares::new(amount),
+            shares: Positive::new(FractionalShares::new(amount))?,
             outcome: TradeOutcome::Filled,
         })
     })()
@@ -821,6 +822,8 @@ enum OnchainTradeRowError {
     Payload(#[from] serde_json::Error),
     #[error("query returned a non-fill onchain event")]
     UnexpectedEvent,
+    #[error("onchain trade quantity is not positive: {0}")]
+    Quantity(#[from] NotPositive<FractionalShares>),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -19,6 +19,7 @@ use tracing::{debug, info, warn};
 
 use st0x_dto::{Statement, Trade, TradeOutcome, TradingVenue};
 use st0x_event_sorcery::{EntityList, Reactor, SendError, deps, load_entity};
+use st0x_finance::{FractionalShares, NotPositive, Positive};
 
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::equity_redemption::EquityRedemption;
@@ -766,6 +767,8 @@ enum DashboardTradePersistenceError {
 pub(crate) enum DashboardTradeEnqueueError {
     #[error("dashboard trade handoff retry queue closed before retaining the outcome: {0}")]
     RetryQueue(#[from] mpsc::error::SendError<DashboardTradeHandoff>),
+    #[error("terminal trade quantity is not positive: {0}")]
+    Quantity(#[from] NotPositive<FractionalShares>),
 }
 
 #[async_trait]
@@ -792,7 +795,7 @@ impl Reactor for Broadcaster {
                         venue: TradingVenue::Raindex,
                         direction,
                         symbol,
-                        shares: st0x_finance::FractionalShares::new(amount),
+                        shares: Positive::new(FractionalShares::new(amount))?,
                         outcome: TradeOutcome::Filled,
                     })
                     .await?;
@@ -928,7 +931,7 @@ mod tests {
             venue: TradingVenue::Alpaca,
             direction: st0x_execution::Direction::Sell,
             symbol: Symbol::new("AAPL").unwrap(),
-            shares: st0x_finance::FractionalShares::new(st0x_float_macro::float!(1)),
+            shares: Positive::new(FractionalShares::new(st0x_float_macro::float!(1))).unwrap(),
             outcome: TradeOutcome::Filled,
         }
     }

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -411,7 +411,10 @@ mod tests {
             venue: TradingVenue::Raindex,
             direction: Direction::Buy,
             symbol: st0x_finance::Symbol::new(symbol).unwrap(),
-            shares: st0x_finance::FractionalShares::new(st0x_float_macro::float!(1)),
+            shares: Positive::new(st0x_finance::FractionalShares::new(
+                st0x_float_macro::float!(1),
+            ))
+            .unwrap(),
             outcome: st0x_dto::TradeOutcome::Filled,
         })
     }
@@ -768,7 +771,7 @@ mod tests {
             venue: TradingVenue::Raindex,
             direction: Direction::Buy,
             symbol: Symbol::new("TSLA").unwrap(),
-            shares: FractionalShares::new(float!(1)),
+            shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
             outcome: TradeOutcome::Filled,
         };
         server

--- a/src/dashboard/trade_loader.rs
+++ b/src/dashboard/trade_loader.rs
@@ -6,9 +6,10 @@ use tracing::warn;
 
 use st0x_dto::{Trade, sort_trades_newest_first};
 use st0x_event_sorcery::{LoadAllIdsError, SendError, load_all_ids, load_entity};
+use st0x_finance::{FractionalShares, NotPositive};
 
 use crate::offchain::order::{OffchainOrder, TradeConversionError};
-use crate::onchain_trade::OnChainTrade;
+use crate::onchain_trade::{OnChainTrade, OnChainTradeId};
 
 const MAX_TRADES: usize = 100;
 
@@ -60,7 +61,14 @@ async fn load_onchain_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHisto
                 }
             };
 
-            Some(entity.into_trade(&id))
+            match entity.try_into_trade(&id) {
+                Ok(trade) => Some(trade),
+                Err(source) => {
+                    let error = TradeHistoryError::OnchainConversion { id, source };
+                    warn!(target: "dashboard", %error, "Skipping unrepresentable onchain trade");
+                    None
+                }
+            }
         })
         .collect()
         .await)
@@ -127,6 +135,12 @@ pub(crate) enum TradeHistoryError {
     },
     #[error("onchain trade {id} replayed to empty state")]
     OnchainMissing { id: String },
+    #[error("onchain trade {id} cannot be represented in history: {source}")]
+    OnchainConversion {
+        id: OnChainTradeId,
+        #[source]
+        source: NotPositive<FractionalShares>,
+    },
     #[error("failed to replay offchain trade {id}: {source}")]
     OffchainReplay {
         id: String,

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -1476,7 +1476,7 @@ impl OffchainOrder {
             },
             direction,
             symbol,
-            shares: shares.inner(),
+            shares,
             outcome,
         })
     }
@@ -2838,7 +2838,7 @@ mod tests {
             .try_into_trade(&OffchainOrderId::new())
             .expect("valid terminal failure should convert");
         assert_eq!(trade.occurred_at, failure_time);
-        assert!(trade.shares.inner().eq(float!(2)).unwrap());
+        assert!(trade.shares.inner().inner().eq(float!(2)).unwrap());
         match trade.outcome {
             TradeOutcome::Failed {
                 error,

--- a/src/onchain_trade.rs
+++ b/src/onchain_trade.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use st0x_dto::{Direction, Trade, TradeOutcome, TradingVenue};
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
 use st0x_execution::Symbol;
-use st0x_finance::FractionalShares;
+use st0x_finance::{FractionalShares, NotPositive, Positive};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 
@@ -264,16 +264,19 @@ impl OnChainTrade {
         self.acknowledged_at.is_some()
     }
 
-    pub(crate) fn into_trade(self, id: &OnChainTradeId) -> Trade {
-        Trade {
+    pub(crate) fn try_into_trade(
+        self,
+        id: &OnChainTradeId,
+    ) -> Result<Trade, NotPositive<FractionalShares>> {
+        Ok(Trade {
             id: id.to_string(),
             occurred_at: self.block_timestamp,
             venue: TradingVenue::Raindex,
             direction: self.direction,
             symbol: self.symbol,
-            shares: FractionalShares::new(self.amount),
+            shares: Positive::new(FractionalShares::new(self.amount))?,
             outcome: TradeOutcome::Filled,
-        }
+        })
     }
 }
 
@@ -879,6 +882,31 @@ mod tests {
         assert!(trade.amount.eq(float!(10.5)).unwrap());
         assert_eq!(trade.direction, Direction::Buy);
         assert!(!trade.is_enriched());
+    }
+
+    #[test]
+    fn dashboard_trade_rejects_non_positive_fill_quantity() {
+        let now = Utc::now();
+        let id = OnChainTradeId {
+            tx_hash: TxHash::ZERO,
+            log_index: 0,
+        };
+
+        for amount in [float!(0), float!(-1)] {
+            let trade = replay::<OnChainTrade>(vec![OnChainTradeEvent::Filled {
+                symbol: Symbol::new("AAPL").unwrap(),
+                amount,
+                direction: Direction::Buy,
+                price_usdc: float!(150.25),
+                block_number: 12345,
+                block_timestamp: now,
+                filled_at: now,
+            }])
+            .unwrap()
+            .unwrap();
+
+            trade.try_into_trade(&id).unwrap_err();
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

[RAI-1433](https://linear.app/makeitrain/issue/RAI-1433/validate-dashboard-trade-payloads-at-runtime)

Validate dashboard trade payloads at runtime before they enter REST or WebSocket state, and encode positive total trade quantity in the Rust DTO.

## Why

Generated TypeScript types only protect compile-time callers. Malformed runtime JSON could previously enter the dashboard cache and render misleading financial data.

## How

- Add one runtime parser for canonical and legacy trade payloads, including timestamps, enum variants, outcome shapes, and decimal quantity invariants.
- Preserve known-good history when REST refreshes, pagination, snapshots, or live updates are rejected.
- Surface WebSocket protocol failures in the dashboard and retain reconnect backoff until a valid message arrives.
- Make `Trade.shares` and `LegacyTrade.shares` positive quantities in Rust, propagating typed conversion failures.
- Keep pagination retries on the failed offset and prevent polling from superseding an in-flight page load.

## Testing

- `nix run .#ci`
- 42 focused dashboard tests covering payload validation, cache preservation, WebSocket errors/backoff, and pagination races
- Final Codex review: no actionable regressions

## Screenshots

Not applicable.

## Anything else

Stacked on #1058.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive validation for trade data received through snapshots, live updates, and paginated history.
  * Invalid trade payloads now display clear errors while preserving the last known-good data.
  * Connection errors now show specific details, retry attempts, and reconnect countdowns.

* **Bug Fixes**
  * Prevented invalid or non-positive trade quantities from entering dashboard state.
  * Improved trade-history pagination retries and prevented polling from interrupting older-page loads.
  * Added validation for timestamps, trade fields, outcomes, and pagination metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->