### PR TITLE
fix: re-check usedNonces before declaring a CCTP mint failed

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2336,6 +2336,46 @@ enum BridgeStage { Burn, Attestation, Mint }
   success is implicit since reverted transactions emit no logs. Any source
   domain or message body mismatch, or absence of the expected `MintAndWithdraw`,
   means the revert remains a bridge mint failure
+- A failed `receiveMessage()` submission is only declared a bridge mint failure
+  after the nonce has stayed unconsumed for a bounded recovery window (two
+  minutes). Two checks run once, before any recovery probe, and fail immediately
+  without waiting out the window: the attested message must carry a real
+  (non-placeholder) nonce, and its destination domain must match the expected
+  direction -- both are structurally deterministic for the fixed attested
+  message and independent of chain state, so checking them first avoids
+  reporting "not yet minted" for a message that could never mint here. Within
+  the window, recovery repeatedly re-reads only the cheap, authoritative
+  `usedNonces()` view call; every probe error is retried, including one shaped
+  like an on-chain revert -- that view call is a plain public-mapping getter
+  with no branch logic and cannot deterministically revert, so a revert-shaped
+  response is a provider/transport artifact, not a decided outcome. The
+  expensive log scan and receipt reconstruction described above run only once
+  per recovery attempt, after a read confirms the nonce consumed, not on every
+  probe, and are themselves bounded to a handful of recent chunks rather than a
+  full-chain walk back to genesis. The burn is irreversible and the attestation
+  is valid, so any party -- including a third-party relayer -- may deliver the
+  mint moments after our own submission failed; a mint that lands inside the
+  window is recovered per the log checks above and the transfer proceeds to the
+  destination deposit. If the window expires WITHOUT ever getting a conclusive
+  `usedNonces()` read (every remaining probe itself failed transiently), OR the
+  nonce is confirmed consumed but its receipt could not be reconstructed (a
+  lagging log scan, a mismatched log, a reverted mint transaction), the transfer
+  is NOT marked `BridgingFailed` -- declaring a terminal failure on unobserved
+  state, or on funds already known to have moved, would strand the rebalancing
+  guard on a false negative. The transfer instead stays in whatever
+  non-terminal-for-this-purpose state it was already in when recovery ran:
+  `Attested` (or the Ethereum-direction equivalent) for a first mint attempt,
+  whose resume adopts an already-landed mint via a bounded scan before minting
+  again; or `BridgingFailed` when recovering an already-failed post-burn
+  transfer, whose next redrive re-attempts the mint directly instead
+  (idempotency there comes from CCTP's nonce being authoritative, not from that
+  bounded scan). That redrive is deliberately unbounded and pages no operator:
+  each attempt re-reads authoritative on-chain state before minting, so
+  repeating it is harmless, whereas a false terminal failure strands the
+  rebalancing guard until an operator reconciles by hand. The cost is that a
+  PERSISTENTLY inconclusive recovery (a durably degraded RPC endpoint, not a
+  one-off blip) holds the guard with no alert. Bounding the redrive and alerting
+  on the bound is a tracked follow-up, not part of this rule
 - Destination deposit must be confirmed to complete rebalancing (for
   AlpacaToBase) or before post-deposit conversion (for BaseToAlpaca)
 - Can mark failed from any non-terminal state

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -50,7 +50,7 @@ rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 st0x-evm = { workspace = true, features = ["local-signer"] }
 st0x-float-macro.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["full", "test-util"] }
 
 [lints]
 workspace = true

--- a/crates/bridge/src/cctp/evm.rs
+++ b/crates/bridge/src/cctp/evm.rs
@@ -5,6 +5,7 @@ use alloy::providers::Provider;
 use alloy::rpc::types::{Filter, TransactionReceipt};
 use alloy::sol;
 use alloy::sol_types::SolEvent;
+use std::num::NonZeroU32;
 use std::time::{Duration, Instant};
 use tokio::time::{MissedTickBehavior, interval};
 use tracing::{debug, info, trace, warn};
@@ -17,8 +18,8 @@ use st0x_evm::{
 };
 
 use super::{
-    CctpError, FAST_TRANSFER_THRESHOLD, MessageTransmitterV2, MintReceipt, TokenMessengerV2,
-    parse_received_message,
+    CctpError, CctpReceivedMessage, FAST_TRANSFER_THRESHOLD, MessageTransmitterV2, MintReceipt,
+    TokenMessengerV2, parse_received_message,
 };
 use crate::BridgeDirection;
 
@@ -73,6 +74,98 @@ const SCAN_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis
 /// Blocks the chain head must be past `from_block` before an empty scan is
 /// trusted as a true absence (the burn lands at/after `from_block`).
 const SCAN_FINALITY_MARGIN: u64 = 2;
+
+/// Number of [`CCTP_RECOVERY_LOG_BLOCK_CHUNK`]-sized chunks
+/// [`CctpEndpoint::reconstruct_existing_mint`]'s retry scans backward from
+/// the current head before giving up, bounding a single scan attempt's cost.
+///
+/// This floor is safe specifically because `reconstruct_existing_mint` only
+/// runs after [`CctpEndpoint::recover_already_minted`]'s probe loop has
+/// itself just observed `usedNonces()` flip to consumed, within the current
+/// recovery window (production: ~2 minutes). The matching `MessageReceived`
+/// log is therefore necessarily within the last few chunks of the current
+/// head, not somewhere deep in chain history, so three chunks (60,000
+/// blocks -- many hours even on a fast chain like Base) is a wide margin
+/// over the sub-minute recency this bound relies on, while still cutting a
+/// worst-case scan from thousands of chunks to three.
+///
+/// [`CctpEndpoint::find_existing_mint`]'s own scan is NOT bounded by this:
+/// it is a proactive check run during crash-recovery resume, which may be
+/// re-checking a transfer that stalled for an arbitrary, unbounded amount of
+/// time (e.g. days, waiting on an operator) before this code ever runs, so
+/// the "the mint is recent" argument above does not hold there.
+const RECONSTRUCTION_SCAN_LOOKBACK_CHUNKS: u64 = 3;
+
+/// Delay between the `usedNonces()` probes that
+/// [`CctpEvm::recover_already_minted`] runs after a failed `receiveMessage`.
+///
+/// This is the production default (see [`MintRecoveryConfig::defaults`]);
+/// tests override the cadence via
+/// [`CctpEndpoint::with_mint_recovery_config`] to pin behaviour against a
+/// short, deterministic interval instead of racing or pausing real time
+/// against this multi-minute production value.
+const MINT_RECOVERY_PROBE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Number of `usedNonces()` probes after a failed `receiveMessage`. The first
+/// is immediate and the rest are spaced by [`MINT_RECOVERY_PROBE_INTERVAL`], so
+/// together they span ~2 minutes (production default; see
+/// [`MintRecoveryConfig`]).
+///
+/// How long [`CctpEvm::recover_already_minted`] keeps re-probing before it
+/// concludes an attested message was not minted by anyone is sized for a
+/// third-party relayer to deliver `receiveMessage` after our own submission
+/// failed: the burn is irreversible and the attestation is valid, so a mint
+/// can still land after our own submission fails. This bound is a **chosen**
+/// trade-off, not a measured one: the sole production data point behind it is
+/// a single incident where a third-party mint landed ~10 seconds after our
+/// submission failed, and two minutes is a 12x pad over that one observation,
+/// not a figure derived from Circle's CCTP V2 docs or a logged distribution of
+/// attestation-to-mint deltas.
+///
+/// The trade-off is asymmetric and deliberately erred toward the safer side:
+/// too short strands the rebalancing guard for hours (the original incident
+/// this window fixes -- an operator must reconcile by hand), while too long
+/// only delays a genuinely terminal failure by extra minutes on top of an
+/// already-failed transfer. If a relayer is ever observed delivering later
+/// than this window, widen it rather than assume the failure is terminal.
+///
+/// Non-zero by construction: a zero probe count would skip the probe loop
+/// entirely and declare the "nonce never consumed" terminal outcome without a
+/// single `usedNonces()` read -- precisely the false negative
+/// [`CctpEvm::recover_already_minted`] exists to prevent. The `match` (rather
+/// than an `unwrap`) keeps the check a compile-time evaluation with no runtime
+/// panic path.
+const MINT_RECOVERY_PROBES: NonZeroU32 = match NonZeroU32::new(13) {
+    Some(probes) => probes,
+    None => panic!("MINT_RECOVERY_PROBES must be non-zero"),
+};
+
+/// Tuning knobs for [`CctpEndpoint::recover_already_minted`]'s probe cadence.
+/// Bundled into a struct, mirroring [`BurnDropConfig`], so tests can drive a
+/// short, deterministic cadence against real awaited state instead of racing
+/// or pausing the clock through production's multi-minute window (see
+/// [`MINT_RECOVERY_PROBES`]).
+#[derive(Debug, Clone, Copy)]
+pub(super) struct MintRecoveryConfig {
+    /// Delay between `usedNonces()` probes.
+    pub(super) probe_interval: Duration,
+    /// Number of probes; the first is immediate, the rest spaced by
+    /// `probe_interval`. Non-zero so that a configured cadence can never skip
+    /// the probe loop and reach the terminal "never minted" outcome without a
+    /// single `usedNonces()` read (see [`MINT_RECOVERY_PROBES`]).
+    pub(super) probes: NonZeroU32,
+}
+
+impl MintRecoveryConfig {
+    /// Production cadence: [`MINT_RECOVERY_PROBES`] probes spaced
+    /// [`MINT_RECOVERY_PROBE_INTERVAL`] apart.
+    const fn defaults() -> Self {
+        Self {
+            probe_interval: MINT_RECOVERY_PROBE_INTERVAL,
+            probes: MINT_RECOVERY_PROBES,
+        }
+    }
+}
 
 /// Grace period before [`CctpEndpoint::burn_status`] may conclude a broadcast
 /// burn tx was dropped from the mempool. Mirrors the wallet's `wait_for_receipt`
@@ -173,6 +266,13 @@ pub(crate) struct CctpEndpoint<W: Wallet> {
     /// [`with_burn_drop_config`](Self::with_burn_drop_config) so the drop grace
     /// resolves immediately instead of after the production 30 s window.
     burn_drop_config: BurnDropConfig,
+    /// Probe cadence for
+    /// [`recover_already_minted`](Self::recover_already_minted). Production
+    /// uses [`MintRecoveryConfig::defaults`]; tests override it via
+    /// [`with_mint_recovery_config`](Self::with_mint_recovery_config) to drive
+    /// a short cadence against real awaited state instead of racing or
+    /// pausing the production multi-minute window.
+    mint_recovery_config: MintRecoveryConfig,
 }
 
 impl<W: Wallet> CctpEndpoint<W> {
@@ -193,6 +293,7 @@ impl<W: Wallet> CctpEndpoint<W> {
             wallet,
             node_sync_poll_interval: NODE_SYNC_POLL_INTERVAL,
             burn_drop_config: BurnDropConfig::defaults(),
+            mint_recovery_config: MintRecoveryConfig::defaults(),
         }
     }
 
@@ -842,55 +943,90 @@ impl<W: Wallet> CctpEndpoint<W> {
         parse_mint_receipt(&receipt).ok_or(CctpError::MintAndWithdrawEventNotFound)
     }
 
-    /// Reconstructs the receipt of an already-executed mint for the attested
+    /// Returns the receipt of an already-executed mint for the attested
     /// `message`, or `None` if its nonce has not been consumed on this chain.
     ///
