### PR TITLE
fix: surface cancelled counter-trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,13 @@ preloads 14 days of seeded hedge-latency, mint, redemption, and USDC-rebalance
 history so Performance tab trends and the Transfers panel are populated
 immediately.
 
+`nix run .#simulate-trade-outcomes` starts the same stack as `simulate-market`,
+but rotates every counter-trade through the three outcomes the trade history
+renders: filled, rejected by the broker, and cancelled by the broker after a
+partial fill. Use it to inspect the Status column, the venue/asset/time-range
+filters, and the accepted/filled/unfilled breakdown in the detail panel without
+waiting for a real failure.
+
 `nix run .#simulate-failures` starts the same stack as `simulate-market`, then
 creates failed mint and redemption rebalances whose mock Alpaca provider later
 completes and prints the `transfer recheck` commands that recover them.

--- a/SPEC.md
+++ b/SPEC.md
@@ -4103,16 +4103,23 @@ multiple broker-specific contexts.
 
 4. **Trade History**: Recent trades filterable by venue (onchain/offchain/both).
    Onchain entries are completed fills. Offchain counter-trade entries include
-   both successful fills and terminal failures; each entry carries its terminal
-   outcome timestamp. Failed entries expose the broker or placement error and
-   keep the requested quantity distinct from the broker-accepted quantity. The
-   accepted and actually-filled quantities are nullable provenance: `null` means
-   the persisted history does not prove that fact, including legacy failures
-   that predate explicit fill evidence. Remaining and excess quantities are
-   derived only when both accepted and filled quantities are known. An overfill
-   reports the complete actual fill plus its excess rather than clamping the
-   fill to the accepted quantity. Terminal outcomes use the same provenance in
-   initial history and live dashboard updates.
+   successful fills, terminal failures, and terminal cancellations; each entry
+   carries its terminal outcome timestamp. Failed entries expose the broker or
+   placement error. Failed and cancelled entries keep the requested quantity
+   distinct from the broker-accepted quantity. The accepted and actually-filled
+   quantities are nullable provenance: `null` means the persisted history does
+   not prove that fact, including legacy outcomes that predate explicit fill
+   evidence. An explicit broker-reported zero therefore distinguishes a wholly
+   unfilled cancellation from an outcome whose fill remains unknown. Remaining
+   and excess quantities are derived only when both accepted and filled
+   quantities are known. An overfill reports the complete actual fill plus its
+   excess rather than clamping the fill to the accepted quantity. Non-terminal
+   submitted, partially-filled, and cancelling orders remain excluded. Terminal
+   outcomes use the same provenance in initial history and live dashboard
+   updates. A broker-terminal failure or cancellation with a positive fill but
+   no execution price is still persisted and surfaced; the owning position
+   remains pending for manual reconciliation so the unpriced fill cannot be
+   silently applied or discarded.
 
    Dashboard trade messages remain compatible during rolling deploys. The
    canonical protocol sends every terminal outcome as `trade_update`. Filled
@@ -4129,15 +4136,18 @@ multiple broker-specific contexts.
    reports the requested quantity as the accepted quantity and derives the split
    from it, because v1 has no way to express an unknown acceptance.
    Provenance-aware nullable failure quantities use
-   `trade_protocol=terminal_outcomes_v2`. A newer dashboard requests v2 and
-   retries both WebSocket and HTTP history with v1 when an older backend rejects
-   the unknown protocol value, while continuing to accept v1 responses and
-   reconstructing the complete fill as the legacy filled plus excess quantity. A
-   legacy zero fill remains unknown because v1 synthesized zero when no fill
-   evidence existed. A successful v1 WebSocket fallback probes v2 again after
-   its next disconnect so a transient restart cannot pin the client to v1.
-   Failed outcomes are sent only through a terminal-outcome protocol. Trade
-   ordering compares the complete RFC 3339 timestamp, including sub-millisecond
+   `trade_protocol=terminal_outcomes_v2`. Cancelled outcomes are also v2-only,
+   because adding a new tagged outcome to v1 would break older exhaustive
+   consumers; a v1 fallback therefore omits cancelled entries from history
+   rather than losing them. A newer dashboard requests v2 and retries both
+   WebSocket and HTTP history with v1 when an older backend rejects the unknown
+   protocol value, while continuing to accept v1 responses and reconstructing
+   the complete fill as the legacy filled plus excess quantity. A legacy zero
+   fill remains unknown because v1 synthesized zero when no fill evidence
+   existed. A successful v1 WebSocket fallback probes v2 again after its next
+   disconnect so a transient restart cannot pin the client to v1. Failed
+   outcomes are sent only through a terminal-outcome protocol. Trade ordering
+   compares the complete RFC 3339 timestamp, including sub-millisecond
    precision, then uses the same stable trade-ID tie-breaker for initial history
    and live updates.
 

--- a/crates/dto/src/trade.rs
+++ b/crates/dto/src/trade.rs
@@ -143,6 +143,16 @@ pub enum TradeOutcome {
         #[ts(type = "string | null")]
         excess_shares: Option<NonNegative<FractionalShares>>,
     },
+    Cancelled {
+        #[ts(type = "string | null")]
+        accepted_shares: Option<Positive<FractionalShares>>,
+        #[ts(type = "string | null")]
+        filled_shares: Option<NonNegative<FractionalShares>>,
+        #[ts(type = "string | null")]
+        remaining_shares: Option<NonNegative<FractionalShares>>,
+        #[ts(type = "string | null")]
+        excess_shares: Option<NonNegative<FractionalShares>>,
+    },
 }
 
 #[derive(Default)]
@@ -176,6 +186,83 @@ enum TradeOutcomeWire {
         remaining_shares: Option<NonNegative<FractionalShares>>,
         excess_shares: Option<NonNegative<FractionalShares>>,
     },
+    Cancelled {
+        #[serde(default, deserialize_with = "deserialize_present")]
+        accepted_shares: FieldPresence<Option<Positive<FractionalShares>>>,
+        filled_shares: Option<NonNegative<FractionalShares>>,
+        remaining_shares: Option<NonNegative<FractionalShares>>,
+        excess_shares: Option<NonNegative<FractionalShares>>,
+    },
+}
+
+/// Rejects a terminal outcome whose derived quantities contradict its
+/// accepted and filled quantities.
+///
+/// The dashboard parser enforces this contract on the same payload, so
+/// without it the two ends of the wire disagree on what a valid outcome is:
+/// `Trade` also deserializes from durable job payloads, and a corrupt row
+/// would pass here only to fail later in the browser.
+fn validate_derived_quantities<E: serde::de::Error>(
+    accepted_shares: Option<Positive<FractionalShares>>,
+    filled_shares: Option<NonNegative<FractionalShares>>,
+    remaining_shares: Option<NonNegative<FractionalShares>>,
+    excess_shares: Option<NonNegative<FractionalShares>>,
+) -> Result<(), E> {
+    let (Some(accepted), Some(filled)) = (accepted_shares, filled_shares) else {
+        if remaining_shares.is_some() {
+            return Err(E::custom(
+                "remainingShares must be null when fill provenance is incomplete",
+            ));
+        }
+        if excess_shares.is_some() {
+            return Err(E::custom(
+                "excessShares must be null when fill provenance is incomplete",
+            ));
+        }
+
+        return Ok(());
+    };
+
+    let remaining = remaining_shares.ok_or_else(|| E::missing_field("remainingShares"))?;
+    let excess = excess_shares.ok_or_else(|| E::missing_field("excessShares"))?;
+    let accepted = accepted.inner();
+    let filled = filled.inner();
+    let overfilled = filled.inner().gt(accepted.inner()).map_err(E::custom)?;
+    let (expected_remaining, expected_excess) = if overfilled {
+        (
+            FractionalShares::ZERO,
+            (filled - accepted).map_err(E::custom)?,
+        )
+    } else {
+        (
+            (accepted - filled).map_err(E::custom)?,
+            FractionalShares::ZERO,
+        )
+    };
+
+    if !remaining
+        .inner()
+        .inner()
+        .eq(expected_remaining.inner())
+        .map_err(E::custom)?
+    {
+        return Err(E::custom(
+            "remainingShares must be the accepted quantity minus the fill",
+        ));
+    }
+
+    if !excess
+        .inner()
+        .inner()
+        .eq(expected_excess.inner())
+        .map_err(E::custom)?
+    {
+        return Err(E::custom(
+            "excessShares must be the fill beyond the accepted quantity",
+        ));
+    }
+
+    Ok(())
 }
 
 impl<'de> Deserialize<'de> for TradeOutcome {
@@ -191,13 +278,22 @@ impl<'de> Deserialize<'de> for TradeOutcome {
                 filled_shares,
                 remaining_shares,
                 excess_shares,
-            } => Ok(Self::Failed {
-                error,
-                accepted_shares,
-                filled_shares,
-                remaining_shares,
-                excess_shares,
-            }),
+            } => {
+                validate_derived_quantities::<D::Error>(
+                    accepted_shares,
+                    filled_shares,
+                    remaining_shares,
+                    excess_shares,
+                )?;
+
+                Ok(Self::Failed {
+                    error,
+                    accepted_shares,
+                    filled_shares,
+                    remaining_shares,
+                    excess_shares,
+                })
+            }
             TradeOutcomeWire::Failed {
                 error,
                 accepted_shares: FieldPresence::Missing,
@@ -232,6 +328,30 @@ impl<'de> Deserialize<'de> for TradeOutcome {
                     excess_shares: None,
                 })
             }
+            TradeOutcomeWire::Cancelled {
+                accepted_shares: FieldPresence::Present(accepted_shares),
+                filled_shares,
+                remaining_shares,
+                excess_shares,
+            } => {
+                validate_derived_quantities::<D::Error>(
+                    accepted_shares,
+                    filled_shares,
+                    remaining_shares,
+                    excess_shares,
+                )?;
+
+                Ok(Self::Cancelled {
+                    accepted_shares,
+                    filled_shares,
+                    remaining_shares,
+                    excess_shares,
+                })
+            }
+            TradeOutcomeWire::Cancelled {
+                accepted_shares: FieldPresence::Missing,
+                ..
+            } => Err(D::Error::missing_field("acceptedShares")),
         }
     }
 }
@@ -249,9 +369,10 @@ pub struct Trade {
     pub direction: Direction,
     #[ts(type = "string")]
     pub symbol: Symbol,
-    /// Executed quantity for fills, or requested quantity for a failed
-    /// counter-trade. Failed outcomes carry broker-accepted and fill provenance
-    /// separately when those facts are known.
+    /// Executed quantity for fills, or requested quantity for a failed or
+    /// cancelled counter-trade. Terminal non-fill outcomes carry
+    /// broker-accepted and fill provenance separately when those facts are
+    /// known.
     #[ts(type = "string")]
     pub shares: Positive<FractionalShares>,
     pub outcome: TradeOutcome,
@@ -608,6 +729,191 @@ mod tests {
         );
         assert_eq!(remaining_shares, None);
         assert_eq!(excess_shares, None);
+    }
+
+    #[test]
+    fn cancelled_trade_roundtrips_explicit_zero_fill() {
+        let trade = Trade {
+            id: "cancelled-order-id".to_string(),
+            occurred_at: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            venue: TradingVenue::Alpaca,
+            direction: Direction::Buy,
+            symbol: Symbol::new("SPCX").unwrap(),
+            shares: positive_shares("1.5"),
+            outcome: TradeOutcome::Cancelled {
+                accepted_shares: Some(positive_shares("1")),
+                filled_shares: Some(NonNegative::new(FractionalShares::ZERO).unwrap()),
+                remaining_shares: Some(NonNegative::new(FractionalShares::new(float!(1))).unwrap()),
+                excess_shares: Some(NonNegative::new(FractionalShares::ZERO).unwrap()),
+            },
+        };
+
+        let wire = serde_json::to_value(&trade).unwrap();
+        assert_eq!(
+            wire["outcome"],
+            json!({
+                "status": "cancelled",
+                "acceptedShares": "1",
+                "filledShares": "0",
+                "remainingShares": "1",
+                "excessShares": "0"
+            })
+        );
+        assert!(
+            wire.get("filledAt").is_none(),
+            "cancelled outcomes must not masquerade as legacy fills"
+        );
+        let restored: Trade = serde_json::from_value(wire).unwrap();
+        assert_eq!(restored.outcome, trade.outcome);
+    }
+
+    #[test]
+    fn cancelled_trade_roundtrips_all_null_provenance_in_job_payload() {
+        let trade = Trade {
+            id: "legacy-cancelled-order-id".to_string(),
+            occurred_at: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            venue: TradingVenue::Alpaca,
+            direction: Direction::Buy,
+            symbol: Symbol::new("SPCX").unwrap(),
+            shares: positive_shares("1"),
+            outcome: TradeOutcome::Cancelled {
+                accepted_shares: None,
+                filled_shares: None,
+                remaining_shares: None,
+                excess_shares: None,
+            },
+        };
+
+        let payload = serde_json::to_vec(&trade).unwrap();
+        let restored: Trade = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(restored.outcome, trade.outcome);
+    }
+
+    #[test]
+    fn cancelled_trade_rejects_missing_v2_acceptance_field() {
+        let wire = json!({
+            "id": "cancelled-order-id",
+            "occurredAt": "2026-07-20T12:00:00Z",
+            "venue": "alpaca",
+            "direction": "buy",
+            "symbol": "SPCX",
+            "shares": "1",
+            "outcome": {
+                "status": "cancelled",
+                "filledShares": "0",
+                "remainingShares": "1",
+                "excessShares": "0"
+            }
+        });
+
+        let error = serde_json::from_value::<Trade>(wire).unwrap_err();
+        assert!(error.to_string().contains("acceptedShares"));
+    }
+
+    fn v2_cancelled_wire(outcome: &serde_json::Value) -> serde_json::Value {
+        json!({
+            "id": "cancelled-order-id",
+            "occurredAt": "2026-07-20T12:00:00Z",
+            "venue": "alpaca",
+            "direction": "buy",
+            "symbol": "SPCX",
+            "shares": "1",
+            "outcome": outcome
+        })
+    }
+
+    #[test]
+    fn v2_outcome_rejects_remaining_shares_that_are_not_the_unfilled_quantity() {
+        let error = serde_json::from_value::<Trade>(v2_cancelled_wire(&json!({
+            "status": "cancelled",
+            "acceptedShares": "1",
+            "filledShares": "0.25",
+            "remainingShares": "0.5",
+            "excessShares": "0"
+        })))
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "remainingShares must be the accepted quantity minus the fill"
+        );
+    }
+
+    #[test]
+    fn v2_outcome_rejects_excess_shares_that_are_not_the_overfill() {
+        let error = serde_json::from_value::<Trade>(v2_cancelled_wire(&json!({
+            "status": "cancelled",
+            "acceptedShares": "1",
+            "filledShares": "1.5",
+            "remainingShares": "0",
+            "excessShares": "0.25"
+        })))
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "excessShares must be the fill beyond the accepted quantity"
+        );
+    }
+
+    #[test]
+    fn v2_outcome_rejects_derived_quantities_without_complete_provenance() {
+        let error = serde_json::from_value::<Trade>(v2_cancelled_wire(&json!({
+            "status": "cancelled",
+            "acceptedShares": null,
+            "filledShares": null,
+            "remainingShares": "1",
+            "excessShares": null
+        })))
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "remainingShares must be null when fill provenance is incomplete"
+        );
+    }
+
+    #[test]
+    fn v2_outcome_rejects_missing_derived_quantities_with_complete_provenance() {
+        let error = serde_json::from_value::<Trade>(v2_cancelled_wire(&json!({
+            "status": "cancelled",
+            "acceptedShares": "1",
+            "filledShares": "0.25",
+            "remainingShares": null,
+            "excessShares": "0"
+        })))
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("remainingShares"),
+            "expected a missing-field error for remainingShares, got: {error}"
+        );
+    }
+
+    #[test]
+    fn v2_failed_outcome_rejects_inconsistent_derived_quantities() {
+        let error = serde_json::from_value::<Trade>(json!({
+            "id": "failed-order-id",
+            "occurredAt": "2026-07-20T12:00:00Z",
+            "venue": "alpaca",
+            "direction": "buy",
+            "symbol": "SPCX",
+            "shares": "1",
+            "outcome": {
+                "status": "failed",
+                "error": "asset is not tradable",
+                "acceptedShares": "1",
+                "filledShares": "0.25",
+                "remainingShares": "0.75",
+                "excessShares": "0.5"
+            }
+        }))
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "excessShares must be the fill beyond the accepted quantity"
+        );
     }
 
     #[test]

--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -48,7 +48,35 @@ pub enum MockMode {
     /// Place succeeds, order stays "new" for N polls before filling.
     /// Simulates real broker latency where fills aren't instant.
     DelayedFill { polls_before_fill: usize },
+    /// Place succeeds, the first poll returns a half-quantity partial fill
+    /// and the next poll returns "canceled" retaining that fill. Models a
+    /// broker-side cancellation the bot never requested.
+    PartialFillThenCancel,
+    /// Place succeeds and each new equity order is assigned its own terminal
+    /// outcome in round-robin order -- filled, rejected, then partially
+    /// filled and cancelled. Unlike the single-outcome modes, one run drives
+    /// the trade history through every outcome the dashboard renders.
+    /// Crypto (USDCUSD) orders are unaffected and keep filling immediately.
+    RotatingOutcomes,
 }
