### PR TITLE
feat: track price-observation timestamp on Position for mark staleness

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -696,14 +696,16 @@ aggregate) as of capture time. A symbol with a balance but no observed price yet
 is recorded with `usd_mark = NULL` -- never a fabricated zero. Marks are fixed
 permanently at capture time as part of the immutable event payload: a later
 price correction does not retroactively change a previously reported day's
-capital. The persisted `mark_captured_at` is `Position.last_updated`, not a
-dedicated price-observation timestamp -- a precise one is a deferred follow-up.
-`last_updated` is the aggregate's last-touched time and is advanced by several
-non-price events too (offchain order placement/fill/cancel, threshold updates),
-so it is only an upper bound on how recently the price was actually observed:
-the staleness guard below reliably excludes a day once the _position_ has gone
-stale, but is not guaranteed to exclude every day with a genuinely stale price
-if that position was otherwise recently touched.
+capital. The persisted `mark_captured_at` is `Position.last_price_observed_at`,
+a dedicated price-observation timestamp set only by the events that also set
+`last_price_usdc` (`OnChainOrderFilled`, using the fill's `block_timestamp`, and
+priced `ManualPositionAdjusted`, using `adjusted_at`). This is distinct from
+`last_updated`, the aggregate's last-touched time, which is also advanced by
+non-price events (offchain order placement/fill/cancel, threshold updates) that
+leave `last_price_observed_at` untouched. So the staleness guard below keys off
+how recently the price itself was actually observed, and does exclude a day with
+a genuinely stale price even when the position was otherwise recently touched by
+a non-price event.
 
 **Derived `/pnl` fields**: for a queried date range, a day's total USD capital
 is computed only when every nonzero-balance row that day has a known, non-stale
