### PR TITLE
chore(config): add MU, AMD, AVGO, AMAT, LRCX, TTWO equities, disable QSEP in prod

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -211,10 +211,10 @@ tokenized_equity = "0x013b782f402d61aa1004cca95b9f5bb402c9d5fe"
 tokenized_equity_derivative = "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2"
 
 [assets.equities.QSEP]
-trading = "enabled"
-rebalancing = "enabled"
-wrapped_equity_recovery = "enabled"
-extended_hours_counter_trading = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
 vault_id = "0xfab"
 tokenized_equity = "0x4a9a9fc94a507559481270d0bff3315ab92fcefa"
 tokenized_equity_derivative = "0x849e389982209f901b7b9ffca57ae4c9eeb11c0d"
@@ -356,3 +356,57 @@ extended_hours_counter_trading = "enabled"
 vault_id = "0xfab"
 tokenized_equity = "0x4DBA41f0feb390F208a85e96168fF5d8aC2b6F5c"
 tokenized_equity_derivative = "0xFcD17aC4c4BF6a72c93018096F3fC09e66573Ff9"
+
+[assets.equities.MU]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x7d89a2DFfDaF9f48A64337C725D925381b431aE2"
+tokenized_equity_derivative = "0x89EcfE9E0728D6b3c5eb0EE7236f8C6F806C7B56"
+
+[assets.equities.AMD]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x50b5225409A55B873fD6C2Fd5880AF5a11acE9b1"
+tokenized_equity_derivative = "0x648042Acd8638E12fEfd51C2b25A9f993f21a612"
+
+[assets.equities.AVGO]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x6088F8ef741AE1f5A61882866f130631b41617E2"
+tokenized_equity_derivative = "0x70A182f481AEF05836666B6CfDbe84dCBCE8AC19"
+
+[assets.equities.AMAT]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x98C02B58b7E65EF5a4262d9536162949e3B2E141"
+tokenized_equity_derivative = "0x522DC65c89C9Af4f410BAe01bbf53aF75854a9f9"
+
+[assets.equities.LRCX]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xDdE9346107609A05439A0B59Ab6eD4f7F81a1FBF"
+tokenized_equity_derivative = "0x328B9aFFa511fE26673edBb4fEa37eDaF908A3bc"
+
+[assets.equities.TTWO]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x1a29eD11DF8295D5F3B5F59849FD94caD615E024"
+tokenized_equity_derivative = "0x045Fb493D970f94a54FeaF931033622fC82192e6"

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -347,3 +347,57 @@ extended_hours_counter_trading = "disabled"
 vault_id = "0xfab"
 tokenized_equity = "0x4DBA41f0feb390F208a85e96168fF5d8aC2b6F5c"
 tokenized_equity_derivative = "0xFcD17aC4c4BF6a72c93018096F3fC09e66573Ff9"
+
+[assets.equities.MU]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x7d89a2DFfDaF9f48A64337C725D925381b431aE2"
+tokenized_equity_derivative = "0x89EcfE9E0728D6b3c5eb0EE7236f8C6F806C7B56"
+
+[assets.equities.AMD]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x50b5225409A55B873fD6C2Fd5880AF5a11acE9b1"
+tokenized_equity_derivative = "0x648042Acd8638E12fEfd51C2b25A9f993f21a612"
+
+[assets.equities.AVGO]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x6088F8ef741AE1f5A61882866f130631b41617E2"
+tokenized_equity_derivative = "0x70A182f481AEF05836666B6CfDbe84dCBCE8AC19"
+
+[assets.equities.AMAT]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x98C02B58b7E65EF5a4262d9536162949e3B2E141"
+tokenized_equity_derivative = "0x522DC65c89C9Af4f410BAe01bbf53aF75854a9f9"
+
+[assets.equities.LRCX]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0xDdE9346107609A05439A0B59Ab6eD4f7F81a1FBF"
+tokenized_equity_derivative = "0x328B9aFFa511fE26673edBb4fEa37eDaF908A3bc"
+
+[assets.equities.TTWO]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x1a29eD11DF8295D5F3B5F59849FD94caD615E024"
+tokenized_equity_derivative = "0x045Fb493D970f94a54FeaF931033622fC82192e6"


### PR DESCRIPTION
## What

- Adds `MU`, `AMD`, `AVGO`, `AMAT`, `LRCX`, and `TTWO` to `config/prod/st0x-hedge.toml` (all flags `enabled`) and `config/staging/st0x-hedge.toml` (all flags `disabled`), per [RAI-1481](https://linear.app/makeitrain/issue/RAI-1481).
- Flips prod `QSEP` (`trading`, `rebalancing`, `wrapped_equity_recovery`, `extended_hours_counter_trading`) from `enabled` to `disabled`.

## Why

- The six tokens are live on Base ([st0x.registry#40](https://github.com/ST0x-Technology/st0x.registry/pull/40)) but the bot doesn't know their addresses, so it can't recognise, account for, or hedge fills on them.
- We want QSEP off in prod. Staging already had all four flags disabled, so this brings prod in line.

## How

- Config only, no Rust changes. Same shape as #1015 (CEG/DRAM/TSM/ASML/SKHY).
- Addresses taken from `token-lists/base.json` at registry commit `9ef0f65`: `tokenized_equity` = `extensions.unwrappedAddress`, `tokenized_equity_derivative` = the `wt<SYM>` `address`. Checked the direction against the existing `SKHY` entry so they aren't flipped.
- `vault_id = "0xfab"` like every other equity.
- `pyth_feed_id` left unset on all six, we only pin feeds we've confirmed on-chain. The oracle won't serve these until the issuer holds positions anyway, so analytics enrichment is skipped, hedging is unaffected.
- staging registers them but keeps all four flags `disabled`, staging only trades RKLB.
- QSEP just gets the four flags flipped, same shape as the `RKLB` block above it. No staging change, it was already disabled there.

## Testing

- `cargo nextest run -p st0x-config --all-features` -> 176/176 pass. `server_config_toml_is_valid` and `all_repo_config_tomls_are_valid` `include_str!` the real prod/staging TOMLs, so the six new blocks are parsed and validated.
- Already applied the same six blocks as a live hotfix on prod (`/run/st0x/st0x-hedge.config`) and restarted: `validate-config` passed, and the bot seeded vaults plus wrap/deposit approvals for all six on boot. This PR is what makes it survive the next deploy.
- Same for the QSEP flip: already hotfixed live on prod and restarted, bot came back `active` with no warnings.

## Anything else

- This turns on live prod trading for all six. To hold one back, flip its prod `trading` to `disabled`.
- The QSEP flip doesn't unwind anything. Whatever QSEP inventory is left just sits there until someone flattens it manually.
- Rest of RAI-1481 is out of scope here: issuance registration (event-sourced, other repo) and the Raindex orders in `st0x.raindex-deploy`. The bot won't see fills until those orders are deployed.
