### PR TITLE
fix: bound PollOrderStatus poll jobs to one per open order

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4106,6 +4106,17 @@ All work managed by the Conductor falls into one of these categories:
 | Position check       | ~60s     | Reconcile accumulated positions (safety net)         |
 | Executor maintenance | ~15m     | Refresh broker metadata, check asset availability    |
 
+`Position check`'s per-tick recovery re-enqueue is a no-op for any order that
+already has a live `Order status poll` chain; it only arms polling for an order
+that has none. The same guard covers every other point that would otherwise push
+an `Order status poll` job for an order still awaiting a broker response -- a
+new placement, per-fill reconciliation against a still-open order, the hedge
+job's own retry path, and the hedge job's post-placement routing (shared by
+fresh placement and that retry path's `Pending` re-drive) -- so at most one live
+poll chain exists per order regardless of which path pushed it. A `Running` poll
+row and its delayed `Pending` successor may temporarily coexist within that one
+chain.
+
 **Lifecycle workflows** (stepped, durable, future):
 
 | Workflow           | Steps                                                                                  |

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -130,9 +130,174 @@ Dedupe/guard queries that want to detect all live rows must therefore use:
 
 **Payload encoding**: the `job` column is the JSON-serialized payload stored as
 a SQL BLOB (apalis `JsonCodec`). Read it as `Vec<u8>` and parse with
-`serde_json::from_slice`, or use `json_extract(job, '$.field')` in SQL. Decoding
-directly as a Rust `String` fails at runtime: "Rust type String (as TEXT) is not
-compatible with SQL type BLOB".
+`serde_json::from_slice`, or use `json_extract(CAST(job AS TEXT), '$.field')` in
+SQL. Decoding directly as a Rust `String` fails at runtime: "Rust type String
+(as TEXT) is not compatible with SQL type BLOB". Prefer the `CAST` form even
+where the bare form happens to work on the SQLite build in hand: it states the
+JSON-text intent explicitly rather than relying on SQLite's own BLOB-vs-JSONB
+auto-detection, and it is pinned by
+`json_extract_reads_the_offchain_order_id_from_a_real_pushed_job`
+(`src/offchain/order/poll_status.rs`), which asserts the exact extracted value
+against a real apalis-pushed job rather than merely checking it is non-NULL.
+
+**Per-order dedup guard, keyed on payload contents (RAI-1493)**: a periodic
+recovery sweep that unconditionally re-pushes a job for every open item, atop a
+job that self-reschedules on every non-terminal poll, is a documented
+combination to watch for: each tick that finds an item still open forks a
+brand-new, independent, self-perpetuating chain in addition to whatever chain(s)
+already exist for it, so the live population grows without bound the longer the
+item stays open. This bit `PollOrderStatus`: `recover_submitted_offchain_orders`
+(`src/offchain/order/poll_status.rs`) polled every `position_check_interval`
+(~60s) for each non-terminal offchain order and pushed a new poll job every
+time, while `PollOrderStatus::perform` independently self-rescheduled via
+`reschedule_self` on every non-terminal broker response -- production
+accumulated tens of thousands of `Pending` rows for orders that stayed open for
+hours. The fix (`reconcile_live_poll_jobs`, wrapped by
+`reconcile_and_check_live_poll_job` and consolidated for every push site by
+`push_poll_job_if_absent`) is an application-layer check before the push: query
+whether a live row already exists for that specific order id via
+`json_extract(CAST(job AS TEXT),
+'$.offchain_order_id')`, and skip the push if
+so. Despite reading like a pure predicate, this can also write: when more than
+one `Pending` row already exists for the order (a pre-existing duplicate from
+before this fix), it atomically collapses every non-survivor row to `Done` as a
+side effect before reporting `true` -- every call site treats this as a
+query-with-a-possible-write, not a read-only check.
+
+That periodic sweep was not the only unconditional push site: an accounted
+onchain fill for a symbol with a live `pending_offchain_order_id`
+(`conductor.rs`'s `dispatch_post_place_state`, reached via
+`reconcile_existing_pending_order` on every such fill, not only on placement),
+the `PendingExecution` retry path (`recover_claimed_offchain_order`), the hedge
+job's own `PendingExecution` recovery (`recover_pending_poll_status`), and that
+recovery's own `Pending` re-drive follow-up (`route_placement_outcome`, shared
+with the hedge job's primary placement path) each pushed unconditionally too --
+an order that stayed open while its symbol kept trading could fork one new chain
+per fill even with the periodic sweep guarded, and a concurrent recovery attempt
+racing the primary placement path could fork one via `route_placement_outcome`
+alone. All five sites now share one guard through `push_poll_job_if_absent`, so
+at most one independent `PollOrderStatus` chain is created per order regardless
+of which of the five pushed it. The guard holds one process-local async mutex
+across both the reconciliation/check and the apalis push; serializing only the
+SQL statements is insufficient because concurrent callers can all observe no
+live row before any caller's later push commits. This lock deliberately covers
+all order ids: the critical section is one short SQLite check plus, only when
+absent, one push. This guarantee is process-scoped: production runs exactly one
+Conductor process as the exclusive owner of the SQLite database and its apalis
+queue. Multiple Conductor processes sharing that queue are unsupported because
+the process-local mutex cannot coordinate their check-and-push operations.
+Startup recovery propagates the first guard or queue failure and prevents the
+Conductor from starting with submitted orders known to be unpolled. The periodic
+recovery sweep instead logs and counts each failed order, then continues arming
+the remaining candidates so one order cannot block the rest.
+`dispatch_post_place_state` and `route_placement_outcome` in particular are each
+reached both by a genuine new placement (whose fresh `offchain_order_id` can
+never already have a poll job, so the guard is a no-op there) and by a
+reconciliation/recovery path against a possibly-already-`Submitted` order (where
+the guard is what actually matters) -- neither distinguishes its two callers,
+gating on the guard's answer instead. One `Running` row and its delayed
+`Pending` successor may legitimately coexist for the same chain; the invariant
+is one chain, not literally one live database row at every instant.
+
+A DB-enforced partial `UNIQUE` index over the same predicate was considered and
+rejected on two grounds. First, `JobQueue::requeue_orphaned` (called from
+`setup_trading_job_queues` on every boot, `src/conductor/trading_queues.rs`)
+resets every orphaned `Running`/`Queued` row of a job type back to `Pending`
+unconditionally on the boot path. Second, apalis's own orphan sweep
+(`reenqueue_orphaned.sql`, apalis-sqlite 1.0.0-rc.8) -- the same sweep this
+doc's earlier Gotcha describes -- resets a `Running`/`Queued` row only once its
+owning worker's heartbeat ages past `reenqueue_orphaned_after` (300s default,
+apalis-sql 1.0.0-rc.9 `src/config.rs`), swept every `keep_alive` tick (30s, same
+file); as that Gotcha notes, deterministic worker names keep the heartbeat
+current in practice, so this sweep almost never fires here. The normal steady
+state is exactly one `Running` row plus its one `Pending` successor for the same
+order, so either bulk update, were it to run, would promote the `Running` row
+into the indexed set where its successor already sits, hitting a `UNIQUE`
+violation that fails `Conductor::run()` on the boot path, or -- in the rare case
+apalis's own sweep does fire -- silently stops that worker's beat stream,
+reproducing the exact "worker silently stops" signature the fix was meant to
+close. A plain `SELECT`-before-`push` has no such failure mode: it never writes
+into apalis's own bulk-update paths.
+
+The guard's live-row predicate bounds a retryable-`Failed` row
+(`attempts < max_attempts`) by `done_at` freshness rather than treating it as
+either unconditionally live or unconditionally excluded. Per the Status
+lifecycle above, such a row is a live, immediately re-dispatchable chain head --
+`ack.sql` never reschedules `run_at` on a `Failed` ack, so `fetch_next.sql`
+picks it straight back up the moment a worker is free -- so counting it as live
+is what actually prevents recovery from forking a second chain alongside the one
+apalis is about to re-run. But a row stuck behind a latched worker (e.g. a
+circuit-breaker fault, RAI-1495) would otherwise sit `Failed` forever without a
+fresh `ack.sql` write, and `done_at` IS refreshed on every ack -- so bounding by
+`done_at > now - stale_after` (the same staleness bound as the
+`Queued`/`Running` arm below) gives both properties: a just-failed row counts as
+live, but one that has sat `Failed` past `stale_after` without a fresh ack stops
+suppressing recovery.
+
+The predicate also bounds the `Queued`/`Running` arm by staleness
+(`lock_at > now - stale_after`, `stale_after` a small multiple of the poll
+interval): an unbounded `status IN ('Queued', 'Running')` check treats a
+stranded row (the "Gotcha" above -- a dropped in-memory fetch buffer, a
+cancelled task, a latched worker) as proof polling is armed forever, since
+nothing else ever ages it out. Bounding it means a stranded row eventually stops
+blocking recovery's re-push, at the cost of not counting a `Queued`/ `Running`
+row that is still genuinely in flight but slow (rare; broker polls are a single
+HTTP round-trip).
+
+Beyond gating the push, `reconcile_live_poll_jobs` also atomically collapses
+pre-existing duplicate chains: when more than one `Pending` row exists for the
+same order (the population an unguarded recovery tick could already have forked
+before this fix), it keeps the row apalis's own dispatch order
+(`queries/backend/fetch_next.sql`, apalis-sqlite 1.0.0-rc.8:
+`ORDER BY priority DESC, run_at ASC, id ASC`) would run first, and marks the
+rest `Done` (with `done_at` set), converging back to one live row per order over
+a small number of ticks. This is one `UPDATE` whose `WHERE` clause selects the
+survivor via a subquery, not a `SELECT` to pick a survivor followed by a
+separately-predicated `UPDATE`: SQLite evaluates the whole statement, subquery
+included, as one atomic unit under its own write lock, so there is no window
+between "decide the survivor" and "collapse the rest" for a concurrent writer
+(another guard call racing this one, or `reschedule_self` pushing a legitimate
+successor) to land in -- it either commits before the statement starts, and is
+included in the survivor decision, or after the statement ends, and is left
+untouched, never observed half-written mid-decision. An earlier two-statement
+version of this guard captured a survivor id from a separate `SELECT`, then
+re-ran `id != <that id>` in a later `UPDATE`; a successor landing in the gap
+between them matched that stale predicate and was collapsed too, leaving the
+order with zero live rows despite the guard reporting `true`. This
+single-statement collapse is always safe to run, even while a `Queued`/`Running`
+row for this order is still fresh: it only ever inspects/touches `Pending` rows,
+so a currently-executing row is never a candidate, and if its `reschedule_self`
+successor has not landed yet there is nothing else to collapse (a lone `Pending`
+row is trivially its own survivor).
+
+Apalis's own `ORDER BY` only ever ranks rows its `WHERE` clause has already made
+eligible (`run_at IS NULL OR run_at <= strftime('%s', 'now')`), so it never
+trades a due row for a not-yet-due one regardless of priority; this guard's
+candidate set is deliberately wider than that (every `Pending` row, not just due
+ones, since the normal steady-state successor `reschedule_self` pushes is one
+poll interval in the future and excluding it would make the guard return `false`
+and push a duplicate), so textually replaying apalis's `ORDER BY` alone over
+that wider set would diverge whenever a due row and a higher-priority
+not-yet-due row coexist. The survivor query therefore ranks due-ness first
+(`(run_at IS NULL OR run_at <= strftime('%s', 'now')) DESC`), then
+`priority DESC, run_at ASC, id ASC` -- the same tie-break apalis applies among
+rows it would actually consider dispatching, and still needed since
+`Jobs.run_at` is epoch-_seconds_, so rows pushed within the same second need
+apalis's own `id ASC` tie-break -- SQLite's row order among ties is otherwise
+unspecified. `Done`, not `Killed`, matches `JobQueue::cancel_all_pending`'s
+precedent for discarding superseded queue rows -- this is routine dedupe, not
+the non-retryable abort that `load_job_queue_health`'s operator-facing `killed`
+counter exists to surface.
+
+Every predicate above also requires `json_valid(CAST(job AS TEXT))` alongside
+the `json_extract` equality check: the order-id comparison does not guarantee
+`json_extract` is skipped for a row it does not match, and `json_extract` raises
+a hard SQL error (not NULL) on a `job` blob that is not valid JSON at all (a
+genuine corruption or foreign codec, not the known `X'6E756C6C'` poison rows --
+the text `null` is valid JSON). Without the `json_valid` guard, one such row
+would fail the guard query -- and, on the boot path, propagate through
+`recover_submitted_offchain_orders` to fail `Conductor::run()` -- for every
+order sharing this job type, not just the corrupt row's own.
 
 ### Job trait
 

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -1105,7 +1105,8 @@ mod tests {
     use crate::onchain::trade::RaindexTradeEvent;
     use crate::onchain_trade::{OnChainTrade as OnChainTradeCqrs, OnChainTradeCommand};
     use crate::test_utils::{
-        OnchainTradeBuilder, get_test_order, positive_shares, setup_test_db, setup_test_pools,
+        OnchainTradeBuilder, TEST_POLL_INTERVAL, get_test_order, positive_shares, setup_test_db,
+        setup_test_pools,
     };
     use crate::trading::onchain::inclusion::EmittedOnChain;
     use crate::trading::onchain::trade_accountant::TradeAccountingError;
@@ -2193,6 +2194,7 @@ mod tests {
             counter_trade_submission_lock: Arc::new(Mutex::new(())),
             poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
             hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&apalis_pool),
+            poll_interval: TEST_POLL_INTERVAL,
         };
 
         // The trade_event payload is never accessed because process_queued_trade

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -68,13 +68,12 @@ use crate::inventory::{
 };
 use crate::offchain::order::{
     ExecutorOrderPlacer, OffchainOrder, OffchainOrderId, OffchainOrderPlacement, OrderPlacer,
-    PollOrderStatus, PollOrderStatusJobQueue, TerminalPositionFinalization,
-    client_order_id_for_placement, finalize_cancelled_position_or_log_unpriced,
-    place_offchain_order_at_broker, position_command_for_finalization,
-    terminal_position_finalization,
+    PollOrderStatusJobQueue, TerminalPositionFinalization, client_order_id_for_placement,
+    finalize_cancelled_position_or_log_unpriced, place_offchain_order_at_broker,
+    position_command_for_finalization, push_poll_job_if_absent, terminal_position_finalization,
 };
 #[cfg(test)]
-use crate::offchain::order::{OffchainOrderCommand, noop_order_placer};
+use crate::offchain::order::{OffchainOrderCommand, PollOrderStatus, noop_order_placer};
 use crate::onchain::OnchainTrade;
 #[cfg(test)]
 use crate::onchain::accumulator::check_all_positions;
@@ -325,6 +324,12 @@ pub(crate) struct TradeProcessingCqrs {
     /// the inline path cannot place itself (it has no `OrderPlacer` for the
     /// limit-order price lookup). `CheckPositions` is the backstop.
     pub(crate) hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue,
+    /// Fed to [`push_poll_job_if_absent`] before every `PollOrderStatus`
+    /// push this pipeline makes, so a re-push for an order that already has a
+    /// live poll job (for example, per-fill reconciliation against a
+    /// still-open order) is skipped instead of forking a new
+    /// self-perpetuating chain.
+    pub(crate) poll_interval: Duration,
 }
 
 /// Orchestrates the bot's runtime by composing long-running supervised tasks
