### PR TITLE
docs: document hedge-margin exclusion from deployed capital

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -689,6 +689,17 @@ positive equity quantities. The collateral or margin supporting shorts is not
 modeled. Hedging-venue USDC (cash) is included -- idle or reserved offchain cash
 is still capital under management.
 
+No separate broker maintenance-margin term is added: the Alpaca account is
+long-only, so it never posts one. Buys are capped to `cash` with no margin loan
+(ADR 0001 -- covers only the buy leg); sells are capped to shares already held
+(`resolve_sell_preflight`, `crates/execution/src/lib.rs`), so a counter-trade
+reduces a pre-existing long position rather than borrowing stock to go
+net-negative. The Hedging-venue cash counted above is therefore not inflated by
+short-sale proceeds, and no Reg-T maintenance margin is posted against it. If
+true short-selling is ever added on Alpaca, this definition must be revisited:
+short-sale proceeds would inflate the counted cash, and posted maintenance
+margin would become genuinely uncounted capital.
+
 **USD marks**: USDC is treated as par (`1:1`), matching the reporting-currency
 assumption used elsewhere in `/pnl`. Equity balances are marked at the symbol's
 `last_price_usdc` (the same fill-derived price already tracked on the `Position`

--- a/src/portfolio_snapshot/read.rs
+++ b/src/portfolio_snapshot/read.rs
@@ -390,8 +390,10 @@ fn evaluate_day(et_day: NaiveDate, rows: Vec<RawBalanceRow>) -> Result<Portfolio
         // counter-trades consume or replenish that inventory rather than
         // creating a separate hedge leg. A negative broker position does not
         // contribute under this long-inventory definition because the margin
-        // supporting shorts is not modeled. Skip it before mark validation:
-        // a row that cannot contribute must not gate the whole day.
+        // supporting shorts is not modeled. The Alpaca account is long-only:
+        // sells are capped to shares already held, so no separate maintenance-
+        // margin term exists today. Skip a defensive negative row before mark
+        // validation: a row that cannot contribute must not gate the whole day.
         if matches!(&row.asset, PortfolioAsset::Equity(_)) && balance.is_negative()? {
             continue;
         }
@@ -758,7 +760,8 @@ mod tests {
 
     /// Positive equity inventory counts at both venues: the Hedging row is
     /// the broker's current holding, not a distinct short leg paired with the
-    /// MarketMaking balance.
+    /// MarketMaking balance. The account is long-only, so there is no
+    /// maintenance-margin term to add beside these holdings.
     #[tokio::test]
     async fn deployed_capital_includes_positive_equity_at_both_venues() {
         let pool = setup_test_db().await;


### PR DESCRIPTION
## What

- Document that broker short-hedge maintenance margin is excluded from the deployed-capital denominator by definition. This PR changes no code and no denominator.

## Why

- Deployed capital v1 is one-sided: it counts cash at every venue plus long equity, and excludes the offchain Hedging equity leg. [RAI-1477](https://linear.app/makeitrain/issue/RAI-1477/model-hedge-leg-margincollateral-in-deployed-capital-denominator) asked whether broker margin backing the short should count.
- Decision: exclude it by definition. The Alpaca hedge account is long-only, so it holds no borrowed short. Buys are capped to cash with no margin loan (ADR 0001, buy leg only). Sells are capped to shares already held (`resolve_sell_preflight` in `crates/execution/src/lib.rs`). So the counted Hedging cash (`offchain_gross_usd_cents`) is not inflated by short-sale proceeds, and no Reg-T maintenance margin is posted. A separate margin term would double-count cash that is already counted.

## How

- Update `SPEC.md` and the `evaluate_day` Hedging-exclusion comment in `src/portfolio_snapshot/read.rs` with this rationale. Add a caveat to revisit if true short-selling on Alpaca is ever added. Add a note that the equity-leg exclusion assumes the Hedging leg exactly mirrors an onchain short. A non-mirrored baseline reservoir would understate capital.

## Testing

- No new logic. Strengthened the existing `deployed_capital_excludes_hedging_equity_leg...` test doc to cover the margin question.

## Screenshots

N/A (docs).

## Anything else

- This decision is reversible. If we ever want to model broker-leverage scenarios, sourcing `maintenance_margin` is a cheap one-field add to `AccountDetailsResponse`. Incorporating it is a denominator modeling change deliberately not done here.
- Stacked on the RAI-1476 branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how deployed capital is calculated for long-only Alpaca accounts.
  * Documented that purchases are limited by available cash and sales by currently held shares.
  * Clarified that short-sale proceeds are excluded from counted cash.
  * Added notes explaining the treatment of hedging-venue cash, negative-balance rows, and maintenance-margin assumptions during portfolio evaluation.
  * Noted that margin handling may require review if short selling is introduced in the future.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->