-    /// Confirms via `usedNonces()` (structural ground truth, not the
-    /// decoder/provider-dependent revert string) and matches the on-chain
-    /// `MessageReceived` log against the attested message's source domain and
-    /// body before trusting the recovered amounts. Used both proactively
-    /// (crash-recovery resume, before minting) and reactively (after a
-    /// `receiveMessage` revert, via `recover_already_minted`).
+    /// The zero-nonce and destination-domain checks run before the
+    /// `usedNonces()` read: both are structurally deterministic for the fixed
+    /// `message` bytes and independent of chain state, so a wrong-direction or
+    /// unattested message fails immediately instead of reading the nonce first
+    /// and reporting "not yet minted" for a message that could never mint
+    /// here. Used proactively by crash-recovery resume, before minting.
+    /// [`recover_already_minted`](Self::recover_already_minted) does not call
+    /// this directly -- see its own doc for why.
     pub(super) async fn find_existing_mint<Registry: IntoErrorRegistry>(
         &self,
         direction: BridgeDirection,
         message: &[u8],
     ) -> Result<Option<MintReceipt>, CctpError> {
-        let received_message = parse_received_message(message)?;
-
-        // CCTP V2 assigns the real nonce only at attestation; an unattested or
-        // invalid message still carries the reserved zero nonce, which the
-        // transmitter reports as used. Such a message was never minted.
-        if received_message.nonce == B256::ZERO {
-            return Ok(None);
-        }
+        let received_message = validate_message_shape(message, direction)?;
 
         // Authoritative gate: usedNonces() is non-zero once the nonce has been
         // consumed (the mint executed and emitted MintAndWithdraw below).
+        if !self
+            .is_nonce_used::<Registry>(received_message.nonce)
+            .await?
+        {
+            return Ok(None);
+        }
+
+        // No lower bound: a crash-recovery resume may be re-checking a
+        // transfer that stalled for an unbounded amount of time before this
+        // runs, so the mint cannot be assumed recent here -- unlike
+        // `reconstruct_existing_mint`'s bounded retry (see
+        // `RECONSTRUCTION_SCAN_LOOKBACK_CHUNKS`'s doc).
+        self.locate_mint_receipt(&received_message, None)
+            .await
+            .map(Some)
+    }
+
+    /// Cheap authoritative gate: `true` once `nonce` has been consumed on this
+    /// chain (the mint executed and emitted `MintAndWithdraw`).
+    ///
+    /// This is the only on-chain call
+    /// [`recover_already_minted`](Self::recover_already_minted)'s probe loop
+    /// makes on every probe -- the expensive log scan and receipt
+    /// reconstruction ([`locate_mint_receipt`](Self::locate_mint_receipt)) run
+    /// only once, after a probe confirms the nonce consumed, rather than on
+    /// every probe: repeating an unbounded backward log scan across the whole
+    /// multi-minute recovery window would multiply its cost by the probe
+    /// count for no benefit, since this cheap view call already gives an
+    /// authoritative answer.
+    async fn is_nonce_used<Registry: IntoErrorRegistry>(
+        &self,
+        nonce: B256,
+    ) -> Result<bool, EvmError> {
         let nonce_used = self
             .wallet
             .call::<Registry, _>(
                 self.message_transmitter_address,
-                MessageTransmitterV2::usedNoncesCall(received_message.nonce),
+                MessageTransmitterV2::usedNoncesCall(nonce),
             )
             .await?;
 
-        if nonce_used.is_zero() {
-            return Ok(None);
-        }
+        Ok(!nonce_used.is_zero())
+    }
 
-        if received_message.destination_domain != direction.dest_domain() {
-            return Err(CctpError::MessageDestinationDomainMismatch {
-                expected: direction.dest_domain(),
-                actual: received_message.destination_domain,
-            });
-        }
-
+    /// Locates and validates the mint receipt for a message whose nonce
+    /// [`is_nonce_used`](Self::is_nonce_used) already confirmed consumed.
+    /// Scans for the `MessageReceived` log matching the attested source
+    /// domain and body, then validates the mint tx did not revert and emitted
+    /// `MintAndWithdraw`.
+    ///
+    /// `min_block` floors the backward scan; passed straight through to
+    /// [`find_received_message_tx`](Self::find_received_message_tx), see its
+    /// doc for when a floor is (and is not) safe to pass.
+    async fn locate_mint_receipt(
+        &self,
+        received_message: &CctpReceivedMessage<'_>,
+        min_block: Option<u64>,
+    ) -> Result<MintReceipt, CctpError> {
         let (tx_hash, message_received_log_index) = self
             .find_received_message_tx(
                 received_message.source_domain,
                 received_message.nonce,
                 received_message.message_body,
+                min_block,
             )
             .await?;
 
@@ -916,51 +1052,275 @@ impl<W: Wallet> CctpEndpoint<W> {
             "Recovered already-minted CCTP transfer"
         );
 
-        Ok(Some(mint_receipt))
+        Ok(mint_receipt)
     }
 