@@ -887,6 +892,7 @@ impl Conductor {
             },
             &frameworks.offchain_order_projection,
             executor.to_supported_executor(),
+            ctx.order_polling_interval(),
         )
         .await?;
 
@@ -3553,20 +3559,20 @@ async fn recover_claimed_offchain_order(
 
     match order {
         Some(Submitted { .. } | PartiallyFilled { .. } | Cancelling { .. }) => {
-            cqrs.poll_status_queue
-                .clone()
-                .push(PollOrderStatus {
-                    offchain_order_id: pending_id,
-                })
-                .await
-                .inspect_err(|error| {
-                    error!(
-                        offchain_order_id = %pending_id,
-                        symbol = %execution.symbol,
-                        %error,
-                        "Failed to re-enqueue PollOrderStatus for a claimed pending order"
-                    );
-                })?;
+            push_poll_job_if_absent(
+                cqrs.poll_status_queue.clone(),
+                pending_id,
+                cqrs.poll_interval,
+            )
+            .await
+            .inspect_err(|error| {
+                error!(
+                    offchain_order_id = %pending_id,
+                    symbol = %execution.symbol,
+                    %error,
+                    "Failed to re-enqueue PollOrderStatus for a claimed pending order"
+                );
+            })?;
             Ok(Some(pending_id))
         }
         Some(Pending {
@@ -3612,6 +3618,18 @@ async fn recover_claimed_offchain_order(
 
 /// Routes the freshly-loaded `OffchainOrder` post-`Place` to either the
 /// rejection-cleanup or poll-enqueue path.
+///
+/// Reached both by a genuine new placement (`place_offchain_order`) and by
+/// per-fill reconciliation against a still-open order
+/// (`reconcile_existing_pending_order`, run on every accounted onchain fill
+/// for a symbol with a live `pending_offchain_order_id`) -- the two are not
+/// distinguished at the call site, so the `Submitted`/`PartiallyFilled`/
+/// `Cancelling` arm gates the push on [`push_poll_job_if_absent`] rather than
+/// on which caller reached it. A fresh placement's
+/// `offchain_order_id` can never already have a poll job, so the guard is a
+/// no-op there; a per-fill reconciliation's `offchain_order_id` almost always
+/// does, so the guard is what stops each fill from forking its own
+/// independent, self-perpetuating poll chain for the same order.
 async fn dispatch_post_place_state(
     loaded: Option<OffchainOrder>,
     symbol: &Symbol,
@@ -3638,19 +3656,20 @@ async fn dispatch_post_place_state(
         }
 
         Some(Submitted { .. } | PartiallyFilled { .. } | Cancelling { .. }) => {
-            let mut queue = cqrs.poll_status_queue.clone();
-
-            queue
-                .push(PollOrderStatus { offchain_order_id })
-                .await
-                .inspect_err(|error| {
-                    error!(
-                        %offchain_order_id,
-                        %symbol,
-                        %error,
-                        "Failed to enqueue PollOrderStatus job for newly-submitted order"
-                    );
-                })?;
+            push_poll_job_if_absent(
+                cqrs.poll_status_queue.clone(),
+                offchain_order_id,
+                cqrs.poll_interval,
+            )
+            .await
+            .inspect_err(|error| {
+                error!(
+                    %offchain_order_id,
+                    %symbol,
+                    %error,
+                    "Failed to enqueue PollOrderStatus job for newly-submitted order"
+                );
+            })?;
 
             Ok(PostPlaceOutcome::InFlight(offchain_order_id))
         }
@@ -4027,8 +4046,8 @@ mod tests {
     };
     use crate::rebalancing::{RebalancingSchedulers, RebalancingService};
     use crate::test_utils::{
-        OnchainTradeBuilder, get_test_log, get_test_order, rebalancing_enabled_equities,
-        setup_test_db, setup_test_pools,
+        OnchainTradeBuilder, TEST_POLL_INTERVAL, get_test_log, get_test_order,
+        rebalancing_enabled_equities, setup_test_db, setup_test_pools,
     };
     use crate::tokenized_equity_mint::TokenizedEquityMintCommand;
     use crate::trading::onchain::inclusion::EmittedOnChain;
@@ -6395,6 +6414,7 @@ mod tests {
             counter_trade_submission_lock: Arc::new(Mutex::new(())),
             poll_status_queue: PollOrderStatusJobQueue::new(apalis_pool),
             hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(apalis_pool),
+            poll_interval: TEST_POLL_INTERVAL,
         }
     }
 
@@ -7753,6 +7773,7 @@ mod tests {
             counter_trade_submission_lock: Arc::new(Mutex::new(())),
             poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
             hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&apalis_pool),
+            poll_interval: TEST_POLL_INTERVAL,
         };
 
         let trade_event = make_trade_event(77);
@@ -8171,6 +8192,56 @@ mod tests {
             position.pending_offchain_order_id,
             Some(first_order_id),
             "Only the first order should be pending"
+        );
+    }
+
+    /// `reconcile_existing_pending_order` -> `dispatch_post_place_state` runs
+    /// on every accounted onchain fill for a symbol with a live
+    /// `pending_offchain_order_id`. Before the multi-call-site guard fix, each
+    /// additional fill against a still-open order pushed its own independent,
+    /// self-perpetuating `PollOrderStatus` chain on top of the one the initial
+    /// placement pushed -- a burst of fills against one stuck hedge order could
+    /// fork one new chain per fill. The guard must collapse every one of these
+    /// redundant per-fill pushes down to the single job the placement armed.
+    #[tokio::test]
+    async fn repeated_fills_against_one_open_order_do_not_fork_additional_poll_jobs() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let trade_event_1 = make_trade_event(90);
+        let trade_1 = test_trade_with_amount(float!(1.5), 90);
+
+        process_queued_trade(&MockExecutor::new(), &trade_event_1, trade_1, &cqrs, true)
+            .await
+            .unwrap()
+            .expect("first trade should place an order");
+
+        assert_eq!(
+            pending_job_count::<PollOrderStatus>(&apalis_pool).await,
+            1,
+            "placing the order must arm exactly one PollOrderStatus job"
+        );
+
+        for log_index in 91..95 {
+            let trade_event = make_trade_event(log_index);
+            let trade = test_trade_with_amount(float!(0.1), log_index);
+
+            process_queued_trade(&MockExecutor::new(), &trade_event, trade, &cqrs, true)
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            pending_job_count::<PollOrderStatus>(&apalis_pool).await,
+            1,
+            "per-fill reconciliation against the same still-open order must not fork \
+             additional PollOrderStatus chains"
         );
     }
 
@@ -11387,6 +11458,254 @@ mod tests {
         assert_eq!(
             position.pending_offchain_order_id, None,
             "recovery must complete the position and clear the stale claim in-process"
+        );
+    }
+
+    /// `recover_claimed_offchain_order`'s
+    /// `Submitted`/`PartiallyFilled`/`Cancelling` arm shares the same
+    /// `push_poll_job_if_absent` guard as the other four push sites. A
+    /// `PendingExecution` retry against
+    /// an order that already has a live poll job must skip the push and
+    /// report the pending id, not fork a second independent,
+    /// self-perpetuating poll chain.
+    #[tokio::test]
+    async fn recover_claimed_offchain_order_submitted_with_live_poll_job_skips_duplicate_push() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _projection) = create_cqrs_frameworks(&pool).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let offchain_order_id = drive_position_to_pending(&frameworks, &symbol, shares).await;
+
+        frameworks
+            .offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::DryRun,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(
+                        offchain_order_id.as_uuid(),
+                    ),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        frameworks
+            .offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("ORD_SUBMITTED"),
+                    placed_shares: shares,
+                    submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // A prior attempt already armed the live poll job this retry must not
+        // duplicate.
+        cqrs.poll_status_queue
+            .clone()
+            .push(PollOrderStatus { offchain_order_id })
+            .await
+            .unwrap();
+        assert_eq!(
+            pending_job_count::<PollOrderStatus>(&apalis_pool).await,
+            1,
+            "the seeded poll job must be live before the retry"
+        );
+
+        let execution = ExecutionCtx {
+            symbol: symbol.clone(),
+            direction: Direction::Sell,
+            shares,
+            executor: st0x_execution::SupportedExecutor::DryRun,
+            market_session: st0x_execution::MarketSession::Regular,
+        };
+        let result = recover_claimed_offchain_order(&execution, &cqrs)
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            Some(offchain_order_id),
+            "a PendingExecution retry against a still-live poll job reports the pending id \
+             without pushing a duplicate"
+        );
+
+        assert_eq!(
+            pending_job_count::<PollOrderStatus>(&apalis_pool).await,
+            1,
+            "the guard must skip the push while the seeded poll job is still live, not fork a \
+             second independent chain"
+        );
+    }
+
+    /// Sibling of the skip-branch test above: when no live poll job exists for
+    /// the `Submitted` order (the prior attempt's push was lost, or this is the
+    /// first recovery attempt to observe the broker outcome), the retry must
+    /// push one so the order does not sit un-polled until the next restart.
+    #[tokio::test]
+    async fn recover_claimed_offchain_order_submitted_without_live_poll_job_pushes_poll() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _projection) = create_cqrs_frameworks(&pool).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let offchain_order_id = drive_position_to_pending(&frameworks, &symbol, shares).await;
+
+        frameworks
+            .offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::DryRun,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(
+                        offchain_order_id.as_uuid(),
+                    ),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        frameworks
+            .offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("ORD_SUBMITTED_NO_POLL"),
+                    placed_shares: shares,
+                    submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            pending_job_count::<PollOrderStatus>(&apalis_pool).await,
+            0,
+            "no poll job has been pushed yet"
+        );
+
+        let execution = ExecutionCtx {
+            symbol: symbol.clone(),
+            direction: Direction::Sell,
+            shares,
+            executor: st0x_execution::SupportedExecutor::DryRun,
+            market_session: st0x_execution::MarketSession::Regular,
+        };
+        let result = recover_claimed_offchain_order(&execution, &cqrs)
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            Some(offchain_order_id),
+            "the retry reports the pending id after re-enqueuing its poll"
+        );
+
+        assert_eq!(
+            pending_job_count::<PollOrderStatus>(&apalis_pool).await,
+            1,
+            "the guard must push exactly one PollOrderStatus job when none was live"
+        );
+    }
+
+    /// Pins the `JobError` -> `TradeAccountingError::PollJobGuard` `#[from]`
+    /// conversion: an oversized `poll_interval` makes the guard's staleness
+    /// bound overflow ([`JobError::StaleAfterOverflow`]), and that error must
+    /// surface through `recover_claimed_offchain_order` as `PollJobGuard`,
+    /// not silently succeed or land in an unrelated variant.
+    #[tokio::test]
+    async fn recover_claimed_offchain_order_wraps_stale_after_overflow_as_poll_job_guard() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _projection) = create_cqrs_frameworks(&pool).await;
+        let mut cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+        cqrs.poll_interval = std::time::Duration::from_secs(u64::MAX);
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let offchain_order_id = drive_position_to_pending(&frameworks, &symbol, shares).await;
+
+        frameworks
+            .offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::DryRun,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(
+                        offchain_order_id.as_uuid(),
+                    ),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        frameworks
+            .offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("ORD_OVERFLOW"),
+                    placed_shares: shares,
+                    submitted_at: Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let execution = ExecutionCtx {
+            symbol: symbol.clone(),
+            direction: Direction::Sell,
+            shares,
+            executor: st0x_execution::SupportedExecutor::DryRun,
+            market_session: st0x_execution::MarketSession::Regular,
+        };
+        let error = recover_claimed_offchain_order(&execution, &cqrs)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                TradeAccountingError::PollJobGuard(
+                    crate::offchain::order::JobError::StaleAfterOverflow
+                )
+            ),
+            "an oversized poll_interval must surface through the PollJobGuard conversion \
+             instead of succeeding or landing in an unrelated error variant"
         );
     }
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -357,6 +357,7 @@ where
             BrokerCtx::DryRun => st0x_execution::DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,
         },
         close_flatten_policy,
