### PR TITLE
fix: redact the issuance endpoint from freeze-guard error logs

### DIFF
--- a/src/rebalancing/trigger/freeze.rs
+++ b/src/rebalancing/trigger/freeze.rs
@@ -37,8 +37,52 @@ pub(crate) enum FreezeCheckError {
     #[error("issuance does not recognize asset {symbol}")]
     AssetUnknown { symbol: Symbol },
     /// The status request itself failed (transport error, unexpected status).
-    #[error("issuance freeze-status request failed")]
-    Client(#[from] ClientError),
+    #[error("issuance freeze-status request failed: {0}")]
+    Client(FreezeClientFailure),
+}
+
+/// Coarse, endpoint-free classification of a failed issuance status request.
+///
+/// The issuance endpoint lives in the encrypted secrets (issuance is not on
+/// the internal network), and [`ClientError`] embeds the request URL and
+/// socket address in both `Debug` and `Display`. The trigger logs freeze-check
+/// errors, so the raw client error is reduced to this classification at the
+/// boundary and never reaches logs.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FreezeClientFailure {
+    #[error("HTTP client could not be built")]
+    Build,
+    #[error("configured base URL is not a valid base")]
+    InvalidBaseUrl,
+    #[error("request timed out")]
+    Timeout,
+    #[error("connection failed")]
+    Connect,
+    #[error("transport error")]
+    Transport,
+    #[error("failed to parse the response body")]
+    ParseResponse,
+    /// Raw status code: the client does not re-export its `StatusCode` type,
+    /// and naming either of the workspace's two reqwest majors here would tie
+    /// this enum to the client's private dependency version.
+    #[error("unexpected status {0}")]
+    UnexpectedStatus(u16),
+}
+
+impl From<ClientError> for FreezeCheckError {
+    fn from(error: ClientError) -> Self {
+        Self::Client(match error {
+            ClientError::Build(_) => FreezeClientFailure::Build,
+            ClientError::NotABase { .. } => FreezeClientFailure::InvalidBaseUrl,
+            ClientError::Http(http) if http.is_timeout() => FreezeClientFailure::Timeout,
+            ClientError::Http(http) if http.is_connect() => FreezeClientFailure::Connect,
+            ClientError::Http(_) => FreezeClientFailure::Transport,
+            ClientError::ParseResponse(_) => FreezeClientFailure::ParseResponse,
+            ClientError::Status { status, .. } => {
+                FreezeClientFailure::UnexpectedStatus(status.as_u16())
+            }
+        })
+    }
 }
 
 #[async_trait]
@@ -161,6 +205,54 @@ mod tests {
                 FreezeCheckError::AssetUnknown { ref symbol } if *symbol == Symbol::new("AAPL").unwrap()
             ),
             "a 404 must map to AssetUnknown so the trigger fails closed, got: {error:?}"
+        );
+    }
+
+    /// The issuance endpoint lives in the encrypted secrets (issuance is not
+    /// on the internal network), and the trigger logs freeze-check errors with
+    /// `?error`. A connect failure must therefore never surface the endpoint
+    /// host in the error's debug representation.
+    #[tokio::test]
+    async fn freeze_check_error_never_leaks_the_endpoint_on_connect_failure() {
+        let client = IssuanceClient::new(
+            Url::parse("http://127.0.0.1:9").expect("valid URL"),
+            "test-key",
+        )
+        .expect("client must build");
+
+        let error = client
+            .is_frozen(&Symbol::new("AAPL").unwrap())
+            .await
+            .expect_err("port 9 must refuse the connection");
+
+        let debug = format!("{error:?}");
+        assert!(
+            !debug.contains("127.0.0.1"),
+            "freeze-check error debug must not leak the issuance endpoint, \
+             got: {debug}"
+        );
+    }
+
+    /// Same redaction requirement for the unexpected-status path, whose client
+    /// error carries the request URL as a field.
+    #[tokio::test]
+    async fn freeze_check_error_never_leaks_the_endpoint_on_status_error() {
+        let server = MockServer::start_async().await;
+        server.mock(|when, then| {
+            when.method(GET).path("/tokenized-assets/AAPL/status");
+            then.status(500);
+        });
+
+        let error = client_for(&server)
+            .is_frozen(&Symbol::new("AAPL").unwrap())
+            .await
+            .expect_err("a 500 must fail closed");
+
+        let debug = format!("{error:?}");
+        assert!(
+            !debug.contains("127.0.0.1") && !debug.contains(&server.address().port().to_string()),
+            "freeze-check error debug must not leak the issuance endpoint, \
+             got: {debug}"
         );
     }
 


### PR DESCRIPTION
## What

- Redact the issuance endpoint from freeze-guard error logs: `FreezeCheckError::Client` now carries an endpoint-free `FreezeClientFailure` classification (build/connect/timeout/transport/parse/status-code) instead of the raw `st0x_issuance_client::ClientError`.

## Why

- The issuance `base_url` lives in the encrypted secrets (issuance is not on the internal network), but the trigger logs freeze-check failures with `?error`, and the raw client error embeds the full request URL and socket address in both `Debug` and `Display` — during the 2026-07-20 outage the endpoint IP was printed into logs (which ship to the observability stack) on every failed-closed cycle.

## How

- Replace the derived `#[from] ClientError` conversion with a manual `From` that classifies the failure at the boundary; the reqwest error (URL, hyper connect error with socket address) is dropped there and can never reach a log site.
- The status code is carried as `u16` because the client crate does not re-export its `StatusCode` type and the workspace has two reqwest majors in the tree.

## Testing

- Two new regression tests exercise the real client against a refused connection and a 500 response and assert the error's `Debug` output contains neither host nor port. Both failed before the fix (reproducing the exact leak shapes from prod logs) and pass after; all pre-existing freeze tests pass unchanged.
