### PR TITLE
refactor: fold Position price fields into one PriceObservation

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -192,7 +192,7 @@ fn parse_float(input: &str) -> Result<Float, String> {
 }
 
 /// Parses a strictly-positive price. A zero or negative `--price` would poison
-/// `last_price_usdc` and make a dollar-value threshold never trigger a hedge --
+/// `last_price` and make a dollar-value threshold never trigger a hedge --
 /// the exact never-hedges state the price requirement exists to prevent.
 fn parse_positive_price(input: &str) -> Result<Float, String> {
     let value = Float::parse(input.to_string()).map_err(|err| format!("{err}"))?;

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -808,7 +808,7 @@ impl Reactor for Broadcaster {
                         self.broadcast_position(st0x_dto::Position {
                             symbol: position.symbol,
                             net: position.net.inner(),
-                            last_price_usdc: position.last_price_usdc,
+                            last_price_usdc: position.last_price.map(|observation| observation.price),
                         });
                     }
                     Ok(None) => warn!(target: "dashboard", %id, "Position not found after event"),

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -408,7 +408,7 @@ async fn load_positions(pool: &SqlitePool) -> Vec<st0x_dto::Position> {
             Ok(Some(position)) => positions.push(st0x_dto::Position {
                 symbol: position.symbol,
                 net: position.net.inner(),
-                last_price_usdc: position.last_price_usdc,
+                last_price_usdc: position.last_price.map(|observation| observation.price),
             }),
             Ok(None) => {
                 warn!(target: "dashboard", %id, "Position disappeared while loading dashboard state");

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -124,8 +124,9 @@ async fn assert_position(
     assert_eq!(position.accumulated_short, accumulated_short);
     assert_eq!(position.pending_offchain_order_id, pending);
     let price = position
-        .last_price_usdc
-        .expect("last_price_usdc should be Some");
+        .last_price
+        .expect("last_price should be Some")
+        .price;
     assert!(price.eq(last_price_usdc).unwrap());
 }
 

--- a/src/portfolio_snapshot/write.rs
+++ b/src/portfolio_snapshot/write.rs
@@ -690,7 +690,7 @@ fn capped_retry_backoff(boundary: Option<DateTime<Utc>>, now: DateTime<Utc>) -> 
 /// underlying units and is left untouched.
 ///
 /// `evaluate_day` (`read.rs`) later multiplies each row's balance directly by
-/// `Position.last_price_usdc`, an UNDERLYING share price -- so a wrapped
+/// `Position.last_price`'s price, an UNDERLYING share price -- so a wrapped
 /// balance persisted without this conversion would be valued as if 1 wrapped
 /// share == 1 underlying share, silently wrong once a vault's ratio departs
 /// from 1:1 (dividends, splits, NAV accrual).
@@ -739,14 +739,14 @@ async fn convert_wrapped_equity_rows(
 }
 
 /// Resolves each row's USD mark (decision 7): USDC is par, equity is
-/// `Position.last_price_usdc` as of capture time. A symbol with a balance but
-/// no observed price yet gets `usd_mark: None, mark_captured_at: None` --
+/// `Position.last_price`'s price as of capture time. A symbol with a balance
+/// but no observed price yet gets `usd_mark: None, mark_captured_at: None` --
 /// never a fabricated zero.
 ///
-/// `mark_captured_at` for an equity row is `Position.last_price_observed_at`,
-/// a dedicated price-observation timestamp set only by the events that also
-/// set `last_price_usdc` (`OnChainOrderFilled`, priced `ManualPositionAdjusted`)
-/// -- unlike `last_updated`, which advances on every event including
+/// `mark_captured_at` for an equity row is `Position.last_price`'s
+/// `observed_at`, a dedicated price-observation timestamp set only by the
+/// events that also set the price (`OnChainOrderFilled`, priced
+/// `ManualPositionAdjusted`) -- unlike `last_updated`, which advances on every event including
 /// price-less ones (offchain order placement/fill/cancel, threshold updates).
 /// `read.rs`'s staleness guard (`is_stale_mark`) therefore keys off how
 /// recently the price itself was actually observed, not how recently the
@@ -768,10 +768,11 @@ async fn resolve_marks(
                     *mark
                 } else {
                     let mark = match position_projection.load(symbol).await? {
-                        Some(position) => match position.last_price_usdc {
-                            Some(mark) => (Some(mark), position.last_price_observed_at),
-                            None => (None, None),
-                        },
+                        Some(position) => {
+                            position.last_price.map_or((None, None), |observation| {
+                                (Some(observation.price), Some(observation.observed_at))
+                            })
+                        }
                         None => (None, None),
                     };
                     equity_marks.insert(symbol.clone(), mark);
@@ -1608,13 +1609,14 @@ mod tests {
     }
 
     /// The one branch of `resolve_marks` that reads a real fill-derived price
-    /// out of `Position` and pairs it with `position.last_price_observed_at`:
-    /// this must persist the position's price-observation time, never
-    /// `last_updated` (which a trailing non-price event advances) nor the
-    /// job's own `captured_at`. A trailing `UpdateThreshold` after the fill
-    /// diverges `last_updated` from `last_price_observed_at` so a regression
-    /// that reverted to `last_updated` would be caught, not accidentally pass
-    /// by coincidence of all three timestamps lining up.
+    /// out of `Position` and pairs it with `position.last_price`'s
+    /// `observed_at`: this must persist the position's price-observation
+    /// time, never `last_updated` (which a trailing non-price event
+    /// advances) nor the job's own `captured_at`. A trailing
+    /// `UpdateThreshold` after the fill diverges `last_updated` from the
+    /// price's `observed_at` so a regression that reverted to `last_updated`
+    /// would be caught, not accidentally pass by coincidence of all three
+    /// timestamps lining up.
     #[tokio::test]
     async fn equity_position_with_known_price_persists_its_price_observation_time() {
         let (pool, apalis_pool) = setup_test_pools().await;
@@ -1646,7 +1648,7 @@ mod tests {
             .unwrap();
 
         // Trailing non-price event: advances last_updated to ~now without
-        // touching last_price_usdc/last_price_observed_at.
+        // touching last_price.
         position
             .send(
                 &aapl(),
@@ -1676,7 +1678,7 @@ mod tests {
         assert_eq!(
             mark_captured_at.as_deref(),
             Some(block_timestamp.to_rfc3339().as_str()),
-            "mark_captured_at must be Position.last_price_observed_at, not last_updated \
+            "mark_captured_at must be Position.last_price's observed_at, not last_updated \
              (which the trailing UpdateThreshold advanced past it)"
         );
     }
@@ -1715,7 +1717,7 @@ mod tests {
             .unwrap();
 
         // Recent, unrelated non-price touch: advances last_updated to ~now
-        // without touching last_price_usdc/last_price_observed_at.
+        // without touching last_price.
         position
             .send(
                 &aapl(),

--- a/src/position.rs
+++ b/src/position.rs
@@ -26,6 +26,26 @@ use st0x_float_serde::{DebugFloat, DebugOptionFloat};
 
 use crate::offchain::order::{CancellationReason, OffchainOrderId};
 
+/// A price economically observed at a specific point in time. Folds
+/// `last_price_usdc` and `last_price_observed_at` into one type so a price
+/// without an observation time (or vice versa) is unrepresentable -- the two
+/// previously had to move in lockstep by discipline alone.
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub struct PriceObservation {
+    #[serde(with = "st0x_float_serde::float_string_serde")]
+    pub price: Float,
+    pub observed_at: DateTime<Utc>,
+}
+
+impl std::fmt::Debug for PriceObservation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PriceObservation")
+            .field("price", &DebugFloat(&self.price))
+            .field("observed_at", &self.observed_at)
+            .finish()
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Position {
     pub symbol: Symbol,
@@ -70,24 +90,17 @@ pub struct Position {
     #[serde(default)]
     pub pending_acknowledged_trade_ids: BTreeSet<TradeId>,
     pub threshold: ExecutionThreshold,
-    #[serde(
-        serialize_with = "st0x_float_serde::serialize_option_float",
-        deserialize_with = "st0x_float_serde::deserialize_option_float_from_number_or_string"
-    )]
-    pub last_price_usdc: Option<Float>,
     pub last_updated: Option<DateTime<Utc>>,
-    /// When `last_price_usdc` was economically observed -- set only by the
-    /// events that also set `last_price_usdc` (`OnChainOrderFilled`,
+    /// The most recently economically observed price, paired with when it was
+    /// observed. Set only by the events that carry a price (`OnChainOrderFilled`,
     /// `ManualPositionAdjusted` with a price), unlike `last_updated`, which
     /// advances on every event including price-less ones. Drives
     /// `resolve_marks`' `mark_captured_at` so mark staleness keys off price
     /// recency, not the aggregate's generic last-touched time. `#[serde(default)]`
     /// so legacy (pre-this-field) snapshots deserialize to `None`; the
-    /// `SCHEMA_VERSION` bump discards those snapshots before load, so the
-    /// `last_price_usdc.is_some() == last_price_observed_at.is_some()`
-    /// invariant holds for every aggregate actually reached by `resolve_marks`.
+    /// `SCHEMA_VERSION` bump discards those snapshots before load.
     #[serde(default)]
-    pub last_price_observed_at: Option<DateTime<Utc>>,
+    pub last_price: Option<PriceObservation>,
 }
 
 impl std::fmt::Debug for Position {
@@ -111,9 +124,8 @@ impl std::fmt::Debug for Position {
                 &self.pending_acknowledged_trade_ids,
             )
             .field("threshold", &self.threshold)
-            .field("last_price_usdc", &DebugOptionFloat(&self.last_price_usdc))
             .field("last_updated", &self.last_updated)
-            .field("last_price_observed_at", &self.last_price_observed_at)
+            .field("last_price", &self.last_price)
             .finish()
     }
 }
@@ -161,7 +173,7 @@ impl EventSourced for Position {
 
     const AGGREGATE_TYPE: &'static str = "Position";
     const PROJECTION: Table = Table("position_view");
-    const SCHEMA_VERSION: u64 = 5;
+    const SCHEMA_VERSION: u64 = 6;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use PositionEvent::*;
@@ -180,9 +192,8 @@ impl EventSourced for Position {
                 last_acknowledged_trade_id: None,
                 pending_acknowledged_trade_ids: BTreeSet::new(),
                 threshold: *threshold,
-                last_price_usdc: None,
                 last_updated: Some(*initialized_at),
-                last_price_observed_at: None,
+                last_price: None,
             }),
 
             _ => None,
@@ -210,13 +221,15 @@ impl EventSourced for Position {
                     net: new_net,
                     accumulated_long: new_accumulated_long,
                     last_acknowledged_trade_id: Some(trade_id.clone()),
-                    last_price_usdc: Some(*price_usdc),
                     last_updated: Some(*seen_at),
                     // block_timestamp, NOT seen_at: the economic time the price
                     // was valid on-chain. seen_at can go fresh on a delayed
                     // catch-up backfill, which would make an old price look
                     // fresh and defeat the staleness gate this field exists for.
-                    last_price_observed_at: Some(*block_timestamp),
+                    last_price: Some(PriceObservation {
+                        price: *price_usdc,
+                        observed_at: *block_timestamp,
+                    }),
                     ..entity.clone()
                 }))
             }
@@ -237,9 +250,11 @@ impl EventSourced for Position {
                     net: new_net,
                     accumulated_short: new_accumulated_short,
                     last_acknowledged_trade_id: Some(trade_id.clone()),
-                    last_price_usdc: Some(*price_usdc),
                     last_updated: Some(*seen_at),
-                    last_price_observed_at: Some(*block_timestamp),
+                    last_price: Some(PriceObservation {
+                        price: *price_usdc,
+                        observed_at: *block_timestamp,
+                    }),
                     ..entity.clone()
                 }))
             }
@@ -385,11 +400,13 @@ impl EventSourced for Position {
                 record_position_gauge(&entity.symbol, target_net);
                 Ok(Some(Self {
                     net: *target_net,
-                    last_price_usdc: (*price_usdc).or(entity.last_price_usdc),
                     last_updated: Some(*adjusted_at),
-                    last_price_observed_at: price_usdc
-                        .map(|_| *adjusted_at)
-                        .or(entity.last_price_observed_at),
+                    last_price: price_usdc
+                        .map(|price| PriceObservation {
+                            price,
+                            observed_at: *adjusted_at,
+                        })
+                        .or(entity.last_price),
                     // A manual reconciliation supersedes any prior failed hedge,
                     // so clear the broker-idempotency anchor. Otherwise the next
                     // hedge could reuse the failed order's client_order_id and be
@@ -663,7 +680,7 @@ impl EventSourced for Position {
                     self.net,
                     target_net,
                     &self.threshold,
-                    self.last_price_usdc,
+                    self.last_price.map(|observation| observation.price),
                     price_usdc,
                 )?;
 
@@ -809,15 +826,16 @@ impl Position {
                 }))
             }
             ExecutionThreshold::DollarValue(threshold_dollars) => {
-                let Some(price) = self.last_price_usdc else {
+                let Some(observation) = self.last_price else {
                     debug!(
                         target: "hedge",
                         net_position = %self.net,
                         threshold_dollars = %threshold_dollars,
-                        "Cannot evaluate ExecutionThreshold::DollarValue: last_price_usdc is None"
+                        "Cannot evaluate ExecutionThreshold::DollarValue: last_price is None"
                     );
                     return Ok(None);
                 };
+                let price = observation.price;
 
                 let net_abs = self.net.abs()?;
                 let dollar_value = (Usdc::new(price) * net_abs.inner())?;
@@ -859,7 +877,7 @@ impl Position {
     /// Enforces optimistic concurrency (the live net must still match what the
     /// operator observed) and ensures a nonzero target under a dollar-value
     /// threshold has a usable price, so the adjusted exposure can actually be
-    /// hedged instead of stalling on a missing `last_price_usdc`.
+    /// hedged instead of stalling on a missing `last_price`.
     fn validate_manual_adjustment(
         expected_net: Option<FractionalShares>,
         current_net: FractionalShares,
@@ -3063,7 +3081,10 @@ mod tests {
         .unwrap();
 
         assert!(
-            option_float_eq(position.last_price_usdc, Some(float!(200))),
+            option_float_eq(
+                position.last_price.map(|observation| observation.price),
+                Some(float!(200))
+            ),
             "manual adjustment should persist the supplied price"
         );
 
@@ -3573,8 +3594,16 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        assert!(option_float_eq(position.last_price_usdc, Some(float!(150))));
-        assert_eq!(position.last_price_observed_at, Some(block_timestamp));
+        assert!(option_float_eq(
+            position.last_price.map(|observation| observation.price),
+            Some(float!(150))
+        ));
+        assert_eq!(
+            position
+                .last_price
+                .map(|observation| observation.observed_at),
+            Some(block_timestamp)
+        );
         assert_eq!(position.last_updated, Some(seen_at));
     }
 
@@ -3604,15 +3633,23 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        assert!(option_float_eq(position.last_price_usdc, Some(float!(150))));
-        assert_eq!(position.last_price_observed_at, Some(block_timestamp));
+        assert!(option_float_eq(
+            position.last_price.map(|observation| observation.price),
+            Some(float!(150))
+        ));
+        assert_eq!(
+            position
+                .last_price
+                .map(|observation| observation.observed_at),
+            Some(block_timestamp)
+        );
         assert_eq!(position.last_updated, Some(seen_at));
     }
 
     /// Representative sample of the non-price arms (`ThresholdUpdated`,
     /// `OffChainOrderPlaced`, `OffChainOrderFilled`): each reconstructs
     /// `Position` via `..entity.clone()`, which auto-preserves
-    /// `last_price_observed_at` once it exists on the struct -- not a
+    /// `last_price` once it exists on the struct -- not a
     /// per-arm business rule worth asserting one-by-one, so this chains a
     /// few of them and checks the field survives to the end while
     /// `last_updated` keeps advancing.
@@ -3671,7 +3708,9 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            position.last_price_observed_at,
+            position
+                .last_price
+                .map(|observation| observation.observed_at),
             Some(block_timestamp),
             "non-price events must not touch the price-observation timestamp"
         );
@@ -3700,8 +3739,16 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        assert!(option_float_eq(position.last_price_usdc, Some(float!(200))));
-        assert_eq!(position.last_price_observed_at, Some(adjusted_at));
+        assert!(option_float_eq(
+            position.last_price.map(|observation| observation.price),
+            Some(float!(200))
+        ));
+        assert_eq!(
+            position
+                .last_price
+                .map(|observation| observation.observed_at),
+            Some(adjusted_at)
+        );
     }
 
     #[test]
@@ -3738,25 +3785,31 @@ mod tests {
         .unwrap();
 
         assert!(
-            option_float_eq(position.last_price_usdc, Some(float!(150))),
+            option_float_eq(
+                position.last_price.map(|observation| observation.price),
+                Some(float!(150))
+            ),
             "no price on the adjustment must preserve the prior known price"
         );
         assert_eq!(
-            position.last_price_observed_at,
+            position
+                .last_price
+                .map(|observation| observation.observed_at),
             Some(block_timestamp),
             "no price on the adjustment must preserve the prior observation time"
         );
         assert_eq!(position.last_updated, Some(adjusted_at));
     }
 
-    /// The invariant the whole field exists to uphold: a price event followed
-    /// by an unrelated touch keeps `last_price_usdc` and
-    /// `last_price_observed_at` both present (never one without the other),
-    /// with the observation timestamp strictly older than the last-touched
+    /// The `PriceObservation` folding makes presence (`price` and
+    /// `observed_at` always Some/None together) compiler-enforced rather
+    /// than a runtime invariant to test. What remains worth asserting is
+    /// that a price event followed by an unrelated touch leaves the
+    /// observation timestamp strictly older than the last-touched
     /// timestamp -- proving the two have actually decoupled, not just that
     /// both happen to be `Some`.
     #[test]
-    fn price_observed_at_and_last_price_usdc_presence_invariant_holds_after_non_price_touch() {
+    fn price_observation_predates_later_non_price_touch() {
         let block_timestamp = Utc::now();
         let updated_at = block_timestamp + chrono::Duration::hours(1);
         let threshold = one_share_threshold();
@@ -3788,30 +3841,26 @@ mod tests {
         .unwrap();
 
         assert!(
-            option_float_eq(position.last_price_usdc, Some(float!(150))),
-            "the priced fill must leave last_price_usdc set"
-        );
-        assert_eq!(
-            position.last_price_observed_at,
-            Some(block_timestamp),
-            "last_price_usdc and last_price_observed_at must be present together"
-        );
-        assert!(
-            position.last_price_observed_at < position.last_updated,
+            position
+                .last_price
+                .map(|observation| observation.observed_at)
+                < position.last_updated,
             "the price observation must predate the later non-price touch: \
-             last_price_observed_at = {:?}, last_updated = {:?}",
-            position.last_price_observed_at,
+             last_price.observed_at = {:?}, last_updated = {:?}",
+            position
+                .last_price
+                .map(|observation| observation.observed_at),
             position.last_updated
         );
     }
 
-    /// `#[serde(default)]` on `last_price_observed_at` is load-bearing only
-    /// for a legacy (pre-this-field) snapshot: the `SCHEMA_VERSION` bump
-    /// discards such snapshots before they are ever loaded (a full event
-    /// replay repopulates the field), so this documents *why* the fallback
-    /// exists rather than a path `resolve_marks` can actually reach.
+    /// `#[serde(default)]` on `last_price` is load-bearing only for a legacy
+    /// (pre-fold) snapshot: the `SCHEMA_VERSION` bump discards such
+    /// snapshots before they are ever loaded (a full event replay
+    /// repopulates the field), so this documents *why* the fallback exists
+    /// rather than a path `resolve_marks` can actually reach.
     #[test]
-    fn legacy_snapshot_json_without_price_observed_at_field_deserializes_to_none() {
+    fn legacy_snapshot_json_without_last_price_field_deserializes_to_none() {
         let block_timestamp = Utc::now();
 
         let position = replay::<Position>(vec![
@@ -3834,22 +3883,26 @@ mod tests {
         ])
         .unwrap()
         .unwrap();
-        assert_eq!(position.last_price_observed_at, Some(block_timestamp));
+        assert_eq!(
+            position
+                .last_price
+                .map(|observation| observation.observed_at),
+            Some(block_timestamp)
+        );
 
         let mut snapshot = serde_json::to_value(&position)
             .expect("Position must serialize for this legacy-snapshot fixture");
         snapshot
             .as_object_mut()
             .expect("Position serializes to a JSON object")
-            .remove("last_price_observed_at");
+            .remove("last_price");
 
         let legacy: Position = serde_json::from_value(snapshot)
-            .expect("a v4-shaped snapshot (missing the new field) must still deserialize");
+            .expect("a pre-fold snapshot (missing the new field) must still deserialize");
 
-        assert!(option_float_eq(legacy.last_price_usdc, Some(float!(150))));
-        assert_eq!(
-            legacy.last_price_observed_at, None,
-            "a legacy snapshot with no last_price_observed_at key must default to None"
+        assert!(
+            legacy.last_price.is_none(),
+            "a legacy snapshot with no last_price key must default to None"
         );
     }
 
@@ -3987,9 +4040,11 @@ mod tests {
             last_acknowledged_trade_id: None,
             pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
-            last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
-            last_price_observed_at: Some(Utc::now()),
+            last_price: Some(PriceObservation {
+                price: float!(150),
+                observed_at: Utc::now(),
+            }),
         };
 
         let (direction, shares) = position
@@ -4017,9 +4072,11 @@ mod tests {
             last_acknowledged_trade_id: None,
             pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
-            last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
-            last_price_observed_at: Some(Utc::now()),
+            last_price: Some(PriceObservation {
+                price: float!(150),
+                observed_at: Utc::now(),
+            }),
         };
 
         let (direction, shares) = position
@@ -4047,9 +4104,11 @@ mod tests {
             last_acknowledged_trade_id: None,
             pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
-            last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
-            last_price_observed_at: Some(Utc::now()),
+            last_price: Some(PriceObservation {
+                price: float!(150),
+                observed_at: Utc::now(),
+            }),
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(50))).unwrap();
@@ -4080,9 +4139,11 @@ mod tests {
             last_acknowledged_trade_id: None,
             pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
-            last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
-            last_price_observed_at: Some(Utc::now()),
+            last_price: Some(PriceObservation {
+                price: float!(150),
+                observed_at: Utc::now(),
+            }),
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(50))).unwrap();
@@ -4113,9 +4174,11 @@ mod tests {
             last_acknowledged_trade_id: None,
             pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
-            last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
-            last_price_observed_at: Some(Utc::now()),
+            last_price: Some(PriceObservation {
+                price: float!(150),
+                observed_at: Utc::now(),
+            }),
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(50.7))).unwrap();
@@ -4145,9 +4208,11 @@ mod tests {
             last_acknowledged_trade_id: None,
             pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
-            last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
-            last_price_observed_at: Some(Utc::now()),
+            last_price: Some(PriceObservation {
+                price: float!(150),
+                observed_at: Utc::now(),
+            }),
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(7.5))).unwrap();
@@ -4178,9 +4243,11 @@ mod tests {
             last_acknowledged_trade_id: None,
             pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
-            last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
-            last_price_observed_at: Some(Utc::now()),
+            last_price: Some(PriceObservation {
+                price: float!(150),
+                observed_at: Utc::now(),
+            }),
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(5))).unwrap();
@@ -4200,7 +4267,7 @@ mod tests {
 
     #[test]
     fn operational_limits_cap_applies_without_price() {
-        // Shares cap works regardless of whether last_price_usdc is available
+        // Shares cap works regardless of whether last_price is available
         let position = Position {
             symbol: Symbol::new("AAPL").unwrap(),
             net: FractionalShares::new(float!(100)),
@@ -4211,9 +4278,8 @@ mod tests {
             last_acknowledged_trade_id: None,
             pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
-            last_price_usdc: None,
             last_updated: Some(Utc::now()),
-            last_price_observed_at: None,
+            last_price: None,
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(50))).unwrap();
@@ -4294,9 +4360,11 @@ mod tests {
             last_acknowledged_trade_id: None,
             pending_acknowledged_trade_ids: BTreeSet::new(),
             threshold: ExecutionThreshold::whole_share(),
-            last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
-            last_price_observed_at: Some(Utc::now()),
+            last_price: Some(PriceObservation {
+                price: float!(150),
+                observed_at: Utc::now(),
+            }),
         };
 
         let (_, first_shares) = position

--- a/tests/e2e/assert.rs
+++ b/tests/e2e/assert.rs
@@ -539,17 +539,15 @@ async fn assert_position_view(
         expected_position.symbol
     );
 
-    let price = position.last_price_usdc.unwrap_or_else(|| {
-        panic!(
-            "last_price_usdc should be set for {}",
-            expected_position.symbol
-        )
-    });
+    let Some(observation) = position.last_price else {
+        panic!("last_price should be set for {}", expected_position.symbol);
+    };
+    let price = observation.price;
     let rounded_price = round_float(price, 2)?;
     let rounded_expected = round_float(expected_position.onchain_price, 2)?;
     assert!(
         rounded_price.eq(rounded_expected).unwrap(),
-        "last_price_usdc for {} should match onchain execution price",
+        "last_price for {} should match onchain execution price",
         expected_position.symbol
     );
 

--- a/tests/e2e/hedging.rs
+++ b/tests/e2e/hedging.rs
@@ -149,9 +149,7 @@ async fn direct_high_precision_sell_price_still_hedges() -> anyhow::Result<()> {
         "Position should be fully hedged after offchain fill",
     );
     let last_price_rounded = crate::assert::round_float(
-        position
-            .last_price_usdc
-            .expect("last_price_usdc should be set"),
+        position.last_price.expect("last_price should be set").price,
         2,
     )?;
     assert!(


### PR DESCRIPTION
## What

- Replace `Position.last_price_usdc: Option<Float>` and `last_price_observed_at: Option<DateTime<Utc>>`, two Options that had to move in lockstep, with one `last_price: Option<PriceObservation>`. Now a price without an observation time, or the reverse, is unrepresentable.

## Why

- The two fields had to be both `Some` or both `None`, an invariant held only by discipline across the `evolve` arms and a re-pairing in `resolve_marks`. A future arm could set one field and forget the other with no compile-time check, silently defeating the mark-staleness gate from RAI-1476.
- Implements [RAI-1497](https://linear.app/makeitrain/issue/RAI-1497/fold-position-price-fields-into-a-single-optionpriceobservation), deferred from the RAI-1476 review.

## How

- Add `PriceObservation { price: Float, observed_at: DateTime<Utc> }`, deriving `Copy` (load-bearing for the `ManualPositionAdjusted` arm's `.or(entity.last_price)`), with a manual `Debug` through `DebugFloat` and `float_string_serde` on `price`. Each `evolve` arm now sets one field. `ManualPositionAdjusted` uses a single `.or`, and `resolve_marks` collapses to `position.last_price.map_or(...)`.
- Bump `Position::SCHEMA_VERSION` from 5 to 6. No event carries these fields (they are reconstructed in the arms from `price_usdc`, `block_timestamp`, and `adjusted_at`), so the version bump discards snapshots and `StoreBuilder` replays the event log, rebuilding both the aggregate state and `position_view`.
- Keep the public `st0x_dto::Position` FLAT (`last_price_usdc`, no `observed_at`). The two aggregate-to-DTO call sites map `position.last_price.map(|observation| observation.price)`, so the ts-rs binding and the dashboard consumers are unchanged.

## Testing

- Updated the Position aggregate tests and around 10 struct literals. Converted the presence-invariant test to keep its `observed_at < last_updated` ordering assertion, since the both-`Some` half is now compiler-enforced. Rewrote the legacy-snapshot serde test to assert that a snapshot missing the `last_price` key deserializes to `None`.

## Screenshots

N/A (backend).

## Anything else

- No SQL migration is needed. `position_view` stores the full serialized `Position` JSON, and no `json_extract` call targets these keys. The `SCHEMA_VERSION` bump, which triggers `StoreBuilder`'s `rebuild_all`, is sufficient.
- Stacked on the RAI-1496 branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Price information is now tracked together with the time it was observed, improving consistency across positions, dashboard updates, and portfolio snapshots.
  * Dollar-value thresholds and manual position adjustments now use the latest complete price observation.
  * Dashboard and portfolio views display prices derived from the latest recorded observation.
* **Bug Fixes**
  * Corrected price propagation after position updates and on-chain executions.
  * Updated validation and messaging for missing or non-positive prices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->