-    /// Reactive recovery for a `receiveMessage` revert: if the nonce was already
-    /// minted, returns the existing receipt; otherwise (nonce not consumed, or
-    /// the recovery probe could not conclusively reconstruct our mint) it
-    /// re-surfaces the original `submit_error` rather than masking it with a
-    /// probe error.
+    /// Reconstructs the mint receipt once
+    /// [`recover_already_minted`](Self::recover_already_minted)'s probe loop
+    /// has confirmed the nonce consumed.
+    ///
+    /// Retries only [`CctpError::AlreadyMintedMessageNotFound`] -- the queried
+    /// node's log index lagging behind the state its own `usedNonces()` view
+    /// call already reflects -- up to `SCAN_ATTEMPTS` times spaced
+    /// `SCAN_RETRY_BACKOFF` apart, the same dRPC-lag tolerance
+    /// [`find_recent_burn`](Self::find_recent_burn) and
+    /// [`find_recent_usdc_transfer`](Self::find_recent_usdc_transfer) already
+    /// apply to their own `get_logs` scans. This runs at most once per
+    /// `recover_already_minted` call (not once per probe). Each retry's scan
+    /// is additionally floored at [`RECONSTRUCTION_SCAN_LOOKBACK_CHUNKS`]
+    /// chunks behind the current head (falling back to an unbounded scan if
+    /// the head read itself fails), so `SCAN_ATTEMPTS` retries are genuinely
+    /// a handful of quick attempts instead of each one repeating a full
+    /// backward walk to genesis.
+    ///
+    /// Any other failure means the nonce is authoritatively consumed but the
+    /// receipt could not be validated (a reverted mint tx, a mismatched log, a
+    /// missing event): this is returned as-is, and the caller reports it as
+    /// [`CctpError::MintRecoveryInconclusive`] rather than a false "never
+    /// minted" terminal failure, since the authoritative nonce read already
+    /// proved the mint landed.
+    async fn reconstruct_existing_mint(
+        &self,
+        received_message: &CctpReceivedMessage<'_>,
+    ) -> Result<MintReceipt, CctpError> {
+        let min_block = match self.current_block().await {
+            Ok(head) => Some(head.saturating_sub(
+                CCTP_RECOVERY_LOG_BLOCK_CHUNK.saturating_mul(RECONSTRUCTION_SCAN_LOOKBACK_CHUNKS),
+            )),
+            Err(error) => {
+                warn!(
+                    target: "bridge",
+                    ?error,
+                    "Failed to read the chain head to floor the reconstruction scan; \
+                     falling back to an unbounded backward scan for this attempt"
+                );
+                None
+            }
+        };
+
+        let mut attempt = 1;
+
+        loop {
+            match self.locate_mint_receipt(received_message, min_block).await {
+                Ok(mint_receipt) => return Ok(mint_receipt),
+                Err(CctpError::AlreadyMintedMessageNotFound { nonce })
+                    if attempt < SCAN_ATTEMPTS =>
+                {
+                    warn!(
+                        target: "bridge",
+                        %nonce,
+                        attempt,
+                        max_attempts = SCAN_ATTEMPTS,
+                        "MessageReceived log not yet visible for a nonce confirmed \
+                         consumed; retrying (load-balanced RPC log-index lag)"
+                    );
+                    tokio::time::sleep(SCAN_RETRY_BACKOFF).await;
+                    attempt += 1;
+                }
+                Err(other_error) => return Err(other_error),
+            }
+        }
+    }
+
+    /// Reactive recovery for a `receiveMessage` revert. Three outcomes:
+    ///
+    /// - the nonce was already minted: returns the existing receipt, via a
+    ///   single [`reconstruct_existing_mint`](Self::reconstruct_existing_mint)
+    ///   call once a probe confirms the nonce consumed;
+    /// - the last probe's read was a clean `usedNonces()` read of unconsumed:
+    ///   re-surfaces the original `submit_error` as a true terminal failure.
+    ///   Earlier probes may have errored transiently along the way -- that
+    ///   does not matter, since a consumed nonce is never un-consumed, so the
+    ///   last clean read is authoritative and conclusively means the mint had
+    ///   not landed as of that read -- a decided outcome, not a guess;
+    /// - the window expires without ever getting a conclusive read (every
+    ///   remaining probe itself errored transiently), OR the nonce is
+    ///   confirmed consumed but its receipt could not be reconstructed:
+    ///   returns [`CctpError::MintRecoveryInconclusive`] instead of masking an
+    ///   unknown state, or a state we know landed, as a decided "never
+    ///   minted" outcome. Declaring a terminal failure here would strand the
+    ///   caller (the USDC rebalancing guard) on a false negative; the caller
+    ///   should redrive instead.
+    ///
+    /// The zero-nonce and destination-domain fail-fast guards are shared with
+    /// [`find_existing_mint`](Self::find_existing_mint); this probe loop,
+    /// though, calls only [`is_nonce_used`](Self::is_nonce_used) on every
+    /// probe -- the expensive log scan and receipt reconstruction run at most
+    /// once, via [`reconstruct_existing_mint`](Self::reconstruct_existing_mint),
+    /// after a probe confirms the nonce consumed, not on every probe.
+    ///
+    /// The probe is repeated over the configured window (production: ~2
+    /// minutes, see [`MINT_RECOVERY_PROBES`] and [`MintRecoveryConfig`])
+    /// rather than run once. Our own submission failing does not mean the
+    /// mint will not happen: the burn is already irreversible and the
+    /// attestation is valid,
+    /// so **any** party -- a third-party relayer, or a later retry -- can
+    /// deliver `receiveMessage` seconds afterwards. A single instant probe
+    /// reports "not minted" for a message that is about to be minted, and the
+    /// caller then declares a post-burn failure that strands the USDC
+    /// rebalancing guard until an operator reconciles it by hand.
+    ///
+    /// Every probe error is retried, including one that is revert-shaped per
+    /// [`EvmError::is_revert`]. An earlier version of this loop fast-failed
+    /// on `is_revert()`, treating it as a deterministic on-chain outcome that
+    /// would recur identically on every remaining probe. That assumption
+    /// does not hold for the single call this loop makes,
+    /// [`is_nonce_used`](Self::is_nonce_used): `usedNonces(bytes32)` is a
+    /// plain public-mapping getter (see the vendored `MessageTransmitterV2`
+    /// ABI -- a `view` function with no `require`/branch logic), so it
+    /// cannot deterministically revert for a well-formed call. Any
+    /// revert-shaped response observed here is therefore necessarily a
+    /// provider/transport artifact (a misrouted or misbehaving RPC backend),
+    /// not a decided on-chain fact -- exactly the class of failure this
+    /// window exists to survive, so fast-failing on it risked reproducing
+    /// the original incident on a transient blip.
     pub(super) async fn recover_already_minted<Registry: IntoErrorRegistry>(
         &self,
         direction: BridgeDirection,
         message: &[u8],
         submit_error: EvmError,
     ) -> Result<MintReceipt, CctpError> {
-        match self
-            .find_existing_mint::<Registry>(direction, message)
-            .await
-        {
-            Ok(Some(mint_receipt)) => Ok(mint_receipt),
-            Ok(None) => Err(submit_error.into()),
-            Err(probe_error) => {
+        // A failure here (an unparseable envelope, the reserved placeholder
+        // nonce, or a destination-domain mismatch) is structurally
+        // deterministic for the fixed `message` bytes: none of these depend
+        // on chain state or RPC health, so all fail fast before any probe is
+        // spent instead of burning the whole recovery window re-checking the
+        // same bytes on every remaining probe. The caller's post-burn failure
+        // surfaces why `receiveMessage` itself failed (`submit_error`), not
+        // this internal check's own error, which is logged alongside it for
+        // diagnosis.
+        let received_message = match validate_message_shape(message, direction) {
+            Ok(received_message) => received_message,
+            Err(validation_error) => {
                 warn!(
                     target: "bridge",
-                    ?probe_error,
-                    "CCTP mint recovery probe failed; surfacing original submit error"
+                    ?validation_error,
+                    "CCTP mint recovery message failed structural validation; failing \
+                     fast and surfacing the original submit error"
                 );
-                Err(submit_error.into())
+                return Err(submit_error.into());
+            }
+        };
+
+        let config = self.mint_recovery_config;
+
+        // Tracks the last probe's outcome so the terminal handling below can
+        // distinguish "every probe read the nonce as genuinely unconsumed"
+        // from "the last probe errored, so the nonce state is unknown" --
+        // collapsing both into one outcome misleads a caller (and an operator
+        // reading a post-burn failure) into reconciling in the wrong
+        // direction.
+        let mut last_probe_error: Option<EvmError> = None;
+        let mut unconsumed_reads = 0u32;
+
+        let mut poll = interval(config.probe_interval);
+        poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        for probe in 1..=config.probes.get() {
+            // First tick completes immediately, so probe 1 runs before any
+            // sleep; subsequent ticks pace the remaining probes.
+            poll.tick().await;
+
+            match self.is_nonce_used::<Registry>(received_message.nonce).await {
+                Ok(true) => {
+                    debug!(
+                        target: "bridge",
+                        probe,
+                        "CCTP mint nonce reads consumed; reconstructing the mint receipt"
+                    );
+                    // The nonce is authoritatively confirmed consumed, so ANY
+                    // reconstruction failure (a lagging log scan that outlasts
+                    // SCAN_ATTEMPTS, a mismatched log, a reverted mint tx, a
+                    // missing MintAndWithdraw event) is reported as
+                    // MintRecoveryInconclusive, never as the raw underlying
+                    // error: the mint is known to have landed, so declaring a
+                    // terminal failure here would strand the caller on a false
+                    // negative exactly like the case this function exists to
+                    // prevent.
+                    return self
+                        .reconstruct_existing_mint(&received_message)
+                        .await
+                        .map_err(|reconstruction_error| CctpError::MintRecoveryInconclusive {
+                            recovery_error: Box::new(reconstruction_error),
+                        });
+                }
+                Ok(false) => {
+                    last_probe_error = None;
+                    unconsumed_reads += 1;
+                    debug!(
+                        target: "bridge",
+                        probe,
+                        "CCTP mint nonce still unconsumed after submit failure"
+                    );
+                }
+                Err(evm_error) => {
+                    // usedNonces() cannot deterministically revert (see this
+                    // function's doc comment), so every probe error -- even
+                    // one shaped like a revert -- is retried rather than
+                    // treated as a decided terminal outcome.
+                    warn!(
+                        target: "bridge",
+                        ?evm_error,
+                        probe,
+                        "CCTP mint recovery probe failed; retrying"
+                    );
+                    last_probe_error = Some(evm_error);
+                }
             }
         }
+
+        if let Some(last_probe_error) = last_probe_error {
+            warn!(
+                target: "bridge",
+                ?last_probe_error,
+                "CCTP mint recovery window expired with the nonce state UNKNOWN (the last \
+                 probe errored rather than reading the nonce as unconsumed); the mint may \
+                 still have landed. Returning a retryable error instead of declaring a \
+                 false terminal failure"
+            );
+            return Err(CctpError::MintRecoveryInconclusive {
+                recovery_error: Box::new(last_probe_error.into()),
+            });
+        }
+
+        let probes = config.probes.get();
+        let window = config
+            .probe_interval
+            .saturating_mul(probes.saturating_sub(1));
+        warn!(
+            target: "bridge",
+            window_secs = window.as_secs(),
+            unconsumed_reads,
+            probes,
+            "CCTP mint nonce read unconsumed on every probe that completed cleanly \
+             ({unconsumed_reads} of {probes}); surfacing the original submit error"
+        );
+
+        Err(submit_error.into())
     }
 
     /// Locates the `receiveMessage` transaction that minted `nonce` and returns
     /// its hash alongside the matched `MessageReceived` log index (used to
     /// correlate the right `MintAndWithdraw` within a multicall transaction).
     ///
-    /// The backward scan has no upper bound and can in principle reach block 0,
-    /// but this is only invoked during crash recovery immediately after a
-    /// submit failure, so the matching mint is always recent and found in the
-    /// first few chunks. A hard scan limit is deliberately omitted to avoid
-    /// failing recovery when a deep reorg or lagging node pushes the log back.
+    /// `min_block` floors how far back the scan walks: `None` (used by
+    /// [`find_existing_mint`](Self::find_existing_mint)'s proactive
+    /// crash-recovery check) leaves it unbounded, walking all the way to
+    /// block 0 if needed, since that caller may be re-checking a transfer
+    /// that stalled for an unbounded amount of time. `Some(block)` (used by
+    /// [`reconstruct_existing_mint`](Self::reconstruct_existing_mint)'s
+    /// retry, see [`RECONSTRUCTION_SCAN_LOOKBACK_CHUNKS`]) stops the walk
+    /// there instead, since that caller only runs immediately after this
+    /// same recovery attempt's own probe loop observed the nonce become
+    /// consumed, so the matching log cannot be older than the floor. A hard
+    /// limit is deliberately omitted in the unbounded case to avoid failing
+    /// recovery when a deep reorg or lagging node pushes the log back.
     async fn find_received_message_tx(
         &self,
         source_domain: u32,
         nonce: B256,
         message_body: &[u8],
+        min_block: Option<u64>,
     ) -> Result<(TxHash, u64), CctpError> {
         let latest = self
             .wallet
@@ -968,12 +1328,20 @@ impl<W: Wallet> CctpEndpoint<W> {
             .get_block_number()
             .await
             .map_err(EvmError::from)?;
+        // `min_block` was derived from a head read the caller took earlier; a
+        // load-balanced endpoint can answer this second read from a node that
+        // is behind that one. Clamping keeps `from_block <= to_block`, since an
+        // inverted range is rejected outright by most providers and would be
+        // charged against the caller's scan attempts as if the mint were
+        // missing.
+        let floor = min_block.unwrap_or(0).min(latest);
         let mut to_block = latest;
         let mut saw_nonce = false;
 
         loop {
-            let from_block =
-                to_block.saturating_sub(CCTP_RECOVERY_LOG_BLOCK_CHUNK.saturating_sub(1));
+            let from_block = to_block
+                .saturating_sub(CCTP_RECOVERY_LOG_BLOCK_CHUNK.saturating_sub(1))
+                .max(floor);
             let filter = Filter::new()
                 .address(self.message_transmitter_address)
                 .from_block(from_block)
@@ -1025,7 +1393,7 @@ impl<W: Wallet> CctpEndpoint<W> {
                 return Ok((tx_hash, log_index));
             }
 
-            if from_block == 0 {
+            if from_block <= floor {
                 break;
             }
 
@@ -1104,6 +1472,51 @@ impl<W: Wallet> CctpEndpoint<W> {
         self.burn_drop_config = config;
         self
     }
+
+    /// Overrides the [`recover_already_minted`](Self::recover_already_minted)
+    /// probe cadence. Test-only: lets recovery tests drive a short interval
+    /// and probe count against real awaited state instead of racing or
+    /// pausing the production multi-minute window.
+    #[cfg(test)]
+    #[must_use]
+    pub(super) fn with_mint_recovery_config(mut self, config: MintRecoveryConfig) -> Self {
+        self.mint_recovery_config = config;
+        self
+    }
+}
+
+/// Parses `message` and validates it can structurally mint on `direction`'s
+/// chain: rejects an unparseable envelope, the reserved placeholder nonce
+/// (CCTP V2 assigns the real nonce only at attestation, so an unattested or
+/// malformed message still carries the reserved zero nonce), and a
+/// destination-domain mismatch (reconstructing a message attested for the
+/// other direction can never succeed here). All three checks are
+/// structurally deterministic for the fixed `message` bytes and independent
+/// of chain state, so they fail fast before any `usedNonces()` read.
+///
+/// Shared by [`CctpEndpoint::find_existing_mint`] and
+/// [`CctpEndpoint::recover_already_minted`], which apply different policies
+/// to a validation failure (a direct error vs. logging it and re-surfacing
+/// the original `receiveMessage` submit error) -- only the validation rule
+/// itself is shared here.
+fn validate_message_shape(
+    message: &[u8],
+    direction: BridgeDirection,
+) -> Result<CctpReceivedMessage<'_>, CctpError> {
+    let received_message = parse_received_message(message)?;
+
+    if received_message.nonce == B256::ZERO {
+        return Err(CctpError::PlaceholderNonce);
+    }
+
+    if received_message.destination_domain != direction.dest_domain() {
+        return Err(CctpError::MessageDestinationDomainMismatch {
+            expected: direction.dest_domain(),
+            actual: received_message.destination_domain,
+        });
+    }
+
+    Ok(received_message)
 }
 
 fn parse_mint_receipt(receipt: &TransactionReceipt) -> Option<MintReceipt> {
@@ -1206,6 +1619,27 @@ mod tests {
             STANDING_ALLOWANCE_THRESHOLD,
             U256::MAX / U256::from(2u8),
             "STANDING_ALLOWANCE_THRESHOLD must be U256::MAX / 2"
+        );
+    }
+
+    /// Pins the production recovery cadence to the two-minute window that
+    /// `SPEC.md` and `recover_already_minted`'s doc both state.
+    ///
+    /// Every recovery test overrides the cadence to keep its runtime short, so
+    /// without this assertion the production constants are never exercised and
+    /// either could drift while the documented contract silently became wrong.
+    /// The span is asserted as `probe_interval * (probes - 1)` because the
+    /// first probe runs immediately, so only the remaining probes are spaced.
+    #[test]
+    fn default_mint_recovery_cadence_spans_the_documented_window() {
+        let config = MintRecoveryConfig::defaults();
+
+        assert_eq!(
+            config
+                .probe_interval
+                .saturating_mul(config.probes.get().saturating_sub(1)),
+            Duration::from_secs(120),
+            "the production mint recovery window must stay at the documented two minutes"
         );
     }
 

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -419,6 +419,28 @@ pub enum CctpError {
          filled in the real nonce yet or the response is malformed"
     )]
     PlaceholderNonce,
+    /// Mint recovery ended without a decided "not minted" outcome, for either
+    /// of two reasons:
+    ///
+    /// - the recovery window expired without ever getting a conclusive
+    ///   `usedNonces()` read, because every remaining probe itself failed with
+    ///   a transient, retryable error, so whether the mint landed is UNKNOWN;
+    /// - a probe read the nonce as consumed -- the mint DID land -- but its
+    ///   receipt could not be reconstructed from the destination-chain logs.
+    ///
+    /// Both are distinct from every probe reading the nonce as genuinely
+    /// unconsumed, which re-surfaces the original `receiveMessage` submission
+    /// error as a true terminal failure. A caller should redrive rather than
+    /// declare a terminal failure on state the probe loop never observed, or
+    /// on funds already known to have moved.
+    #[error(
+        "CCTP mint recovery inconclusive (nonce state unknown, or nonce consumed with no \
+         reconstructable receipt): {recovery_error}"
+    )]
+    MintRecoveryInconclusive {
+        #[source]
+        recovery_error: Box<Self>,
+    },
     #[error("Fee calculation overflow")]
     FeeCalculationOverflow,
     #[error("Float operation error: {0}")]
@@ -490,6 +512,7 @@ impl CctpError {
             | Self::RecoveredMintReceiptReverted { .. }
             | Self::RecoveredMintAndWithdrawEventNotFound { .. }
             | Self::PlaceholderNonce
+            | Self::MintRecoveryInconclusive { .. }
             | Self::FeeCalculationOverflow
             | Self::Float(_)
             | Self::AmountConversion(_)
@@ -972,6 +995,15 @@ impl<EthWallet: Wallet, BaseWallet: Wallet> CctpBridge<EthWallet, BaseWallet> {
     /// confirming event was not yet persisted. Passing the full message (not
     /// just the nonce) lets the reconstruction match the on-chain log against
     /// the attested source domain and body.
+    ///
+    /// A message still carrying the reserved zero nonce (unattested, or a
+    /// malformed attestation response) errors with
+    /// [`CctpError::PlaceholderNonce`] rather than reporting `None`: no party
+    /// could ever have delivered `receiveMessage` for it, so "unused" would
+    /// misrepresent a message that was never attested. A caller resuming from
+    /// a pre-attestation envelope must handle this case deliberately (e.g. by
+    /// re-polling the attestation) rather than treating it as "not yet
+    /// minted".
     pub async fn find_existing_mint(
         &self,
         direction: BridgeDirection,
@@ -1285,6 +1317,7 @@ mod tests {
     use alloy::providers::ext::AnvilApi as _;
     use alloy::providers::{Provider, ProviderBuilder};
     use alloy::rpc::json_rpc::ErrorPayload;
+    use alloy::rpc::types::TransactionReceipt;
     use alloy::signers::Signer;
     use alloy::signers::local::PrivateKeySigner;
     use alloy::sol_types::{SolCall, SolEvent};
@@ -1295,13 +1328,18 @@ mod tests {
     use rand::Rng;
     use serde_json::value::to_raw_value;
     use std::borrow::Cow;
+    use std::num::NonZeroU32;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
 
     use st0x_evm::AbiDecodedErrorType;
+    use st0x_evm::Evm;
     use st0x_evm::NoOpErrorRegistry;
     use st0x_evm::local::RawPrivateKeyWallet;
     use st0x_evm::{USDC_BASE, USDC_ETHEREUM};
 
+    use super::evm::MintRecoveryConfig;
     use super::*;
     use crate::{Attestation, Bridge};
 
@@ -1527,6 +1565,208 @@ mod tests {
         let endpoint = anvil.endpoint();
         let private_key = B256::from_slice(&anvil.keys()[0].to_bytes());
         (anvil, endpoint, private_key)
+    }
+
+    /// Test-only [`Provider`] wrapper that answers `get_logs` with an empty
+    /// result for the first `empty_scans` invocations before delegating to
+    /// `inner`. Simulates the dRPC read-after-write lag
+    /// `find_received_message_tx`'s backward log scan is exposed to:
+    /// `usedNonces()` already reports the nonce consumed but the
+    /// `MessageReceived` log has not yet been indexed by the queried node.
+    /// Wrapped by [`FlakyProbeWallet`], never constructed directly by tests.
+    #[derive(Clone)]
+    struct FlakyGetLogsProvider<InnerProvider> {
+        inner: InnerProvider,
+        remaining_empty_scans: Arc<AtomicU32>,
+    }
+
+    #[async_trait]
+    impl<InnerProvider: Provider + Clone> Provider for FlakyGetLogsProvider<InnerProvider> {
+        fn root(&self) -> &alloy::providers::RootProvider {
+            self.inner.root()
+        }
+
+        async fn get_logs(
+            &self,
+            filter: &alloy::rpc::types::Filter,
+        ) -> alloy::transports::TransportResult<Vec<alloy::rpc::types::Log>> {
+            let should_return_empty = self
+                .remaining_empty_scans
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok();
+
+            if should_return_empty {
+                return Ok(Vec::new());
+            }
+
+            self.inner.get_logs(filter).await
+        }
+    }
+
+    /// Test-only `Wallet` wrapper around `recover_already_minted`'s two probe
+    /// paths: the `usedNonces()` view call (`Evm::call`) and the
+    /// `MessageReceived` log scan (`Provider::get_logs`, reached through
+    /// `find_received_message_tx`). Fails the first `revert_failures`
+    /// invocations of the call path with a deterministic on-chain-revert
+    /// shape, then the next `call_failures` invocations with a transient
+    /// transport-shaped failure, and/or answers the first `empty_log_scans`
+    /// invocations of the log scan with no logs, before delegating to `inner`
+    /// for the rest. Counts every `call` invocation (successful or not) into
+    /// `call_count`, an externally-supplied `Arc` so a test can read it after
+    /// the wallet has been moved into a `CctpEndpoint`.
+    ///
+    /// Reused by the retry, fail-fast, log-lag, and recovery-window tests
+    /// below rather than one single-use wrapper per test.
+    struct FlakyProbeWallet<InnerWallet: Wallet> {
+        inner: InnerWallet,
+        provider: FlakyGetLogsProvider<InnerWallet::Provider>,
+        remaining_revert_failures: AtomicU32,
+        remaining_call_failures: AtomicU32,
+        call_count: Arc<AtomicU32>,
+    }
+
+    /// Named failure-injection counts for [`FlakyProbeWallet::new`], bundled
+    /// into a struct so the two same-typed `u32` counters -- which drive
+    /// genuinely different failure paths (transient `usedNonces()` call
+    /// errors vs. empty `get_logs` scans) -- cannot be silently transposed at
+    /// a call site, mirroring [`MintRecoveryConfig`]'s own named-field
+    /// bundling.
+    #[derive(Debug, Clone, Copy, Default)]
+    struct FlakyProbeFailures {
+        /// Leading `usedNonces()` calls that fail with a transient
+        /// transport-shaped error before delegating to the real chain.
+        call_failures: u32,
+        /// Leading `get_logs` scans that answer empty before delegating to
+        /// the real chain.
+        empty_log_scans: u32,
+    }
+
+    impl<InnerWallet: Wallet> FlakyProbeWallet<InnerWallet> {
+        fn new(
+            inner: InnerWallet,
+            failures: FlakyProbeFailures,
+            call_count: Arc<AtomicU32>,
+        ) -> Self {
+            let provider = FlakyGetLogsProvider {
+                inner: inner.provider().clone(),
+                remaining_empty_scans: Arc::new(AtomicU32::new(failures.empty_log_scans)),
+            };
+            Self {
+                inner,
+                provider,
+                remaining_revert_failures: AtomicU32::new(0),
+                remaining_call_failures: AtomicU32::new(failures.call_failures),
+                call_count,
+            }
+        }
+
+        /// Injects `revert_failures` revert-shaped (`EvmError::DecodedRevert`)
+        /// failures on the first calls, checked before the transient
+        /// `call_failures` injected by [`Self::new`]. Used to prove
+        /// `recover_already_minted` retries a revert-shaped probe error the
+        /// same as any other transient one, since `usedNonces()` cannot
+        /// deterministically revert.
+        fn with_revert_failures(mut self, revert_failures: u32) -> Self {
+            self.remaining_revert_failures = AtomicU32::new(revert_failures);
+            self
+        }
+
+        /// Returns a handle to the remaining-empty-log-scans counter, so a
+        /// test can capture it before the wallet moves into a `CctpEndpoint`
+        /// and assert afterward that the injected empty scan was actually
+        /// consumed (not merely that recovery happened to succeed anyway).
+        fn remaining_empty_log_scans(&self) -> Arc<AtomicU32> {
+            Arc::clone(&self.provider.remaining_empty_scans)
+        }
+    }
+
+    #[async_trait]
+    impl<InnerWallet: Wallet> Evm for FlakyProbeWallet<InnerWallet> {
+        type Provider = FlakyGetLogsProvider<InnerWallet::Provider>;
+
+        fn provider(&self) -> &Self::Provider {
+            &self.provider
+        }
+
+        async fn call<Registry: IntoErrorRegistry, Call: SolCall + Send>(
+            &self,
+            contract: Address,
+            call: Call,
+        ) -> Result<Call::Return, EvmError>
+        where
+            Self: Sized,
+        {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+
+            let should_revert = self
+                .remaining_revert_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok();
+
+            if should_revert {
+                return Err(EvmError::DecodedRevert(AbiDecodedErrorType::Unknown(vec![
+                    0x12, 0x34, 0x56, 0x78,
+                ])));
+            }
+
+            let should_fail = self
+                .remaining_call_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok();
+
+            if should_fail {
+                // `Evm::call`'s only implementation (`execute_call`) funnels every
+                // provider failure through `decode_rpc_revert`, which always wraps a
+                // non-decodable RPC failure as `alloy::contract::Error::TransportError`
+                // -- `EvmError::Transport` is never constructed on this path (only by
+                // the unrelated node-sync spin-poll and tx-submission paths). Inject
+                // the shape the real probe actually produces, not a synthetic one.
+                return Err(EvmError::Contract(ContractError::TransportError(
+                    RpcError::ErrorResp(ErrorPayload {
+                        code: -32000,
+                        message: Cow::Borrowed("connection reset (synthetic transient failure)"),
+                        data: None,
+                    }),
+                )));
+            }
+
+            self.inner.call::<Registry, Call>(contract, call).await
+        }
+    }
+
+    #[async_trait]
+    impl<InnerWallet: Wallet> Wallet for FlakyProbeWallet<InnerWallet> {
+        fn address(&self) -> Address {
+            self.inner.address()
+        }
+
+        async fn send_pending(
+            &self,
+            contract: Address,
+            calldata: Bytes,
+            note: &str,
+        ) -> Result<TxHash, EvmError> {
+            self.inner.send_pending(contract, calldata, note).await
+        }
+
+        async fn await_receipt(&self, tx_hash: TxHash) -> Result<TransactionReceipt, EvmError> {
+            self.inner.await_receipt(tx_hash).await
+        }
+
+        async fn send(
+            &self,
+            contract: Address,
+            calldata: Bytes,
+            note: &str,
+        ) -> Result<TransactionReceipt, EvmError> {
+            self.inner.send(contract, calldata, note).await
+        }
     }
 
     async fn create_bridge(
@@ -3380,14 +3620,20 @@ mod tests {
         assert_eq!(recovered_mint.fee_collected, first_mint.fee_collected);
 
         // A revert whose nonce is NOT marked used on-chain is not an already-minted
-        // case: the reactive path must re-surface the original submit error rather
-        // than fabricate a recovery outcome. Mutating the nonce yields a
-        // never-minted nonce on a structurally valid message (usedNonces == 0).
+        // case: once the recovery window expires, the reactive path must re-surface
+        // the original submit error rather than fabricate a recovery outcome.
+        // Mutating the nonce yields a never-minted nonce on a structurally valid
+        // message (usedNonces == 0).
         let sentinel_error = || EvmError::Reverted {
             tx_hash: TxHash::repeat_byte(0xEE),
         };
         let mut unused_nonce_message = message_with_nonce.to_vec();
         unused_nonce_message[NONCE_INDEX..NONCE_INDEX + NONCE_SIZE].fill(0xAB);
+
+        // The window is minutes long by design; auto-advance the clock through it
+        // instead of sleeping. The probes themselves are I/O-bound, so they still
+        // run for real.
+        tokio::time::pause();
 
         let unused_nonce_error = bridge
             .base
@@ -3405,6 +3651,774 @@ mod tests {
                     if tx_hash == TxHash::repeat_byte(0xEE)
             ),
             "unused nonce must propagate the original submit error: {unused_nonce_error:?}"
+        );
+    }
+
+    /// Our own `receiveMessage` failing does not mean the mint will not happen:
+    /// the burn is irreversible and the attestation is valid, so any relayer can
+    /// deliver it moments later. Recovery must wait out its window and return
+    /// that mint, instead of reporting a post-burn failure that strands the
+    /// rebalancing guard.
+    ///
+    /// Does NOT pause the clock: `tokio::time::pause`'s paused-clock
+    /// auto-advance fires a sleeping timer as soon as the runtime has no other
+    /// *ready* work, even while an unrelated real I/O future (like
+    /// `mint_internal`'s sign/broadcast/confirm round trips) is still pending
+    /// on the network -- it is not a barrier against that concurrent I/O, only
+    /// against other timers. Relying on it here would make the "recovery must
+    /// not succeed on the very first probe" property a race, not a guarantee.
+    ///
+    /// Instead this injects a short, real probe cadence via
+    /// `with_mint_recovery_config` (an order of magnitude below how long a
+    /// mint against a local anvil chain takes) with a generous probe budget,
+    /// so the two concurrent futures race in real time with a wide safety
+    /// margin, and asserts on `call_count` (an observable probe count) rather
+    /// than on wall-clock elapsed time to prove recovery actually waited past
+    /// the first probe instead of asserting on race-prone timing.
+    #[tokio::test]
+    async fn mint_recovers_when_another_party_mints_inside_the_recovery_window() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let amount = U256::from(2_000_000u64);
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap();
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, true)
+            .await
+            .unwrap();
+        let (attestation, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+
+        // A second endpoint on the same chain/contracts, purely to count
+        // usedNonces() probes (no injected failures) and to drive a short
+        // recovery cadence.
+        let flaky_provider = ProviderBuilder::new()
+            .connect(&cctp.base_endpoint)
+            .await
+            .unwrap();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let counting_wallet = FlakyProbeWallet::new(
+            RawPrivateKeyWallet::new(&cctp.deployer_key, flaky_provider, 1).unwrap(),
+            FlakyProbeFailures {
+                call_failures: 0,
+                empty_log_scans: 0,
+            },
+            Arc::clone(&call_count),
+        );
+        let recovering_endpoint = CctpEndpoint::new(
+            cctp.base.usdc,
+            cctp.base.token_messenger,
+            cctp.base.message_transmitter,
+            counting_wallet,
+        )
+        .with_node_sync_poll_interval(Duration::ZERO)
+        // A large probe budget costs nothing on the passing path -- the loop
+        // returns as soon as `is_nonce_used` reads consumed -- and only
+        // widens how long a genuine failure would take to surface, so it is
+        // sized generously (~40 s ceiling) rather than tightly (~2 s) to
+        // avoid flaking under a loaded CI runner racing two anvil instances
+        // plus a full sign/broadcast/receipt round trip.
+        .with_mint_recovery_config(MintRecoveryConfig {
+            probe_interval: Duration::from_millis(20),
+            probes: NonZeroU32::new(2_000).unwrap(),
+        });
+
+        let (recovered, relayed_mint) = tokio::join!(
+            recovering_endpoint.recover_already_minted::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                &message_with_nonce,
+                EvmError::Reverted {
+                    tx_hash: TxHash::repeat_byte(0xEE),
+                },
+            ),
+            bridge.mint_internal::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                message_with_nonce.clone(),
+                attestation.clone(),
+            )
+        );
+
+        let relayed_mint = relayed_mint.unwrap();
+        let recovered = recovered.unwrap();
+
+        assert_eq!(
+            recovered.tx, relayed_mint.tx,
+            "recovery must return the mint that landed inside the window"
+        );
+        assert_eq!(recovered.amount, relayed_mint.amount);
+        assert_eq!(recovered.fee_collected, relayed_mint.fee_collected);
+
+        let probes = call_count.load(Ordering::SeqCst);
+        assert!(
+            probes >= 2,
+            "recovery must not have succeeded on the very first probe -- got {probes} \
+             usedNonces() calls"
+        );
+    }
+
+    /// A destination-domain mismatch is structurally deterministic: it only
+    /// depends on the fixed attested `message` bytes and the fixed
+    /// `direction` argument, neither of which change across probes. It must
+    /// fail fast with the original submit error, checked before the probe
+    /// loop even starts -- not merely on the first probe -- since a
+    /// wrong-direction message whose nonce was never consumed on this chain
+    /// would otherwise report the nonce "unconsumed" and burn the whole
+    /// recovery window before this error is ever reached.
+    #[tokio::test]
+    async fn recover_already_minted_fails_fast_on_destination_domain_mismatch_before_any_probe() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let amount = U256::from(1_500_000u64);
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap();
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, true)
+            .await
+            .unwrap();
+        let (_, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+
+        // The nonce is deliberately left unconsumed (no mint performed): a
+        // wrong-direction message can never mint here regardless of chain
+        // state, so the mismatch must fail fast without ever probing
+        // usedNonces().
+        let sentinel_error = EvmError::Reverted {
+            tx_hash: TxHash::repeat_byte(0xEE),
+        };
+
+        // Wrap the endpoint's wallet purely to count usedNonces() probes (no
+        // injected failures): the domain check must fail fast before any
+        // probe, so a zero call count is the observable proof -- not an
+        // elapsed-time guess, which can flake under CI load or a slow anvil
+        // round trip, or blow up to the full multi-minute window if the
+        // check ever moves back after the usedNonces() read.
+        let flaky_provider = ProviderBuilder::new()
+            .connect(&cctp.base_endpoint)
+            .await
+            .unwrap();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let counting_wallet = FlakyProbeWallet::new(
+            RawPrivateKeyWallet::new(&cctp.deployer_key, flaky_provider, 1).unwrap(),
+            FlakyProbeFailures {
+                call_failures: 0,
+                empty_log_scans: 0,
+            },
+            Arc::clone(&call_count),
+        );
+        let counting_endpoint = CctpEndpoint::new(
+            cctp.base.usdc,
+            cctp.base.token_messenger,
+            cctp.base.message_transmitter,
+            counting_wallet,
+        )
+        .with_node_sync_poll_interval(Duration::ZERO);
+
+        // The message was attested for Base (EthereumToBase); asking recovery
+        // to reconstruct it as BaseToEthereum is a destination-domain
+        // mismatch regardless of chain state.
+        let error = counting_endpoint
+            .recover_already_minted::<NoOpErrorRegistry>(
+                BridgeDirection::BaseToEthereum,
+                &message_with_nonce,
+                sentinel_error,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                CctpError::Evm(EvmError::Reverted { tx_hash })
+                    if tx_hash == TxHash::repeat_byte(0xEE)
+            ),
+            "a destination-domain mismatch must surface the original submit error: {error:?}"
+        );
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            0,
+            "a destination-domain mismatch must fail fast before any usedNonces() probe"
+        );
+    }
+
+    /// A revert-shaped `usedNonces()` probe error (`EvmError::is_revert()` ==
+    /// `true`) must be retried, not treated as a decided terminal outcome.
+    /// `usedNonces(bytes32)` is a plain public-mapping getter with no
+    /// `require`/branch logic (see the vendored `MessageTransmitterV2` ABI),
+    /// so it cannot deterministically revert for a well-formed call; a
+    /// revert-shaped response here is necessarily a provider/transport
+    /// artifact, not an on-chain fact. An earlier version of this function
+    /// fast-failed on this shape -- this test proves the opposite: recovery
+    /// must survive it exactly like any other transient probe error and
+    /// still find the mint that had already landed.
+    #[tokio::test]
+    async fn recover_already_minted_retries_after_a_revert_shaped_probe_error() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let amount = U256::from(1_500_000u64);
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap();
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, true)
+            .await
+            .unwrap();
+        let (attestation, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+
+        // Mint fully lands before recovery ever probes, so the only thing
+        // that could prevent recovery from returning it is the injected
+        // revert-shaped probe failure.
+        let mint_receipt = bridge
+            .mint_internal::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                message_with_nonce.clone(),
+                attestation,
+            )
+            .await
+            .unwrap();
+
+        let sentinel_error = EvmError::Reverted {
+            tx_hash: TxHash::repeat_byte(0xEE),
+        };
+
+        let flaky_provider = ProviderBuilder::new()
+            .connect(&cctp.base_endpoint)
+            .await
+            .unwrap();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let reverting_wallet = FlakyProbeWallet::new(
+            RawPrivateKeyWallet::new(&cctp.deployer_key, flaky_provider, 1).unwrap(),
+            FlakyProbeFailures {
+                call_failures: 0,
+                empty_log_scans: 0,
+            },
+            Arc::clone(&call_count),
+        )
+        .with_revert_failures(1);
+        let reverting_endpoint = CctpEndpoint::new(
+            cctp.base.usdc,
+            cctp.base.token_messenger,
+            cctp.base.message_transmitter,
+            reverting_wallet,
+        )
+        .with_node_sync_poll_interval(Duration::ZERO);
+
+        tokio::time::pause();
+
+        let recovered = reverting_endpoint
+            .recover_already_minted::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                &message_with_nonce,
+                sentinel_error,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recovered.tx, mint_receipt.tx,
+            "recovery must return the already-landed mint despite the revert-shaped probe error"
+        );
+        assert_eq!(recovered.amount, mint_receipt.amount);
+        assert_eq!(recovered.fee_collected, mint_receipt.fee_collected);
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            2,
+            "the revert-shaped probe error must be retried (probe 1), not fail fast, so a \
+             second probe (probe 2) is what actually observes the nonce consumed"
+        );
+    }
+
+    /// A transient probe error (an RPC/transport blip, not a structural
+    /// mismatch) must not surface the original submit error: `recover_already_minted`
+    /// retries and finds the mint that had already landed, instead of giving up
+    /// on the very first bad read.
+    #[tokio::test]
+    async fn recover_already_minted_retries_after_a_transient_probe_error() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let amount = U256::from(1_750_000u64);
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap();
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, true)
+            .await
+            .unwrap();
+        let (attestation, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+
+        // Mint fully lands before recovery ever probes, so the only thing that
+        // can prevent recovery from returning it is the injected probe failure.
+        let mint_receipt = bridge
+            .mint_internal::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                message_with_nonce.clone(),
+                attestation,
+            )
+            .await
+            .unwrap();
+
+        // A second endpoint on the same chain/contracts, whose first `call` (the
+        // usedNonces() probe) fails once with a synthetic transient transport
+        // error before delegating to the real chain.
+        let flaky_provider = ProviderBuilder::new()
+            .connect(&cctp.base_endpoint)
+            .await
+            .unwrap();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let flaky_wallet = FlakyProbeWallet::new(
+            RawPrivateKeyWallet::new(&cctp.deployer_key, flaky_provider, 1).unwrap(),
+            FlakyProbeFailures {
+                call_failures: 1,
+                empty_log_scans: 0,
+            },
+            Arc::clone(&call_count),
+        );
+        let flaky_endpoint = CctpEndpoint::new(
+            cctp.base.usdc,
+            cctp.base.token_messenger,
+            cctp.base.message_transmitter,
+            flaky_wallet,
+        )
+        .with_node_sync_poll_interval(Duration::ZERO);
+
+        tokio::time::pause();
+
+        let recovered = flaky_endpoint
+            .recover_already_minted::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                &message_with_nonce,
+                EvmError::Reverted {
+                    tx_hash: TxHash::repeat_byte(0xEE),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recovered.tx, mint_receipt.tx,
+            "recovery must return the already-landed mint despite the first probe erroring"
+        );
+        assert_eq!(recovered.amount, mint_receipt.amount);
+        assert_eq!(recovered.fee_collected, mint_receipt.fee_collected);
+    }
+
+    /// Proves `last_probe_error` is reset to `None` on a later clean
+    /// `Ok(false)` read, not left "sticky" from an earlier transient probe
+    /// failure. `recover_already_minted`'s terminal branch decides between
+    /// the original `submit_error` and `MintRecoveryInconclusive` purely on
+    /// whether `last_probe_error` is `Some` once the window ends: injects one
+    /// transient probe failure (probe 1) against a nonce that is genuinely
+    /// never minted, with a 2-probe window so probe 2 gets a real clean
+    /// unconsumed read as the window closes. If a future refactor made
+    /// `last_probe_error` sticky (never reset on a clean read), this would
+    /// wrongly surface `MintRecoveryInconclusive` here instead of the
+    /// original submit error -- misclassifying a genuinely terminal outcome
+    /// as inconclusive and redriving forever.
+    #[tokio::test]
+    async fn recover_already_minted_resets_last_probe_error_after_transient_failure() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let amount = U256::from(1_650_000u64);
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap();
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, true)
+            .await
+            .unwrap();
+        let (_, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+
+        // Deliberately never mint: the nonce is genuinely never consumed, so
+        // a correct implementation must surface the original submit error
+        // once the window ends, not MintRecoveryInconclusive.
+        let flaky_provider = ProviderBuilder::new()
+            .connect(&cctp.base_endpoint)
+            .await
+            .unwrap();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let flaky_wallet = FlakyProbeWallet::new(
+            RawPrivateKeyWallet::new(&cctp.deployer_key, flaky_provider, 1).unwrap(),
+            FlakyProbeFailures {
+                call_failures: 1,
+                empty_log_scans: 0,
+            },
+            Arc::clone(&call_count),
+        );
+        let flaky_endpoint = CctpEndpoint::new(
+            cctp.base.usdc,
+            cctp.base.token_messenger,
+            cctp.base.message_transmitter,
+            flaky_wallet,
+        )
+        .with_node_sync_poll_interval(Duration::ZERO)
+        .with_mint_recovery_config(MintRecoveryConfig {
+            probe_interval: Duration::from_millis(5),
+            probes: NonZeroU32::new(2).unwrap(),
+        });
+
+        let error = flaky_endpoint
+            .recover_already_minted::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                &message_with_nonce,
+                EvmError::Reverted {
+                    tx_hash: TxHash::repeat_byte(0xEE),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                CctpError::Evm(EvmError::Reverted { tx_hash })
+                    if tx_hash == TxHash::repeat_byte(0xEE)
+            ),
+            "the clean unconsumed read on probe 2 must reset last_probe_error, surfacing the \
+             original submit error rather than MintRecoveryInconclusive: {error:?}"
+        );
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            2,
+            "both probes must have run: probe 1 failed transiently, probe 2 read cleanly"
+        );
+    }
+
+    /// The one production-analogous retry scenario: `usedNonces()` already
+    /// reports the nonce consumed, but the backward `MessageReceived` log scan
+    /// comes up empty because a load-balanced RPC node's log index lags
+    /// behind the state its own `usedNonces()` view call already reflects.
+    /// This is what actually produces `CctpError::AlreadyMintedMessageNotFound`
+    /// -- the variant `reconstruct_existing_mint` retries, bounded by
+    /// `SCAN_ATTEMPTS` -- and is distinct from
+    /// `recover_already_minted_retries_after_a_transient_probe_error`, which
+    /// only fails the `usedNonces()` call itself and never reaches the log
+    /// scan. The retry happens once, after the probe loop confirms the nonce
+    /// consumed, not once per `usedNonces()` probe: `call_count` (the
+    /// `usedNonces()` invocation count) therefore stays at 1 here, unlike the
+    /// old design this replaced.
+    #[tokio::test]
+    async fn recover_already_minted_retries_after_the_message_received_log_lags() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let amount = U256::from(1_250_000u64);
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap();
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, true)
+            .await
+            .unwrap();
+        let (attestation, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+
+        // Mint fully lands before recovery ever probes, so usedNonces() reads
+        // true on the first probe; only the log scan needs to catch up.
+        let mint_receipt = bridge
+            .mint_internal::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                message_with_nonce.clone(),
+                attestation,
+            )
+            .await
+            .unwrap();
+
+        // A second endpoint on the same chain/contracts, whose first
+        // `get_logs` (the MessageReceived backward scan) answers empty before
+        // delegating to the real chain.
+        let flaky_provider = ProviderBuilder::new()
+            .connect(&cctp.base_endpoint)
+            .await
+            .unwrap();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let flaky_wallet = FlakyProbeWallet::new(
+            RawPrivateKeyWallet::new(&cctp.deployer_key, flaky_provider, 1).unwrap(),
+            FlakyProbeFailures {
+                call_failures: 0,
+                empty_log_scans: 1,
+            },
+            Arc::clone(&call_count),
+        );
+        let remaining_empty_log_scans = flaky_wallet.remaining_empty_log_scans();
+        let flaky_endpoint = CctpEndpoint::new(
+            cctp.base.usdc,
+            cctp.base.token_messenger,
+            cctp.base.message_transmitter,
+            flaky_wallet,
+        )
+        .with_node_sync_poll_interval(Duration::ZERO);
+
+        let recovered = flaky_endpoint
+            .recover_already_minted::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                &message_with_nonce,
+                EvmError::Reverted {
+                    tx_hash: TxHash::repeat_byte(0xEE),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recovered.tx, mint_receipt.tx,
+            "recovery must return the already-landed mint despite the first log scan missing it"
+        );
+        assert_eq!(recovered.amount, mint_receipt.amount);
+        assert_eq!(recovered.fee_collected, mint_receipt.fee_collected);
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "the log-scan retry must not re-probe usedNonces(); it already read consumed"
+        );
+        assert_eq!(
+            remaining_empty_log_scans.load(Ordering::SeqCst),
+            0,
+            "the injected empty log scan must actually have been consumed by a retry, \
+             not bypassed"
+        );
+    }
+
+    /// A nonce confirmed consumed by `usedNonces()` but whose receipt can
+    /// never be reconstructed (the `MessageReceived` log scan stays empty
+    /// well past `SCAN_ATTEMPTS`) must still surface as
+    /// `CctpError::MintRecoveryInconclusive`, not the raw
+    /// `AlreadyMintedMessageNotFound` that `reconstruct_existing_mint`
+    /// produces once its own retries are exhausted. The mint is known to
+    /// have landed -- the authoritative `usedNonces()` read already proved
+    /// it -- so anything other than `MintRecoveryInconclusive` here would
+    /// strand the caller on a false "never minted" terminal failure.
+    #[tokio::test]
+    async fn recover_already_minted_reports_inconclusive_when_reconstruction_exhausts_retries() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let amount = U256::from(1_100_000u64);
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap();
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, true)
+            .await
+            .unwrap();
+        let (attestation, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+
+        // Mint fully lands before recovery ever probes, so usedNonces() reads
+        // true on the first probe; the log scan must never catch up.
+        bridge
+            .mint_internal::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                message_with_nonce.clone(),
+                attestation,
+            )
+            .await
+            .unwrap();
+
+        // A second endpoint on the same chain/contracts whose `get_logs` (the
+        // MessageReceived backward scan) answers empty every time. 10 empty
+        // scans exceeds evm.rs's SCAN_ATTEMPTS (5), so
+        // reconstruct_existing_mint exhausts its own retries and returns
+        // AlreadyMintedMessageNotFound instead of ever finding the log.
+        let flaky_provider = ProviderBuilder::new()
+            .connect(&cctp.base_endpoint)
+            .await
+            .unwrap();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let flaky_wallet = FlakyProbeWallet::new(
+            RawPrivateKeyWallet::new(&cctp.deployer_key, flaky_provider, 1).unwrap(),
+            FlakyProbeFailures {
+                call_failures: 0,
+                empty_log_scans: 10,
+            },
+            Arc::clone(&call_count),
+        );
+        let flaky_endpoint = CctpEndpoint::new(
+            cctp.base.usdc,
+            cctp.base.token_messenger,
+            cctp.base.message_transmitter,
+            flaky_wallet,
+        )
+        .with_node_sync_poll_interval(Duration::ZERO);
+
+        let error = flaky_endpoint
+            .recover_already_minted::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                &message_with_nonce,
+                EvmError::Reverted {
+                    tx_hash: TxHash::repeat_byte(0xEE),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        let CctpError::MintRecoveryInconclusive { recovery_error } = error else {
+            panic!(
+                "a nonce confirmed consumed whose receipt could not be reconstructed must \
+                 surface MintRecoveryInconclusive, not the raw error; got: {error:?}"
+            );
+        };
+        assert!(
+            matches!(
+                *recovery_error,
+                CctpError::AlreadyMintedMessageNotFound { .. }
+            ),
+            "the wrapped recovery_error must be the exhausted-retries \
+             AlreadyMintedMessageNotFound; got: {recovery_error:?}"
+        );
+    }
+
+    /// The window-exhaustion branch of `recover_already_minted` -- every
+    /// probe from some point on fails with a transient (non-revert) error
+    /// all the way to the end of the configured window -- is the only
+    /// production code path that constructs `CctpError::MintRecoveryInconclusive`
+    /// from a run of transient probe failures, as opposed to a
+    /// reconstruction failure after a confirmed-consumed nonce (covered by
+    /// `recover_already_minted_reports_inconclusive_when_reconstruction_exhausts_retries`
+    /// above). This drives the real branch -- not a hand-fed error through a
+    /// stub -- and asserts the caller receives `MintRecoveryInconclusive`
+    /// wrapping the last transient error, not the original submit error.
+    #[tokio::test]
+    async fn recover_already_minted_reports_inconclusive_when_every_probe_errors_transiently() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let amount = U256::from(900_000u64);
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap();
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, true)
+            .await
+            .unwrap();
+        let (_, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+
+        // Deliberately never mint: every usedNonces() probe must fail
+        // transiently instead, so the window expires without a single
+        // conclusive read.
+        let flaky_provider = ProviderBuilder::new()
+            .connect(&cctp.base_endpoint)
+            .await
+            .unwrap();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let flaky_wallet = FlakyProbeWallet::new(
+            RawPrivateKeyWallet::new(&cctp.deployer_key, flaky_provider, 1).unwrap(),
+            FlakyProbeFailures {
+                call_failures: 10,
+                empty_log_scans: 0,
+            },
+            Arc::clone(&call_count),
+        );
+        let flaky_endpoint = CctpEndpoint::new(
+            cctp.base.usdc,
+            cctp.base.token_messenger,
+            cctp.base.message_transmitter,
+            flaky_wallet,
+        )
+        .with_node_sync_poll_interval(Duration::ZERO)
+        .with_mint_recovery_config(MintRecoveryConfig {
+            probe_interval: Duration::from_millis(5),
+            probes: NonZeroU32::new(3).unwrap(),
+        });
+
+        let error = flaky_endpoint
+            .recover_already_minted::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                &message_with_nonce,
+                EvmError::Reverted {
+                    tx_hash: TxHash::repeat_byte(0xEE),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        let CctpError::MintRecoveryInconclusive { recovery_error } = error else {
+            panic!(
+                "a window that expires with every probe erroring transiently must surface \
+                 MintRecoveryInconclusive, not a decided outcome; got: {error:?}"
+            );
+        };
+        // Pinned to the exact shape `FlakyProbeWallet` injects rather than the
+        // broader `CctpError::Evm(_)`: the original submit error handed to
+        // `recover_already_minted` is an `EvmError::Reverted`, which is also a
+        // `CctpError::Evm(_)`, so the broader match would pass even if the
+        // implementation wrapped the submit error instead of the last transient
+        // probe error -- the very substitution this assertion exists to rule out.
+        assert!(
+            matches!(
+                *recovery_error,
+                CctpError::Evm(EvmError::Contract(ContractError::TransportError(_)))
+            ),
+            "the wrapped recovery_error must be the last transient EvmError, not the original \
+             submit error; got: {recovery_error:?}"
+        );
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            3,
+            "the window must have been exhausted (all 3 configured probes attempted)"
+        );
+    }
+
+    /// A message carrying the reserved zero nonce (unattested, or a malformed
+    /// attestation response) was never assigned a real nonce, so no party
+    /// could ever have delivered `receiveMessage` for it: this is structurally
+    /// deterministic for the fixed `message` bytes, and must fail fast with
+    /// `PlaceholderNonce` rather than reporting "not yet minted" -- which
+    /// would otherwise let `recover_already_minted` burn its whole recovery
+    /// window re-parsing the same bytes on every probe.
+    #[tokio::test]
+    async fn find_existing_mint_fails_fast_on_placeholder_nonce() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let amount = U256::from(1_000_000u64);
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap();
+
+        // Pre-attestation message: still carries the reserved zero nonce.
+        let raw_message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, true)
+            .await
+            .unwrap();
+
+        let error = bridge
+            .base
+            .find_existing_mint::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, &raw_message)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, CctpError::PlaceholderNonce),
+            "a zero-nonce message must fail fast with PlaceholderNonce, got: {error:?}"
         );
     }
 