@@ -1404,6 +1406,9 @@ struct Position {
                                      // dollar-threshold hedging. None until a
                                      // priced fill or manual adjustment sets it.
     last_updated: Option<DateTime<Utc>>,
+    last_price_observed_at: Option<DateTime<Utc>>,  // When last_price_usdc was
+                                     // observed; set only by price-bearing
+                                     // events, paired with last_price_usdc.
 }
 
 enum ExecutionThreshold {

--- a/src/portfolio_snapshot/write.rs
+++ b/src/portfolio_snapshot/write.rs
@@ -620,19 +620,15 @@ async fn convert_wrapped_equity_rows(
 /// no observed price yet gets `usd_mark: None, mark_captured_at: None` --
 /// never a fabricated zero.
 ///
-/// `mark_captured_at` for an equity row is `Position.last_updated`, NOT a
-/// dedicated price-observation timestamp -- a precise one is a deferred
-/// follow-up. `last_updated` is the aggregate's last-touched time, advanced by
-/// several non-price events too (offchain order placement/fill/cancel,
-/// threshold updates), so it is only an UPPER BOUND on how recently
-/// `last_price_usdc` was actually observed: a symbol whose price hasn't moved
-/// in weeks but was otherwise recently touched still reports a "fresh"
-/// `mark_captured_at`. `read.rs`'s staleness guard (`is_stale_mark`) therefore
-/// reliably EXCLUDES a day once the position itself has gone stale, but is not
-/// guaranteed to exclude every day with a genuinely stale price -- a stale
-/// `last_price_usdc` can still pass the guard if its position was recently
-/// touched for an unrelated (non-price) reason. Known and accepted for this
-/// iteration; see SPEC.md "Portfolio Capital and Return Tracking".
+/// `mark_captured_at` for an equity row is `Position.last_price_observed_at`,
+/// a dedicated price-observation timestamp set only by the events that also
+/// set `last_price_usdc` (`OnChainOrderFilled`, priced `ManualPositionAdjusted`)
+/// -- unlike `last_updated`, which advances on every event including
+/// price-less ones (offchain order placement/fill/cancel, threshold updates).
+/// `read.rs`'s staleness guard (`is_stale_mark`) therefore keys off how
+/// recently the price itself was actually observed, not how recently the
+/// position was last touched for any reason; see SPEC.md "Portfolio Capital
+/// and Return Tracking".
 async fn resolve_marks(
     position_projection: &Projection<Position>,
     captured_at: DateTime<Utc>,
@@ -650,7 +646,7 @@ async fn resolve_marks(
                 } else {
                     let mark = match position_projection.load(symbol).await? {
                         Some(position) => match position.last_price_usdc {
-                            Some(mark) => (Some(mark), position.last_updated),
+                            Some(mark) => (Some(mark), position.last_price_observed_at),
                             None => (None, None),
                         },
                         None => (None, None),
@@ -776,7 +772,8 @@ mod tests {
 
     use crate::inventory::view::{InFlightCashLocation, InFlightEquityLocation};
     use crate::inventory::{Inventory, InventoryView, Operator, Venue};
-    use crate::portfolio_snapshot::PortfolioSnapshotProjection;
+    use crate::portfolio_snapshot::read::{DayCapital, DayExclusionReason};
+    use crate::portfolio_snapshot::{EtDayRange, PortfolioSnapshotProjection, load_portfolio_days};
     use crate::position::{PositionCommand, TradeId};
     use crate::test_utils::setup_test_pools;
 
@@ -1393,19 +1390,23 @@ mod tests {
     }
 
     /// The one branch of `resolve_marks` that reads a real fill-derived price
-    /// out of `Position` and pairs it with `position.last_updated`: this must
-    /// persist the position's OWN `last_updated`, never the job's `captured_at`
-    /// (an easy one-line regression, since both are `DateTime<Utc>` and
-    /// `captured_at` is in scope at that line).
+    /// out of `Position` and pairs it with `position.last_price_observed_at`:
+    /// this must persist the position's price-observation time, never
+    /// `last_updated` (which a trailing non-price event advances) nor the
+    /// job's own `captured_at`. A trailing `UpdateThreshold` after the fill
+    /// diverges `last_updated` from `last_price_observed_at` so a regression
+    /// that reverted to `last_updated` would be caught, not accidentally pass
+    /// by coincidence of all three timestamps lining up.
     #[tokio::test]
-    async fn equity_position_with_known_price_persists_that_price_and_its_own_last_updated() {
+    async fn equity_position_with_known_price_persists_its_price_observation_time() {
         let (pool, apalis_pool) = setup_test_pools().await;
         let (ctx, position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
 
-        // Deliberately far from "now" so a regression that swapped in the
-        // job's own `captured_at` would be unmistakable in the assertion
-        // below, rather than accidentally matching by coincidence.
-        let seen_at = Utc.with_ymd_and_hms(2026, 7, 10, 12, 0, 0).unwrap();
+        // Deliberately far from "now" so a regression that swapped in
+        // `last_updated` or the job's own `captured_at` would be unmistakable
+        // in the assertion below, rather than accidentally matching by
+        // coincidence.
+        let block_timestamp = Utc.with_ymd_and_hms(2026, 7, 10, 12, 0, 0).unwrap();
         position
             .send(
                 &aapl(),
@@ -1419,8 +1420,20 @@ mod tests {
                     amount: FractionalShares::new(float!(1)),
                     direction: Direction::Buy,
                     price_usdc: float!(150),
-                    block_timestamp: seen_at,
-                    seen_at,
+                    block_timestamp,
+                    seen_at: block_timestamp,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Trailing non-price event: advances last_updated to ~now without
+        // touching last_price_usdc/last_price_observed_at.
+        position
+            .send(
+                &aapl(),
+                PositionCommand::UpdateThreshold {
+                    threshold: ExecutionThreshold::whole_share(),
                 },
             )
             .await
@@ -1441,8 +1454,134 @@ mod tests {
         assert_eq!(usd_mark.as_deref(), Some("150"));
         assert_eq!(
             mark_captured_at.as_deref(),
-            Some(seen_at.to_rfc3339().as_str()),
-            "mark_captured_at must be Position.last_updated, not the job's own captured_at"
+            Some(block_timestamp.to_rfc3339().as_str()),
+            "mark_captured_at must be Position.last_price_observed_at, not last_updated \
+             (which the trailing UpdateThreshold advanced past it)"
+        );
+    }
+
+    /// The ticket's regression: a position whose price is genuinely stale
+    /// (over `MARK_STALENESS_THRESHOLD_DAYS` old) but was touched again today
+    /// by an unrelated non-price event must still have its day excluded.
+    /// Before this change `mark_captured_at` was `Position.last_updated`,
+    /// which the trailing `UpdateThreshold` below would have refreshed to
+    /// "now" -- passing the staleness gate despite the price being over a
+    /// week old.
+    #[tokio::test]
+    async fn stale_price_with_recent_non_price_touch_excludes_the_day() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
+
+        let block_timestamp = Utc::now() - chrono::Duration::days(10);
+        position
+            .send(
+                &aapl(),
+                PositionCommand::AcknowledgeOnChainFillAt {
+                    symbol: aapl(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId {
+                        tx_hash: TxHash::ZERO,
+                        log_index: 0,
+                    },
+                    amount: FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp,
+                    seen_at: block_timestamp,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Recent, unrelated non-price touch: advances last_updated to ~now
+        // without touching last_price_usdc/last_price_observed_at.
+        position
+            .send(
+                &aapl(),
+                PositionCommand::UpdateThreshold {
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let today = et_day(Utc::now());
+        let days = load_portfolio_days(
+            &pool,
+            EtDayRange {
+                from: Some(today),
+                to: Some(today),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(days.len(), 1);
+        assert_eq!(
+            days[0].capital,
+            DayCapital::Excluded(DayExclusionReason::StaleMark(
+                PortfolioAsset::Equity(aapl()),
+                block_timestamp
+            )),
+            "a stale price must exclude the day even though the position was touched today"
+        );
+    }
+
+    /// `resolve_marks` must key staleness off `block_timestamp` (the
+    /// economic price time), not `seen_at` (when the bot detected the fill).
+    /// A fill seen recently but whose `block_timestamp` is old simulates
+    /// catch-up backfill after downtime -- using `seen_at` here would read as
+    /// fresh and reintroduce the false-fresh bug this field exists to close.
+    #[tokio::test]
+    async fn stale_block_timestamp_with_recent_seen_at_excludes_the_day() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
+
+        let block_timestamp = Utc::now() - chrono::Duration::days(10);
+        let seen_at = Utc::now();
+        position
+            .send(
+                &aapl(),
+                PositionCommand::AcknowledgeOnChainFillAt {
+                    symbol: aapl(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId {
+                        tx_hash: TxHash::ZERO,
+                        log_index: 0,
+                    },
+                    amount: FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp,
+                    seen_at,
+                },
+            )
+            .await
+            .unwrap();
+
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let today = et_day(Utc::now());
+        let days = load_portfolio_days(
+            &pool,
+            EtDayRange {
+                from: Some(today),
+                to: Some(today),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(days.len(), 1);
+        assert_eq!(
+            days[0].capital,
+            DayCapital::Excluded(DayExclusionReason::StaleMark(
+                PortfolioAsset::Equity(aapl()),
+                block_timestamp
+            )),
+            "staleness must key off block_timestamp, not the recent seen_at"
         );
     }
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -76,6 +76,18 @@ pub struct Position {
     )]
     pub last_price_usdc: Option<Float>,
     pub last_updated: Option<DateTime<Utc>>,
+    /// When `last_price_usdc` was economically observed -- set only by the
+    /// events that also set `last_price_usdc` (`OnChainOrderFilled`,
+    /// `ManualPositionAdjusted` with a price), unlike `last_updated`, which
+    /// advances on every event including price-less ones. Drives
+    /// `resolve_marks`' `mark_captured_at` so mark staleness keys off price
+    /// recency, not the aggregate's generic last-touched time. `#[serde(default)]`
+    /// so legacy (pre-this-field) snapshots deserialize to `None`; the
+    /// `SCHEMA_VERSION` bump discards those snapshots before load, so the
+    /// `last_price_usdc.is_some() == last_price_observed_at.is_some()`
+    /// invariant holds for every aggregate actually reached by `resolve_marks`.
+    #[serde(default)]
+    pub last_price_observed_at: Option<DateTime<Utc>>,
 }
 
 impl std::fmt::Debug for Position {
@@ -101,6 +113,7 @@ impl std::fmt::Debug for Position {
             .field("threshold", &self.threshold)
             .field("last_price_usdc", &DebugOptionFloat(&self.last_price_usdc))
             .field("last_updated", &self.last_updated)
+            .field("last_price_observed_at", &self.last_price_observed_at)
             .finish()
     }
 }
@@ -148,7 +161,7 @@ impl EventSourced for Position {
 
     const AGGREGATE_TYPE: &'static str = "Position";
     const PROJECTION: Table = Table("position_view");
-    const SCHEMA_VERSION: u64 = 4;
+    const SCHEMA_VERSION: u64 = 5;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use PositionEvent::*;
@@ -169,6 +182,7 @@ impl EventSourced for Position {
                 threshold: *threshold,
                 last_price_usdc: None,
                 last_updated: Some(*initialized_at),
+                last_price_observed_at: None,
             }),
 
             _ => None,
@@ -185,6 +199,7 @@ impl EventSourced for Position {
                 amount,
                 direction: Buy,
                 price_usdc,
+                block_timestamp,
                 seen_at,
                 ..
             } => {
@@ -197,6 +212,11 @@ impl EventSourced for Position {
                     last_acknowledged_trade_id: Some(trade_id.clone()),
                     last_price_usdc: Some(*price_usdc),
                     last_updated: Some(*seen_at),
+                    // block_timestamp, NOT seen_at: the economic time the price
+                    // was valid on-chain. seen_at can go fresh on a delayed
+                    // catch-up backfill, which would make an old price look
+                    // fresh and defeat the staleness gate this field exists for.
+                    last_price_observed_at: Some(*block_timestamp),
                     ..entity.clone()
                 }))
             }
@@ -206,6 +226,7 @@ impl EventSourced for Position {
                 direction: Sell,
                 amount,
                 price_usdc,
+                block_timestamp,
                 seen_at,
                 ..
             } => {
@@ -218,6 +239,7 @@ impl EventSourced for Position {
                     last_acknowledged_trade_id: Some(trade_id.clone()),
                     last_price_usdc: Some(*price_usdc),
                     last_updated: Some(*seen_at),
+                    last_price_observed_at: Some(*block_timestamp),
                     ..entity.clone()
                 }))
             }
@@ -365,6 +387,9 @@ impl EventSourced for Position {
                     net: *target_net,
                     last_price_usdc: (*price_usdc).or(entity.last_price_usdc),
                     last_updated: Some(*adjusted_at),
+                    last_price_observed_at: price_usdc
+                        .map(|_| *adjusted_at)
+                        .or(entity.last_price_observed_at),
                     // A manual reconciliation supersedes any prior failed hedge,
                     // so clear the broker-idempotency anchor. Otherwise the next
                     // hedge could reuse the failed order's client_order_id and be
@@ -3523,6 +3548,312 @@ mod tests {
     }
 
     #[test]
+    fn on_chain_order_filled_buy_sets_price_observed_at_to_block_timestamp_not_seen_at() {
+        let block_timestamp = Utc::now();
+        let seen_at = block_timestamp + chrono::Duration::hours(1);
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: block_timestamp,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(1)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp,
+                seen_at,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert!(option_float_eq(position.last_price_usdc, Some(float!(150))));
+        assert_eq!(position.last_price_observed_at, Some(block_timestamp));
+        assert_eq!(position.last_updated, Some(seen_at));
+    }
+
+    #[test]
+    fn on_chain_order_filled_sell_sets_price_observed_at_to_block_timestamp_not_seen_at() {
+        let block_timestamp = Utc::now();
+        let seen_at = block_timestamp + chrono::Duration::hours(1);
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: block_timestamp,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(1)),
+                direction: Direction::Sell,
+                price_usdc: float!(150),
+                block_timestamp,
+                seen_at,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert!(option_float_eq(position.last_price_usdc, Some(float!(150))));
+        assert_eq!(position.last_price_observed_at, Some(block_timestamp));
+        assert_eq!(position.last_updated, Some(seen_at));
+    }
+
+    /// Representative sample of the non-price arms (`ThresholdUpdated`,
+    /// `OffChainOrderPlaced`, `OffChainOrderFilled`): each reconstructs
+    /// `Position` via `..entity.clone()`, which auto-preserves
+    /// `last_price_observed_at` once it exists on the struct -- not a
+    /// per-arm business rule worth asserting one-by-one, so this chains a
+    /// few of them and checks the field survives to the end while
+    /// `last_updated` keeps advancing.
+    #[test]
+    fn non_price_events_advance_last_updated_but_not_price_observed_at() {
+        let block_timestamp = Utc::now();
+        let updated_at = block_timestamp + chrono::Duration::hours(1);
+        let placed_at = block_timestamp + chrono::Duration::hours(2);
+        let broker_timestamp = block_timestamp + chrono::Duration::hours(3);
+        let offchain_order_id = OffchainOrderId::new();
+        let threshold = one_share_threshold();
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold,
+                initialized_at: block_timestamp,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(1.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp,
+                seen_at: block_timestamp,
+            },
+            PositionEvent::ThresholdUpdated {
+                old_threshold: threshold,
+                new_threshold: threshold,
+                updated_at,
+            },
+            PositionEvent::OffChainOrderPlaced {
+                offchain_order_id,
+                shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor: SupportedExecutor::DryRun,
+                trigger_reason: TriggerReason::SharesThreshold {
+                    net_position_shares: float!(1.5),
+                    threshold_shares: float!(1),
+                },
+                placed_at,
+            },
+            PositionEvent::OffChainOrderFilled {
+                offchain_order_id,
+                shares_filled: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor_order_id: ExecutorOrderId::new("ORDER123"),
+                price: Usd::new(float!(151)),
+                broker_timestamp,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            position.last_price_observed_at,
+            Some(block_timestamp),
+            "non-price events must not touch the price-observation timestamp"
+        );
+        assert_eq!(position.last_updated, Some(broker_timestamp));
+    }
+
+    #[test]
+    fn manual_position_adjusted_with_price_sets_price_observed_at() {
+        let initialized_at = Utc::now();
+        let adjusted_at = initialized_at + chrono::Duration::hours(1);
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at,
+            },
+            PositionEvent::ManualPositionAdjusted {
+                previous_net: FractionalShares::ZERO,
+                target_net: FractionalShares::new(float!(3)),
+                reason: "operator seed".to_string(),
+                price_usdc: Some(float!(200)),
+                adjusted_at,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert!(option_float_eq(position.last_price_usdc, Some(float!(200))));
+        assert_eq!(position.last_price_observed_at, Some(adjusted_at));
+    }
+
+    #[test]
+    fn manual_position_adjusted_without_price_preserves_price_observed_at() {
+        let block_timestamp = Utc::now();
+        let adjusted_at = block_timestamp + chrono::Duration::hours(1);
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: block_timestamp,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp,
+                seen_at: block_timestamp,
+            },
+            PositionEvent::ManualPositionAdjusted {
+                previous_net: FractionalShares::new(float!(5)),
+                target_net: FractionalShares::new(float!(2)),
+                reason: "partial manual reconciliation".to_string(),
+                price_usdc: None,
+                adjusted_at,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            option_float_eq(position.last_price_usdc, Some(float!(150))),
+            "no price on the adjustment must preserve the prior known price"
+        );
+        assert_eq!(
+            position.last_price_observed_at,
+            Some(block_timestamp),
+            "no price on the adjustment must preserve the prior observation time"
+        );
+        assert_eq!(position.last_updated, Some(adjusted_at));
+    }
+
+    /// The invariant the whole field exists to uphold: a price event followed
+    /// by an unrelated touch keeps `last_price_usdc` and
+    /// `last_price_observed_at` both present (never one without the other),
+    /// with the observation timestamp strictly older than the last-touched
+    /// timestamp -- proving the two have actually decoupled, not just that
+    /// both happen to be `Some`.
+    #[test]
+    fn price_observed_at_and_last_price_usdc_presence_invariant_holds_after_non_price_touch() {
+        let block_timestamp = Utc::now();
+        let updated_at = block_timestamp + chrono::Duration::hours(1);
+        let threshold = one_share_threshold();
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold,
+                initialized_at: block_timestamp,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(1)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp,
+                seen_at: block_timestamp,
+            },
+            PositionEvent::ThresholdUpdated {
+                old_threshold: threshold,
+                new_threshold: threshold,
+                updated_at,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            option_float_eq(position.last_price_usdc, Some(float!(150))),
+            "the priced fill must leave last_price_usdc set"
+        );
+        assert_eq!(
+            position.last_price_observed_at,
+            Some(block_timestamp),
+            "last_price_usdc and last_price_observed_at must be present together"
+        );
+        assert!(
+            position.last_price_observed_at < position.last_updated,
+            "the price observation must predate the later non-price touch: \
+             last_price_observed_at = {:?}, last_updated = {:?}",
+            position.last_price_observed_at,
+            position.last_updated
+        );
+    }
+
+    /// `#[serde(default)]` on `last_price_observed_at` is load-bearing only
+    /// for a legacy (pre-this-field) snapshot: the `SCHEMA_VERSION` bump
+    /// discards such snapshots before they are ever loaded (a full event
+    /// replay repopulates the field), so this documents *why* the fallback
+    /// exists rather than a path `resolve_marks` can actually reach.
+    #[test]
+    fn legacy_snapshot_json_without_price_observed_at_field_deserializes_to_none() {
+        let block_timestamp = Utc::now();
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: block_timestamp,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(1)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp,
+                seen_at: block_timestamp,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+        assert_eq!(position.last_price_observed_at, Some(block_timestamp));
+
+        let mut snapshot = serde_json::to_value(&position)
+            .expect("Position must serialize for this legacy-snapshot fixture");
+        snapshot
+            .as_object_mut()
+            .expect("Position serializes to a JSON object")
+            .remove("last_price_observed_at");
+
+        let legacy: Position = serde_json::from_value(snapshot)
+            .expect("a v4-shaped snapshot (missing the new field) must still deserialize");
+
+        assert!(option_float_eq(legacy.last_price_usdc, Some(float!(150))));
+        assert_eq!(
+            legacy.last_price_observed_at, None,
+            "a legacy snapshot with no last_price_observed_at key must default to None"
+        );
+    }
+
+    #[test]
     fn non_genesis_event_on_uninitialized_fails() {
         let error = replay::<Position>(vec![PositionEvent::OnChainOrderFilled {
             trade_id: TradeId {
@@ -3658,6 +3989,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_price_observed_at: Some(Utc::now()),
         };
 
         let (direction, shares) = position
@@ -3687,6 +4019,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_price_observed_at: Some(Utc::now()),
         };
 
         let (direction, shares) = position
@@ -3716,6 +4049,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_price_observed_at: Some(Utc::now()),
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(50))).unwrap();
@@ -3748,6 +4082,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_price_observed_at: Some(Utc::now()),
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(50))).unwrap();
@@ -3780,6 +4115,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_price_observed_at: Some(Utc::now()),
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(50.7))).unwrap();
@@ -3811,6 +4147,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_price_observed_at: Some(Utc::now()),
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(7.5))).unwrap();
@@ -3843,6 +4180,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_price_observed_at: Some(Utc::now()),
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(5))).unwrap();
@@ -3875,6 +4213,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: None,
             last_updated: Some(Utc::now()),
+            last_price_observed_at: None,
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(50))).unwrap();
@@ -3957,6 +4296,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_price_observed_at: Some(Utc::now()),
         };
 
         let (_, first_shares) = position


### PR DESCRIPTION
## What

- Add `last_price_observed_at: Option<DateTime<Utc>>` to the `Position` aggregate. Key the daily-snapshot mark staleness off this field instead of the generic `Position.last_updated`.

## Why

- `resolve_marks` (`src/portfolio_snapshot/write.rs`) used `Position.last_updated` as a mark's `mark_captured_at`. But `last_updated` advances on many NON-price events (offchain order placement, fill, failure, cancel, threshold updates, manual adjust). So a genuinely stale price could pass the read-side staleness gate when the position was otherwise recently touched.
- [RAI-1476](https://linear.app/makeitrain/issue/RAI-1476/precise-price-observation-timestamp-on-position-for-mark-staleness).

## How

- Set `last_price_observed_at` in exactly the `evolve` arms that write `last_price_usdc`. `OnChainOrderFilled` Buy and Sell use `block_timestamp`, the economic price time, not `seen_at`, which goes fresh on catch-up backfill and would hide a stale price. `ManualPositionAdjusted` sets it only when the event carries a price. Every other arm auto-preserves the field through `..entity.clone()`, so the invariant `last_price_usdc.is_some() == last_price_observed_at.is_some()` holds.
- Bump `Position::SCHEMA_VERSION` from 4 to 5, so the schema reconciler clears snapshots and replays every position. This repopulates the field from historical price events (`Position` retains all events, so no compaction is needed). `#[serde(default)]` keeps legacy events deserializing.
- No `position_view` column and no migration are needed. `resolve_marks` loads the aggregate through `.load()`, not the view, so a column would be dead weight.
- Sync `SPEC.md` ("Portfolio Capital and Return Tracking" and the `Position` struct listing) to the new behavior.

## Testing

- Position tests: price arms set the field to `block_timestamp`, non-price arms leave it alone, manual adjust with and without a price, the presence invariant, and a legacy-snapshot serde fence (this documents why the version bump is load-bearing). Portfolio tests: rewrote the coincidental test so `last_updated` diverges from `last_price_observed_at`, plus the stale-price and stale-`block_timestamp` regressions (the day is excluded by `is_stale_mark`).

## Screenshots

N/A (backend).

## Anything else

- **Follow-up:** `last_price_usdc` and `last_price_observed_at` are two Options that must move in lockstep, currently held together only by discipline. Folding them into one `Option<PriceObservation>` would make the invariant compiler-enforced. But `last_price_usdc` is a pre-existing field read across the codebase, so that refactor is out of scope here. It is now filed as [RAI-1497](https://linear.app/makeitrain/issue/RAI-1497/fold-position-price-fields-into-a-single-optionpriceobservation).
- Stacked on the RAI-1475 branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portfolio capital snapshots to identify stale prices more accurately.
  * Non-price position updates no longer make outdated prices appear fresh.
  * Snapshot exclusions now reflect when a price was actually observed.
  * Manual adjustments without a price no longer refresh price freshness.
  * Preserved correct price timing when processing delayed or historical events.

* **Documentation**
  * Clarified how price observation times affect capital snapshot staleness and exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->