### PR TITLE
feat: gate daily portfolio snapshot capture on poll-driven freshness

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -638,13 +638,41 @@ partially-hydrated view (e.g. equity seen onchain but not yet offchain) is
 skipped and retried shortly after, since a captured day can never be amended.
 This is a PRESENCE check, not a freshness check: a balance that is merely
 present (e.g. replayed from a persisted `InventorySnapshot` at startup, without
-ever being re-polled this run) still satisfies it. In steady state the capture
-job only wakes shortly after the `00:05` ET boundary, by which point the poller
-has already polled fresh this run, so the residual risk is narrow: a restart
-that hydrates stale data from a persisted snapshot and then captures before the
-poller gets a chance to poll again. A robust poll-driven freshness signal (an
-independent signal that records successful polls even when balances are
-unchanged) is accepted as out of scope for v1 and tracked as a follow-up.
+ever being re-polled this run) still satisfies it on its own. An earlier attempt
+at a time-window freshness gate was reverted: the underlying `InventorySnapshot`
+suppresses events, and their watermarks, on unchanged balances, so tying
+freshness to that watermark freezes on a static book and the window would
+eventually block every future capture.
+
+**Poll-driven freshness gate**: an additional, independent freshness check now
+closes the gap presence alone leaves open. An ephemeral `PollFreshness` tracker
+(`src/inventory/freshness.rs`) records the timestamp of each `(location,
+asset)`
+slot's most recent successful poll, updated by the live inventory poller on
+every fetch -- independent of `InventorySnapshot`'s change suppression, so a
+static book still refreshes its timestamp on every tick. The capture job
+additionally requires every required slot to have been observed on or after the
+TARGET ET day's `00:00` midnight, not merely "observed at some point since
+process start": day-scoping (rather than plain run-scoped membership) prevents a
+slot polled once early in a long-running process's life from reading as
+permanently fresh for every later day's capture, even after the venue that fed
+it stops polling entirely -- the same stale-capture hole the gate exists to
+close, just on a longer timescale than a single restart.
+
+If a required slot never becomes fresh (a persistently failing venue, or a
+`poll_inflight_equity` outage that aborts the whole poll tick before any slot
+stamps), an escape hatch abandons that day's capture rather than blocking
+forever: `perform` gives up once `now` is more than `MAX_FRESHNESS_DEFER` (~6h)
+past the LATER of the target day's capture boundary or the poller's own
+process-start time. Anchoring to the later of the two matters for restarts: a
+process that restarts late in the trading day still gets a full defer window
+measured from when it actually started, rather than being judged solely against
+a boundary whose own window may have elapsed hours earlier (which would abandon
+the day on the very first freshness check after such a restart). Once a running
+process abandons a day, its capture loop advances to the next boundary, leaving
+that day absent from the capital series and `/pnl` coverage sparse for that run.
+A same-day process restart can currently schedule a fresh catch-up capture for
+the abandoned day; RAI-1496 tracks bounding that off-boundary recapture.
 
 **Deployed capital definition**: a day's total USD capital is the sum of cash
 (USDC) balances across every location (both trading venues plus every

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -41,7 +41,7 @@ use crate::dashboard::{
 };
 use crate::inventory::{
     BroadcastingInventory, InventoryDivergenceRecoveryCtx, InventoryPollingService,
-    InventorySnapshot, InventorySnapshotId, WalletPollingCtx,
+    InventorySnapshot, InventorySnapshotId, PollFreshness, WalletPollingCtx,
 };
 use crate::offchain::order::handle_rejection::HandleOrderRejectionCtx;
 use crate::offchain::order::poll_status::PollOrderStatusCtx;
@@ -249,7 +249,13 @@ where
     let wallet_polling_enabled = wallet_polling.is_some();
     let tokenizer = context.tokenizer;
 
+    // Constructed once and cloned into both the live poller and the daily
+    // capture job's ctx below, so `freshness_gap` (write.rs) sees exactly
+    // what this poller has stamped this run.
+    let poll_freshness = PollFreshness::new();
+
     let mut polling_service = InventoryPollingService::new(
+        poll_freshness.clone(),
         raindex_service,
         context.executor.clone(),
         context.frameworks.vault_registry.clone(),
@@ -359,6 +365,7 @@ where
         configured_equity_symbols,
         usdc_tracking_enabled: context.ctx.assets.cash.is_some(),
         wallet_polling_enabled,
+        poll_freshness,
         queue: portfolio_snapshot_queue.clone(),
     });
 

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -50,7 +50,9 @@ use crate::equity_redemption::{
     EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,
 };
 use crate::inventory::view::InFlightEquityLocation;
-use crate::inventory::{BroadcastingInventory, ImbalanceThreshold, InventoryView, Venue};
+use crate::inventory::{
+    BroadcastingInventory, ImbalanceThreshold, InventoryView, PollFreshness, Venue,
+};
 use crate::offchain::order::OffchainOrderId;
 use crate::onchain::mock::MockRaindex;
 use crate::position::{Position, PositionCommand, TradeId};