@@ -3429,6 +4443,11 @@ mod tests {
         let (_, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
 
         let invalid_attestation = Bytes::from(vec![0u8; 65]);
+
+        // An invalid attestation still runs the full mint-recovery window before
+        // the failure is declared; auto-advance the clock through it rather than
+        // sleeping out its minutes.
+        tokio::time::pause();
 
         let err = bridge
             .mint_internal::<NoOpErrorRegistry>(
@@ -3469,6 +4488,10 @@ mod tests {
 
         let invalid_attestation = Bytes::from(vec![0u8; 65]);
 
+        // `message` is the raw, pre-attestation envelope (still carrying the
+        // reserved zero nonce): recovery's zero-nonce check fails fast here
+        // instead of exhausting the recovery window, so no clock manipulation
+        // is needed.
         let err = bridge
             .mint_internal::<NoOpErrorRegistry>(
                 BridgeDirection::EthereumToBase,

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -303,11 +303,27 @@ impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
             // condition resolves as the chain advances, and failing a transfer
             // for slow on-chain settlement would be wrong. Mirrors the
             // market-making settlement-wait arm.
-            Err(UsdcTransferError::SettlementCheckTransient { id, .. }) => {
+            //
+            // When `source` wraps a `CctpError::MintRecoveryInconclusive` (see
+            // `CrossVenueCashTransfer::redrive_on_mint_recovery_inconclusive` in
+            // manager.rs), this redrive is UNBOUNDED with NO operator alert: a
+            // durably degraded RPC endpoint redrives here forever at
+            // `SETTLEMENT_REDRIVE_DELAY`, holding the `usdc_in_progress` guard the
+            // whole time, with only this `warn!` (never `ctx.notifier.notify`) to
+            // observe it. A deadline-based alert mirroring
+            // `WithdrawalPollInconclusive` is a deliberate, tracked follow-up (see
+            // `redrive_on_mint_recovery_inconclusive`'s doc for why it is not
+            // included here), not an oversight.
+            Err(UsdcTransferError::SettlementCheckTransient { id, source }) => {
+                // `source` is logged (not just the generic reason) so an
+                // operator watching this redrive can see, e.g., a
+                // `CctpError::MintRecoveryInconclusive` probe error directly,
+                // rather than only "settlement-phase RPC check failed".
                 warn!(
                     target: "rebalance",
                     %id,
                     delay = ?SETTLEMENT_REDRIVE_DELAY,
+                    ?source,
                     "Rescheduling Base->Alpaca USDC transfer: settlement-phase RPC check \
                      failed transiently or burn scan inconclusive"
                 );
@@ -771,10 +787,26 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
                     // This arm is unreachable; it exists only to satisfy exhaustiveness.
                     _ => unreachable!("outer or-pattern limits to settlement variants"),
                 };
+                // `settlement_err` (which for `SettlementCheckTransient` carries
+                // the boxed `CctpError` source, e.g. a
+                // `MintRecoveryInconclusive` probe error) is logged in full so
+                // an operator watching this redrive sees the underlying cause,
+                // not just the generic `reason` string.
+                //
+                // When that source is `CctpError::MintRecoveryInconclusive` (see
+                // `CrossVenueCashTransfer::redrive_on_mint_recovery_inconclusive`
+                // in manager.rs), this redrive is UNBOUNDED with NO operator
+                // alert: a durably degraded RPC endpoint redrives here forever at
+                // `SETTLEMENT_REDRIVE_DELAY`, holding the `usdc_in_progress` guard
+                // the whole time, with only this `warn!` (never
+                // `ctx.notifier.notify`) to observe it. A deadline-based alert
+                // mirroring `WithdrawalPollInconclusive` is a deliberate, tracked
+                // follow-up, not an oversight.
                 warn!(
                     target: "rebalance",
                     %id,
                     delay = ?SETTLEMENT_REDRIVE_DELAY,
+                    ?settlement_err,
                     "Rescheduling Alpaca->Base USDC transfer: {reason}"
                 );
                 let mut job_queue = ctx.job_queue.clone();

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -194,6 +194,25 @@ enum AttestationPollOutcome {
     TimedOut,
 }
 
+/// Identifies which of the three `Bridge::mint` call sites is redriving a
+/// `CctpError::MintRecoveryInconclusive`, so
+/// `CrossVenueCashTransfer::redrive_on_mint_recovery_inconclusive`'s `warn!`
+/// log names the call site without a hand-maintained string fragment that a
+/// copy-paste or a new call site could get wrong with no compiler feedback.
+/// Emitted as a structured `Debug` tracing field rather than interpolated into
+/// the message, so the message stays static and every variant names itself.
+#[derive(Debug, Clone, Copy)]
+enum MintCallSite {
+    /// `execute_cctp_mint`, reached from `Attested`.
+    ExecuteCctpMint,
+    /// `execute_cctp_mint_on_ethereum`, reached from the Ethereum-direction
+    /// equivalent of `Attested`.
+    ExecuteCctpMintOnEthereum,
+    /// `recover_from_bridging_failed`, reached from an already-terminal
+    /// `BridgingFailed`.
+    RecoverFromBridgingFailed,
+}
+
 impl<
     Chain: Wallet,
     B: Bridge<Error = CctpError, Attestation = AttestationResponse> + UsdcBridgeHelper,
@@ -1679,6 +1698,80 @@ impl<
             })
     }
 
+    /// Converts a `CctpError::MintRecoveryInconclusive` into the redrive
+    /// error the job layer expects, logging the occurrence at `warn` level.
+    /// Shared by the three `Bridge::mint` call sites (`execute_cctp_mint`,
+    /// `execute_cctp_mint_on_ethereum`, `recover_from_bridging_failed`),
+    /// which otherwise duplicated this exact match arm with only the log
+    /// message's context differing.
+    ///
+    /// This variant is also reached when `usedNonces()` already confirmed
+    /// the nonce consumed but exact receipt reconstruction failed (a
+    /// mismatched or missing `MessageReceived`/`MintAndWithdraw` log), not
+    /// only when the nonce state itself is unknown. Both cases redrive into
+    /// the SAME generic resume path (`continue_from_attested` /
+    /// `recover_from_bridging_failed`'s own next attempt), whose mint
+    /// adoption (`find_recent_mint`) matches by recipient and block window,
+    /// not by the specific CCTP nonce/message that just failed exact
+    /// reconstruction -- a looser proof than `recover_already_minted`'s own
+    /// nonce-scoped check. This is believed safe today only because the
+    /// single-USDC-rebalance-in-flight invariant means no other mint to this
+    /// wallet should land inside that window; it is NOT an independent proof
+    /// that the adopted mint is this transfer's. A guard-latch bug (this
+    /// codebase has a documented history of them) or a manual/external mint
+    /// landing in the window would let a redrive adopt the wrong mint.
+    ///
+    /// UNBOUNDED BY DESIGN, with NO operator alert: every call site redrives
+    /// via `UsdcTransferError::SettlementCheckTransient` for as long as
+    /// `CctpEndpoint::recover_already_minted`'s probe loop keeps returning
+    /// `MintRecoveryInconclusive` (e.g. a durably degraded RPC endpoint),
+    /// with no attempt limit and no `ctx.notifier.notify` call anywhere on
+    /// this path -- see `job.rs`'s handling of `SettlementCheckTransient`,
+    /// which is deliberately silent and unbounded here (unlike the generic
+    /// terminal arm below, which pages on `FailBridging`). The
+    /// `usdc_in_progress` rebalancing guard stays held for the entire
+    /// redrive, exactly as it would for a genuine in-flight transfer, so a
+    /// PERSISTENTLY inconclusive mint recovery (not a one-off RPC blip) is
+    /// currently invisible to an operator until someone notices inventory
+    /// drift or inspects the Jobs table directly.
+    ///
+    /// This is a known, deliberately deferred gap, not an oversight: adding
+    /// a `WithdrawalPollInconclusive`-style deadline-based alert here
+    /// requires a durable counter or timestamp that survives redrives and
+    /// restarts, which this error's `SettlementCheckTransient` mapping does
+    /// not carry. The two available anchors both have a blast radius well
+    /// beyond this fix: (1) `WithdrawalPollInconclusive`'s own
+    /// `initiated_at` comes from the single aggregate state that reaches its
+    /// one call site (`Withdrawing`); this error's three call sites are
+    /// reached from FOUR different aggregate states (`Bridging`,
+    /// `AwaitingAttestation`, `Attested`, `BridgingFailed`) across BOTH
+    /// transfer directions, so threading an equivalent timestamp means
+    /// plumbing it through every one of those call chains; (2) tracking it
+    /// instead as a counter on the job payload (mirroring
+    /// `revert_redrive_attempts`) means adding a new mandatory field to
+    /// `TransferUsdcToHedging`/`TransferUsdcToMarketMaking`, which are
+    /// constructed at roughly 90 call sites across `job.rs`'s own tests and
+    /// `rebalancing/trigger/mod.rs`. Either is real, scoped work -- tracked
+    /// as a deliberate follow-up (mirroring `WithdrawalPollInconclusive`'s
+    /// deadline alert), not something to invent ad hoc inside this fix.
+    fn redrive_on_mint_recovery_inconclusive(
+        id: &UsdcRebalanceId,
+        error: CctpError,
+        call_site: MintCallSite,
+    ) -> UsdcTransferError {
+        warn!(
+            target: "rebalance",
+            %id,
+            ?call_site,
+            "CCTP mint recovery inconclusive: the nonce state is unknown, or the nonce read \
+             consumed but its receipt could not be reconstructed; will retry: {error}"
+        );
+        UsdcTransferError::SettlementCheckTransient {
+            id: id.clone(),
+            source: Box::new(error),
+        }
+    }
+
     #[instrument(target = "rebalance", skip(self, attestation_response), fields(%id), level = tracing::Level::DEBUG)]
     async fn execute_cctp_mint(
         &self,
@@ -1691,6 +1784,28 @@ impl<
             .await
         {
             Ok(receipt) => receipt,
+            // Either the recovery window expired without ever getting a
+            // conclusive usedNonces() read (every remaining probe itself
+            // errored), or the nonce was confirmed consumed but its receipt
+            // could not be reconstructed (a lagging log scan, a mismatched
+            // log, a reverted mint tx) -- in both cases whether/how the mint
+            // landed is UNKNOWN or already-landed-but-unconfirmed, not
+            // "definitely not minted". Declaring FailBridging here would
+            // strand the rebalancing guard on state we never actually
+            // observed, or on funds we already know moved; redriving instead
+            // is safe -- the aggregate stays in `Attested`, whose resume
+            // adopts an already-landed mint via a bounded scan before minting
+            // again, so a redrive cannot double-mint.
+            //
+            // See `redrive_on_mint_recovery_inconclusive`'s doc for why this
+            // is unbounded and deliberately pages no operator.
+            Err(error @ CctpError::MintRecoveryInconclusive { .. }) => {
+                return Err(Self::redrive_on_mint_recovery_inconclusive(
+                    id,
+                    error,
+                    MintCallSite::ExecuteCctpMint,
+                ));
+            }
             Err(error) => {
                 warn!(target: "rebalance", "CCTP mint failed: {error}");
                 self.cqrs
@@ -2102,11 +2217,38 @@ impl<
 
         // Idempotent: if the nonce was already consumed, `mint` returns the
         // existing receipt via `recover_already_minted` instead of re-minting.
-        let mint_receipt = self
+        let mint_receipt = match self
             .cctp_bridge
             .mint(BridgeDirection::BaseToEthereum, &attestation)
             .await
-            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?;
+        {
+            Ok(receipt) => receipt,
+            // Mirrors the same arm in `execute_cctp_mint`/
+            // `execute_cctp_mint_on_ethereum`: whether/how the mint landed is
+            // UNKNOWN or already-landed-but-unconfirmed, not "definitely not
+            // minted". Blanket-mapping this to `UsdcTransferError::Cctp` would
+            // land in the job's generic terminal arm, alerting and opening
+            // the circuit on a transfer whose USDC already burned -- exactly
+            // the multi-hour stranding this recovery path exists to fix.
+            // Redriving is safe: the aggregate stays `BridgingFailed` (already
+            // terminal), and the next redrive re-polls the attestation and
+            // re-attempts the mint. Idempotency here does NOT come from a
+            // bounded scan (this path never calls `find_recent_mint` -- that
+            // is `continue_from_attested`'s mechanism, not this one's): it
+            // comes from CCTP's nonce being authoritative (`receiveMessage`
+            // reverts on an already-consumed nonce) plus
+            // `recover_already_minted`'s own reconstruction, whose backward
+            // scan is bounded (not unbounded) by
+            // `RECONSTRUCTION_SCAN_LOOKBACK_CHUNKS` on the bridge side.
+            Err(error @ CctpError::MintRecoveryInconclusive { .. }) => {
+                return Err(Self::redrive_on_mint_recovery_inconclusive(
+                    id,
+                    error,
+                    MintCallSite::RecoverFromBridgingFailed,
+                ));
+            }
+            Err(error) => return Err(UsdcTransferError::Cctp(Box::new(error))),
+        };
 
         let amount_received = u256_to_usdc(mint_receipt.amount)?;
 
@@ -3373,21 +3515,32 @@ impl<
         id: &UsdcRebalanceId,
         attestation_response: AttestationResponse,
     ) -> Result<MintReceipt, UsdcTransferError> {
-        // This `Err` arm records a durable, terminal `FailBridging`. What it
-        // implies about the CCTP nonce depends on which `mint()` error landed:
+        // The final `Err` arm below records a durable, terminal `FailBridging`.
+        // What it implies about the CCTP nonce depends on which `mint()` error
+        // landed:
         //
         // - A `receiveMessage` SUBMISSION error (e.g. a dropped/timed-out
         //   receipt on a load-balanced RPC) is routed through
         //   `recover_already_minted`, which probes `usedNonces()` and returns
-        //   the real receipt if the mint landed. Reaching this arm that way
-        //   means recovery found no receipt: the nonce read UNUSED, or the probe
-        //   was inconclusive (the `usedNonces()` read or log scan failed, or the
-        //   receipt could not be reconstructed). Both re-surface the submit
-        //   error, so "definitely unused" and "unknown" are indistinguishable.
+        //   the real receipt if the mint landed. Reaching the terminal arm
+        //   that way means the LAST probe's `usedNonces()` read confirmed the
+        //   nonce still unconsumed -- and since a consumed nonce is never
+        //   un-consumed, that single conclusive read is a decided outcome, not
+        //   a guess, even if earlier probes errored transiently along the way.
         // - Other `mint()` errors skip recovery entirely: notably a SUCCESSFUL
         //   `receiveMessage` whose receipt lacks the `MintAndWithdraw` event
         //   returns `MintAndWithdrawEventNotFound` with no `usedNonces()` probe,
         //   and there the nonce may already be consumed.
+        //
+        // A THIRD case -- the window expired without ever getting a
+        // conclusive `usedNonces()` read (every remaining probe itself
+        // errored), OR the nonce was confirmed consumed but its receipt could
+        // not be reconstructed (a lagging log scan, a mismatched log, a
+        // reverted mint tx) -- is distinguished by
+        // `CctpError::MintRecoveryInconclusive` and handled by the first
+        // match arm: it redrives via `SettlementCheckTransient` instead of
+        // declaring a false terminal failure on unobserved state, or on funds
+        // we already know moved.
         //
         // Do not re-probe synchronously here -- a re-check cannot observe a mint
         // that confirms after this decision, and recovery is deferred, not lost:
@@ -3402,6 +3555,21 @@ impl<
             .await
         {
             Ok(receipt) => receipt,
+            // See "A THIRD case" above: redrive rather than strand the guard
+            // on state the probe loop never actually observed, or on funds we
+            // already know moved. The aggregate stays in `Attested`, whose
+            // resume adopts an already-landed mint via a bounded scan before
+            // minting again, so a redrive cannot double-mint.
+            //
+            // See `redrive_on_mint_recovery_inconclusive`'s doc for why this
+            // is unbounded and deliberately pages no operator.
+            Err(error @ CctpError::MintRecoveryInconclusive { .. }) => {
+                return Err(Self::redrive_on_mint_recovery_inconclusive(
+                    id,
+                    error,
+                    MintCallSite::ExecuteCctpMintOnEthereum,
+                ));
+            }
             Err(error) => {
                 warn!(target: "rebalance", "CCTP mint on Ethereum failed: {error}");
                 self.cqrs
@@ -3761,6 +3929,166 @@ mod tests {
             _from_block: u64,
         ) -> Result<Option<TxHash>, CctpError> {
             unimplemented!("MockBridge: find_recent_usdc_transfer not used in this test")
+        }
+    }
+
+    /// A `Bridge` decorator whose `mint()` always returns
+    /// `CctpError::MintRecoveryInconclusive`, forwarding every other `Bridge`
+    /// and `UsdcBridgeHelper` method to a wrapped real bridge. Used to test
+    /// that `execute_cctp_mint`/`execute_cctp_mint_on_ethereum`/
+    /// `recover_from_bridging_failed` redrive via `SettlementCheckTransient`
+    /// instead of declaring `FailBridging` on that error class.
+    ///
+    /// Generic over `InnerBridge` (rather than a unit struct with
+    /// `unimplemented!()` methods) because `recover_from_bridging_failed`
+    /// calls `poll_attestation` before `mint`, and constructing a real
+    /// `AttestationResponse` requires `AttestationResponse::from_parts`,
+    /// which is intentionally module-private to `st0x-bridge` -- the only
+    /// sanctioned way this crate's tests can produce one is through a real
+    /// bridge's `Bridge::reconstruct_attestation`/`poll_attestation`.
+    struct MintErrorBridge<InnerBridge> {
+        inner: InnerBridge,
+    }
+
+    #[async_trait::async_trait]
+    impl<InnerBridge> st0x_bridge::Bridge for MintErrorBridge<InnerBridge>
+    where
+        InnerBridge: st0x_bridge::Bridge<Error = CctpError, Attestation = AttestationResponse>,
+    {
+        type Error = CctpError;
+        type Attestation = AttestationResponse;
+
+        async fn burn(
+            &self,
+            direction: BridgeDirection,
+            amount: U256,
+            recipient: Address,
+        ) -> Result<BurnReceipt, CctpError> {
+            self.inner.burn(direction, amount, recipient).await
+        }
+
+        async fn submit_burn(
+            &self,
+            direction: BridgeDirection,
+            amount: U256,
+            recipient: Address,
+        ) -> Result<TxHash, CctpError> {
+            self.inner.submit_burn(direction, amount, recipient).await
+        }
+
+        async fn confirm_burn(
+            &self,
+            direction: BridgeDirection,
+            tx_hash: TxHash,
+            amount: U256,
+        ) -> Result<BurnReceipt, CctpError> {
+            self.inner.confirm_burn(direction, tx_hash, amount).await
+        }
+
+        async fn burn_status(
+            &self,
+            direction: BridgeDirection,
+            tx_hash: TxHash,
+        ) -> Result<st0x_bridge::BurnTxStatus, CctpError> {
+            self.inner.burn_status(direction, tx_hash).await
+        }
+
+        async fn poll_attestation(
+            &self,
+            direction: BridgeDirection,
+            burn_tx: TxHash,
+        ) -> Result<AttestationResponse, CctpError> {
+            self.inner.poll_attestation(direction, burn_tx).await
+        }
+
+        async fn mint(
+            &self,
+            _direction: BridgeDirection,
+            _attestation: &AttestationResponse,
+        ) -> Result<st0x_bridge::MintReceipt, CctpError> {
+            Err(CctpError::MintRecoveryInconclusive {
+                recovery_error: Box::new(CctpError::ScanInconclusive { from_block: 0 }),
+            })
+        }
+
+        fn reconstruct_attestation(
+            &self,
+            message: Vec<u8>,
+            attestation: Vec<u8>,
+        ) -> Result<AttestationResponse, CctpError> {
+            self.inner.reconstruct_attestation(message, attestation)
+        }
+
+        async fn find_recent_burn(
+            &self,
+            direction: BridgeDirection,
+            amount: U256,
+            recipient: Address,
+            from_block: u64,
+        ) -> Result<Option<TxHash>, CctpError> {
+            self.inner
+                .find_recent_burn(direction, amount, recipient, from_block)
+                .await
+        }
+
+        async fn find_recent_mint(
+            &self,
+            direction: BridgeDirection,
+            recipient: Address,
+            from_block: u64,
+        ) -> Result<Option<st0x_bridge::MintReceipt>, CctpError> {
+            self.inner
+                .find_recent_mint(direction, recipient, from_block)
+                .await
+        }
+
+        async fn destination_block(&self, direction: BridgeDirection) -> Result<u64, CctpError> {
+            self.inner.destination_block(direction).await
+        }
+
+        async fn source_block(&self, direction: BridgeDirection) -> Result<u64, CctpError> {
+            self.inner.source_block(direction).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<InnerBridge> UsdcBridgeHelper for MintErrorBridge<InnerBridge>
+    where
+        InnerBridge: UsdcBridgeHelper,
+    {
+        async fn ethereum_tx_confirmations(
+            &self,
+            tx_hash: TxHash,
+        ) -> Result<Option<u64>, CctpError> {
+            self.inner.ethereum_tx_confirmations(tx_hash).await
+        }
+
+        async fn ethereum_tx_block(&self, tx_hash: TxHash) -> Result<u64, CctpError> {
+            self.inner.ethereum_tx_block(tx_hash).await
+        }
+
+        async fn ethereum_usdc_balance(&self, holder: Address) -> Result<U256, CctpError> {
+            self.inner.ethereum_usdc_balance(holder).await
+        }
+
+        async fn send_usdc_on_ethereum(
+            &self,
+            to: Address,
+            amount: U256,
+        ) -> Result<TxHash, CctpError> {
+            self.inner.send_usdc_on_ethereum(to, amount).await
+        }
+
+        async fn find_recent_usdc_transfer(
+            &self,
+            from: Address,
+            to: Address,
+            amount: U256,
+            from_block: u64,
+        ) -> Result<Option<TxHash>, CctpError> {
+            self.inner
+                .find_recent_usdc_transfer(from, to, amount, from_block)
+                .await
         }
     }
 
@@ -11530,6 +11858,246 @@ mod tests {
         assert_eq!(
             last_burn_tx, expected_second_hash,
             "last PendingBurnRecorded must carry the second-attempt hash"
+        );
+    }
+
+    /// A `mint()` failure classified `CctpError::MintRecoveryInconclusive` (the
+    /// recovery window expired without ever getting a conclusive `usedNonces()`
+    /// read) must NOT be treated the same as a decided mint failure: declaring
+    /// `FailBridging` would strand the rebalancing guard on state the probe
+    /// loop never actually observed. `execute_cctp_mint` must instead return
+    /// `SettlementCheckTransient` so the job delayed-redrives, leaving the
+    /// aggregate at `Attested` (whose resume adopts an already-landed mint via
+    /// a bounded scan before minting again, so the redrive is safe).
+    #[tokio::test]
+    async fn mint_recovery_inconclusive_redrives_instead_of_failing_bridging() {
+        let (_anvil, endpoint, private_key) = setup_anvil();
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (real_cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+
+        // The message/attestation bytes are irrelevant to this test:
+        // MintErrorBridge's `mint()` ignores its argument and always returns
+        // the same canned error. `reconstruct_attestation` only needs a
+        // byte-valid envelope to construct one.
+        let attestation_response = real_cctp_bridge
+            .reconstruct_attestation(valid_cctp_message(), vec![0x01])
+            .unwrap();
+
+        let server = MockServer::start();
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+
+        let cqrs = create_test_store_instance().await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        advance_to_attested_alpaca_to_base(&cqrs, &id, amount).await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(MintErrorBridge {
+                inner: real_cctp_bridge,
+            }),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            address!("0x2222222222222222222222222222222222222222"),
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let error = manager
+            .execute_cctp_mint(&id, attestation_response)
+            .await
+            .unwrap_err();
+
+        let UsdcTransferError::SettlementCheckTransient { id: err_id, .. } = error else {
+            panic!(
+                "a mint recovery window that expired inconclusively must redrive via \
+                 SettlementCheckTransient, not fail the bridge; got: {error:?}"
+            );
+        };
+        assert_eq!(err_id, id);
+
+        // No FailBridging must have been emitted: the aggregate stays at
+        // Attested so the next redrive can adopt a late mint or retry cleanly.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::Attested { .. }),
+            "aggregate must remain at Attested (no FailBridging emitted); got: {state:?}"
+        );
+    }
+
+    /// Mirrors `mint_recovery_inconclusive_redrives_instead_of_failing_bridging`
+    /// for the BaseToAlpaca (Ethereum-side) mint direction: a `mint()` failure
+    /// classified `CctpError::MintRecoveryInconclusive` must redrive via
+    /// `SettlementCheckTransient` from `execute_cctp_mint_on_ethereum` too, not
+    /// just from the AlpacaToBase `execute_cctp_mint`. This is the direction
+    /// described as the actual production incident (a stranded post-burn
+    /// `BridgingFailed` blocking USDC rebalancing for hours), so it needs its
+    /// own direct coverage rather than relying on the AlpacaToBase test alone.
+    #[tokio::test]
+    async fn mint_recovery_inconclusive_redrives_instead_of_failing_bridging_on_ethereum() {
+        let (_anvil, endpoint, private_key) = setup_anvil();
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (real_cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+
+        // The message/attestation bytes are irrelevant to this test:
+        // MintErrorBridge's `mint()` ignores its argument and always returns
+        // the same canned error. `reconstruct_attestation` only needs a
+        // byte-valid envelope to construct one.
+        let attestation_response = real_cctp_bridge
+            .reconstruct_attestation(valid_cctp_message(), vec![0x01])
+            .unwrap();
+
+        let server = MockServer::start();
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+
+        let cqrs = create_test_store_instance().await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        advance_to_attested_base_to_alpaca(&cqrs, &id, amount).await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(MintErrorBridge {
+                inner: real_cctp_bridge,
+            }),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            address!("0x2222222222222222222222222222222222222222"),
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let error = manager
+            .execute_cctp_mint_on_ethereum(&id, attestation_response)
+            .await
+            .unwrap_err();
+
+        let UsdcTransferError::SettlementCheckTransient { id: err_id, .. } = error else {
+            panic!(
+                "a mint recovery window that expired inconclusively must redrive via \
+                 SettlementCheckTransient, not fail the bridge; got: {error:?}"
+            );
+        };
+        assert_eq!(err_id, id);
+
+        // No FailBridging must have been emitted: the aggregate stays at
+        // Attested so the next redrive can adopt a late mint or retry cleanly.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::Attested { .. }),
+            "aggregate must remain at Attested (no FailBridging emitted); got: {state:?}"
+        );
+    }
+
+    /// The third `Bridge::mint` call site, `recover_from_bridging_failed` (the
+    /// post-burn `BridgingFailed` recovery path), must also redrive on
+    /// `CctpError::MintRecoveryInconclusive` rather than blanket-mapping every
+    /// mint error to `UsdcTransferError::Cctp`, which would land in the job's
+    /// generic terminal arm and open the circuit on a transfer whose USDC
+    /// already burned -- the exact multi-hour stranding this recovery path
+    /// exists to fix.
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn recover_from_bridging_failed_redrives_on_mint_recovery_inconclusive() {
+        let server = MockServer::start();
+        // `recover_from_bridging_failed` polls the attestation before minting;
+        // mock it complete so the test reaches `mint()` (MintErrorBridge's
+        // canned failure) instead of retrying Circle's real API for minutes.
+        let _attestation_mock = mock_complete_attestation(&server);
+
+        let (_anvil, endpoint, private_key) = setup_anvil();
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (real_cctp_bridge, vault_service) =
+            create_test_onchain_services_with_circle_api(wallet, server.base_url());
+
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+
+        let cqrs = create_test_store_instance().await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        // Drive to a POST-burn BridgingFailed (carries burn_tx_hash): the only
+        // shape `recover_from_bridging_failed` attempts to recover.
+        let burn_tx =
+            fixed_bytes!("0xaaaa000000000000000000000000000000000000000000000000000000000003");
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount,
+                withdrawal: TransferRef::OnchainTx(burn_tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::FailBridging {
+                reason: "transient receipt error while the mint may have landed".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(MintErrorBridge {
+                inner: real_cctp_bridge,
+            }),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            address!("0x2222222222222222222222222222222222222222"),
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        let UsdcTransferError::SettlementCheckTransient { id: err_id, .. } = error else {
+            panic!(
+                "a post-burn BridgingFailed recovery whose mint recovery window expired \
+                 inconclusively must redrive via SettlementCheckTransient, not stay \
+                 terminally mapped to Cctp; got: {error:?}"
+            );
+        };
+        assert_eq!(err_id, id);
+
+        // The aggregate must remain BridgingFailed (no further command
+        // emitted): the next redrive re-polls the attestation and idempotently
+        // adopts an already-landed mint via a bounded scan.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::BridgingFailed { .. }),
+            "aggregate must remain BridgingFailed (no re-fail, no false recovery); got: {state:?}"
         );
     }
 


### PR DESCRIPTION
## What

[RAI-1482](https://linear.app/makeitrain/issue/RAI-1482/re-check-usednonces-before-declaring-a-cctp-mint-terminally-failed)

- After a failed `receiveMessage`, re-probe `usedNonces()` over a bounded window instead of once, so a mint delivered by anyone else is recovered rather than declared a post-burn failure.
- Split the three possible outcomes apart: recovered, definitely-not-minted, and **unknown**. Unknown no longer becomes `BridgingFailed`.

## Why

- Prod, 2026-07-21: transfer `517ade73-8841-4e99-af82-cf68567483ad` failed its mint at 08:10:05 UTC. A third-party relayer delivered the same mint at 08:10:15. The bot had already gone terminal, and a post-burn `BridgingFailed` holds the rebalancing guard, so all USDC rebalancing was blocked for 8.5h until a manual reconcile.
- Our submission failing says nothing about whether the mint happens. The burn is irreversible and the attestation is valid, so any party can deliver `receiveMessage` seconds later. `recover_already_minted` was asking the right question, just 10 seconds too early.

## How

- The probe loop polls only the cheap `usedNonces()` gate, up to 13 times at 10s intervals. The expensive log scan and receipt reconstruction run **once**, after a probe reports the nonce consumed. Polling the full reconstruction instead would have re-run an unbounded backward `eth_getLogs` scan on every probe, which on Base is thousands of calls and would wedge the single-concurrency worker for hours with the guard held.
- Reconstruction retries only the log-lag case, using the file's existing 5-attempt/150ms idiom, and its scan is floored to a recent lookback since the mint is necessarily recent by the time we get there. `find_existing_mint` keeps its unbounded scan for the crash-recovery caller, where "recent" does not hold.
- `CctpError::MintRecoveryInconclusive` is returned when the state cannot be decided: every probe errored, or the nonce read consumed but the receipt would not reconstruct. All three `Bridge::mint` call sites map it to `SettlementCheckTransient` so the transfer redrives instead of going terminal. Declaring failure on unobserved state is the false negative that strands the guard.
- Probe errors are all retried. An earlier revision failed fast on a revert-shaped error, but `usedNonces()` is a plain view getter with no revert path, so a revert-shaped response there can only be a provider artifact.
- The recovery cadence is injectable so tests pin behaviour without depending on production timing.

## Testing

- `crates/bridge/src/cctp/mod.rs`: a relayed mint landing inside the window is recovered; a transient probe error is retried; a revert-shaped probe error is retried; the `MessageReceived` log lagging behind `usedNonces()` is retried; reconstruction exhausting its retries reports inconclusive; every probe erroring reports inconclusive with the last probe error; a transient failure followed by a clean unconsumed read still surfaces the original submit error, which pins the `last_probe_error` reset; a destination-domain mismatch fails before any probe.
- `src/rebalancing/usdc/manager.rs`: all three call sites redrive on inconclusive rather than emitting `FailBridging`.
- Green: `cargo nextest run -p st0x-bridge --all-features` (107), `-p st0x-hedge --lib rebalancing::usdc::` (179), full `st0x-hedge` suite (2564), and `cargo clippy --workspace --all-targets --all-features`.
- The old 11-second wall-clock race test is gone; the bridge suite now runs in about 10s.

## Anything else

- Known gap, tracked as [RAI-1498](https://linear.app/makeitrain/issue/RAI-1498/bound-the-inconclusive-mint-redrive-with-a-deadline-alert): the inconclusive redrive is unbounded and unpaged, so a persistently inconclusive mint redrives forever holding the guard without alerting anyone. Bounding it needs either a durable `initiated_at` threaded through four aggregate states or a job-payload counter touching ~90 construction sites, both wider than this PR. The code documents it at the redrive site.
- The 120s window is a chosen bound, not a measured one. It is a 12x pad over the single observed 10s delivery.
- Stacked on [RAI-1483](https://linear.app/makeitrain/issue/RAI-1483/recover-from-nonce-too-low-using-the-nodes-reported-next-nonce), which attacks the same incident from the nonce side.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USDC bridge-mint recovery after submission failures.
  * Added bounded checks to distinguish completed, pending, and inconclusive mint operations.
  * Prevented uncertain recovery outcomes from being marked as permanent bridging failures.
  * Enabled automatic redrive and retry behavior for recoverable transfers.
  * Added clearer warning details for settlement delays and recovery issues.

* **Documentation**
  * Clarified USDC rebalancing failure-handling and recovery rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->