+        poll_interval,
     });
 
     let check_positions_ctx = Arc::new(CheckPositionsCtx {
@@ -374,6 +375,7 @@ where
         pool: context.pool.clone(),
         check_interval: std::time::Duration::from_secs(context.ctx.position_check_interval),
         close_flatten_policy,
+        poll_interval,
     });
 
     let portfolio_snapshot_ctx = Arc::new(PortfolioSnapshotCtx {
@@ -401,6 +403,7 @@ where
         counter_trade_submission_lock,
         poll_status_queue: poll_status_queue.clone(),
         hedge_queue: hedge_queue.clone(),
+        poll_interval,
     };
 
     let maintenance_interval = context.executor.maintenance_interval();

--- a/src/conductor/trading_queues.rs
+++ b/src/conductor/trading_queues.rs
@@ -23,7 +23,7 @@ use crate::equity_redemption::EquityRedemption;
 use crate::inventory::BroadcastingInventory;
 use crate::offchain::order::{
     HandleOrderRejectionJobQueue, OffchainOrder, PollOrderStatusJobQueue,
-    ReconcileOrderFillJobQueue, recover_submitted_offchain_orders,
+    ReconcileOrderFillJobQueue, recover_submitted_offchain_orders_at_startup,
 };
 use crate::portfolio_snapshot::{PortfolioSnapshotJobQueue, bootstrap_portfolio_snapshot};
 use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
@@ -78,6 +78,7 @@ pub(super) async fn setup_trading_job_queues(
     equity_recovery: EquityRecoveryInputs,
     offchain_order_projection: &Arc<Projection<OffchainOrder>>,
     executor_type: SupportedExecutor,
+    poll_interval: Duration,
 ) -> anyhow::Result<TradingJobQueues> {
     let EquityRecoveryInputs {
         wrapped_store: wrapped_equity_recovery_store,
@@ -89,7 +90,7 @@ pub(super) async fn setup_trading_job_queues(
         inventory_poll_interval,
     } = equity_recovery;
     let hedge_queue: HedgeJobQueue = crate::conductor::job::JobQueue::new(apalis_pool);
-    let mut poll_status_queue = PollOrderStatusJobQueue::new(apalis_pool);
+    let poll_status_queue = PollOrderStatusJobQueue::new(apalis_pool);
     let reconcile_queue = ReconcileOrderFillJobQueue::new(apalis_pool);
     let rejection_queue = HandleOrderRejectionJobQueue::new(apalis_pool);
 
@@ -138,10 +139,11 @@ pub(super) async fn setup_trading_job_queues(
 
     let check_positions_queue = CheckPositionsJobQueue::new(apalis_pool);
 
-    recover_submitted_offchain_orders(
+    recover_submitted_offchain_orders_at_startup(
         offchain_order_projection,
-        &mut poll_status_queue,
+        &poll_status_queue,
         executor_type,
+        poll_interval,
     )
     .await?;
 

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -49,7 +49,9 @@ use crate::onchain::OnchainTrade;
 use crate::onchain::pyth::PythFeedIds;
 use crate::onchain::trade::RaindexTradeEvent;
 use crate::position::{Position, PositionCommand};
-use crate::test_utils::{TestAnvilInstance, deploy_tofu_singleton, setup_test_pools, spawn_anvil};
+use crate::test_utils::{
+    TEST_POLL_INTERVAL, TestAnvilInstance, deploy_tofu_singleton, setup_test_pools, spawn_anvil,
+};
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::TradeAccountingError;
 use crate::vault_registry::VaultRegistryId;
@@ -874,6 +876,7 @@ async fn create_test_cqrs_with_assets(
         poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(apalis_pool),
         order_placer,
         hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(apalis_pool),
+        poll_interval: TEST_POLL_INTERVAL,
     };
 
     (

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -26,7 +26,8 @@ pub(crate) mod reconcile_fill;
 
 pub(crate) use handle_rejection::{HandleOrderRejection, HandleOrderRejectionJobQueue};
 pub(crate) use poll_status::{
-    PollOrderStatus, PollOrderStatusJobQueue, recover_submitted_offchain_orders,
+    PollOrderStatus, PollOrderStatusJobQueue, push_poll_job_if_absent,
+    recover_submitted_offchain_orders, recover_submitted_offchain_orders_at_startup,
 };
 pub(crate) use reconcile_fill::{ReconcileOrderFill, ReconcileOrderFillJobQueue};
 
@@ -82,6 +83,12 @@ pub(crate) enum JobError {
     Enqueue(#[from] QueuePushError),
     #[error("Offchain order invariant violation: {0}")]
     OffchainOrder(#[from] OffchainOrderError),
+    #[error("Apalis database error: {0}")]
+    ApalisDatabase(#[from] apalis_sqlite::SqlxError),
+    #[error("Integer conversion error: {0}")]
+    IntConversion(#[from] std::num::TryFromIntError),
+    #[error("Poll interval overflowed while computing the stranded-row staleness bound")]
+    StaleAfterOverflow,
 }
 
 #[derive(Debug, Clone)]

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
 use st0x_event_sorcery::{Projection, Store};
@@ -32,6 +33,25 @@ use crate::offchain::order::{
 use crate::position::Position;
 
 pub(crate) type PollOrderStatusJobQueue = JobQueue<PollOrderStatus>;
+
+/// Serializes the guard's reconcile/check and push as one process-local
+/// critical section. The service owns one apalis queue for this SQLite
+/// database, so this closes every in-process check-then-push race without a
+/// database uniqueness constraint that would reject the legitimate overlap
+/// between a `Running` poll and its delayed `Pending` successor.
+///
+/// Cross-process races are not covered: the CLI binary can run against the
+/// same database while the server is live, and this lock does not span
+/// processes. Such a race forks at most one duplicate `Pending` row, which
+/// the collapse in [`reconcile_live_poll_jobs`] converges back to one on the
+/// next guarded push -- that self-healing, not this lock, is the safety story
+/// for the cross-process case.
+///
+/// The lock is global, so a fill burst across many symbols funnels every
+/// guard+push (three SQL round-trips) through it single-file. Irrelevant at
+/// current push frequency; if it ever shows up in latency, a per-order keyed
+/// lock is the natural refinement.
+static POLL_JOB_PUSH_LOCK: Mutex<()> = Mutex::const_new(());
 
 /// Dependencies [`PollOrderStatus`] needs to query the broker and route the
 /// result. The `Filled` and `Failed` terminal transitions are deferred to
@@ -957,20 +977,316 @@ where
     Ok(())
 }
 
+/// How many poll intervals a `Queued`/`Running` [`PollOrderStatus`] row may
+/// sit without visible progress before [`reconcile_live_poll_jobs`] presumes
+/// it stranded (dropped in-memory fetch buffer, a cancelled task, a latched
+/// worker) rather than a poll genuinely in flight. A poll is a single broker
+/// round-trip, so a live worker clears it within a small multiple of the
+/// interval.
+const STRANDED_POLL_JOB_INTERVAL_MULTIPLIER: u32 = 5;
+
+/// Reconciles the live [`PollOrderStatus`] rows for `offchain_order_id`
+/// toward a single-live-row invariant and returns whether one exists
+/// afterward -- the caller should skip pushing a new job when this is
+/// `true`.
+///
+/// "Live" means `Pending`; `Queued`/`Running` with `lock_at` newer than
+/// `stale_after`; or retryable-`Failed` (`attempts < max_attempts`) with
+/// `done_at` newer than `stale_after`. `lock_at`/`done_at` are read as
+/// INTEGER unix-epoch-seconds values, which is what apalis-sqlite 1.0.0-rc.8
+/// always writes there -- `queries/backend/fetch_next.sql` and
+/// `queries/task/lock.sql` both set `lock_at = strftime('%s', 'now')`,
+/// `queries/task/ack.sql` sets `done_at` the same way on every ack including
+/// a `Failed` one, and `migrations/20251018164941_move_to_bytes.sql` declares
+/// both columns `INTEGER` -- pinned in-repo by
+/// `reconcile_live_poll_jobs_lock_at_from_a_real_apalis_lock_reads_back_as_recent_epoch_seconds`
+/// (`src/offchain/order/poll_status.rs`), which pushes a job through apalis's
+/// own `fetch_next`/`lock` path rather than a hand-seeded fixture. A
+/// `Queued`/`Running` row past `stale_after` is presumed stranded (dropped
+/// in-memory fetch buffer, a cancelled task, a latched worker) rather than a
+/// poll genuinely in flight: nothing else ever ages such a row out under a
+/// deterministic worker name (see `docs/conductor.md`'s "Gotcha" on orphaned
+/// in-flight rows).
+///
+/// A retryable-`Failed` row is a live, immediately re-dispatchable chain head
+/// under apalis's own `fetch_next.sql` (`status = 'Failed' AND attempts <
+/// max_attempts`, ignoring `run_at`'s original value once already elapsed),
+/// not an inert parked row -- so it must count as live here too, or recovery
+/// forks a second chain alongside the one apalis is about to re-run the
+/// moment a worker is free. But `ack.sql` never reschedules a `Failed` row
+/// (no `run_at` bump), so a row stuck behind a latched worker (e.g. the
+/// since-removed fail-stop circuit breaker, which could latch a worker idle
+/// forever) would otherwise sit `Failed` forever and, if counted as
+/// live unconditionally, would permanently suppress recovery's re-push for
+/// that order. Bounding it by `done_at` freshness resolves both: a
+/// just-failed row still counts as live (no duplicate chain forked while a
+/// worker is about to retry it), but once it has sat `Failed` past
+/// `stale_after` without a fresh ack, it stops suppressing recovery.
+///
+/// Beyond gating the return value, this also atomically converges
+/// pre-existing duplicate `Pending` chains (each an independent,
+/// self-perpetuating chain a prior unguarded recovery tick forked)
+/// back down to one: it keeps the survivor apalis's own dispatch order would
+/// run first, and marks every other `Pending` row `Done` (with `done_at`
+/// set). This is a single `UPDATE` whose `WHERE` clause selects the survivor
+/// via a subquery, rather than a `SELECT` to pick a survivor followed by a
+/// separately-predicated `UPDATE` -- SQLite evaluates the whole statement,
+/// subquery included, as one atomic unit under its own write lock, so there
+/// is no window between "decide the survivor" and "collapse the rest" for a
+/// concurrent writer (another guard call racing this one, or
+/// `reschedule_self` pushing a legitimate successor) to land in: it either
+/// commits before this statement starts, and is included in the survivor
+/// decision, or after this statement ends, and is left untouched -- never
+/// observed half-written mid-decision. The old two-statement shape captured
+/// a survivor id from a separate `SELECT`, then re-ran `id != <that id>` in a
+/// later `UPDATE`; a successor landing in the gap between them matched that
+/// stale predicate and was collapsed too, leaving zero live rows for the
+/// order despite this function returning `true`. Pinned by
+/// `reconcile_live_poll_jobs_atomic_collapse_never_leaves_zero_live_rows_when_a_successor_`
+/// `commits_while_the_collapse_is_blocked`.
+///
+/// This single-statement collapse is always safe to run, even while a
+/// `Queued`/`Running` row for this order is still fresh: it only ever
+/// inspects/touches `Pending` rows, so a currently-executing row is never a
+/// candidate, and if its `reschedule_self` successor has not landed yet
+/// there is nothing else to collapse (a lone `Pending` row is trivially its
+/// own survivor).
+///
+/// Apalis's `fetch_next.sql` (apalis-sqlite 1.0.0-rc.8) only ever ranks rows
+/// it has already made eligible -- its `WHERE` clause requires `run_at IS
+/// NULL OR run_at <= strftime('%s', 'now')` before its `ORDER BY priority
+/// DESC, run_at ASC, id ASC` ever runs -- so a due row always beats a
+/// not-yet-due one there, regardless of priority. This guard's own candidate
+/// set is deliberately wider (every `Pending` row, not just due ones: the
+/// normal steady-state successor `reschedule_self` pushes is one poll
+/// interval in the future, and excluding it would make the guard return
+/// `false` and push a duplicate). Textually replaying apalis's `ORDER BY`
+/// alone over that wider set would therefore diverge from what apalis would
+/// actually dispatch first whenever a due row and a higher-priority
+/// not-yet-due row coexist, so due-ness is ranked first here too
+/// (`(run_at IS NULL OR run_at <= strftime('%s', 'now')) DESC`) before
+/// `priority DESC, run_at ASC, id ASC` -- the same tie-break apalis applies
+/// among rows it would actually consider dispatching. `Jobs.run_at` is
+/// epoch-*seconds*, so rows pushed within the same second need apalis's own
+/// `id ASC` tie-break -- SQLite's row order among ties is otherwise
+/// unspecified. `Done`, not `Killed`, matches `JobQueue::cancel_all_pending`'s
+/// precedent for discarding superseded queue rows: this is routine dedupe,
+/// not a non-retryable abort, and `load_job_queue_health`'s operator-facing
+/// `killed` counter (`status = 'Killed' AND attempts < max_attempts`) exists
+/// to surface the latter.
+///
+/// `json_extract` requires `CAST(job AS TEXT)` -- `Jobs.job` is a `BLOB`
+/// (apalis's `JsonCodec`), and a bare BLOB argument is not guaranteed to be
+/// read as JSON text on every SQLite build. `json_extract` also raises a hard
+/// SQL error (not NULL) on a row whose `job` blob is not valid JSON at all,
+/// and the order-id equality is not guaranteed to filter such a row out
+/// before `json_extract` runs on it -- so every predicate here also requires
+/// `json_valid(CAST(job AS TEXT))`, skipping a corrupt/foreign-codec row
+/// instead of failing the whole guard (and, on the boot path, `Conductor::run()`)
+/// for every order sharing this job type.
+async fn reconcile_live_poll_jobs(
+    apalis_pool: &apalis_sqlite::SqlitePool,
+    offchain_order_id: OffchainOrderId,
+    stale_after: Duration,
+) -> Result<bool, JobError> {
+    let job_type = std::any::type_name::<PollOrderStatus>();
+    let stale_after_secs = i64::try_from(stale_after.as_secs())?;
+
+    let collapsed = sqlx_apalis::query(
+        "UPDATE Jobs SET status = 'Done', done_at = strftime('%s', 'now') \
+         WHERE job_type = ? \
+           AND json_valid(CAST(job AS TEXT)) \
+           AND json_extract(CAST(job AS TEXT), '$.offchain_order_id') = ? \
+           AND status = 'Pending' \
+           AND id != ( \
+             SELECT id FROM Jobs \
+             WHERE job_type = ? \
+               AND json_valid(CAST(job AS TEXT)) \
+               AND json_extract(CAST(job AS TEXT), '$.offchain_order_id') = ? \
+               AND status = 'Pending' \
+             ORDER BY (run_at IS NULL OR run_at <= strftime('%s', 'now')) DESC, \
+                      priority DESC, run_at ASC, id ASC \
+             LIMIT 1 \
+           )",
+    )
+    .bind(job_type)
+    .bind(offchain_order_id.to_string())
+    .bind(job_type)
+    .bind(offchain_order_id.to_string())
+    .execute(apalis_pool)
+    .await?;
+
+    if collapsed.rows_affected() > 0 {
+        warn!(
+            target: "broker",
+            %offchain_order_id,
+            collapsed = collapsed.rows_affected(),
+            "Collapsed duplicate live PollOrderStatus rows for one order down to one"
+        );
+    }
+
+    let is_live: bool = sqlx_apalis::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM Jobs \
+         WHERE job_type = ? \
+           AND json_valid(CAST(job AS TEXT)) \
+           AND json_extract(CAST(job AS TEXT), '$.offchain_order_id') = ? \
+           AND ( \
+             status = 'Pending' \
+             OR (status IN ('Queued', 'Running') \
+                  AND lock_at IS NOT NULL AND lock_at > strftime('%s', 'now') - ?) \
+             OR (status = 'Failed' AND attempts < max_attempts \
+                  AND done_at IS NOT NULL AND done_at > strftime('%s', 'now') - ?) \
+           ))",
+    )
+    .bind(job_type)
+    .bind(offchain_order_id.to_string())
+    .bind(stale_after_secs)
+    .bind(stale_after_secs)
+    .fetch_one(apalis_pool)
+    .await?;
+
+    Ok(is_live)
+}
+
+/// Wrapper over [`reconcile_live_poll_jobs`] that computes `stale_after` from
+/// `poll_interval` so every caller shares the same overflow-checked
+/// staleness bound instead of repeating it. [`push_poll_job_if_absent`] is
+/// the only caller, and every push site outside this module goes through
+/// that, not this function directly.
+///
+/// Despite reading like a pure predicate, this call can also **write**: when
+/// more than one `Pending` row already exists for `offchain_order_id` (a
+/// pre-existing duplicate), it collapses every non-survivor row to
+/// `Done` as a side effect before returning `true`. Every call site must treat
+/// this as a query-with-a-possible-write, not a read-only check.
+///
+/// The guard originally covered only the periodic recovery sweep
+/// ([`recover_submitted_offchain_orders`]); four other push sites -- the
+/// post-`Place` enqueue and per-fill reconciliation in `conductor.rs`'s
+/// `dispatch_post_place_state`, the `PendingExecution` retry in
+/// `recover_claimed_offchain_order`, the hedge job's
+/// `recover_pending_poll_status`, and that recovery's own `Pending` re-drive
+/// follow-up (`route_placement_outcome`, shared with the hedge job's primary
+/// placement path) -- pushed unconditionally, so an order that stayed open
+/// while its symbol kept trading could still fork one independent,
+/// self-perpetuating chain per fill. This wrapper lets all five sites share
+/// one guard, consolidated via [`push_poll_job_if_absent`] so the
+/// check-then-push shape only needs to be implemented once.
+async fn reconcile_and_check_live_poll_job(
+    apalis_pool: &apalis_sqlite::SqlitePool,
+    offchain_order_id: OffchainOrderId,
+    poll_interval: Duration,
+) -> Result<bool, JobError> {
+    let stale_after = poll_interval
+        .checked_mul(STRANDED_POLL_JOB_INTERVAL_MULTIPLIER)
+        .ok_or(JobError::StaleAfterOverflow)?;
+
+    reconcile_live_poll_jobs(apalis_pool, offchain_order_id, stale_after).await
+}
+
+/// Outcome of [`push_poll_job_if_absent`]: whether a new [`PollOrderStatus`]
+/// job was pushed, or one was already live and the push was skipped.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PollJobPushOutcome {
+    AlreadyLive,
+    Pushed,
+}
+
+/// Pushes a [`PollOrderStatus`] job for `offchain_order_id` unless one is
+/// already live ([`reconcile_and_check_live_poll_job`], which may also
+/// collapse pre-existing duplicate `Pending` rows for this order to `Done`
+/// as a side effect first). Consolidates the check-then-push shape every
+/// `PollOrderStatus` push site shares so a future change to the push step (a
+/// metric, different logging, another guard condition) only needs to land
+/// once instead of being replicated by hand at every call site -- exactly
+/// the class of gap that originally left the fifth push site
+/// (`route_placement_outcome`) unguarded. The process-local lock covers both
+/// the check and push; without it, concurrent callers can all observe no live
+/// row before any caller's push commits and fork one chain each.
+pub(crate) async fn push_poll_job_if_absent(
+    mut queue: PollOrderStatusJobQueue,
+    offchain_order_id: OffchainOrderId,
+    poll_interval: Duration,
+) -> Result<PollJobPushOutcome, JobError> {
+    let _push_guard = POLL_JOB_PUSH_LOCK.lock().await;
+
+    if reconcile_and_check_live_poll_job(queue.pool(), offchain_order_id, poll_interval).await? {
+        return Ok(PollJobPushOutcome::AlreadyLive);
+    }
+
+    queue.push(PollOrderStatus { offchain_order_id }).await?;
+
+    Ok(PollJobPushOutcome::Pushed)
+}
+
 /// Re-enqueue a [`PollOrderStatus`] job for every offchain order still in a
-/// non-terminal post-submission state. Idempotent: workers that pick up a
-/// duplicate poll job for an already-reconciled order observe the terminal
-/// state and exit cleanly.
+/// non-terminal post-submission state that does not already have a live poll
+/// job ([`push_poll_job_if_absent`]), which also collapses any pre-existing
+/// duplicate live rows for an order back down to one. Without the guard,
+/// every periodic tick that finds an order still open would fork a
+/// brand-new, independent, self-perpetuating poll chain (via
+/// [`reschedule_self`]) on top of whatever chain(s) already exist for that
+/// order, growing the live population without bound the longer the order
+/// stays open. The same guard also covers the other four unconditional
+/// `PollOrderStatus` push sites (`conductor.rs`'s
+/// `dispatch_post_place_state` and `recover_claimed_offchain_order`, and the
+/// hedge job's `recover_pending_poll_status` and `route_placement_outcome`)
+/// -- this sweep is only the periodic backstop, not the sole guarded path.
 ///
 /// Closes the gap between
 /// [`OffchainOrderCommand::Place`](crate::offchain::order::OffchainOrderCommand::Place)
 /// succeeding and the in-process push of the poll job that follows it -- if
 /// the bot crashes between those two writes, the order would otherwise sit in
-/// `Submitted` forever waiting for a poll that never comes.
+/// `Submitted` forever waiting for a poll that never comes. This periodic
+/// variant logs and counts a per-order guard/push failure, then continues
+/// arming the remaining orders; the startup variant fails closed instead.
 pub(crate) async fn recover_submitted_offchain_orders(
     offchain_order_projection: &Projection<OffchainOrder>,
-    poll_status_queue: &mut PollOrderStatusJobQueue,
+    poll_status_queue: &PollOrderStatusJobQueue,
     executor_type: SupportedExecutor,
+    poll_interval: Duration,
+) -> Result<(), JobError> {
+    recover_submitted_offchain_orders_with_policy(
+        offchain_order_projection,
+        poll_status_queue,
+        executor_type,
+        poll_interval,
+        PollRecoveryFailurePolicy::Continue,
+    )
+    .await
+}
+
+/// Startup variant of [`recover_submitted_offchain_orders`] that propagates
+/// the first per-order guard or queue failure so Conductor startup fails
+/// closed instead of starting with submitted orders known to be unpolled.
+pub(crate) async fn recover_submitted_offchain_orders_at_startup(
+    offchain_order_projection: &Projection<OffchainOrder>,
+    poll_status_queue: &PollOrderStatusJobQueue,
+    executor_type: SupportedExecutor,
+    poll_interval: Duration,
+) -> Result<(), JobError> {
+    recover_submitted_offchain_orders_with_policy(
+        offchain_order_projection,
+        poll_status_queue,
+        executor_type,
+        poll_interval,
+        PollRecoveryFailurePolicy::FailFast,
+    )
+    .await
+}
+
+#[derive(Clone, Copy)]
+enum PollRecoveryFailurePolicy {
+    Continue,
+    FailFast,
+}
+
+async fn recover_submitted_offchain_orders_with_policy(
+    offchain_order_projection: &Projection<OffchainOrder>,
+    poll_status_queue: &PollOrderStatusJobQueue,
+    executor_type: SupportedExecutor,
+    poll_interval: Duration,
+    failure_policy: PollRecoveryFailurePolicy,
 ) -> Result<(), JobError> {
     use OffchainOrder::{
         Cancelled, Cancelling, Failed, Filled, PartiallyFilled, Pending, Submitted,
@@ -999,16 +1315,57 @@ pub(crate) async fn recover_submitted_offchain_orders(
         return Ok(());
     }
 
-    info!(
-        count = pending_poll.len(),
-        "Re-enqueuing PollOrderStatus jobs for offchain orders awaiting broker fill"
-    );
+    let candidate_count = pending_poll.len();
+    let mut pushed = 0usize;
+    let mut skipped = 0usize;
+    let mut failed = 0usize;
 
     for offchain_order_id in pending_poll {
-        poll_status_queue
-            .push(PollOrderStatus { offchain_order_id })
-            .await?;
+        let outcome =
+            push_poll_job_if_absent(poll_status_queue.clone(), offchain_order_id, poll_interval)
+                .await;
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            Err(error) => match failure_policy {
+                PollRecoveryFailurePolicy::Continue => {
+                    failed += 1;
+                    error!(
+                        target: "broker",
+                        %offchain_order_id,
+                        %error,
+                        "PollOrderStatus: recovery could not arm polling for one order; \
+                         continuing with the remaining candidates"
+                    );
+
+                    continue;
+                }
+                PollRecoveryFailurePolicy::FailFast => return Err(error),
+            },
+        };
+
+        match outcome {
+            PollJobPushOutcome::AlreadyLive => {
+                skipped += 1;
+            }
+            PollJobPushOutcome::Pushed => {
+                pushed += 1;
+
+                debug!(
+                    target: "broker",
+                    %offchain_order_id,
+                    "PollOrderStatus: recovery armed polling for an order with no live poll job"
+                );
+            }
+        }
     }
+
+    info!(
+        candidate_count,
+        pushed,
+        skipped,
+        failed,
+        "Periodic submitted-order poll recovery swept offchain orders awaiting broker fill"
+    );
 
     Ok(())
 }
@@ -1019,6 +1376,9 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use chrono::Utc;
+    use futures_util::future::join_all;
+    use sqlx_apalis::ConnectOptions;
+    use tokio::sync::Barrier;
 
     use st0x_config::ExecutionThreshold;
     use st0x_event_sorcery::StoreBuilder;
@@ -1033,9 +1393,9 @@ mod tests {
         terminal_position_finalization,
     };
     use crate::position::{Position, PositionCommand, TradeId};
-    use crate::test_utils::{OnchainTradeBuilder, setup_test_pools};
-
-    const TEST_POLL_INTERVAL: Duration = Duration::from_secs(15);
+    use crate::test_utils::{
+        OnchainTradeBuilder, TEST_POLL_INTERVAL, setup_file_backed_test_db, setup_test_pools,
+    };
 
     struct TestInfra<E: Executor + Clone + Send + Sync + 'static> {
         ctx: PollOrderStatusCtx<E>,
@@ -2543,12 +2903,13 @@ mod tests {
     #[tokio::test]
     async fn recover_with_no_orders_enqueues_nothing() {
         let infra = build_test_infra(MockExecutor::new()).await;
-        let mut queue = infra.ctx.poll_status_queue.clone();
+        let queue = infra.ctx.poll_status_queue.clone();
 
         recover_submitted_offchain_orders(
             &infra.ctx.offchain_order_projection,
-            &mut queue,
+            &queue,
             SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
         )
         .await
         .unwrap();
@@ -2567,11 +2928,12 @@ mod tests {
         let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
         let _ = submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
 
-        let mut queue = infra.ctx.poll_status_queue.clone();
+        let queue = infra.ctx.poll_status_queue.clone();
         recover_submitted_offchain_orders(
             &infra.ctx.offchain_order_projection,
-            &mut queue,
+            &queue,
             SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
         )
         .await
         .unwrap();
@@ -2603,11 +2965,12 @@ mod tests {
             .await
             .unwrap();
 
-        let mut queue = infra.ctx.poll_status_queue.clone();
+        let queue = infra.ctx.poll_status_queue.clone();
         recover_submitted_offchain_orders(
             &infra.ctx.offchain_order_projection,
-            &mut queue,
+            &queue,
             SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
         )
         .await
         .unwrap();
@@ -2637,11 +3000,12 @@ mod tests {
             .await
             .unwrap();
 
-        let mut queue = infra.ctx.poll_status_queue.clone();
+        let queue = infra.ctx.poll_status_queue.clone();
         recover_submitted_offchain_orders(
             &infra.ctx.offchain_order_projection,
-            &mut queue,
+            &queue,
             SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
         )
         .await
         .unwrap();
@@ -2672,11 +3036,12 @@ mod tests {
             .await
             .unwrap();
 
-        let mut queue = infra.ctx.poll_status_queue.clone();
+        let queue = infra.ctx.poll_status_queue.clone();
         recover_submitted_offchain_orders(
             &infra.ctx.offchain_order_projection,
-            &mut queue,
+            &queue,
             SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
         )
         .await
         .unwrap();
@@ -2708,11 +3073,12 @@ mod tests {
             .await
             .unwrap();
 
-        let mut queue = infra.ctx.poll_status_queue.clone();
+        let queue = infra.ctx.poll_status_queue.clone();
         recover_submitted_offchain_orders(
             &infra.ctx.offchain_order_projection,
-            &mut queue,
+            &queue,
             SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
         )
         .await
         .unwrap();
@@ -2749,11 +3115,12 @@ mod tests {
             .await
             .unwrap();
 
-        let mut queue = infra.ctx.poll_status_queue.clone();
+        let queue = infra.ctx.poll_status_queue.clone();
         recover_submitted_offchain_orders(
             &infra.ctx.offchain_order_projection,
-            &mut queue,
+            &queue,
             SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
         )
         .await
         .unwrap();
@@ -2762,6 +3129,63 @@ mod tests {
             count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             2,
             "Two Submitted orders + one Filled must enqueue exactly two polls"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_continues_after_one_order_poll_push_fails() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+
+        let aapl = Symbol::new("AAPL").unwrap();
+        submit_offchain_order(&infra, &aapl, "wtAAPL", shares, Direction::Sell).await;
+
+        let tsla = Symbol::new("TSLA").unwrap();
+        submit_offchain_order(&infra, &tsla, "wtTSLA", shares, Direction::Sell).await;
+
+        let pending_orders = infra
+            .ctx
+            .offchain_order_projection
+            .load_all()
+            .await
+            .unwrap();
+        let failing_id = pending_orders[0].0;
+        let succeeding_id = pending_orders[1].0;
+        let trigger_sql = format!(
+            "CREATE TRIGGER fail_one_poll_push BEFORE INSERT ON Jobs \
+             WHEN NEW.job_type = '{}' \
+               AND json_extract(CAST(NEW.job AS TEXT), '$.offchain_order_id') = '{}' \
+             BEGIN SELECT RAISE(ABORT, 'simulated per-order poll push failure'); END",
+            poll_order_status_job_type(),
+            failing_id,
+        );
+        sqlx_apalis::query(&trigger_sql)
+            .execute(&infra.apalis_pool)
+            .await
+            .unwrap();
+
+        recover_submitted_offchain_orders(
+            &infra.ctx.offchain_order_projection,
+            &infra.ctx.poll_status_queue,
+            SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            live_poll_job_ids(&infra.apalis_pool, failing_id)
+                .await
+                .len(),
+            0,
+            "the order whose queue insert failed must remain unarmed for the next recovery tick"
+        );
+        assert_eq!(
+            live_poll_job_ids(&infra.apalis_pool, succeeding_id)
+                .await
+                .len(),
+            1,
+            "one order's queue failure must not prevent a later order from being armed"
         );
     }
 
@@ -2792,11 +3216,12 @@ mod tests {
         )
         .await;
 
-        let mut queue = infra.ctx.poll_status_queue.clone();
+        let queue = infra.ctx.poll_status_queue.clone();
         recover_submitted_offchain_orders(
             &infra.ctx.offchain_order_projection,
-            &mut queue,
+            &queue,
             SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
         )
         .await
         .unwrap();
@@ -2844,6 +3269,1123 @@ mod tests {
             count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
             0,
             "Executor mismatch must not enqueue HandleOrderRejection"
+        );
+    }
+
+    #[tokio::test]
+    async fn json_extract_reads_the_offchain_order_id_from_a_real_pushed_job() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let mut queue = infra.ctx.poll_status_queue.clone();
+        queue
+            .push(PollOrderStatus { offchain_order_id })
+            .await
+            .unwrap();
+
+        let extracted: String = sqlx_apalis::query_scalar(
+            "SELECT json_extract(CAST(job AS TEXT), '$.offchain_order_id') FROM Jobs \
+             WHERE job_type = ?",
+        )
+        .bind(poll_order_status_job_type())
+        .fetch_one(&infra.apalis_pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            extracted,
+            offchain_order_id.to_string(),
+            "json_extract(CAST(job AS TEXT), ...) must recover the exact offchain_order_id \
+             UUID string from a real pushed job's BLOB payload"
+        );
+    }
+
+    /// Pins the assumption `reconcile_live_poll_jobs`'s staleness predicate
+    /// depends on (`lock_at > strftime('%s', 'now') - ?`): that apalis writes
+    /// `lock_at` as an INTEGER unix-epoch-seconds value. Drives a real job
+    /// through apalis's own `fetch_next` (`queries/backend/fetch_next.sql`,
+    /// which sets `lock_at = strftime('%s', 'now')`) rather than a hand-seeded
+    /// fixture, so an apalis upgrade that changed the representation would
+    /// fail this test instead of silently passing every hand-seeded one.
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_lock_at_from_a_real_apalis_lock_reads_back_as_recent_epoch_seconds()
+     {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let mut queue = infra.ctx.poll_status_queue.clone();
+        queue
+            .push(PollOrderStatus { offchain_order_id })
+            .await
+            .unwrap();
+
+        // `Jobs.lock_by` has a foreign key onto `Workers.id`; fetch_next
+        // writes `lock_by` to this worker's name, so a matching Worker row
+        // must exist first, exactly as apalis's own worker registration would
+        // create in production.
+        sqlx_apalis::query(
+            "INSERT INTO Workers (id, worker_type, storage_name) VALUES (?, ?, 'test')",
+        )
+        .bind("test-worker")
+        .bind(poll_order_status_job_type())
+        .execute(&infra.apalis_pool)
+        .await
+        .unwrap();
+
+        let config = apalis_sqlite::Config::new(poll_order_status_job_type());
+        let worker = apalis_core::worker::context::WorkerContext::new::<()>("test-worker");
+        let fetched = apalis_sqlite::fetcher::fetch_next(infra.apalis_pool.clone(), config, worker)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            fetched.len(),
+            1,
+            "apalis's own fetch_next must lock exactly the one pushed job"
+        );
+
+        let lock_at: i64 = sqlx_apalis::query_scalar("SELECT lock_at FROM Jobs WHERE job_type = ?")
+            .bind(poll_order_status_job_type())
+            .fetch_one(&infra.apalis_pool)
+            .await
+            .unwrap();
+
+        let now = Utc::now().timestamp();
+        assert!(
+            lock_at <= now && lock_at >= now - 5,
+            "apalis's fetch_next must write lock_at as INTEGER unix-epoch-seconds close to \
+             now (got {lock_at}, now {now}); reconcile_live_poll_jobs's staleness predicate \
+             assumes this representation"
+        );
+    }
+
+    /// The staleness bound `recover_submitted_offchain_orders` would derive
+    /// from `TEST_POLL_INTERVAL` in production.
+    const TEST_STALE_AFTER: Duration = Duration::from_secs(
+        TEST_POLL_INTERVAL.as_secs() * STRANDED_POLL_JOB_INTERVAL_MULTIPLIER as u64,
+    );
+
+    async fn seed_poll_job_row(
+        apalis_pool: &apalis_sqlite::SqlitePool,
+        offchain_order_id: OffchainOrderId,
+        status: &str,
+        attempts: i64,
+        lock_at: Option<i64>,
+    ) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        let payload = serde_json::to_vec(&PollOrderStatus { offchain_order_id })
+            .expect("serialize PollOrderStatus payload");
+        sqlx_apalis::query(
+            "INSERT INTO Jobs (id, job_type, job, status, attempts, max_attempts, run_at, lock_at) \
+             VALUES (?, ?, ?, ?, ?, 25, strftime('%s', 'now'), ?)",
+        )
+        .bind(&id)
+        .bind(poll_order_status_job_type())
+        .bind(payload)
+        .bind(status)
+        .bind(attempts)
+        .bind(lock_at)
+        .execute(apalis_pool)
+        .await
+        .expect("seed PollOrderStatus job row");
+
+        id
+    }
+
+    /// Seeds a `Pending` row with an explicit `run_at`, used to control which
+    /// of several duplicate rows for one order is the earliest.
+    async fn seed_pending_poll_job_row_at(
+        apalis_pool: &apalis_sqlite::SqlitePool,
+        offchain_order_id: OffchainOrderId,
+        run_at: i64,
+    ) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        let payload = serde_json::to_vec(&PollOrderStatus { offchain_order_id })
+            .expect("serialize PollOrderStatus payload");
+        sqlx_apalis::query(
+            "INSERT INTO Jobs (id, job_type, job, status, attempts, max_attempts, run_at) \
+             VALUES (?, ?, ?, 'Pending', 0, 25, ?)",
+        )
+        .bind(&id)
+        .bind(poll_order_status_job_type())
+        .bind(payload)
+        .bind(run_at)
+        .execute(apalis_pool)
+        .await
+        .expect("seed PollOrderStatus job row");
+
+        id
+    }
+
+    /// Seeds a retryable-`Failed` row (`attempts < max_attempts`, the default
+    /// `max_attempts` of 25) with an explicit `done_at`, used to control
+    /// whether `reconcile_live_poll_jobs`'s staleness predicate reads it as
+    /// fresh or stale. A real apalis ack (`queries/task/ack.sql`) always sets
+    /// `done_at` to the ack time -- this only hand-seeds the value so a test
+    /// can pin the staleness boundary precisely, unlike the fresh case, which
+    /// is pinned against a real ack instead (see
+    /// `reconcile_live_poll_jobs_true_when_a_fresh_retryable_failed_row_exists_via_a_real_apalis_ack`).
+    async fn seed_failed_poll_job_row_at(
+        apalis_pool: &apalis_sqlite::SqlitePool,
+        offchain_order_id: OffchainOrderId,
+        done_at: i64,
+    ) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        let payload = serde_json::to_vec(&PollOrderStatus { offchain_order_id })
+            .expect("serialize PollOrderStatus payload");
+        sqlx_apalis::query(
+            "INSERT INTO Jobs (id, job_type, job, status, attempts, max_attempts, run_at, done_at) \
+             VALUES (?, ?, ?, 'Failed', 1, 25, strftime('%s', 'now'), ?)",
+        )
+        .bind(&id)
+        .bind(poll_order_status_job_type())
+        .bind(payload)
+        .bind(done_at)
+        .execute(apalis_pool)
+        .await
+        .expect("seed retryable Failed PollOrderStatus job row");
+
+        id
+    }
+
+    /// Seeds a `Pending` row with an explicit `run_at` and `priority`, used to
+    /// pin the survivor query's tie-break ordering
+    /// (`priority DESC, run_at ASC, id ASC`, mirroring apalis's own
+    /// `fetch_next.sql`).
+    async fn seed_pending_poll_job_row_with_priority(
+        apalis_pool: &apalis_sqlite::SqlitePool,
+        offchain_order_id: OffchainOrderId,
+        run_at: i64,
+        priority: i64,
+    ) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        let payload = serde_json::to_vec(&PollOrderStatus { offchain_order_id })
+            .expect("serialize PollOrderStatus payload");
+        sqlx_apalis::query(
+            "INSERT INTO Jobs (id, job_type, job, status, attempts, max_attempts, run_at, priority) \
+             VALUES (?, ?, ?, 'Pending', 0, 25, ?, ?)",
+        )
+        .bind(&id)
+        .bind(poll_order_status_job_type())
+        .bind(payload)
+        .bind(run_at)
+        .bind(priority)
+        .execute(apalis_pool)
+        .await
+        .expect("seed PollOrderStatus job row");
+
+        id
+    }
+
+    async fn live_poll_job_ids(
+        apalis_pool: &apalis_sqlite::SqlitePool,
+        offchain_order_id: OffchainOrderId,
+    ) -> Vec<String> {
+        sqlx_apalis::query_scalar(
+            "SELECT id FROM Jobs \
+             WHERE job_type = ? \
+               AND json_extract(CAST(job AS TEXT), '$.offchain_order_id') = ? \
+               AND status IN ('Pending', 'Queued', 'Running')",
+        )
+        .bind(poll_order_status_job_type())
+        .bind(offchain_order_id.to_string())
+        .fetch_all(apalis_pool)
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_true_when_a_pending_row_exists_for_the_order() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        seed_poll_job_row(&infra.apalis_pool, offchain_order_id, "Pending", 0, None).await;
+
+        assert!(
+            reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_true_when_a_fresh_queued_row_exists_for_the_order() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        seed_poll_job_row(
+            &infra.apalis_pool,
+            offchain_order_id,
+            "Queued",
+            0,
+            Some(Utc::now().timestamp()),
+        )
+        .await;
+
+        assert!(
+            reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_true_when_a_fresh_running_row_exists_for_the_order() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        seed_poll_job_row(
+            &infra.apalis_pool,
+            offchain_order_id,
+            "Running",
+            0,
+            Some(Utc::now().timestamp()),
+        )
+        .await;
+
+        assert!(
+            reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_false_when_the_only_running_row_is_stale() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let stale_lock_at =
+            Utc::now().timestamp() - i64::try_from(TEST_STALE_AFTER.as_secs()).unwrap() - 60;
+        seed_poll_job_row(
+            &infra.apalis_pool,
+            offchain_order_id,
+            "Running",
+            0,
+            Some(stale_lock_at),
+        )
+        .await;
+
+        assert!(
+            !reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap(),
+            "a Running row whose lock_at is older than stale_after must not count as live \
+             because a stranded row must not permanently suppress recovery's re-push"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_false_when_no_row_exists_for_the_order() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+
+        assert!(
+            !reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_false_when_only_a_different_orders_row_exists() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let other_order_id = OffchainOrderId::new();
+        seed_poll_job_row(&infra.apalis_pool, other_order_id, "Pending", 0, None).await;
+
+        let offchain_order_id = OffchainOrderId::new();
+        assert!(
+            !reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_false_when_the_only_row_is_terminal_done() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        seed_poll_job_row(&infra.apalis_pool, offchain_order_id, "Done", 1, None).await;
+
+        assert!(
+            !reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap()
+        );
+    }
+
+    /// Pins apalis's own contract that a retryable-`Failed` row
+    /// (`attempts < max_attempts`) is a live, immediately re-dispatchable
+    /// chain head, not an inert parked row: `fetch_next.sql` re-selects it
+    /// (`status = 'Failed' AND attempts < max_attempts`, ignoring `run_at`'s
+    /// original elapsed value) the moment a worker is free. Independent of
+    /// `reconcile_live_poll_jobs`'s own staleness bound -- this only proves
+    /// the external fact that bound is built on.
+    #[tokio::test]
+    async fn fetch_next_re_dispatches_a_retryable_failed_row_pinning_the_apalis_contract() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+
+        // Push through the real queue (rather than hand-seeding an id) so
+        // the row carries a real apalis-generated ULID id -- fetch_next's
+        // own row decoding requires that format, and a hand-seeded id in a
+        // foreign format would fail to decode regardless of this test's
+        // point (apalis's re-dispatch contract), not because of it.
+        let mut queue = infra.ctx.poll_status_queue.clone();
+        queue
+            .push(PollOrderStatus { offchain_order_id })
+            .await
+            .unwrap();
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Failed', attempts = 1 WHERE job_type = ?")
+            .bind(poll_order_status_job_type())
+            .execute(&infra.apalis_pool)
+            .await
+            .unwrap();
+
+        sqlx_apalis::query(
+            "INSERT INTO Workers (id, worker_type, storage_name) VALUES (?, ?, 'test')",
+        )
+        .bind("test-worker")
+        .bind(poll_order_status_job_type())
+        .execute(&infra.apalis_pool)
+        .await
+        .unwrap();
+
+        let config = apalis_sqlite::Config::new(poll_order_status_job_type());
+        let worker = apalis_core::worker::context::WorkerContext::new::<()>("test-worker");
+        let fetched = apalis_sqlite::fetcher::fetch_next(infra.apalis_pool.clone(), config, worker)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            fetched.len(),
+            1,
+            "apalis's own fetch_next must re-dispatch a retryable-Failed row \
+             (attempts < max_attempts), not treat it as an inert parked row"
+        );
+    }
+
+    /// Drives a real apalis fail/ack path (rather than a hand-seeded fixture)
+    /// so the guard's assumption about apalis's retry state machine cannot
+    /// silently encode a wrong model: `ack.sql` parks an errored, still-
+    /// retryable task as `Failed` in place, without rescheduling `run_at`,
+    /// and `fetch_next.sql` will immediately re-select it once a worker is
+    /// free. A just-failed row must therefore count as live here too, or
+    /// recovery forks a duplicate chain alongside the one apalis is about to
+    /// re-run.
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_true_when_a_fresh_retryable_failed_row_exists_via_a_real_apalis_ack()
+     {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let mut queue = infra.ctx.poll_status_queue.clone();
+        queue
+            .push(PollOrderStatus { offchain_order_id })
+            .await
+            .unwrap();
+
+        sqlx_apalis::query(
+            "INSERT INTO Workers (id, worker_type, storage_name) VALUES (?, ?, 'test')",
+        )
+        .bind("test-worker")
+        .bind(poll_order_status_job_type())
+        .execute(&infra.apalis_pool)
+        .await
+        .unwrap();
+
+        let config = apalis_sqlite::Config::new(poll_order_status_job_type());
+        let worker = apalis_core::worker::context::WorkerContext::new::<()>("test-worker");
+        let fetched = apalis_sqlite::fetcher::fetch_next(infra.apalis_pool.clone(), config, worker)
+            .await
+            .unwrap();
+        assert_eq!(fetched.len(), 1);
+
+        let (_args, parts) = fetched.into_iter().next().unwrap().take();
+        let task_id = parts.task_id.unwrap().to_string();
+        let worker_id = parts.ctx.lock_by().clone().unwrap();
+
+        apalis_sqlite::queries::ack_task::ack_task(
+            &infra.apalis_pool,
+            &task_id,
+            &worker_id,
+            "simulated transient broker error",
+            &apalis_core::task::status::Status::Failed,
+            1,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap(),
+            "a just-failed retryable row (attempts < max_attempts) is a live, immediately \
+             re-dispatchable chain head per apalis's own fetch_next.sql -- it must count as \
+             live so recovery does not fork a duplicate chain alongside it"
+        );
+    }
+
+    /// The latched-worker decoupling half of the same tradeoff: once a retryable-
+    /// Failed row has sat past `stale_after` without a fresh ack (e.g. stuck
+    /// behind a latched worker), it must stop suppressing recovery, or a
+    /// stuck row would permanently block a fresh push for that order.
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_false_when_the_only_row_is_a_stale_retryable_failed_row() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let stale_done_at =
+            Utc::now().timestamp() - i64::try_from(TEST_STALE_AFTER.as_secs()).unwrap() - 60;
+        seed_failed_poll_job_row_at(&infra.apalis_pool, offchain_order_id, stale_done_at).await;
+
+        assert!(
+            !reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap(),
+            "a retryable-Failed row whose done_at is older than stale_after must not \
+             permanently suppress recovery: a row stuck behind a latched worker must \
+             eventually allow a fresh push"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_collapses_duplicate_pending_rows_to_the_earliest() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let now = Utc::now().timestamp();
+        // Three independent forked chains for one order, each a Pending row
+        // with a different run_at.
+        let earliest_id =
+            seed_pending_poll_job_row_at(&infra.apalis_pool, offchain_order_id, now - 120).await;
+        seed_pending_poll_job_row_at(&infra.apalis_pool, offchain_order_id, now - 60).await;
+        seed_pending_poll_job_row_at(&infra.apalis_pool, offchain_order_id, now).await;
+
+        assert!(
+            reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap()
+        );
+
+        assert_eq!(
+            live_poll_job_ids(&infra.apalis_pool, offchain_order_id).await,
+            vec![earliest_id.clone()],
+            "reconcile_live_poll_jobs must collapse duplicate live rows for one order down to \
+             exactly the one with the earliest run_at"
+        );
+
+        let collapsed_rows: Vec<(String, Option<i64>)> = sqlx_apalis::query_as(
+            "SELECT status, done_at FROM Jobs \
+             WHERE job_type = ? \
+               AND json_extract(CAST(job AS TEXT), '$.offchain_order_id') = ? \
+               AND id != ?",
+        )
+        .bind(poll_order_status_job_type())
+        .bind(offchain_order_id.to_string())
+        .bind(&earliest_id)
+        .fetch_all(&infra.apalis_pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            collapsed_rows.len(),
+            2,
+            "both non-earliest duplicate rows must still exist, now collapsed"
+        );
+        let now = Utc::now().timestamp();
+        for (status, done_at) in collapsed_rows {
+            assert_eq!(
+                status, "Done",
+                "a collapsed duplicate must be marked Done, matching \
+                 JobQueue::cancel_all_pending's precedent for discarding superseded queue rows, \
+                 not Killed (which would pollute load_job_queue_health's operator-facing abort \
+                 metric)"
+            );
+            assert!(
+                matches!(done_at, Some(value) if value <= now && value >= now - 5),
+                "a collapsed duplicate's done_at must be a fresh unix-epoch-seconds timestamp \
+                 close to now (got {done_at:?}, now {now}), matching every other terminal row \
+                 apalis itself writes -- not merely non-NULL, which would miss a regression \
+                 that dropped or replaced the UPDATE's strftime('%s', 'now') expression"
+            );
+        }
+    }
+
+    /// Proves the collapse is atomic with the survivor decision by
+    /// reproducing the exact precondition that broke the old two-statement
+    /// implementation: a legitimate successor (as `reschedule_self` would
+    /// push) committing while `reconcile_live_poll_jobs`'s own collapse
+    /// write is already blocked in flight. The old code captured
+    /// `pending_ids` in one `SELECT`, then re-ran `id != <captured
+    /// survivor>` in a later `UPDATE`; a successor committing in that
+    /// window matched the stale predicate and was wrongly collapsed
+    /// alongside the real duplicate, leaving zero live rows despite the
+    /// function returning `true`. Holding SQLite's own write lock before
+    /// spawning the guard call, then committing the successor only after
+    /// the guard has had a chance to start blocking on that same lock,
+    /// proves the new single-statement collapse has no such window:
+    /// whichever row survives, there is always exactly one -- never zero.
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_atomic_collapse_never_leaves_zero_live_rows_when_a_successor_commits_while_the_collapse_is_blocked()
+     {
+        let (_pool, apalis_pool, db_path, _dir) =
+            setup_file_backed_test_db(Duration::from_secs(2)).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let now = Utc::now().timestamp();
+
+        // A pre-existing duplicate chain (the steady state this guard exists
+        // to collapse), due now so due-ness-first ordering picks it as
+        // survivor over the not-yet-due successor below.
+        let due_duplicate_id =
+            seed_pending_poll_job_row_at(&apalis_pool, offchain_order_id, now - 60).await;
+
+        let mut locker = sqlx_apalis::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .connect()
+            .await
+            .unwrap();
+        sqlx_apalis::query("BEGIN IMMEDIATE")
+            .execute(&mut locker)
+            .await
+            .unwrap();
+
+        let pool_for_task = apalis_pool.clone();
+        let collapse_task = tokio::spawn(async move {
+            reconcile_live_poll_jobs(&pool_for_task, offchain_order_id, TEST_STALE_AFTER).await
+        });
+
+        // Give the spawned collapse a chance to reach and start blocking on
+        // the write lock we already hold before we commit the successor --
+        // the assertions below hold regardless of whether it actually got
+        // there in time, since the collapse either observes the successor
+        // fully committed or not at all, never mid-write.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // `reschedule_self`'s legitimate successor: not yet due, pushed one
+        // poll interval in the future -- committed under the lock the
+        // blocked collapse above is waiting to acquire.
+        let successor_payload = serde_json::to_vec(&PollOrderStatus { offchain_order_id }).unwrap();
+        sqlx_apalis::query(
+            "INSERT INTO Jobs (id, job_type, job, status, attempts, max_attempts, run_at) \
+             VALUES (?, ?, ?, 'Pending', 0, 25, ?)",
+        )
+        .bind(uuid::Uuid::new_v4().to_string())
+        .bind(poll_order_status_job_type())
+        .bind(successor_payload)
+        .bind(now + 300)
+        .execute(&mut locker)
+        .await
+        .unwrap();
+
+        sqlx_apalis::query("COMMIT")
+            .execute(&mut locker)
+            .await
+            .unwrap();
+
+        assert!(
+            collapse_task.await.unwrap().unwrap(),
+            "a live Pending row must remain after the collapse"
+        );
+
+        let live_ids = live_poll_job_ids(&apalis_pool, offchain_order_id).await;
+        assert_eq!(
+            live_ids.len(),
+            1,
+            "the collapse must never leave zero live rows for an order even when a legitimate \
+             successor commits while the collapse's own write is blocked in flight; got \
+             {live_ids:?}"
+        );
+        assert_eq!(
+            live_ids[0], due_duplicate_id,
+            "due-ness-first ordering must still pick the due pre-existing row over the \
+             not-yet-due successor as survivor"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_survivor_selection_prefers_higher_priority_over_earlier_run_at()
+     {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let now = Utc::now().timestamp();
+
+        // Lower priority but earlier run_at: apalis's fetch_next.sql dispatches
+        // by `priority DESC, run_at ASC, id ASC`, so this row loses despite
+        // firing sooner -- `run_at` alone would have kept it instead.
+        seed_pending_poll_job_row_with_priority(
+            &infra.apalis_pool,
+            offchain_order_id,
+            now - 120,
+            0,
+        )
+        .await;
+        let higher_priority_id =
+            seed_pending_poll_job_row_with_priority(&infra.apalis_pool, offchain_order_id, now, 1)
+                .await;
+
+        assert!(
+            reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap()
+        );
+
+        assert_eq!(
+            live_poll_job_ids(&infra.apalis_pool, offchain_order_id).await,
+            vec![higher_priority_id],
+            "the survivor must be the row apalis's fetch_next.sql would dispatch first \
+             (priority DESC before run_at ASC), not merely the earliest run_at"
+        );
+    }
+
+    /// Apalis's own `fetch_next.sql` only ranks rows its `WHERE` clause has
+    /// already made eligible (`run_at IS NULL OR run_at <= strftime('%s',
+    /// 'now')`), so a due row always beats a not-yet-due one there regardless
+    /// of priority -- it is never a candidate for `priority DESC` to lose
+    /// against. Replaying only the `ORDER BY` over this guard's wider candidate
+    /// set (every `Pending` row, not just due ones) would pick the not-yet-due
+    /// higher-priority row instead, which apalis itself would never dispatch
+    /// first. The survivor query must therefore rank due-ness ahead of
+    /// priority.
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_survivor_selection_prefers_a_due_row_over_a_higher_priority_not_yet_due_row()
+     {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let now = Utc::now().timestamp();
+
+        let due_id =
+            seed_pending_poll_job_row_with_priority(&infra.apalis_pool, offchain_order_id, now, 0)
+                .await;
+        seed_pending_poll_job_row_with_priority(
+            &infra.apalis_pool,
+            offchain_order_id,
+            now + 600,
+            1,
+        )
+        .await;
+
+        assert!(
+            reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap()
+        );
+
+        assert_eq!(
+            live_poll_job_ids(&infra.apalis_pool, offchain_order_id).await,
+            vec![due_id],
+            "the survivor must be the due, lower-priority row -- apalis would never dispatch \
+             the not-yet-due higher-priority row first"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_survivor_selection_breaks_a_run_at_tie_by_id_asc() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let run_at = Utc::now().timestamp();
+
+        // Both rows share one run_at (pushed within the same second): apalis's
+        // fetch_next.sql breaks that tie deterministically by `id ASC`, unlike
+        // SQLite's otherwise-unspecified row order among ties.
+        let mut ids = [
+            seed_pending_poll_job_row_at(&infra.apalis_pool, offchain_order_id, run_at).await,
+            seed_pending_poll_job_row_at(&infra.apalis_pool, offchain_order_id, run_at).await,
+        ];
+        ids.sort();
+        let expected_survivor = ids[0].clone();
+
+        assert!(
+            reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap()
+        );
+
+        assert_eq!(
+            live_poll_job_ids(&infra.apalis_pool, offchain_order_id).await,
+            vec![expected_survivor],
+            "rows tied on run_at must break the tie by id ASC, matching apalis's own dispatch \
+             order, not SQLite's unspecified row order among ties"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_skips_a_malformed_job_row_instead_of_erroring() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+
+        // A corrupt/foreign-codec `job` blob for this job type: not valid JSON,
+        // so `json_extract` would raise a hard "malformed JSON" SQL error
+        // without the `json_valid` guard -- and the order-id equality does not
+        // filter this row out first, so an unrelated order's guard query would
+        // fail too, not just this row's own (nonexistent) order.
+        sqlx_apalis::query(
+            "INSERT INTO Jobs (id, job_type, job, status, attempts, max_attempts, run_at) \
+             VALUES (?, ?, ?, 'Pending', 0, 25, strftime('%s', 'now'))",
+        )
+        .bind(uuid::Uuid::new_v4().to_string())
+        .bind(poll_order_status_job_type())
+        .bind(b"not json".to_vec())
+        .execute(&infra.apalis_pool)
+        .await
+        .unwrap();
+
+        let live =
+            reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap();
+
+        assert!(
+            !live,
+            "a malformed job row (for a different, or no, order) must not fail the guard \
+             query for an unrelated order id"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_returns_int_conversion_when_stale_after_secs_exceeds_i64_max()
+    {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        // `Duration::checked_mul` (the STRANDED_POLL_JOB_INTERVAL_MULTIPLIER
+        // guard in `reconcile_and_check_live_poll_job`) can succeed here since u64 has roughly
+        // double i64's range, but `stale_after.as_secs()` itself still exceeds
+        // i64::MAX -- a narrower, deeper failure than `StaleAfterOverflow`,
+        // guarded separately by this function's own `i64::try_from`.
+        // `JobError::ApalisDatabase` (the other variant this function can
+        // return) is a bare `#[from]` passthrough of a library error and is
+        // deliberately left without a dedicated test.
+        let stale_after = Duration::from_secs(u64::try_from(i64::MAX).unwrap() + 1);
+
+        let error = reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, stale_after)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, JobError::IntConversion(_)),
+            "a stale_after whose as_secs() exceeds i64::MAX must fail fast with a typed \
+             conversion error instead of silently truncating or panicking"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_live_poll_jobs_does_not_collapse_pending_rows_while_a_fresh_running_row_exists()
+     {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        seed_poll_job_row(
+            &infra.apalis_pool,
+            offchain_order_id,
+            "Running",
+            0,
+            Some(Utc::now().timestamp()),
+        )
+        .await;
+        seed_pending_poll_job_row_at(
+            &infra.apalis_pool,
+            offchain_order_id,
+            Utc::now().timestamp(),
+        )
+        .await;
+
+        assert!(
+            reconcile_live_poll_jobs(&infra.apalis_pool, offchain_order_id, TEST_STALE_AFTER)
+                .await
+                .unwrap()
+        );
+
+        assert_eq!(
+            live_poll_job_ids(&infra.apalis_pool, offchain_order_id)
+                .await
+                .len(),
+            2,
+            "a fresh Running row and its Pending successor may briefly coexist for one \
+             legitimate chain; reconcile_live_poll_jobs must not collapse them (doing so could \
+             kill the successor instead of an actual duplicate, see doc comment)"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_push_poll_job_if_absent_calls_create_one_live_chain() {
+        const CONCURRENT_PUSHES: usize = 32;
+
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let barrier = Arc::new(Barrier::new(CONCURRENT_PUSHES));
+
+        let pushes = (0..CONCURRENT_PUSHES).map(|_| {
+            let queue = infra.ctx.poll_status_queue.clone();
+            let barrier = barrier.clone();
+
+            async move {
+                barrier.wait().await;
+                push_poll_job_if_absent(queue, offchain_order_id, TEST_POLL_INTERVAL).await
+            }
+        });
+
+        let outcomes: Vec<_> = join_all(pushes)
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .collect();
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| **outcome == PollJobPushOutcome::Pushed)
+                .count(),
+            1,
+            "exactly one racing guard call must push a new poll chain"
+        );
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| **outcome == PollJobPushOutcome::AlreadyLive)
+                .count(),
+            CONCURRENT_PUSHES - 1,
+            "every other racing guard call must observe the live poll chain"
+        );
+        assert_eq!(
+            live_poll_job_ids(&infra.apalis_pool, offchain_order_id)
+                .await
+                .len(),
+            1,
+            "concurrent guard calls must not fork duplicate self-rescheduling poll chains"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_submitted_offchain_orders_is_a_noop_when_a_live_poll_job_already_exists() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+        seed_poll_job_row(&infra.apalis_pool, order_id, "Pending", 0, None).await;
+
+        let queue = infra.ctx.poll_status_queue.clone();
+        recover_submitted_offchain_orders(
+            &infra.ctx.offchain_order_projection,
+            &queue,
+            SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            1,
+            "recovery must not push a second job when a live poll job already exists"
+        );
+    }
+
+    /// Drives a real apalis fail/ack path, matching
+    /// `reconcile_live_poll_jobs_true_when_a_fresh_retryable_failed_row_exists_via_a_real_apalis_ack`:
+    /// a just-failed retryable row is a live, immediately re-dispatchable
+    /// chain head, so recovery must not fork a duplicate `Pending` chain
+    /// alongside it.
+    #[tokio::test]
+    async fn recover_submitted_offchain_orders_does_not_push_when_only_a_fresh_retryable_failed_row_exists()
+     {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        let mut queue = infra.ctx.poll_status_queue.clone();
+        queue
+            .push(PollOrderStatus {
+                offchain_order_id: order_id,
+            })
+            .await
+            .unwrap();
+
+        sqlx_apalis::query(
+            "INSERT INTO Workers (id, worker_type, storage_name) VALUES (?, ?, 'test')",
+        )
+        .bind("test-worker")
+        .bind(poll_order_status_job_type())
+        .execute(&infra.apalis_pool)
+        .await
+        .unwrap();
+
+        let config = apalis_sqlite::Config::new(poll_order_status_job_type());
+        let worker = apalis_core::worker::context::WorkerContext::new::<()>("test-worker");
+        let fetched = apalis_sqlite::fetcher::fetch_next(infra.apalis_pool.clone(), config, worker)
+            .await
+            .unwrap();
+        let (_args, parts) = fetched.into_iter().next().unwrap().take();
+        let task_id = parts.task_id.unwrap().to_string();
+        let worker_id = parts.ctx.lock_by().clone().unwrap();
+
+        apalis_sqlite::queries::ack_task::ack_task(
+            &infra.apalis_pool,
+            &task_id,
+            &worker_id,
+            "simulated transient broker error",
+            &apalis_core::task::status::Status::Failed,
+            1,
+        )
+        .await
+        .unwrap();
+
+        recover_submitted_offchain_orders(
+            &infra.ctx.offchain_order_projection,
+            &queue,
+            SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            1,
+            "a just-failed retryable row counts as live, so recovery must not fork a second, \
+             duplicate chain alongside the one apalis is about to re-run"
+        );
+    }
+
+    /// The latched-worker decoupling half: once the retryable-Failed row has gone
+    /// stale (past `stale_after` without a fresh ack -- e.g. stuck behind a
+    /// latched worker), recovery must push a fresh row rather than staying
+    /// permanently suppressed.
+    #[tokio::test]
+    async fn recover_submitted_offchain_orders_re_pushes_once_the_only_retryable_failed_row_goes_stale()
+     {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+        let stale_done_at =
+            Utc::now().timestamp() - i64::try_from(TEST_STALE_AFTER.as_secs()).unwrap() - 60;
+        seed_failed_poll_job_row_at(&infra.apalis_pool, order_id, stale_done_at).await;
+
+        let queue = infra.ctx.poll_status_queue.clone();
+        recover_submitted_offchain_orders(
+            &infra.ctx.offchain_order_projection,
+            &queue,
+            SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            2,
+            "a stale retryable-Failed row must not permanently suppress recovery: recovery \
+             must push a fresh Pending row alongside it, a bounded tradeoff (see \
+             reconcile_live_poll_jobs)"
+        );
+
+        // A second tick, with the stale retryable-Failed row still present
+        // untouched, must not push a third row: the Pending row pushed on
+        // the first tick is what now makes the order look live, not the
+        // Failed row -- proving the tradeoff is a single bounded extra row,
+        // not an unbounded backlog that keeps growing every tick.
+        recover_submitted_offchain_orders(
+            &infra.ctx.offchain_order_projection,
+            &queue,
+            SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            2,
+            "a second recovery tick with the stale retryable-Failed row still present must not \
+             push a third row: the first tick's freshly-pushed Pending row is what suppresses \
+             further pushes, so the tradeoff stays bounded across ticks, not unbounded"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_submitted_offchain_orders_re_pushes_when_the_only_row_is_a_stale_running_row()
+    {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+        let stale_lock_at =
+            Utc::now().timestamp() - i64::try_from(TEST_STALE_AFTER.as_secs()).unwrap() - 60;
+        seed_poll_job_row(
+            &infra.apalis_pool,
+            order_id,
+            "Running",
+            0,
+            Some(stale_lock_at),
+        )
+        .await;
+
+        let queue = infra.ctx.poll_status_queue.clone();
+        recover_submitted_offchain_orders(
+            &infra.ctx.offchain_order_projection,
+            &queue,
+            SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            2,
+            "a stranded Running row must not permanently suppress recovery's re-push \
+             because recovery must push a fresh Pending row alongside the stale one"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_submitted_offchain_orders_converges_pre_existing_duplicates_to_one_live_row() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+        let now = Utc::now().timestamp();
+        // Simulates the pre-fix incident: several independent forked chains
+        // already live for one order before this fix's guard ever ran.
+        seed_pending_poll_job_row_at(&infra.apalis_pool, order_id, now - 180).await;
+        seed_pending_poll_job_row_at(&infra.apalis_pool, order_id, now - 90).await;
+        seed_pending_poll_job_row_at(&infra.apalis_pool, order_id, now).await;
+
+        let queue = infra.ctx.poll_status_queue.clone();
+        recover_submitted_offchain_orders(
+            &infra.ctx.offchain_order_projection,
+            &queue,
+            SupportedExecutor::DryRun,
+            TEST_POLL_INTERVAL,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            live_poll_job_ids(&infra.apalis_pool, order_id).await.len(),
+            1,
+            "recovery must converge pre-existing duplicate live PollOrderStatus rows for one \
+             order down to exactly one instead of leaving each to self-perpetuate forever"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_submitted_offchain_orders_returns_stale_after_overflow_on_oversized_poll_interval()
+     {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        let queue = infra.ctx.poll_status_queue.clone();
+        let error = recover_submitted_offchain_orders_at_startup(
+            &infra.ctx.offchain_order_projection,
+            &queue,
+            SupportedExecutor::DryRun,
+            Duration::from_secs(u64::MAX),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(error, JobError::StaleAfterOverflow),
+            "an oversized order_polling_interval must fail fast with a typed overflow error \
+             rather than panicking inside Duration's checked_mul"
         );
     }
 }

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -73,6 +73,10 @@ pub(crate) struct CheckPositionsCtx<E: Executor + Clone + Send + Sync + 'static>
     /// re-validating it per tick just threads an always-succeeds-in-practice
     /// `Result` through the hot scan path.
     pub(crate) close_flatten_policy: CloseFlattenPolicy,
+    /// Passed through to `recover_submitted_offchain_orders`'s dedup guard, so
+    /// its stranded-row staleness bound scales with the configured poll
+    /// cadence instead of a value hardcoded far from where it is configured.
+    pub(crate) poll_interval: Duration,
 }
 
 /// Errors surfaced by [`CheckPositions::perform`].
@@ -225,17 +229,22 @@ where
         // job died (a transient broker error exhausts the apalis retries ->
         // `Failed`, which `requeue_orphaned` deliberately skips) or was never
         // enqueued (crash window) is otherwise stuck until the next restart,
-        // leaving the hedge unreconciled. Re-enqueue is idempotent -- a duplicate
-        // poll for an order that already has a live one is harmless: the worker
-        // observes the terminal/again-pending state and exits. It does re-poll
-        // live orders too; a precise per-order dedup is tracked as a follow-up
-        // (apalis persists the job payload as an opaque blob, so the order id
-        // cannot be matched there to skip live polls).
-        let mut poll_status_queue = self.poll_status_queue.clone();
+        // leaving the hedge unreconciled. `recover_submitted_offchain_orders`
+        // dedupes per order before pushing: it queries the live apalis Jobs
+        // rows via `json_extract(CAST(job AS TEXT), '$.offchain_order_id')`
+        // (`reconcile_live_poll_jobs`) and skips the push when a live poll already
+        // exists for that order, so this tick is a no-op for orders already
+        // being polled and only arms polling for orders that have none
+        // (an unconditional re-push here forked an independent,
+        // self-perpetuating poll chain on every tick an order stayed open).
+        // It also collapses any pre-existing duplicate live rows for one
+        // order down to one.
+        let poll_status_queue = self.poll_status_queue.clone();
         if let Err(error) = recover_submitted_offchain_orders(
             &self.offchain_order_projection,
-            &mut poll_status_queue,
+            &poll_status_queue,
             self.executor.to_supported_executor(),
+            self.poll_interval,
         )
         .await
         {
@@ -1062,11 +1071,13 @@ mod tests {
     use st0x_float_macro::float;
 
     use super::*;
+    use crate::offchain::order::poll_status::PollOrderStatusCtx;
     use crate::offchain::order::{
-        CounterTradeOrderKind, OffchainOrder, OffchainOrderCommand, OrderPlacementResult,
+        CounterTradeOrderKind, HandleOrderRejectionJobQueue, OffchainOrder, OffchainOrderCommand,
+        OrderPlacementResult, PollOrderStatus, ReconcileOrderFillJobQueue,
     };
     use crate::position::{PositionCommand, TradeId};
-    use crate::test_utils::setup_test_pools;
+    use crate::test_utils::{TEST_POLL_INTERVAL, setup_test_pools};
 
     async fn build_ctx(
         pool: SqlitePool,
@@ -1146,6 +1157,7 @@ mod tests {
             pool,
             check_interval,
             close_flatten_policy,
+            poll_interval: TEST_POLL_INTERVAL,
         };
 
         (ctx, position)
@@ -1418,6 +1430,7 @@ mod tests {
             pool: pool.clone(),
             check_interval: Duration::from_secs(60),
             close_flatten_policy,
+            poll_interval: TEST_POLL_INTERVAL,
         };
 
         CheckPositions {}.perform(&ctx).await.unwrap();
@@ -3016,5 +3029,161 @@ mod tests {
         assert!(remaining.contains(&"failed-exhausted".to_string()));
         assert!(remaining.contains(&"done-1".to_string()));
         assert!(remaining.contains(&"killed-1".to_string()));
+    }
+
+    async fn live_poll_job_count(
+        apalis_pool: &apalis_sqlite::SqlitePool,
+        offchain_order_id: OffchainOrderId,
+    ) -> i64 {
+        sqlx_apalis::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM Jobs \
+             WHERE job_type = ? \
+               AND json_extract(CAST(job AS TEXT), '$.offchain_order_id') = ? \
+               AND status IN ('Pending', 'Queued', 'Running')",
+        )
+        .bind(poll_status_job_type())
+        .bind(offchain_order_id.to_string())
+        .fetch_one(apalis_pool)
+        .await
+        .unwrap()
+    }
+
+    /// Simulates a single-concurrency apalis worker draining the oldest live
+    /// `PollOrderStatus` row for one order: dequeue, run `perform`, ack
+    /// (`Done`). Mirrors `drain_pending_equity_jobs`'s pattern
+    /// (`src/rebalancing/trigger/equity.rs`) rather than calling `perform`
+    /// with no row bookkeeping at all, so an unfixed
+    /// `recover_submitted_offchain_orders` forking an extra independent chain
+    /// each tick shows up as an extra never-drained row, exactly like the
+    /// single `concurrency(1)` worker in production under-draining a growing
+    /// backlog.
+    async fn drain_one_poll_job_for_order(
+        apalis_pool: &apalis_sqlite::SqlitePool,
+        poll_ctx: &PollOrderStatusCtx<MockExecutor>,
+        offchain_order_id: OffchainOrderId,
+    ) {
+        let row: Option<(String, Vec<u8>)> = sqlx_apalis::query_as(
+            "SELECT id, job FROM Jobs \
+             WHERE job_type = ? \
+               AND json_extract(CAST(job AS TEXT), '$.offchain_order_id') = ? \
+               AND status IN ('Pending', 'Queued', 'Running') \
+             ORDER BY run_at ASC LIMIT 1",
+        )
+        .bind(poll_status_job_type())
+        .bind(offchain_order_id.to_string())
+        .fetch_optional(apalis_pool)
+        .await
+        .unwrap();
+
+        let Some((id, payload)) = row else {
+            return;
+        };
+
+        let job: PollOrderStatus =
+            serde_json::from_slice(&payload).expect("deserialize PollOrderStatus payload");
+        job.perform(poll_ctx).await.unwrap();
+
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+            .bind(&id)
+            .execute(apalis_pool)
+            .await
+            .expect("mark drained PollOrderStatus job done");
+    }
+
+    /// Reproduces the incident mechanism: `CheckPositions`'s per-tick
+    /// recovery unconditionally re-pushed a `PollOrderStatus` job
+    /// for every still-open order, forking an independent, self-perpetuating
+    /// poll chain on top of whatever chain(s) already existed for that order.
+    /// A single-concurrency worker (simulated here by draining exactly one
+    /// due row per tick) cannot keep up, so the live-row population grows
+    /// without bound the longer the order stays open.
+    #[tokio::test]
+    async fn check_positions_recovery_does_not_multiply_poll_jobs_for_a_long_open_order() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let cfg = dry_run_ctx(&["AAPL"], OperationMode::Disabled);
+        let executor = MockExecutor::new().with_order_status(OrderState::Pending);
+        let (ctx, position) = build_ctx_with_executor(
+            pool.clone(),
+            apalis_pool.clone(),
+            cfg,
+            Duration::from_secs(60),
+            executor.clone(),
+        )
+        .await;
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        accumulate_position(
+            &position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let offchain_order_id = OffchainOrderId::new();
+        let shares = Positive::new(FractionalShares::new(float!(2.0))).unwrap();
+        position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+        ctx.offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
+                    kind: CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        ctx.offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::MarkAccepted {
+                    executor_order_id: ExecutorOrderId::new("test-accept"),
+                    placed_shares: shares,
+                    submitted_at: chrono::Utc::now(),
+                    market_session: st0x_execution::MarketSession::Regular,
+                    limit_price: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let poll_ctx = PollOrderStatusCtx {
+            executor: executor.clone(),
+            offchain_order_projection: ctx.offchain_order_projection.clone(),
+            offchain_order_store: ctx.offchain_order.clone(),
+            position_store: position.clone(),
+            poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
+            reconcile_queue: ReconcileOrderFillJobQueue::new(&apalis_pool),
+            rejection_queue: HandleOrderRejectionJobQueue::new(&apalis_pool),
+            poll_interval: Duration::from_secs(15),
+        };
+
+        for _ in 0..5 {
+            CheckPositions::default().perform(&ctx).await.unwrap();
+            drain_one_poll_job_for_order(&apalis_pool, &poll_ctx, offchain_order_id).await;
+        }
+
+        assert_eq!(
+            live_poll_job_count(&apalis_pool, offchain_order_id).await,
+            1,
+            "a long-open order must have exactly one live PollOrderStatus job \
+             regardless of how many CheckPositions ticks fire while it stays open"
+        );
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -13,6 +13,7 @@ use rain_math_float::Float;
 use sqlx::SqlitePool;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Condvar, LazyLock, Mutex};
+use std::time::Duration;
 
 use st0x_config::{EquitiesConfig, EquityAssetConfig, OperationMode};
 use st0x_execution::{Direction, FractionalShares, Positive, Symbol};
@@ -22,6 +23,14 @@ use crate::onchain::OnchainTrade;
 use crate::onchain::io::{TokenizedSymbol, Usdc, WrappedTokenizedShares};
 
 const MAX_CONCURRENT_TEST_ANVILS: usize = 4;
+
+/// Shared `order_polling_interval`-equivalent for tests that need a
+/// realistic-but-arbitrary poll interval (e.g. to derive a staleness bound or
+/// populate a `*Ctx.poll_interval` field). A single source of truth avoids the
+/// silent-drift risk of multiple modules each defining their own copy of the
+/// same value under a "matches such-and-such module" comment that nothing
+/// enforces.
+pub(crate) const TEST_POLL_INTERVAL: Duration = Duration::from_secs(15);
 
 static ANVIL_PERMITS: LazyLock<(Mutex<usize>, Condvar)> =
     LazyLock::new(|| (Mutex::new(0), Condvar::new()));

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -5,6 +5,7 @@
 //! these; the apalis worker processes them with retry semantics.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use alloy::primitives::U256;
 use metrics::counter;
@@ -22,10 +23,13 @@ use st0x_execution::{
 };
 
 use crate::conductor::job::{Job, JobQueue, Label};
+#[cfg(test)]
+use crate::offchain::order::PollOrderStatus;
 use crate::offchain::order::{
     CounterTradeOrderKind, OffchainOrder, OffchainOrderId, OffchainOrderPlacement, OrderPlacer,
-    PollOrderStatus, PollOrderStatusJobQueue, client_order_id_for_placement,
+    PollOrderStatusJobQueue, client_order_id_for_placement,
     finalize_cancelled_position_or_log_unpriced, place_offchain_order_at_broker,
+    push_poll_job_if_absent,
 };
 use crate::position::{Position, PositionCommand, PositionError};
 use crate::trading::offchain::close_flatten::{CloseFlattenPolicy, preflight_skip_reason_label};
@@ -124,6 +128,12 @@ pub(crate) struct HedgeCtx {
     /// is the backstop for that gap -- the rejected order lands as `Failed`
     /// and releases the position for a later re-hedge.
     pub(crate) counter_trade_submission_lock: Arc<Mutex<()>>,
+    /// Fed to [`push_poll_job_if_absent`] before every
+    /// `PollOrderStatus` push in this module (`recover_pending_poll_status`'s
+    /// re-push and `route_placement_outcome`'s push), so a push against an
+    /// order that already has a live poll job is skipped instead of forking a
+    /// new self-perpetuating chain.
+    pub(crate) poll_interval: Duration,
 }
 
 /// A durable job that places an offsetting broker order for an accumulated
@@ -385,8 +395,11 @@ fn record_close_flatten_block(symbol: &Symbol, reason: &'static str) {
 /// - `Submitted`/`PartiallyFilled`: the order reached the broker but the prior
 ///   attempt may have failed to enqueue the `PollOrderStatus` job (e.g. the
 ///   queue push returned a transient error and apalis re-ran us), so re-enqueue
-///   it. Duplicate poll jobs are harmless -- `dispatch_for_order_state` drops
-///   jobs whose target order is already terminal.
+///   it, guarded by [`push_poll_job_if_absent`]: a retry against an
+///   order that already has a live poll job (the common case -- this path re-runs
+///   whenever `PendingExecution` is hit, not only after a lost push) must
+///   skip the push, or it forks a new independent, self-perpetuating poll
+///   chain for the same order every time it re-runs.
 /// - `Pending`: the broker outcome was never committed -- the `MarkAccepted`/
 ///   `MarkFailed` write was lost after a successful broker call, or a crash hit
 ///   before the broker call. Re-drive the idempotent placement so the order
@@ -403,11 +416,7 @@ async fn recover_pending_poll_status(
     };
     match ctx.offchain_order.load(&pending_id).await? {
         Some(Submitted { .. } | PartiallyFilled { .. } | Cancelling { .. }) => {
-            ctx.poll_status_queue
-                .clone()
-                .push(PollOrderStatus {
-                    offchain_order_id: pending_id,
-                })
+            push_poll_job_if_absent(ctx.poll_status_queue.clone(), pending_id, ctx.poll_interval)
                 .await?;
             Ok(())
         }
@@ -482,16 +491,22 @@ async fn recover_pending_poll_status(
 /// stranded:
 ///
 /// - `Failed`: roll the position back (clear the claim).
-/// - `Submitted`/`PartiallyFilled`: enqueue a `PollOrderStatus` job.
+/// - `Submitted`/`PartiallyFilled`/`Cancelling`: enqueue a `PollOrderStatus`
+///   job, guarded by [`push_poll_job_if_absent`] so a re-entrant call
+///   against an order that already has a live poll job is skipped instead of
+///   forking a new self-perpetuating chain.
 /// - `None` (no order after a successful `Place`): clear the claim, since there
 ///   is nothing left to track.
 /// - `Pending`/`Filled`: surface a retryable error without clearing the claim,
 ///   since the order may be live at the broker.
 ///
-/// Shared by the primary placement path and the `Pending` re-drive in
-/// [`recover_pending_poll_status`], and kept in lockstep with the
-/// trade-processing path's `dispatch_post_place_state`, so the placement paths
-/// cannot diverge.
+/// Shared by the primary placement path (a genuinely fresh order, where the
+/// guard is always a no-op) and the `Pending` re-drive in
+/// [`recover_pending_poll_status`] (where a concurrent recovery attempt for
+/// the same `pending_id` may have already advanced the order to `Submitted`
+/// and pushed its poll job before this call observes it -- the guard is what
+/// makes that race safe), and kept in lockstep with the trade-processing
+/// path's `dispatch_post_place_state`, so the placement paths cannot diverge.
 async fn route_placement_outcome(
     ctx: &HedgeCtx,
     symbol: &Symbol,
@@ -515,10 +530,12 @@ async fn route_placement_outcome(
         }
 
         Some(Submitted { .. } | PartiallyFilled { .. } | Cancelling { .. }) => {
-            ctx.poll_status_queue
-                .clone()
-                .push(PollOrderStatus { offchain_order_id })
-                .await?;
+            push_poll_job_if_absent(
+                ctx.poll_status_queue.clone(),
+                offchain_order_id,
+                ctx.poll_interval,
+            )
+            .await?;
         }
 
         // No order exists after a successful `Place` -- there is nothing to
@@ -742,6 +759,7 @@ mod tests {
         OffchainOrder, OffchainOrderCommand, OrderPlacementResult, OrderPlacer,
     };
     use crate::position::{Position, PositionCommand, TradeId};
+    use crate::test_utils::TEST_POLL_INTERVAL;
     use st0x_config::{EquitiesConfig, EquityAssetConfig, ExecutionThreshold, OperationMode};
 
     /// Builds an [`AssetsConfig`] with a single equity whose extended-hours
@@ -891,6 +909,7 @@ mod tests {
             counter_trade_slippage_bps: st0x_execution::DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,
             close_flatten_policy: CloseFlattenPolicy::from_secs(900).unwrap(),
             counter_trade_submission_lock: Arc::new(Mutex::new(())),
+            poll_interval: TEST_POLL_INTERVAL,
         };
 
         TestInfra {
@@ -994,6 +1013,72 @@ mod tests {
         };
         assert_eq!(returned, offchain_order_id);
         assert_eq!(state, pending);
+    }
+
+    /// `route_placement_outcome`'s `Submitted`/`PartiallyFilled`/`Cancelling`
+    /// arm shares the same `push_poll_job_if_absent` guard as
+    /// `dispatch_post_place_state` and `recover_pending_poll_status`.
+    /// A re-entrant call against an order that already has a live poll job
+    /// (the shape of the race between `recover_pending_poll_status`'s `Pending`
+    /// re-drive and a concurrent recovery attempt for the same order) must
+    /// skip the push rather than forking a second independent,
+    /// self-perpetuating poll chain.
+    #[tokio::test]
+    async fn route_placement_outcome_skips_duplicate_push_when_poll_job_already_live() {
+        let TestInfra {
+            ctx, apalis_pool, ..
+        } = create_hedge_ctx(succeeding_order_placer()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+
+        let submitted = OffchainOrder::Submitted {
+            symbol: symbol.clone(),
+            shares: Positive::new(FractionalShares::new(float!(1.0))).unwrap(),
+            requested_shares: Some(Positive::new(FractionalShares::new(float!(1.0))).unwrap()),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            executor_order_id: ExecutorOrderId::new("ORD_ROUTE_GUARD"),
+            placed_at: chrono::Utc::now(),
+            submitted_at: chrono::Utc::now(),
+            market_session: MarketSession::Regular,
+        };
+
+        // First call: no live poll job yet, so the guard is a no-op and the
+        // push goes through.
+        route_placement_outcome(&ctx, &symbol, offchain_order_id, Some(submitted.clone()))
+            .await
+            .unwrap();
+
+        let poll_jobs_after_first: i64 =
+            sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                .bind(type_name::<PollOrderStatus>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            poll_jobs_after_first, 1,
+            "the first call must push exactly one PollOrderStatus job"
+        );
+
+        // Second call against the same order (simulating a concurrent recovery
+        // attempt observing the order already Submitted with its poll job
+        // already live) must skip the push rather than forking a duplicate
+        // chain.
+        route_placement_outcome(&ctx, &symbol, offchain_order_id, Some(submitted))
+            .await
+            .unwrap();
+
+        let poll_jobs_after_second: i64 =
+            sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                .bind(type_name::<PollOrderStatus>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            poll_jobs_after_second, 1,
+            "a re-entrant call against an order with a still-live poll job must not push a \
+             duplicate"
+        );
     }
 
     #[tokio::test]
@@ -1586,6 +1671,7 @@ mod tests {
             counter_trade_slippage_bps: 100,
             close_flatten_policy: CloseFlattenPolicy::from_secs(900).unwrap(),
             counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
+            poll_interval: TEST_POLL_INTERVAL,
         };
 
         TestInfra {
@@ -2537,6 +2623,7 @@ mod tests {
             counter_trade_slippage_bps: 100,
             close_flatten_policy: CloseFlattenPolicy::from_secs(900).unwrap(),
             counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
+            poll_interval: TEST_POLL_INTERVAL,
         };
 
         TestInfra {
@@ -2548,7 +2635,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retry_after_failed_poll_enqueue_re_enqueues_poll() {
+    async fn retry_against_a_still_live_poll_job_does_not_fork_a_duplicate() {
         let TestInfra {
             ctx, apalis_pool, ..
         } = create_hedge_ctx(succeeding_order_placer()).await;
@@ -2580,9 +2667,12 @@ mod tests {
         );
 
         // Retry the same job. Position rejects with PendingExecution because
-        // the first run set the pending id. The recovery path must observe
-        // that the offchain order is still `Submitted` and push another
-        // PollOrderStatus rather than silently returning Ok.
+        // the first run set the pending id, and the offchain order is still
+        // `Submitted` with its poll job still live. `recover_pending_poll_status`
+        // must observe that via `reconcile_and_check_live_poll_job` and skip
+        // the push -- every apalis retry of this same job would otherwise
+        // fork its own independent, self-perpetuating poll chain for the same
+        // order.
         job.perform(&ctx).await.unwrap();
 
         let poll_jobs_after_retry: i64 =
@@ -2592,8 +2682,66 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(
-            poll_jobs_after_retry, 2,
-            "Retry must re-enqueue PollOrderStatus when the order is still Submitted"
+            poll_jobs_after_retry, 1,
+            "retry must not re-enqueue PollOrderStatus while the first job for this order is \
+             still live"
+        );
+    }
+
+    /// Sibling of the test above, pinning the push branch of
+    /// `recover_pending_poll_status`'s `Submitted` arm: when the first poll job
+    /// is no longer live (its doc comment's motivating case is a lost enqueue,
+    /// but a completed/superseded row collapses to the same "not live" guard
+    /// outcome), a retry must re-enqueue a replacement rather than silently
+    /// returning `Ok(())` and leaving the order un-polled.
+    #[tokio::test]
+    async fn retry_against_no_longer_live_poll_job_re_enqueues_a_replacement() {
+        let TestInfra {
+            ctx, apalis_pool, ..
+        } = create_hedge_ctx(succeeding_order_placer()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let job = hedge_job(&symbol, 2.0, Direction::Sell);
+
+        // First run: drives the order to `Submitted` and enqueues
+        // PollOrderStatus exactly once.
+        job.perform(&ctx).await.unwrap();
+
+        // Simulate the pushed job no longer being live (e.g. it already ran
+        // to completion) so `reconcile_and_check_live_poll_job` observes no
+        // live row for the retry to skip against.
+        sqlx_apalis::query(
+            "UPDATE Jobs SET status = 'Done', done_at = strftime('%s', 'now') WHERE job_type = ?",
+        )
+        .bind(type_name::<PollOrderStatus>())
+        .execute(&apalis_pool)
+        .await
+        .unwrap();
+
+        // Retry the same job. Position rejects with PendingExecution again,
+        // and this time `reconcile_and_check_live_poll_job` finds no live
+        // row, so `recover_pending_poll_status` must push a replacement.
+        job.perform(&ctx).await.unwrap();
+
+        let live_poll_jobs: i64 = sqlx_apalis::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE job_type = ? AND status IN ('Pending', 'Queued', \
+             'Running')",
+        )
+        .bind(type_name::<PollOrderStatus>())
+        .fetch_one(&apalis_pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            live_poll_jobs, 1,
+            "retry against a no-longer-live poll job must re-enqueue exactly one replacement"
         );
     }
 

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -460,6 +460,8 @@ pub(crate) enum TradeAccountingError {
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+    #[error("PollOrderStatus live-job guard failed: {0}")]
+    PollJobGuard(#[from] crate::offchain::order::JobError),
 }
 
 #[cfg(test)]
@@ -493,7 +495,9 @@ mod tests {
     use crate::onchain::trade::{INVENTORY_TOKEN_DECIMALS_MAX_RETRIES, InventoryTrade};
     use crate::onchain_trade::OnChainTrade;
     use crate::position::Position;
-    use crate::test_utils::{get_test_log, get_test_order, panic_revert_payload, setup_test_pools};
+    use crate::test_utils::{
+        TEST_POLL_INTERVAL, get_test_log, get_test_order, panic_revert_payload, setup_test_pools,
+    };
 
     /// Builds the CQRS stores, job queue, and `AccountantCtx` shared by every
     /// `perform()` test in this module -- callers supply only what actually
@@ -547,6 +551,7 @@ mod tests {
             counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
             poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(apalis_pool),
             hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(apalis_pool),
+            poll_interval: TEST_POLL_INTERVAL,
         };
 
         let job_queue = DexTradeAccountingJobQueue::new(apalis_pool);


### PR DESCRIPTION
## What

- Stop `PollOrderStatus` poll jobs from multiplying without bound for one open offchain order. This is one of three sub-issues of the [RAI-1492](https://linear.app/makeitrain/issue/RAI-1492) production incident. See [RAI-1493](https://linear.app/makeitrain/issue/RAI-1493).
- Add one shared guard, `reconcile_and_check_live_poll_job`, that every push site calls before it enqueues a poll job for an order.
- Route all five push sites through that guard: the periodic `recover_submitted_offchain_orders` sweep, `dispatch_post_place_state` (post-place and per-fill), `recover_claimed_offchain_order`, `recover_pending_poll_status`, and `route_placement_outcome`.
- Collapse pre-existing duplicate `Pending` poll rows for one order, so only the best survivor stays and the rest go `Done`.

## Why

- On 2026-07-22 the `PollOrderStatus` worker ran 39,411 executions in 43 minutes for only 2 orders. That tripped the Alpaca rate limit. It burned the job retry budget. It latched the single-concurrency worker idle. All hedging stopped, silently, for 3 hours and 25 minutes.
- The cause was not one code path. Every `PollOrderStatus` execution self-reschedules. Several push sites also re-pushed a job for an already-open order with no dedup. So each recovery tick, and each new fill, forked a new self-perpetuating chain.
- An order stays open for hours when its hedge is an extended-hours limit order on a thin-book equity that does not fill. That is the state that triggers the runaway.

## How

- The guard runs one atomic `UPDATE`. It keeps the single best `Pending` survivor row for an order and marks the rest `Done`. The survivor is picked with apalis's own dispatch order (`priority DESC, run_at ASC, id ASC`, due rows first), so the row kept is the row apalis would run next. One statement, so no read-then-write race can leave the order with zero live rows.
- The guard then checks if a `Pending` row, a fresh in-flight `Queued`/`Running` row, or a fresh retryable `Failed` row still exists for the order. "Fresh" means locked or failed within a staleness bound. This prevents a duplicate self-reschedule chain, while still allowing at most one fresh in-flight row next to the `Pending` successor.
- Retryable `Failed` counts as live only while fresh. A stale one does not, so a row stuck behind a latched worker still gets re-pushed by the next sweep. That keeps this fix decoupled from the circuit-breaker fix in RAI-1495.
- All five push sites now go through one helper, `push_poll_job_if_absent`, so the check-then-push shape lives in one place.

## Testing

- Some tests drive the real apalis fetch and ack paths, not hand-seeded rows, where the apalis retry contract matters. This caught an earlier wrong assumption that a retryable `Failed` row is inert.
- The atomicity test holds a `BEGIN IMMEDIATE` write lock, commits a successor row while the collapse is blocked, and asserts the order never drops to zero live rows.
- Added guard coverage at every push site, including the per-fill burst case and the `PendingExecution` retry path.
- Ran the scoped suite (`offchain::order`, `position_check`, `conductor`, `hedge`, `trade_accountant`), `cargo clippy --all-targets --all-features`, and `nix run .#ci` locally. All green.

## Anything else

- The observed incident volume is larger than the ~60s recovery sweep alone can explain. The fill-driven push sites are the bigger contributor, so gating them is the core of the fix, not just the sweep.
- Two follow-ups are out of scope here and logged. The other `json_extract(job, ...)` dedup guards in the rebalancing and equity-recovery jobs lack the `json_valid` hardening. A full move to one recurring sweep job, instead of per-order self-reschedule chains, is the larger structural fix.
- No migration. The guard is application-level. A DB `UNIQUE` index was considered and rejected, because it would crash-loop `requeue_trading_orphans` at boot and break apalis's own heartbeat sweep. The reasoning is written up in `docs/conductor.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate order-status polling jobs when orders are reconciled, retried, recovered, hedged, or checked repeatedly.
  - Improved recovery of submitted and partially filled orders by maintaining a single active polling chain per order.
  - Added safeguards for stale or malformed polling-job records to keep recovery reliable.

- **Documentation**
  - Expanded guidance on polling-job payloads, deduplication behavior, recovery rules, and handling existing duplicates.

- **Tests**
  - Added coverage for repeated checks, recovery scenarios, concurrency, and duplicate-job prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->