@@ -1348,6 +1350,7 @@ async fn cash_reserve_does_not_shift_rebalancing_ratio() {
     let reserved_cash = Usd::new(float!(300));
 
     let polling_service = InventoryPollingService::new(
+        PollFreshness::new(),
         raindex_service,
         executor,
         vault_registry,

--- a/src/inventory/freshness.rs
+++ b/src/inventory/freshness.rs
@@ -1,0 +1,273 @@
+//! Day-scoped poll-freshness tracking.
+//!
+//! `hydration_gap` (`crate::portfolio_snapshot::write`) gates the daily
+//! portfolio snapshot capture on PRESENCE: every required `(location, asset)`
+//! balance exists in the live `InventoryView`. On restart, the view hydrates
+//! from persisted `InventorySnapshot` state, so presence passes immediately
+//! even though the CURRENT process has not polled anything yet -- if the
+//! daily capture fires before the first poll cycle, it would otherwise
+//! persist an immutable snapshot built from a prior run's stale balances
+//! (the aggregate rejects a second `Capture`, so there is no fixing it after
+//! the fact).
+//!
+//! [`PollFreshness`] closes that hole with a FRESHNESS signal: a per-slot
+//! timestamp, updated by the poll loop
+//! (`crate::inventory::polling::InventoryPollingService`) on every successful
+//! fetch, independent of `InventorySnapshot`'s change-suppression. An earlier
+//! attempt tied freshness to that aggregate's own event watermark, which
+//! freezes whenever a poll observes an unchanged balance -- a static book
+//! would eventually block every future capture, not just a stale-hydrated
+//! one, so that attempt was reverted.
+//!
+//! The gate ([`Self::observed_since`]) is DAY-SCOPED, not merely "observed at
+//! some point this process run": a slot only counts as fresh for a given
+//! capture if its stored timestamp is at or after that capture's target ET
+//! day's midnight. Plain run-scoped membership would let a slot observed once
+//! early in a long-running process's life stay "fresh" for every later day's
+//! capture too, even after the venue that fed it stops polling entirely --
+//! reopening the same stale-capture hole this module exists to close, just on
+//! a longer timescale than the restart case above. Callers pass the floor
+//! explicitly (see `crate::portfolio_snapshot::write::freshness_gap`) rather
+//! than this module hard-coding a wall-clock window, so the gate stays
+//! decoupled from the (config-driven) poll interval.
+//!
+//! Keyed by `(PortfolioLocation, PortfolioAsset)`, the SAME identity
+//! `InventoryView::to_portfolio_snapshot_rows` and the presence gate use --
+//! keying by location alone would collapse the two co-located rows at
+//! `PortfolioLocation::BaseWalletUnwrapped` (USDC and unwrapped equity are
+//! distinct assets tracked independently at that one location).
+
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+use tracing::warn;
+
+use crate::inventory::view::{PortfolioAsset, PortfolioLocation};
+
+type LocationFreshness = HashMap<PortfolioAsset, DateTime<Utc>>;
+type FreshnessMap = HashMap<PortfolioLocation, LocationFreshness>;
+
+/// Shared state behind [`PollFreshness`]'s `Arc`: the per-slot observation
+/// timestamps, plus `created_at` -- this tracker's own construction time, used
+/// by `crate::portfolio_snapshot::write::freshness_defer_exhausted` to grant a
+/// freshly-restarted process its own defer grace window instead of judging it
+/// solely against the target day's capture boundary.
+struct Inner {
+    created_at: DateTime<Utc>,
+    map: Mutex<FreshnessMap>,
+}
+
+/// Tracks the most recent successful-poll timestamp for each
+/// `(PortfolioLocation, PortfolioAsset)` slot. See the module doc for why the
+/// read side ([`Self::observed_since`]) is day-scoped, not plain membership.
+///
+/// `std::sync::Mutex`, not `tokio::sync::Mutex`: every operation is a
+/// synchronous map read/write and no lock is ever held across an `.await`
+/// (mirrors the existing `std` mutexes in
+/// `crate::inventory::polling::InventoryPollingService`).
+#[derive(Clone)]
+pub(crate) struct PollFreshness(Arc<Inner>);
+
+impl PollFreshness {
+    /// An empty tracker, `created_at` stamped to the current instant: every
+    /// slot reads un-observed until [`Self::observe`] marks it, which is
+    /// exactly what makes the freshness signal restart-safe -- startup
+    /// hydration alone can never make a slot read fresh.
+    pub(crate) fn new() -> Self {
+        Self::with_created_at(Utc::now())
+    }
+
+    /// Test-only: builds a tracker whose [`Self::created_at`] is an injected
+    /// instant rather than the real construction time, so
+    /// `freshness_defer_exhausted`'s restart-anchored grace window can be
+    /// tested deterministically instead of racing the real wall clock.
+    #[cfg(test)]
+    pub(crate) fn new_at(created_at: DateTime<Utc>) -> Self {
+        Self::with_created_at(created_at)
+    }
+
+    fn with_created_at(created_at: DateTime<Utc>) -> Self {
+        Self(Arc::new(Inner {
+            created_at,
+            map: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    /// When this tracker was constructed (a fresh, empty map) -- i.e. this
+    /// process run's start, or an injected instant in tests.
+    pub(crate) fn created_at(&self) -> DateTime<Utc> {
+        self.0.created_at
+    }
+
+    /// Marks `(location, asset)` as observed by a successful poll just now.
+    /// Idempotent: re-observing an already-fresh slot (e.g. a second poll
+    /// tick of an unchanged balance) simply refreshes its timestamp.
+    pub(crate) fn observe(&self, location: PortfolioLocation, asset: PortfolioAsset) {
+        self.lock()
+            .entry(location)
+            .or_default()
+            .insert(asset, Utc::now());
+    }
+
+    /// Whether `(location, asset)` was observed by a successful poll at or
+    /// after `floor`. See the module doc: this is deliberately day-scoped,
+    /// not plain membership, so a slot's freshness is judged against the
+    /// specific capture it is gating, not merely "observed at some point
+    /// since process start".
+    pub(crate) fn observed_since(
+        &self,
+        location: PortfolioLocation,
+        asset: &PortfolioAsset,
+        floor: DateTime<Utc>,
+    ) -> bool {
+        self.lock()
+            .get(&location)
+            .and_then(|assets| assets.get(asset))
+            .is_some_and(|observed_at| *observed_at >= floor)
+    }
+
+    fn lock(&self) -> MutexGuard<'_, FreshnessMap> {
+        self.0.map.lock().unwrap_or_else(|poisoned| {
+            warn!(
+                target: "inventory",
+                "Poll freshness tracker was poisoned; recovering state"
+            );
+            poisoned.into_inner()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use st0x_execution::Symbol;
+
+    use super::*;
+
+    fn symbol(value: &str) -> Symbol {
+        Symbol::new(value).unwrap()
+    }
+
+    /// Any `floor` at or before construction sees no slots observed --
+    /// including the earliest representable instant, so this doubles as an
+    /// "observed ever" check.
+    #[test]
+    fn new_instance_has_no_slots_observed() {
+        let poll_freshness = PollFreshness::new();
+
+        assert!(!poll_freshness.observed_since(
+            PortfolioLocation::MarketMaking,
+            &PortfolioAsset::Usdc,
+            DateTime::<Utc>::MIN_UTC
+        ));
+    }
+
+    #[test]
+    fn observe_marks_the_exact_slot_observed_since_before_the_call() {
+        let before = Utc::now();
+        let poll_freshness = PollFreshness::new();
+
+        poll_freshness.observe(PortfolioLocation::MarketMaking, PortfolioAsset::Usdc);
+
+        assert!(poll_freshness.observed_since(
+            PortfolioLocation::MarketMaking,
+            &PortfolioAsset::Usdc,
+            before
+        ));
+    }
+
+    /// The core new behavior this module's day-scoping fix exists to provide:
+    /// a slot observed once does not read as fresh forever -- only for floors
+    /// at or before its stored timestamp.
+    #[test]
+    fn observed_since_returns_false_once_the_floor_moves_past_the_stored_timestamp() {
+        let poll_freshness = PollFreshness::new();
+
+        poll_freshness.observe(PortfolioLocation::MarketMaking, PortfolioAsset::Usdc);
+
+        let floor_in_the_future = Utc::now() + chrono::Duration::hours(1);
+        assert!(
+            !poll_freshness.observed_since(
+                PortfolioLocation::MarketMaking,
+                &PortfolioAsset::Usdc,
+                floor_in_the_future
+            ),
+            "a slot observed before the floor must not read as fresh for that floor"
+        );
+    }
+
+    #[test]
+    fn observing_one_location_does_not_mark_a_different_location_for_the_same_asset() {
+        let poll_freshness = PollFreshness::new();
+
+        poll_freshness.observe(PortfolioLocation::MarketMaking, PortfolioAsset::Usdc);
+
+        assert!(!poll_freshness.observed_since(
+            PortfolioLocation::Hedging,
+            &PortfolioAsset::Usdc,
+            DateTime::<Utc>::MIN_UTC
+        ));
+    }
+
+    /// The exact regression this module exists to prevent: keying by
+    /// location alone would collapse USDC and unwrapped equity at
+    /// `BaseWalletUnwrapped` into one slot.
+    #[test]
+    fn base_wallet_unwrapped_usdc_and_equity_are_tracked_as_distinct_slots() {
+        let poll_freshness = PollFreshness::new();
+
+        poll_freshness.observe(PortfolioLocation::BaseWalletUnwrapped, PortfolioAsset::Usdc);
+
+        assert!(poll_freshness.observed_since(
+            PortfolioLocation::BaseWalletUnwrapped,
+            &PortfolioAsset::Usdc,
+            DateTime::<Utc>::MIN_UTC
+        ));
+        assert!(!poll_freshness.observed_since(
+            PortfolioLocation::BaseWalletUnwrapped,
+            &PortfolioAsset::Equity(symbol("AAPL")),
+            DateTime::<Utc>::MIN_UTC
+        ));
+    }
+
+    #[test]
+    fn re_observing_an_already_fresh_slot_advances_its_timestamp() {
+        let poll_freshness = PollFreshness::new();
+
+        poll_freshness.observe(PortfolioLocation::Hedging, PortfolioAsset::Usdc);
+        let floor_between_the_two_observations = Utc::now();
+        poll_freshness.observe(PortfolioLocation::Hedging, PortfolioAsset::Usdc);
+
+        assert!(
+            poll_freshness.observed_since(
+                PortfolioLocation::Hedging,
+                &PortfolioAsset::Usdc,
+                floor_between_the_two_observations
+            ),
+            "the second observe must refresh the stored timestamp, not just no-op"
+        );
+    }
+
+    #[test]
+    fn cloned_handle_shares_the_same_underlying_state() {
+        let poll_freshness = PollFreshness::new();
+        let clone = poll_freshness.clone();
+
+        clone.observe(PortfolioLocation::Hedging, PortfolioAsset::Usdc);
+
+        assert!(poll_freshness.observed_since(
+            PortfolioLocation::Hedging,
+            &PortfolioAsset::Usdc,
+            DateTime::<Utc>::MIN_UTC
+        ));
+    }
+
+    #[test]
+    fn new_stamps_created_at_to_the_construction_instant() {
+        let before = Utc::now();
+        let poll_freshness = PollFreshness::new();
+        let after = Utc::now();
+
+        assert!(poll_freshness.created_at() >= before);
+        assert!(poll_freshness.created_at() <= after);
+    }
+}

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -2,6 +2,7 @@
 
 mod broadcasting;
 pub(crate) mod divergence;
+mod freshness;
 mod polling;
 pub(crate) mod projection;
 pub(crate) mod snapshot;
@@ -12,6 +13,7 @@ pub(crate) use st0x_config::ImbalanceThreshold;
 
 pub(crate) use broadcasting::BroadcastingInventory;
 pub(crate) use divergence::{InventoryDivergenceGate, InventoryDivergenceRecoveryCtx};
+pub(crate) use freshness::PollFreshness;
 #[cfg(test)]
 pub(crate) use polling::PollerError;
 pub(crate) use polling::{

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -26,9 +26,11 @@ use st0x_tokenization::{TokenizationRequestType, Tokenizer, TokenizerError};
 
 use super::divergence::InventoryDivergenceRecoveryCtx;
 use super::view::Venue;
+use crate::inventory::freshness::PollFreshness;
 use crate::inventory::snapshot::{
     InventorySnapshot, InventorySnapshotCommand, InventorySnapshotId,
 };
+use crate::inventory::view::{PortfolioAsset, PortfolioLocation};
 use crate::rebalancing::usdc::{UsdcTransferError, u256_to_usdc};
 use crate::vault_registry::{VaultRegistry, VaultRegistryId};
 
@@ -166,6 +168,12 @@ where
     /// Consecutive diverging polls per symbol. Kept in memory on purpose: a
     /// restart resets the count, and restart hydration restores the view.
     divergence_counters: Mutex<HashMap<Symbol, u32>>,
+    /// Stamped on every successful sub-poll fetch this run, so the
+    /// daily portfolio snapshot capture can gate on FRESHNESS in addition to
+    /// presence. Defaults to a fresh, empty tracker; production wiring passes
+    /// the same clone the capture job's `PortfolioSnapshotCtx` reads
+    /// (`crate::conductor::builder`).
+    poll_freshness: PollFreshness,
 }
 
 impl<Chain, Exe> InventoryPollingService<Chain, Exe>
@@ -175,6 +183,7 @@ where
 {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        poll_freshness: PollFreshness,
         raindex_service: Arc<RaindexService<Chain>>,
         executor: Exe,
         vault_registry: Arc<Store<VaultRegistry>>,
@@ -205,6 +214,7 @@ where
             reserved_cash,
             divergence_recovery: None,
             divergence_counters: Mutex::new(HashMap::new()),
+            poll_freshness,
         }
     }
 
@@ -380,12 +390,23 @@ where
             });
         }
 
+        let symbols: Vec<Symbol> = balances.keys().cloned().collect();
+
         self.snapshot
             .send(
                 snapshot_id,
                 InventorySnapshotCommand::OnchainEquity { balances },
             )
             .await?;
+
+        // Stamped only after `send` returns Ok, so a failed persist (which
+        // propagates via `?` above) never leaves this slot falsely fresh.
+        for symbol in symbols {
+            self.poll_freshness.observe(
+                PortfolioLocation::MarketMaking,
+                PortfolioAsset::Equity(symbol),
+            );
+        }
 
         Ok(())
     }
@@ -426,6 +447,11 @@ where
             )
             .await?;
 
+        // Stamped only after `send` returns Ok, so a failed persist (which
+        // propagates via `?` above) never leaves this slot falsely fresh.
+        self.poll_freshness
+            .observe(PortfolioLocation::MarketMaking, PortfolioAsset::Usdc);
+
         Ok(())
     }
 
@@ -450,6 +476,7 @@ where
                 &wallets.unwrapped_equity_token_addresses,
             )
             .await?;
+        let symbols: Vec<Symbol> = balances.keys().cloned().collect();
 
         if !balances.is_empty() {
             self.snapshot
@@ -460,9 +487,21 @@ where
                 .await?;
         }
 
+        // Reached whether or not `send` ran above (a configured token polled
+        // to a zero balance is still a real observation), but never reached
+        // when `send` errors, so a failed persist never leaves these slots
+        // falsely fresh.
+        for symbol in symbols {
+            self.poll_freshness.observe(
+                PortfolioLocation::BaseWalletUnwrapped,
+                PortfolioAsset::Equity(symbol),
+            );
+        }
+
         let balances = self
             .poll_base_wallet_token_balances(&wallets.base, &wallets.wrapped_equity_token_addresses)
             .await?;
+        let symbols: Vec<Symbol> = balances.keys().cloned().collect();
 
         if !balances.is_empty() {
             self.snapshot
@@ -471,6 +510,13 @@ where
                     InventorySnapshotCommand::BaseWalletWrappedEquity { balances },
                 )
                 .await?;
+        }
+
+        for symbol in symbols {
+            self.poll_freshness.observe(
+                PortfolioLocation::BaseWalletWrapped,
+                PortfolioAsset::Equity(symbol),
+            );
         }
 
         Ok(())
@@ -499,6 +545,11 @@ where
             )
             .await?;
 
+        // Stamped only after `send` returns Ok, so a failed persist (which
+        // propagates via `?` above) never leaves this slot falsely fresh.
+        self.poll_freshness
+            .observe(PortfolioLocation::EthereumWallet, PortfolioAsset::Usdc);
+
         Ok(())
     }
 
@@ -524,6 +575,11 @@ where
                 InventorySnapshotCommand::BaseWalletUsdc { usdc_balance },
             )
             .await?;
+
+        // Stamped only after `send` returns Ok, so a failed persist (which
+        // propagates via `?` above) never leaves this slot falsely fresh.
+        self.poll_freshness
+            .observe(PortfolioLocation::BaseWalletUnwrapped, PortfolioAsset::Usdc);
 
         Ok(())
     }
@@ -573,6 +629,7 @@ where
         };
 
         let positions = self.normalize_offchain_positions(inventory.positions);
+        let symbols: Vec<Symbol> = positions.keys().cloned().collect();
 
         self.snapshot
             .send(
@@ -583,6 +640,13 @@ where
                 },
             )
             .await?;
+
+        // Stamped only after `send` returns Ok, so a failed persist (which
+        // propagates via `?` above) never leaves these slots falsely fresh.
+        for symbol in symbols {
+            self.poll_freshness
+                .observe(PortfolioLocation::Hedging, PortfolioAsset::Equity(symbol));
+        }
 
         let (gross_usd_cents, available_usd_cents) =
             compute_available_cash(inventory.usd_balance_cents, self.reserved_cash)?;
