### PR TITLE
fix: preserve counter-trade quantity provenance

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4104,26 +4104,42 @@ multiple broker-specific contexts.
 4. **Trade History**: Recent trades filterable by venue (onchain/offchain/both).
    Onchain entries are completed fills. Offchain counter-trade entries include
    both successful fills and terminal failures; each entry carries its terminal
-   outcome timestamp. Failed entries expose the broker or placement error plus
-   the filled and unfilled portions of that broker order so operators can see
-   partial execution without inspecting logs. Fills beyond the broker-accepted
-   order quantity expose the excess separately rather than clamping it or making
-   history unavailable. Terminal outcomes appear in both initial history and
-   live dashboard updates.
+   outcome timestamp. Failed entries expose the broker or placement error and
+   keep the requested quantity distinct from the broker-accepted quantity. The
+   accepted and actually-filled quantities are nullable provenance: `null` means
+   the persisted history does not prove that fact, including legacy failures
+   that predate explicit fill evidence. Remaining and excess quantities are
+   derived only when both accepted and filled quantities are known. An overfill
+   reports the complete actual fill plus its excess rather than clamping the
+   fill to the accepted quantity. Terminal outcomes use the same provenance in
+   initial history and live dashboard updates.
 
    Dashboard trade messages remain compatible during rolling deploys. The
    canonical protocol sends every terminal outcome as `trade_update`. Filled
    outcomes also carry the legacy `filledAt` timestamp field and are broadcast
    as a legacy `trade_fill`, so an older dashboard connected to a newer backend
    continues to receive fills. Snapshot, HTTP, and live protocols default to
-   legacy filled-only behavior; a newer dashboard opts into terminal outcomes
-   with `trade_protocol=terminal_outcomes_v1`. Old backends ignore that query
+   legacy filled-only behavior; dashboards opt into versioned terminal outcomes
+   with a `trade_protocol` query parameter. Old backends ignore that query
    parameter. A newer dashboard accepts legacy `trade_fill` messages and legacy
    snapshot/HTTP trade rows, normalizing them to a filled outcome before merging
-   by trade ID. Failed outcomes are sent only through the canonical protocol.
-   Trade ordering compares the complete RFC 3339 timestamp, including
-   sub-millisecond precision, then uses the same stable trade-ID tie-breaker for
-   initial history and live updates.
+   by trade ID. The original `terminal_outcomes_v1` contract remains stable for
+   older dashboards: its failed quantities are always non-null and retain the
+   legacy split representation. When accepted-quantity provenance is unknown, v1
+   reports the requested quantity as the accepted quantity and derives the split
+   from it, because v1 has no way to express an unknown acceptance.
+   Provenance-aware nullable failure quantities use
+   `trade_protocol=terminal_outcomes_v2`. A newer dashboard requests v2 and
+   retries both WebSocket and HTTP history with v1 when an older backend rejects
+   the unknown protocol value, while continuing to accept v1 responses and
+   reconstructing the complete fill as the legacy filled plus excess quantity. A
+   legacy zero fill remains unknown because v1 synthesized zero when no fill
+   evidence existed. A successful v1 WebSocket fallback probes v2 again after
+   its next disconnect so a transient restart cannot pin the client to v1.
+   Failed outcomes are sent only through a terminal-outcome protocol. Trade
+   ordering compares the complete RFC 3339 timestamp, including sub-millisecond
+   precision, then uses the same stable trade-ID tie-breaker for initial history
+   and live updates.
 
    Every dashboard transport validates trade payloads at runtime before they
    enter client state. Snapshot, live WebSocket, and paginated HTTP paths use

--- a/crates/dto/src/trade.rs
+++ b/crates/dto/src/trade.rs
@@ -1,8 +1,9 @@
 //! Trade fill DTOs for completed onchain and offchain trades.
 
 use chrono::{DateTime, Utc};
-use serde::ser::SerializeStruct;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::de::Error as _;
+use serde::ser::{Error as _, SerializeStruct};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ts_rs::TS;
 
 use st0x_finance::{FractionalShares, NonNegative, Positive, Symbol};
@@ -120,7 +121,7 @@ pub struct InvalidDirectionError {
 }
 
 /// Terminal outcome of a dashboard trade entry.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 #[serde(
     tag = "status",
     rename_all = "snake_case",
@@ -130,16 +131,109 @@ pub enum TradeOutcome {
     Filled,
     Failed {
         error: String,
-        #[ts(type = "string")]
-        filled_shares: NonNegative<FractionalShares>,
-        #[ts(type = "string")]
-        remaining_shares: NonNegative<FractionalShares>,
+        #[ts(type = "string | null")]
+        accepted_shares: Option<Positive<FractionalShares>>,
+        #[ts(type = "string | null")]
+        filled_shares: Option<NonNegative<FractionalShares>>,
+        #[ts(type = "string | null")]
+        remaining_shares: Option<NonNegative<FractionalShares>>,
         /// Shares filled beyond the broker-accepted order quantity. This is
         /// separate from remaining shares so anomalous broker state is never
         /// clamped away.
-        #[ts(type = "string")]
-        excess_shares: NonNegative<FractionalShares>,
+        #[ts(type = "string | null")]
+        excess_shares: Option<NonNegative<FractionalShares>>,
     },
+}
+
+#[derive(Default)]
+enum FieldPresence<T> {
+    #[default]
+    Missing,
+    Present(T),
+}
+
+fn deserialize_present<'de, D, T>(deserializer: D) -> Result<FieldPresence<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    T::deserialize(deserializer).map(FieldPresence::Present)
+}
+
+#[derive(Deserialize)]
+#[serde(
+    tag = "status",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+enum TradeOutcomeWire {
+    Filled,
+    Failed {
+        error: String,
+        #[serde(default, deserialize_with = "deserialize_present")]
+        accepted_shares: FieldPresence<Option<Positive<FractionalShares>>>,
+        filled_shares: Option<NonNegative<FractionalShares>>,
+        remaining_shares: Option<NonNegative<FractionalShares>>,
+        excess_shares: Option<NonNegative<FractionalShares>>,
+    },
+}
+
+impl<'de> Deserialize<'de> for TradeOutcome {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match TradeOutcomeWire::deserialize(deserializer)? {
+            TradeOutcomeWire::Filled => Ok(Self::Filled),
+            TradeOutcomeWire::Failed {
+                error,
+                accepted_shares: FieldPresence::Present(accepted_shares),
+                filled_shares,
+                remaining_shares,
+                excess_shares,
+            } => Ok(Self::Failed {
+                error,
+                accepted_shares,
+                filled_shares,
+                remaining_shares,
+                excess_shares,
+            }),
+            TradeOutcomeWire::Failed {
+                error,
+                accepted_shares: FieldPresence::Missing,
+                filled_shares,
+                remaining_shares,
+                excess_shares,
+            } => {
+                // terminal_outcomes_v1 predates accepted-quantity provenance.
+                // It split an overfill between filledShares and excessShares,
+                // so reconstruct the complete broker fill before discarding the
+                // request-derived remaining/excess values.
+                let filled =
+                    filled_shares.ok_or_else(|| D::Error::missing_field("filledShares"))?;
+                // Presence-only: the request-derived remainder is discarded in
+                // favour of the reconstructed complete fill below.
+                let _ =
+                    remaining_shares.ok_or_else(|| D::Error::missing_field("remainingShares"))?;
+                let excess =
+                    excess_shares.ok_or_else(|| D::Error::missing_field("excessShares"))?;
+                let complete_fill = (filled.inner() + excess.inner()).map_err(D::Error::custom)?;
+                let filled_shares = if complete_fill.inner().is_zero().map_err(D::Error::custom)? {
+                    None
+                } else {
+                    Some(NonNegative::new(complete_fill).map_err(D::Error::custom)?)
+                };
+
+                Ok(Self::Failed {
+                    error,
+                    accepted_shares: None,
+                    filled_shares,
+                    remaining_shares: None,
+                    excess_shares: None,
+                })
+            }
+        }
+    }
 }
 
 /// A completed onchain fill or terminal offchain counter-trade.
@@ -155,10 +249,9 @@ pub struct Trade {
     pub direction: Direction,
     #[ts(type = "string")]
     pub symbol: Symbol,
-    /// Quantity submitted for this counter-trade. Before broker acceptance this
-    /// is the requested quantity; afterward it is the quantity the broker
-    /// accepted. Failed outcomes split this order quantity into filled and
-    /// remaining portions in [`TradeOutcome::Failed`].
+    /// Executed quantity for fills, or requested quantity for a failed
+    /// counter-trade. Failed outcomes carry broker-accepted and fill provenance
+    /// separately when those facts are known.
     #[ts(type = "string")]
     pub shares: Positive<FractionalShares>,
     pub outcome: TradeOutcome,
@@ -185,6 +278,94 @@ impl Serialize for Trade {
     }
 }
 
+/// Stable `terminal_outcomes_v1` representation.
+///
+/// Retained for older dashboard bundles. That contract cannot express unknown
+/// quantity provenance, so its
+/// failed outcome uses the legacy non-null split while v2 exposes the canonical
+/// nullable fields from [`TradeOutcome`].
+pub struct TerminalOutcomesV1Trade<'a> {
+    trade: &'a Trade,
+}
+
+#[derive(Serialize)]
+#[serde(
+    tag = "status",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+enum TerminalOutcomesV1Outcome<'a> {
+    Failed {
+        error: &'a str,
+        filled_shares: NonNegative<FractionalShares>,
+        remaining_shares: NonNegative<FractionalShares>,
+        excess_shares: NonNegative<FractionalShares>,
+    },
+}
+
+impl Serialize for TerminalOutcomesV1Trade<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let TradeOutcome::Failed {
+            error,
+            accepted_shares,
+            filled_shares,
+            ..
+        } = &self.trade.outcome
+        else {
+            return self.trade.serialize(serializer);
+        };
+
+        // When acceptance provenance is unknown, v1 has no way to express
+        // that, so it reports the requested quantity as the accepted quantity
+        // and derives the split from it. An older dashboard therefore cannot
+        // tell an assumed accepted quantity from a proven one.
+        let shares = accepted_shares.unwrap_or(self.trade.shares);
+        let accepted = shares.inner();
+        // v1 represented a failure observed before fill provenance existed as
+        // an unfilled order. Keep that historical wire contract only in this
+        // compatibility adapter; the canonical v2 outcome remains unknown.
+        let filled = filled_shares
+            .map(NonNegative::inner)
+            .unwrap_or(FractionalShares::ZERO);
+        let (filled_portion, remaining_shares, excess_shares) = if filled
+            .inner()
+            .gt(accepted.inner())
+            .map_err(S::Error::custom)?
+        {
+            (
+                accepted,
+                FractionalShares::ZERO,
+                (filled - accepted).map_err(S::Error::custom)?,
+            )
+        } else {
+            (
+                filled,
+                (accepted - filled).map_err(S::Error::custom)?,
+                FractionalShares::ZERO,
+            )
+        };
+        let outcome = TerminalOutcomesV1Outcome::Failed {
+            error,
+            filled_shares: NonNegative::new(filled_portion).map_err(S::Error::custom)?,
+            remaining_shares: NonNegative::new(remaining_shares).map_err(S::Error::custom)?,
+            excess_shares: NonNegative::new(excess_shares).map_err(S::Error::custom)?,
+        };
+
+        let mut trade = serializer.serialize_struct("Trade", 7)?;
+        trade.serialize_field("id", &self.trade.id)?;
+        trade.serialize_field("occurredAt", &self.trade.occurred_at)?;
+        trade.serialize_field("venue", &self.trade.venue)?;
+        trade.serialize_field("direction", &self.trade.direction)?;
+        trade.serialize_field("symbol", &self.trade.symbol)?;
+        trade.serialize_field("shares", &shares)?;
+        trade.serialize_field("outcome", &outcome)?;
+        trade.end()
+    }
+}
+
 /// Filled-trade wire shape consumed by dashboard versions before terminal
 /// outcomes were added to [`Trade`].
 #[derive(Debug, Clone, Serialize, TS)]
