### PR TITLE
chore: cut staging over to managed inventory

### DIFF
--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -37,20 +37,14 @@ orderbook = "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D"
 # with bot-EOA-owned vaults) or "managed" (settle through the shared
 # RaindexInventory, which the bot must operate via OPERATOR_ROLE).
 #
-# Kept "legacy" until the RAI-1198 cutover: the bot's EOA does not hold
-# OPERATOR_ROLE on the shared inventory
-# (0x6b7B523fADd1677413AD92c9404C8F0796bACF6F) yet, so enabling "managed" now
-# would fail the startup preflight and block the whole bot. RAI-1198 should
-# give staging its own inventory redeploy; at that cutover switch this to
-# "managed", set `inventory` to the staging inventory, and flip `vault_owner`
-# below to that same address so a staging bug can't touch prod-owned vaults.
-inventory_mode = "legacy"
+# Staging settles through its dedicated shared inventory. The Turnkey wallet
+# holds OPERATOR_ROLE on this contract; startup fails closed if that changes.
+inventory_mode = "managed"
+inventory = "0x5FE36e6b6c320f8FD0B6109B2315253387DbdeF2"
 # REQUIRED. Owner of the Raindex orders/vaults on-chain (vaultBalance2 /
-# registry / fill match key). Currently the bot's Turnkey wallet
-# (= [wallet].address below) because the vaults are bot-EOA-owned
-# pre-migration; flip to the `inventory` address once RAI-1198 migrates the
-# vaults under it.
-vault_owner = "0x16ca08a5825612aAe805D172a81B1a52b43574bf"
+# registry / fill match key). Managed mode scopes all three to the inventory
+# contract, not the bot's Turnkey wallet.
+vault_owner = "0x5FE36e6b6c320f8FD0B6109B2315253387DbdeF2"
 # Block number to start backfilling order events from.
 deployment_block = 43259507
 # Block confirmations required before a submitted transaction is treated as
@@ -137,7 +131,7 @@ rebalancing = "disabled"
 [assets.equities.RKLB]
 trading = "enabled"
 rebalancing = "enabled"
-wrapped_equity_recovery = "disabled"
+wrapped_equity_recovery = "enabled"
 extended_hours_counter_trading = "enabled"
 # operational_limit = 1
 vault_id = "0xfab"


### PR DESCRIPTION
## What

[RAI-1399](https://linear.app/makeitrain/issue/RAI-1399/cut-staging-over-to-managed-raindexinventory-mode-for-rklb)

- Set staging to managed `RaindexInventory` mode.
- Point `inventory` and `vault_owner` to `0x5FE36e6b6c320f8FD0B6109B2315253387DbdeF2`.
- Enable automatic wrapped and unwrapped RKLB recovery from the bot wallet.

## Why

- Staging still used legacy bot-wallet vault ownership.
- The cutover validates managed settlement against the staging inventory contract.
- RKLB had `2.224555998` unwrapped tokens stranded in the bot wallet because recovery was disabled.

## How

- Scope vault reads, fill matching, and registry keys to the inventory contract.
- Keep the existing RKLB and USDC vault ID `0xfab`.
- Let the recovery worker wrap orphan tRKLB and deposit wtRKLB through managed `deposit4`.
- Update the staging comments to describe the live ownership model.

## Testing

- Verified `OPERATOR_ROLE` preflight and three transaction confirmations.
- Verified zero OrderBook allowance for USDC and all 29 wrapped equities.
- Completed a `0.01 RKLB` mint through wrapping and `inventory.deposit4`.
- Completed a `0.01 RKLB` redemption through `inventory.withdraw4`, unwrapping, and Alpaca detokenization.
- Recovered `2.224555998 RKLB` from the bot wallet through the audited orphan recovery flow.
- The normal rebalance redeemed `1.089519826 RKLB` and restored the configured 50/50 target.
- Verified zero tRKLB and wtRKLB wallet balances after recovery.
- Passed `cargo check --workspace --all-features`, Clippy, Rust formatting, Nix formatting, and pre-commit hooks.
- No new tests, this PR changes staging configuration only.

## Screenshots

N/A.

## Anything else

- The cutover baseline accepts the historical `0.5211593225662848 wtRKLB` gap. The bot did not replay those fills.
- A natural post-cutover RKLB fill has not occurred yet, so that hedge evidence remains pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787266246&installation_model_id=19370&pr_number=1072&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1072&signature=f819bc9536b643f2cd606d0a7e27a5812aa8d72545f98c21d177c68dac9de579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated staging inventory and settlement handling to use managed inventory.
  * Added the staging inventory contract and aligned vault ownership with it.
  * Enabled wrapped equity recovery for RKLB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->