@@ -596,6 +660,11 @@ where
                 },
             )
             .await?;
+
+        // Stamped only after `send` returns Ok, so a failed persist (which
+        // propagates via `?` above) never leaves this slot falsely fresh.
+        self.poll_freshness
+            .observe(PortfolioLocation::Hedging, PortfolioAsset::Usdc);
 
         self.snapshot
             .send(
@@ -1533,6 +1602,7 @@ mod tests {
         let executor = MockExecutor::new().with_inventory(inventory.clone());
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -1592,6 +1662,7 @@ mod tests {
         let executor = MockExecutor::new().with_inventory(inventory);
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -1658,6 +1729,7 @@ mod tests {
         let executor = MockExecutor::new().with_inventory(inventory);
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -1717,6 +1789,7 @@ mod tests {
         let executor = MockExecutor::new().with_inventory(inventory);
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -1770,6 +1843,7 @@ mod tests {
         let reserved = Usd::new(float!(50000)); // $50,000 reserved
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -1831,6 +1905,7 @@ mod tests {
         let reserved = Usd::new(float!(50000)); // $50,000 reserved > balance
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -1890,6 +1965,7 @@ mod tests {
         let executor = MockExecutor::new().with_inventory(inventory);
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -1948,6 +2024,7 @@ mod tests {
         let executor = MockExecutor::new().with_inventory(inventory);
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -1987,6 +2064,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2052,6 +2130,7 @@ mod tests {
         let executor = MockExecutor::new().with_inventory(inventory);
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2100,6 +2179,7 @@ mod tests {
         let executor = MockExecutor::new().with_inventory(inventory);
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2150,6 +2230,7 @@ mod tests {
         let executor = MockExecutor::new().with_inventory(inventory);
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2248,6 +2329,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2302,6 +2384,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2357,6 +2440,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2420,6 +2504,7 @@ mod tests {
         let raindex_service = create_test_raindex_service(provider);
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             MockExecutor::new(),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2473,6 +2558,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2514,6 +2600,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2576,6 +2663,7 @@ mod tests {
         let raindex_service = create_test_raindex_service(provider);
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             MockExecutor::new(),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2628,6 +2716,7 @@ mod tests {
         let raindex_service = create_test_raindex_service(provider);
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             MockExecutor::new(),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2677,6 +2766,7 @@ mod tests {
         };
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             MockExecutor::new().with_inventory(inventory),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2728,6 +2818,7 @@ mod tests {
         };
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             MockExecutor::new().with_inventory(inventory),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2772,6 +2863,7 @@ mod tests {
         };
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             MockExecutor::new().with_inventory(inventory),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2816,6 +2908,7 @@ mod tests {
             Arc::new(st0x_tokenization::mock::MockTokenizer::new().with_list_pending_failure());
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             MockExecutor::new().with_inventory(inventory),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2837,6 +2930,76 @@ mod tests {
             events.is_empty(),
             "Inflight poll failure must abort the tick before any balance \
              snapshot is emitted, but got: {events:?}"
+        );
+    }
+
+    /// `MAX_FRESHNESS_DEFER`'s doc comment (`crate::portfolio_snapshot::write`)
+    /// names a persistent `poll_inflight_equity` outage -- which aborts the
+    /// whole poll tick before any of the onchain/wallet/offchain groups run --
+    /// as one of the two motivating scenarios for the escape hatch. This is
+    /// the freshness-side counterpart to the test above: not only must no
+    /// `InventorySnapshot` event be emitted, `PollFreshness` itself must stay
+    /// fully unobserved, so a future refactor that accidentally moved an
+    /// `observe()` call ahead of the inflight-equity check would be caught
+    /// here.
+    #[tokio::test]
+    async fn poll_and_record_leaves_poll_freshness_fully_unobserved_when_inflight_poll_aborts_the_tick()
+     {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(provider.clone());
+        let (orderbook, order_owner) = test_addresses();
+        let symbol = test_symbol("AAPL");
+
+        // Inventory is present, so poll_offchain would stamp Hedging
+        // equity/USDC freshness if the tick were allowed to continue past the
+        // failed inflight poll.
+        let inventory = Inventory {
+            positions: vec![EquityPosition {
+                symbol: symbol.clone(),
+                quantity: test_shares(5),
+                market_value: Some(float!(750)),
+            }],
+            usd_balance_cents: 10_000_000,
+            cash_buying_power_cents: Some(10_000_000),
+            alpaca_usdc: Some(Usdc::new(float!(125.75))),
+            cash_withdrawable_cents: None,
+        };
+
+        let tokenizer =
+            Arc::new(st0x_tokenization::mock::MockTokenizer::new().with_list_pending_failure());
+
+        let poll_freshness = PollFreshness::new();
+        let service = InventoryPollingService::new(
+            poll_freshness.clone(),
+            raindex_service,
+            MockExecutor::new().with_inventory(inventory),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            order_owner,
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            Some(tokenizer),
+            Usd::ZERO,
+        );
+
+        service.poll_and_record().await.unwrap();
+
+        let equity_asset = PortfolioAsset::Equity(symbol);
+        assert!(
+            !observed(&poll_freshness, PortfolioLocation::Hedging, &equity_asset),
+            "Hedging equity must stay unobserved when the inflight poll aborts the whole tick"
+        );
+        assert!(
+            !observed(
+                &poll_freshness,
+                PortfolioLocation::Hedging,
+                &PortfolioAsset::Usdc
+            ),
+            "Hedging USDC must stay unobserved when the inflight poll aborts the whole tick"
         );
     }
 
@@ -2896,6 +3059,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2945,6 +3109,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -2989,6 +3154,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3031,6 +3197,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3077,6 +3244,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3117,6 +3285,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3163,6 +3332,7 @@ mod tests {
         };
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             MockExecutor::new().with_inventory(inventory),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3220,6 +3390,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3274,6 +3445,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3330,6 +3502,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3383,6 +3556,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3438,6 +3612,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3511,6 +3686,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3562,6 +3738,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3618,6 +3795,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3674,6 +3852,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3722,6 +3901,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3861,6 +4041,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3914,6 +4095,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -3960,6 +4142,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -4000,6 +4183,7 @@ mod tests {
             Arc::new(st0x_tokenization::mock::MockTokenizer::new().with_pending_requests(vec![]));
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -4060,6 +4244,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -4127,6 +4312,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -4195,6 +4381,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -4260,6 +4447,7 @@ mod tests {
         let executor = MockExecutor::new();
 
         let service = InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -4382,6 +4570,7 @@ mod tests {
         let executor = MockExecutor::new().with_inventory(zero_broker_inventory());
 
         InventoryPollingService::new(
+            PollFreshness::new(),
             raindex_service,
             executor,
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
@@ -4878,5 +5067,504 @@ mod tests {
             !gate.is_engaged(&spym),
             "the sent escalation must lift the transfer gate"
         );
+    }
+
+    // PollFreshness stamping. The constructor requires a caller-owned handle
+    // so tests can inspect exactly what got stamped, mirroring how production
+    // wires the same clone into `PortfolioSnapshotCtx`
+    // (`crate::conductor::builder`).
+
+    /// Test-only "was this slot ever observed, at all" check --
+    /// `PollFreshness::observed_since` is day-scoped and needs an explicit
+    /// floor (see `crate::portfolio_snapshot::write`'s tests for coverage of
+    /// that day-scoping); the polling tests in this module only care whether
+    /// a sub-poll stamped a slot at all, so `DateTime::<Utc>::MIN_UTC` is
+    /// always at or before any real stamp.
+    fn observed(
+        poll_freshness: &PollFreshness,
+        location: PortfolioLocation,
+        asset: &PortfolioAsset,
+    ) -> bool {
+        poll_freshness.observed_since(location, asset, chrono::DateTime::<Utc>::MIN_UTC)
+    }
+
+    /// The core regression this feature exists to fix: an earlier attempt
+    /// tied freshness to `InventorySnapshot`'s own event watermark, which
+    /// freezes whenever a poll observes an UNCHANGED balance (that aggregate
+    /// returns `Ok(vec![])`, emitting no event -- see
+    /// `InventorySnapshot::transition`'s `OnchainEquity` arm). Two ticks with
+    /// the identical balance must still leave the slot observed AT OR AFTER a
+    /// floor captured before either tick, proving the day-scoped signal is
+    /// stamped (and its timestamp advanced) on every successful fetch,
+    /// independent of the aggregate's change-suppression.
+    #[tokio::test]
+    async fn poll_freshness_stamped_on_both_ticks_of_a_static_onchain_equity_book() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+
+        discover_equity_vault(
+            &pool,
+            orderbook,
+            order_owner,
+            TEST_TOKEN,
+            TEST_VAULT_ID,
+            test_symbol("AAPL"),
+        )
+        .await;
+
+        let asserter = Asserter::new();
+        asserter.push_success(&vault_balance_hex(float!(7))); // tick 1
+        asserter.push_success(&vault_balance_hex(float!(7))); // tick 2, unchanged
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let raindex_service = create_test_raindex_service(provider);
+
+        let poll_freshness = PollFreshness::new();
+        let service = InventoryPollingService::new(
+            poll_freshness.clone(),
+            raindex_service,
+            MockExecutor::new(),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            order_owner,
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            None,
+            Usd::ZERO,
+        );
+
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        let asset = PortfolioAsset::Equity(test_symbol("AAPL"));
+        // Captured before tick 1: both ticks' stamps must land at or after
+        // this instant, proving the day-scoped timestamp is refreshed on
+        // every successful fetch, not just set once.
+        let floor = Utc::now();
+
+        service.poll_onchain(&snapshot_id).await.unwrap();
+        assert!(
+            poll_freshness.observed_since(PortfolioLocation::MarketMaking, &asset, floor),
+            "tick 1 must stamp freshness at/after the floor"
+        );
+
+        service.poll_onchain(&snapshot_id).await.unwrap();
+        assert!(
+            poll_freshness.observed_since(PortfolioLocation::MarketMaking, &asset, floor),
+            "tick 2 (unchanged balance) must still stamp freshness at/after the floor -- the \
+             day-scoped signal is independent of InventorySnapshot's change-suppression"
+        );
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        let onchain_equity_events = events
+            .iter()
+            .filter(|event| matches!(event, InventorySnapshotEvent::OnchainEquity { .. }))
+            .count();
+        assert_eq!(
+            onchain_equity_events, 1,
+            "the aggregate must have suppressed the second, unchanged-balance event -- freshness \
+             must not depend on the aggregate actually emitting one"
+        );
+    }
+
+    /// A zero on-chain balance for a configured wallet-transit symbol is
+    /// still a real observation and must be stamped, even though the send of
+    /// `BaseWalletUnwrappedEquity` is gated by `if !balances.is_empty()`
+    /// (the map has one entry here, so that guard passes regardless -- the
+    /// point under test is that stamping happens for every symbol actually
+    /// queried, not filtered by a nonzero balance).
+    #[tokio::test]
+    async fn poll_wallets_stamps_base_wallet_unwrapped_equity_freshness_even_at_zero_balance() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(provider.clone());
+        let (orderbook, order_owner) = test_addresses();
+
+        let token_addr = address!("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        let zero_encoded = alloy::hex::encode_prefixed(U256::ZERO.abi_encode());
+        let asserter = Asserter::new();
+        asserter.push_success(&zero_encoded); // base wallet USDC balanceOf (zero)
+        asserter.push_success(&zero_encoded); // equity token balanceOf (zero)
+        let base_wallet = MockBaseWallet::with_asserter(&asserter);
+
+        let mut equity_tokens = HashMap::new();
+        equity_tokens.insert(test_symbol("AAPL"), token_addr);
+
+        let server = MockServer::start();
+        let poll_freshness = PollFreshness::new();
+
+        let service = InventoryPollingService::new(
+            poll_freshness.clone(),
+            raindex_service,
+            MockExecutor::new(),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            order_owner,
+            Arc::new(test_store(pool.clone(), ())),
+            Some(WalletPollingCtx {
+                base: base_wallet,
+                unwrapped_equity_token_addresses: equity_tokens,
+                ..mock_wallet_polling_ctx(&server)
+            }),
+            None,
+            Usd::ZERO,
+        );
+
+        service.poll_and_record().await.unwrap();
+
+        assert!(
+            observed(
+                &poll_freshness,
+                PortfolioLocation::BaseWalletUnwrapped,
+                &PortfolioAsset::Equity(test_symbol("AAPL"))
+            ),
+            "a zero on-chain balance is still a real observation and must be stamped"
+        );
+    }
+
+    /// A failed fetch must leave its slot un-observed, so the freshness gate
+    /// keeps it closed rather than treating a failed venue as polled.
+    #[tokio::test]
+    async fn poll_wallets_ethereum_rpc_failure_leaves_ethereum_usdc_freshness_unobserved() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(provider.clone());
+        let (orderbook, order_owner) = test_addresses();
+
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("Ethereum RPC failure");
+        let ethereum_wallet = MockEthereumWallet::with_asserter(&asserter);
+
+        let server = MockServer::start();
+        let poll_freshness = PollFreshness::new();
+
+        let service = InventoryPollingService::new(
+            poll_freshness.clone(),
+            raindex_service,
+            MockExecutor::new(),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            order_owner,
+            Arc::new(test_store(pool.clone(), ())),
+            Some(WalletPollingCtx {
+                ethereum: ethereum_wallet,
+                ..mock_wallet_polling_ctx(&server)
+            }),
+            None,
+            Usd::ZERO,
+        );
+
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        let error = service.poll_wallets(&snapshot_id).await.unwrap_err();
+        assert!(matches!(error, InventoryPollingError::Evm(_)));
+
+        assert!(
+            !observed(
+                &poll_freshness,
+                PortfolioLocation::EthereumWallet,
+                &PortfolioAsset::Usdc
+            ),
+            "a failed fetch must leave the slot un-observed so the gate keeps it closed"
+        );
+    }
+
+    /// Onchain-vault-fetch failure leg of the same invariant: an RPC failure
+    /// while fetching an equity vault's balance must leave that symbol's
+    /// MarketMaking slot un-observed, mirroring
+    /// `poll_wallets_ethereum_rpc_failure_leaves_ethereum_usdc_freshness_unobserved`
+    /// for the onchain side.
+    #[tokio::test]
+    async fn poll_onchain_equity_vault_rpc_failure_leaves_market_making_equity_freshness_unobserved()
+     {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+
+        discover_equity_vault(
+            &pool,
+            orderbook,
+            order_owner,
+            TEST_TOKEN,
+            TEST_VAULT_ID,
+            test_symbol("AAPL"),
+        )
+        .await;
+
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("RPC failure"); // vaultBalance2 for equity vault
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let raindex_service = create_test_raindex_service(provider);
+
+        let poll_freshness = PollFreshness::new();
+        let service = InventoryPollingService::new(
+            poll_freshness.clone(),
+            raindex_service,
+            MockExecutor::new(),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            order_owner,
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            None,
+            Usd::ZERO,
+        );
+
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        let error = service.poll_onchain(&snapshot_id).await.unwrap_err();
+        assert!(matches!(error, InventoryPollingError::Raindex(_)));
+
+        assert!(
+            !observed(
+                &poll_freshness,
+                PortfolioLocation::MarketMaking,
+                &PortfolioAsset::Equity(test_symbol("AAPL"))
+            ),
+            "a failed vault-balance fetch must leave the slot un-observed so the gate keeps it \
+             closed"
+        );
+    }
+
+    /// Wallet-fetch failure leg of the same invariant, on the BASE wallet
+    /// USDC slot (distinct from the ethereum-wallet slot already covered by
+    /// `poll_wallets_ethereum_rpc_failure_leaves_ethereum_usdc_freshness_unobserved`):
+    /// a failed base-wallet balance fetch must leave `BaseWalletUnwrapped`'s
+    /// USDC slot un-observed, even though `poll_ethereum_usdc` (which runs
+    /// first in `poll_wallets`) succeeded and stamped its own slot.
+    #[tokio::test]
+    async fn poll_wallets_base_wallet_rpc_failure_leaves_base_wallet_usdc_freshness_unobserved() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(provider.clone());
+        let (orderbook, order_owner) = test_addresses();
+
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("Base RPC failure");
+        let base_wallet = MockBaseWallet::with_asserter(&asserter);
+
+        let server = MockServer::start();
+        let poll_freshness = PollFreshness::new();
+
+        let service = InventoryPollingService::new(
+            poll_freshness.clone(),
+            raindex_service,
+            MockExecutor::new(),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            order_owner,
+            Arc::new(test_store(pool.clone(), ())),
+            Some(WalletPollingCtx {
+                base: base_wallet,
+                ..mock_wallet_polling_ctx(&server)
+            }),
+            None,
+            Usd::ZERO,
+        );
+
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        let error = service.poll_wallets(&snapshot_id).await.unwrap_err();
+        assert!(matches!(error, InventoryPollingError::Evm(_)));
+
+        assert!(
+            !observed(
+                &poll_freshness,
+                PortfolioLocation::BaseWalletUnwrapped,
+                &PortfolioAsset::Usdc
+            ),
+            "a failed fetch must leave the slot un-observed so the gate keeps it closed"
+        );
+        assert!(
+            observed(
+                &poll_freshness,
+                PortfolioLocation::EthereumWallet,
+                &PortfolioAsset::Usdc
+            ),
+            "the ethereum-wallet slot, which succeeded before the base-wallet failure, must \
+             stay observed"
+        );
+    }
+
+    /// Exercises the onchain-equity/onchain-usdc/offchain-equity/offchain-usdc
+    /// leg of the row->sub-poll mapping table in one
+    /// successful `poll_and_record`: (MarketMaking, Equity), (Hedging,
+    /// Equity), (MarketMaking, Usdc), (Hedging, Usdc).
+    #[tokio::test]
+    async fn poll_and_record_stamps_onchain_and_offchain_freshness_slots_on_success() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let symbol = test_symbol("AAPL");
+
+        discover_equity_vault(
+            &pool,
+            orderbook,
+            order_owner,
+            TEST_TOKEN,
+            TEST_VAULT_ID,
+            symbol.clone(),
+        )
+        .await;
+        discover_usdc_vault(&pool, orderbook, order_owner, TEST_VAULT_ID).await;
+
+        let asserter = Asserter::new();
+        asserter.push_success(&vault_balance_hex(float!(7))); // equity vaultBalance2
+        asserter.push_success(&vault_balance_hex(float!(3))); // usdc vaultBalance2
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let raindex_service = create_test_raindex_service(provider);
+
+        let inventory = Inventory {
+            positions: vec![EquityPosition {
+                symbol: symbol.clone(),
+                quantity: test_shares(5),
+                market_value: Some(float!(750)),
+            }],
+            usd_balance_cents: 10_000_000,
+            cash_buying_power_cents: Some(10_000_000),
+            alpaca_usdc: None,
+            cash_withdrawable_cents: None,
+        };
+        let executor = MockExecutor::new().with_inventory(inventory);
+
+        let poll_freshness = PollFreshness::new();
+        let service = InventoryPollingService::new(
+            poll_freshness.clone(),
+            raindex_service,
+            executor,
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            order_owner,
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            None,
+            Usd::ZERO,
+        );
+
+        service.poll_and_record().await.unwrap();
+
+        let equity_asset = PortfolioAsset::Equity(symbol);
+        assert!(observed(
+            &poll_freshness,
+            PortfolioLocation::MarketMaking,
+            &equity_asset
+        ));
+        assert!(observed(
+            &poll_freshness,
+            PortfolioLocation::Hedging,
+            &equity_asset
+        ));
+        assert!(observed(
+            &poll_freshness,
+            PortfolioLocation::MarketMaking,
+            &PortfolioAsset::Usdc
+        ));
+        assert!(observed(
+            &poll_freshness,
+            PortfolioLocation::Hedging,
+            &PortfolioAsset::Usdc
+        ));
+    }
+
+    /// The wallet-transit leg of the row->sub-poll mapping table:
+    /// (EthereumWallet, Usdc), (BaseWalletUnwrapped, Usdc),
+    /// (BaseWalletUnwrapped, Equity), (BaseWalletWrapped, Equity).
+    #[tokio::test]
+    async fn poll_wallets_stamps_freshness_for_all_wallet_transit_slots_on_success() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(provider.clone());
+        let (orderbook, order_owner) = test_addresses();
+        let symbol = test_symbol("AAPL");
+
+        let zero_encoded = alloy::hex::encode_prefixed(U256::ZERO.abi_encode());
+
+        let ethereum_asserter = Asserter::new();
+        ethereum_asserter.push_success(&zero_encoded);
+        let ethereum_wallet = MockEthereumWallet::with_asserter(&ethereum_asserter);
+
+        let base_asserter = Asserter::new();
+        base_asserter.push_success(&zero_encoded); // base wallet USDC
+        base_asserter.push_success(&zero_encoded); // unwrapped equity balanceOf
+        base_asserter.push_success(&zero_encoded); // wrapped equity balanceOf
+        let base_wallet = MockBaseWallet::with_asserter(&base_asserter);
+
+        let token_addr = address!("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        let mut unwrapped_equity_token_addresses = HashMap::new();
+        unwrapped_equity_token_addresses.insert(symbol.clone(), token_addr);
+        let mut wrapped_equity_token_addresses = HashMap::new();
+        wrapped_equity_token_addresses.insert(symbol.clone(), token_addr);
+
+        let poll_freshness = PollFreshness::new();
+        let service = InventoryPollingService::new(
+            poll_freshness.clone(),
+            raindex_service,
+            MockExecutor::new(),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            order_owner,
+            Arc::new(test_store(pool.clone(), ())),
+            Some(WalletPollingCtx {
+                ethereum: ethereum_wallet,
+                base: base_wallet,
+                unwrapped_equity_token_addresses,
+                wrapped_equity_token_addresses,
+            }),
+            None,
+            Usd::ZERO,
+        );
+
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        service.poll_wallets(&snapshot_id).await.unwrap();
+
+        let equity_asset = PortfolioAsset::Equity(symbol);
+        assert!(observed(
+            &poll_freshness,
+            PortfolioLocation::EthereumWallet,
+            &PortfolioAsset::Usdc
+        ));
+        assert!(observed(
+            &poll_freshness,
+            PortfolioLocation::BaseWalletUnwrapped,
+            &PortfolioAsset::Usdc
+        ));
+        assert!(observed(
+            &poll_freshness,
+            PortfolioLocation::BaseWalletUnwrapped,
+            &equity_asset
+        ));
+        assert!(observed(
+            &poll_freshness,
+            PortfolioLocation::BaseWalletWrapped,
+            &equity_asset
+        ));
     }
 }

--- a/src/portfolio_snapshot/write.rs
+++ b/src/portfolio_snapshot/write.rs
@@ -20,9 +20,12 @@
 //! Return Tracking"):** one snapshot per ET day, labeled by the ET day it is
 //! captured on, taken at/after that day's `CAPTURE_BUFFER` boundary using
 //! same-day inventory ([`hydration_gap`] guarantees COMPLETE -- every
-//! required slot has been polled at least once this run; see that
-//! function's doc for the presence-vs-freshness tradeoff accepted for v1).
-//! In steady state this fires once a day, right after the
+//! required slot has a row this run; [`freshness_gap`] additionally
+//! guarantees FRESH -- every required slot was observed by a poll on or after
+//! the TARGET ET day's midnight, day-scoped rather than merely "observed at
+//! some point this process run", closing both the restart-stale hole AND the
+//! long-running-process hole presence alone cannot see; see both functions'
+//! docs). In steady state this fires once a day, right after the
 //! boundary. If a restart or a stuck hydration retry causes `perform` to
 //! run after its `target_et_day` has already passed, it CATCHES UP to a
 //! fresh reading for the CURRENT ET day rather than either back-dating a live
@@ -43,7 +46,7 @@ use chrono::{DateTime, Datelike, Days, NaiveDate, TimeZone, Utc};
 use chrono_tz::America::New_York;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::warn;
+use tracing::{error, warn};
 
 use st0x_event_sorcery::{AggregateError, LifecycleError, Projection, SendError, Store};
 use st0x_execution::{FractionalShares, Symbol};
@@ -55,7 +58,7 @@ use super::{
 };
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::inventory::{
-    BroadcastingInventory, InventoryViewError, PortfolioAsset, PortfolioBalanceRow,
+    BroadcastingInventory, InventoryViewError, PollFreshness, PortfolioAsset, PortfolioBalanceRow,
     PortfolioLocation,
 };
 use crate::position::Position;
@@ -80,6 +83,16 @@ const HYDRATION_RETRY_BACKOFF: Duration = Duration::from_secs(5 * 60);
 /// rather than any change to `target_et_day`.
 const EARLY_WAKE_BACKOFF: Duration = HYDRATION_RETRY_BACKOFF;
 
+/// Bounds how long [`freshness_gap`] may keep deferring today's capture
+/// before giving up and abandoning the day entirely (livelock escape
+/// hatch): a venue that never polls this run -- or a persistent
+/// `poll_inflight_equity` outage, which aborts the whole poll tick before any
+/// slot stamps (`crate::inventory::polling`) -- would otherwise block capture
+/// forever. ~6h: long enough to ride out a startup hydration retry loop or a
+/// temporary venue outage, short enough that a genuinely stuck freshness
+/// signal does not silently swallow the whole trading day's capital sample.
+const MAX_FRESHNESS_DEFER: chrono::Duration = chrono::Duration::hours(6);
+
 /// Shared dependencies for the [`PortfolioSnapshotJob`].
 pub(crate) struct PortfolioSnapshotCtx {
     pub(crate) inventory: Arc<BroadcastingInventory>,
@@ -103,6 +116,13 @@ pub(crate) struct PortfolioSnapshotCtx {
     /// locations (Ethereum wallet, Base wallet unwrapped/wrapped) to have
     /// been polled at least once before capture.
     pub(crate) wallet_polling_enabled: bool,
+    /// Ephemeral "observed this run" freshness signal, stamped by the live
+    /// inventory poller on every successful sub-poll
+    /// (`crate::inventory::polling`). Wired from the same clone the poller
+    /// got (`crate::conductor::builder`), so [`freshness_gap`] sees exactly
+    /// what this process has actually polled -- closing the restart-stale
+    /// hole [`hydration_gap`] alone cannot see (see that function's doc).
+    pub(crate) poll_freshness: PollFreshness,
     pub(crate) queue: PortfolioSnapshotJobQueue,
 }
 
@@ -164,7 +184,21 @@ impl Job<PortfolioSnapshotCtx> for PortfolioSnapshotJob {
     }
 
     async fn perform(&self, ctx: &PortfolioSnapshotCtx) -> Result<Self::Output, Self::Error> {
-        let now = Utc::now();
+        self.perform_at(ctx, Utc::now()).await
+    }
+}
+
+impl PortfolioSnapshotJob {
+    /// The full body of [`Job::perform`], with `now` taken as a parameter
+    /// instead of read from the wall clock, so tests can deterministically
+    /// exercise time-dependent branches (the freshness-defer escape hatch in
+    /// particular) without racing real time. `perform` itself is a thin
+    /// `Utc::now()` -> here delegation.
+    async fn perform_at(
+        &self,
+        ctx: &PortfolioSnapshotCtx,
+        now: DateTime<Utc>,
+    ) -> Result<(), PortfolioSnapshotJobError> {
         let today = et_day(now);
 
         if self.target_et_day > today {
@@ -192,6 +226,39 @@ impl Job<PortfolioSnapshotCtx> for PortfolioSnapshotJob {
             );
         }
         let target_et_day = today;
+
+        // Freshness is checked BEFORE the inventory view is read: the live
+        // poller always updates the view and only then stamps
+        // `poll_freshness` (see each `observe()` call site's own comment in
+        // `crate::inventory::polling`), so checking freshness first and
+        // reading `rows` only after it passes guarantees the captured rows
+        // can never predate the freshness confirmation that gated them. The
+        // reverse order (read `rows` first, check freshness second) would let
+        // a poll tick land in the gap between the two reads, stamping
+        // freshness for a view that has since moved past the already-read
+        // `rows` -- see this module's `PortfolioSnapshotCtx::poll_freshness`
+        // doc.
+        if let Some(gap) = freshness_gap(ctx, target_et_day) {
+            if !freshness_defer_exhausted(target_et_day, now, ctx.poll_freshness.created_at()) {
+                warn!(
+                    %gap,
+                    %target_et_day,
+                    "Portfolio snapshot capture skipped this tick: inventory view is not fresh \
+                     yet this run; retrying shortly"
+                );
+                return ctx.reschedule(target_et_day, HYDRATION_RETRY_BACKOFF).await;
+            }
+
+            error!(
+                %gap,
+                %target_et_day,
+                max_freshness_defer = ?MAX_FRESHNESS_DEFER,
+                "Portfolio snapshot capture never became fresh within the defer window; \
+                 abandoning today's capture rather than persisting stale data"
+            );
+            let (delay, next_target_et_day) = next_capture_delay(now);
+            return ctx.reschedule(next_target_et_day, delay).await;
+        }
 
         let rows = {
             let view = ctx.inventory.read().await;
@@ -345,8 +412,61 @@ fn next_capture_delay(now: DateTime<Utc>) -> (Duration, NaiveDate) {
     (delay, target_et_day)
 }
 
-/// Checks that every REQUIRED `(location, asset)` balance has been observed
-/// at least once this run -- i.e. is PRESENT in `rows`
+/// Enumerates every `(location, asset)` slot the daily portfolio snapshot
+/// capture requires to have been observed before it may capture, driven by
+/// `configured_equity_symbols`, `usdc_tracking_enabled`, and
+/// `wallet_polling_enabled`. Shared by both [`hydration_gap`] (PRESENCE --
+/// the slot has a row in the live `InventoryView`) and [`freshness_gap`]
+/// (FRESHNESS -- the slot has been observed by a poll THIS process run,
+/// membership) so the two gates can never diverge on what "complete" means.
+fn required_slots(
+    ctx: &PortfolioSnapshotCtx,
+) -> impl Iterator<Item = (PortfolioLocation, PortfolioAsset)> + '_ {
+    let equity_pairs = ctx.configured_equity_symbols.iter().flat_map(|symbol| {
+        [PortfolioLocation::MarketMaking, PortfolioLocation::Hedging]
+            .into_iter()
+            .map(move |location| (location, PortfolioAsset::Equity(symbol.clone())))
+    });
+
+    let usdc_pairs = ctx
+        .usdc_tracking_enabled
+        .then_some([PortfolioLocation::MarketMaking, PortfolioLocation::Hedging])
+        .into_iter()
+        .flatten()
+        .map(|location| (location, PortfolioAsset::Usdc));
+
+    let wallet_usdc_pairs = ctx
+        .wallet_polling_enabled
+        .then_some([
+            PortfolioLocation::EthereumWallet,
+            PortfolioLocation::BaseWalletUnwrapped,
+        ])
+        .into_iter()
+        .flatten()
+        .map(|location| (location, PortfolioAsset::Usdc));
+
+    let wallet_equity_pairs = ctx
+        .wallet_polling_enabled
+        .then(|| ctx.configured_equity_symbols.iter())
+        .into_iter()
+        .flatten()
+        .flat_map(|symbol| {
+            [
+                PortfolioLocation::BaseWalletUnwrapped,
+                PortfolioLocation::BaseWalletWrapped,
+            ]
+            .into_iter()
+            .map(move |location| (location, PortfolioAsset::Equity(symbol.clone())))
+        });
+
+    equity_pairs
+        .chain(usdc_pairs)
+        .chain(wallet_usdc_pairs)
+        .chain(wallet_equity_pairs)
+}
+
+/// Checks that every REQUIRED `(location, asset)` balance ([`required_slots`])
+/// has been observed at least once this run -- i.e. is PRESENT in `rows`
 /// (`InventoryView::to_portfolio_snapshot_rows` only emits a row for a slot
 /// once it has actually been polled, distinguishing "never polled" from
 /// "polled to a genuine zero balance"; see that function's doc comment). A
@@ -355,75 +475,88 @@ fn next_capture_delay(now: DateTime<Utc>) -> (Duration, NaiveDate) {
 /// unconditionally rejects a second `Capture`). Returns a human-readable
 /// description of the first gap found, or `None` if fully hydrated.
 ///
-/// **v1 accepted limitation** (see SPEC.md "Portfolio Capital and Return
-/// Tracking"): this is a PRESENCE gate, not a FRESHNESS gate -- it does not
-/// verify the observation happened recently, only that it happened at all
-/// this run (including via startup hydration replaying a persisted
-/// `InventorySnapshot`'s original readings). An earlier revision attempted a
-/// time-window freshness gate on top of presence, but `InventorySnapshot`
-/// suppresses events (and their watermarks) whenever a poll observes an
-/// unchanged balance, so the watermark freezes on a static book and the
-/// freshness window would eventually block every future capture, not just a
-/// stale-hydrated one. In steady state this job only wakes shortly after the
-/// ET-midnight `CAPTURE_BUFFER` boundary, by which point the poller has
-/// already polled fresh this run, so the residual risk is narrow: a restart
-/// that hydrates stale data from a persisted snapshot and then captures
-/// before the poller gets a chance to poll again. A robust poll-driven
-/// freshness signal (distinct from `InventorySnapshot`'s change-suppressed
-/// events) is a tracked follow-up, accepted as out of scope for v1.
+/// This is a PRESENCE gate, not a FRESHNESS gate -- it does not verify the
+/// observation happened recently, only that it happened at all this run
+/// (including via startup hydration replaying a persisted
+/// `InventorySnapshot`'s original readings). [`freshness_gap`] is the
+/// poll-driven freshness signal that closes the restart-stale hole this gate
+/// alone cannot see; both run in `perform`, FRESHNESS first (it only needs
+/// `ctx`, not `rows`, so it gates before the inventory view is even read) and
+/// PRESENCE second, against the rows read after that freshness check passed
+/// -- never the reverse, so a captured row can never predate the freshness
+/// confirmation that gated it.
 fn hydration_gap(rows: &[PortfolioBalanceRow], ctx: &PortfolioSnapshotCtx) -> Option<String> {
     let present: HashSet<(PortfolioLocation, &PortfolioAsset)> =
         rows.iter().map(|row| (row.location, &row.asset)).collect();
 
-    let is_polled = |location: PortfolioLocation, asset: &PortfolioAsset| -> bool {
-        present.contains(&(location, asset))
+    required_slots(ctx).find_map(|(location, asset)| {
+        if present.contains(&(location, &asset)) {
+            None
+        } else {
+            Some(format!("{asset} not yet polled at {location}"))
+        }
+    })
+}
+
+/// Checks that every REQUIRED `(location, asset)` slot ([`required_slots`])
+/// has been observed by a successful poll on or after `target_et_day`'s ET
+/// midnight (`PollFreshness::observed_since` -- see
+/// `crate::inventory::freshness`). Closes two holes [`hydration_gap`] alone
+/// cannot see: (1) the restart-stale hole -- after a restart the inventory
+/// view hydrates from persisted `InventorySnapshot` state, so presence passes
+/// immediately even though the current process has not polled anything yet;
+/// (2) a slot observed once early in a long-running process's life staying
+/// "fresh" for every later day's capture even after the venue that fed it
+/// stops polling entirely -- day-scoping, not plain run-scoped membership, is
+/// what closes this second hole (see `crate::inventory::freshness`'s module
+/// doc). Returns a human-readable description of the first un-observed slot,
+/// or `None` if every required slot has been freshly polled since that day's
+/// midnight. A DST-ambiguous midnight (`et_midnight` returns `None`) is
+/// treated as a gap: retry rather than guessing a floor.
+fn freshness_gap(ctx: &PortfolioSnapshotCtx, target_et_day: NaiveDate) -> Option<String> {
+    let Some(floor) = et_midnight(target_et_day) else {
+        warn!(
+            %target_et_day,
+            "Ambiguous ET midnight while checking portfolio snapshot freshness; treating as not \
+             yet fresh"
+        );
+        return Some(format!(
+            "ET midnight for {target_et_day} is ambiguous (DST transition)"
+        ));
     };
 
-    for symbol in &ctx.configured_equity_symbols {
-        for location in [PortfolioLocation::MarketMaking, PortfolioLocation::Hedging] {
-            let asset = PortfolioAsset::Equity(symbol.clone());
-            if !is_polled(location, &asset) {
-                return Some(format!("{symbol} not yet polled at {location}"));
-            }
+    required_slots(ctx).find_map(|(location, asset)| {
+        if ctx.poll_freshness.observed_since(location, &asset, floor) {
+            None
+        } else {
+            Some(format!(
+                "{asset} not observed by a poll on/after {target_et_day} at {location}"
+            ))
         }
-    }
+    })
+}
 
-    if ctx.usdc_tracking_enabled {
-        for location in [PortfolioLocation::MarketMaking, PortfolioLocation::Hedging] {
-            if !is_polled(location, &PortfolioAsset::Usdc) {
-                return Some(format!("USDC not yet polled at {location}"));
-            }
-        }
-    }
-
-    if ctx.wallet_polling_enabled {
-        for location in [
-            PortfolioLocation::EthereumWallet,
-            PortfolioLocation::BaseWalletUnwrapped,
-        ] {
-            if !is_polled(location, &PortfolioAsset::Usdc) {
-                return Some(format!(
-                    "USDC wallet-transit balance not yet polled at {location}"
-                ));
-            }
-        }
-
-        for symbol in &ctx.configured_equity_symbols {
-            for location in [
-                PortfolioLocation::BaseWalletUnwrapped,
-                PortfolioLocation::BaseWalletWrapped,
-            ] {
-                let asset = PortfolioAsset::Equity(symbol.clone());
-                if !is_polled(location, &asset) {
-                    return Some(format!(
-                        "{symbol} wallet-transit balance not yet polled at {location}"
-                    ));
-                }
-            }
-        }
-    }
-
-    None
+/// Whether [`freshness_gap`]'s escape hatch should abandon `target_et_day`'s
+/// capture rather than keep deferring it: true once `now` is more than
+/// [`MAX_FRESHNESS_DEFER`] past the LATER of that day's capture boundary or
+/// `poll_freshness_created_at` (livelock fix -- see this module's `perform`
+/// for the caller). Anchoring to only the day's boundary would give a
+/// freshly-restarted process almost no grace on a restart late in the trading
+/// day (the boundary+defer window may have already elapsed hours earlier);
+/// taking the max with the tracker's own construction time instead grants
+/// such a restart a full `MAX_FRESHNESS_DEFER` window from when it actually
+/// started polling, while a long-running process (whose `poll_freshness` was
+/// created well before the boundary) is still bounded by the boundary-anchored
+/// window as before. A DST-ambiguous boundary (`et_midnight` returns `None`)
+/// is treated as "not yet exhausted": keep retrying rather than guessing.
+fn freshness_defer_exhausted(
+    target_et_day: NaiveDate,
+    now: DateTime<Utc>,
+    poll_freshness_created_at: DateTime<Utc>,
+) -> bool {
+    et_midnight(target_et_day)
+        .map(|midnight| midnight + CAPTURE_BUFFER)
+        .is_some_and(|boundary| now > boundary.max(poll_freshness_created_at) + MAX_FRESHNESS_DEFER)
 }
 
 /// Converts MarketMaking-venue and BaseWalletWrapped-transit equity balances
@@ -632,6 +765,7 @@ mod tests {
     use chrono::TimeZone;
     use sqlx::SqlitePool;
     use tokio::sync::broadcast;
+    use tokio::time::timeout;
 
     use st0x_config::ExecutionThreshold;
     use st0x_dto::Statement;
@@ -687,17 +821,36 @@ mod tests {
             configured_equity_symbols,
             usdc_tracking_enabled,
             wallet_polling_enabled,
+            // Always starts empty, mirroring a fresh process boot: callers
+            // that need the freshness gate to pass call
+            // `mark_all_required_fresh` explicitly, the same way they mutate
+            // `ctx.inventory` to simulate a poll landing.
+            poll_freshness: PollFreshness::new(),
             queue,
         };
 
         (ctx, position)
     }
 
+    /// Observes every `(location, asset)` slot [`required_slots`] would name
+    /// for `ctx`, onto `ctx.poll_freshness` -- the test-side stand-in for
+    /// what a real poll tick (`crate::inventory::polling`) would stamp,
+    /// without needing a fully wired `InventoryPollingService` in every
+    /// `write.rs` test. Reuses the same enumeration `freshness_gap` itself
+    /// walks, so a test marking "all required slots fresh" can never drift
+    /// from what the gate actually requires.
+    fn mark_all_required_fresh(ctx: &PortfolioSnapshotCtx) {
+        for (location, asset) in required_slots(ctx) {
+            ctx.poll_freshness.observe(location, asset);
+        }
+    }
+
     /// A view with equity and USDC balances present at both venues for
-    /// `symbol` -- `hydration_gap` is a PRESENCE gate (v1, see its doc
-    /// comment), so `with_equity`/`with_usdc` alone are sufficient; this
-    /// helper exists purely so callers can pass one `InventoryView` around
-    /// instead of chaining both builders inline at every call site.
+    /// `symbol` -- `hydration_gap` is a PRESENCE gate, so `with_equity`/
+    /// `with_usdc` alone are sufficient; this helper exists purely so callers
+    /// can pass one `InventoryView` around instead of chaining both builders
+    /// inline at every call site. Callers that also need the FRESHNESS gate
+    /// to pass must additionally call `mark_all_required_fresh`.
     fn freshly_polled_view(
         symbol: Symbol,
         onchain: FractionalShares,
@@ -724,7 +877,7 @@ mod tests {
             Usdc::new(float!(500)),
         );
 
-        build_ctx(
+        let (ctx, position) = build_ctx(
             pool,
             apalis_pool,
             view,
@@ -733,7 +886,11 @@ mod tests {
             false,
             Some(Arc::new(MockWrapper::new())),
         )
-        .await
+        .await;
+
+        mark_all_required_fresh(&ctx);
+
+        (ctx, position)
     }
 
     async fn portfolio_snapshot_job_count(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {
@@ -820,6 +977,7 @@ mod tests {
             None,
         )
         .await;
+        mark_all_required_fresh(&ctx);
 
         pool.close().await;
 
@@ -873,6 +1031,96 @@ mod tests {
         assert_eq!(
             et_day(after_midnight),
             NaiveDate::from_ymd_opt(2026, 7, 15).unwrap()
+        );
+    }
+
+    /// The DST spring-forward gap (2026: 2am ET on March 8, second Sunday of
+    /// March) is 02:00-03:00 local, never midnight -- so `et_midnight` for
+    /// this calendar day is an ordinary, unambiguous EST instant, not the
+    /// `None` branch. Locks in that assumption so a future change to the
+    /// transition-detection logic that wrongly treats midnight itself as
+    /// ambiguous is caught here, not first noticed on a real DST day.
+    #[test]
+    fn et_midnight_on_the_spring_forward_date_is_an_unambiguous_est_instant() {
+        let spring_forward_day = NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
+
+        let midnight = et_midnight(spring_forward_day).unwrap();
+
+        assert_eq!(midnight, Utc.with_ymd_and_hms(2026, 3, 8, 5, 0, 0).unwrap());
+    }
+
+    /// Complements the spring-forward test: the DST fall-back ambiguous
+    /// window (2026: 1am-2am ET on November 1, first Sunday of November) is
+    /// also never midnight, so `et_midnight` for this calendar day is an
+    /// ordinary, unambiguous EDT instant.
+    #[test]
+    fn et_midnight_on_the_fall_back_date_is_an_unambiguous_edt_instant() {
+        let fall_back_day = NaiveDate::from_ymd_opt(2026, 11, 1).unwrap();
+
+        let midnight = et_midnight(fall_back_day).unwrap();
+
+        assert_eq!(
+            midnight,
+            Utc.with_ymd_and_hms(2026, 11, 1, 4, 0, 0).unwrap()
+        );
+    }
+
+    /// `freshness_gap`'s DST-ambiguous branch (`et_midnight` returning
+    /// `None`) is never reached on a real spring-forward day -- this locks in
+    /// that a target day right on the transition still gates and passes
+    /// normally, not via the "treating as not yet fresh" ambiguous-midnight
+    /// arm.
+    #[tokio::test]
+    async fn freshness_gap_passes_normally_on_the_spring_forward_et_day() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_ctx(
+            pool,
+            apalis_pool,
+            InventoryView::default(),
+            HashSet::from([aapl()]),
+            true,
+            false,
+            None,
+        )
+        .await;
+        mark_all_required_fresh(&ctx);
+
+        let target_et_day = NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
+        assert_eq!(
+            freshness_gap(&ctx, target_et_day),
+            None,
+            "spring-forward midnight is unambiguous, so a freshly-observed slot must pass \
+             normally, not hit the DST-ambiguous gap branch"
+        );
+    }
+
+    /// `freshness_defer_exhausted`'s DST-ambiguous branch (treats `None` as
+    /// "never exhausted") is never reached on a real fall-back day -- this
+    /// locks in that ordinary within-window/past-window defer behavior holds
+    /// on that day, not the always-keep-retrying ambiguous-midnight arm.
+    #[test]
+    fn freshness_defer_exhausted_behaves_normally_on_the_fall_back_et_day() {
+        let target_et_day = NaiveDate::from_ymd_opt(2026, 11, 1).unwrap();
+        let boundary = et_midnight(target_et_day).unwrap() + CAPTURE_BUFFER;
+        let poll_freshness_created_at = boundary - chrono::Duration::days(1);
+
+        assert!(
+            !freshness_defer_exhausted(
+                target_et_day,
+                boundary + MAX_FRESHNESS_DEFER - chrono::Duration::minutes(1),
+                poll_freshness_created_at
+            ),
+            "fall-back midnight is unambiguous, so ordinary within-defer-window behavior must \
+             hold, not the DST-ambiguous never-exhausted branch"
+        );
+        assert!(
+            freshness_defer_exhausted(
+                target_et_day,
+                boundary + MAX_FRESHNESS_DEFER + chrono::Duration::minutes(1),
+                poll_freshness_created_at
+            ),
+            "fall-back midnight is unambiguous, so the day must still become abandonable past \
+             the defer window"
         );
     }
 
@@ -969,6 +1217,7 @@ mod tests {
             Some(Arc::new(MockWrapper::new())),
         )
         .await;
+        mark_all_required_fresh(&ctx);
 
         job_for_today().perform(&ctx).await.unwrap();
 
@@ -1072,6 +1321,10 @@ mod tests {
                 Usdc::new(float!(500)),
             );
         }
+        // Mirrors what a real poll tick would additionally stamp alongside
+        // the view update above: presence alone (the view mutation) is not
+        // enough once the freshness gate is in play.
+        mark_all_required_fresh(&ctx);
 
         job_for_today().perform(&ctx).await.unwrap();
         assert_eq!(portfolio_snapshot_row_count(&pool, &et_day_string).await, 4);
@@ -1269,7 +1522,10 @@ mod tests {
     /// Round-3 fix scenario (a): a job whose `target_et_day` is yesterday
     /// (hydration stuck past midnight, or a very late wake) must capture
     /// TODAY's fresh balances under TODAY's id -- never back-date a live read
-    /// under yesterday's stale id.
+    /// under yesterday's stale id. `build_fully_hydrated_ctx` marks every
+    /// required slot fresh, so this also doubles as the "catch-up
+    /// succeeds once fresh" half of the catch-up+freshness coverage -- the
+    /// complementary "catch-up is gated by freshness" half is the next test.
     #[tokio::test]
     async fn perform_past_its_target_day_catches_up_and_captures_under_today() {
         let (pool, apalis_pool) = setup_test_pools().await;
@@ -1291,6 +1547,48 @@ mod tests {
             portfolio_snapshot_row_count(&pool, &today.to_string()).await,
             4,
             "the catch-up must contain the complete four-row fixture under today"
+        );
+    }
+
+    /// Complements the test above: the catch-up rebind to today must still be
+    /// gated by FRESHNESS, not just presence -- a fully-hydrated view
+    /// (presence passes) with an empty `PollFreshness` (nothing observed by a
+    /// poll this run) must never capture, even under the rebound `today` id.
+    #[tokio::test]
+    async fn catch_up_capture_is_gated_by_freshness_even_when_presence_gate_passes() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let view = freshly_polled_view(
+            aapl(),
+            FractionalShares::new(float!(10)),
+            FractionalShares::new(float!(5)),
+            Usdc::new(float!(1000)),
+            Usdc::new(float!(500)),
+        );
+        let (ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool,
+            view,
+            HashSet::from([aapl()]),
+            true,
+            false,
+            Some(Arc::new(MockWrapper::new())),
+        )
+        .await;
+        // Deliberately no `mark_all_required_fresh`: presence passes (the
+        // view is fully hydrated) but nothing has been observed by a poll
+        // this run.
+
+        let today = et_day(Utc::now());
+        let stale_job = PortfolioSnapshotJob {
+            target_et_day: today - Days::new(1),
+        };
+
+        stale_job.perform(&ctx).await.unwrap();
+
+        assert_eq!(
+            portfolio_snapshot_row_count(&pool, &today.to_string()).await,
+            0,
+            "the catch-up rebind to today must still be gated by freshness, not just presence"
         );
     }
 
@@ -1602,6 +1900,7 @@ mod tests {
             None,
         )
         .await;
+        mark_all_required_fresh(&ctx);
 
         let error = job_for_today().perform(&ctx).await.unwrap_err();
 
@@ -1668,6 +1967,7 @@ mod tests {
             Some(Arc::new(MockWrapper::with_ratio(ratio_1_5))),
         )
         .await;
+        mark_all_required_fresh(&ctx);
 
         job_for_today().perform(&ctx).await.unwrap();
 
@@ -1716,6 +2016,359 @@ mod tests {
             inflight_balance(&pool, &et_day, "base_wallet_unwrapped").await,
             "3",
             "unwrapped transit balance is already underlying units and must stay unconverted"
+        );
+    }
+
+    /// Proves `perform_at` checks `freshness_gap` before it ever reads
+    /// `ctx.inventory` (the fix for the restart-stale race: reading `rows`
+    /// first would let a poll tick land in the gap between the read and the
+    /// freshness check, stamping freshness for a view that has since moved
+    /// past the already-captured `rows`). Holds the inventory's write lock
+    /// for the whole call: if `perform_at` regressed to reading the view
+    /// before rejecting on an unmet freshness gate, the read would deadlock
+    /// against this held write guard (same task, non-reentrant
+    /// `tokio::sync::RwLock`) and the `timeout` below would fire instead of
+    /// `perform_at` returning promptly.
+    #[tokio::test]
+    async fn freshness_gate_is_checked_before_the_inventory_view_is_read() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_ctx(
+            pool,
+            apalis_pool,
+            InventoryView::default(),
+            HashSet::from([aapl()]),
+            true,
+            false,
+            None,
+        )
+        .await;
+        // Deliberately no `mark_all_required_fresh`: freshness_gap must fail
+        // and the job must reschedule without ever touching ctx.inventory.
+
+        let _held_write_guard = ctx.inventory.write().await;
+
+        let perform_result = timeout(Duration::from_millis(200), job_for_today().perform(&ctx))
+            .await
+            .expect(
+                "perform_at must reject on the freshness gate before reading ctx.inventory; \
+                 timed out waiting for the held write lock, meaning the view was read first",
+            );
+        perform_result.unwrap();
+    }
+
+    // freshness_gap and its escape hatch.
+
+    #[tokio::test]
+    async fn freshness_gap_blocks_when_a_required_slot_was_never_observed_since_target_et_day() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_ctx(
+            pool,
+            apalis_pool,
+            InventoryView::default(),
+            HashSet::from([aapl()]),
+            true,
+            false,
+            None,
+        )
+        .await;
+
+        // Deterministic: with a single configured symbol, `required_slots`
+        // always yields (MarketMaking, Equity(AAPL)) first.
+        let target_et_day = et_day(Utc::now());
+        assert_eq!(
+            freshness_gap(&ctx, target_et_day),
+            Some(format!(
+                "AAPL not observed by a poll on/after {target_et_day} at market_making"
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn freshness_gap_passes_when_every_required_slot_was_observed_on_or_after_target_et_day()
+    {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_ctx(
+            pool,
+            apalis_pool,
+            InventoryView::default(),
+            HashSet::from([aapl()]),
+            true,
+            false,
+            None,
+        )
+        .await;
+
+        mark_all_required_fresh(&ctx);
+        // Re-observing an already-fresh slot (simulating a second poll tick
+        // of an unchanged balance) must not un-freshen it -- the core
+        // regression this module exists to fix: a static book
+        // must stay fresh across ticks, unlike the reverted
+        // InventorySnapshot-watermark-based attempt.
+        mark_all_required_fresh(&ctx);
+
+        assert_eq!(freshness_gap(&ctx, et_day(Utc::now())), None);
+    }
+
+    /// Proves the `(location, asset)` key does not collapse the two
+    /// co-located rows at `BaseWalletUnwrapped`: USDC observed, equity not,
+    /// must still block on the equity slot specifically.
+    #[tokio::test]
+    async fn base_wallet_unwrapped_equity_and_usdc_freshness_are_tracked_independently() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_ctx(
+            pool,
+            apalis_pool,
+            InventoryView::default(),
+            HashSet::from([aapl()]),
+            false,
+            true,
+            None,
+        )
+        .await;
+
+        for (location, asset) in required_slots(&ctx) {
+            if location == PortfolioLocation::BaseWalletUnwrapped
+                && asset == PortfolioAsset::Equity(aapl())
+            {
+                continue;
+            }
+            ctx.poll_freshness.observe(location, asset);
+        }
+
+        let target_et_day = et_day(Utc::now());
+        assert_eq!(
+            freshness_gap(&ctx, target_et_day),
+            Some(format!(
+                "AAPL not observed by a poll on/after {target_et_day} at base_wallet_unwrapped"
+            ))
+        );
+        assert!(
+            ctx.poll_freshness.observed_since(
+                PortfolioLocation::BaseWalletUnwrapped,
+                &PortfolioAsset::Usdc,
+                DateTime::<Utc>::MIN_UTC
+            ),
+            "the USDC leg at the same location must remain observed"
+        );
+    }
+
+    #[test]
+    fn freshness_defer_exhausted_false_within_the_defer_window() {
+        let target_et_day = NaiveDate::from_ymd_opt(2026, 7, 15).unwrap();
+        let boundary = et_midnight(target_et_day).unwrap() + CAPTURE_BUFFER;
+        let now = boundary + MAX_FRESHNESS_DEFER - chrono::Duration::minutes(1);
+        // A long-running process: created well before the boundary, so the
+        // boundary alone drives exhaustion, matching this test's original
+        // (pre-restart-anchoring) semantics.
+        let poll_freshness_created_at = boundary - chrono::Duration::days(1);
+
+        assert!(!freshness_defer_exhausted(
+            target_et_day,
+            now,
+            poll_freshness_created_at
+        ));
+    }
+
+    #[test]
+    fn freshness_defer_exhausted_true_past_the_defer_window() {
+        let target_et_day = NaiveDate::from_ymd_opt(2026, 7, 15).unwrap();
+        let boundary = et_midnight(target_et_day).unwrap() + CAPTURE_BUFFER;
+        let now = boundary + MAX_FRESHNESS_DEFER + chrono::Duration::minutes(1);
+        let poll_freshness_created_at = boundary - chrono::Duration::days(1);
+
+        assert!(freshness_defer_exhausted(
+            target_et_day,
+            now,
+            poll_freshness_created_at
+        ));
+    }
+
+    #[test]
+    fn freshness_defer_exhausted_false_exactly_at_the_defer_window_boundary() {
+        let target_et_day = NaiveDate::from_ymd_opt(2026, 7, 15).unwrap();
+        let boundary = et_midnight(target_et_day).unwrap() + CAPTURE_BUFFER;
+        let now = boundary + MAX_FRESHNESS_DEFER;
+        let poll_freshness_created_at = boundary - chrono::Duration::days(1);
+
+        assert!(
+            !freshness_defer_exhausted(target_et_day, now, poll_freshness_created_at),
+            "exactly at the boundary must still defer (strictly greater-than triggers abandonment)"
+        );
+    }
+
+    /// Round-4 fix (restart-anchoring): a process that restarts late in the
+    /// trading day must still get a full `MAX_FRESHNESS_DEFER` grace window
+    /// measured from when IT started, not from the target day's boundary
+    /// (which may have elapsed its own defer window hours earlier). Here the
+    /// boundary+defer window ended long ago, but `poll_freshness` was only
+    /// created an hour ago.
+    #[test]
+    fn freshness_defer_exhausted_grants_full_window_from_a_late_restart_not_the_days_boundary() {
+        let target_et_day = NaiveDate::from_ymd_opt(2026, 7, 15).unwrap();
+        let boundary = et_midnight(target_et_day).unwrap() + CAPTURE_BUFFER;
+        let poll_freshness_created_at = boundary + chrono::Duration::hours(20);
+        let now = poll_freshness_created_at + chrono::Duration::hours(1);
+
+        assert!(
+            !freshness_defer_exhausted(target_et_day, now, poll_freshness_created_at),
+            "a freshly-restarted process must get its own MAX_FRESHNESS_DEFER grace window, not \
+             be judged against the day's boundary alone"
+        );
+    }
+
+    /// Complements the test above: once that late restart's OWN grace window
+    /// elapses, the day must still be abandoned.
+    #[test]
+    fn freshness_defer_exhausted_true_once_a_late_restarts_own_grace_window_elapses() {
+        let target_et_day = NaiveDate::from_ymd_opt(2026, 7, 15).unwrap();
+        let boundary = et_midnight(target_et_day).unwrap() + CAPTURE_BUFFER;
+        let poll_freshness_created_at = boundary + chrono::Duration::hours(20);
+        let now = poll_freshness_created_at + MAX_FRESHNESS_DEFER + chrono::Duration::minutes(1);
+
+        assert!(freshness_defer_exhausted(
+            target_et_day,
+            now,
+            poll_freshness_created_at
+        ));
+    }
+
+    /// Deterministic coverage of `perform_at`'s "keep deferring" branch
+    /// (finding: the prior single wall-clock-dependent test could not tell
+    /// which of the two escape-hatch branches it exercised on a given CI
+    /// run). `now` is pinned inside the defer window, so the freshness-gap
+    /// failure must reschedule under the SAME `target_et_day` with the short
+    /// hydration-retry backoff, never capture.
+    #[tokio::test]
+    async fn perform_at_keeps_deferring_target_et_day_when_freshness_gap_fails_within_the_defer_window()
+     {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let view = freshly_polled_view(
+            aapl(),
+            FractionalShares::new(float!(10)),
+            FractionalShares::new(float!(5)),
+            Usdc::new(float!(1000)),
+            Usdc::new(float!(500)),
+        );
+        let (mut ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool.clone(),
+            view,
+            HashSet::from([aapl()]),
+            true,
+            false,
+            Some(Arc::new(MockWrapper::new())),
+        )
+        .await;
+        // Deliberately no `mark_all_required_fresh`: presence passes (the
+        // view is fully hydrated) but nothing has been observed by a poll
+        // this run -- exactly the restart-stale hole freshness_gap closes.
+
+        let target_et_day = NaiveDate::from_ymd_opt(2026, 7, 15).unwrap();
+        let boundary = et_midnight(target_et_day).unwrap() + CAPTURE_BUFFER;
+        let now = boundary + chrono::Duration::minutes(1);
+        // A long-running process, created well before the boundary, so the
+        // boundary alone (not this test's `now`) determines the defer state.
+        ctx.poll_freshness = PollFreshness::new_at(boundary - chrono::Duration::days(1));
+
+        let job = PortfolioSnapshotJob { target_et_day };
+        job.perform_at(&ctx, now).await.unwrap();
+
+        assert_eq!(
+            portfolio_snapshot_row_count(&pool, &target_et_day.to_string()).await,
+            0,
+            "freshness gap must block capture even though presence-only hydration_gap passes"
+        );
+
+        let rescheduled_job: Vec<u8> =
+            sqlx_apalis::query_scalar("SELECT job FROM Jobs WHERE job_type = ? LIMIT 1")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        let rescheduled: PortfolioSnapshotJob = serde_json::from_slice(&rescheduled_job).unwrap();
+        assert_eq!(
+            rescheduled.target_et_day, target_et_day,
+            "within the defer window, the retry must keep targeting the same day"
+        );
+    }
+
+    /// Deterministic coverage of `perform_at`'s "abandon the day" branch: the
+    /// actual livelock-escape-hatch behavior this feature introduces. `now`
+    /// is pinned past `MAX_FRESHNESS_DEFER`, so the job must give up on
+    /// `target_et_day`, never capture stale data, and reschedule under the
+    /// NEXT capture day computed by `next_capture_delay`.
+    #[tokio::test]
+    async fn perform_at_abandons_target_et_day_once_the_defer_window_is_exhausted() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let view = freshly_polled_view(
+            aapl(),
+            FractionalShares::new(float!(10)),
+            FractionalShares::new(float!(5)),
+            Usdc::new(float!(1000)),
+            Usdc::new(float!(500)),
+        );
+        let (mut ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool.clone(),
+            view,
+            HashSet::from([aapl()]),
+            true,
+            false,
+            Some(Arc::new(MockWrapper::new())),
+        )
+        .await;
+        // Deliberately no `mark_all_required_fresh`.
+
+        let target_et_day = NaiveDate::from_ymd_opt(2026, 7, 15).unwrap();
+        let boundary = et_midnight(target_et_day).unwrap() + CAPTURE_BUFFER;
+        let now = boundary + MAX_FRESHNESS_DEFER + chrono::Duration::minutes(1);
+        // A long-running process: the boundary-anchored window alone must
+        // drive this exhaustion, not a fresh restart's own grace window.
+        ctx.poll_freshness = PollFreshness::new_at(boundary - chrono::Duration::days(1));
+
+        let job = PortfolioSnapshotJob { target_et_day };
+        // `reschedule` (via apalis's `push_with_delay`) anchors `run_at` to
+        // the REAL wall clock at insertion time, not the fictitious injected
+        // `now` -- only the delay's LENGTH is derived from `now`.
+        let real_before = Utc::now();
+        job.perform_at(&ctx, now).await.unwrap();
+
+        assert_eq!(
+            portfolio_snapshot_row_count(&pool, &target_et_day.to_string()).await,
+            0,
+            "the abandoned day must never be captured with stale data"
+        );
+
+        let (expected_delay, expected_next_target_et_day) = next_capture_delay(now);
+        assert_ne!(
+            expected_next_target_et_day, target_et_day,
+            "sanity: the abandon branch must advance to a different day"
+        );
+
+        let rescheduled_job: Vec<u8> =
+            sqlx_apalis::query_scalar("SELECT job FROM Jobs WHERE job_type = ? LIMIT 1")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        let rescheduled: PortfolioSnapshotJob = serde_json::from_slice(&rescheduled_job).unwrap();
+        assert_eq!(
+            rescheduled.target_et_day, expected_next_target_et_day,
+            "past the defer window, the job must abandon target_et_day and advance to the next \
+             capture day computed by next_capture_delay, never resume retrying the abandoned day"
+        );
+
+        let run_at: i64 =
+            sqlx_apalis::query_scalar("SELECT run_at FROM Jobs WHERE job_type = ? LIMIT 1")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        let expected_run_at =
+            real_before.timestamp() + i64::try_from(expected_delay.as_secs()).unwrap();
+        assert!(
+            (run_at - expected_run_at).abs() <= 5,
+            "expected run_at near {expected_run_at}, got {run_at}"
         );
     }
 }


### PR DESCRIPTION
## What

- Gate the daily portfolio-snapshot capture on poll-driven freshness. A snapshot is now written only from balances that the current run actually polled on this Eastern Time (ET) day, never from stale hydrated state after a restart.
- Add a new ephemeral `PollFreshness` type (`src/inventory/freshness.rs`). It holds in-memory, per-`(location, asset)` timestamps of the last successful poll, stamped by the poll loop in `src/inventory/polling.rs`.
- Add a new `freshness_gap` check, layered on the existing presence gate in `src/portfolio_snapshot/write.rs`, plus a `MAX_FRESHNESS_DEFER` escape hatch.

## Why

- The capture gate (`hydration_gap`) checked only PRESENCE, that a row exists, not freshness. On restart the inventory view hydrates from persisted `InventorySnapshot` state, so rows exist immediately. If the ~00:05 ET capture fires before the first poll, it persists that day's IMMUTABLE snapshot from prior-run balances, with no way to fix it afterward.
- An earlier wall-clock freshness attempt was reverted. `InventorySnapshot::transition` suppresses events, and their watermarks, on unchanged balances, so watermarks freeze on a static book. This new signal is fetch-driven, so it does not depend on that suppression.
- [RAI-1475](https://linear.app/makeitrain/issue/RAI-1475/poll-driven-freshness-signal-for-daily-portfolio-snapshot-capture).

## How

- Freshness is stamped only AFTER the CQRS `send` call persists. A failed persist never latches false freshness over a stale view row. Freshness is also stamped on every successful fetch, so an unchanged, static book still keeps advancing. This is the behavior the reverted attempt got wrong.
- The gate checks "observed since `et_midnight(target_et_day)`" against the stored timestamp, not membership. This makes the gate day-scoped without coupling it to the poll interval, so a slot polled once does not read fresh forever across days.
- Escape hatch: keep deferring up to `max(capture_boundary, process_start) + MAX_FRESHNESS_DEFER`, then abandon the day rather than capture stale data. A missing day is left as a gap, never a fabricated snapshot. The window is anchored to process start, so a late restart still gets a full grace window.
- One `PollFreshness` clone is wired into both the inventory poller and `PortfolioSnapshotCtx`, through the conductor builder.
- This change has no migration and no `SCHEMA_VERSION` change. Freshness is ephemeral runtime state. Persisting it would only bloat the event stream and fight compaction.

## Testing

- New unit tests cover `freshness.rs`, `polling.rs`, and `write.rs`: a static book stays fresh through the gate, `(location, asset)` slots are tracked independently (BaseWalletUnwrapped USDC versus equity), a zero-balance fetch still stamps, a fetch error or an inflight abort leaves slots unobserved, the day-scoped floor holds, the escape hatch defers then abandons (and never captures stale data), Daylight Saving Time (DST) spring-forward and fall-back both work, and the freshness gate runs before the view read.

## Screenshots

N/A (backend).

## Anything else

- **Known follow-up:** a same-day restart after abandoning a day can re-attempt and capture it off-boundary. The data is fresh and for the correct day, just not captured at the ~00:05 boundary. The fix needs a design choice between a durable per-day "abandoned" marker and a boundary-anchored cap on capture lateness that reverses the process-start anchoring above. I did not decide that here. It is now filed as [RAI-1496](https://linear.app/makeitrain/issue/RAI-1496/prevent-off-boundary-recapture-of-an-abandoned-portfolio-snapshot-day).
- Stacked on #1054.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily portfolio snapshots now require inventory data to have been successfully refreshed since the start of the target day.
  * Freshness is tracked for each portfolio location and asset, including zero-balance assets and unchanged inventory.
* **Bug Fixes**
  * Prevented snapshots from relying on stale data after restarts or missed polling updates.
  * Capture jobs now abandon an unavailable day after a defined defer period and schedule the next eligible capture instead of waiting indefinitely.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->