+
+/// The terminal outcome the mock drives one order to, assigned at placement
+/// under [`MockMode::RotatingOutcomes`] so that concurrent orders keep their
+/// own outcome instead of racing on the server-wide mode.
+#[derive(Debug, Clone, Copy)]
+enum PlannedOutcome {
+    Filled,
+    Rejected,
+    CancelledAfterPartialFill,
+}
+
+/// The outcomes [`MockMode::RotatingOutcomes`] cycles through, in the order
+/// they are handed to newly placed orders.
+const ROTATING_OUTCOMES: [PlannedOutcome; 3] = [
+    PlannedOutcome::Filled,
+    PlannedOutcome::Rejected,
+    PlannedOutcome::CancelledAfterPartialFill,
+];
 
 pub struct MockPosition {
     pub symbol: Symbol,
@@ -82,7 +110,9 @@ impl std::fmt::Display for OrderSide {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OrderStatus {
     New,
+    PartiallyFilled,
     Filled,
+    Canceled,
     Rejected,
 }
 
@@ -90,7 +120,9 @@ impl std::fmt::Display for OrderStatus {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::New => write!(formatter, "new"),
+            Self::PartiallyFilled => write!(formatter, "partially_filled"),
             Self::Filled => write!(formatter, "filled"),
+            Self::Canceled => write!(formatter, "canceled"),
             Self::Rejected => write!(formatter, "rejected"),
         }
     }
@@ -101,9 +133,16 @@ struct MockOrder {
     quantity: Float,
     side: OrderSide,
     status: OrderStatus,
+    /// Quantity executed so far. Zero until a fill applies, the ordered
+    /// quantity once filled, and the partial quantity for an order that was
+    /// cancelled after a partial fill.
+    filled_quantity: Float,
     poll_count: usize,
     filled_price: Option<Float>,
     client_order_id: Option<String>,
+    /// Set only for orders placed under [`MockMode::RotatingOutcomes`];
+    /// overrides the server-wide mode when this order is polled.
+    planned_outcome: Option<PlannedOutcome>,
 }
 
 /// A single calendar entry controlling market open/close times.
@@ -156,6 +195,9 @@ struct MockState {
     orders: HashMap<String, MockOrder>,
     symbol_fill_prices: HashMap<Symbol, Float>,
     mode: MockMode,
+    /// Cursor into [`ROTATING_OUTCOMES`], advanced once per equity order
+    /// placed under [`MockMode::RotatingOutcomes`].
+    rotating_outcome_index: usize,
     /// Per-symbol fill delays: number of polls before filling.
     /// Symbols without an entry fill immediately in `HappyPath` mode.
     symbol_fill_delays: HashMap<Symbol, usize>,
@@ -336,6 +378,7 @@ impl AlpacaBrokerMock {
             orders: HashMap::new(),
             symbol_fill_prices,
             mode: MockMode::HappyPath,
+            rotating_outcome_index: 0,
             symbol_fill_delays: HashMap::new(),
             calendar_entries,
             wallet_transfers: Vec::new(),
@@ -1057,6 +1100,20 @@ fn register_order_placement_endpoint(server: &MockServer, state: &Arc<Mutex<Mock
                 }
             }
 
+            let planned_outcome = match state.mode {
+                MockMode::RotatingOutcomes => {
+                    let outcome = ROTATING_OUTCOMES[state.rotating_outcome_index];
+                    state.rotating_outcome_index =
+                        (state.rotating_outcome_index + 1) % ROTATING_OUTCOMES.len();
+                    Some(outcome)
+                }
+                MockMode::HappyPath
+                | MockMode::OrderRejected
+                | MockMode::PlacementFails
+                | MockMode::DelayedFill { .. }
+                | MockMode::PartialFillThenCancel => None,
+            };
+
             state.orders.insert(
                 order_id.clone(),
                 MockOrder {
@@ -1064,9 +1121,11 @@ fn register_order_placement_endpoint(server: &MockServer, state: &Arc<Mutex<Mock
                     quantity,
                     side,
                     status: OrderStatus::New,
+                    filled_quantity: float!(0),
                     poll_count: 0,
                     filled_price: None,
                     client_order_id: client_order_id.clone(),
+                    planned_outcome,
                 },
             );
 
@@ -1216,9 +1275,11 @@ fn handle_crypto_order(
             quantity: quantized_quantity,
             side,
             status: OrderStatus::Filled,
+            filled_quantity: quantized_quantity,
             poll_count: 0,
             filled_price: Some(fill_price),
             client_order_id: None,
+            planned_outcome: None,
         },
     );
 
@@ -1301,85 +1362,14 @@ fn register_order_status_endpoint(server: &MockServer, state: &Arc<Mutex<MockSta
                     order.poll_count += 1;
                 }
 
-                let mode = state.mode;
-
-                match mode {
-                    MockMode::HappyPath => {
-                        let symbol_key = state.orders[&order_id].symbol.clone();
-
-                        let delay = state
-                            .symbol_fill_delays
-                            .get(&symbol_key)
-                            .copied()
-                            .unwrap_or(0);
-                        let poll_count = state.orders[&order_id].poll_count;
-
-                        if poll_count >= delay {
-                            let Some(fill_price) =
-                                state.symbol_fill_prices.get(&symbol_key).copied()
-                            else {
-                                return json_response(
-                                    500,
-                                    &json!({"message": "no fill price configured"}),
-                                );
-                            };
-
-                            if let Err(error) =
-                                apply_happy_path_fill(&mut state, &order_id, fill_price)
-                            {
-                                return json_response(
-                                    500,
-                                    &json!({"message": format!("fill arithmetic error: {error}")}),
-                                );
-                            }
-                        }
-                    }
-                    MockMode::OrderRejected => {
-                        if let Some(order) = state.orders.get_mut(&order_id) {
-                            order.status = OrderStatus::Rejected;
-                        }
-                    }
-                    MockMode::DelayedFill { polls_before_fill } => {
-                        let ready = state
-                            .orders
-                            .get(&order_id)
-                            .is_some_and(|o| o.poll_count >= polls_before_fill);
-
-                        if ready {
-                            let symbol_key = state.orders[&order_id].symbol.clone();
-                            let Some(fill_price) =
-                                state.symbol_fill_prices.get(&symbol_key).copied()
-                            else {
-                                return json_response(
-                                    500,
-                                    &json!({"message": "no fill price configured"}),
-                                );
-                            };
-
-                            if let Err(error) =
-                                apply_happy_path_fill(&mut state, &order_id, fill_price)
-                            {
-                                return json_response(
-                                    500,
-                                    &json!({"message": format!("fill arithmetic error: {error}")}),
-                                );
-                            }
-                        }
-                    }
-                    MockMode::PlacementFails => {
-                        // Placement already rejected at order creation -
-                        // no orders exist to poll.
-                    }
+                if let Err(error) = advance_polled_order(&mut state, &order_id) {
+                    return json_response(500, &json!({"message": error.to_string()}));
                 }
 
                 let order = &state.orders[&order_id];
                 // The real API always reports filled_qty ("0" when unfilled);
                 // the client fails closed on terminal responses without it.
-                let filled_quantity = if order.status == OrderStatus::Filled {
-                    format_float_with_fallback(&order.quantity)
-                } else {
-                    "0".to_string()
-                };
+                let filled_quantity = format_float_with_fallback(&order.filled_quantity);
                 let filled_price: Option<String> =
                     order.filled_price.as_ref().map(format_float_with_fallback);
                 let quantity = format_float_with_fallback(&order.quantity);
@@ -1389,6 +1379,8 @@ fn register_order_status_endpoint(server: &MockServer, state: &Arc<Mutex<MockSta
                     (order.status == OrderStatus::Filled).then_some("2025-01-01T00:00:01Z");
                 let failed_at =
                     (order.status == OrderStatus::Rejected).then_some("2025-01-01T00:00:01Z");
+                let canceled_at =
+                    (order.status == OrderStatus::Canceled).then_some("2025-01-01T00:00:01Z");
                 let body = json!({
                     "id": order_id,
                     "symbol": order.symbol,
@@ -1401,6 +1393,7 @@ fn register_order_status_endpoint(server: &MockServer, state: &Arc<Mutex<MockSta
                     "updated_at": "2025-01-01T00:00:01Z",
                     "filled_at": filled_at,
                     "failed_at": failed_at,
+                    "canceled_at": canceled_at,
                 });
                 drop(state);
                 body
@@ -1411,11 +1404,118 @@ fn register_order_status_endpoint(server: &MockServer, state: &Arc<Mutex<MockSta
     });
 }
 
-/// Transitions a "new" order to "filled" and updates account balances.
-fn apply_happy_path_fill(
+/// Resolves which single-outcome mode governs one polled order. An order
+/// placed under [`MockMode::RotatingOutcomes`] follows the outcome it was
+/// assigned at placement; every other order follows the server-wide mode.
+const fn poll_mode(mode: MockMode, planned_outcome: Option<PlannedOutcome>) -> MockMode {
+    match planned_outcome {
+        Some(PlannedOutcome::Filled) => MockMode::HappyPath,
+        Some(PlannedOutcome::Rejected) => MockMode::OrderRejected,
+        Some(PlannedOutcome::CancelledAfterPartialFill) => MockMode::PartialFillThenCancel,
+        // Orders placed before the switch to `RotatingOutcomes` carry no
+        // planned outcome; they keep the happy path they were placed under.
+        None => match mode {
+            MockMode::RotatingOutcomes => MockMode::HappyPath,
+            other => other,
+        },
+    }
+}
+
+/// Why the mock could not advance a polled order.
+#[derive(Debug, thiserror::Error)]
+enum PollAdvanceError {
+    #[error("no fill price configured for {symbol}")]
+    NoFillPrice { symbol: Symbol },
+    #[error("fill arithmetic error: {0}")]
+    Arithmetic(#[from] rain_math_float::FloatError),
+}
+
+/// Applies one poll's worth of state transition to an order, per the mode
+/// governing it. Called once per status request, after the poll counter has
+/// been incremented.
+fn advance_polled_order(state: &mut MockState, order_id: &str) -> Result<(), PollAdvanceError> {
+    let order = &state.orders[order_id];
+    let symbol = order.symbol.clone();
+    let poll_count = order.poll_count;
+
+    match poll_mode(state.mode, order.planned_outcome) {
+        MockMode::HappyPath => {
+            let delay = state.symbol_fill_delays.get(&symbol).copied().unwrap_or(0);
+            if poll_count >= delay {
+                apply_fill(
+                    state,
+                    order_id,
+                    fill_price(state, &symbol)?,
+                    FillExtent::Full,
+                )?;
+            }
+            Ok(())
+        }
+        MockMode::DelayedFill { polls_before_fill } => {
+            if poll_count >= polls_before_fill {
+                apply_fill(
+                    state,
+                    order_id,
+                    fill_price(state, &symbol)?,
+                    FillExtent::Full,
+                )?;
+            }
+            Ok(())
+        }
+        MockMode::OrderRejected => {
+            if let Some(order) = state.orders.get_mut(order_id) {
+                order.status = OrderStatus::Rejected;
+            }
+            Ok(())
+        }
+        MockMode::PartialFillThenCancel => {
+            // The first poll reports the partial fill so the bot records it
+            // on the aggregate; the next poll cancels, retaining that fill.
+            if state.orders[order_id].status == OrderStatus::New {
+                apply_fill(
+                    state,
+                    order_id,
+                    fill_price(state, &symbol)?,
+                    FillExtent::Half,
+                )?;
+            } else if let Some(order) = state.orders.get_mut(order_id) {
+                order.status = OrderStatus::Canceled;
+            }
+            Ok(())
+        }
+        // `PlacementFails` rejects at order creation, so no order exists to
+        // poll; `poll_mode` never resolves to the rotating mode itself.
+        MockMode::PlacementFails | MockMode::RotatingOutcomes => Ok(()),
+    }
+}
+
+fn fill_price(state: &MockState, symbol: &Symbol) -> Result<Float, PollAdvanceError> {
+    state
+        .symbol_fill_prices
+        .get(symbol)
+        .copied()
+        .ok_or_else(|| PollAdvanceError::NoFillPrice {
+            symbol: symbol.clone(),
+        })
+}
+
+/// How much of an order's quantity a fill executes.
+#[derive(Debug, Clone, Copy)]
+enum FillExtent {
+    Full,
+    Half,
+}
+
+/// Executes a fill against a "new" order and updates account balances.
+///
+/// A [`FillExtent::Full`] fill moves the order to "filled"; a
+/// [`FillExtent::Half`] fill moves it to "partially_filled", leaving the
+/// remainder open for a later cancellation.
+fn apply_fill(
     state: &mut MockState,
     order_id: &str,
     fill_price: Float,
+    extent: FillExtent,
 ) -> Result<(), rain_math_float::FloatError> {
     let should_fill = state
         .orders
@@ -1426,14 +1526,22 @@ fn apply_happy_path_fill(
     }
 
     let symbol_key = state.orders[order_id].symbol.clone();
-    let qty = state.orders[order_id].quantity;
     let side = state.orders[order_id].side;
+    let ordered_quantity = state.orders[order_id].quantity;
+    let (qty, status) = match extent {
+        FillExtent::Full => (ordered_quantity, OrderStatus::Filled),
+        FillExtent::Half => (
+            (ordered_quantity * float!(0.5))?,
+            OrderStatus::PartiallyFilled,
+        ),
+    };
     let raw_cost = (qty * fill_price)?;
     let (cost_fixed, _) = raw_cost.to_fixed_decimal_lossy(2)?;
     let cost = Float::from_fixed_decimal(cost_fixed, 2)?;
 
     if let Some(order) = state.orders.get_mut(order_id) {
-        order.status = OrderStatus::Filled;
+        order.status = status;
+        order.filled_quantity = qty;
         order.filled_price = Some(fill_price);
     }
 
@@ -1973,6 +2081,82 @@ mod tests {
         );
     }
 
+    /// Places one order per rotation step and polls each to its terminal
+    /// status. `RotatingOutcomes` is only useful if a single run yields all
+    /// three outcomes the dashboard renders, so this asserts the full cycle
+    /// -- including the fill quantities and terminal timestamps the order
+    /// status parser needs to accept a cancellation.
+    #[tokio::test]
+    async fn rotating_outcomes_drives_each_order_to_its_own_terminal_status() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let broker = AlpacaBrokerMock::start()
+            .symbol_fill_prices(vec![(symbol, float!(150))])
+            .symbol_positions(vec![])
+            .call()
+            .await;
+        broker.set_mode(MockMode::RotatingOutcomes);
+
+        let client = reqwest::Client::new();
+        let orders_url = format!(
+            "{}/v1/trading/accounts/{TEST_ACCOUNT_ID}/orders",
+            broker.base_url()
+        );
+
+        let mut order_ids = Vec::new();
+        for index in 0..3 {
+            let placed: serde_json::Value = client
+                .post(&orders_url)
+                .json(&serde_json::json!({
+                    "symbol": "AAPL",
+                    "qty": "4",
+                    "side": "buy",
+                    "client_order_id": format!("rotating-{index}"),
+                }))
+                .send()
+                .await
+                .unwrap()
+                .json()
+                .await
+                .unwrap();
+            order_ids.push(placed["id"].as_str().unwrap().to_string());
+        }
+
+        let poll = async |order_id: &str| -> serde_json::Value {
+            client
+                .get(format!("{orders_url}/{order_id}"))
+                .send()
+                .await
+                .unwrap()
+                .json()
+                .await
+                .unwrap()
+        };
+
+        let filled = poll(&order_ids[0]).await;
+        assert_eq!(filled["status"], serde_json::json!("filled"));
+        assert_eq!(filled["filled_qty"], serde_json::json!("4"));
+        assert_eq!(
+            filled["filled_at"],
+            serde_json::json!("2025-01-01T00:00:01Z")
+        );
+
+        let rejected = poll(&order_ids[1]).await;
+        assert_eq!(rejected["status"], serde_json::json!("rejected"));
+        assert_eq!(rejected["filled_qty"], serde_json::json!("0"));
+
+        let partial = poll(&order_ids[2]).await;
+        assert_eq!(partial["status"], serde_json::json!("partially_filled"));
+        assert_eq!(partial["filled_qty"], serde_json::json!("2"));
+
+        let cancelled = poll(&order_ids[2]).await;
+        assert_eq!(cancelled["status"], serde_json::json!("canceled"));
+        assert_eq!(cancelled["filled_qty"], serde_json::json!("2"));
+        assert_eq!(
+            cancelled["canceled_at"],
+            serde_json::json!("2025-01-01T00:00:01Z")
+        );
+    }
+
     #[test]
     fn format_u256_as_usdc_cases() {
         assert_eq!(format_u256_as_usdc(U256::ZERO), "0");
@@ -2066,6 +2250,7 @@ mod tests {
             orders: HashMap::new(),
             symbol_fill_prices: HashMap::new(),
             mode: MockMode::HappyPath,
+            rotating_outcome_index: 0,
             symbol_fill_delays: HashMap::new(),
             calendar_entries: vec![],
             wallet_transfers: vec![],
@@ -2113,6 +2298,7 @@ mod tests {
             orders: HashMap::new(),
             symbol_fill_prices: HashMap::new(),
             mode: MockMode::HappyPath,
+            rotating_outcome_index: 0,
             symbol_fill_delays: HashMap::new(),
             calendar_entries: vec![],
             wallet_transfers: vec![],
@@ -2167,6 +2353,7 @@ mod tests {
             orders: HashMap::new(),
             symbol_fill_prices: HashMap::new(),
             mode: MockMode::HappyPath,
+            rotating_outcome_index: 0,
             symbol_fill_delays: HashMap::new(),
             calendar_entries: vec![],
             wallet_transfers: vec![],

--- a/dashboard/src/lib/components/trade-history-panel.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.svelte
@@ -240,15 +240,19 @@
     void fetchTrades('append', offset.current + PAGE_SIZE)
   }
 
+  const applyFilterChange = () => {
+    offset.update(() => 0)
+    resetHistoryForFilter()
+    void fetchTrades('replace')
+  }
+
   const applyPreset = (minutes: number) => () => {
     const sinceDate = new Date(Date.now() - minutes * 60_000)
     since.update(() => toDatetimeLocal(sinceDate))
     until.update(() => '')
     if (sinceInput) sinceInput.value = toDatetimeLocal(sinceDate)
     if (untilInput) untilInput.value = ''
-    offset.update(() => 0)
-    resetHistoryForFilter()
-    void fetchTrades('replace')
+    applyFilterChange()
   }
 
   const jumpToLatest = () => {
@@ -256,11 +260,9 @@
     until.update(() => '')
     selectedVenues.update(() => new Set(ALL_VENUES))
     selectedSymbols.update(() => new Set())
-    offset.update(() => 0)
     if (sinceInput) sinceInput.value = ''
     if (untilInput) untilInput.value = ''
-    resetHistoryForFilter()
-    void fetchTrades('replace')
+    applyFilterChange()
   }
 
   const hasFilters = $derived(
@@ -281,30 +283,22 @@
 
   const handleVenueChange = (selected: Set<TradingVenue>) => {
     selectedVenues.update(() => selected)
-    offset.update(() => 0)
-    resetHistoryForFilter()
-    void fetchTrades('replace')
+    applyFilterChange()
   }
 
   const handleSymbolChange = (selected: Set<string>) => {
     selectedSymbols.update(() => selected)
-    offset.update(() => 0)
-    resetHistoryForFilter()
-    void fetchTrades('replace')
+    applyFilterChange()
   }
 
   const handleSinceChange = (event: Event) => {
     since.update(() => (event.target as HTMLInputElement).value)
-    offset.update(() => 0)
-    resetHistoryForFilter()
-    void fetchTrades('replace')
+    applyFilterChange()
   }
 
   const handleUntilChange = (event: Event) => {
     until.update(() => (event.target as HTMLInputElement).value)
-    offset.update(() => 0)
-    resetHistoryForFilter()
-    void fetchTrades('replace')
+    applyFilterChange()
   }
 
   const directionColor = (direction: string): string =>
@@ -313,7 +307,7 @@
   const fmtSize = (value: string): string => formatDecimal(value, 3)
 
   const shareTooltip = (trade: TradeEntry): string =>
-    `${trade.outcome.status === 'failed' ? 'Order quantity. ' : ''}${equityUsdTooltip(
+    `${trade.outcome.status !== 'filled' ? 'Order quantity. ' : ''}${equityUsdTooltip(
       trade.shares,
       positionPrices.get(trade.symbol) ?? null
     )}`

--- a/dashboard/src/lib/components/trade-history-panel.test.ts
+++ b/dashboard/src/lib/components/trade-history-panel.test.ts
@@ -304,10 +304,18 @@ describe('TradeHistoryPanel', () => {
 
     const { queryClient, target } = mountPanel()
 
+    // Rows carry the outcome label alone -- the reason and the share
+    // breakdown belong to the detail panel -- so every row stays one line
+    // tall regardless of outcome.
+    const outcomeCells = () =>
+      Array.from(target.querySelectorAll('tbody tr'))
+        .map((row) => row.lastElementChild?.textContent.trim())
+        .sort()
+
     await vi.waitFor(() => {
-      expect(target.textContent).toContain('initial broker failure')
-      expect(target.textContent).toContain('Failed')
+      expect(outcomeCells()).toEqual(['Failed', 'Filled'])
     })
+    expect(target.textContent).not.toContain('initial broker failure')
 
     const connection = createWebSocket('ws://localhost/api/ws', queryClient)
     connection.connect()
@@ -329,14 +337,14 @@ describe('TradeHistoryPanel', () => {
     }
     await tick()
 
+    // The live update for `counter-trade-1` replaces the initially filled row
+    // with its failed outcome, so no filled row survives.
     await vi.waitFor(() => {
-      expect(target.textContent).toContain('broker rejected remainder')
-      expect(target.textContent).toContain('Filled 0.25')
-      expect(target.textContent).toContain('Unfilled 0.75')
-      expect(target.textContent).toContain('broker overfilled before rejecting')
-      expect(target.textContent).toContain('Excess fill 0.5')
+      expect(outcomeCells()).toEqual(['Failed', 'Failed', 'Failed'])
       expect(target.textContent).toContain('3 of 151')
     })
+    expect(target.textContent).not.toContain('broker overfilled before rejecting')
+    expect(target.textContent).not.toContain('Excess fill 0.5')
 
     expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('limit=100'), expect.any(Object))
     expect(fetchMock).toHaveBeenCalledWith(

--- a/dashboard/src/lib/components/trade-outcome.svelte
+++ b/dashboard/src/lib/components/trade-outcome.svelte
@@ -3,15 +3,18 @@
   import { decimalIsZero, formatDecimal } from '$lib/decimal'
   import {
     tradeFailureReason,
-    tradeFailureShares,
+    tradeOutcomeShares,
     tradeOutcomeClass,
     tradeOutcomeLabel
   } from '$lib/trade'
 
+  // Compact is the trade-history row: label only, so a failed row keeps the
+  // same height as a filled one. The reason and the share breakdown live in
+  // the detail panel behind the row's info button.
   let { outcome, compact = true }: { outcome: TradeOutcome; compact?: boolean } = $props()
 
   const failureReason = $derived(tradeFailureReason(outcome))
-  const failureShares = $derived(tradeFailureShares(outcome))
+  const outcomeShares = $derived(tradeOutcomeShares(outcome))
   const quantity = (value: string | null): string =>
     value === null ? 'unknown' : formatDecimal(value, 9)
 </script>
@@ -19,24 +22,21 @@
 <div class="font-medium {tradeOutcomeClass(outcome)}">
   {tradeOutcomeLabel(outcome)}
 </div>
-{#if failureReason !== null}
-  <div
-    class={compact ? 'truncate text-destructive/80' : 'break-all text-destructive'}
-    title={failureReason}
-  >
+{#if !compact && failureReason !== null}
+  <div class="break-all text-destructive">
     {failureReason}
   </div>
 {/if}
-{#if failureShares !== null}
+{#if !compact && outcomeShares !== null}
   <div class="text-muted-foreground">
-    Accepted {quantity(failureShares.accepted)} · Filled {quantity(failureShares.filled)}
-    {#if failureShares.remaining !== null}
-      · Unfilled {formatDecimal(failureShares.remaining, 9)}
+    Accepted {quantity(outcomeShares.accepted)} · Filled {quantity(outcomeShares.filled)}
+    {#if outcomeShares.remaining !== null}
+      · Unfilled {formatDecimal(outcomeShares.remaining, 9)}
     {/if}
   </div>
-  {#if failureShares.excess !== null && !decimalIsZero(failureShares.excess)}
+  {#if outcomeShares.excess !== null && !decimalIsZero(outcomeShares.excess)}
     <div class="text-destructive">
-      Excess fill {formatDecimal(failureShares.excess, 9)}
+      Excess fill {formatDecimal(outcomeShares.excess, 9)}
     </div>
   {/if}
 {/if}

--- a/dashboard/src/lib/components/trade-outcome.test.ts
+++ b/dashboard/src/lib/components/trade-outcome.test.ts
@@ -13,9 +13,30 @@ describe('TradeOutcome', () => {
     expect(body).not.toContain('Unfilled')
   })
 
+  it('renders only the label in a trade-history row, keeping every row one line tall', () => {
+    const { body } = render(TradeOutcome, {
+      props: {
+        outcome: {
+          status: 'failed',
+          error: 'broker rejected remainder',
+          acceptedShares: '1',
+          filledShares: '0.25',
+          remainingShares: '0.75',
+          excessShares: '0'
+        }
+      }
+    })
+
+    expect(body).toContain('Failed')
+    expect(body).not.toContain('broker rejected remainder')
+    expect(body).not.toContain('Accepted')
+    expect(body).not.toContain('Unfilled')
+  })
+
   it('renders a failed counter-trade error and partial-fill quantities', () => {
     const { body } = render(TradeOutcome, {
       props: {
+        compact: false,
         outcome: {
           status: 'failed',
           error: 'broker rejected remainder',
@@ -37,6 +58,7 @@ describe('TradeOutcome', () => {
   it('does not render a nonzero partial fill as zero', () => {
     const { body } = render(TradeOutcome, {
       props: {
+        compact: false,
         outcome: {
           status: 'failed',
           error: 'broker rejected remainder',
@@ -55,6 +77,7 @@ describe('TradeOutcome', () => {
   it('renders broker fills beyond the accepted order quantity', () => {
     const { body } = render(TradeOutcome, {
       props: {
+        compact: false,
         outcome: {
           status: 'failed',
           error: 'broker overfilled before rejecting',
@@ -74,6 +97,7 @@ describe('TradeOutcome', () => {
   it('renders missing provenance as unknown instead of zero', () => {
     const { body } = render(TradeOutcome, {
       props: {
+        compact: false,
         outcome: {
           status: 'failed',
           error: 'placement failed before acceptance',
@@ -88,5 +112,44 @@ describe('TradeOutcome', () => {
     expect(body).toContain('Accepted unknown')
     expect(body).toContain('Filled unknown')
     expect(body).not.toContain('Unfilled 0')
+  })
+
+  it('renders a partially-filled cancellation distinctly', () => {
+    const { body } = render(TradeOutcome, {
+      props: {
+        compact: false,
+        outcome: {
+          status: 'cancelled',
+          acceptedShares: '1',
+          filledShares: '0.25',
+          remainingShares: '0.75',
+          excessShares: '0'
+        }
+      }
+    })
+
+    expect(body).toContain('Cancelled')
+    expect(body).toContain('text-amber-500')
+    expect(body).toContain('Filled 0.25')
+    expect(body).toContain('Unfilled 0.75')
+  })
+
+  it('renders an explicit zero-fill cancellation as wholly unfilled', () => {
+    const { body } = render(TradeOutcome, {
+      props: {
+        compact: false,
+        outcome: {
+          status: 'cancelled',
+          acceptedShares: '1',
+          filledShares: '0',
+          remainingShares: '1',
+          excessShares: '0'
+        }
+      }
+    })
+
+    expect(body).toContain('Filled 0')
+    expect(body).toContain('Unfilled 1')
+    expect(body).not.toContain('Filled unknown')
   })
 })

--- a/dashboard/src/lib/trade-payload.test.ts
+++ b/dashboard/src/lib/trade-payload.test.ts
@@ -95,6 +95,45 @@ describe('trade payload validation', () => {
     expect(parseTrade(failed)).toEqual(failed)
   })
 
+  it('accepts zero-fill and partial-fill cancellations', () => {
+    const zeroFill = validTrade({
+      outcome: {
+        status: 'cancelled',
+        acceptedShares: '1.25',
+        filledShares: '0',
+        remainingShares: '1.25',
+        excessShares: '0'
+      }
+    })
+    const partialFill = validTrade({
+      outcome: {
+        status: 'cancelled',
+        acceptedShares: '1.25',
+        filledShares: '0.5',
+        remainingShares: '0.75',
+        excessShares: '0'
+      }
+    })
+
+    expect(parseTrade(zeroFill)).toEqual(zeroFill)
+    expect(parseTrade(partialFill)).toEqual(partialFill)
+  })
+
+  it('rejects a cancelled outcome without explicit v2 acceptance provenance', () => {
+    expect(() =>
+      parseTrade(
+        validTrade({
+          outcome: {
+            status: 'cancelled',
+            filledShares: '0',
+            remainingShares: '1.25',
+            excessShares: '0'
+          }
+        })
+      )
+    ).toThrow('Invalid trade payload at outcome.acceptedShares')
+  })
+
   it('normalizes the v1 failure shape without accepted quantity to unknown', () => {
     const legacy = validTrade({
       outcome: {
@@ -165,6 +204,20 @@ describe('trade payload validation', () => {
         excessShares: null
       }
     })
+  })
+
+  it('accepts a cancelled trade with explicit unknown provenance', () => {
+    const trade = validTrade({
+      outcome: {
+        status: 'cancelled',
+        acceptedShares: null,
+        filledShares: null,
+        remainingShares: null,
+        excessShares: null
+      }
+    })
+
+    expect(parseTrade(trade)).toEqual(trade)
   })
 
   it.each(['filledShares', 'remainingShares', 'excessShares'] as const)(

--- a/dashboard/src/lib/trade-payload.ts
+++ b/dashboard/src/lib/trade-payload.ts
@@ -124,13 +124,22 @@ const parseDirection = (value: unknown, path: string): Direction => {
   return invalid(path, 'a known trade direction')
 }
 
-const parseOutcome = (value: unknown, path: string): TradeOutcome => {
-  const outcome = parseRecord(value, path)
-  const statusPath = fieldPath(path, 'status')
-  if (outcome['status'] === 'filled') return { status: 'filled' }
-  if (outcome['status'] !== 'failed') return invalid(statusPath, 'a known terminal outcome')
+type OutcomeQuantities = {
+  acceptedShares: string | null
+  filledShares: string | null
+  remainingShares: string | null
+  excessShares: string | null
+}
 
+const parseOutcomeQuantities = (
+  outcome: Record<string, unknown>,
+  path: string,
+  allowLegacyFailure: boolean
+): OutcomeQuantities => {
   const hasAcceptedShares = 'acceptedShares' in outcome
+  if (!hasAcceptedShares && !allowLegacyFailure) {
+    return invalid(fieldPath(path, 'acceptedShares'), 'an explicit nullable quantity')
+  }
   const acceptedShares = parseNullableDecimal(
     outcome['acceptedShares'] ?? null,
     fieldPath(path, 'acceptedShares'),
@@ -217,13 +226,32 @@ const parseOutcome = (value: unknown, path: string): TradeOutcome => {
   }
 
   return {
-    status: 'failed',
-    error: parseString(outcome['error'], fieldPath(path, 'error')),
     acceptedShares,
     filledShares,
     remainingShares,
     excessShares
   }
+}
+
+const parseOutcome = (value: unknown, path: string): TradeOutcome => {
+  const outcome = parseRecord(value, path)
+  const statusPath = fieldPath(path, 'status')
+  if (outcome['status'] === 'filled') return { status: 'filled' }
+  if (outcome['status'] === 'failed') {
+    return {
+      status: 'failed',
+      error: parseString(outcome['error'], fieldPath(path, 'error')),
+      ...parseOutcomeQuantities(outcome, path, true)
+    }
+  }
+  if (outcome['status'] === 'cancelled') {
+    return {
+      status: 'cancelled',
+      ...parseOutcomeQuantities(outcome, path, false)
+    }
+  }
+
+  return invalid(statusPath, 'a known terminal outcome')
 }
 
 const parseCommonTradeFields = (trade: JsonRecord, path: string): CommonTradeFields => ({

--- a/dashboard/src/lib/trade.test.ts
+++ b/dashboard/src/lib/trade.test.ts
@@ -5,7 +5,7 @@ import {
   mergeTradeHistory,
   normalizeTrade,
   tradeFailureReason,
-  tradeFailureShares,
+  tradeOutcomeShares,
   tradeOutcomeClass,
   tradeOutcomeLabel
 } from './trade'
@@ -32,7 +32,27 @@ describe('trade outcome presentation', () => {
     expect(tradeOutcomeLabel(outcome)).toBe('Failed')
     expect(tradeOutcomeClass(outcome)).toBe('text-destructive')
     expect(tradeFailureReason(outcome)).toBe('asset is not tradable')
-    expect(tradeFailureShares(outcome)).toEqual({
+    expect(tradeOutcomeShares(outcome)).toEqual({
+      accepted: '1',
+      filled: '0.25',
+      remaining: '0.75',
+      excess: '0'
+    })
+  })
+
+  it('renders cancelled outcomes distinctly with their fill provenance', () => {
+    const outcome = {
+      status: 'cancelled',
+      acceptedShares: '1',
+      filledShares: '0.25',
+      remainingShares: '0.75',
+      excessShares: '0'
+    } as const
+
+    expect(tradeOutcomeLabel(outcome)).toBe('Cancelled')
+    expect(tradeOutcomeClass(outcome)).toBe('text-amber-500')
+    expect(tradeFailureReason(outcome)).toBeNull()
+    expect(tradeOutcomeShares(outcome)).toEqual({
       accepted: '1',
       filled: '0.25',
       remaining: '0.75',
@@ -50,7 +70,7 @@ describe('trade outcome presentation', () => {
       excessShares: null
     } as const
 
-    expect(tradeFailureShares(outcome)).toEqual({
+    expect(tradeOutcomeShares(outcome)).toEqual({
       accepted: null,
       filled: null,
       remaining: null,

--- a/dashboard/src/lib/trade.ts
+++ b/dashboard/src/lib/trade.ts
@@ -23,22 +23,25 @@ export const normalizeTrade = (trade: Trade | LegacyTrade): Trade => {
 export const tradeOutcomeLabel = (outcome: TradeOutcome): string =>
   matchOutcome(outcome, {
     filled: () => 'Filled',
-    failed: () => 'Failed'
+    failed: () => 'Failed',
+    cancelled: () => 'Cancelled'
   })
 
 export const tradeOutcomeClass = (outcome: TradeOutcome): string =>
   matchOutcome(outcome, {
     filled: () => 'text-green-500',
-    failed: () => 'text-destructive'
+    failed: () => 'text-destructive',
+    cancelled: () => 'text-amber-500'
   })
 
 export const tradeFailureReason = (outcome: TradeOutcome): string | null =>
   matchOutcome(outcome, {
     filled: () => null,
-    failed: ({ error }) => error
+    failed: ({ error }) => error,
+    cancelled: () => null
   })
 
-export const tradeFailureShares = (
+export const tradeOutcomeShares = (
   outcome: TradeOutcome
 ): {
   accepted: string | null
@@ -49,6 +52,12 @@ export const tradeFailureShares = (
   matchOutcome(outcome, {
     filled: () => null,
     failed: ({ acceptedShares, filledShares, remainingShares, excessShares }) => ({
+      accepted: acceptedShares,
+      filled: filledShares,
+      remaining: remainingShares,
+      excess: excessShares
+    }),
+    cancelled: ({ acceptedShares, filledShares, remainingShares, excessShares }) => ({
       accepted: acceptedShares,
       filled: filledShares,
       remaining: remainingShares,

--- a/flake.nix
+++ b/flake.nix
@@ -418,6 +418,16 @@
                 backendEnv = "SIMULATE_LATENCY_FIXTURE_DAYS=14";
               };
 
+              # Same live dashboard stack as `simulate-market`, but rotates each
+              # counter-trade through filled, rejected, and
+              # partially-filled-then-cancelled so the trade history shows every
+              # outcome the dashboard renders.
+              "simulate-trade-outcomes" = mkSimulation {
+                name = "simulate-trade-outcomes";
+                testFilter = "simulate";
+                backendEnv = "SIMULATE_BROKER_OUTCOME_ROTATION=1";
+              };
+
               # Same live dashboard stack as `simulate-market`, but first creates
               # stuck mint and redemption rebalances whose Alpaca mock
               # provider later completes. The backend logs the

--- a/src/api.rs
+++ b/src/api.rs
@@ -577,9 +577,7 @@ async fn trades(
         .await
         .inspect_err(|error| warn!(target: "dashboard", ?error, "Failed to load trade history"))
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    if query.trade_protocol == TradeProtocol::LegacyFills {
-        all_trades.retain(|trade| matches!(trade.outcome, TradeOutcome::Filled));
-    }
+    all_trades.retain(|trade| query.trade_protocol.includes_trade(trade));
     sort_trades_newest_first(&mut all_trades);
 
     let total = all_trades.len();
@@ -790,7 +788,7 @@ async fn load_offchain_trade_rows(
 ) -> Result<Vec<Trade>, TradeHistoryError> {
     let rows: Vec<(String, String)> = sqlx::query_as(
         "SELECT view_id, payload FROM offchain_order_view \
-         WHERE status IN ('Filled', 'Failed')",
+         WHERE status IN ('Filled', 'Failed', 'Cancelled')",
     )
     .fetch_all(pool)
     .await?;
@@ -1988,6 +1986,14 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
+        let cancelled_view_id = "00000000-0000-0000-0000-000000000139";
+        let cancelled_payload = r#"{"Live":{"Cancelled":{"symbol":"MSFT","shares":"1","requested_shares":"1.5","filled_shares":"0","direction":"Sell","executor":"AlpacaBrokerApi","executor_order_id":"broker-cancel","reason":"MarketOpenReplacement","placed_at":"2026-01-01T00:00:01Z","cancelled_at":"2026-01-01T00:00:02Z"}}}"#;
+        sqlx::query("INSERT INTO offchain_order_view (view_id, version, payload) VALUES (?, 1, ?)")
+            .bind(cancelled_view_id)
+            .bind(cancelled_payload)
+            .execute(&pool)
+            .await
+            .unwrap();
 
         let entries = load_offchain_trade_rows(
             &pool,
@@ -2001,7 +2007,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(entries.len(), 2);
+        assert_eq!(entries.len(), 3);
         let failed = entries
             .iter()
             .find(|trade| trade.id == view_id)
@@ -2028,7 +2034,9 @@ mod tests {
                 assert_eq!(remaining_shares, &None);
                 assert_eq!(excess_shares, &None);
             }
-            TradeOutcome::Filled => panic!("failed projection must remain failed"),
+            TradeOutcome::Filled | TradeOutcome::Cancelled { .. } => {
+                panic!("failed projection must remain failed")
+            }
         }
 
         let legacy_response = build_app(state.clone())
@@ -2059,6 +2067,21 @@ mod tests {
             "legacy clients must not receive failed trades"
         );
 
+        let legacy_page = build_app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/trades?limit=1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let legacy_page: serde_json::Value =
+            serde_json::from_str(&body_to_string(legacy_page).await).unwrap();
+        assert_eq!(legacy_page["total"], 1);
+        assert_eq!(legacy_page["entries"][0]["id"], filled_view_id);
+        assert_eq!(legacy_page["hasMore"], false);
+
         let v1_response = build_app(state.clone())
             .oneshot(
                 Request::builder()
@@ -2071,11 +2094,35 @@ mod tests {
         assert_eq!(v1_response.status(), StatusCode::OK);
         let v1_body: serde_json::Value =
             serde_json::from_str(&body_to_string(v1_response).await).unwrap();
+        assert_eq!(v1_body["total"], 2);
+        assert!(
+            v1_body["entries"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|trade| trade["id"] != cancelled_view_id),
+            "v1 clients must not receive cancelled trades"
+        );
         let v1_outcome = &v1_body["entries"][0]["outcome"];
         assert!(v1_outcome.get("acceptedShares").is_none());
         assert_eq!(v1_outcome["filledShares"], "0.25");
         assert_eq!(v1_outcome["remainingShares"], "0.75");
         assert_eq!(v1_outcome["excessShares"], "0");
+
+        let v1_page = build_app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/trades?trade_protocol=terminal_outcomes_v1&limit=1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let v1_page: serde_json::Value =
+            serde_json::from_str(&body_to_string(v1_page).await).unwrap();
+        assert_eq!(v1_page["total"], 2);
+        assert_eq!(v1_page["entries"][0]["id"], view_id);
+        assert_eq!(v1_page["hasMore"], true);
 
         let response = build_app(state)
             .oneshot(
@@ -2089,25 +2136,35 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body: serde_json::Value =
             serde_json::from_str(&body_to_string(response).await).unwrap();
-        assert_eq!(body["entries"][0]["occurredAt"], "2026-01-01T00:00:01Z");
-        assert_eq!(body["entries"][0]["outcome"]["status"], "failed");
+        assert_eq!(body["total"], 3);
+        assert_eq!(body["entries"][0]["occurredAt"], "2026-01-01T00:00:02Z");
+        let failed = body["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|trade| trade["id"] == view_id)
+            .expect("v2 clients should receive failed trades");
+        assert_eq!(failed["outcome"]["status"], "failed");
+        assert_eq!(failed["outcome"]["error"], "asset is not tradable");
+        assert_eq!(failed["outcome"]["acceptedShares"], serde_json::Value::Null);
+        assert_eq!(failed["outcome"]["filledShares"], "0.25");
         assert_eq!(
-            body["entries"][0]["outcome"]["error"],
-            "asset is not tradable"
-        );
-        assert_eq!(
-            body["entries"][0]["outcome"]["acceptedShares"],
+            failed["outcome"]["remainingShares"],
             serde_json::Value::Null
         );
-        assert_eq!(body["entries"][0]["outcome"]["filledShares"], "0.25");
-        assert_eq!(
-            body["entries"][0]["outcome"]["remainingShares"],
-            serde_json::Value::Null
-        );
-        assert_eq!(
-            body["entries"][0]["outcome"]["excessShares"],
-            serde_json::Value::Null
-        );
+        assert_eq!(failed["outcome"]["excessShares"], serde_json::Value::Null);
+        let cancelled = body["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|trade| trade["id"] == cancelled_view_id)
+            .expect("v2 clients should receive cancelled trades");
+        assert_eq!(cancelled["shares"], "1.5");
+        assert_eq!(cancelled["outcome"]["status"], "cancelled");
+        assert_eq!(cancelled["outcome"]["acceptedShares"], "1");
+        assert_eq!(cancelled["outcome"]["filledShares"], "0");
+        assert_eq!(cancelled["outcome"]["remainingShares"], "1");
+        assert_eq!(cancelled["outcome"]["excessShares"], "0");
     }
 
     #[tokio::test]

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -2648,7 +2648,9 @@ mod tests {
         let cancelled_order = OffchainOrder::Cancelled {
             symbol: symbol.clone(),
             shares: positive_shares("1"),
+            requested_shares: Some(positive_shares("1")),
             retained_fill: None,
+            filled_shares: Some(FractionalShares::ZERO),
             direction: Direction::Sell,
             executor: SupportedExecutor::DryRun,
             executor_order_id: ExecutorOrderId::new("broker-order-id"),

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -263,7 +263,8 @@ async fn rebuild_stale_offchain_order_projection(
     // sequence. Detect the old serialized shape itself so an interruption
     // between version registration and this rebuild remains repairable on the
     // next startup. A present JSON null is current; SQL NULL means the field is
-    // absent from a pre-v3 projection row.
+    // absent from a projection row created before the corresponding schema
+    // version.
     let has_stale_rows: i64 = sqlx::query_scalar(
         "SELECT EXISTS( \
              SELECT 1 FROM offchain_order_view \
@@ -276,6 +277,9 @@ async fn rebuild_stale_offchain_order_projection(
                 OR (json_type(payload, '$.Live.Failed') IS NOT NULL \
                     AND (json_type(payload, '$.Live.Failed.requested_shares') IS NULL \
                          OR json_type(payload, '$.Live.Failed.filled_shares') IS NULL)) \
+                OR (json_type(payload, '$.Live.Cancelled') IS NOT NULL \
+                    AND (json_type(payload, '$.Live.Cancelled.requested_shares') IS NULL \
+                         OR json_type(payload, '$.Live.Cancelled.filled_shares') IS NULL)) \
              LIMIT 1 \
          )",
     )
@@ -4155,6 +4159,17 @@ mod tests {
             .unwrap();
     }
 
+    async fn remove_projection_field(pool: &SqlitePool, id: &OffchainOrderId, path: &str) {
+        sqlx::query(
+            "UPDATE offchain_order_view SET payload = json_remove(payload, ?) WHERE view_id = ?",
+        )
+        .bind(path)
+        .bind(id.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
     #[tokio::test]
     async fn interrupted_schema_change_rebuilds_live_offchain_order_projection_rows() {
         let pool = setup_test_db().await;
@@ -4189,25 +4204,12 @@ mod tests {
             )
             .await
             .unwrap();
+        // `place_and_accept_projection_order` requests 1 share for every
+        // aggregate, so exact comparisons catch a rebuild that restores a
+        // corrupted value or pairs a value with the wrong aggregate.
+        let requested_shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
 
-        for (id, path) in [
-            (&submitted_id, "$.Live.Submitted.requested_shares"),
-            (
-                &partially_filled_id,
-                "$.Live.PartiallyFilled.requested_shares",
-            ),
-            (&cancelling_id, "$.Live.Cancelling.requested_shares"),
-        ] {
-            sqlx::query(
-                "UPDATE offchain_order_view SET payload = json_remove(payload, ?) WHERE view_id = ?",
-            )
-            .bind(path)
-            .bind(id.to_string())
-            .execute(&pool)
-            .await
-            .unwrap();
-        }
-
+        remove_projection_field(&pool, &submitted_id, "$.Live.Submitted.requested_shares").await;
         assert!(matches!(
             projection.load(&submitted_id).await.unwrap().unwrap(),
             OffchainOrder::Submitted {
@@ -4215,6 +4217,24 @@ mod tests {
                 ..
             }
         ));
+
+        rebuild_stale_offchain_order_projection(&pool, &projection)
+            .await
+            .unwrap();
+        assert!(matches!(
+            projection.load(&submitted_id).await.unwrap().unwrap(),
+            OffchainOrder::Submitted {
+                requested_shares: Some(requested),
+                ..
+            } if requested == requested_shares
+        ));
+
+        remove_projection_field(
+            &pool,
+            &partially_filled_id,
+            "$.Live.PartiallyFilled.requested_shares",
+        )
+        .await;
         assert!(matches!(
             projection
                 .load(&partially_filled_id)
@@ -4226,29 +4246,10 @@ mod tests {
                 ..
             }
         ));
-        assert!(matches!(
-            projection.load(&cancelling_id).await.unwrap().unwrap(),
-            OffchainOrder::Cancelling {
-                requested_shares: None,
-                ..
-            }
-        ));
 
         rebuild_stale_offchain_order_projection(&pool, &projection)
             .await
             .unwrap();
-
-        // `place_and_accept_projection_order` requests 1 share for every
-        // aggregate, so an exact comparison catches a rebuild that restores a
-        // corrupted value or pairs a value with the wrong aggregate.
-        let requested_shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
-        assert!(matches!(
-            projection.load(&submitted_id).await.unwrap().unwrap(),
-            OffchainOrder::Submitted {
-                requested_shares: Some(requested),
-                ..
-            } if requested == requested_shares
-        ));
         assert!(matches!(
             projection
                 .load(&partially_filled_id)
@@ -4262,12 +4263,121 @@ mod tests {
             } if requested == requested_shares
                 && shares_filled == FractionalShares::new(float!(0.25))
         ));
+
+        remove_projection_field(&pool, &cancelling_id, "$.Live.Cancelling.requested_shares").await;
+        assert!(matches!(
+            projection.load(&cancelling_id).await.unwrap().unwrap(),
+            OffchainOrder::Cancelling {
+                requested_shares: None,
+                ..
+            }
+        ));
+
+        rebuild_stale_offchain_order_projection(&pool, &projection)
+            .await
+            .unwrap();
         assert!(matches!(
             projection.load(&cancelling_id).await.unwrap().unwrap(),
             OffchainOrder::Cancelling {
                 requested_shares: Some(requested),
                 ..
             } if requested == requested_shares
+        ));
+    }
+
+    #[tokio::test]
+    async fn interrupted_cancellation_schema_change_rebuilds_projection_provenance() {
+        let pool = setup_test_db().await;
+        let (store, projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .build(noop_order_placer())
+            .await
+            .unwrap();
+        let id = OffchainOrderId::new();
+        let requested_shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        let accepted_shares = Positive::new(FractionalShares::new(float!(0.5))).unwrap();
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("SPCX").unwrap(),
+                    shares: requested_shares,
+                    direction: Direction::Buy,
+                    executor: SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("TEST-CANCELLED"),
+                    placed_shares: accepted_shares,
+                    submitted_at: Utc::now(),
+                    market_session: MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::ConfirmCancellation {
+                    filled_shares: FractionalShares::ZERO,
+                    cancelled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "UPDATE offchain_order_view \
+             SET payload = json_remove(\
+                 payload,\
+                 '$.Live.Cancelled.requested_shares',\
+                 '$.Live.Cancelled.filled_shares'\
+             ) \
+             WHERE view_id = ?",
+        )
+        .bind(id.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+        let stale = projection.load(&id).await.unwrap().unwrap();
+        assert!(matches!(
+            stale,
+            OffchainOrder::Cancelled {
+                requested_shares: None,
+                filled_shares: None,
+                ..
+            }
+        ));
+
+        rebuild_stale_offchain_order_projection(&pool, &projection)
+            .await
+            .unwrap();
+
+        let rebuilt = projection.load(&id).await.unwrap().unwrap();
+        assert!(matches!(
+            rebuilt,
+            OffchainOrder::Cancelled {
+                requested_shares: Some(requested),
+                filled_shares: Some(filled),
+                ..
+            } if requested == requested_shares && filled == FractionalShares::ZERO
         ));
     }
 
@@ -10099,6 +10209,7 @@ mod tests {
             .send(
                 &offchain_order_id,
                 OffchainOrderCommand::ConfirmCancellation {
+                    filled_shares: FractionalShares::ZERO,
                     cancelled_at: Utc::now(),
                 },
             )
@@ -10383,6 +10494,7 @@ mod tests {
             .send(
                 &offchain_order_id,
                 OffchainOrderCommand::ConfirmCancellation {
+                    filled_shares: FractionalShares::new(float!(0.3)),
                     cancelled_at: Utc::now(),
                 },
             )
@@ -10429,9 +10541,13 @@ mod tests {
         let order = OffchainOrder::Cancelled {
             symbol: symbol.clone(),
             shares: Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap(),
+            requested_shares: Some(
+                Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap(),
+            ),
             retained_fill: Some(RetainedFill::Unpriced {
                 shares_filled: st0x_execution::FractionalShares::new(float!(0.3)),
             }),
+            filled_shares: Some(st0x_execution::FractionalShares::new(float!(0.3))),
             direction: Direction::Sell,
             executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
             executor_order_id: ExecutorOrderId::new("unpriced-fill"),
@@ -10458,7 +10574,11 @@ mod tests {
         let order = OffchainOrder::Cancelled {
             symbol: symbol.clone(),
             shares: Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap(),
+            requested_shares: Some(
+                Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap(),
+            ),
             retained_fill: None,
+            filled_shares: Some(st0x_execution::FractionalShares::ZERO),
             direction: Direction::Sell,
             executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
             executor_order_id: ExecutorOrderId::new("cancelled-no-fill"),
@@ -10605,7 +10725,9 @@ mod tests {
         let cancelled = OffchainOrder::Cancelled {
             symbol: symbol.clone(),
             shares,
+            requested_shares: Some(shares),
             retained_fill: None,
+            filled_shares: Some(FractionalShares::ZERO),
             direction: Direction::Sell,
             executor: st0x_execution::SupportedExecutor::DryRun,
             executor_order_id: ExecutorOrderId::new("cancelled-after-place"),
@@ -11061,11 +11183,13 @@ mod tests {
         let cancelled_partial = OffchainOrder::Cancelled {
             symbol: symbol.clone(),
             shares,
+            requested_shares: Some(shares),
             retained_fill: Some(RetainedFill::Priced {
                 shares_filled: st0x_execution::FractionalShares::new(float!(0.3)),
                 avg_price: Usd::new(float!(95.0)),
                 partially_filled_at: Utc::now(),
             }),
+            filled_shares: Some(st0x_execution::FractionalShares::new(float!(0.3))),
             direction: Direction::Sell,
             executor: st0x_execution::SupportedExecutor::DryRun,
             executor_order_id: ExecutorOrderId::new("cancelled-partial-after-place"),

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -310,28 +310,9 @@ impl DashboardTradeHandoffMonitor {
                     })?
                     .ok_or(DashboardTradeHandoffAttemptError::Missing { id: *id })?;
 
-                match order.try_into_trade(id) {
-                    Ok(trade) => trade,
-                    // A cancellation racing an earlier terminal handoff is
-                    // benign: the rest of the system treats cancelled orders
-                    // as "nothing to deliver", so the handoff completes as a
-                    // no-op instead of fail-stopping the monitor.
-                    Err(TradeConversionError::Cancelled) => {
-                        warn!(
-                            target: "dashboard",
-                            %id,
-                            "Offchain order was cancelled after its terminal handoff; \
-                             skipping dashboard delivery",
-                        );
-                        return Ok(());
-                    }
-                    Err(source) => {
-                        return Err(DashboardTradeHandoffAttemptError::Conversion {
-                            id: *id,
-                            source,
-                        });
-                    }
-                }
+                order.try_into_trade(id).map_err(|source| {
+                    DashboardTradeHandoffAttemptError::Conversion { id: *id, source }
+                })?
             }
         };
 
@@ -488,13 +469,10 @@ impl DashboardTradeHandoffAttemptError {
                 | TradeConversionError::Submitted
                 | TradeConversionError::PartiallyFilled
                 | TradeConversionError::Cancelling => true,
-                // A cancellation is terminal, and corrupt persisted
-                // quantities never become convertible, so neither is worth
-                // retrying. `persist_once` completes a cancelled order as a
-                // no-op, so that variant does not reach here in practice.
-                TradeConversionError::Cancelled
-                | TradeConversionError::Arithmetic(_)
-                | TradeConversionError::NegativeShares(_) => false,
+                // Corrupt persisted quantities never become convertible.
+                TradeConversionError::Arithmetic(_) | TradeConversionError::NegativeShares(_) => {
+                    false
+                }
             },
         }
     }
@@ -843,15 +821,14 @@ impl Reactor for Broadcaster {
             .on(|id, event| async move {
                 use OffchainOrderEvent::*;
                 match event {
-                    Filled { .. } | Failed { .. } => {
+                    Filled { .. } | Failed { .. } | Cancelled { .. } => {
                         self.enqueue_offchain_trade(id).await?;
                     }
                     Placed { .. }
                     | Submitted { .. }
                     | Accepted { .. }
                     | PartiallyFilled { .. }
-                    | CancelRequested { .. }
-                    | Cancelled { .. } => {}
+                    | CancelRequested { .. } => {}
                 }
 
                 Ok(())
@@ -1001,60 +978,54 @@ mod tests {
             .unwrap();
     }
 
-    async fn persist_cancelled_offchain_order(pool: SqlitePool, id: OffchainOrderId) {
-        let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool)
-            .build(crate::offchain::order::noop_order_placer())
-            .await
-            .unwrap();
-        let shares = st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
-            st0x_float_macro::float!(1),
-        ))
+    /// Rewrites the persisted terminal fill to a negative quantity, modelling
+    /// history written before the aggregate rejected corrupt broker fills.
+    /// `MarkFailed` refuses that value now, so replayed legacy rows are the
+    /// only remaining source of a non-retryable conversion failure.
+    async fn corrupt_persisted_terminal_fill(pool: &SqlitePool, id: OffchainOrderId) {
+        let rows: Vec<(i64, String)> = sqlx::query_as(
+            "SELECT sequence, payload FROM events \
+             WHERE aggregate_id = ? AND payload LIKE '%filled_shares%'",
+        )
+        .bind(id.to_string())
+        .fetch_all(pool)
+        .await
         .unwrap();
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::Place {
-                    symbol: Symbol::new("AAPL").unwrap(),
-                    shares,
-                    direction: st0x_execution::Direction::Sell,
-                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
-                    client_order_id: st0x_execution::ClientOrderId::from_uuid(id.as_uuid()),
-                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
-                },
-            )
+        let [(sequence, payload)] = rows.as_slice() else {
+            panic!("expected exactly one persisted event carrying a fill, got: {rows:?}");
+        };
+
+        let mut event: serde_json::Value = serde_json::from_str(payload).unwrap();
+        assert!(
+            replace_filled_shares(&mut event, "-0.5"),
+            "the persisted terminal event must carry a filled_shares field: {payload}"
+        );
+
+        sqlx::query("UPDATE events SET payload = ? WHERE aggregate_id = ? AND sequence = ?")
+            .bind(serde_json::to_string(&event).unwrap())
+            .bind(id.to_string())
+            .bind(sequence)
+            .execute(pool)
             .await
             .unwrap();
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::MarkAccepted {
-                    executor_order_id: st0x_execution::ExecutorOrderId::new("broker-order"),
-                    placed_shares: shares,
-                    submitted_at: chrono::Utc::now(),
-                    market_session: st0x_execution::MarketSession::Regular,
-                    limit_price: None,
-                },
-            )
-            .await
-            .unwrap();
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::CancelOrder {
-                    reason: crate::offchain::order::CancellationReason::MarketOpenReplacement,
-                },
-            )
-            .await
-            .unwrap();
-        store
-            .send(
-                &id,
-                OffchainOrderCommand::ConfirmCancellation {
-                    cancelled_at: chrono::Utc::now(),
-                },
-            )
-            .await
-            .unwrap();
+    }
+
+    fn replace_filled_shares(event: &mut serde_json::Value, shares: &str) -> bool {
+        let serde_json::Value::Object(fields) = event else {
+            return false;
+        };
+
+        if fields.contains_key("filled_shares") {
+            fields.insert(
+                "filled_shares".to_string(),
+                serde_json::Value::String(shares.to_string()),
+            );
+            return true;
+        }
+
+        fields
+            .values_mut()
+            .any(|nested| replace_filled_shares(nested, shares))
     }
 
     async fn enqueue_test_delivery(
@@ -1355,10 +1326,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancelled_offchain_order_handoff_is_a_noop() {
+    async fn deterministic_trade_conversion_failure_stops_the_handoff_monitor() {
         let (pool, apalis_pool) = setup_test_pools().await;
         let id = OffchainOrderId::new();
-        persist_cancelled_offchain_order(pool.clone(), id).await;
+        persist_failed_offchain_order(
+            pool.clone(),
+            id,
+            Some(st0x_execution::FractionalShares::new(
+                st0x_float_macro::float!(0.5),
+            )),
+        )
+        .await;
+        corrupt_persisted_terminal_fill(&pool, id).await;
         let (sender, _receiver) = broadcast::channel(16);
         let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
         let mut handoff_monitor = delivery.handoff_monitor.clone();
@@ -1370,34 +1349,18 @@ mod tests {
             .send(DashboardTradeHandoff::ReloadOffchainOrder(id))
             .await
             .unwrap();
-        delivery
-            .broadcaster
-            .handoff_retry_sender
-            .send(DashboardTradeHandoff::Trade(Box::new(test_trade())))
+
+        let error = tokio::time::timeout(Duration::from_secs(1), monitor)
             .await
-            .unwrap();
-
-        // The handoffs are processed in order, so once the trade job lands the
-        // monitor has survived the cancelled handoff, and exactly one job
-        // proves the cancellation delivered nothing.
-        tokio::time::timeout(Duration::from_secs(5), async {
-            loop {
-                let jobs: i64 =
-                    sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
-                        .bind(std::any::type_name::<DeliverDashboardTrade>())
-                        .fetch_one(delivery.queue.pool())
-                        .await
-                        .unwrap();
-                if jobs == 1 {
-                    break;
-                }
-
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("a cancelled handoff must not stop the monitor or deliver anything");
-        monitor.abort();
+            .expect("deterministic conversion must stop the monitor")
+            .unwrap()
+            .unwrap_err();
+        assert!(matches!(
+            error.downcast_ref::<DashboardTradeHandoffMonitorError>(),
+            Some(DashboardTradeHandoffMonitorError::DeterministicConversion(
+                _
+            ))
+        ));
     }
 
     #[tokio::test]
@@ -2009,7 +1972,10 @@ mod tests {
         let message = receiver.recv().await.expect("should receive failure");
         match message {
             Statement::TradeUpdate(trade) => {
-                let history = load_trades(&pool).await.unwrap();
+                let history =
+                    load_trades(&pool, crate::dashboard::TradeProtocol::TerminalOutcomesV2)
+                        .await
+                        .unwrap();
                 assert_eq!(
                     &trade.outcome, &history[0].outcome,
                     "live and historical failure provenance must be identical"
@@ -2049,7 +2015,7 @@ mod tests {
                         );
                         assert!(excess_shares.unwrap().inner().inner().is_zero().unwrap());
                     }
-                    st0x_dto::TradeOutcome::Filled => {
+                    st0x_dto::TradeOutcome::Filled | st0x_dto::TradeOutcome::Cancelled { .. } => {
                         panic!("failed order must broadcast a failure outcome")
                     }
                 }
@@ -2063,6 +2029,108 @@ mod tests {
             unexpected.is_err(),
             "failed outcomes must not be broadcast as legacy fills"
         );
+    }
+
+    #[tokio::test]
+    async fn offchain_order_cancelled_broadcasts_same_provenance_as_history() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .build(crate::offchain::order::noop_order_placer())
+            .await
+            .unwrap();
+        let (broadcaster, mut receiver, queue, delivery_ctx) =
+            test_broadcaster(&pool, &apalis_pool);
+        let harness = ReactorHarness::new(broadcaster);
+        let id = crate::offchain::order::OffchainOrderId::new();
+        let now = chrono::Utc::now();
+        let shares = Positive::new(FractionalShares::new(st0x_float_macro::float!(1))).unwrap();
+        let filled = FractionalShares::new(st0x_float_macro::float!(0.25));
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    shares,
+                    direction: st0x_execution::Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: st0x_execution::ExecutorOrderId::new("partial-cancel"),
+                    placed_shares: shares,
+                    submitted_at: now,
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: filled,
+                    avg_price: st0x_finance::Usd::new(st0x_float_macro::float!(25)),
+                    partially_filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: crate::offchain::order::CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::ConfirmCancellation {
+                    filled_shares: filled,
+                    cancelled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+
+        let cancelled = OffchainOrderEvent::Cancelled {
+            reason: crate::offchain::order::CancellationReason::MarketOpenReplacement,
+            filled_shares: Some(filled),
+            cancelled_at: now,
+        };
+        harness
+            .receive::<OffchainOrder>(id, cancelled)
+            .await
+            .unwrap();
+        perform_pending_delivery(&queue, &delivery_ctx).await;
+
+        let Statement::TradeUpdate(trade) = receiver.recv().await.unwrap() else {
+            panic!("cancelled order must broadcast a trade update");
+        };
+        let history = load_trades(&pool, crate::dashboard::TradeProtocol::TerminalOutcomesV2)
+            .await
+            .unwrap();
+        assert_eq!(trade.outcome, history[0].outcome);
+        assert!(matches!(
+            trade.outcome,
+            TradeOutcome::Cancelled {
+                filled_shares: Some(observed),
+                remaining_shares: Some(remaining),
+                ..
+            } if observed.inner().inner().eq(st0x_float_macro::float!(0.25)).unwrap()
+                && remaining.inner().inner().eq(st0x_float_macro::float!(0.75)).unwrap()
+        ));
     }
 
     #[tokio::test]

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -39,14 +39,20 @@ pub(crate) enum TradeProtocol {
 }
 
 impl TradeProtocol {
-    fn includes_trade(self, trade: &Trade) -> bool {
+    pub(crate) fn includes_trade(self, trade: &Trade) -> bool {
         match self {
             Self::LegacyFills => match trade.outcome {
                 TradeOutcome::Filled => true,
-                TradeOutcome::Failed { .. } => false,
+                TradeOutcome::Failed { .. } | TradeOutcome::Cancelled { .. } => false,
             },
-            Self::TerminalOutcomesV1 | Self::TerminalOutcomesV2 => match trade.outcome {
+            Self::TerminalOutcomesV1 => match trade.outcome {
                 TradeOutcome::Filled | TradeOutcome::Failed { .. } => true,
+                TradeOutcome::Cancelled { .. } => false,
+            },
+            Self::TerminalOutcomesV2 => match trade.outcome {
+                TradeOutcome::Filled
+                | TradeOutcome::Failed { .. }
+                | TradeOutcome::Cancelled { .. } => true,
             },
         }
     }
@@ -63,8 +69,8 @@ impl TradeProtocol {
             },
             Self::TerminalOutcomesV1 | Self::TerminalOutcomesV2 => match statement {
                 Statement::TradeFill(_) => false,
+                Statement::TradeUpdate(trade) => self.includes_trade(trade),
                 Statement::CurrentState(_)
-                | Statement::TradeUpdate(_)
                 | Statement::PositionUpdate(_)
                 | Statement::InventorySnapshot(_)
                 | Statement::TransferUpdate(_) => true,
@@ -187,7 +193,7 @@ async fn send_initial_state(
     let inventory_dto = state.inventory.read().await.to_dto();
     let transfers = transfer_loader::load_transfers(&state.pool).await;
     let mut warnings = transfers.warnings;
-    let mut trades = match trade_loader::load_trades(&state.pool).await {
+    let trades = match trade_loader::load_trades(&state.pool, trade_protocol).await {
         Ok(trades) => trades,
         Err(error) => {
             warn!(
@@ -199,7 +205,6 @@ async fn send_initial_state(
             Vec::new()
         }
     };
-    trades.retain(|trade| trade_protocol.includes_trade(trade));
     let positions = load_positions(&state.pool).await;
 
     let initial = Statement::CurrentState(Box::new(CurrentState {
@@ -476,6 +481,38 @@ mod tests {
         assert!(!TradeProtocol::TerminalOutcomesV1.includes_statement(&legacy_fill));
         assert!(TradeProtocol::TerminalOutcomesV2.includes_statement(&trade_update));
         assert!(!TradeProtocol::TerminalOutcomesV2.includes_statement(&legacy_fill));
+    }
+
+    #[test]
+    fn cancelled_outcomes_are_v2_only() {
+        let trade = Trade {
+            id: "cancelled-order".to_string(),
+            occurred_at: chrono::Utc::now(),
+            venue: TradingVenue::Alpaca,
+            direction: Direction::Sell,
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            outcome: TradeOutcome::Cancelled {
+                accepted_shares: Some(Positive::new(FractionalShares::new(float!(1))).unwrap()),
+                filled_shares: Some(
+                    st0x_finance::NonNegative::new(FractionalShares::ZERO).unwrap(),
+                ),
+                remaining_shares: Some(
+                    st0x_finance::NonNegative::new(FractionalShares::new(float!(1))).unwrap(),
+                ),
+                excess_shares: Some(
+                    st0x_finance::NonNegative::new(FractionalShares::ZERO).unwrap(),
+                ),
+            },
+        };
+        let update = Statement::TradeUpdate(trade.clone());
+
+        assert!(!TradeProtocol::LegacyFills.includes_trade(&trade));
+        assert!(!TradeProtocol::TerminalOutcomesV1.includes_trade(&trade));
+        assert!(TradeProtocol::TerminalOutcomesV2.includes_trade(&trade));
+        assert!(!TradeProtocol::LegacyFills.includes_statement(&update));
+        assert!(!TradeProtocol::TerminalOutcomesV1.includes_statement(&update));
+        assert!(TradeProtocol::TerminalOutcomesV2.includes_statement(&update));
     }
 
     fn empty_settings() -> st0x_dto::Settings {

--- a/src/dashboard/trade_loader.rs
+++ b/src/dashboard/trade_loader.rs
@@ -8,6 +8,7 @@ use st0x_dto::{Trade, sort_trades_newest_first};
 use st0x_event_sorcery::{LoadAllIdsError, SendError, load_all_ids, load_entity};
 use st0x_finance::{FractionalShares, NotPositive};
 
+use super::TradeProtocol;
 use crate::offchain::order::{OffchainOrder, TradeConversionError};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeId};
 
@@ -15,15 +16,24 @@ const MAX_TRADES: usize = 100;
 
 /// Load recent terminal trades from both onchain and offchain sources.
 ///
-/// Onchain trades are always fills; offchain counter-trades contribute both
-/// filled and failed outcomes. Returns up to [`MAX_TRADES`] trades sorted by
-/// the time the outcome occurred, newest first.
-pub(crate) async fn load_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHistoryError> {
+/// Onchain trades are always fills; offchain counter-trades contribute filled,
+/// failed, and cancelled outcomes, narrowed to what `trade_protocol` carries.
+/// Returns up to [`MAX_TRADES`] trades sorted by the time the outcome
+/// occurred, newest first.
+pub(crate) async fn load_trades(
+    pool: &SqlitePool,
+    trade_protocol: TradeProtocol,
+) -> Result<Vec<Trade>, TradeHistoryError> {
     let mut trades = load_all_trades(pool).await?;
 
-    trades.truncate(MAX_TRADES);
+    retain_recent_trades(&mut trades, trade_protocol);
 
     Ok(trades)
+}
+
+fn retain_recent_trades(trades: &mut Vec<Trade>, trade_protocol: TradeProtocol) {
+    trades.retain(|trade| trade_protocol.includes_trade(trade));
+    trades.truncate(MAX_TRADES);
 }
 
 /// Loads every terminal trade for delivery-ledger reconciliation.
@@ -106,8 +116,7 @@ async fn load_offchain_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHist
                     TradeConversionError::Pending
                     | TradeConversionError::Submitted
                     | TradeConversionError::PartiallyFilled
-                    | TradeConversionError::Cancelling
-                    | TradeConversionError::Cancelled,
+                    | TradeConversionError::Cancelling,
                 ) => None,
                 Err(source) => {
                     let error = TradeHistoryError::OffchainConversion {
@@ -163,6 +172,7 @@ pub(crate) enum TradeHistoryError {
 mod tests {
     use chrono::Utc;
 
+    use st0x_dto::{TradeOutcome, TradingVenue};
     use st0x_execution::{
         ClientOrderId, Direction, ExecutorOrderId, FractionalShares, MarketSession, Positive,
         Symbol,
@@ -175,10 +185,81 @@ mod tests {
     use crate::onchain_trade::{OnChainTradeCommand, OnChainTradeId};
     use crate::test_utils::setup_test_db;
 
+    async fn seed_cancelled_order(
+        store: &st0x_event_sorcery::Store<OffchainOrder>,
+        symbol: &str,
+        filled_shares: FractionalShares,
+    ) -> OffchainOrderId {
+        let id = OffchainOrderId::new();
+        let shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new(symbol).unwrap(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: st0x_execution::ExecutorOrderId::new(symbol),
+                    placed_shares: shares,
+                    submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+        if filled_shares != FractionalShares::ZERO {
+            store
+                .send(
+                    &id,
+                    OffchainOrderCommand::UpdatePartialFill {
+                        shares_filled: filled_shares,
+                        avg_price: st0x_finance::Usd::new(float!(100)),
+                        partially_filled_at: Utc::now(),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: crate::offchain::order::CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::ConfirmCancellation {
+                    filled_shares,
+                    cancelled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        id
+    }
+
     #[tokio::test]
     async fn load_trades_empty_database() {
         let pool = setup_test_db().await;
-        let trades = load_trades(&pool).await.unwrap();
+        let trades = load_trades(&pool, TradeProtocol::TerminalOutcomesV2)
+            .await
+            .unwrap();
         assert!(trades.is_empty());
     }
 
@@ -212,7 +293,9 @@ mod tests {
             .await
             .unwrap();
 
-        let trades = load_trades(&pool).await.unwrap();
+        let trades = load_trades(&pool, TradeProtocol::TerminalOutcomesV2)
+            .await
+            .unwrap();
         assert_eq!(trades.len(), 1);
         assert_eq!(trades[0].symbol, Symbol::new("AAPL").unwrap());
         assert!(matches!(trades[0].venue, st0x_dto::TradingVenue::Raindex));
@@ -271,7 +354,9 @@ mod tests {
             .await
             .unwrap();
 
-        let trades = load_trades(&pool).await.unwrap();
+        let trades = load_trades(&pool, TradeProtocol::TerminalOutcomesV2)
+            .await
+            .unwrap();
         assert_eq!(trades.len(), 1);
         assert_eq!(trades[0].symbol, Symbol::new("TSLA").unwrap());
         assert!(matches!(trades[0].venue, st0x_dto::TradingVenue::Alpaca));
@@ -350,7 +435,9 @@ mod tests {
             .await
             .unwrap();
 
-        let trades = load_trades(&pool).await.unwrap();
+        let trades = load_trades(&pool, TradeProtocol::TerminalOutcomesV2)
+            .await
+            .unwrap();
         assert_eq!(trades.len(), 3);
         assert_eq!(trades[0].id, tied_id.to_string());
         assert_eq!(trades[1].id, newer_id.to_string());
@@ -408,7 +495,9 @@ mod tests {
             .await
             .unwrap();
 
-        let trades = load_trades(&pool).await.unwrap();
+        let trades = load_trades(&pool, TradeProtocol::TerminalOutcomesV2)
+            .await
+            .unwrap();
 
         assert_eq!(trades.len(), 1);
         assert_eq!(trades[0].id, intact_id.to_string());
@@ -446,8 +535,40 @@ mod tests {
                 .unwrap();
         }
 
-        let trades = load_trades(&pool).await.unwrap();
+        let trades = load_trades(&pool, TradeProtocol::TerminalOutcomesV2)
+            .await
+            .unwrap();
         assert_eq!(trades.len(), MAX_TRADES, "should be capped at {MAX_TRADES}");
+    }
+
+    #[test]
+    fn protocol_filter_runs_before_history_limit() {
+        let cancelled = Trade {
+            id: "cancelled".to_string(),
+            occurred_at: Utc::now(),
+            venue: TradingVenue::Alpaca,
+            direction: Direction::Sell,
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            outcome: TradeOutcome::Cancelled {
+                accepted_shares: None,
+                filled_shares: None,
+                remaining_shares: None,
+                excess_shares: None,
+            },
+        };
+        let filled = Trade {
+            id: "older-fill".to_string(),
+            outcome: TradeOutcome::Filled,
+            ..cancelled.clone()
+        };
+        let mut trades = vec![cancelled; MAX_TRADES];
+        trades.push(filled);
+
+        retain_recent_trades(&mut trades, TradeProtocol::TerminalOutcomesV1);
+
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].id, "older-fill");
     }
 
     #[tokio::test]
@@ -487,7 +608,9 @@ mod tests {
             .await
             .unwrap();
 
-        let trades = load_trades(&pool).await.unwrap();
+        let trades = load_trades(&pool, TradeProtocol::TerminalOutcomesV2)
+            .await
+            .unwrap();
         assert_eq!(trades.len(), 1, "failed orders should appear");
         assert!(matches!(
             &trades[0].outcome,
@@ -502,6 +625,47 @@ mod tests {
                 && filled_shares.is_none()
                 && remaining_shares.is_none()
                 && excess_shares.is_none()
+        ));
+    }
+
+    #[tokio::test]
+    async fn load_trades_includes_zero_and_partial_fill_cancellations() {
+        let pool = setup_test_db().await;
+        let (store, _projection) =
+            st0x_event_sorcery::StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(crate::offchain::order::noop_order_placer())
+                .await
+                .unwrap();
+        let zero_id = seed_cancelled_order(&store, "ZERO", FractionalShares::ZERO).await;
+        let partial_id =
+            seed_cancelled_order(&store, "PARTIAL", FractionalShares::new(float!(0.25))).await;
+
+        let trades = load_trades(&pool, TradeProtocol::TerminalOutcomesV2)
+            .await
+            .unwrap();
+        let cancelled = |id: OffchainOrderId| {
+            trades
+                .iter()
+                .find(|trade| trade.id == id.to_string())
+                .expect("cancelled order should appear in history")
+        };
+        assert!(matches!(
+            cancelled(zero_id).outcome,
+            st0x_dto::TradeOutcome::Cancelled {
+                filled_shares: Some(filled),
+                remaining_shares: Some(remaining),
+                ..
+            } if filled.inner().inner().is_zero().unwrap()
+                && remaining.inner().inner().eq(float!(1)).unwrap()
+        ));
+        assert!(matches!(
+            cancelled(partial_id).outcome,
+            st0x_dto::TradeOutcome::Cancelled {
+                filled_shares: Some(filled),
+                remaining_shares: Some(remaining),
+                ..
+            } if filled.inner().inner().eq(float!(0.25)).unwrap()
+                && remaining.inner().inner().eq(float!(0.75)).unwrap()
         ));
     }
 
@@ -584,7 +748,9 @@ mod tests {
             .await
             .unwrap();
 
-        let trades = load_trades(&pool).await.unwrap();
+        let trades = load_trades(&pool, TradeProtocol::TerminalOutcomesV2)
+            .await
+            .unwrap();
         assert!(trades.is_empty(), "nonterminal orders should not appear");
     }
 }

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -513,16 +513,20 @@ pub enum OffchainOrder {
     /// from `Failed` so analytics and the cancel-and-replace recovery
     /// path can tell intentional cancellation apart from broker rejection.
     ///
-    /// `retained_fill`/`executor_order_id` carry any partial fills the order
-    /// incurred before cancellation so the position-side cleanup can issue
-    /// `CompleteOffChainOrder` for the filled quantity (otherwise the broker
-    /// keeps those shares but `Position.net` never records them, leading to a
-    /// duplicate hedge on the next scan).
+    /// `retained_fill`/`executor_order_id` carry any priced partial fills the
+    /// order incurred before cancellation so the position-side cleanup can
+    /// issue `CompleteOffChainOrder`. `requested_shares` and `filled_shares`
+    /// separately retain dashboard provenance, including an explicit
+    /// broker-reported zero fill.
     Cancelled {
         symbol: Symbol,
         shares: Positive<FractionalShares>,
         #[serde(default)]
+        requested_shares: Option<Positive<FractionalShares>>,
+        #[serde(default)]
         retained_fill: Option<RetainedFill>,
+        #[serde(default)]
+        filled_shares: Option<FractionalShares>,
         direction: Direction,
         executor: SupportedExecutor,
         executor_order_id: ExecutorOrderId,
@@ -616,6 +620,7 @@ async fn cancel_order_events(
                     );
                     events.push(OffchainOrderEvent::Cancelled {
                         reason,
+                        filled_shares: None,
                         cancelled_at: Utc::now(),
                     });
                 }
@@ -669,7 +674,7 @@ impl EventSourced for OffchainOrder {
 
     const AGGREGATE_TYPE: &'static str = "OffchainOrder";
     const PROJECTION: Table = Table("offchain_order_view");
-    const SCHEMA_VERSION: u64 = 3;
+    const SCHEMA_VERSION: u64 = 4;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         originate_offchain_order(event)
@@ -779,8 +784,14 @@ impl EventSourced for OffchainOrder {
 
             Cancelled {
                 reason,
+                filled_shares,
                 cancelled_at,
-            } => Ok(evolve_cancelled(entity, *reason, *cancelled_at)),
+            } => Ok(evolve_cancelled(
+                entity,
+                *reason,
+                *filled_shares,
+                *cancelled_at,
+            )),
         }
     }
 
@@ -871,18 +882,15 @@ impl EventSourced for OffchainOrder {
                 cancel_order_events(self, services.as_ref(), reason).await
             }
 
-            OffchainOrderCommand::ConfirmCancellation { cancelled_at } => match self {
-                Self::Cancelling { reason, .. } => Ok(vec![OffchainOrderEvent::Cancelled {
-                    reason: *reason,
-                    cancelled_at,
-                }]),
-                Self::Pending { .. } | Self::Submitted { .. } | Self::PartiallyFilled { .. } => {
-                    Err(OffchainOrderError::CancellationNotRequested)
-                }
-                Self::Filled { .. } | Self::Failed { .. } | Self::Cancelled { .. } => {
-                    Err(OffchainOrderError::AlreadyCompleted)
-                }
-            },
+            OffchainOrderCommand::ConfirmCancellation {
+                filled_shares,
+                cancelled_at,
+            } => confirm_cancellation_events(self, filled_shares, cancelled_at),
+
+            OffchainOrderCommand::MarkUnrequestedCancellation {
+                filled_shares,
+                cancelled_at,
+            } => mark_unrequested_cancellation_events(self, filled_shares, cancelled_at),
 
             OffchainOrderCommand::UpdatePartialFill {
                 shares_filled,
@@ -1033,23 +1041,107 @@ impl EventSourced for OffchainOrder {
                 error,
                 filled_shares,
                 failed_at,
-            } => match self {
-                Self::Pending { .. }
-                | Self::Submitted { .. }
-                | Self::PartiallyFilled { .. }
-                | Self::Cancelling { .. } => Ok(vec![OffchainOrderEvent::Failed {
-                    error,
-                    filled_shares,
-                    failed_at,
-                }]),
-                // Idempotent: re-failing an already-failed order records nothing.
-                Self::Failed { .. } => Ok(vec![]),
-                Self::Filled { .. } | Self::Cancelled { .. } => {
-                    Err(OffchainOrderError::AlreadyCompleted)
-                }
-            },
+            } => mark_failed_events(self, error, filled_shares, failed_at),
         }
     }
+}
+
+fn confirm_cancellation_events(
+    order: &OffchainOrder,
+    filled_shares: FractionalShares,
+    cancelled_at: DateTime<Utc>,
+) -> Result<Vec<OffchainOrderEvent>, OffchainOrderError> {
+    match order {
+        OffchainOrder::Cancelling {
+            reason,
+            retained_fill,
+            ..
+        } => {
+            validate_terminal_fill_comparison(order, *retained_fill, Some(filled_shares))?;
+            Ok(vec![OffchainOrderEvent::Cancelled {
+                reason: *reason,
+                filled_shares: Some(filled_shares),
+                cancelled_at,
+            }])
+        }
+        OffchainOrder::Pending { .. }
+        | OffchainOrder::Submitted { .. }
+        | OffchainOrder::PartiallyFilled { .. } => {
+            Err(OffchainOrderError::CancellationNotRequested)
+        }
+        OffchainOrder::Filled { .. }
+        | OffchainOrder::Failed { .. }
+        | OffchainOrder::Cancelled { .. } => Err(OffchainOrderError::AlreadyCompleted),
+    }
+}
+
+fn mark_unrequested_cancellation_events(
+    order: &OffchainOrder,
+    filled_shares: FractionalShares,
+    cancelled_at: DateTime<Utc>,
+) -> Result<Vec<OffchainOrderEvent>, OffchainOrderError> {
+    let retained_fill = match order {
+        OffchainOrder::Submitted { .. } => None,
+        OffchainOrder::PartiallyFilled {
+            shares_filled,
+            avg_price,
+            partially_filled_at,
+            ..
+        } => Some(RetainedFill::priced(
+            *shares_filled,
+            *avg_price,
+            *partially_filled_at,
+        )),
+        OffchainOrder::Pending { .. } | OffchainOrder::Cancelling { .. } => {
+            return Err(OffchainOrderError::CancellationNotRequested);
+        }
+        OffchainOrder::Filled { .. }
+        | OffchainOrder::Failed { .. }
+        | OffchainOrder::Cancelled { .. } => {
+            return Err(OffchainOrderError::AlreadyCompleted);
+        }
+    };
+
+    validate_terminal_fill_comparison(order, retained_fill, Some(filled_shares))?;
+    Ok(vec![OffchainOrderEvent::Cancelled {
+        reason: CancellationReason::Unrequested,
+        filled_shares: Some(filled_shares),
+        cancelled_at,
+    }])
+}
+
+fn mark_failed_events(
+    order: &OffchainOrder,
+    error: String,
+    filled_shares: Option<FractionalShares>,
+    failed_at: DateTime<Utc>,
+) -> Result<Vec<OffchainOrderEvent>, OffchainOrderError> {
+    let retained_fill = match order {
+        OffchainOrder::Pending { .. } | OffchainOrder::Submitted { .. } => None,
+        OffchainOrder::PartiallyFilled {
+            shares_filled,
+            avg_price,
+            partially_filled_at,
+            ..
+        } => Some(RetainedFill::priced(
+            *shares_filled,
+            *avg_price,
+            *partially_filled_at,
+        )),
+        OffchainOrder::Cancelling { retained_fill, .. } => *retained_fill,
+        // Idempotent: re-failing an already-failed order records nothing.
+        OffchainOrder::Failed { .. } => return Ok(vec![]),
+        OffchainOrder::Filled { .. } | OffchainOrder::Cancelled { .. } => {
+            return Err(OffchainOrderError::AlreadyCompleted);
+        }
+    };
+
+    validate_terminal_fill_comparison(order, retained_fill, filled_shares)?;
+    Ok(vec![OffchainOrderEvent::Failed {
+        error,
+        filled_shares,
+        failed_at,
+    }])
 }
 
 fn evolve_filled(
@@ -1277,7 +1369,7 @@ fn evolve_failed(
             requested_shares: None,
             direction: *direction,
             executor: *executor,
-            retained_fill: None,
+            retained_fill: retained_fill_for_terminal(None, filled_shares),
             filled_shares,
             executor_order_id: None,
             error,
@@ -1299,7 +1391,7 @@ fn evolve_failed(
             requested_shares: *requested_shares,
             direction: *direction,
             executor: *executor,
-            retained_fill: None,
+            retained_fill: retained_fill_for_terminal(None, filled_shares),
             filled_shares,
             executor_order_id: Some(executor_order_id.clone()),
             error,
@@ -1324,11 +1416,14 @@ fn evolve_failed(
             requested_shares: *requested_shares,
             direction: *direction,
             executor: *executor,
-            retained_fill: Some(RetainedFill::priced(
-                *shares_filled,
-                *avg_price,
-                *partially_filled_at,
-            )),
+            retained_fill: retained_fill_for_terminal(
+                Some(RetainedFill::priced(
+                    *shares_filled,
+                    *avg_price,
+                    *partially_filled_at,
+                )),
+                filled_shares,
+            ),
             filled_shares: filled_shares.or(Some(*shares_filled)),
             executor_order_id: Some(executor_order_id.clone()),
             error,
@@ -1351,7 +1446,7 @@ fn evolve_failed(
             requested_shares: *requested_shares,
             direction: *direction,
             executor: *executor,
-            retained_fill: *retained_fill,
+            retained_fill: retained_fill_for_terminal(*retained_fill, filled_shares),
             filled_shares: filled_shares.or_else(|| retained_fill.map(RetainedFill::shares_filled)),
             executor_order_id: Some(executor_order_id.clone()),
             error,
@@ -1367,12 +1462,14 @@ fn evolve_failed(
 fn evolve_cancelled(
     entity: &OffchainOrder,
     reason: CancellationReason,
+    filled_shares: Option<FractionalShares>,
     cancelled_at: DateTime<Utc>,
 ) -> Option<OffchainOrder> {
     match entity {
         OffchainOrder::Submitted {
             symbol,
             shares,
+            requested_shares,
             direction,
             executor,
             executor_order_id,
@@ -1381,7 +1478,9 @@ fn evolve_cancelled(
         } => Some(OffchainOrder::Cancelled {
             symbol: symbol.clone(),
             shares: *shares,
-            retained_fill: None,
+            requested_shares: *requested_shares,
+            retained_fill: retained_fill_for_terminal(None, filled_shares),
+            filled_shares,
             direction: *direction,
             executor: *executor,
             executor_order_id: executor_order_id.clone(),
@@ -1392,6 +1491,7 @@ fn evolve_cancelled(
         OffchainOrder::PartiallyFilled {
             symbol,
             shares,
+            requested_shares,
             shares_filled,
             direction,
             executor,
@@ -1403,11 +1503,16 @@ fn evolve_cancelled(
         } => Some(OffchainOrder::Cancelled {
             symbol: symbol.clone(),
             shares: *shares,
-            retained_fill: Some(RetainedFill::priced(
-                *shares_filled,
-                *avg_price,
-                *partially_filled_at,
-            )),
+            requested_shares: *requested_shares,
+            retained_fill: retained_fill_for_terminal(
+                Some(RetainedFill::priced(
+                    *shares_filled,
+                    *avg_price,
+                    *partially_filled_at,
+                )),
+                filled_shares,
+            ),
+            filled_shares: filled_shares.or(Some(*shares_filled)),
             direction: *direction,
             executor: *executor,
             executor_order_id: executor_order_id.clone(),
@@ -1418,6 +1523,7 @@ fn evolve_cancelled(
         OffchainOrder::Cancelling {
             symbol,
             shares,
+            requested_shares,
             retained_fill,
             direction,
             executor,
@@ -1428,7 +1534,9 @@ fn evolve_cancelled(
         } => Some(OffchainOrder::Cancelled {
             symbol: symbol.clone(),
             shares: *shares,
-            retained_fill: *retained_fill,
+            requested_shares: *requested_shares,
+            retained_fill: retained_fill_for_terminal(*retained_fill, filled_shares),
+            filled_shares: filled_shares.or_else(|| retained_fill.map(RetainedFill::shares_filled)),
             direction: *direction,
             executor: *executor,
             executor_order_id: executor_order_id.clone(),
@@ -1441,6 +1549,140 @@ fn evolve_cancelled(
         | OffchainOrder::Failed { .. }
         | OffchainOrder::Cancelled { .. } => None,
     }
+}
+
+fn retained_fill_for_terminal(
+    retained_fill: Option<RetainedFill>,
+    terminal_filled_shares: Option<FractionalShares>,
+) -> Option<RetainedFill> {
+    match terminal_filled_shares {
+        Some(shares_filled) if Positive::new(shares_filled).is_ok() => {
+            let Some(retained) = retained_fill else {
+                return Some(RetainedFill::Unpriced { shares_filled });
+            };
+            match shares_filled.inner().gt(retained.shares_filled().inner()) {
+                Ok(true) => Some(RetainedFill::Unpriced { shares_filled }),
+                Ok(false) => Some(retained),
+                Err(error) => {
+                    tracing::error!(
+                        ?error,
+                        terminal_shares_filled = %shares_filled,
+                        retained_shares_filled = %retained.shares_filled(),
+                        "Float comparison failed while replaying a terminal fill; preserving retained evidence"
+                    );
+                    Some(retained)
+                }
+            }
+        }
+        Some(_) | None => retained_fill,
+    }
+}
+
+fn validate_terminal_fill_comparison(
+    order: &OffchainOrder,
+    retained_fill: Option<RetainedFill>,
+    terminal_filled_shares: Option<FractionalShares>,
+) -> Result<(), OffchainOrderError> {
+    let Some(terminal) = terminal_filled_shares else {
+        return Ok(());
+    };
+
+    // A zero terminal fill is the broker's legitimate "nothing filled"
+    // report. Any other non-positive quantity is corrupt and must fail here:
+    // persisting it only defers the rejection to
+    // `terminal_quantity_provenance`, which cannot build a dashboard trade
+    // from a negative fill and would fail the conversion at render time.
+    if Positive::new(terminal).is_err() {
+        if terminal == FractionalShares::ZERO {
+            return Ok(());
+        }
+
+        // An order with no broker order id was never submitted, so no
+        // broker-reported fill of any size can belong to it.
+        let Some(executor_order_id) = order.executor_order_id() else {
+            return Err(OffchainOrderError::NotSubmitted);
+        };
+
+        return Err(OffchainOrderError::InvalidTerminalFillQuantity {
+            executor_order_id: executor_order_id.clone(),
+            shares_filled: terminal,
+        });
+    }
+
+    let Some(retained) = retained_fill else {
+        return Ok(());
+    };
+
+    broker_fill_exceeds_local(terminal, retained.shares_filled())?;
+    Ok(())
+}
+
+struct TerminalQuantityProvenance {
+    requested: Positive<FractionalShares>,
+    accepted: Option<Positive<FractionalShares>>,
+    filled: Option<NonNegative<FractionalShares>>,
+    remaining: Option<NonNegative<FractionalShares>>,
+    excess: Option<NonNegative<FractionalShares>>,
+}
+
+fn terminal_quantity_provenance(
+    accepted_or_legacy_requested: Positive<FractionalShares>,
+    requested_shares: Option<Positive<FractionalShares>>,
+    retained_fill: Option<RetainedFill>,
+    terminal_filled_shares: Option<FractionalShares>,
+) -> Result<TerminalQuantityProvenance, TradeConversionError> {
+    // Modern acceptance preserves the original request separately, proving
+    // that the state's `shares` is broker-accepted. Legacy Submitted events do
+    // not, so acceptance remains unknown and `shares` is only safe to report as
+    // the original request.
+    let accepted_shares = requested_shares
+        .is_some()
+        .then_some(accepted_or_legacy_requested);
+    let requested_shares = requested_shares.unwrap_or(accepted_or_legacy_requested);
+    let terminal_fill = terminal_filled_shares.map(NonNegative::new).transpose()?;
+    let retained_fill = retained_fill
+        .map(RetainedFill::shares_filled)
+        .map(NonNegative::new)
+        .transpose()?;
+    // Cumulative fill evidence cannot regress. If a stale terminal broker
+    // response reports less than an earlier persisted partial fill, retain the
+    // larger proven quantity rather than replacing it.
+    let filled_shares = match (terminal_fill, retained_fill) {
+        (Some(terminal), Some(retained))
+            if terminal.inner().inner().gt(retained.inner().inner())? =>
+        {
+            Some(terminal)
+        }
+        (Some(_), Some(retained)) => Some(retained),
+        (Some(terminal), None) => Some(terminal),
+        (None, retained) => retained,
+    };
+    let (remaining_shares, excess_shares) = match (accepted_shares, filled_shares) {
+        (Some(accepted), Some(filled)) => {
+            let accepted = accepted.inner();
+            let filled = filled.inner();
+            if filled.inner().gt(accepted.inner())? {
+                (
+                    Some(NonNegative::new(FractionalShares::ZERO)?),
+                    Some(NonNegative::new((filled - accepted)?)?),
+                )
+            } else {
+                (
+                    Some(NonNegative::new((accepted - filled)?)?),
+                    Some(NonNegative::new(FractionalShares::ZERO)?),
+                )
+            }
+        }
+        _ => (None, None),
+    };
+
+    Ok(TerminalQuantityProvenance {
+        requested: requested_shares,
+        accepted: accepted_shares,
+        filled: filled_shares,
+        remaining: remaining_shares,
+        excess: excess_shares,
+    })
 }
 
 impl OffchainOrder {
@@ -1477,62 +1719,57 @@ impl OffchainOrder {
                 failed_at,
                 ..
             } => {
-                // Modern acceptance preserves the original request separately,
-                // proving that `shares` is the broker-accepted quantity. Legacy
-                // `Submitted` events do not, so acceptance remains unknown and
-                // `shares` is only safe to report as the original request.
-                let accepted_shares = requested_shares.map(|_| shares);
-                let requested_shares = requested_shares.unwrap_or(shares);
-                let event_fill = filled_shares.map(NonNegative::new).transpose()?;
-                let retained_fill = retained_fill
-                    .map(RetainedFill::shares_filled)
-                    .map(NonNegative::new)
-                    .transpose()?;
-                // Cumulative fill evidence cannot regress. If a stale terminal
-                // broker response reports less than an earlier persisted partial
-                // fill, retain the larger proven quantity rather than replacing
-                // it with the stale observation.
-                let filled_shares = match (event_fill, retained_fill) {
-                    (Some(event), Some(retained))
-                        if event.inner().inner().gt(retained.inner().inner())? =>
-                    {
-                        Some(event)
-                    }
-                    (Some(_), Some(retained)) => Some(retained),
-                    (Some(event), None) => Some(event),
-                    (None, retained) => retained,
-                };
-                let (remaining_shares, excess_shares) = match (accepted_shares, filled_shares) {
-                    (Some(accepted), Some(filled)) => {
-                        let accepted = accepted.inner();
-                        let filled = filled.inner();
-                        if filled.inner().gt(accepted.inner())? {
-                            (
-                                Some(NonNegative::new(FractionalShares::ZERO)?),
-                                Some(NonNegative::new((filled - accepted)?)?),
-                            )
-                        } else {
-                            (
-                                Some(NonNegative::new((accepted - filled)?)?),
-                                Some(NonNegative::new(FractionalShares::ZERO)?),
-                            )
-                        }
-                    }
-                    _ => (None, None),
-                };
+                let quantities = terminal_quantity_provenance(
+                    shares,
+                    requested_shares,
+                    retained_fill,
+                    filled_shares,
+                )?;
 
                 (
                     symbol,
-                    requested_shares,
+                    quantities.requested,
                     direction,
                     executor,
                     failed_at,
                     TradeOutcome::Failed {
                         error,
-                        accepted_shares,
-                        filled_shares,
-                        remaining_shares,
-                        excess_shares,
+                        accepted_shares: quantities.accepted,
+                        filled_shares: quantities.filled,
+                        remaining_shares: quantities.remaining,
+                        excess_shares: quantities.excess,
+                    },
+                )
+            }
+            Self::Cancelled {
+                symbol,
+                shares,
+                requested_shares,
+                direction,
+                executor,
+                retained_fill,
+                filled_shares,
+                cancelled_at,
+                ..
+            } => {
+                let quantities = terminal_quantity_provenance(
+                    shares,
+                    requested_shares,
+                    retained_fill,
+                    filled_shares,
+                )?;
+
+                (
+                    symbol,
+                    quantities.requested,
+                    direction,
+                    executor,
+                    cancelled_at,
+                    TradeOutcome::Cancelled {
+                        accepted_shares: quantities.accepted,
+                        filled_shares: quantities.filled,
+                        remaining_shares: quantities.remaining,
+                        excess_shares: quantities.excess,
                     },
                 )
             }
@@ -1540,7 +1777,6 @@ impl OffchainOrder {
             Self::Submitted { .. } => return Err(TradeConversionError::Submitted),
             Self::PartiallyFilled { .. } => return Err(TradeConversionError::PartiallyFilled),
             Self::Cancelling { .. } => return Err(TradeConversionError::Cancelling),
-            Self::Cancelled { .. } => return Err(TradeConversionError::Cancelled),
         };
 
         Ok(Trade {
@@ -1660,8 +1896,9 @@ pub(crate) enum TerminalPositionFinalization {
     /// cancelled-vs-failed mapping cannot drift between them.
     NoFill(NoFillOutcome),
     /// A positive fill quantity with no average price: the fill cannot be
-    /// recorded correctly, so the position must NOT be finalized (the caller
-    /// retries) rather than silently dropping the filled shares.
+    /// recorded correctly, so the position must NOT be finalized. The order is
+    /// terminal and surfaced for manual reconciliation rather than silently
+    /// dropping the filled shares.
     UnpricedFill { shares_filled: FractionalShares },
 }
 
@@ -2045,6 +2282,7 @@ async fn reconcile_pre_cancel(
                 cancelled_at,
                 OffchainOrderEvent::Cancelled {
                     reason: cancellation_reason,
+                    filled_shares: Some(shares_filled),
                     cancelled_at,
                 },
             )
@@ -2402,10 +2640,15 @@ pub enum OffchainOrderCommand {
     /// Request broker cancellation for a submitted order and persist the
     /// in-flight cancellation state. The order becomes terminal only after the
     /// broker later reports `Cancelled`.
-    CancelOrder {
-        reason: CancellationReason,
-    },
+    CancelOrder { reason: CancellationReason },
     ConfirmCancellation {
+        filled_shares: FractionalShares,
+        cancelled_at: DateTime<Utc>,
+    },
+    /// Records a broker-side cancellation observed without a durable local
+    /// cancel request (for example, an operator cancellation).
+    MarkUnrequestedCancellation {
+        filled_shares: FractionalShares,
         cancelled_at: DateTime<Utc>,
     },
     UpdatePartialFill {
@@ -2444,9 +2687,7 @@ pub enum OffchainOrderCommand {
     /// `Pending`, so a stale attempt cannot fail a live order a concurrent attempt
     /// already accepted. The poll-rejection path instead uses `MarkFailed`, which
     /// may fail a live `Submitted`/`PartiallyFilled` order.
-    MarkPlacementFailed {
-        error: String,
-    },
+    MarkPlacementFailed { error: String },
     MarkFailed {
         error: String,
         /// Broker-reported cumulative fill quantity. `None` means the caller
@@ -2534,6 +2775,8 @@ pub enum OffchainOrderEvent {
     },
     Cancelled {
         reason: CancellationReason,
+        #[serde(default)]
+        filled_shares: Option<FractionalShares>,
         cancelled_at: DateTime<Utc>,
     },
 }
@@ -2607,8 +2850,6 @@ pub(crate) enum TradeConversionError {
     PartiallyFilled,
     #[error("cancelling OffchainOrder cannot be rendered as a Trade")]
     Cancelling,
-    #[error("cancelled OffchainOrder cannot be rendered as a Trade")]
-    Cancelled,
     #[error("failed to calculate the remaining counter-trade shares: {0}")]
     Arithmetic(#[from] FloatError),
     #[error("failed counter-trade shares cannot be negative: {0}")]
@@ -2837,11 +3078,13 @@ mod tests {
         let order = OffchainOrder::Cancelled {
             symbol: Symbol::new("AAPL").unwrap(),
             shares: Positive::new(FractionalShares::new(float!(2))).unwrap(),
+            requested_shares: Some(Positive::new(FractionalShares::new(float!(2))).unwrap()),
             retained_fill: Some(RetainedFill::priced(
                 FractionalShares::new(float!(0.5)),
                 Usd::new(float!(195.25)),
                 fill_time,
             )),
+            filled_shares: Some(FractionalShares::new(float!(0.5))),
             direction: Direction::Sell,
             executor: SupportedExecutor::DryRun,
             executor_order_id: ExecutorOrderId::new("cancelled-with-fill"),
@@ -2966,7 +3209,9 @@ mod tests {
                 );
                 assert!(excess_shares.unwrap().inner().inner().is_zero().unwrap());
             }
-            TradeOutcome::Filled => panic!("failed order must retain its failure outcome"),
+            TradeOutcome::Filled | TradeOutcome::Cancelled { .. } => {
+                panic!("failed order must retain its failure outcome")
+            }
         }
     }
 
@@ -3020,6 +3265,133 @@ mod tests {
                 .eq(float!(0.5))
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn cancelled_trade_distinguishes_explicit_zero_fill() {
+        let cancelled_at = Utc::now();
+        let accepted = Positive::new(FractionalShares::new(float!(1.5))).unwrap();
+        let requested = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order = OffchainOrder::Cancelled {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: accepted,
+            requested_shares: Some(requested),
+            retained_fill: None,
+            filled_shares: Some(FractionalShares::ZERO),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            executor_order_id: ExecutorOrderId::new("cancelled-without-fill"),
+            reason: CancellationReason::MarketOpenReplacement,
+            placed_at: cancelled_at,
+            cancelled_at,
+        };
+
+        let trade = order.try_into_trade(&OffchainOrderId::new()).unwrap();
+        assert_eq!(trade.shares, requested);
+        let TradeOutcome::Cancelled {
+            accepted_shares,
+            filled_shares,
+            remaining_shares,
+            excess_shares,
+        } = trade.outcome
+        else {
+            panic!("cancelled order must retain its cancellation outcome");
+        };
+        assert_eq!(accepted_shares, Some(accepted));
+        assert_eq!(
+            filled_shares,
+            Some(NonNegative::new(FractionalShares::ZERO).unwrap())
+        );
+        assert_eq!(
+            remaining_shares,
+            Some(NonNegative::new(accepted.inner()).unwrap())
+        );
+        assert_eq!(
+            excess_shares,
+            Some(NonNegative::new(FractionalShares::ZERO).unwrap())
+        );
+    }
+
+    #[test]
+    fn cancelled_trade_preserves_partial_fill_provenance() {
+        let cancelled_at = Utc::now();
+        let order = OffchainOrder::Cancelled {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            requested_shares: Some(Positive::new(FractionalShares::new(float!(1.25))).unwrap()),
+            retained_fill: Some(RetainedFill::priced(
+                FractionalShares::new(float!(0.25)),
+                Usd::new(float!(195.25)),
+                cancelled_at,
+            )),
+            filled_shares: Some(FractionalShares::new(float!(0.25))),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            executor_order_id: ExecutorOrderId::new("cancelled-with-partial-fill"),
+            reason: CancellationReason::MarketOpenReplacement,
+            placed_at: cancelled_at,
+            cancelled_at,
+        };
+
+        let trade = order.try_into_trade(&OffchainOrderId::new()).unwrap();
+        let TradeOutcome::Cancelled {
+            filled_shares,
+            remaining_shares,
+            excess_shares,
+            ..
+        } = trade.outcome
+        else {
+            panic!("cancelled order must retain its cancellation outcome");
+        };
+        assert!(
+            filled_shares
+                .unwrap()
+                .inner()
+                .inner()
+                .eq(float!(0.25))
+                .unwrap()
+        );
+        assert!(
+            remaining_shares
+                .unwrap()
+                .inner()
+                .inner()
+                .eq(float!(0.75))
+                .unwrap()
+        );
+        assert!(excess_shares.unwrap().inner().inner().is_zero().unwrap());
+    }
+
+    #[test]
+    fn legacy_cancelled_state_keeps_fill_provenance_unknown() {
+        let legacy_payload = json!({
+            "Cancelled": {
+                "symbol": "AAPL",
+                "shares": "1",
+                "direction": "Sell",
+                "executor": "DryRun",
+                "executor_order_id": "cancelled-legacy",
+                "reason": "MarketOpenReplacement",
+                "placed_at": "2026-01-01T00:00:00Z",
+                "cancelled_at": "2026-01-01T00:00:01Z"
+            }
+        });
+
+        let state: OffchainOrder = serde_json::from_value(legacy_payload).unwrap();
+        let trade = state.try_into_trade(&OffchainOrderId::new()).unwrap();
+        let TradeOutcome::Cancelled {
+            accepted_shares,
+            filled_shares,
+            remaining_shares,
+            excess_shares,
+        } = trade.outcome
+        else {
+            panic!("legacy cancelled state must retain its cancellation outcome");
+        };
+        assert_eq!(accepted_shares, None);
+        assert_eq!(filled_shares, None);
+        assert_eq!(remaining_shares, None);
+        assert_eq!(excess_shares, None);
     }
 
     #[test]
@@ -4188,6 +4560,7 @@ mod tests {
     async fn mark_failed_from_partially_filled() {
         let store = TestStore::<OffchainOrder>::new(noop_order_placer());
         let id = OffchainOrderId::new();
+        let partially_filled_at = Utc::now();
 
         place_and_submit(&store, &id).await;
         store
@@ -4196,7 +4569,7 @@ mod tests {
                 OffchainOrderCommand::UpdatePartialFill {
                     shares_filled: FractionalShares::new(float!(50)),
                     avg_price: Usd::new(float!(150.00)),
-                    partially_filled_at: Utc::now(),
+                    partially_filled_at,
                 },
             )
             .await
@@ -4206,7 +4579,7 @@ mod tests {
                 &id,
                 OffchainOrderCommand::MarkFailed {
                     error: "Order cancelled".to_string(),
-                    filled_shares: None,
+                    filled_shares: Some(FractionalShares::new(float!(25))),
                     failed_at: Utc::now(),
                 },
             )
@@ -4221,13 +4594,59 @@ mod tests {
                     retained_fill:
                         Some(RetainedFill::Priced {
                             shares_filled,
+                            partially_filled_at: fill_time,
                             ..
                         }),
+                    filled_shares: Some(terminal_filled),
                     executor_order_id: Some(_),
                     ..
                 } if shares_filled == FractionalShares::new(float!(50))
+                    && fill_time == partially_filled_at
+                    && terminal_filled == FractionalShares::new(float!(25))
             ),
-            "Failed order must retain partial-fill metadata for retry recovery, got: {inner:?}"
+            "A stale terminal failure must preserve the larger priced fill, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn larger_unpriced_failure_replaces_smaller_priced_fill() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let id = OffchainOrderId::new();
+
+        place_and_submit(&store, &id).await;
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(25)),
+                    avg_price: Usd::new(float!(150.00)),
+                    partially_filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkFailed {
+                    error: "Order cancelled".to_string(),
+                    filled_shares: Some(FractionalShares::new(float!(50))),
+                    failed_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                inner,
+                OffchainOrder::Failed {
+                    retained_fill: Some(RetainedFill::Unpriced { shares_filled }),
+                    ..
+                } if shares_filled == FractionalShares::new(float!(50))
+            ),
+            "A larger unpriced terminal fill must replace stale priced evidence, got: {inner:?}"
         );
     }
 
@@ -4535,6 +4954,7 @@ mod tests {
             .send(
                 &id,
                 OffchainOrderCommand::ConfirmCancellation {
+                    filled_shares: FractionalShares::ZERO,
                     cancelled_at: Utc::now(),
                 },
             )
@@ -4551,6 +4971,149 @@ mod tests {
                 }
             ),
             "Expected confirmed cancellation to become terminal Cancelled, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_failed_rejects_negative_terminal_fill() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkFailed {
+                    error: "broker rejected".to_string(),
+                    filled_shares: Some(FractionalShares::new(float!(-1))),
+                    failed_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    OffchainOrderError::InvalidTerminalFillQuantity { .. }
+                ))
+            ),
+            "A negative terminal fill must be rejected before it is persisted, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_failed_accepts_zero_terminal_fill() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkFailed {
+                    error: "broker rejected".to_string(),
+                    filled_shares: Some(FractionalShares::ZERO),
+                    failed_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(inner, OffchainOrder::Failed { .. }),
+            "A zero terminal fill is the broker's legitimate no-fill report, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_unrequested_cancellation_rejects_negative_terminal_fill() {
+        let store = TestStore::<OffchainOrder>::new(noop_order_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        let err = store
+            .send(
+                &id,
+                OffchainOrderCommand::MarkUnrequestedCancellation {
+                    filled_shares: FractionalShares::new(float!(-1)),
+                    cancelled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AggregateError::UserError(LifecycleError::Apply(
+                    OffchainOrderError::InvalidTerminalFillQuantity { .. }
+                ))
+            ),
+            "A negative terminal fill must be rejected before it is persisted, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_cancellation_preserves_larger_priced_fill() {
+        let partially_filled_at = Utc::now();
+        let store = TestStore::<OffchainOrder>::new(broker_partial_fill_placer(
+            float!(50),
+            partially_filled_at,
+        ));
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(50)),
+                    avg_price: Usd::new(float!(150.0)),
+                    partially_filled_at,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::ConfirmCancellation {
+                    filled_shares: FractionalShares::new(float!(25)),
+                    cancelled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                inner,
+                OffchainOrder::Cancelled {
+                    retained_fill:
+                        Some(RetainedFill::Priced {
+                            shares_filled,
+                            partially_filled_at: fill_time,
+                            ..
+                        }),
+                    filled_shares: Some(terminal_filled),
+                    ..
+                } if shares_filled == FractionalShares::new(float!(50))
+                    && fill_time == partially_filled_at
+                    && terminal_filled == FractionalShares::new(float!(25))
+            ),
+            "A stale terminal cancellation must preserve the larger priced fill, got: {inner:?}"
         );
     }
 
@@ -4986,6 +5549,17 @@ mod tests {
         placed_object.remove("limit_price");
         placed_object.remove("client_order_id");
 
+        let mut failed_value = serde_json::to_value(OffchainOrderEvent::Failed {
+            error: "broker rejected".to_string(),
+            filled_shares: None,
+            failed_at,
+        })
+        .unwrap();
+        failed_value["Failed"]
+            .as_object_mut()
+            .unwrap()
+            .remove("filled_shares");
+
         let legacy_events: Vec<OffchainOrderEvent> = [
             placed_value,
             serde_json::to_value(OffchainOrderEvent::Submitted {
@@ -4993,12 +5567,7 @@ mod tests {
                 submitted_at: Utc::now(),
             })
             .unwrap(),
-            serde_json::to_value(OffchainOrderEvent::Failed {
-                error: "broker rejected".to_string(),
-                filled_shares: None,
-                failed_at,
-            })
-            .unwrap(),
+            failed_value,
         ]
         .into_iter()
         .map(|value| serde_json::from_value(value).unwrap())
@@ -5030,6 +5599,49 @@ mod tests {
         );
         assert_eq!(error, "broker rejected");
         assert_eq!(replayed_failed_at, failed_at);
+    }
+
+    #[test]
+    fn legacy_event_stream_replays_to_cancelled_without_fill_data() {
+        let placed_at = Utc::now();
+        let cancelled_at = Utc::now();
+        let mut cancelled_value = serde_json::to_value(OffchainOrderEvent::Cancelled {
+            reason: CancellationReason::Unrequested,
+            filled_shares: None,
+            cancelled_at,
+        })
+        .unwrap();
+        cancelled_value["Cancelled"]
+            .as_object_mut()
+            .unwrap()
+            .remove("filled_shares");
+        let events = vec![
+            OffchainOrderEvent::Placed {
+                symbol: Symbol::new("TSLA").unwrap(),
+                shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor: SupportedExecutor::DryRun,
+                placed_at,
+                is_extended_hours: false,
+                limit_price: None,
+                client_order_id: None,
+            },
+            OffchainOrderEvent::Submitted {
+                executor_order_id: ExecutorOrderId::new("broker-cancelled"),
+                submitted_at: placed_at,
+            },
+            serde_json::from_value(cancelled_value).unwrap(),
+        ];
+
+        let replayed = replay::<OffchainOrder>(events).unwrap().unwrap();
+        assert!(matches!(
+            replayed,
+            OffchainOrder::Cancelled {
+                filled_shares: None,
+                retained_fill: None,
+                ..
+            }
+        ));
     }
 
     #[tokio::test]
@@ -5822,6 +6434,7 @@ mod tests {
             .send(
                 &id,
                 OffchainOrderCommand::ConfirmCancellation {
+                    filled_shares: FractionalShares::ZERO,
                     cancelled_at: Utc::now(),
                 },
             )

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -17,7 +17,7 @@ use st0x_event_sorcery::{Projection, Store};
 use st0x_execution::{
     Executor, ExecutorOrderId, FractionalShares, OrderState, Positive, SupportedExecutor, Symbol,
 };
-use st0x_finance::Usd;
+use st0x_finance::{NonNegative, Usd};
 
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::offchain::order::handle_rejection::{
@@ -25,8 +25,8 @@ use crate::offchain::order::handle_rejection::{
 };
 use crate::offchain::order::reconcile_fill::{ReconcileOrderFill, ReconcileOrderFillJobQueue};
 use crate::offchain::order::{
-    CancellationReason, JobError, OffchainOrder, OffchainOrderCommand, OffchainOrderId,
-    RetainedFill, TerminalPositionFinalization, position_command_for_finalization,
+    CancellationReason, JobError, OffchainOrder, OffchainOrderCommand, OffchainOrderError,
+    OffchainOrderId, RetainedFill, TerminalPositionFinalization, position_command_for_finalization,
     terminal_position_finalization,
 };
 use crate::position::Position;
@@ -139,7 +139,7 @@ impl PollOrderStatus {
         let parsed_order_id = ctx.executor.parse_order_id(executor_order_id.as_ref())?;
         let order_state = ctx.executor.get_order_status(&parsed_order_id).await?;
 
-        self.dispatch_for_broker_state(ctx, order, order_state)
+        self.dispatch_for_broker_state(ctx, order, &executor_order_id, order_state)
             .await
     }
 
@@ -147,6 +147,7 @@ impl PollOrderStatus {
         &self,
         ctx: &PollOrderStatusCtx<E>,
         order: &OffchainOrder,
+        executor_order_id: &ExecutorOrderId,
         order_state: OrderState,
     ) -> Result<(), JobError>
     where
@@ -154,6 +155,7 @@ impl PollOrderStatus {
         JobError: From<E::Error>,
     {
         use OrderState::{Cancelled, Failed, Filled, PartiallyFilled, Pending, Submitted};
+        validate_broker_terminal_fill(executor_order_id, &order_state)?;
         let symbol = order.symbol();
         match order_state {
             Filled {
@@ -188,15 +190,14 @@ impl PollOrderStatus {
             // never surface the missing price -- the old `reschedule_self`
             // looped forever. Fail closed instead: leave the position pending
             // (NEVER clear it -- clearing under-accounts the executed shares and
-            // double-hedges on the next scan) and stop re-polling. The order
-            // stays non-terminal, so startup orphan-recovery re-polls it on the
-            // next restart without an in-process tight loop; the error log
-            // surfaces it for manual reconciliation.
+            // double-hedges on the next scan), persist the terminal order, and
+            // stop re-polling. The dashboard outcome and error log surface it
+            // for manual reconciliation.
             Failed {
-                error_reason: _,
+                error_reason,
                 shares_filled: Some(shares_filled),
                 avg_price: None,
-                ..
+                failed_at,
             } if Positive::new(shares_filled).is_ok() => {
                 error!(
                     target: "broker",
@@ -204,9 +205,10 @@ impl PollOrderStatus {
                     offchain_order_id = %self.offchain_order_id,
                     %shares_filled,
                     "Broker reports Failed with filled shares but no avg_price; \
-                     leaving the position pending (fail closed) and not re-polling"
+                     recording the terminal failure while leaving the position pending"
                 );
-                Ok(())
+                self.persist_unpriced_failure(ctx, symbol, error_reason, shares_filled, failed_at)
+                    .await
             }
 
             Failed {
@@ -227,7 +229,8 @@ impl PollOrderStatus {
             } if Positive::new(shares_filled).is_ok() => {
                 self.record_partial_fill(ctx, symbol, shares_filled, Some(avg_price), cancelled_at)
                     .await?;
-                self.confirm_cancellation(ctx, symbol, cancelled_at).await
+                self.confirm_cancellation(ctx, symbol, shares_filled, cancelled_at)
+                    .await
             }
 
             // Broker-terminal Cancelled with a positive unpriced fill -- same
@@ -235,7 +238,7 @@ impl PollOrderStatus {
             // pending and stop re-polling rather than looping forever or
             // clearing the executed shares.
             Cancelled {
-                cancelled_at: _,
+                cancelled_at,
                 shares_filled,
                 avg_price: None,
                 ..
@@ -246,13 +249,19 @@ impl PollOrderStatus {
                     offchain_order_id = %self.offchain_order_id,
                     %shares_filled,
                     "Broker reports Cancelled with filled shares but no avg_price; \
-                     leaving the position pending (fail closed) and not re-polling"
+                     recording the terminal cancellation while leaving the position pending"
                 );
-                Ok(())
+                self.persist_unpriced_cancellation(ctx, symbol, shares_filled, cancelled_at)
+                    .await
             }
 
-            Cancelled { cancelled_at, .. } => {
-                self.confirm_cancellation(ctx, symbol, cancelled_at).await
+            Cancelled {
+                shares_filled,
+                cancelled_at,
+                ..
+            } => {
+                self.confirm_cancellation(ctx, symbol, shares_filled, cancelled_at)
+                    .await
             }
 
             PartiallyFilled {
@@ -479,6 +488,7 @@ impl PollOrderStatus {
         &self,
         ctx: &PollOrderStatusCtx<E>,
         symbol: &Symbol,
+        filled_shares: FractionalShares,
         cancelled_at: DateTime<Utc>,
     ) -> Result<(), JobError>
     where
@@ -510,7 +520,10 @@ impl PollOrderStatus {
                 ctx.offchain_order_store
                     .send(
                         &self.offchain_order_id,
-                        OffchainOrderCommand::ConfirmCancellation { cancelled_at },
+                        OffchainOrderCommand::ConfirmCancellation {
+                            filled_shares,
+                            cancelled_at,
+                        },
                     )
                     .await?;
 
@@ -527,7 +540,7 @@ impl PollOrderStatus {
             // and let the next replacement adopt the cancelled broker order
             // via duplicate-client-order-id recovery.
             OffchainOrder::Submitted { .. } | OffchainOrder::PartiallyFilled { .. } => {
-                self.recover_unrequested_cancellation(ctx, symbol, cancelled_at)
+                self.recover_unrequested_cancellation(ctx, symbol, filled_shares, cancelled_at)
                     .await
             }
 
@@ -555,6 +568,95 @@ impl PollOrderStatus {
         }
     }
 
+    async fn persist_unpriced_failure<E>(
+        &self,
+        ctx: &PollOrderStatusCtx<E>,
+        symbol: &Symbol,
+        error_reason: Option<String>,
+        shares_filled: FractionalShares,
+        failed_at: DateTime<Utc>,
+    ) -> Result<(), JobError>
+    where
+        E: Executor + Clone + Send + Sync + 'static,
+    {
+        ctx.offchain_order_store
+            .send(
+                &self.offchain_order_id,
+                OffchainOrderCommand::MarkFailed {
+                    error: error_reason
+                        .unwrap_or_else(|| "Order failed with no error reason".to_string()),
+                    filled_shares: Some(shares_filled),
+                    failed_at,
+                },
+            )
+            .await?;
+
+        self.finalize_position_for_terminal_order(ctx, symbol).await
+    }
+
+    /// Reloads the aggregate before branching. The state this job read at
+    /// startup predates the broker round-trip, so a cancellation persisted in
+    /// that window would otherwise steer this into a command the current
+    /// state rejects. The priced `confirm_cancellation` path reloads for the
+    /// same reason.
+    async fn persist_unpriced_cancellation<E>(
+        &self,
+        ctx: &PollOrderStatusCtx<E>,
+        symbol: &Symbol,
+        shares_filled: FractionalShares,
+        cancelled_at: DateTime<Utc>,
+    ) -> Result<(), JobError>
+    where
+        E: Executor + Clone + Send + Sync + 'static,
+    {
+        let Some(order) = ctx
+            .offchain_order_projection
+            .load(&self.offchain_order_id)
+            .await?
+        else {
+            warn!(
+                target: "broker",
+                %symbol,
+                offchain_order_id = %self.offchain_order_id,
+                "PollOrderStatus: order disappeared before recording an unpriced cancellation"
+            );
+            return Ok(());
+        };
+
+        let command = match order {
+            OffchainOrder::Cancelling { .. } => OffchainOrderCommand::ConfirmCancellation {
+                filled_shares: shares_filled,
+                cancelled_at,
+            },
+            OffchainOrder::Submitted { .. } | OffchainOrder::PartiallyFilled { .. } => {
+                OffchainOrderCommand::MarkUnrequestedCancellation {
+                    filled_shares: shares_filled,
+                    cancelled_at,
+                }
+            }
+            OffchainOrder::Pending { .. }
+            | OffchainOrder::Filled { .. }
+            | OffchainOrder::Failed { .. }
+            | OffchainOrder::Cancelled { .. } => {
+                warn!(
+                    target: "broker",
+                    %symbol,
+                    offchain_order_id = %self.offchain_order_id,
+                    state = ?order,
+                    %shares_filled,
+                    "Broker reported an unpriced cancellation fill for an order that is \
+                     neither live nor Cancelling; ignoring terminal-state discrepancy"
+                );
+                return Ok(());
+            }
+        };
+        ctx.offchain_order_store
+            .send(&self.offchain_order_id, command)
+            .await?;
+
+        self.finalize_position_for_terminal_order(ctx, symbol).await
+    }
+
     /// Recovers a broker-side cancellation observed while the local order is
     /// still `Submitted`/`PartiallyFilled` (the cancel request did not survive
     /// a crash). Re-drives `CancelOrder`: its pre-cancel reconcile reads the
@@ -566,6 +668,7 @@ impl PollOrderStatus {
         &self,
         ctx: &PollOrderStatusCtx<E>,
         symbol: &Symbol,
+        filled_shares: FractionalShares,
         cancelled_at: DateTime<Utc>,
     ) -> Result<(), JobError>
     where
@@ -614,7 +717,10 @@ impl PollOrderStatus {
                 ctx.offchain_order_store
                     .send(
                         &self.offchain_order_id,
-                        OffchainOrderCommand::ConfirmCancellation { cancelled_at },
+                        OffchainOrderCommand::ConfirmCancellation {
+                            filled_shares,
+                            cancelled_at,
+                        },
                     )
                     .await?;
             }
@@ -732,6 +838,31 @@ impl PollOrderStatus {
             }
         }
     }
+}
+
+fn validate_broker_terminal_fill(
+    executor_order_id: &ExecutorOrderId,
+    order_state: &OrderState,
+) -> Result<(), OffchainOrderError> {
+    let filled_shares = match order_state {
+        OrderState::Failed { shares_filled, .. } => *shares_filled,
+        OrderState::Cancelled { shares_filled, .. } => Some(*shares_filled),
+        OrderState::Pending
+        | OrderState::Submitted { .. }
+        | OrderState::PartiallyFilled { .. }
+        | OrderState::Filled { .. } => None,
+    };
+
+    if let Some(shares_filled) = filled_shares {
+        NonNegative::new(shares_filled).map_err(|_| {
+            OffchainOrderError::InvalidTerminalFillQuantity {
+                executor_order_id: executor_order_id.clone(),
+                shares_filled,
+            }
+        })?;
+    }
+
+    Ok(())
 }
 
 /// Decision derived from the order's current aggregate state, before any
@@ -884,6 +1015,7 @@ pub(crate) async fn recover_submitted_offchain_orders(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::OnceLock;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use chrono::Utc;
@@ -1316,6 +1448,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn poll_rejects_negative_terminal_cancellation_fill() {
+        let executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
+            cancelled_at: Utc::now(),
+            order_id: ExecutorOrderId::new("noop"),
+            shares_filled: FractionalShares::new(float!(-0.5)),
+            avg_price: None,
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        infra
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let error = PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            JobError::OffchainOrder(
+                crate::offchain::order::OffchainOrderError::InvalidTerminalFillQuantity { .. }
+            )
+        ));
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(
+            matches!(order, OffchainOrder::Cancelling { .. }),
+            "invalid broker fill must not make the cancellation terminal, got: {order:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn retry_after_confirmed_cancellation_finalizes_position() {
         let executor = MockExecutor::new();
         let infra = build_test_infra(executor).await;
@@ -1339,6 +1516,7 @@ mod tests {
             .send(
                 &order_id,
                 OffchainOrderCommand::ConfirmCancellation {
+                    filled_shares: FractionalShares::ZERO,
                     cancelled_at: Utc::now(),
                 },
             )
@@ -1766,12 +1944,245 @@ mod tests {
             0,
             "Unpriced terminal fill must not be routed to rejection"
         );
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(matches!(
+            order,
+            OffchainOrder::Cancelled {
+                retained_fill: Some(RetainedFill::Unpriced { shares_filled }),
+                filled_shares: Some(terminal_filled),
+                ..
+            } if shares_filled == FractionalShares::new(float!(50))
+                && terminal_filled == shares_filled
+        ));
 
         let position = infra.position.load(&symbol).await.unwrap().unwrap();
         assert_eq!(
             position.pending_offchain_order_id,
             Some(order_id),
             "Unpriced fill must leave the position pending (fail closed), never cleared"
+        );
+    }
+
+    #[tokio::test]
+    async fn larger_unpriced_cancellation_from_partial_fill_keeps_position_pending() {
+        let executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
+            cancelled_at: Utc::now(),
+            order_id: ExecutorOrderId::new("noop"),
+            shares_filled: FractionalShares::new(float!(50)),
+            avg_price: None,
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(100))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+        infra
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(25)),
+                    avg_price: Usd::new(float!(150.0)),
+                    partially_filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(matches!(
+            order,
+            OffchainOrder::Cancelled {
+                retained_fill: Some(RetainedFill::Unpriced { shares_filled }),
+                reason: CancellationReason::Unrequested,
+                ..
+            } if shares_filled == FractionalShares::new(float!(50))
+        ));
+        let position = infra.position.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(position.pending_offchain_order_id, Some(order_id));
+    }
+
+    #[tokio::test]
+    async fn larger_unpriced_cancellation_while_cancelling_keeps_position_pending() {
+        let executor = MockExecutor::new().with_order_status(OrderState::Cancelled {
+            cancelled_at: Utc::now(),
+            order_id: ExecutorOrderId::new("noop"),
+            shares_filled: FractionalShares::new(float!(50)),
+            avg_price: None,
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(100))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+        infra
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(25)),
+                    avg_price: Usd::new(float!(150.0)),
+                    partially_filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        infra
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(matches!(
+            order,
+            OffchainOrder::Cancelled {
+                retained_fill: Some(RetainedFill::Unpriced { shares_filled }),
+                reason: CancellationReason::MarketOpenReplacement,
+                ..
+            } if shares_filled == FractionalShares::new(float!(50))
+        ));
+        let position = infra.position.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(position.pending_offchain_order_id, Some(order_id));
+    }
+
+    /// The job reads the aggregate before the broker round-trip, so a
+    /// cancellation persisted during that call leaves the job holding stale
+    /// state. Acting on it would send `MarkUnrequestedCancellation` to an
+    /// order that is already `Cancelling`, which the aggregate rejects.
+    #[tokio::test]
+    async fn unpriced_cancellation_reloads_state_that_changed_during_the_broker_call() {
+        #[derive(Clone)]
+        struct CancelDuringStatusExecutor {
+            target: Arc<OnceLock<(Arc<Store<OffchainOrder>>, OffchainOrderId)>>,
+            inner: MockExecutor,
+        }
+
+        #[async_trait::async_trait]
+        impl Executor for CancelDuringStatusExecutor {
+            type Error = ExecutionError;
+            type OrderId = String;
+            type Ctx = ();
+
+            async fn try_from_ctx(_ctx: Self::Ctx) -> Result<Self, Self::Error> {
+                unimplemented!()
+            }
+
+            async fn is_market_open(&self) -> Result<bool, Self::Error> {
+                self.inner.is_market_open().await
+            }
+
+            async fn place_market_order(
+                &self,
+                order: st0x_execution::MarketOrder,
+            ) -> Result<st0x_execution::OrderPlacement<Self::OrderId>, Self::Error> {
+                self.inner.place_market_order(order).await
+            }
+
+            async fn place_limit_order(
+                &self,
+                order: st0x_execution::LimitOrder,
+            ) -> Result<st0x_execution::OrderPlacement<Self::OrderId>, Self::Error> {
+                self.inner.place_limit_order(order).await
+            }
+
+            async fn cancel_order(
+                &self,
+                order_id: &Self::OrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Self::Error> {
+                self.inner.cancel_order(order_id).await
+            }
+
+            async fn get_order_status(
+                &self,
+                order_id: &Self::OrderId,
+            ) -> Result<OrderState, Self::Error> {
+                if let Some((store, offchain_order_id)) = self.target.get() {
+                    store
+                        .send(
+                            offchain_order_id,
+                            OffchainOrderCommand::CancelOrder {
+                                reason: CancellationReason::MarketOpenReplacement,
+                            },
+                        )
+                        .await
+                        .unwrap();
+                }
+
+                self.inner.get_order_status(order_id).await
+            }
+
+            fn parse_order_id(&self, order_id_str: &str) -> Result<Self::OrderId, Self::Error> {
+                self.inner.parse_order_id(order_id_str)
+            }
+
+            async fn get_inventory(&self) -> Result<st0x_execution::InventoryResult, Self::Error> {
+                self.inner.get_inventory().await
+            }
+
+            fn to_supported_executor(&self) -> SupportedExecutor {
+                self.inner.to_supported_executor()
+            }
+        }
+
+        let target = Arc::new(OnceLock::new());
+        let infra = build_test_infra(CancelDuringStatusExecutor {
+            target: Arc::clone(&target),
+            inner: MockExecutor::new().with_order_status(OrderState::Cancelled {
+                cancelled_at: Utc::now(),
+                order_id: ExecutorOrderId::new("noop"),
+                shares_filled: FractionalShares::new(float!(50)),
+                avg_price: None,
+            }),
+        })
+        .await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(100))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+        assert!(
+            target
+                .set((Arc::clone(&infra.offchain_order), order_id))
+                .is_ok(),
+            "the cancellation target must only be armed once"
+        );
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                order,
+                OffchainOrder::Cancelled {
+                    reason: CancellationReason::MarketOpenReplacement,
+                    ..
+                }
+            ),
+            "The reloaded Cancelling state must confirm the requested cancellation, got: {order:?}"
         );
     }
 
@@ -1806,14 +2217,123 @@ mod tests {
         assert_eq!(
             count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
             0,
-            "Unpriced terminal fill must not be routed to rejection"
+            "Unpriced terminal failure is persisted directly without rejection cleanup"
         );
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(matches!(
+            order,
+            OffchainOrder::Failed {
+                retained_fill: Some(RetainedFill::Unpriced { shares_filled }),
+                filled_shares: Some(terminal_filled),
+                ..
+            } if shares_filled == FractionalShares::new(float!(50))
+                && terminal_filled == shares_filled
+        ));
 
         let position = infra.position.load(&symbol).await.unwrap().unwrap();
         assert_eq!(
             position.pending_offchain_order_id,
             Some(order_id),
             "Unpriced fill must leave the position pending (fail closed), never cleared"
+        );
+    }
+
+    #[tokio::test]
+    async fn unpriced_failure_equal_to_priced_partial_fill_finalizes_position() {
+        let failed_at = Utc::now();
+        let executor = MockExecutor::new().with_order_status(OrderState::Failed {
+            failed_at,
+            error_reason: Some("broker rejected remainder".to_string()),
+            shares_filled: Some(FractionalShares::new(float!(50))),
+            avg_price: None,
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(100))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+        let partially_filled_at = failed_at - chrono::Duration::seconds(1);
+        infra
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(50)),
+                    avg_price: Usd::new(float!(150.0)),
+                    partially_filled_at,
+                },
+            )
+            .await
+            .unwrap();
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(matches!(
+            order,
+            OffchainOrder::Failed {
+                retained_fill: Some(RetainedFill::Priced { shares_filled, .. }),
+                ..
+            } if shares_filled == FractionalShares::new(float!(50))
+        ));
+        let position = infra.position.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "Matching terminal quantity must retain the known price and finalize the position"
+        );
+    }
+
+    #[tokio::test]
+    async fn larger_unpriced_failure_keeps_position_pending() {
+        let executor = MockExecutor::new().with_order_status(OrderState::Failed {
+            failed_at: Utc::now(),
+            error_reason: Some("broker rejected remainder".to_string()),
+            shares_filled: Some(FractionalShares::new(float!(50))),
+            avg_price: None,
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(100))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+        infra
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(25)),
+                    avg_price: Usd::new(float!(150.0)),
+                    partially_filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let order = infra.offchain_order.load(&order_id).await.unwrap().unwrap();
+        assert!(matches!(
+            order,
+            OffchainOrder::Failed {
+                retained_fill: Some(RetainedFill::Unpriced { shares_filled }),
+                ..
+            } if shares_filled == FractionalShares::new(float!(50))
+        ));
+        let position = infra.position.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            position.pending_offchain_order_id,
+            Some(order_id),
+            "A larger unpriced terminal fill must remain pending for manual reconciliation"
         );
     }
 

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -1170,6 +1170,7 @@ mod tests {
             .send(
                 &offchain_order_id,
                 OffchainOrderCommand::ConfirmCancellation {
+                    filled_shares: FractionalShares::ZERO,
                     cancelled_at: chrono::Utc::now(),
                 },
             )
@@ -1249,6 +1250,7 @@ mod tests {
             .send(
                 &offchain_order_id,
                 OffchainOrderCommand::ConfirmCancellation {
+                    filled_shares: FractionalShares::new(float!(0.5)),
                     cancelled_at: chrono::Utc::now(),
                 },
             )

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -1002,6 +1002,21 @@ async fn simulate() -> anyhow::Result<()> {
         Some(db_path),
     )
     .await?;
+
+    // Every counter-trade fills by default, so the dashboard's trade history
+    // only ever shows one outcome. This knob rotates each hedge through
+    // filled, rejected, and partially-filled-then-cancelled instead, so the
+    // Outcome column can be inspected (and screenshotted) in one run.
+    if std::env::var_os("SIMULATE_BROKER_OUTCOME_ROTATION").is_some() {
+        infra
+            .broker_service
+            .set_mode(st0x_execution::alpaca_broker_api::MockMode::RotatingOutcomes);
+        info!(
+            "Rotating counter-trade outcomes: every third hedge is rejected, every third is \
+             cancelled after a partial fill"
+        );
+    }
+
     debug!("Starting CCTP mock infrastructure");
     let cctp = CctpInfra::start(&infra).await?;
 

--- a/tests/e2e/hedging.rs
+++ b/tests/e2e/hedging.rs
@@ -1075,6 +1075,98 @@ async fn broker_order_rejected() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Verifies that a broker cancellation the bot never requested lands the
+/// offchain order in `Cancelled` -- retaining the partial fill the broker
+/// executed before cancelling -- instead of `Failed`. The two outcomes carry
+/// different meaning downstream (the dashboard renders them apart, and only
+/// `Failed` reports an error), so a cancellation must not collapse into a
+/// failure.
+#[test_log::test(tokio::test)]
+async fn broker_order_cancelled_after_partial_fill() -> anyhow::Result<()> {
+    let onchain_price = float!(150.00);
+    let broker_fill_price = float!(150.00);
+    let sell_amount = float!(5.25);
+    let expected_partial_fill = float!(2.625);
+
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+
+    infra
+        .broker_service
+        .set_mode(st0x_execution::alpaca_broker_api::MockMode::PartialFillThenCancel);
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    infra
+        .base_chain
+        .take_order()
+        .symbol("AAPL")
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_aggregate_events_containing(&mut bot, &infra.db_path, "OffchainOrder", "Cancelled", 1)
+        .await;
+
+    let pool = connect_db(&infra.db_path).await?;
+
+    // The position checker re-hedges the unfilled remainder each cycle, so
+    // several cancelled orders can accumulate; every one of them must carry
+    // the partial fill the broker reported at cancellation.
+    let offchain_orders = Projection::<OffchainOrder>::sqlite(pool.clone())
+        .load_all()
+        .await?;
+    let cancelled: Vec<_> = offchain_orders
+        .iter()
+        .filter_map(|(order_id, order)| match order {
+            OffchainOrder::Cancelled {
+                shares,
+                filled_shares,
+                ..
+            } => Some((order_id, *shares, *filled_shares)),
+            _ => None,
+        })
+        .collect();
+
+    let (order_id, _, filled_shares) = cancelled
+        .iter()
+        .find(|(_, shares, _)| shares.inner() == FractionalShares::new(sell_amount))
+        .expect("The hedge for the full onchain amount should be Cancelled");
+    assert_eq!(
+        *filled_shares,
+        Some(FractionalShares::new(expected_partial_fill)),
+        "Cancelled order {order_id} should retain the partial fill the broker executed"
+    );
+
+    // A re-hedge placed after the cancellation can still be in flight here,
+    // so assert on the cancelled one rather than on every broker order.
+    let broker_statuses: Vec<_> = infra
+        .broker_service
+        .orders()
+        .into_iter()
+        .map(|order| order.status)
+        .collect();
+    assert!(
+        broker_statuses.contains(&OrderStatus::Canceled),
+        "The broker should report the hedge as cancelled, got: {broker_statuses:?}"
+    );
+
+    pool.close().await;
+    bot.abort();
+    Ok(())
+}
+
 /// Verifies that the bot correctly handles orders that take multiple poll
 /// cycles to fill (simulating real broker latency). The order stays in
 /// "new" status for 3 polls before transitioning to "filled".


### PR DESCRIPTION
## What

- [RAI-1432](https://linear.app/makeitrain/issue/RAI-1432/surface-cancelled-counter-trades-in-trade-history)
- Show terminal cancelled counter-trades in dashboard history and live updates.
- Distinguish explicit zero fills, partial fills, and unknown legacy fill provenance.

## Why

- A cancelled broker order can leave hedge exposure behind, but the dashboard hid it once it became terminal.
- Operators need the requested, accepted, filled, remaining, and excess quantities to understand the outcome.

## How

- Add `TradeOutcome::Cancelled` to the DTO. The dashboard renders it amber with the same quantity block as failures.
- Persist broker-reported cancellation fills: `ConfirmCancellation` now carries `filled_shares`, and the `Cancelled` event and state retain `requested_shares` and `filled_shares` (`SCHEMA_VERSION` 4 plus a stale-projection rebuild in `conductor.rs`).
- Add `MarkUnrequestedCancellation` for a broker-side cancellation that has no durable local cancel request.
- Reuse the failure quantity rules (`terminal_quantity_provenance`) for zero, partial, remaining, and excess quantities.
- Gate cancelled outcomes behind `terminal_outcomes_v2`. Legacy and v1 clients keep their current contracts.
- Reject a negative broker terminal fill (`validate_broker_terminal_fill`) before it becomes terminal state.
- Behavior change beyond cancellations, on purpose: a broker-terminal `Failed` or `Cancelled` with a positive fill but no average price was left non-terminal forever. `persist_unpriced_failure` and `persist_unpriced_cancellation` in `poll_status.rs` now persist the terminal order and surface it, while the owning position stays pending for manual reconciliation, same as before.

## Testing

- Backend: aggregate tests for zero-fill, partial-fill, stale smaller terminal fills, legacy events without fill data, and negative-fill rejection; provenance parity between history and live broadcast; projection rebuild for interrupted schema upgrades.
- Dashboard: payload-validation, presentation, and component tests for the cancelled rendering.
- `cargo nextest run -p st0x-hedge dashboard::event` is green on every branch of the stack; full CI runs remotely.

## Screenshots

![CleanShot 2026-07-24 at 21.07.21@2x.png](https://app.graphite.com/user-attachments/assets/1c77a566-735a-403a-9910-b232342b811c.png)

## Anything else

- Stacked on RAI-1430 so cancellation outcomes use the same quantity provenance model as failed counter-trades.
- Finalizing the owning Position on cancellation stays out of scope; [RAI-1172](https://linear.app/makeitrain/issue/RAI-1172) tracks it.
- The handoff-monitor hardening that first landed here (bounded retry queue, retry cap, periodic reconciliation) moved down to #1058, where the delivery mechanism lives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trade history now displays cancelled trades with partial, zero, remaining, and excess-fill details.
  * Positive unpriced fills remain visible for manual reconciliation while positions stay pending.
  * Added a simulation command cycling through filled, rejected, and partially filled-then-cancelled outcomes.

* **Bug Fixes**
  * Improved trade ordering, reconnection handling, and compatibility across dashboard protocols.
  * Corrected filtering, pagination, tooltips, and compact outcome presentation.

* **Documentation**
  * Expanded guidance for simulating broker outcomes and reviewing trade-history displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->