@@ -201,6 +382,12 @@ pub struct LegacyTrade {
 }
 
 impl Trade {
+    /// Returns the stable terminal-outcomes v1 wire representation.
+    #[must_use]
+    pub const fn terminal_outcomes_v1(&self) -> TerminalOutcomesV1Trade<'_> {
+        TerminalOutcomesV1Trade { trade: self }
+    }
+
     /// Returns the pre-terminal-outcome representation for filled trades.
     #[must_use]
     pub fn legacy_fill(&self) -> Option<LegacyTrade> {
@@ -357,9 +544,12 @@ mod tests {
             shares: positive_shares("1"),
             outcome: TradeOutcome::Failed {
                 error: "asset is not tradable".to_string(),
-                filled_shares: NonNegative::new(FractionalShares::new(float!(0.25))).unwrap(),
-                remaining_shares: NonNegative::new(FractionalShares::new(float!(0.75))).unwrap(),
-                excess_shares: NonNegative::new(FractionalShares::ZERO).unwrap(),
+                accepted_shares: Some(positive_shares("1")),
+                filled_shares: Some(NonNegative::new(FractionalShares::new(float!(0.25))).unwrap()),
+                remaining_shares: Some(
+                    NonNegative::new(FractionalShares::new(float!(0.75))).unwrap(),
+                ),
+                excess_shares: Some(NonNegative::new(FractionalShares::ZERO).unwrap()),
             },
         };
 
@@ -369,6 +559,7 @@ mod tests {
             json!({
                 "status": "failed",
                 "error": "asset is not tradable",
+                "acceptedShares": "1",
                 "filledShares": "0.25",
                 "remainingShares": "0.75",
                 "excessShares": "0"
@@ -378,6 +569,179 @@ mod tests {
             json.get("filledAt").is_none(),
             "failed outcomes must not masquerade as legacy fills"
         );
+    }
+
+    #[test]
+    fn failed_trade_deserializes_legacy_outcome_without_accepted_shares() {
+        let legacy = json!({
+            "id": "failed-order-id",
+            "occurredAt": "2026-07-20T12:00:00Z",
+            "venue": "alpaca",
+            "direction": "buy",
+            "symbol": "SPCX",
+            "shares": "1",
+            "outcome": {
+                "status": "failed",
+                "error": "asset is not tradable",
+                "filledShares": "0.25",
+                "remainingShares": "0.75",
+                "excessShares": "0"
+            }
+        });
+
+        let trade: Trade = serde_json::from_value(legacy).expect("legacy trade should deserialize");
+        let TradeOutcome::Failed {
+            accepted_shares,
+            filled_shares,
+            remaining_shares,
+            excess_shares,
+            ..
+        } = trade.outcome
+        else {
+            panic!("legacy failed trade must retain its outcome");
+        };
+
+        assert_eq!(accepted_shares, None);
+        assert_eq!(
+            filled_shares,
+            Some(NonNegative::new(FractionalShares::new(float!(0.25))).unwrap())
+        );
+        assert_eq!(remaining_shares, None);
+        assert_eq!(excess_shares, None);
+    }
+
+    #[test]
+    fn failed_trade_deserialization_reconstructs_legacy_overfill() {
+        let legacy = json!({
+            "id": "overfilled-order-id",
+            "occurredAt": "2026-07-20T12:00:00Z",
+            "venue": "alpaca",
+            "direction": "buy",
+            "symbol": "SPCX",
+            "shares": "1",
+            "outcome": {
+                "status": "failed",
+                "error": "broker failed after overfill",
+                "filledShares": "1",
+                "remainingShares": "0",
+                "excessShares": "0.25"
+            }
+        });
+
+        let trade: Trade = serde_json::from_value(legacy).expect("legacy trade should deserialize");
+        let TradeOutcome::Failed {
+            accepted_shares,
+            filled_shares,
+            remaining_shares,
+            excess_shares,
+            ..
+        } = trade.outcome
+        else {
+            panic!("legacy failed trade must retain its outcome");
+        };
+
+        assert_eq!(accepted_shares, None);
+        assert_eq!(
+            filled_shares,
+            Some(NonNegative::new(FractionalShares::new(float!(1.25))).unwrap())
+        );
+        assert_eq!(remaining_shares, None);
+        assert_eq!(excess_shares, None);
+    }
+
+    #[test]
+    fn failed_trade_deserialization_keeps_legacy_zero_fill_unknown() {
+        let legacy = json!({
+            "id": "placement-failure-id",
+            "occurredAt": "2026-07-20T12:00:00Z",
+            "venue": "alpaca",
+            "direction": "buy",
+            "symbol": "SPCX",
+            "shares": "1",
+            "outcome": {
+                "status": "failed",
+                "error": "placement rejected",
+                "filledShares": "0",
+                "remainingShares": "1",
+                "excessShares": "0"
+            }
+        });
+
+        let trade: Trade = serde_json::from_value(legacy).expect("legacy trade should deserialize");
+        let TradeOutcome::Failed {
+            accepted_shares,
+            filled_shares,
+            remaining_shares,
+            excess_shares,
+            ..
+        } = trade.outcome
+        else {
+            panic!("legacy failed trade must retain its outcome");
+        };
+
+        assert_eq!(accepted_shares, None);
+        assert_eq!(filled_shares, None);
+        assert_eq!(remaining_shares, None);
+        assert_eq!(excess_shares, None);
+    }
+
+    #[test]
+    fn terminal_outcomes_v1_preserves_non_null_legacy_failure_shape() {
+        let trade = Trade {
+            id: "failed-order-id".to_string(),
+            occurred_at: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            venue: TradingVenue::Alpaca,
+            direction: Direction::Buy,
+            symbol: Symbol::new("SPCX").unwrap(),
+            shares: positive_shares("2"),
+            outcome: TradeOutcome::Failed {
+                error: "broker failed after overfill".to_string(),
+                accepted_shares: Some(positive_shares("1")),
+                filled_shares: Some(NonNegative::new(FractionalShares::new(float!(1.25))).unwrap()),
+                remaining_shares: Some(NonNegative::new(FractionalShares::ZERO).unwrap()),
+                excess_shares: Some(NonNegative::new(FractionalShares::new(float!(0.25))).unwrap()),
+            },
+        };
+
+        let wire = serde_json::to_value(trade.terminal_outcomes_v1())
+            .expect("v1 compatibility serialization should succeed");
+
+        assert_eq!(wire["shares"], "1");
+        assert_eq!(wire["outcome"]["filledShares"], "1");
+        assert_eq!(wire["outcome"]["remainingShares"], "0");
+        assert_eq!(wire["outcome"]["excessShares"], "0.25");
+        assert!(wire["outcome"].get("acceptedShares").is_none());
+    }
+
+    #[test]
+    fn terminal_outcomes_v1_assumes_the_requested_quantity_when_acceptance_is_unknown() {
+        let trade = Trade {
+            id: "failed-order-id".to_string(),
+            occurred_at: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            venue: TradingVenue::Alpaca,
+            direction: Direction::Buy,
+            symbol: Symbol::new("SPCX").unwrap(),
+            shares: positive_shares("2"),
+            outcome: TradeOutcome::Failed {
+                error: "asset is not tradable".to_string(),
+                accepted_shares: None,
+                filled_shares: None,
+                remaining_shares: None,
+                excess_shares: None,
+            },
+        };
+
+        let wire = serde_json::to_value(trade.terminal_outcomes_v1())
+            .expect("v1 compatibility serialization should succeed");
+
+        // Unknown acceptance falls back to the requested quantity, and the
+        // absent fill becomes v1's synthesized zero, so the whole request
+        // reads as unfilled.
+        assert_eq!(wire["shares"], "2");
+        assert_eq!(wire["outcome"]["filledShares"], "0");
+        assert_eq!(wire["outcome"]["remainingShares"], "2");
+        assert_eq!(wire["outcome"]["excessShares"], "0");
+        assert!(wire["outcome"].get("acceptedShares").is_none());
     }
 
     #[test]

--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -198,7 +198,8 @@ impl Executor for AlpacaBrokerApi {
             // (the poll retries the same read forever and the position never
             // releases). A genuine partial fill on a failed order carries
             // filled_qty, which the retained-fill path records; an absent
-            // field on a rejection means no fill.
+            // field remains unknown downstream rather than being treated as
+            // proof of a zero fill.
             OrderStatus::Failed => Ok(OrderState::Failed {
                 failed_at: order_update.updated_at,
                 error_reason: None,

--- a/dashboard/src/lib/components/trade-history-panel.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.svelte
@@ -97,11 +97,15 @@
   const venueOptions = ALL_VENUES.map((venue) => ({ value: venue, label: venueLabel(venue) }))
   const symbolOptions = $derived(allSymbols.current.map((sym) => ({ value: sym, label: sym })))
 
-  const buildParams = (limit = PAGE_SIZE, requestOffset = offset.current): URLSearchParams => {
+  const buildParams = (
+    limit = PAGE_SIZE,
+    requestOffset = offset.current,
+    protocol: 'terminal_outcomes_v2' | 'terminal_outcomes_v1' = 'terminal_outcomes_v2'
+  ): URLSearchParams => {
     const params = new URLSearchParams({
       limit: String(limit),
       offset: String(requestOffset),
-      trade_protocol: 'terminal_outcomes_v1'
+      trade_protocol: protocol
     })
 
     if (selectedVenues.current.size > 0 && selectedVenues.current.size < ALL_VENUES.length) {
@@ -153,10 +157,7 @@
     })
   })
 
-  const fetchTrades = async (
-    mode: 'replace' | 'append',
-    requestOffset = offset.current
-  ) => {
+  const fetchTrades = async (mode: 'replace' | 'append', requestOffset = offset.current) => {
     if (selectedVenues.current.size === 0) {
       historyRequestVersion += 1
       entries.update(() => [])
@@ -179,9 +180,14 @@
 
     try {
       const baseUrl = getApiBaseUrl()
-      const response = await fetch(`${baseUrl}/trades?${buildParams(PAGE_SIZE, requestOffset).toString()}`, {
-        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
-      })
+      const fetchWithProtocol = (protocol: 'terminal_outcomes_v2' | 'terminal_outcomes_v1') =>
+        fetch(`${baseUrl}/trades?${buildParams(PAGE_SIZE, requestOffset, protocol).toString()}`, {
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+        })
+      let response = await fetchWithProtocol('terminal_outcomes_v2')
+      if (response.status === 400) {
+        response = await fetchWithProtocol('terminal_outcomes_v1')
+      }
 
       if (!response.ok) {
         if (requestVersion === historyRequestVersion) {
@@ -307,7 +313,10 @@
   const fmtSize = (value: string): string => formatDecimal(value, 3)
 
   const shareTooltip = (trade: TradeEntry): string =>
-    equityUsdTooltip(trade.shares, positionPrices.get(trade.symbol) ?? null)
+    `${trade.outcome.status === 'failed' ? 'Order quantity. ' : ''}${equityUsdTooltip(
+      trade.shares,
+      positionPrices.get(trade.symbol) ?? null
+    )}`
 
   const isNumeric = (value: unknown): boolean =>
     typeof value === 'string' && value !== '' && !Number.isNaN(Number(value))

--- a/dashboard/src/lib/components/trade-history-panel.test.ts
+++ b/dashboard/src/lib/components/trade-history-panel.test.ts
@@ -31,6 +31,7 @@ const failedTrade = (id: string, overrides: Partial<Trade> = {}): Trade => ({
   outcome: {
     status: 'failed',
     error: 'broker rejected remainder',
+    acceptedShares: '1',
     filledShares: '0.25',
     remainingShares: '0.75',
     excessShares: '0'
@@ -74,11 +75,17 @@ const setupTestWebSocket = () => {
   }
 }
 
-const tradeResponse = (entries: Array<Trade | LegacyTrade>, total: number, hasMore = false): Response =>
+const tradeResponse = (
+  entries: Array<Trade | LegacyTrade>,
+  total: number,
+  hasMore = false
+): Response =>
   new Response(JSON.stringify({ entries, total, hasMore }), {
     status: 200,
     headers: { 'content-type': 'application/json' }
   })
+
+const mountedPanels: ReturnType<typeof mount>[] = []
 
 const mountPanel = () => {
   const queryClient = new QueryClient({
@@ -90,12 +97,21 @@ const mountPanel = () => {
     target,
     props: { client: queryClient }
   })
+  mountedPanels.push(component)
 
   return { queryClient, target, component }
 }
 
 describe('TradeHistoryPanel', () => {
-  afterEach(() => {
+  // Unmount here rather than at the end of each test body: a failed assertion
+  // would skip an inline unmount and leak a live component, whose polling
+  // interval then fires against the next test's mocks.
+  afterEach(async () => {
+    while (mountedPanels.length > 0) {
+      const component = mountedPanels.pop()
+      if (component) await unmount(component)
+    }
+
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
@@ -109,9 +125,12 @@ describe('TradeHistoryPanel', () => {
       symbol: 'TSLA',
       shares: '2'
     }
-    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(tradeResponse([legacyTrade], 1))))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(tradeResponse([legacyTrade], 1)))
+    )
 
-    const { target, component } = mountPanel()
+    const { target } = mountPanel()
 
     await vi.waitFor(() => {
       expect(target.textContent).toContain('TSLA')
@@ -119,7 +138,142 @@ describe('TradeHistoryPanel', () => {
       expect(target.textContent).toContain('1 of 1')
     })
 
-    await unmount(component)
+    target.remove()
+  })
+
+  it('retries trade history with v1 when the previous backend rejects v2', async () => {
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 400 }))
+      .mockResolvedValueOnce(tradeResponse([staleTrade], 1))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { target } = mountPanel()
+
+    await vi.waitFor(() => expect(target.textContent).toContain('1 of 1'))
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('trade_protocol=terminal_outcomes_v2'),
+      expect.any(Object)
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('trade_protocol=terminal_outcomes_v1'),
+      expect.any(Object)
+    )
+
+    target.remove()
+  })
+
+  it('labels a fallback v1 failure quantity without claiming request provenance', async () => {
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 400 }))
+      .mockResolvedValueOnce(tradeResponse([failedTrade('v1-failure')], 1))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { target } = mountPanel()
+
+    await vi.waitFor(() => expect(target.textContent).toContain('1 of 1'))
+    const quantityTooltip = Array.from(target.querySelectorAll('button')).find((button) =>
+      button.getAttribute('aria-label')?.startsWith('Order quantity.') === true
+    )
+    expect(quantityTooltip).toBeDefined()
+    expect(quantityTooltip?.getAttribute('aria-label')).not.toContain('Requested quantity')
+
+    target.remove()
+  })
+
+  it('re-probes v2 on the next refresh after a v1 fallback', async () => {
+    let poll: (() => void) | undefined
+    vi.spyOn(globalThis, 'setInterval').mockImplementation((handler) => {
+      poll = handler as () => void
+      return {} as ReturnType<typeof setInterval>
+    })
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 400 }))
+      .mockResolvedValueOnce(tradeResponse([failedTrade('v1-failure')], 1))
+      .mockResolvedValueOnce(
+        tradeResponse(
+          [
+            failedTrade('v2-failure', {
+              symbol: 'UPGRADED',
+              outcome: {
+                status: 'failed',
+                error: 'broker rejected remainder',
+                acceptedShares: '0.5',
+                filledShares: '0.25',
+                remainingShares: '0.25',
+                excessShares: '0'
+              }
+            })
+          ],
+          1
+        )
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { target } = mountPanel()
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    poll?.()
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('trade_protocol=terminal_outcomes_v2'),
+      expect.any(Object)
+    )
+    await vi.waitFor(() => expect(target.textContent).toContain('UPGRADED'))
+
+    target.remove()
+  })
+
+  it('retries each concurrent v2 history request independently', async () => {
+    let poll: (() => void) | undefined
+    vi.spyOn(globalThis, 'setInterval').mockImplementation((handler) => {
+      poll = handler as () => void
+      return {} as ReturnType<typeof setInterval>
+    })
+    const pendingRequests: Array<{
+      url: string
+      resolve: (response: Response) => void
+    }> = []
+    const fetchMock = vi.fn<(url: string) => Promise<Response>>(
+      (url) =>
+        new Promise<Response>((resolve) => {
+          pendingRequests.push({ url, resolve })
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { target } = mountPanel()
+    await vi.waitFor(() => expect(pendingRequests).toHaveLength(1))
+
+    poll?.()
+    await vi.waitFor(() => expect(pendingRequests).toHaveLength(2))
+
+    expect(pendingRequests[0]?.url).toContain('trade_protocol=terminal_outcomes_v2')
+    expect(pendingRequests[1]?.url).toContain('trade_protocol=terminal_outcomes_v2')
+
+    pendingRequests[0]?.resolve(new Response(null, { status: 400 }))
+    await vi.waitFor(() => expect(pendingRequests).toHaveLength(3))
+    expect(pendingRequests[2]?.url).toContain('trade_protocol=terminal_outcomes_v1')
+    pendingRequests[2]?.resolve(tradeResponse([staleTrade], 1))
+
+    pendingRequests[1]?.resolve(new Response(null, { status: 400 }))
+    await vi.waitFor(() => expect(pendingRequests).toHaveLength(4))
+    expect(pendingRequests[3]?.url).toContain('trade_protocol=terminal_outcomes_v1')
+    pendingRequests[3]?.resolve(
+      tradeResponse([failedTrade('current-request', { symbol: 'CURR' })], 1)
+    )
+
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('CURR')
+      expect(target.textContent).toContain('1 of 1')
+    })
+
     target.remove()
   })
 
@@ -134,6 +288,7 @@ describe('TradeHistoryPanel', () => {
               outcome: {
                 status: 'failed',
                 error: 'initial broker failure',
+                acceptedShares: '1',
                 filledShares: '0',
                 remainingShares: '1',
                 excessShares: '0'
@@ -147,7 +302,7 @@ describe('TradeHistoryPanel', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { queryClient, target, component } = mountPanel()
+    const { queryClient, target } = mountPanel()
 
     await vi.waitFor(() => {
       expect(target.textContent).toContain('initial broker failure')
@@ -163,6 +318,7 @@ describe('TradeHistoryPanel', () => {
         outcome: {
           status: 'failed',
           error: 'broker overfilled before rejecting',
+          acceptedShares: '0.5',
           filledShares: '1',
           remainingShares: '0',
           excessShares: '0.5'
@@ -184,13 +340,12 @@ describe('TradeHistoryPanel', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('limit=100'), expect.any(Object))
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('trade_protocol=terminal_outcomes_v1'),
+      expect.stringContaining('trade_protocol=terminal_outcomes_v2'),
       expect.any(Object)
     )
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
     connection.disconnect()
-    await unmount(component)
     target.remove()
   })
 
@@ -206,7 +361,7 @@ describe('TradeHistoryPanel', () => {
       .mockReturnValueOnce(refreshResponse)
     vi.stubGlobal('fetch', fetchMock)
 
-    const { queryClient, target, component } = mountPanel()
+    const { queryClient, target } = mountPanel()
     await vi.waitFor(() => expect(target.textContent).toContain('1 of 150'))
 
     const connection = createWebSocket('ws://localhost/api/ws', queryClient)
@@ -238,7 +393,6 @@ describe('TradeHistoryPanel', () => {
     })
 
     connection.disconnect()
-    await unmount(component)
     target.remove()
   })
 
@@ -250,7 +404,7 @@ describe('TradeHistoryPanel', () => {
       .mockResolvedValueOnce(tradeResponse([failedTrade('live-1'), staleTrade], 2, false))
     vi.stubGlobal('fetch', fetchMock)
 
-    const { queryClient, target, component } = mountPanel()
+    const { queryClient, target } = mountPanel()
     await vi.waitFor(() => expect(target.textContent).toContain('1 of 3'))
 
     const connection = createWebSocket('ws://localhost/api/ws', queryClient)
@@ -271,7 +425,6 @@ describe('TradeHistoryPanel', () => {
     })
 
     connection.disconnect()
-    await unmount(component)
     target.remove()
   })
 
@@ -293,7 +446,7 @@ describe('TradeHistoryPanel', () => {
       .mockResolvedValueOnce(invalidResponse)
     vi.stubGlobal('fetch', fetchMock)
 
-    const { target, component } = mountPanel()
+    const { target } = mountPanel()
     await vi.waitFor(() => {
       expect(target.textContent).toContain('SPCX')
       expect(target.textContent).toContain('1 of 1')
@@ -313,7 +466,6 @@ describe('TradeHistoryPanel', () => {
       expect(target.textContent).toContain('1 of 1')
     })
 
-    await unmount(component)
     target.remove()
   })
 
@@ -325,7 +477,7 @@ describe('TradeHistoryPanel', () => {
       .mockResolvedValueOnce(tradeResponse([failedTrade('older-trade')], 201, true))
     vi.stubGlobal('fetch', fetchMock)
 
-    const { target, component } = mountPanel()
+    const { target } = mountPanel()
     await vi.waitFor(() => expect(target.textContent).toContain('1 of 201'))
 
     const findLoadMore = (): HTMLButtonElement | undefined =>
@@ -349,7 +501,6 @@ describe('TradeHistoryPanel', () => {
     expect(requestedUrls[1]).toContain('offset=100')
     expect(requestedUrls[2]).toContain('offset=100')
 
-    await unmount(component)
     target.remove()
   })
 
@@ -371,7 +522,7 @@ describe('TradeHistoryPanel', () => {
       )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { target, component } = mountPanel()
+    const { target } = mountPanel()
     await vi.waitFor(() => expect(target.textContent).toContain('1 of 201'))
 
     const loadMore = [...target.querySelectorAll('button')].find(
@@ -386,7 +537,6 @@ describe('TradeHistoryPanel', () => {
     resolveOlder?.(tradeResponse([failedTrade('older-trade')], 201, true))
     await vi.waitFor(() => expect(target.textContent).toContain('2 of 201'))
 
-    await unmount(component)
     target.remove()
   })
 
@@ -403,7 +553,7 @@ describe('TradeHistoryPanel', () => {
       )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { target, component } = mountPanel()
+    const { target } = mountPanel()
     await vi.waitFor(() => expect(target.textContent).toContain('1 of 150'))
 
     const loadMore = [...target.querySelectorAll('button')].find(
@@ -450,7 +600,6 @@ describe('TradeHistoryPanel', () => {
       expect(target.textContent).not.toContain('Load older trades')
     })
 
-    await unmount(component)
     target.remove()
   })
 })

--- a/dashboard/src/lib/components/trade-outcome.svelte
+++ b/dashboard/src/lib/components/trade-outcome.svelte
@@ -12,6 +12,8 @@
 
   const failureReason = $derived(tradeFailureReason(outcome))
   const failureShares = $derived(tradeFailureShares(outcome))
+  const quantity = (value: string | null): string =>
+    value === null ? 'unknown' : formatDecimal(value, 9)
 </script>
 
 <div class="font-medium {tradeOutcomeClass(outcome)}">
@@ -27,12 +29,12 @@
 {/if}
 {#if failureShares !== null}
   <div class="text-muted-foreground">
-    Filled {formatDecimal(failureShares.filled, 9)} · Unfilled {formatDecimal(
-      failureShares.remaining,
-      9
-    )}
+    Accepted {quantity(failureShares.accepted)} · Filled {quantity(failureShares.filled)}
+    {#if failureShares.remaining !== null}
+      · Unfilled {formatDecimal(failureShares.remaining, 9)}
+    {/if}
   </div>
-  {#if !decimalIsZero(failureShares.excess)}
+  {#if failureShares.excess !== null && !decimalIsZero(failureShares.excess)}
     <div class="text-destructive">
       Excess fill {formatDecimal(failureShares.excess, 9)}
     </div>

--- a/dashboard/src/lib/components/trade-outcome.test.ts
+++ b/dashboard/src/lib/components/trade-outcome.test.ts
@@ -19,6 +19,7 @@ describe('TradeOutcome', () => {
         outcome: {
           status: 'failed',
           error: 'broker rejected remainder',
+          acceptedShares: '1',
           filledShares: '0.25',
           remainingShares: '0.75',
           excessShares: '0'
@@ -28,6 +29,7 @@ describe('TradeOutcome', () => {
 
     expect(body).toContain('Failed')
     expect(body).toContain('broker rejected remainder')
+    expect(body).toContain('Accepted 1')
     expect(body).toContain('Filled 0.25')
     expect(body).toContain('Unfilled 0.75')
   })
@@ -38,6 +40,7 @@ describe('TradeOutcome', () => {
         outcome: {
           status: 'failed',
           error: 'broker rejected remainder',
+          acceptedShares: '1',
           filledShares: '0.0004',
           remainingShares: '0.9996',
           excessShares: '0'
@@ -55,6 +58,7 @@ describe('TradeOutcome', () => {
         outcome: {
           status: 'failed',
           error: 'broker overfilled before rejecting',
+          acceptedShares: '0.5',
           filledShares: '1',
           remainingShares: '0',
           excessShares: '0.5'
@@ -65,5 +69,24 @@ describe('TradeOutcome', () => {
     expect(body).toContain('Filled 1')
     expect(body).toContain('Unfilled 0')
     expect(body).toContain('Excess fill 0.5')
+  })
+
+  it('renders missing provenance as unknown instead of zero', () => {
+    const { body } = render(TradeOutcome, {
+      props: {
+        outcome: {
+          status: 'failed',
+          error: 'placement failed before acceptance',
+          acceptedShares: null,
+          filledShares: null,
+          remainingShares: null,
+          excessShares: null
+        }
+      }
+    })
+
+    expect(body).toContain('Accepted unknown')
+    expect(body).toContain('Filled unknown')
+    expect(body).not.toContain('Unfilled 0')
   })
 })

--- a/dashboard/src/lib/trade-payload.test.ts
+++ b/dashboard/src/lib/trade-payload.test.ts
@@ -55,6 +55,7 @@ describe('trade payload validation', () => {
         outcome: {
           status: 'failed',
           error: 'rejected',
+          acceptedShares: '1',
           filledShares: '-1',
           remainingShares: '2',
           excessShares: '0'
@@ -68,6 +69,7 @@ describe('trade payload validation', () => {
         outcome: {
           status: 'failed',
           error: 'rejected',
+          acceptedShares: '1',
           filledShares: '0',
           remainingShares: '1'
         }
@@ -76,6 +78,145 @@ describe('trade payload validation', () => {
     ]
   ])('rejects an invalid %s', (_case, overrides, path) => {
     expect(() => parseTrade(validTrade(overrides))).toThrow(`Invalid trade payload at ${path}`)
+  })
+
+  it('accepts explicit unknown provenance without inventing zero quantities', () => {
+    const failed = validTrade({
+      outcome: {
+        status: 'failed',
+        error: 'placement failed before acceptance',
+        acceptedShares: null,
+        filledShares: null,
+        remainingShares: null,
+        excessShares: null
+      }
+    })
+
+    expect(parseTrade(failed)).toEqual(failed)
+  })
+
+  it('normalizes the v1 failure shape without accepted quantity to unknown', () => {
+    const legacy = validTrade({
+      outcome: {
+        status: 'failed',
+        error: 'partially filled before cancellation',
+        filledShares: '0.25',
+        remainingShares: '0.75',
+        excessShares: '0'
+      }
+    }) as Record<string, unknown>
+
+    expect(parseTrade(legacy)).toEqual({
+      ...legacy,
+      outcome: {
+        status: 'failed',
+        error: 'partially filled before cancellation',
+        acceptedShares: null,
+        filledShares: '0.25',
+        remainingShares: null,
+        excessShares: null
+      }
+    })
+  })
+
+  it('reconstructs the complete fill from a v1 overfill split', () => {
+    const legacy = validTrade({
+      outcome: {
+        status: 'failed',
+        error: 'broker failed after overfill',
+        filledShares: '1',
+        remainingShares: '0',
+        excessShares: '0.25'
+      }
+    }) as Record<string, unknown>
+
+    expect(parseTrade(legacy)).toEqual({
+      ...legacy,
+      outcome: {
+        status: 'failed',
+        error: 'broker failed after overfill',
+        acceptedShares: null,
+        filledShares: '1.25',
+        remainingShares: null,
+        excessShares: null
+      }
+    })
+  })
+
+  it('keeps a synthetic v1 zero fill unknown', () => {
+    const legacy = validTrade({
+      outcome: {
+        status: 'failed',
+        error: 'placement rejected',
+        filledShares: '0',
+        remainingShares: '1.25',
+        excessShares: '0'
+      }
+    }) as Record<string, unknown>
+
+    expect(parseTrade(legacy)).toEqual({
+      ...legacy,
+      outcome: {
+        status: 'failed',
+        error: 'placement rejected',
+        acceptedShares: null,
+        filledShares: null,
+        remainingShares: null,
+        excessShares: null
+      }
+    })
+  })
+
+  it.each(['filledShares', 'remainingShares', 'excessShares'] as const)(
+    'rejects a nullable %s in a v1 failure',
+    (field) => {
+      const outcome = {
+        status: 'failed',
+        error: 'malformed v1 failure',
+        filledShares: '0',
+        remainingShares: '1.25',
+        excessShares: '0',
+        [field]: null
+      }
+
+      expect(() => parseTrade(validTrade({ outcome }))).toThrow(
+        `Invalid trade payload at outcome.${field}`
+      )
+    }
+  )
+
+  it('rejects derived quantities when acceptance or fill provenance is unknown', () => {
+    expect(() =>
+      parseTrade(
+        validTrade({
+          outcome: {
+            status: 'failed',
+            error: 'legacy failure',
+            acceptedShares: null,
+            filledShares: null,
+            remainingShares: '1',
+            excessShares: null
+          }
+        })
+      )
+    ).toThrow('Invalid trade payload at outcome.remainingShares')
+  })
+
+  it('rejects quantities that do not derive from accepted and filled evidence', () => {
+    expect(() =>
+      parseTrade(
+        validTrade({
+          outcome: {
+            status: 'failed',
+            error: 'inconsistent broker evidence',
+            acceptedShares: '1',
+            filledShares: '1.5',
+            remainingShares: '0',
+            excessShares: '0'
+          }
+        })
+      )
+    ).toThrow('Invalid trade payload at outcome.excessShares')
   })
 
   it('identifies the invalid entry in a snapshot', () => {

--- a/dashboard/src/lib/trade-payload.ts
+++ b/dashboard/src/lib/trade-payload.ts
@@ -69,13 +69,17 @@ const parseDecimal = (
 
   const valid =
     decimal.value.isFinite() &&
-    (minimum === 'positive'
-      ? decimal.value.greaterThan(0)
-      : decimal.value.greaterThanOrEqualTo(0))
+    (minimum === 'positive' ? decimal.value.greaterThan(0) : decimal.value.greaterThanOrEqualTo(0))
   if (valid) return parsed
 
   return invalid(path, `a ${minimum} decimal string`)
 }
+
+const parseNullableDecimal = (
+  value: unknown,
+  path: string,
+  minimum: 'positive' | 'non-negative'
+): string | null => (value === null ? null : parseDecimal(value, path, minimum))
 
 const daysInMonth = (year: number, month: number): number => {
   if (month === 2) {
@@ -126,24 +130,99 @@ const parseOutcome = (value: unknown, path: string): TradeOutcome => {
   if (outcome['status'] === 'filled') return { status: 'filled' }
   if (outcome['status'] !== 'failed') return invalid(statusPath, 'a known terminal outcome')
 
-  return {
-    status: 'failed',
-    error: parseString(outcome['error'], fieldPath(path, 'error')),
-    filledShares: parseDecimal(
+  const hasAcceptedShares = 'acceptedShares' in outcome
+  const acceptedShares = parseNullableDecimal(
+    outcome['acceptedShares'] ?? null,
+    fieldPath(path, 'acceptedShares'),
+    'positive'
+  )
+  // terminal_outcomes_v1 originally omitted acceptedShares and derived these
+  // quantities from the request. It also split overfills between filledShares
+  // and excessShares, so reconstruct the complete observed fill and discard
+  // request-derived values that are not broker evidence. v1 synthesized zero
+  // when no fill evidence existed, so only a positive legacy total proves an
+  // actual broker fill.
+  const normalizeV1 = (): {
+    filledShares: string | null
+    remainingShares: null
+    excessShares: null
+  } => {
+    const filled = parseDecimal(
       outcome['filledShares'],
       fieldPath(path, 'filledShares'),
       'non-negative'
-    ),
-    remainingShares: parseDecimal(
-      outcome['remainingShares'],
-      fieldPath(path, 'remainingShares'),
-      'non-negative'
-    ),
-    excessShares: parseDecimal(
+    )
+    // Presence-only: the request-derived remainder is discarded, but a v1
+    // payload without it is malformed.
+    parseDecimal(outcome['remainingShares'], fieldPath(path, 'remainingShares'), 'non-negative')
+    const excess = parseDecimal(
       outcome['excessShares'],
       fieldPath(path, 'excessShares'),
       'non-negative'
     )
+    const completeFill = new Decimal(filled).plus(excess)
+
+    return {
+      filledShares: completeFill.isZero() ? null : completeFill.toString(),
+      remainingShares: null,
+      excessShares: null
+    }
+  }
+
+  const { filledShares, remainingShares, excessShares } = hasAcceptedShares
+    ? {
+        filledShares: parseNullableDecimal(
+          outcome['filledShares'],
+          fieldPath(path, 'filledShares'),
+          'non-negative'
+        ),
+        remainingShares: parseNullableDecimal(
+          outcome['remainingShares'],
+          fieldPath(path, 'remainingShares'),
+          'non-negative'
+        ),
+        excessShares: parseNullableDecimal(
+          outcome['excessShares'],
+          fieldPath(path, 'excessShares'),
+          'non-negative'
+        )
+      }
+    : normalizeV1()
+
+  if (acceptedShares === null || filledShares === null) {
+    if (remainingShares !== null) {
+      return invalid(fieldPath(path, 'remainingShares'), 'null when fill provenance is incomplete')
+    }
+    if (excessShares !== null) {
+      return invalid(fieldPath(path, 'excessShares'), 'null when fill provenance is incomplete')
+    }
+  } else {
+    if (remainingShares === null) {
+      return invalid(fieldPath(path, 'remainingShares'), 'a derived non-negative decimal string')
+    }
+    if (excessShares === null) {
+      return invalid(fieldPath(path, 'excessShares'), 'a derived non-negative decimal string')
+    }
+
+    const accepted = new Decimal(acceptedShares)
+    const filled = new Decimal(filledShares)
+    const expectedRemaining = Decimal.max(accepted.minus(filled), 0)
+    const expectedExcess = Decimal.max(filled.minus(accepted), 0)
+    if (!new Decimal(remainingShares).equals(expectedRemaining)) {
+      return invalid(fieldPath(path, 'remainingShares'), 'the accepted quantity minus the fill')
+    }
+    if (!new Decimal(excessShares).equals(expectedExcess)) {
+      return invalid(fieldPath(path, 'excessShares'), 'the fill beyond the accepted quantity')
+    }
+  }
+
+  return {
+    status: 'failed',
+    error: parseString(outcome['error'], fieldPath(path, 'error')),
+    acceptedShares,
+    filledShares,
+    remainingShares,
+    excessShares
   }
 }
 

--- a/dashboard/src/lib/trade.test.ts
+++ b/dashboard/src/lib/trade.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import type { LegacyTrade } from '$lib/api/LegacyTrade'
 import type { Trade } from '$lib/api/Trade'
 import {
   mergeTradeHistory,
+  normalizeTrade,
   tradeFailureReason,
   tradeFailureShares,
   tradeOutcomeClass,
@@ -21,6 +23,7 @@ describe('trade outcome presentation', () => {
     const outcome = {
       status: 'failed',
       error: 'asset is not tradable',
+      acceptedShares: '1',
       filledShares: '0.25',
       remainingShares: '0.75',
       excessShares: '0'
@@ -30,10 +33,66 @@ describe('trade outcome presentation', () => {
     expect(tradeOutcomeClass(outcome)).toBe('text-destructive')
     expect(tradeFailureReason(outcome)).toBe('asset is not tradable')
     expect(tradeFailureShares(outcome)).toEqual({
+      accepted: '1',
       filled: '0.25',
       remaining: '0.75',
       excess: '0'
     })
+  })
+
+  it('reports unknown fill provenance as all-null rather than zero', () => {
+    const outcome = {
+      status: 'failed',
+      error: 'asset is not tradable',
+      acceptedShares: null,
+      filledShares: null,
+      remainingShares: null,
+      excessShares: null
+    } as const
+
+    expect(tradeFailureShares(outcome)).toEqual({
+      accepted: null,
+      filled: null,
+      remaining: null,
+      excess: null
+    })
+  })
+})
+
+describe('legacy trade normalization', () => {
+  it('maps a legacy fill onto a filled outcome keyed by its fill time', () => {
+    const legacy: LegacyTrade = {
+      id: 'legacy-fill',
+      filledAt: '2026-01-01T00:00:00Z',
+      venue: 'alpaca',
+      direction: 'buy',
+      symbol: 'SPCX',
+      shares: '1.5'
+    }
+
+    expect(normalizeTrade(legacy)).toEqual({
+      id: 'legacy-fill',
+      occurredAt: '2026-01-01T00:00:00Z',
+      venue: 'alpaca',
+      direction: 'buy',
+      symbol: 'SPCX',
+      shares: '1.5',
+      outcome: { status: 'filled' }
+    })
+  })
+
+  it('passes a canonical trade through unchanged', () => {
+    const trade: Trade = {
+      id: 'canonical-fill',
+      occurredAt: '2026-01-01T00:00:00Z',
+      venue: 'raindex',
+      direction: 'sell',
+      symbol: 'SPCX',
+      shares: '2',
+      outcome: { status: 'filled' }
+    }
+
+    expect(normalizeTrade(trade)).toBe(trade)
   })
 })
 
@@ -55,6 +114,7 @@ describe('live trade history', () => {
       outcome: {
         status: 'failed',
         error: 'broker rejected remainder',
+        acceptedShares: '1',
         filledShares: '0.25',
         remainingShares: '0.75',
         excessShares: '0'

--- a/dashboard/src/lib/trade.ts
+++ b/dashboard/src/lib/trade.ts
@@ -40,10 +40,16 @@ export const tradeFailureReason = (outcome: TradeOutcome): string | null =>
 
 export const tradeFailureShares = (
   outcome: TradeOutcome
-): { filled: string; remaining: string; excess: string } | null =>
+): {
+  accepted: string | null
+  filled: string | null
+  remaining: string | null
+  excess: string | null
+} | null =>
   matchOutcome(outcome, {
     filled: () => null,
-    failed: ({ filledShares, remainingShares, excessShares }) => ({
+    failed: ({ acceptedShares, filledShares, remainingShares, excessShares }) => ({
+      accepted: acceptedShares,
       filled: filledShares,
       remaining: remainingShares,
       excess: excessShares
@@ -109,7 +115,16 @@ const compareRfc3339Timestamps = (left: string, right: string): number => {
     )
   }
 
-  return Date.parse(left) - Date.parse(right)
+  // Fall back to whole-millisecond parsing. An unparseable timestamp yields
+  // NaN, and returning NaN from a comparator makes the sort order undefined,
+  // so treat an unparseable side as equal-or-older explicitly.
+  const leftMillis = Date.parse(left)
+  const rightMillis = Date.parse(right)
+  if (Number.isNaN(leftMillis) && Number.isNaN(rightMillis)) return 0
+  if (Number.isNaN(leftMillis)) return -1
+  if (Number.isNaN(rightMillis)) return 1
+
+  return leftMillis - rightMillis
 }
 
 const compareTradeIds = (left: Trade, right: Trade): number => {

--- a/dashboard/src/lib/websocket/connection.svelte.test.ts
+++ b/dashboard/src/lib/websocket/connection.svelte.test.ts
@@ -8,6 +8,7 @@ import type { TransferOperation } from '$lib/api/TransferOperation'
 
 class MockWebSocket {
   url: string
+  closeCalls = 0
   onopen: (() => void) | null = null
   onclose: ((event: CloseEvent) => void) | null = null
   onmessage: ((event: { data: string }) => void) | null = null
@@ -22,6 +23,7 @@ class MockWebSocket {
   }
 
   close() {
+    this.closeCalls += 1
     this.onclose?.({ code: 1000, reason: '' } as CloseEvent)
   }
 
@@ -191,6 +193,26 @@ describe('createWebSocket', () => {
 
       getInstance(0).simulateOpen()
       expect(ws.state).toBe('connected')
+    })
+
+    it('retries with v1 when the previous backend rejects v2', () => {
+      const { getInstance } = setupWebSocketTest()
+      const queryClient = createMockQueryClient()
+      const ws = createWebSocket(WS_URL, queryClient)
+
+      ws.connect()
+      expect(getInstance(0).url).toContain('trade_protocol=terminal_outcomes_v2')
+
+      getInstance(0).simulateError()
+      vi.advanceTimersByTime(1000)
+
+      expect(getInstance(1).url).toContain('trade_protocol=terminal_outcomes_v1')
+
+      getInstance(1).simulateOpen()
+      getInstance(1).simulateClose()
+      vi.advanceTimersByTime(2000)
+
+      expect(getInstance(2).url).toContain('trade_protocol=terminal_outcomes_v2')
     })
 
     it('transitions to error on close from connected', () => {
@@ -402,6 +424,7 @@ describe('createWebSocket', () => {
       expect(queryClient.cache.get('["trades"]')).toEqual([knownGood])
       expect(ws.state).toBe('error')
       expect(ws.error?.message).toContain('Invalid trade payload')
+      expect(getInstance(0).closeCalls).toBe(1)
       expect(consoleError).toHaveBeenCalledWith(
         'Failed to parse WebSocket message:',
         expect.objectContaining({ message: expect.stringContaining('shares') }),
@@ -454,6 +477,7 @@ describe('createWebSocket', () => {
         outcome: {
           status: 'failed',
           error: 'asset is not tradable',
+          acceptedShares: '10',
           filledShares: '0',
           remainingShares: '10',
           excessShares: '0'
@@ -629,7 +653,7 @@ describe('createWebSocket', () => {
       expect(ws.error).toBeNull()
     })
 
-    it('backs off repeated invalid messages until a valid message arrives', () => {
+    it('caps exponential backoff for repeated invalid messages', () => {
       const { instances, getInstance } = setupWebSocketTest()
       const queryClient = createMockQueryClient()
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
@@ -653,7 +677,29 @@ describe('createWebSocket', () => {
       expect(instances).toHaveLength(2)
       vi.advanceTimersByTime(1000)
       expect(instances).toHaveLength(3)
-      expect(consoleError).toHaveBeenCalledTimes(2)
+      getInstance(2).simulateOpen()
+      getInstance(2).simulateRawMessage('{"not":"valid"}')
+      expect(ws.error?.attempts).toBe(3)
+      expect(ws.error?.nextRetryMs).toBe(4000)
+
+      vi.advanceTimersByTime(4000)
+      getInstance(3).simulateOpen()
+      getInstance(3).simulateRawMessage('{"not":"valid"}')
+      expect(ws.error?.attempts).toBe(4)
+      expect(ws.error?.nextRetryMs).toBe(8000)
+
+      vi.advanceTimersByTime(8000)
+      getInstance(4).simulateOpen()
+      getInstance(4).simulateRawMessage('{"not":"valid"}')
+      expect(ws.error?.attempts).toBe(5)
+      expect(ws.error?.nextRetryMs).toBe(10000)
+
+      vi.advanceTimersByTime(10000)
+      getInstance(5).simulateOpen()
+      getInstance(5).simulateRawMessage('{"not":"valid"}')
+      expect(ws.error?.attempts).toBe(6)
+      expect(ws.error?.nextRetryMs).toBe(10000)
+      expect(consoleError).toHaveBeenCalledTimes(6)
     })
   })
 })

--- a/dashboard/src/lib/websocket/connection.svelte.ts
+++ b/dashboard/src/lib/websocket/connection.svelte.ts
@@ -16,10 +16,11 @@ type ConnectionEvent = 'connect' | 'open' | 'close' | 'error' | 'disconnect'
 
 const RECONNECT_DELAY_MS = 1000
 const MAX_RECONNECT_DELAY_MS = 10000
+type TradeProtocol = 'terminal_outcomes_v2' | 'terminal_outcomes_v1'
 
-const withTradeProtocol = (url: string): string => {
+const withTradeProtocol = (url: string, tradeProtocol: TradeProtocol): string => {
   const protocolUrl = new URL(url)
-  protocolUrl.searchParams.set('trade_protocol', 'terminal_outcomes_v1')
+  protocolUrl.searchParams.set('trade_protocol', tradeProtocol)
   return protocolUrl.toString()
 }
 
@@ -33,8 +34,8 @@ export type ErrorContext = {
 }
 
 export const createWebSocket = (url: string, queryClient: QueryClient) => {
-  const protocolUrl = withTradeProtocol(url)
   let socket: WebSocket | null = null
+  let tradeProtocol: TradeProtocol = 'terminal_outcomes_v2'
   let reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null
   let failureMessage = 'WebSocket connection error'
   const reconnectAttempts = reactive(0)
@@ -76,9 +77,19 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
   }
 
   const createSocket = () => {
+    const attemptedProtocol = tradeProtocol
+    const protocolUrl = withTradeProtocol(url, attemptedProtocol)
+    let opened = false
     socket = new WebSocket(protocolUrl)
 
     socket.onopen = () => {
+      opened = true
+      // A v1 connection proves the fallback works, not that v2 is permanently
+      // unavailable. Probe v2 again after the next disconnect so a transient
+      // restart cannot pin this dashboard to the lower-fidelity protocol.
+      if (attemptedProtocol === 'terminal_outcomes_v1') {
+        tradeProtocol = 'terminal_outcomes_v2'
+      }
       if (import.meta.env.DEV) console.log(`[ws] connected to ${protocolUrl}`)
       fsm.send('open')
     }
@@ -118,6 +129,9 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
     }
 
     socket.onclose = (event) => {
+      if (!opened && attemptedProtocol === 'terminal_outcomes_v2') {
+        tradeProtocol = 'terminal_outcomes_v1'
+      }
       if (import.meta.env.DEV)
         console.log(`[ws] closed (code=${String(event.code)}, reason="${event.reason}")`)
       failureMessage = 'WebSocket connection closed'
@@ -126,6 +140,9 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
     }
 
     socket.onerror = () => {
+      if (!opened && attemptedProtocol === 'terminal_outcomes_v2') {
+        tradeProtocol = 'terminal_outcomes_v1'
+      }
       failureMessage = 'WebSocket connection error'
       fsm.send('error')
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -144,7 +144,7 @@ struct StuckTransferInfo {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct TradeResponse {
-    entries: Vec<Trade>,
+    entries: Vec<serde_json::Value>,
     total: usize,
     has_more: bool,
 }
@@ -584,7 +584,20 @@ async fn trades(
 
     let total = all_trades.len();
     let end = total.min(offset.saturating_add(limit));
-    let entries = all_trades[offset.min(total)..end].to_vec();
+    let entries = all_trades[offset.min(total)..end]
+        .iter()
+        .map(|trade| {
+            if query.trade_protocol == TradeProtocol::TerminalOutcomesV1 {
+                serde_json::to_value(trade.terminal_outcomes_v1())
+            } else {
+                serde_json::to_value(trade)
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .inspect_err(
+            |error| warn!(target: "dashboard", ?error, "Failed to serialize trade history"),
+        )
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let has_more = end < total;
 
     Ok(Json(TradeResponse {
@@ -1997,26 +2010,23 @@ mod tests {
         match &failed.outcome {
             TradeOutcome::Failed {
                 error,
+                accepted_shares,
                 filled_shares,
                 remaining_shares,
                 excess_shares,
             } => {
                 assert_eq!(error, "asset is not tradable");
+                assert_eq!(accepted_shares, &None);
                 assert!(
                     filled_shares
+                        .unwrap()
                         .inner()
                         .inner()
                         .eq(st0x_float_macro::float!(0.25))
                         .unwrap()
                 );
-                assert!(
-                    remaining_shares
-                        .inner()
-                        .inner()
-                        .eq(st0x_float_macro::float!(0.75))
-                        .unwrap()
-                );
-                assert!(excess_shares.inner().inner().is_zero().unwrap());
+                assert_eq!(remaining_shares, &None);
+                assert_eq!(excess_shares, &None);
             }
             TradeOutcome::Filled => panic!("failed projection must remain failed"),
         }
@@ -2049,10 +2059,28 @@ mod tests {
             "legacy clients must not receive failed trades"
         );
 
-        let response = build_app(state)
+        let v1_response = build_app(state.clone())
             .oneshot(
                 Request::builder()
                     .uri("/trades?trade_protocol=terminal_outcomes_v1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(v1_response.status(), StatusCode::OK);
+        let v1_body: serde_json::Value =
+            serde_json::from_str(&body_to_string(v1_response).await).unwrap();
+        let v1_outcome = &v1_body["entries"][0]["outcome"];
+        assert!(v1_outcome.get("acceptedShares").is_none());
+        assert_eq!(v1_outcome["filledShares"], "0.25");
+        assert_eq!(v1_outcome["remainingShares"], "0.75");
+        assert_eq!(v1_outcome["excessShares"], "0");
+
+        let response = build_app(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/trades?trade_protocol=terminal_outcomes_v2")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -2067,8 +2095,19 @@ mod tests {
             body["entries"][0]["outcome"]["error"],
             "asset is not tradable"
         );
+        assert_eq!(
+            body["entries"][0]["outcome"]["acceptedShares"],
+            serde_json::Value::Null
+        );
         assert_eq!(body["entries"][0]["outcome"]["filledShares"], "0.25");
-        assert_eq!(body["entries"][0]["outcome"]["remainingShares"], "0.75");
+        assert_eq!(
+            body["entries"][0]["outcome"]["remainingShares"],
+            serde_json::Value::Null
+        );
+        assert_eq!(
+            body["entries"][0]["outcome"]["excessShares"],
+            serde_json::Value::Null
+        );
     }
 
     #[tokio::test]
@@ -3043,6 +3082,7 @@ mod tests {
                 OffchainOrderId::new(),
                 OffchainOrderEvent::Failed {
                     error: "rejected".to_string(),
+                    filled_shares: None,
                     failed_at: now,
                 },
             )

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2739,6 +2739,7 @@ mod tests {
         // genuine serialized OffchainOrderEvent, not a hand-written shape.
         let failed = OffchainOrderEvent::Failed {
             error: "rejected".to_string(),
+            filled_shares: None,
             failed_at: Utc::now(),
         };
         sqlx::query(

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -321,6 +321,7 @@ async fn fail_offchain_order_aggregate<W: Write>(
             &offchain_order_id,
             OffchainOrderCommand::MarkFailed {
                 error: reason,
+                filled_shares: None,
                 failed_at: chrono::Utc::now(),
             },
         )
@@ -888,6 +889,7 @@ mod tests {
             &failed_id,
             OffchainOrderCommand::MarkFailed {
                 error: "bot failed it".to_string(),
+                filled_shares: None,
                 failed_at: chrono::Utc::now(),
             },
             repair_order_placer(),
@@ -977,6 +979,7 @@ mod tests {
             &order_id,
             OffchainOrderCommand::MarkFailed {
                 error: "bot failed it concurrently".to_string(),
+                filled_shares: None,
                 failed_at: chrono::Utc::now(),
             },
             repair_order_placer(),
@@ -1029,6 +1032,7 @@ mod tests {
             &order_id,
             OffchainOrderCommand::MarkFailed {
                 error: "pre-failed".to_string(),
+                filled_shares: None,
                 failed_at: chrono::Utc::now(),
             },
             repair_order_placer(),

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -2413,9 +2413,11 @@ mod tests {
         let failed_order = OffchainOrder::Failed {
             symbol: symbol.clone(),
             shares: positive_shares("1"),
+            requested_shares: None,
             direction: Direction::Sell,
             executor: SupportedExecutor::DryRun,
             retained_fill: None,
+            filled_shares: None,
             executor_order_id: None,
             error: "previous placement failed".to_string(),
             placed_at: block_timestamp,
@@ -2557,6 +2559,7 @@ mod tests {
         let cancelling_order = OffchainOrder::Cancelling {
             symbol: symbol.clone(),
             shares: positive_shares("1"),
+            requested_shares: None,
             retained_fill: None,
             direction: Direction::Sell,
             executor: SupportedExecutor::DryRun,

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -236,6 +236,8 @@ where
             .build(order_placer.clone())
             .await?;
 
+    rebuild_stale_offchain_order_projection(pool, &offchain_order_projection).await?;
+
     // Startup recovery runs before any job worker starts, so no concurrent
     // placement can race its broker re-drive -- it intentionally runs without
     // `counter_trade_submission_lock` (which the builder constructs later). The
@@ -250,6 +252,45 @@ where
     .await?;
 
     Ok((offchain_order, offchain_order_projection))
+}
+
+async fn rebuild_stale_offchain_order_projection(
+    pool: &SqlitePool,
+    projection: &Projection<OffchainOrder>,
+) -> Result<(), st0x_event_sorcery::ProjectionError<OffchainOrder>> {
+    // StoreBuilder records the aggregate schema version before its catch-up,
+    // which intentionally skips projection rows already at the latest event
+    // sequence. Detect the old serialized shape itself so an interruption
+    // between version registration and this rebuild remains repairable on the
+    // next startup. A present JSON null is current; SQL NULL means the field is
+    // absent from a pre-v3 projection row.
+    let has_stale_rows: i64 = sqlx::query_scalar(
+        "SELECT EXISTS( \
+             SELECT 1 FROM offchain_order_view \
+             WHERE (json_type(payload, '$.Live.Submitted') IS NOT NULL \
+                    AND json_type(payload, '$.Live.Submitted.requested_shares') IS NULL) \
+                OR (json_type(payload, '$.Live.PartiallyFilled') IS NOT NULL \
+                    AND json_type(payload, '$.Live.PartiallyFilled.requested_shares') IS NULL) \
+                OR (json_type(payload, '$.Live.Cancelling') IS NOT NULL \
+                    AND json_type(payload, '$.Live.Cancelling.requested_shares') IS NULL) \
+                OR (json_type(payload, '$.Live.Failed') IS NOT NULL \
+                    AND (json_type(payload, '$.Live.Failed.requested_shares') IS NULL \
+                         OR json_type(payload, '$.Live.Failed.filled_shares') IS NULL)) \
+             LIMIT 1 \
+         )",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    if has_stale_rows != 0 {
+        info!(
+            "Offchain order projection rows predate quantity provenance; \
+             rebuilding the full projection"
+        );
+        projection.rebuild_all().await?;
+    }
+
+    Ok(())
 }
 
 /// Bundles CQRS frameworks used throughout the trade processing pipeline.
@@ -3681,7 +3722,7 @@ mod tests {
         create_test_ctx_with_order_owner, test_issuance_status_ctx,
     };
     use st0x_dto::Statement;
-    use st0x_event_sorcery::{DomainEvent, StoreBuilder, test_store};
+    use st0x_event_sorcery::{DomainEvent, Reconciler, StoreBuilder, test_store};
     use st0x_evm::local::RawPrivateKeyWallet;
     use st0x_execution::{
         Direction, EquityPosition, ExecutorOrderId, Inventory as ExecutionInventory, MarketOrder,
@@ -3981,6 +4022,252 @@ mod tests {
                 outcome: st0x_dto::TradeOutcome::Failed { error, .. },
                 ..
             }) if error == "asset is not tradable"
+        ));
+    }
+
+    #[tokio::test]
+    async fn interrupted_schema_change_rebuilds_existing_offchain_order_projection_rows() {
+        let pool = setup_test_db().await;
+        let (store, projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .build(noop_order_placer())
+            .await
+            .unwrap();
+        let id = OffchainOrderId::new();
+        let requested_shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        let accepted_shares = Positive::new(FractionalShares::new(float!(0.5))).unwrap();
+        let filled_shares = FractionalShares::new(float!(0.25));
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("SPCX").unwrap(),
+                    shares: requested_shares,
+                    direction: Direction::Buy,
+                    executor: SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("TEST-ACCEPTED"),
+                    placed_shares: accepted_shares,
+                    submitted_at: Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkFailed {
+                    error: "broker rejected remainder".to_string(),
+                    filled_shares: Some(filled_shares),
+                    failed_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "UPDATE offchain_order_view \
+             SET payload = json_remove(\
+                 payload,\
+                 '$.Live.Failed.requested_shares',\
+                 '$.Live.Failed.filled_shares'\
+             ) \
+             WHERE view_id = ?",
+        )
+        .bind(id.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let stale = projection.load(&id).await.unwrap().unwrap();
+        assert!(matches!(
+            stale,
+            OffchainOrder::Failed {
+                requested_shares: None,
+                filled_shares: None,
+                ..
+            }
+        ));
+
+        let schema_changed = Reconciler::new(pool.clone())
+            .reconcile::<OffchainOrder>()
+            .await
+            .unwrap();
+        assert_eq!(
+            schema_changed,
+            st0x_event_sorcery::SchemaReconciliation::Unchanged,
+            "the schema registry is already current"
+        );
+
+        rebuild_stale_offchain_order_projection(&pool, &projection)
+            .await
+            .unwrap();
+
+        let rebuilt = projection.load(&id).await.unwrap().unwrap();
+        assert!(matches!(
+            rebuilt,
+            OffchainOrder::Failed {
+                requested_shares: Some(requested),
+                filled_shares: Some(filled),
+                ..
+            } if requested == requested_shares && filled == filled_shares
+        ));
+    }
+
+    async fn place_and_accept_projection_order(store: &Store<OffchainOrder>, id: &OffchainOrderId) {
+        store
+            .send(
+                id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("SPCX").unwrap(),
+                    shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                    direction: Direction::Buy,
+                    executor: SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new(id),
+                    placed_shares: Positive::new(FractionalShares::new(float!(0.5))).unwrap(),
+                    submitted_at: Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn interrupted_schema_change_rebuilds_live_offchain_order_projection_rows() {
+        let pool = setup_test_db().await;
+        let (store, projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .build(noop_order_placer())
+            .await
+            .unwrap();
+        let submitted_id = OffchainOrderId::new();
+        let partially_filled_id = OffchainOrderId::new();
+        let cancelling_id = OffchainOrderId::new();
+
+        place_and_accept_projection_order(&store, &submitted_id).await;
+        place_and_accept_projection_order(&store, &partially_filled_id).await;
+        store
+            .send(
+                &partially_filled_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(0.25)),
+                    avg_price: Usd::new(float!(100)),
+                    partially_filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        place_and_accept_projection_order(&store, &cancelling_id).await;
+        store
+            .send(
+                &cancelling_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        for (id, path) in [
+            (&submitted_id, "$.Live.Submitted.requested_shares"),
+            (
+                &partially_filled_id,
+                "$.Live.PartiallyFilled.requested_shares",
+            ),
+            (&cancelling_id, "$.Live.Cancelling.requested_shares"),
+        ] {
+            sqlx::query(
+                "UPDATE offchain_order_view SET payload = json_remove(payload, ?) WHERE view_id = ?",
+            )
+            .bind(path)
+            .bind(id.to_string())
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        assert!(matches!(
+            projection.load(&submitted_id).await.unwrap().unwrap(),
+            OffchainOrder::Submitted {
+                requested_shares: None,
+                ..
+            }
+        ));
+        assert!(matches!(
+            projection
+                .load(&partially_filled_id)
+                .await
+                .unwrap()
+                .unwrap(),
+            OffchainOrder::PartiallyFilled {
+                requested_shares: None,
+                ..
+            }
+        ));
+        assert!(matches!(
+            projection.load(&cancelling_id).await.unwrap().unwrap(),
+            OffchainOrder::Cancelling {
+                requested_shares: None,
+                ..
+            }
+        ));
+
+        rebuild_stale_offchain_order_projection(&pool, &projection)
+            .await
+            .unwrap();
+
+        // `place_and_accept_projection_order` requests 1 share for every
+        // aggregate, so an exact comparison catches a rebuild that restores a
+        // corrupted value or pairs a value with the wrong aggregate.
+        let requested_shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        assert!(matches!(
+            projection.load(&submitted_id).await.unwrap().unwrap(),
+            OffchainOrder::Submitted {
+                requested_shares: Some(requested),
+                ..
+            } if requested == requested_shares
+        ));
+        assert!(matches!(
+            projection
+                .load(&partially_filled_id)
+                .await
+                .unwrap()
+                .unwrap(),
+            OffchainOrder::PartiallyFilled {
+                requested_shares: Some(requested),
+                shares_filled,
+                ..
+            } if requested == requested_shares
+                && shares_filled == FractionalShares::new(float!(0.25))
+        ));
+        assert!(matches!(
+            projection.load(&cancelling_id).await.unwrap().unwrap(),
+            OffchainOrder::Cancelling {
+                requested_shares: Some(requested),
+                ..
+            } if requested == requested_shares
         ));
     }
 
@@ -9682,6 +9969,7 @@ mod tests {
                 &offchain_order_id,
                 OffchainOrderCommand::MarkFailed {
                     error: "insufficient qty".to_string(),
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 },
             )
@@ -10560,9 +10848,11 @@ mod tests {
         let failed_state = OffchainOrder::Failed {
             symbol: symbol.clone(),
             shares,
+            requested_shares: None,
             direction: Direction::Sell,
             executor: st0x_execution::SupportedExecutor::DryRun,
             retained_fill: None,
+            filled_shares: None,
             executor_order_id: None,
             error: "broker rejected".to_string(),
             placed_at: Utc::now(),
@@ -10713,6 +11003,7 @@ mod tests {
         let cancelling = OffchainOrder::Cancelling {
             symbol: symbol.clone(),
             shares,
+            requested_shares: None,
             retained_fill: None,
             direction: Direction::Sell,
             executor: st0x_execution::SupportedExecutor::DryRun,

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -478,13 +478,24 @@ impl DashboardTradeHandoffAttemptError {
     fn is_retryable(&self) -> bool {
         match self {
             Self::Persistence(_) | Self::Replay { .. } | Self::Missing { .. } => true,
-            Self::Conversion { source, .. } => matches!(
-                source,
+            // Exhaustive: a new conversion failure must force a deliberate
+            // retry-or-fail-stop decision here. A catch-all would silently
+            // classify it as fail-stop, which terminates the monitor.
+            Self::Conversion { source, .. } => match source {
+                // Non-terminal states convert as soon as the order reaches a
+                // terminal outcome.
                 TradeConversionError::Pending
-                    | TradeConversionError::Submitted
-                    | TradeConversionError::PartiallyFilled
-                    | TradeConversionError::Cancelling
-            ),
+                | TradeConversionError::Submitted
+                | TradeConversionError::PartiallyFilled
+                | TradeConversionError::Cancelling => true,
+                // A cancellation is terminal, and corrupt persisted
+                // quantities never become convertible, so neither is worth
+                // retrying. `persist_once` completes a cancelled order as a
+                // no-op, so that variant does not reach here in practice.
+                TradeConversionError::Cancelled
+                | TradeConversionError::Arithmetic(_)
+                | TradeConversionError::NegativeShares(_) => false,
+            },
         }
     }
 }
@@ -891,6 +902,7 @@ mod tests {
     use crate::conductor::job::{
         FAIL_STOP_RECOVERY_TIMEOUT, FailureInjector, build_supervised_worker, build_worker_inner,
     };
+    use crate::dashboard::trade_loader::load_trades;
     use crate::offchain::order::{OffchainOrderCommand, OffchainOrderEvent};
     use crate::position::{PositionCommand, PositionEvent, TradeId};
     use crate::test_utils::setup_test_pools;
@@ -936,7 +948,11 @@ mod tests {
         }
     }
 
-    async fn persist_failed_offchain_order(pool: SqlitePool, id: OffchainOrderId) {
+    async fn persist_failed_offchain_order(
+        pool: SqlitePool,
+        id: OffchainOrderId,
+        filled_shares: Option<st0x_execution::FractionalShares>,
+    ) {
         let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool)
             .build(crate::offchain::order::noop_order_placer())
             .await
@@ -977,6 +993,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "broker unavailable".to_string(),
+                    filled_shares,
                     failed_at: chrono::Utc::now(),
                 },
             )
@@ -1197,6 +1214,7 @@ mod tests {
                 id,
                 OffchainOrderEvent::Failed {
                     error: "broker unavailable".to_string(),
+                    filled_shares: None,
                     failed_at: now,
                 },
             )
@@ -1278,7 +1296,7 @@ mod tests {
             .await
             .expect("the missing handoff must exhaust its immediate retry budget");
 
-        persist_failed_offchain_order(pool, id).await;
+        persist_failed_offchain_order(pool, id, None).await;
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
                 let pending: i64 = sqlx_apalis::query_scalar(
@@ -1972,6 +1990,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "asset is not tradable".to_string(),
+                    filled_shares: None,
                     failed_at: now,
                 },
             )
@@ -1980,6 +1999,7 @@ mod tests {
 
         let failed = OffchainOrderEvent::Failed {
             error: "asset is not tradable".to_string(),
+            filled_shares: None,
             failed_at: now,
         };
         harness.receive::<OffchainOrder>(id, failed).await.unwrap();
@@ -1988,34 +2008,52 @@ mod tests {
 
         let message = receiver.recv().await.expect("should receive failure");
         match message {
-            Statement::TradeUpdate(trade) => match trade.outcome {
-                st0x_dto::TradeOutcome::Failed {
-                    error,
-                    filled_shares,
-                    remaining_shares,
-                    excess_shares,
-                } => {
-                    assert_eq!(error, "asset is not tradable");
-                    assert!(
-                        filled_shares
-                            .inner()
-                            .inner()
-                            .eq(st0x_float_macro::float!(0.25))
-                            .unwrap()
-                    );
-                    assert!(
-                        remaining_shares
-                            .inner()
-                            .inner()
-                            .eq(st0x_float_macro::float!(0.75))
-                            .unwrap()
-                    );
-                    assert!(excess_shares.inner().inner().is_zero().unwrap());
+            Statement::TradeUpdate(trade) => {
+                let history = load_trades(&pool).await.unwrap();
+                assert_eq!(
+                    &trade.outcome, &history[0].outcome,
+                    "live and historical failure provenance must be identical"
+                );
+                match trade.outcome {
+                    st0x_dto::TradeOutcome::Failed {
+                        error,
+                        accepted_shares,
+                        filled_shares,
+                        remaining_shares,
+                        excess_shares,
+                    } => {
+                        assert_eq!(error, "asset is not tradable");
+                        assert!(
+                            accepted_shares
+                                .unwrap()
+                                .inner()
+                                .inner()
+                                .eq(st0x_float_macro::float!(1))
+                                .unwrap()
+                        );
+                        assert!(
+                            filled_shares
+                                .unwrap()
+                                .inner()
+                                .inner()
+                                .eq(st0x_float_macro::float!(0.25))
+                                .unwrap()
+                        );
+                        assert!(
+                            remaining_shares
+                                .unwrap()
+                                .inner()
+                                .inner()
+                                .eq(st0x_float_macro::float!(0.75))
+                                .unwrap()
+                        );
+                        assert!(excess_shares.unwrap().inner().inner().is_zero().unwrap());
+                    }
+                    st0x_dto::TradeOutcome::Filled => {
+                        panic!("failed order must broadcast a failure outcome")
+                    }
                 }
-                st0x_dto::TradeOutcome::Filled => {
-                    panic!("failed order must broadcast a failure outcome")
-                }
-            },
+            }
             other => panic!("expected TradeUpdate message, got {other:?}"),
         }
 

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -35,6 +35,7 @@ pub(crate) enum TradeProtocol {
     #[default]
     LegacyFills,
     TerminalOutcomesV1,
+    TerminalOutcomesV2,
 }
 
 impl TradeProtocol {
@@ -44,7 +45,7 @@ impl TradeProtocol {
                 TradeOutcome::Filled => true,
                 TradeOutcome::Failed { .. } => false,
             },
-            Self::TerminalOutcomesV1 => match trade.outcome {
+            Self::TerminalOutcomesV1 | Self::TerminalOutcomesV2 => match trade.outcome {
                 TradeOutcome::Filled | TradeOutcome::Failed { .. } => true,
             },
         }
@@ -60,7 +61,7 @@ impl TradeProtocol {
                 | Statement::InventorySnapshot(_)
                 | Statement::TransferUpdate(_) => true,
             },
-            Self::TerminalOutcomesV1 => match statement {
+            Self::TerminalOutcomesV1 | Self::TerminalOutcomesV2 => match statement {
                 Statement::TradeFill(_) => false,
                 Statement::CurrentState(_)
                 | Statement::TradeUpdate(_)
@@ -93,8 +94,46 @@ enum SendOutcome {
     SocketClosed,
 }
 
-async fn send_json(sink: &mut SplitSink<WebSocket, Message>, value: &Statement) -> SendOutcome {
-    let json = match serde_json::to_string(value) {
+fn serialize_statement(
+    statement: &Statement,
+    trade_protocol: TradeProtocol,
+) -> Result<String, serde_json::Error> {
+    match trade_protocol {
+        TradeProtocol::LegacyFills | TradeProtocol::TerminalOutcomesV2 => {
+            return serde_json::to_string(statement);
+        }
+        TradeProtocol::TerminalOutcomesV1 => {}
+    }
+
+    let mut wire = serde_json::to_value(statement)?;
+    match statement {
+        Statement::CurrentState(state) => {
+            wire["data"]["trades"] = serde_json::Value::Array(
+                state
+                    .trades
+                    .iter()
+                    .map(|trade| serde_json::to_value(trade.terminal_outcomes_v1()))
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+        }
+        Statement::TradeUpdate(trade) => {
+            wire["data"] = serde_json::to_value(trade.terminal_outcomes_v1())?;
+        }
+        Statement::TradeFill(_)
+        | Statement::PositionUpdate(_)
+        | Statement::InventorySnapshot(_)
+        | Statement::TransferUpdate(_) => {}
+    }
+
+    serde_json::to_string(&wire)
+}
+
+async fn send_json(
+    sink: &mut SplitSink<WebSocket, Message>,
+    value: &Statement,
+    trade_protocol: TradeProtocol,
+) -> SendOutcome {
+    let json = match serialize_statement(value, trade_protocol) {
         Ok(serialized) => serialized,
         Err(error) => {
             warn!(target: "dashboard", %error, "Failed to serialize message");
@@ -173,7 +212,7 @@ async fn send_initial_state(
         warnings,
     }));
 
-    match send_json(sink, &initial).await {
+    match send_json(sink, &initial, trade_protocol).await {
         SendOutcome::Sent => {
             info!(target: "dashboard", "Sent initial state to dashboard client");
             true
@@ -194,7 +233,7 @@ async fn stream_broadcasts(
                     continue;
                 }
                 trace!(target: "dashboard", ?msg, "Broadcasting to dashboard client");
-                match send_json(sink, &msg).await {
+                match send_json(sink, &msg, trade_protocol).await {
                     SendOutcome::Sent => {}
                     SendOutcome::SerializeFailed | SendOutcome::SocketClosed => break,
                 }
@@ -386,7 +425,7 @@ mod tests {
     use serde_json::json;
     use std::sync::Arc;
     use tokio::net::TcpListener;
-    use tokio_tungstenite::connect_async;
+    use tokio_tungstenite::{WebSocketStream, connect_async};
 
     use st0x_config::{EquityAssetConfig, create_test_ctx_with_order_owner};
     use st0x_dto::{Direction, Trade, TradingVenue};
@@ -435,6 +474,8 @@ mod tests {
         assert!(!TradeProtocol::LegacyFills.includes_statement(&trade_update));
         assert!(TradeProtocol::TerminalOutcomesV1.includes_statement(&trade_update));
         assert!(!TradeProtocol::TerminalOutcomesV1.includes_statement(&legacy_fill));
+        assert!(TradeProtocol::TerminalOutcomesV2.includes_statement(&trade_update));
+        assert!(!TradeProtocol::TerminalOutcomesV2.includes_statement(&legacy_fill));
     }
 
     fn empty_settings() -> st0x_dto::Settings {
@@ -661,6 +702,25 @@ mod tests {
         server.shutdown().await;
     }
 
+    /// Reads the next WebSocket message and parses it as JSON. The
+    /// next-unwrap-unwrap-into_text-unwrap-from_str-unwrap chain is repeated
+    /// for every client in every protocol test, so keep it in one place.
+    async fn next_json<Stream>(client: &mut WebSocketStream<Stream>) -> serde_json::Value
+    where
+        Stream: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    {
+        let message = client.next().await.unwrap().unwrap().into_text().unwrap();
+        serde_json::from_str(&message).unwrap()
+    }
+
+    fn assert_terminal_outcomes_v1_failure(trade: &serde_json::Value) {
+        assert_eq!(trade["outcome"]["status"], "failed");
+        assert!(trade["outcome"].get("acceptedShares").is_none());
+        assert_eq!(trade["outcome"]["filledShares"], "0");
+        assert_eq!(trade["outcome"]["remainingShares"], "1");
+        assert_eq!(trade["outcome"]["excessShares"], "0");
+    }
+
     #[tokio::test]
     async fn websocket_initial_state_includes_failed_counter_trades() {
         let state = create_test_state().await;
@@ -734,36 +794,38 @@ mod tests {
         let mut server = start_test_server_with_state(state).await;
         let legacy_url = format!("ws://127.0.0.1:{}/api/ws", server.port);
         let (mut legacy_client, _) = connect_async(&legacy_url).await.unwrap();
-        let legacy_message = legacy_client
-            .next()
-            .await
-            .unwrap()
-            .unwrap()
-            .into_text()
-            .unwrap();
-        let legacy_state: serde_json::Value = serde_json::from_str(&legacy_message).unwrap();
+        let legacy_state = next_json(&mut legacy_client).await;
         assert_eq!(legacy_state["data"]["trades"].as_array().unwrap().len(), 1);
         let legacy_trade = &legacy_state["data"]["trades"][0];
         assert_eq!(legacy_trade["id"], filled_id.to_string());
         assert!(legacy_trade["filledAt"].as_str().is_some());
         assert_eq!(legacy_trade["outcome"]["status"], "filled");
 
-        let url = format!(
+        let v1_url = format!(
             "ws://127.0.0.1:{}/api/ws?trade_protocol=terminal_outcomes_v1",
             server.port
         );
+        let (mut v1_client, _) = connect_async(&v1_url).await.unwrap();
+        let v1_state = next_json(&mut v1_client).await;
+        let v1_trade = &v1_state["data"]["trades"][0];
+        assert_terminal_outcomes_v1_failure(v1_trade);
+
+        let url = format!(
+            "ws://127.0.0.1:{}/api/ws?trade_protocol=terminal_outcomes_v2",
+            server.port
+        );
         let (mut client, _) = connect_async(&url).await.unwrap();
-        let message = client.next().await.unwrap().unwrap().into_text().unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+        let parsed = next_json(&mut client).await;
         let trade = &parsed["data"]["trades"][0];
 
         assert_eq!(trade["id"], id.to_string());
         assert!(trade["occurredAt"].as_str().is_some());
         assert_eq!(trade["outcome"]["status"], "failed");
         assert_eq!(trade["outcome"]["error"], "asset is not tradable");
-        assert_eq!(trade["outcome"]["filledShares"], "0");
-        assert_eq!(trade["outcome"]["remainingShares"], "1");
-        assert_eq!(trade["outcome"]["excessShares"], "0");
+        assert_eq!(trade["outcome"]["acceptedShares"], serde_json::Value::Null);
+        assert_eq!(trade["outcome"]["filledShares"], serde_json::Value::Null);
+        assert_eq!(trade["outcome"]["remainingShares"], serde_json::Value::Null);
+        assert_eq!(trade["outcome"]["excessShares"], serde_json::Value::Null);
 
         let live_trade = Trade {
             id: "live-fill".to_string(),
@@ -783,27 +845,59 @@ mod tests {
             .send(Statement::TradeFill(live_trade.legacy_fill().unwrap()))
             .unwrap();
 
-        let legacy_live: serde_json::Value = serde_json::from_str(
-            &legacy_client
-                .next()
-                .await
-                .unwrap()
-                .unwrap()
-                .into_text()
-                .unwrap(),
-        )
-        .unwrap();
+        let legacy_live = next_json(&mut legacy_client).await;
         assert_eq!(legacy_live["type"], "trade_fill");
         assert_eq!(legacy_live["data"]["id"], "live-fill");
         assert!(legacy_live["data"]["filledAt"].as_str().is_some());
         assert!(legacy_live["data"].get("outcome").is_none());
 
-        let canonical_live: serde_json::Value =
-            serde_json::from_str(&client.next().await.unwrap().unwrap().into_text().unwrap())
-                .unwrap();
+        let canonical_live = next_json(&mut client).await;
         assert_eq!(canonical_live["type"], "trade_update");
         assert_eq!(canonical_live["data"]["id"], "live-fill");
         assert_eq!(canonical_live["data"]["outcome"]["status"], "filled");
+
+        let v1_live_fill = next_json(&mut v1_client).await;
+        assert_eq!(v1_live_fill["data"]["outcome"]["status"], "filled");
+
+        let failed_live_trade = Trade {
+            id: "live-failure".to_string(),
+            occurred_at: chrono::Utc::now(),
+            venue: TradingVenue::Alpaca,
+            direction: Direction::Sell,
+            symbol: Symbol::new("TSLA").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            outcome: TradeOutcome::Failed {
+                error: "broker rejected order".to_string(),
+                accepted_shares: None,
+                filled_shares: None,
+                remaining_shares: None,
+                excess_shares: None,
+            },
+        };
+        server
+            .event_sender
+            .send(Statement::TradeUpdate(failed_live_trade))
+            .unwrap();
+
+        let canonical_live_failure = next_json(&mut client).await;
+        assert_eq!(canonical_live_failure["type"], "trade_update");
+        assert_eq!(canonical_live_failure["data"]["id"], "live-failure");
+        assert_eq!(
+            canonical_live_failure["data"]["outcome"],
+            serde_json::json!({
+                "status": "failed",
+                "error": "broker rejected order",
+                "acceptedShares": null,
+                "filledShares": null,
+                "remainingShares": null,
+                "excessShares": null
+            })
+        );
+
+        let v1_live_failure = next_json(&mut v1_client).await;
+        assert_eq!(v1_live_failure["type"], "trade_update");
+        assert_eq!(v1_live_failure["data"]["id"], "live-failure");
+        assert_terminal_outcomes_v1_failure(&v1_live_failure["data"]);
 
         server.shutdown().await;
     }

--- a/src/dashboard/trade_loader.rs
+++ b/src/dashboard/trade_loader.rs
@@ -13,9 +13,11 @@ use crate::onchain_trade::{OnChainTrade, OnChainTradeId};
 
 const MAX_TRADES: usize = 100;
 
-/// Load recent filled trades from both onchain and offchain sources.
+/// Load recent terminal trades from both onchain and offchain sources.
 ///
-/// Returns up to [`MAX_TRADES`] trades sorted by fill time (newest first).
+/// Onchain trades are always fills; offchain counter-trades contribute both
+/// filled and failed outcomes. Returns up to [`MAX_TRADES`] trades sorted by
+/// the time the outcome occurred, newest first.
 pub(crate) async fn load_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHistoryError> {
     let mut trades = load_all_trades(pool).await?;
 
@@ -161,11 +163,15 @@ pub(crate) enum TradeHistoryError {
 mod tests {
     use chrono::Utc;
 
-    use st0x_execution::{ClientOrderId, Direction, FractionalShares, Positive, Symbol};
+    use st0x_execution::{
+        ClientOrderId, Direction, ExecutorOrderId, FractionalShares, MarketSession, Positive,
+        Symbol,
+    };
+    use st0x_finance::Usd;
     use st0x_float_macro::float;
 
     use super::*;
-    use crate::offchain::order::{OffchainOrderCommand, OffchainOrderId};
+    use crate::offchain::order::{CancellationReason, OffchainOrderCommand, OffchainOrderId};
     use crate::onchain_trade::{OnChainTradeCommand, OnChainTradeId};
     use crate::test_utils::setup_test_db;
 
@@ -487,29 +493,25 @@ mod tests {
             &trades[0].outcome,
             st0x_dto::TradeOutcome::Failed {
                 error,
+                accepted_shares,
                 filled_shares,
                 remaining_shares,
                 excess_shares,
             } if error == "asset is not tradable"
-                && filled_shares.inner().inner().eq(float!(0)).unwrap()
-                && remaining_shares.inner().inner().eq(float!(10)).unwrap()
-                && excess_shares.inner().inner().is_zero().unwrap()
+                && accepted_shares.is_none()
+                && filled_shares.is_none()
+                && remaining_shares.is_none()
+                && excess_shares.is_none()
         ));
     }
 
-    #[tokio::test]
-    async fn load_trades_excludes_pending_offchain_orders() {
-        let pool = setup_test_db().await;
-        let (store, _projection) =
-            st0x_event_sorcery::StoreBuilder::<OffchainOrder>::new(pool.clone())
-                .build(crate::offchain::order::noop_order_placer())
-                .await
-                .unwrap();
-        let id = OffchainOrderId::new();
-
+    async fn place_pending_order(
+        store: &st0x_event_sorcery::Store<OffchainOrder>,
+        id: &OffchainOrderId,
+    ) {
         store
             .send(
-                &id,
+                id,
                 OffchainOrderCommand::Place {
                     symbol: Symbol::new("NVDA").unwrap(),
                     shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
@@ -521,8 +523,68 @@ mod tests {
             )
             .await
             .unwrap();
+    }
+
+    async fn accept_order(store: &st0x_event_sorcery::Store<OffchainOrder>, id: &OffchainOrderId) {
+        store
+            .send(
+                id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new(id),
+                    placed_shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
+                    submitted_at: Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn load_trades_excludes_all_nonterminal_offchain_orders() {
+        let pool = setup_test_db().await;
+        let (store, _projection) =
+            st0x_event_sorcery::StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(crate::offchain::order::noop_order_placer())
+                .await
+                .unwrap();
+        let pending_id = OffchainOrderId::new();
+        place_pending_order(&store, &pending_id).await;
+
+        let submitted_id = OffchainOrderId::new();
+        place_pending_order(&store, &submitted_id).await;
+        accept_order(&store, &submitted_id).await;
+
+        let partially_filled_id = OffchainOrderId::new();
+        place_pending_order(&store, &partially_filled_id).await;
+        accept_order(&store, &partially_filled_id).await;
+        store
+            .send(
+                &partially_filled_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(1)),
+                    avg_price: Usd::new(float!(100)),
+                    partially_filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let cancelling_id = OffchainOrderId::new();
+        place_pending_order(&store, &cancelling_id).await;
+        accept_order(&store, &cancelling_id).await;
+        store
+            .send(
+                &cancelling_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
 
         let trades = load_trades(&pool).await.unwrap();
-        assert!(trades.is_empty(), "pending orders should not appear");
+        assert!(trades.is_empty(), "nonterminal orders should not appear");
     }
 }

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -274,6 +274,7 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
                         &order_id,
                         OffchainOrderCommand::MarkFailed {
                             error: error.clone(),
+                            filled_shares: None,
                             failed_at,
                         },
                     )

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -426,6 +426,8 @@ pub enum OffchainOrder {
     Submitted {
         symbol: Symbol,
         shares: Positive<FractionalShares>,
+        #[serde(default)]
+        requested_shares: Option<Positive<FractionalShares>>,
         direction: Direction,
         executor: SupportedExecutor,
         executor_order_id: ExecutorOrderId,
@@ -441,6 +443,8 @@ pub enum OffchainOrder {
     PartiallyFilled {
         symbol: Symbol,
         shares: Positive<FractionalShares>,
+        #[serde(default)]
+        requested_shares: Option<Positive<FractionalShares>>,
         shares_filled: FractionalShares,
         direction: Direction,
         executor: SupportedExecutor,
@@ -459,6 +463,8 @@ pub enum OffchainOrder {
     Cancelling {
         symbol: Symbol,
         shares: Positive<FractionalShares>,
+        #[serde(default)]
+        requested_shares: Option<Positive<FractionalShares>>,
         #[serde(default)]
         retained_fill: Option<RetainedFill>,
         direction: Direction,
@@ -489,10 +495,14 @@ pub enum OffchainOrder {
     Failed {
         symbol: Symbol,
         shares: Positive<FractionalShares>,
+        #[serde(default)]
+        requested_shares: Option<Positive<FractionalShares>>,
         direction: Direction,
         executor: SupportedExecutor,
         #[serde(default)]
         retained_fill: Option<RetainedFill>,
+        #[serde(default)]
+        filled_shares: Option<FractionalShares>,
         #[serde(default)]
         executor_order_id: Option<ExecutorOrderId>,
         error: String,
@@ -659,7 +669,7 @@ impl EventSourced for OffchainOrder {
 
     const AGGREGATE_TYPE: &'static str = "OffchainOrder";
     const PROJECTION: Table = Table("offchain_order_view");
-    const SCHEMA_VERSION: u64 = 2;
+    const SCHEMA_VERSION: u64 = 3;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         originate_offchain_order(event)
@@ -689,6 +699,7 @@ impl EventSourced for OffchainOrder {
                 Ok(Some(Self::Submitted {
                     symbol: symbol.clone(),
                     shares: *shares,
+                    requested_shares: None,
                     direction: *direction,
                     executor: *executor,
                     executor_order_id: executor_order_id.clone(),
@@ -707,6 +718,7 @@ impl EventSourced for OffchainOrder {
             } => {
                 let Self::Pending {
                     symbol,
+                    shares: requested_shares,
                     direction,
                     executor,
                     placed_at,
@@ -722,6 +734,7 @@ impl EventSourced for OffchainOrder {
                 Ok(Some(Self::Submitted {
                     symbol: symbol.clone(),
                     shares: *placed_shares,
+                    requested_shares: Some(*requested_shares),
                     direction: *direction,
                     executor: *executor,
                     executor_order_id: executor_order_id.clone(),
@@ -753,7 +766,16 @@ impl EventSourced for OffchainOrder {
                 *cancel_requested_at,
             )),
 
-            Failed { error, failed_at } => Ok(evolve_failed(entity, error.clone(), *failed_at)),
+            Failed {
+                error,
+                filled_shares,
+                failed_at,
+            } => Ok(evolve_failed(
+                entity,
+                error.clone(),
+                *filled_shares,
+                *failed_at,
+            )),
 
             Cancelled {
                 reason,
@@ -989,6 +1011,7 @@ impl EventSourced for OffchainOrder {
             OffchainOrderCommand::MarkPlacementFailed { error } => match self {
                 Self::Pending { .. } => Ok(vec![OffchainOrderEvent::Failed {
                     error,
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 }]),
                 Self::Submitted { symbol, .. }
@@ -1006,13 +1029,19 @@ impl EventSourced for OffchainOrder {
                 }
             },
 
-            OffchainOrderCommand::MarkFailed { error, failed_at } => match self {
+            OffchainOrderCommand::MarkFailed {
+                error,
+                filled_shares,
+                failed_at,
+            } => match self {
                 Self::Pending { .. }
                 | Self::Submitted { .. }
                 | Self::PartiallyFilled { .. }
-                | Self::Cancelling { .. } => {
-                    Ok(vec![OffchainOrderEvent::Failed { error, failed_at }])
-                }
+                | Self::Cancelling { .. } => Ok(vec![OffchainOrderEvent::Failed {
+                    error,
+                    filled_shares,
+                    failed_at,
+                }]),
                 // Idempotent: re-failing an already-failed order records nothing.
                 Self::Failed { .. } => Ok(vec![]),
                 Self::Filled { .. } | Self::Cancelled { .. } => {
@@ -1087,6 +1116,7 @@ fn evolve_partially_filled(
         OffchainOrder::Submitted {
             symbol,
             shares,
+            requested_shares,
             direction,
             executor,
             executor_order_id,
@@ -1097,6 +1127,7 @@ fn evolve_partially_filled(
         | OffchainOrder::PartiallyFilled {
             symbol,
             shares,
+            requested_shares,
             direction,
             executor,
             executor_order_id,
@@ -1107,6 +1138,7 @@ fn evolve_partially_filled(
         } => Some(OffchainOrder::PartiallyFilled {
             symbol: symbol.clone(),
             shares: *shares,
+            requested_shares: *requested_shares,
             shares_filled,
             direction: *direction,
             executor: *executor,
@@ -1120,6 +1152,7 @@ fn evolve_partially_filled(
         OffchainOrder::Cancelling {
             symbol,
             shares,
+            requested_shares,
             direction,
             executor,
             executor_order_id,
@@ -1132,6 +1165,7 @@ fn evolve_partially_filled(
         } => Some(OffchainOrder::Cancelling {
             symbol: symbol.clone(),
             shares: *shares,
+            requested_shares: *requested_shares,
             retained_fill: Some(RetainedFill::priced(
                 shares_filled,
                 avg_price,
@@ -1162,6 +1196,7 @@ fn evolve_cancel_requested(
         OffchainOrder::Submitted {
             symbol,
             shares,
+            requested_shares,
             direction,
             executor,
             executor_order_id,
@@ -1171,6 +1206,7 @@ fn evolve_cancel_requested(
         } => Some(OffchainOrder::Cancelling {
             symbol: symbol.clone(),
             shares: *shares,
+            requested_shares: *requested_shares,
             retained_fill: None,
             direction: *direction,
             executor: *executor,
@@ -1184,6 +1220,7 @@ fn evolve_cancel_requested(
         OffchainOrder::PartiallyFilled {
             symbol,
             shares,
+            requested_shares,
             shares_filled,
             direction,
             executor,
@@ -1197,6 +1234,7 @@ fn evolve_cancel_requested(
         } => Some(OffchainOrder::Cancelling {
             symbol: symbol.clone(),
             shares: *shares,
+            requested_shares: *requested_shares,
             retained_fill: Some(RetainedFill::priced(
                 *shares_filled,
                 *avg_price,
@@ -1222,6 +1260,7 @@ fn evolve_cancel_requested(
 fn evolve_failed(
     entity: &OffchainOrder,
     error: String,
+    filled_shares: Option<FractionalShares>,
     failed_at: DateTime<Utc>,
 ) -> Option<OffchainOrder> {
     match entity {
@@ -1235,9 +1274,11 @@ fn evolve_failed(
         } => Some(OffchainOrder::Failed {
             symbol: symbol.clone(),
             shares: *shares,
+            requested_shares: None,
             direction: *direction,
             executor: *executor,
             retained_fill: None,
+            filled_shares,
             executor_order_id: None,
             error,
             placed_at: *placed_at,
@@ -1246,6 +1287,7 @@ fn evolve_failed(
         OffchainOrder::Submitted {
             symbol,
             shares,
+            requested_shares,
             direction,
             executor,
             executor_order_id,
@@ -1254,9 +1296,11 @@ fn evolve_failed(
         } => Some(OffchainOrder::Failed {
             symbol: symbol.clone(),
             shares: *shares,
+            requested_shares: *requested_shares,
             direction: *direction,
             executor: *executor,
             retained_fill: None,
+            filled_shares,
             executor_order_id: Some(executor_order_id.clone()),
             error,
             placed_at: *placed_at,
@@ -1265,6 +1309,7 @@ fn evolve_failed(
         OffchainOrder::PartiallyFilled {
             symbol,
             shares,
+            requested_shares,
             shares_filled,
             direction,
             executor,
@@ -1276,6 +1321,7 @@ fn evolve_failed(
         } => Some(OffchainOrder::Failed {
             symbol: symbol.clone(),
             shares: *shares,
+            requested_shares: *requested_shares,
             direction: *direction,
             executor: *executor,
             retained_fill: Some(RetainedFill::priced(
@@ -1283,6 +1329,7 @@ fn evolve_failed(
                 *avg_price,
                 *partially_filled_at,
             )),
+            filled_shares: filled_shares.or(Some(*shares_filled)),
             executor_order_id: Some(executor_order_id.clone()),
             error,
             placed_at: *placed_at,
@@ -1291,6 +1338,7 @@ fn evolve_failed(
         OffchainOrder::Cancelling {
             symbol,
             shares,
+            requested_shares,
             retained_fill,
             direction,
             executor,
@@ -1300,9 +1348,11 @@ fn evolve_failed(
         } => Some(OffchainOrder::Failed {
             symbol: symbol.clone(),
             shares: *shares,
+            requested_shares: *requested_shares,
             direction: *direction,
             executor: *executor,
             retained_fill: *retained_fill,
+            filled_shares: filled_shares.or_else(|| retained_fill.map(RetainedFill::shares_filled)),
             executor_order_id: Some(executor_order_id.clone()),
             error,
             placed_at: *placed_at,
@@ -1418,42 +1468,68 @@ impl OffchainOrder {
             Self::Failed {
                 symbol,
                 shares,
+                requested_shares,
                 direction,
                 executor,
                 retained_fill,
+                filled_shares,
                 error,
                 failed_at,
                 ..
             } => {
-                let filled_shares =
-                    retained_fill.map_or(FractionalShares::ZERO, RetainedFill::shares_filled);
-                let accepted_shares = shares.inner();
-                let (filled_portion, remaining_shares, excess_shares) =
-                    if filled_shares.inner().gt(accepted_shares.inner())? {
-                        (
-                            accepted_shares,
-                            FractionalShares::ZERO,
-                            (filled_shares - accepted_shares)?,
-                        )
-                    } else {
-                        (
-                            filled_shares,
-                            (accepted_shares - filled_shares)?,
-                            FractionalShares::ZERO,
-                        )
-                    };
-                let filled_shares = NonNegative::new(filled_portion)?;
-                let remaining_shares = NonNegative::new(remaining_shares)?;
-                let excess_shares = NonNegative::new(excess_shares)?;
+                // Modern acceptance preserves the original request separately,
+                // proving that `shares` is the broker-accepted quantity. Legacy
+                // `Submitted` events do not, so acceptance remains unknown and
+                // `shares` is only safe to report as the original request.
+                let accepted_shares = requested_shares.map(|_| shares);
+                let requested_shares = requested_shares.unwrap_or(shares);
+                let event_fill = filled_shares.map(NonNegative::new).transpose()?;
+                let retained_fill = retained_fill
+                    .map(RetainedFill::shares_filled)
+                    .map(NonNegative::new)
+                    .transpose()?;
+                // Cumulative fill evidence cannot regress. If a stale terminal
+                // broker response reports less than an earlier persisted partial
+                // fill, retain the larger proven quantity rather than replacing
+                // it with the stale observation.
+                let filled_shares = match (event_fill, retained_fill) {
+                    (Some(event), Some(retained))
+                        if event.inner().inner().gt(retained.inner().inner())? =>
+                    {
+                        Some(event)
+                    }
+                    (Some(_), Some(retained)) => Some(retained),
+                    (Some(event), None) => Some(event),
+                    (None, retained) => retained,
+                };
+                let (remaining_shares, excess_shares) = match (accepted_shares, filled_shares) {
+                    (Some(accepted), Some(filled)) => {
+                        let accepted = accepted.inner();
+                        let filled = filled.inner();
+                        if filled.inner().gt(accepted.inner())? {
+                            (
+                                Some(NonNegative::new(FractionalShares::ZERO)?),
+                                Some(NonNegative::new((filled - accepted)?)?),
+                            )
+                        } else {
+                            (
+                                Some(NonNegative::new((accepted - filled)?)?),
+                                Some(NonNegative::new(FractionalShares::ZERO)?),
+                            )
+                        }
+                    }
+                    _ => (None, None),
+                };
 
                 (
                     symbol,
-                    shares,
+                    requested_shares,
                     direction,
                     executor,
                     failed_at,
                     TradeOutcome::Failed {
                         error,
+                        accepted_shares,
                         filled_shares,
                         remaining_shares,
                         excess_shares,
@@ -1942,7 +2018,11 @@ async fn reconcile_pre_cancel(
                 shares_filled,
                 avg_price,
                 failed_at,
-                OffchainOrderEvent::Failed { error, failed_at },
+                OffchainOrderEvent::Failed {
+                    error,
+                    filled_shares: shares_filled,
+                    failed_at,
+                },
             )
         }
 
@@ -2369,6 +2449,9 @@ pub enum OffchainOrderCommand {
     },
     MarkFailed {
         error: String,
+        /// Broker-reported cumulative fill quantity. `None` means the caller
+        /// has no persisted evidence for the actual fill.
+        filled_shares: Option<FractionalShares>,
         /// Broker-reported failure time when available; callers without a
         /// broker timestamp pass their observation time, which is still
         /// closer to the truth than stamping inside the handler after
@@ -2442,6 +2525,11 @@ pub enum OffchainOrderEvent {
     },
     Failed {
         error: String,
+        /// Broker-reported cumulative fill quantity. Absent on legacy events,
+        /// where the actual fill remains explicitly unknown unless an earlier
+        /// partial-fill event proves it.
+        #[serde(default)]
+        filled_shares: Option<FractionalShares>,
         failed_at: DateTime<Utc>,
     },
     Cancelled {
@@ -2787,6 +2875,7 @@ mod tests {
         let order = OffchainOrder::Failed {
             symbol: Symbol::new("AAPL").unwrap(),
             shares: Positive::new(FractionalShares::new(float!(2))).unwrap(),
+            requested_shares: Some(Positive::new(FractionalShares::new(float!(2))).unwrap()),
             direction: Direction::Sell,
             executor: SupportedExecutor::DryRun,
             retained_fill: Some(RetainedFill::priced(
@@ -2794,6 +2883,7 @@ mod tests {
                 Usd::new(float!(195.25)),
                 fill_time,
             )),
+            filled_shares: Some(FractionalShares::new(float!(0.5))),
             executor_order_id: Some(ExecutorOrderId::new("failed-with-fill")),
             error: "broker rejected remainder".to_string(),
             placed_at: fill_time,
@@ -2815,12 +2905,13 @@ mod tests {
     }
 
     #[test]
-    fn failed_trade_reports_filled_and_remaining_shares() {
+    fn failed_trade_preserves_requested_accepted_and_filled_shares() {
         let fill_time = "2026-01-05T14:30:00Z".parse::<DateTime<Utc>>().unwrap();
         let failure_time = "2026-01-06T14:32:01Z".parse::<DateTime<Utc>>().unwrap();
         let order = OffchainOrder::Failed {
             symbol: Symbol::new("AAPL").unwrap(),
-            shares: Positive::new(FractionalShares::new(float!(2))).unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(1.5))).unwrap(),
+            requested_shares: Some(Positive::new(FractionalShares::new(float!(2))).unwrap()),
             direction: Direction::Sell,
             executor: SupportedExecutor::DryRun,
             retained_fill: Some(RetainedFill::priced(
@@ -2828,6 +2919,7 @@ mod tests {
                 Usd::new(float!(195.25)),
                 fill_time,
             )),
+            filled_shares: Some(FractionalShares::new(float!(0.5))),
             executor_order_id: Some(ExecutorOrderId::new("failed-with-fill")),
             error: "broker rejected remainder".to_string(),
             placed_at: fill_time,
@@ -2842,14 +2934,37 @@ mod tests {
         match trade.outcome {
             TradeOutcome::Failed {
                 error,
+                accepted_shares,
                 filled_shares,
                 remaining_shares,
                 excess_shares,
             } => {
                 assert_eq!(error, "broker rejected remainder");
-                assert!(filled_shares.inner().inner().eq(float!(0.5)).unwrap());
-                assert!(remaining_shares.inner().inner().eq(float!(1.5)).unwrap());
-                assert!(excess_shares.inner().inner().is_zero().unwrap());
+                assert!(
+                    accepted_shares
+                        .unwrap()
+                        .inner()
+                        .inner()
+                        .eq(float!(1.5))
+                        .unwrap()
+                );
+                assert!(
+                    filled_shares
+                        .unwrap()
+                        .inner()
+                        .inner()
+                        .eq(float!(0.5))
+                        .unwrap()
+                );
+                assert!(
+                    remaining_shares
+                        .unwrap()
+                        .inner()
+                        .inner()
+                        .eq(float!(1))
+                        .unwrap()
+                );
+                assert!(excess_shares.unwrap().inner().inner().is_zero().unwrap());
             }
             TradeOutcome::Filled => panic!("failed order must retain its failure outcome"),
         }
@@ -2861,6 +2976,7 @@ mod tests {
         let order = OffchainOrder::Failed {
             symbol: Symbol::new("AAPL").unwrap(),
             shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            requested_shares: Some(Positive::new(FractionalShares::new(float!(1))).unwrap()),
             direction: Direction::Sell,
             executor: SupportedExecutor::DryRun,
             retained_fill: Some(RetainedFill::priced(
@@ -2868,6 +2984,7 @@ mod tests {
                 Usd::new(float!(195.25)),
                 failed_at,
             )),
+            filled_shares: Some(FractionalShares::new(float!(1.5))),
             executor_order_id: Some(ExecutorOrderId::new("invalid-retained-fill")),
             error: "broker reported an impossible fill".to_string(),
             placed_at: failed_at,
@@ -2886,16 +3003,65 @@ mod tests {
         else {
             panic!("failed order must retain its failure outcome");
         };
-        assert!(filled_shares.inner().inner().eq(float!(1)).unwrap());
-        assert!(remaining_shares.inner().inner().is_zero().unwrap());
-        assert!(excess_shares.inner().inner().eq(float!(0.5)).unwrap());
+        assert!(
+            filled_shares
+                .unwrap()
+                .inner()
+                .inner()
+                .eq(float!(1.5))
+                .unwrap()
+        );
+        assert!(remaining_shares.unwrap().inner().inner().is_zero().unwrap());
+        assert!(
+            excess_shares
+                .unwrap()
+                .inner()
+                .inner()
+                .eq(float!(0.5))
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn failed_trade_does_not_regress_earlier_cumulative_fill_evidence() {
+        let failed_at = Utc::now();
+        let order = OffchainOrder::Failed {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(2))).unwrap(),
+            requested_shares: Some(Positive::new(FractionalShares::new(float!(2))).unwrap()),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            retained_fill: Some(RetainedFill::priced(
+                FractionalShares::new(float!(0.5)),
+                Usd::new(float!(195.25)),
+                failed_at,
+            )),
+            filled_shares: Some(FractionalShares::new(float!(0.25))),
+            executor_order_id: Some(ExecutorOrderId::new("stale-terminal-fill")),
+            error: "broker rejected remainder".to_string(),
+            placed_at: failed_at,
+            failed_at,
+        };
+
+        let trade = order.try_into_trade(&OffchainOrderId::new()).unwrap();
+        let TradeOutcome::Failed { filled_shares, .. } = trade.outcome else {
+            panic!("failed order must retain its failure outcome");
+        };
+        assert!(
+            filled_shares
+                .unwrap()
+                .inner()
+                .inner()
+                .eq(float!(0.5))
+                .unwrap()
+        );
     }
 
     #[test]
     fn legacy_failed_state_without_fill_fields_deserializes() {
-        // Materialized `Failed` payloads persisted before this PR lack the new
-        // retained-fill key; they must deserialize with the fill defaulted to
-        // None, not error.
+        // Materialized `Failed` payloads persisted before provenance tracking
+        // lack the requested, retained-fill, and explicit-fill keys. They must
+        // deserialize as unknown rather than inventing zero quantities.
         let legacy_payload = json!({
             "Failed": {
                 "symbol": "AAPL",
@@ -2920,6 +3086,22 @@ mod tests {
             ),
             "legacy Failed payload must default fill metadata to None, got: {state:?}"
         );
+        let trade = state.try_into_trade(&OffchainOrderId::new()).unwrap();
+        let TradeOutcome::Failed {
+            accepted_shares,
+            filled_shares,
+            remaining_shares,
+            excess_shares,
+            ..
+        } = trade.outcome
+        else {
+            panic!("legacy failed state must retain its failure outcome");
+        };
+        assert!(trade.shares.inner().inner().eq(float!(100)).unwrap());
+        assert_eq!(accepted_shares, None);
+        assert_eq!(filled_shares, None);
+        assert_eq!(remaining_shares, None);
+        assert_eq!(excess_shares, None);
     }
 
     #[test]
@@ -2928,6 +3110,7 @@ mod tests {
         let submitted = OffchainOrder::Submitted {
             symbol: Symbol::new("AAPL").unwrap(),
             shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
+            requested_shares: None,
             direction: Direction::Buy,
             executor: SupportedExecutor::DryRun,
             executor_order_id: ExecutorOrderId::new("broker-123"),
@@ -2972,6 +3155,118 @@ mod tests {
             expected,
             "Persisted shares should reflect the broker-accepted quantity, not the original request"
         );
+        assert!(matches!(
+            inner,
+            OffchainOrder::Submitted {
+                requested_shares: Some(requested),
+                ..
+            } if requested.inner().inner().eq(float!(100)).unwrap()
+        ));
+    }
+
+    #[tokio::test]
+    async fn failed_trade_replays_requested_accepted_and_fill_provenance() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let id = OffchainOrderId::new();
+        let accepted = Positive::new(FractionalShares::new(float!(50))).unwrap();
+        let filled = FractionalShares::new(float!(25));
+
+        store.send(&id, place_command()).await.unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("TEST-ACCEPT"),
+                    placed_shares: accepted,
+                    submitted_at: Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkFailed {
+                    error: "broker rejected remainder".to_string(),
+                    filled_shares: Some(filled),
+                    failed_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let trade = store
+            .load(&id)
+            .await
+            .unwrap()
+            .unwrap()
+            .try_into_trade(&id)
+            .unwrap();
+        assert!(trade.shares.inner().inner().eq(float!(100)).unwrap());
+        let TradeOutcome::Failed {
+            accepted_shares,
+            filled_shares,
+            remaining_shares,
+            excess_shares,
+            ..
+        } = trade.outcome
+        else {
+            panic!("failed order must retain its failure outcome");
+        };
+        assert_eq!(accepted_shares, Some(accepted));
+        assert_eq!(
+            filled_shares,
+            Some(NonNegative::new(FractionalShares::new(float!(25))).unwrap())
+        );
+        assert_eq!(
+            remaining_shares,
+            Some(NonNegative::new(FractionalShares::new(float!(25))).unwrap())
+        );
+        assert_eq!(
+            excess_shares,
+            Some(NonNegative::new(FractionalShares::ZERO).unwrap())
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_acceptance_failure_keeps_broker_provenance_unknown() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let id = OffchainOrderId::new();
+
+        store.send(&id, place_command()).await.unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkPlacementFailed {
+                    error: "broker did not accept order".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let trade = store
+            .load(&id)
+            .await
+            .unwrap()
+            .unwrap()
+            .try_into_trade(&id)
+            .unwrap();
+        let TradeOutcome::Failed {
+            accepted_shares,
+            filled_shares,
+            remaining_shares,
+            excess_shares,
+            ..
+        } = trade.outcome
+        else {
+            panic!("failed order must retain its failure outcome");
+        };
+        assert_eq!(accepted_shares, None);
+        assert_eq!(filled_shares, None);
+        assert_eq!(remaining_shares, None);
+        assert_eq!(excess_shares, None);
     }
 
     /// Builds a real store and runs the durable placement path against
@@ -3475,6 +3770,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "Market closed".to_string(),
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 },
             )
@@ -3570,6 +3866,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "first failure".to_string(),
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 },
             )
@@ -3584,6 +3881,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "second failure".to_string(),
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 },
             )
@@ -3608,6 +3906,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "broker rejected".to_string(),
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 },
             )
@@ -3874,6 +4173,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "Insufficient funds".to_string(),
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 },
             )
@@ -3906,6 +4206,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "Order cancelled".to_string(),
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 },
             )
@@ -4004,6 +4305,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "Test error".to_string(),
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 },
             )
@@ -4693,6 +4995,7 @@ mod tests {
             .unwrap(),
             serde_json::to_value(OffchainOrderEvent::Failed {
                 error: "broker rejected".to_string(),
+                filled_shares: None,
                 failed_at,
             })
             .unwrap(),
@@ -5808,6 +6111,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "Extended hours session expired".to_string(),
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 },
             )

--- a/src/offchain/order/handle_rejection.rs
+++ b/src/offchain/order/handle_rejection.rs
@@ -36,6 +36,10 @@ pub(crate) struct HandleOrderRejectionCtx {
 pub(crate) struct HandleOrderRejection {
     pub(crate) offchain_order_id: OffchainOrderId,
     pub(crate) error: String,
+    /// Broker-reported cumulative fill quantity. `None` means this rejection
+    /// carries no persisted evidence for the actual fill.
+    #[serde(default)]
+    pub(crate) broker_filled_shares: Option<FractionalShares>,
     /// Broker-reported failure time, when the enqueuing poll observed a
     /// broker `Failed` state. `None` when the rejection has no broker
     /// timestamp (the job then stamps its own observation time).
@@ -92,6 +96,7 @@ impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
                         &self.offchain_order_id,
                         OffchainOrderCommand::MarkFailed {
                             error: self.error.clone(),
+                            filled_shares: self.broker_filled_shares,
                             // Prefer the broker's failure time; rejections
                             // without one (e.g. cleanup paths) fall back to
                             // this job's observation time.
@@ -436,6 +441,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: error_message.clone(),
+            broker_filled_shares: Some(FractionalShares::ZERO),
             broker_failed_at: None,
         }
         .perform(&infra.ctx)
@@ -451,12 +457,14 @@ mod tests {
             .expect("offchain order should exist");
         let OffchainOrder::Failed {
             error: stored_error,
+            filled_shares,
             ..
         } = offchain
         else {
             panic!("expected OffchainOrder::Failed, got {offchain:?}");
         };
         assert_eq!(stored_error, error_message);
+        assert_eq!(filled_shares, Some(FractionalShares::ZERO));
 
         let position = infra
             .ctx
@@ -498,6 +506,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: "broker cancelled after partial fill".to_string(),
+            broker_filled_shares: None,
             broker_failed_at: None,
         }
         .perform(&infra.ctx)
@@ -568,6 +577,7 @@ mod tests {
                 &order_id,
                 OffchainOrderCommand::MarkFailed {
                     error: original_error.clone(),
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 },
             )
@@ -590,6 +600,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: original_error,
+            broker_filled_shares: None,
             broker_failed_at: None,
         }
         .perform(&infra.ctx)
@@ -638,6 +649,7 @@ mod tests {
                 &order_id,
                 OffchainOrderCommand::MarkFailed {
                     error: "broker failed after partial fill".to_string(),
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 },
             )
@@ -647,6 +659,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: "broker failed after partial fill".to_string(),
+            broker_filled_shares: None,
             broker_failed_at: None,
         }
         .perform(&infra.ctx)
@@ -683,6 +696,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: error_message.clone(),
+            broker_filled_shares: None,
             broker_failed_at: None,
         }
         .perform(&infra.ctx)
@@ -693,6 +707,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: error_message,
+            broker_filled_shares: None,
             broker_failed_at: None,
         }
         .perform(&infra.ctx)
@@ -728,6 +743,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: "broker rejected".to_string(),
+            broker_filled_shares: None,
             broker_failed_at: Some(broker_failed_at),
         }
         .perform(&infra.ctx)
@@ -792,6 +808,7 @@ mod tests {
         HandleOrderRejection {
             offchain_order_id: order_id,
             error: "broker rejected during cancellation".to_string(),
+            broker_filled_shares: None,
             broker_failed_at: None,
         }
         .perform(&infra.ctx)

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -173,8 +173,14 @@ impl PollOrderStatus {
             } => {
                 self.record_partial_fill(ctx, symbol, shares_filled, Some(avg_price), failed_at)
                     .await?;
-                self.enqueue_rejection(ctx, symbol, error_reason, Some(failed_at))
-                    .await
+                self.enqueue_rejection(
+                    ctx,
+                    symbol,
+                    error_reason,
+                    Some(shares_filled),
+                    Some(failed_at),
+                )
+                .await
             }
 
             // Broker-*terminal* Failed with a positive fill it never priced.
@@ -205,10 +211,11 @@ impl PollOrderStatus {
 
             Failed {
                 error_reason,
+                shares_filled,
                 failed_at,
                 ..
             } => {
-                self.enqueue_rejection(ctx, symbol, error_reason, Some(failed_at))
+                self.enqueue_rejection(ctx, symbol, error_reason, shares_filled, Some(failed_at))
                     .await
             }
 
@@ -426,6 +433,10 @@ impl PollOrderStatus {
         Ok(())
     }
 
+    /// `broker_filled_shares` is the broker-reported cumulative fill quantity
+    /// for this rejection; `None` when the rejection carries no persisted fill
+    /// evidence.
+    ///
     /// `broker_failed_at` is the broker-reported failure time when this
     /// rejection stems from a broker `Failed` state; `None` when no broker
     /// timestamp exists for the rejection (the job then stamps its own
@@ -435,6 +446,7 @@ impl PollOrderStatus {
         ctx: &PollOrderStatusCtx<E>,
         symbol: &Symbol,
         error_reason: Option<String>,
+        broker_filled_shares: Option<FractionalShares>,
         broker_failed_at: Option<DateTime<Utc>>,
     ) -> Result<(), JobError>
     where
@@ -455,6 +467,7 @@ impl PollOrderStatus {
             .push(HandleOrderRejection {
                 offchain_order_id: self.offchain_order_id,
                 error: error_message,
+                broker_filled_shares,
                 broker_failed_at,
             })
             .await?;
@@ -534,6 +547,7 @@ impl PollOrderStatus {
                     ctx,
                     symbol,
                     Some("Broker reported Cancelled before local cancellation request".to_string()),
+                    None,
                     None,
                 )
                 .await
@@ -2147,6 +2161,7 @@ mod tests {
                 &order_id,
                 OffchainOrderCommand::MarkFailed {
                     error: "broker rejected".to_string(),
+                    filled_shares: None,
                     failed_at: Utc::now(),
                 },
             )

--- a/src/performance/reliability.rs
+++ b/src/performance/reliability.rs
@@ -829,6 +829,7 @@ mod tests {
     fn offchain_order_failed(failed_offset: i64) -> OffchainOrderEvent {
         OffchainOrderEvent::Failed {
             error: "rejected".to_string(),
+            filled_shares: None,
             failed_at: timestamp(failed_offset),
         }
     }
@@ -1221,6 +1222,7 @@ mod tests {
                 FailureEventType::OffchainOrderFailed,
                 OffchainOrderEvent::Failed {
                     error: "rejected".to_string(),
+                    filled_shares: None,
                     failed_at: timestamp(0),
                 }
                 .event_type(),
@@ -1397,6 +1399,7 @@ mod tests {
         // offchain_order_failure
         let (event_type, _) = offchain_order_failure(&OffchainOrderEvent::Failed {
             error: "rejected".to_string(),
+            filled_shares: None,
             failed_at: timestamp(0),
         })
         .unwrap();
@@ -1405,6 +1408,7 @@ mod tests {
             event_type.as_str(),
             OffchainOrderEvent::Failed {
                 error: "rejected".to_string(),
+                filled_shares: None,
                 failed_at: timestamp(0),
             }
             .event_type()

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -2103,6 +2103,7 @@ mod tests {
                 &order_id,
                 OffchainOrderCommand::MarkFailed {
                     error: "broker rejected".to_string(),
+                    filled_shares: None,
                     failed_at: chrono::Utc::now(),
                 },
             )


### PR DESCRIPTION
## What

[RAI-1430](https://linear.app/makeitrain/issue/RAI-1430)

Preserves requested, broker-accepted, and actually-filled counter-trade quantities through terminal failures, then surfaces that provenance consistently in dashboard history and live updates.

## Why

A failed counter-trade could lose the distinction between what we requested, what the broker accepted, and what actually filled. That made partial fills, overfills, and legacy unknowns look more certain than the persisted evidence supported.

## How

- Persists requested quantity and observed fill evidence on the offchain order aggregate and rejection job.
- Projects nullable provenance for failed outcomes, deriving remaining and excess only when accepted and filled quantities are both known.
- Rebuilds stale offchain order projections safely after interrupted schema upgrades.
- Adds `terminal_outcomes_v2` while keeping v1 stable for rolling deploys, with HTTP and WebSocket fallback and re-probing.
- Validates and renders unknown, partial-fill, and overfill states without inference or clamping.

## Testing

- Added backend coverage for pre-acceptance failure, post-acceptance failure, partial fill, overfill, legacy replay, durable jobs, and interrupted projection upgrades.
- Added dashboard coverage for v1/v2 normalization, REST/WebSocket fallback and re-probing, concurrent requests, runtime validation, and unknown quantity rendering.
- Ran `RUSTC_WRAPPER= nix run .#ci` successfully.

## Screenshots

N/A

## Anything else

Stacked on #1060.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trade history now provides accepted, filled, remaining, and excess quantities when available.
  * Dashboard clients use the latest trade protocol and automatically fall back to the legacy protocol when needed.
  * Trade outcome displays identify unknown quantities clearly and show accepted-share information.

* **Bug Fixes**
  * Improved compatibility with older trade-history data and rolling deployments.
  * Preserved accurate fill details for broker-reported failures and overfills.
  * Excluded non-terminal orders from trade history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->