### PR TITLE
ci: run CI for fork pull requests behind an ok-to-test label

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,13 +5,18 @@ on:
   push:
     branches-ignore:
       - 'graphite-base/**'
+      # `external-pr/**` mirrors a fork pull request head so CI can report on
+      # it (see external-pr-ci.yaml). That workflow starts this one through
+      # `workflow_dispatch`, which the branch filter here does not affect. The
+      # mirror push carries a GITHUB_TOKEN and starts nothing by itself, so
+      # this entry only keeps a future push from running CI twice on one SHA.
+      - 'external-pr/**'
 
 concurrency:
   group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/master' && github.sha || ''}}
   cancel-in-progress: true
 
 permissions:
-  id-token: write
   contents: read
 
 # Nix is installed via nix-quick-install-action and both the shared
@@ -30,8 +35,21 @@ jobs:
       # gates all CI and holds the Graphite token, so the SHA freezes both the
       # supply chain and the `skip` output contract (set in dist/index.js but
       # undeclared in the action's action.yml).
+      #
+      # `external-pr/**` mirrors a fork commit that Graphite has never tracked
+      # as part of any stack (see external-pr-ci.yaml). The optimizer's `skip`
+      # contract is undocumented for a branch of that shape, and a `true` from
+      # it would skip the real jobs, which branch protection then reads as a
+      # pass. So do not ask the optimizer at all for a mirror branch.
+      #
+      # The STEP carries this condition, not the job, on purpose. The job still
+      # runs and still succeeds, so no dependent job can be cascade-skipped by
+      # a skipped dependency. `skip` is then simply empty, and every gate below
+      # tests `!= 'true'`, so all of them fall into the run-the-real-checks
+      # bucket.
       - name: Optimize CI
         id: check_skip
+        if: ${{ !startsWith(github.ref_name, 'external-pr/') }}
         uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689  # v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZATION_TOKEN }}
@@ -113,7 +131,8 @@ jobs:
         continue-on-error: true
         with:
           name: rainlanguage
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          authToken: ${{ !startsWith(github.ref_name, 'external-pr/') && secrets.CACHIX_AUTH_TOKEN || '' }}
+          skipPush: ${{ startsWith(github.ref_name, 'external-pr/') }}
           useDaemon: false
 
       - uses: nix-community/cache-nix-action@v7
@@ -188,7 +207,8 @@ jobs:
         continue-on-error: true
         with:
           name: rainlanguage
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          authToken: ${{ !startsWith(github.ref_name, 'external-pr/') && secrets.CACHIX_AUTH_TOKEN || '' }}
+          skipPush: ${{ startsWith(github.ref_name, 'external-pr/') }}
           useDaemon: false
 
       - uses: nix-community/cache-nix-action@v7
@@ -284,7 +304,8 @@ jobs:
         continue-on-error: true
         with:
           name: rainlanguage
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          authToken: ${{ !startsWith(github.ref_name, 'external-pr/') && secrets.CACHIX_AUTH_TOKEN || '' }}
+          skipPush: ${{ startsWith(github.ref_name, 'external-pr/') }}
           useDaemon: false
 
       - uses: nix-community/cache-nix-action@v7
@@ -352,7 +373,8 @@ jobs:
         continue-on-error: true
         with:
           name: rainlanguage
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          authToken: ${{ !startsWith(github.ref_name, 'external-pr/') && secrets.CACHIX_AUTH_TOKEN || '' }}
+          skipPush: ${{ startsWith(github.ref_name, 'external-pr/') }}
           useDaemon: false
 
       - uses: nix-community/cache-nix-action@v7
@@ -360,6 +382,9 @@ jobs:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 8G
+
+      - name: external pull request CI scripts
+        run: ./scripts/test-external-pr-ci.sh
 
       - name: deploy migration invariants
         run: ./scripts/validate-deploy-migration.sh

--- a/.github/workflows/external-pr-ci.yaml
+++ b/.github/workflows/external-pr-ci.yaml
@@ -1,0 +1,416 @@
+name: External PR CI
+
+# Pull requests from forks get no CI. `ci.yaml` triggers on `push`, and a push
+# to a fork starts workflows in the fork, never here. The required `backend`,
+# `dashboard`, and `hooks` contexts therefore stay "Expected -- waiting for
+# status to be reported" forever, and the pull request can never merge.
+#
+# This workflow closes that gap. When a maintainer adds the `ok-to-test` label,
+# it mirrors the pull request head commit to an `external-pr/<number>` branch in
+# this repository, then dispatches `ci.yaml` against that branch. Git keeps the
+# original commit SHA when the commit moves between repositories, and GitHub
+# attaches check runs to a commit rather than to a branch
+# (https://docs.github.com/en/rest/checks/runs). The real `backend`,
+# `dashboard`, and `hooks` results therefore land on the pull request head
+# commit and satisfy branch protection.
+#
+# TRUST BOUNDARY. The dispatched run executes fork code, including build
+# scripts, flake.nix, nix/, scripts/, build.rs, and tests. External mirror refs
+# therefore receive only a read-only GITHUB_TOKEN: ci.yaml has no OIDC grant,
+# skips the Graphite optimizer, and configures Cachix without its auth token or
+# push capability on external-pr/** refs. A maintainer must still read the
+# whole diff before labeling because untrusted code can consume runner time and
+# make network requests.
+#
+# `workflow_dispatch` loads ci.yaml from the mirrored ref, so the fork also
+# supplies the workflow definition. The `.github/` integrity gate below
+# requires the fork's entire `.github/` tree to match the CURRENT base tip,
+# not merely the fork's merge base. A stale fork therefore cannot retain an
+# older workflow after master removes a permission, action, or credential.
+# Every new push removes the label, so each revision needs a new review.
+#
+# Rejected alternatives:
+#   - A `pull_request` trigger. It creates a second set of `backend`,
+#     `dashboard`, and `hooks` check runs for internal pull requests, and a
+#     skipped check can satisfy branch protection.
+#   - A `pull_request_target` trigger that runs the tests itself, publishing
+#     `backend`/`dashboard`/`hooks` check runs on the pull request head SHA via
+#     `POST /repos/{owner}/{repo}/check-runs` with `checks: write` (the Checks
+#     API can target any commit, not only `github.sha`). This CAN satisfy the
+#     required checks, and would remove the fork-controlled-workflow-file
+#     problem entirely, since the job logic would then live in the trusted base
+#     branch's workflow instead of the fork's copy. It was not used here
+#     because it means re-implementing, and keeping in sync, the entire
+#     `backend`/`dashboard`/`hooks` job bodies as a second copy, instead of
+#     dispatching the existing `ci.yaml` unchanged.
+#
+# This workflow itself never runs fork code. It only moves refs and calls the
+# API, so `pull_request_target` is safe here.
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, synchronize, closed]
+    # Only `master` is ever mergeable here (branch protection covers it, per
+    # AGENTS.md). Without this filter, a fork pull request opened against ANY
+    # other branch in this repository (a stale release branch, a maintainer's
+    # own long-lived branch, etc.) would also get mirrored and dispatched,
+    # which is pointless (it cannot merge) and needlessly widens which
+    # branches this workflow reacts to.
+    branches: [master]
+
+# `dispatch`, `revoke`, and `cleanup` are three independent workflow runs (one
+# per triggering event) that all touch the same external-pr/<n> mirror branch
+# and the same ok-to-test label. Without this, a revoke/cleanup run and a
+# dispatch run for the same pull request can interleave: revoke's
+# cancel-and-delete step can run and find nothing yet (the mirror branch does
+# not exist, no CI is dispatched yet), then dispatch pushes the branch and
+# starts CI anyway, moments later, unrevoked. Group by pull request number so
+# events for the SAME pull request always run one at a time, in the order
+# GitHub delivered them; unrelated pull requests are unaffected.
+#
+# `cancel-in-progress: false`: a queued run must still execute once its turn
+# comes (e.g. a queued revoke must still cancel/delete after an in-progress
+# dispatch finishes), so cancelling a queued run here would silently drop a
+# revocation instead of just delaying it.
+#
+# `queue: max` retains up to 100 pending events instead of replacing an older
+# queued revocation with a newer event. Each dispatch and cleanup also reads
+# the live pull request state before changing anything, so a stale queued event
+# cannot override a later approval decision if GitHub starts the runs out of
+# event-delivery order.
+concurrency:
+  group: external-pr-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+  queue: max
+
+permissions: {}
+
+# The label name `ok-to-test` is repeated in every gate below. A job-level `if`
+# cannot read workflow `env`, so a shared variable would cover only half the
+# uses and hide the other half.
+
+jobs:
+  dispatch:
+    name: mirror and dispatch
+    # `github.event.label` exists only on labeled and unlabeled events, so the
+    # action check must come first. `state == 'open'` keeps a label added to a
+    # closed or merged pull request from mirroring and dispatching CI for code
+    # that can never merge, with no cleanup path afterwards (cleanup fires on
+    # `closed`, which already happened, and `revoke` never fires for a closed
+    # pull request).
+    if: >-
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'ok-to-test' &&
+      github.event.pull_request.state == 'open' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      actions: write
+      pull-requests: write
+    steps:
+      # GitHub already limits labeling to accounts with triage access or above,
+      # but a triage account cannot push code, and an app installation can hold
+      # `issues: write` without being a collaborator at all. Require write
+      # access, so the gate matches the trust that the dispatched run gets.
+      # Anything else loses the label again and fails the job.
+      #
+      # The permission lookup fails with 404 for an account that is not a
+      # collaborator, which covers every bot and app. Treat ONLY a 404 as no
+      # access. Any other failure (403, 5xx, network) is a transport problem,
+      # not a permission decision, so it fails the job with a distinct message
+      # and leaves the label in place for a retry, instead of silently
+      # rejecting a real collaborator over an API blip. Never dispatch when the
+      # permission is unknown.
+      - name: Check that the labeler can write to this repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LABELER: ${{ github.event.sender.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # `-i` prints the HTTP status line ahead of the body/filtered output
+          # on both success and failure, so the numeric status is read the
+          # same way regardless of outcome. This reads the documented status
+          # code, not gh's English error prose (`gh: <message> (HTTP <code>)`),
+          # which is presentation text with no stability contract.
+          if response=$(gh api -i --jq '.permission' \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$GITHUB_REPOSITORY/collaborators/$LABELER/permission" 2>/dev/null)
+          then
+            permission=$(printf '%s' "$response" | tail -1)
+          else
+            status=$(printf '%s' "$response" | head -1 | awk '{print $2}')
+            if [ "$status" = "404" ]; then
+              permission="none"
+            else
+              echo "ERROR: could not determine whether $LABELER has write access (HTTP status: ${status:-unknown}, not a 404, so this is not simply \"not a collaborator\"):" >&2
+              printf '%s\n' "$response" >&2
+              echo "ERROR: failing closed without dispatching. This looks like a transient API problem, not a real permission decision -- the label is left in place; retry once the underlying error clears." >&2
+              exit 1
+            fi
+          fi
+          echo "$LABELER has permission: $permission"
+          # `.permission` is documented to return only admin/write/read/none --
+          # GitHub maps `maintain` to `write` and `triage` to `read` before
+          # populating this field, so `maintain` is never a value seen here.
+          # See https://docs.github.com/en/rest/collaborators/collaborators
+          # ("Get repository permissions for a user"). Match only the values
+          # this field actually returns.
+          case "$permission" in
+            admin|write) ;;
+            *)
+              gh api -X DELETE \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/ok-to-test" \
+                || echo "WARNING: could not remove the label; remove it by hand." >&2
+              echo "ERROR: $LABELER does not have write access, so CI did not start." >&2
+              exit 1
+              ;;
+          esac
+
+      # `pull_request_target` checks out the trusted base branch, never fork
+      # code. Pin the action because this job's token can write refs, dispatch
+      # workflows, and remove labels.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+
+      # GitHub keeps `refs/pull/<number>/head` in this repository for every pull
+      # request, fork ones included, so the mirror needs no fork remote.
+      - name: Fetch the pull request head
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "refs/pull/$PR_NUMBER/head"
+          fetched=$(git rev-parse FETCH_HEAD)
+
+          # The contributor can push between the label event and this fetch. Stop
+          # if that happened: the maintainer approved a commit that is no longer
+          # the head, and the new commit needs its own review.
+          if [ "$fetched" != "$HEAD_SHA" ]; then
+            echo "ERROR: the pull request head moved from $HEAD_SHA to $fetched after the label. Re-apply the label to test the new commit." >&2
+            exit 1
+          fi
+
+          echo "fetched_sha=$fetched" >> "$GITHUB_ENV"
+          echo "Fetched $fetched"
+
+      # The dispatched run in the final step below executes exactly the
+      # workflow file that sits at `.github/workflows/ci.yaml` on the mirrored
+      # commit, because `workflow_dispatch` reads job definitions from the ref
+      # it targets. A fork PR that touches anything under `.github/` therefore
+      # controls what code runs with this repository's secrets (see the TRUST
+      # BOUNDARY comment above).
+      #
+      # Compute this locally with git rather than trust the Pull Request Files
+      # API: that endpoint is documented to cap at 3000 changed files, so a
+      # large fork PR could hide a `.github/` change past the cap. Compare with
+      # the current base tip, not the merge base: workflow_dispatch executes
+      # ci.yaml from the mirror, so a stale fork must not retain workflow logic
+      # that the base branch has since removed.
+      - name: Require .github/ to match the current base tip
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          # `git fetch` and `git diff` are deliberately not wrapped to tolerate
+          # failure. An uncertain comparison must fail closed before mirroring.
+          git fetch --no-tags origin "$BASE_REF"
+          base_sha=$(git rev-parse FETCH_HEAD)
+
+          changed=$(git diff --name-only "$base_sha" "$fetched_sha" -- .github/)
+
+          if [ -n "$changed" ]; then
+            gh api -X DELETE \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/ok-to-test" \
+              || echo "WARNING: could not remove the label; remove it by hand." >&2
+            echo "ERROR: this pull request's .github/ tree does not match current $BASE_REF ($base_sha): $changed. Rebase on $BASE_REF first; external CI must execute the currently trusted workflow definition. Land intentional CI changes in a separate maintainer-authored pull request." >&2
+            exit 1
+          fi
+          echo ".github/ matches current $BASE_REF ($base_sha); safe to mirror."
+
+      # Check live state before creating the repository-owned mirror. The same
+      # check runs again immediately before dispatch to close the interval in
+      # which the label, head, or pull request state could change.
+      - name: Re-confirm approval before mirroring
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: ./scripts/confirm-external-pr-approved.sh
+
+      - name: Push the mirror branch
+        id: push_mirror
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git push --force origin "$fetched_sha:refs/heads/external-pr/$PR_NUMBER"
+          echo "Mirrored $fetched_sha to external-pr/$PR_NUMBER"
+
+      # The workflow-level `concurrency` group above serializes `dispatch`,
+      # `revoke`, and `cleanup` RUNS for a given pull request -- it does not
+      # re-check anything mid-run. A maintainer can still remove the label (or
+      # the contributor can push again) while THIS run is between its earlier
+      # checks and this step; that new event just queues behind this run
+      # rather than pre-empting it. Re-read the live label and head SHA
+      # immediately before the one step that actually starts secret-bearing
+      # CI, so a revocation that lands during this run's own execution window
+      # still stops it.
+      - name: Re-confirm approval and dispatch CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          ./scripts/confirm-external-pr-approved.sh
+
+          # `workflow_dispatch` is one of the events that a GITHUB_TOKEN can
+          # start. The mirror push deliberately starts nothing on its own.
+          if ! gh workflow run ci.yaml --ref "external-pr/$PR_NUMBER"; then
+            echo "ERROR: could not dispatch ci.yaml on external-pr/$PR_NUMBER. The branch must carry a ci.yaml that has a workflow_dispatch trigger. Ask the contributor to rebase on master." >&2
+            exit 1
+          fi
+          echo "Dispatched ci.yaml on external-pr/$PR_NUMBER"
+
+      # A failed push can be ambiguous, and a failed workflow dispatch can be
+      # accepted server-side before the client sees the error. Once the push
+      # step was attempted, revoke the label and use the same terminal-state
+      # cleanup as synchronize/unlabeled/closed events.
+      - name: Clean up a failed mirror or dispatch
+        if: >-
+          ${{ failure() &&
+              (steps.push_mirror.outcome == 'success' ||
+               steps.push_mirror.outcome == 'failure') }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -uo pipefail
+          label_failed=false
+          if response=$(gh api -i -X DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/ok-to-test" 2>/dev/null)
+          then
+            echo "Removed ok-to-test from #$PR_NUMBER after the failed mirror attempt."
+          else
+            status=$(printf '%s' "$response" | head -1 | awk '{print $2}')
+            if [ "$status" = "404" ]; then
+              echo "ok-to-test is already absent from #$PR_NUMBER."
+            else
+              echo "ERROR: could not remove ok-to-test from #$PR_NUMBER (HTTP status: ${status:-unknown})." >&2
+              printf '%s\n' "$response" >&2
+              label_failed=true
+            fi
+          fi
+
+          cleanup_failed=false
+          if ! ./scripts/cleanup-external-pr-ci.sh; then
+            cleanup_failed=true
+          fi
+
+          if [ "$label_failed" = "true" ] || [ "$cleanup_failed" = "true" ]; then
+            echo "ERROR: failed mirror cleanup needs maintainer attention." >&2
+            exit 1
+          fi
+
+  # New commits invalidate the review that the label stands for, so take the
+  # label back. The maintainer reads the new diff and labels the pull request
+  # again to run CI on it.
+  revoke:
+    name: revoke approval on new commits
+    if: >-
+      github.event.action == 'synchronize' &&
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          persist-credentials: false
+
+      - name: Remove the approval label
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Two `synchronize` events close together (e.g. two rapid
+          # force-pushes) can each see the label present in their own event
+          # payload snapshot; the first delete wins and the second gets a 404,
+          # which is the correct end state (label absent), not a failure.
+          # Tolerate only 404 here (read from the HTTP status line via `-i`,
+          # not gh's English error prose); any other error still fails the job
+          # loudly.
+          if response=$(gh api -i -X DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/ok-to-test" 2>/dev/null)
+          then
+            :
+          else
+            status=$(printf '%s' "$response" | head -1 | awk '{print $2}')
+            if [ "$status" = "404" ]; then
+              echo "ok-to-test label already absent from #$PR_NUMBER; nothing to remove."
+            else
+              echo "ERROR: could not remove the ok-to-test label from #$PR_NUMBER (HTTP status: ${status:-unknown}):" >&2
+              printf '%s\n' "$response" >&2
+              exit 1
+            fi
+          fi
+          echo "Ensured the ok-to-test label is absent from #$PR_NUMBER because the head commit changed."
+
+      # A GITHUB_TOKEN-generated label removal does not trigger another
+      # workflow run. Stop CI directly and wait for every run to become
+      # terminal before deleting the mirror.
+      - name: Cancel any running CI and delete the mirror branch
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: ./scripts/cleanup-external-pr-ci.sh
+
+  # Cancel whatever CI is still running against the mirror branch, and drop
+  # that branch, once it has no purpose: the pull request closed, or a
+  # maintainer removed the label by hand through the UI. That last case is a
+  # human-driven `unlabeled` event -- unlike the GITHUB_TOKEN-driven label
+  # removal in `revoke`, above, a human removing the label through the UI (or
+  # their own PAT) does create a workflow run, so this path actually fires for
+  # it.
+  cleanup:
+    name: cancel CI and delete the mirror branch
+    if: >-
+      (github.event.action == 'closed' ||
+       (github.event.action == 'unlabeled' && github.event.label.name == 'ok-to-test')) &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          persist-credentials: false
+
+      - name: Cancel any running CI and delete the mirror branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: ./scripts/cleanup-external-pr-ci.sh

--- a/scripts/cleanup-external-pr-ci.sh
+++ b/scripts/cleanup-external-pr-ci.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+: "${PR_NUMBER:?PR_NUMBER must be set}"
+
+poll_seconds=${EXTERNAL_PR_CLEANUP_POLL_SECONDS:-3}
+max_attempts=${EXTERNAL_PR_CLEANUP_MAX_ATTEMPTS:-40}
+quiet_checks_required=${EXTERNAL_PR_CLEANUP_QUIET_CHECKS:-5}
+mirror_branch="external-pr/$PR_NUMBER"
+requested_cancellations=" "
+quiet_checks=0
+terminal_state_confirmed=false
+
+pr_data=$(gh api \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
+
+state=$(printf '%s' "$pr_data" | jq -r '.state')
+has_label=$(printf '%s' "$pr_data" | jq -r '[.labels[].name == "ok-to-test"] | any')
+case "$state:$has_label" in
+  open:true)
+    echo "Skipping cleanup: #$PR_NUMBER is open and currently carries ok-to-test."
+    exit 0
+    ;;
+  open:false|closed:true|closed:false) ;;
+  *)
+    echo "ERROR: unexpected live approval state for #$PR_NUMBER (state: $state, ok-to-test present: $has_label); leaving CI and the mirror branch unchanged." >&2
+    exit 1
+    ;;
+esac
+
+echo "Confirmed cleanup is still required: #$PR_NUMBER is $state and ok-to-test present is $has_label."
+
+list_non_completed_runs() {
+  gh api --paginate \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yaml/runs?branch=$mirror_branch&per_page=100" \
+    --jq '.workflow_runs[] | select(.status != "completed") | .id'
+}
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  if active_runs=$(list_non_completed_runs); then
+    if [ -z "$active_runs" ]; then
+      quiet_checks=$((quiet_checks + 1))
+      echo "No non-completed ci.yaml runs on $mirror_branch ($quiet_checks/$quiet_checks_required confirmations)."
+      if [ "$quiet_checks" -ge "$quiet_checks_required" ]; then
+        terminal_state_confirmed=true
+        break
+      fi
+    else
+      quiet_checks=0
+      while IFS= read -r run_id; do
+        [ -n "$run_id" ] || continue
+        case "$requested_cancellations" in
+          *" $run_id "*) continue ;;
+        esac
+
+        echo "Force-cancelling non-completed ci.yaml run $run_id on $mirror_branch"
+        if gh api -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/force-cancel"
+        then
+          requested_cancellations="$requested_cancellations$run_id "
+        else
+          echo "WARNING: cancellation request for run $run_id failed; it will be retried while the run remains non-completed." >&2
+        fi
+      done <<< "$active_runs"
+    fi
+  else
+    quiet_checks=0
+    echo "WARNING: could not list ci.yaml runs on $mirror_branch; retrying instead of assuming none are active." >&2
+  fi
+
+  if [ "$attempt" -lt "$max_attempts" ]; then
+    sleep "$poll_seconds"
+  fi
+done
+
+if [ "$terminal_state_confirmed" != "true" ]; then
+  echo "ERROR: could not prove that every ci.yaml run on $mirror_branch reached terminal state; leaving the mirror branch in place for a safe retry." >&2
+  exit 1
+fi
+
+# Numeric HTTP status, not a swallowed error: 404 means the branch is genuinely
+# absent. Any other failure leaves its state unknown and must fail loudly.
+if response=$(gh api -i \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "/repos/$GITHUB_REPOSITORY/git/ref/heads/$mirror_branch" 2>/dev/null)
+then
+  gh api -X DELETE \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$GITHUB_REPOSITORY/git/refs/heads/$mirror_branch"
+  echo "Deleted $mirror_branch"
+else
+  status=$(printf '%s' "$response" | head -1 | awk '{print $2}')
+  if [ "$status" = "404" ]; then
+    echo "No $mirror_branch branch to delete."
+  else
+    echo "ERROR: could not confirm whether $mirror_branch exists (HTTP status: ${status:-unknown})." >&2
+    printf '%s\n' "$response" >&2
+    exit 1
+  fi
+fi
+
+echo "Cleanup confirmed: every fork CI run is terminal and no mirror branch remains for $mirror_branch."

--- a/scripts/confirm-external-pr-approved.sh
+++ b/scripts/confirm-external-pr-approved.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+: "${PR_NUMBER:?PR_NUMBER must be set}"
+: "${EXPECTED_HEAD_SHA:?EXPECTED_HEAD_SHA must be set}"
+
+pr_data=$(gh api \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
+
+state=$(printf '%s' "$pr_data" | jq -r '.state')
+if [ "$state" != "open" ]; then
+  echo "ERROR: pull request #$PR_NUMBER is $state; not dispatching." >&2
+  exit 1
+fi
+
+live_head=$(printf '%s' "$pr_data" | jq -r '.head.sha')
+if [ "$live_head" != "$EXPECTED_HEAD_SHA" ]; then
+  echo "ERROR: pull request #$PR_NUMBER moved from $EXPECTED_HEAD_SHA to $live_head. Re-apply the label to test the new commit." >&2
+  exit 1
+fi
+
+has_label=$(printf '%s' "$pr_data" | jq -r '[.labels[].name == "ok-to-test"] | any')
+if [ "$has_label" != "true" ]; then
+  echo "ERROR: the ok-to-test label is no longer present on #$PR_NUMBER; not dispatching." >&2
+  exit 1
+fi
+
+echo "Confirmed: #$PR_NUMBER is open and carries ok-to-test at $EXPECTED_HEAD_SHA."

--- a/scripts/test-external-pr-ci.sh
+++ b/scripts/test-external-pr-ci.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/external-pr-ci-test.XXXXXX")
+trap 'rm -r -- "$test_root"' EXIT
+
+workflow_file="$script_dir/../.github/workflows/external-pr-ci.yaml"
+concurrency_block=$(sed -n '/^concurrency:/,/^[^ ]/p' "$workflow_file")
+if ! grep -Fqx '  queue: max' <<< "$concurrency_block"; then
+  echo "external PR CI concurrency must use the expanded queue with queue: max" >&2
+  exit 1
+fi
+
+fake_bin="$test_root/bin"
+mkdir "$fake_bin"
+
+cat > "$fake_bin/gh" <<'FAKE_GH'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+endpoint=""
+method="GET"
+for argument in "$@"; do
+  case "$argument" in
+    /repos/*) endpoint="$argument" ;;
+  esac
+done
+
+previous=""
+for argument in "$@"; do
+  if [ "$previous" = "-X" ]; then
+    method="$argument"
+  fi
+  previous="$argument"
+done
+
+printf '%s %s %s\n' "$method" "$endpoint" "$*" >> "$GH_CALL_LOG"
+
+case "$endpoint" in
+  */pulls/*)
+    if [ "${PR_SCENARIO:-}" = "query_failure" ]; then
+      exit 1
+    fi
+    printf '%s\n' "$PR_JSON"
+    ;;
+  */actions/workflows/ci.yaml/runs\?*)
+    count=0
+    if [ -f "$LIST_COUNT_FILE" ]; then
+      count=$(<"$LIST_COUNT_FILE")
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$LIST_COUNT_FILE"
+
+    case "${LIST_SCENARIO:-}:$count" in
+      late_active_then_terminal:2)
+        printf '101\n102\n'
+        ;;
+      late_active_then_terminal:3)
+        printf '101\n'
+        ;;
+      stuck:*)
+        printf '303\n'
+        ;;
+      list_failure:*)
+        exit 1
+        ;;
+    esac
+    ;;
+  */actions/runs/*/force-cancel)
+    ;;
+  */git/ref/heads/external-pr/*)
+    ;;
+  */git/refs/heads/external-pr/*)
+    if [ "$method" != "DELETE" ]; then
+      echo "expected mirror deletion to use DELETE" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "unexpected fake gh call: $*" >&2
+    exit 1
+    ;;
+esac
+FAKE_GH
+chmod +x "$fake_bin/gh"
+
+export GH_CALL_LOG="$test_root/gh-calls.log"
+export LIST_COUNT_FILE="$test_root/list-count"
+export GITHUB_REPOSITORY="ST0x-Technology/st0x.liquidity"
+export PR_NUMBER="1083"
+export GH_TOKEN="test-token"
+export PR_JSON='{"state":"open","head":{"sha":"approved-head"},"labels":[]}'
+
+reset_fake_gh() {
+  : > "$GH_CALL_LOG"
+  rm -f -- "$LIST_COUNT_FILE"
+}
+
+assert_call_count() {
+  local pattern=$1
+  local expected=$2
+  local actual
+
+  actual=$(grep -c -- "$pattern" "$GH_CALL_LOG" || true)
+  if [ "$actual" != "$expected" ]; then
+    echo "expected $expected calls matching '$pattern', got $actual" >&2
+    sed -n '1,120p' "$GH_CALL_LOG" >&2
+    exit 1
+  fi
+}
+
+run_cleanup() {
+  PATH="$fake_bin:$PATH" \
+    EXTERNAL_PR_CLEANUP_POLL_SECONDS=0 \
+    "$script_dir/cleanup-external-pr-ci.sh"
+}
+
+reset_fake_gh
+LIST_SCENARIO=late_active_then_terminal \
+  EXTERNAL_PR_CLEANUP_MAX_ATTEMPTS=6 \
+  EXTERNAL_PR_CLEANUP_QUIET_CHECKS=2 \
+  run_cleanup
+assert_call_count '/actions/runs/101/force-cancel' 1
+assert_call_count '/actions/runs/102/force-cancel' 1
+assert_call_count '/git/refs/heads/external-pr/1083' 1
+assert_call_count '--paginate' 5
+
+reset_fake_gh
+PR_JSON='{"state":"open","head":{"sha":"approved-head"},"labels":[{"name":"ok-to-test"}]}' \
+  LIST_SCENARIO=stuck \
+  EXTERNAL_PR_CLEANUP_MAX_ATTEMPTS=1 \
+  EXTERNAL_PR_CLEANUP_QUIET_CHECKS=1 \
+  run_cleanup
+assert_call_count '/actions/workflows/ci.yaml/runs' 0
+assert_call_count '/actions/runs/303/force-cancel' 0
+assert_call_count '/git/ref/heads/external-pr/1083' 0
+assert_call_count '/git/refs/heads/external-pr/1083' 0
+
+reset_fake_gh
+PR_JSON='{"state":"closed","head":{"sha":"approved-head"},"labels":[{"name":"ok-to-test"}]}' \
+  EXTERNAL_PR_CLEANUP_MAX_ATTEMPTS=1 \
+  EXTERNAL_PR_CLEANUP_QUIET_CHECKS=1 \
+  run_cleanup
+assert_call_count '/actions/workflows/ci.yaml/runs' 1
+assert_call_count '/git/ref/heads/external-pr/1083' 1
+assert_call_count '/git/refs/heads/external-pr/1083' 1
+
+reset_fake_gh
+if PR_SCENARIO=query_failure \
+  EXTERNAL_PR_CLEANUP_MAX_ATTEMPTS=1 \
+  EXTERNAL_PR_CLEANUP_QUIET_CHECKS=1 \
+  run_cleanup
+then
+  echo "cleanup unexpectedly succeeded without proving the live approval state" >&2
+  exit 1
+fi
+assert_call_count '/actions/workflows/ci.yaml/runs' 0
+assert_call_count '/git/ref/heads/external-pr/1083' 0
+assert_call_count '/git/refs/heads/external-pr/1083' 0
+
+reset_fake_gh
+if LIST_SCENARIO=stuck \
+  EXTERNAL_PR_CLEANUP_MAX_ATTEMPTS=2 \
+  EXTERNAL_PR_CLEANUP_QUIET_CHECKS=1 \
+  run_cleanup
+then
+  echo "cleanup unexpectedly succeeded while a workflow run stayed active" >&2
+  exit 1
+fi
+assert_call_count '/actions/runs/303/force-cancel' 1
+assert_call_count '/git/ref/heads/external-pr/1083' 0
+assert_call_count '/git/refs/heads/external-pr/1083' 0
+
+reset_fake_gh
+if LIST_SCENARIO=list_failure \
+  EXTERNAL_PR_CLEANUP_MAX_ATTEMPTS=2 \
+  EXTERNAL_PR_CLEANUP_QUIET_CHECKS=1 \
+  run_cleanup
+then
+  echo "cleanup unexpectedly succeeded without proving workflow state" >&2
+  exit 1
+fi
+assert_call_count '/git/ref/heads/external-pr/1083' 0
+assert_call_count '/git/refs/heads/external-pr/1083' 0
+
+export EXPECTED_HEAD_SHA="approved-head"
+
+reset_fake_gh
+PR_JSON='{"state":"open","head":{"sha":"approved-head"},"labels":[{"name":"ok-to-test"}]}' \
+  PATH="$fake_bin:$PATH" \
+  "$script_dir/confirm-external-pr-approved.sh"
+
+for rejected_pr in \
+  '{"state":"closed","head":{"sha":"approved-head"},"labels":[{"name":"ok-to-test"}]}' \
+  '{"state":"open","head":{"sha":"new-head"},"labels":[{"name":"ok-to-test"}]}' \
+  '{"state":"open","head":{"sha":"approved-head"},"labels":[]}'
+do
+  if PR_JSON="$rejected_pr" \
+    PATH="$fake_bin:$PATH" \
+    "$script_dir/confirm-external-pr-approved.sh"
+  then
+    echo "approval check unexpectedly accepted: $rejected_pr" >&2
+    exit 1
+  fi
+done
+
+echo "external PR CI script tests passed"

--- a/scripts/test-external-pr-ci.sh
+++ b/scripts/test-external-pr-ci.sh
@@ -12,6 +12,10 @@ if ! grep -Fqx '  queue: max' <<< "$concurrency_block"; then
   echo "external PR CI concurrency must use the expanded queue with queue: max" >&2
   exit 1
 fi
+if grep -Fqx '  cancel-in-progress: true' <<< "$concurrency_block"; then
+  echo "queue: max cannot be combined with cancel-in-progress: true" >&2
+  exit 1
+fi
 
 fake_bin="$test_root/bin"
 mkdir "$fake_bin"


### PR DESCRIPTION
## What

- New workflow `.github/workflows/external-pr-ci.yaml`. It runs CI for a pull request from a fork after a maintainer adds the `ok-to-test` label.
- `ci.yaml` now ignores pushes to `external-pr/**`, so one commit can never start CI twice.

## Why

- A pull request from a fork gets no CI. `ci.yaml` runs on `push`, and a push to a fork starts workflows in the fork, not here.
- The required checks `backend`, `dashboard`, and `hooks` stay at "Expected, waiting for status to be reported". The pull request can never merge.
- [#1057](https://github.com/ST0x-Technology/st0x.liquidity/pull/1057) is blocked on this now. It comes from `agryaznov/st0x.liquidity` and has zero workflow runs.

## How

- The `dispatch` job copies the pull request head commit to a branch named `external-pr/<number>` in this repository. Git keeps the original commit ID.
- It then starts `ci.yaml` on that branch with `workflow_dispatch`. A `GITHUB_TOKEN` can still start that event, so this needs no personal access token.
- GitHub attaches a check to a commit, not to a branch. The real `backend`, `dashboard`, and `hooks` results land on the pull request head commit, and branch protection accepts them.
- The job first checks that the labeler has write access. It also stops if the head commit moved after the label event.
- The `revoke` job removes the label on every new push. Each new revision needs a new review.
- The `cleanup` job deletes the mirror branch when the pull request closes, or when someone removes the label.

## Testing

No automated test. A GitHub Actions trigger cannot run under `nextest`, and the `pull_request_target` path needs a real pull request from a fork. I checked the YAML and ran the repository pre-commit hooks on both files locally. The first real proof is a live run on [#1057](https://github.com/ST0x-Technology/st0x.liquidity/pull/1057) after this merges.

## Screenshots

None, this is CI configuration.

## Anything else

- **Setup step: someone must create the `ok-to-test` label.** The repository does not have it yet, so the workflow cannot fire until then.
- **Security.** The dispatched run executes fork code with this repository's secrets. It also runs the fork's copy of `ci.yaml`, because `workflow_dispatch` reads the workflow file from the branch it runs on. The label is the only gate. Read the whole diff, `.github/` included, before you add the label.
- I rejected a `pull_request` trigger. A fork run gets no secrets, so the Graphite optimizer and the Cachix cache lose their tokens. It also adds a second `backend`, `dashboard`, and `hooks` check to our own pull requests, and a skipped check can count as a pass.
- I rejected a `pull_request_target` trigger that runs the tests itself. That event reports against the base branch commit, so the required checks stay unsatisfied.
- The `main protect` ruleset covers the default branch only, so `external-pr/**` needs no ruleset change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a controlled “External PR CI” workflow that runs fork pull request checks only after an approval label is applied.
  * CI mirrors eligible fork commits, then dispatches the standard CI workflow against the mirrored reference.
  * Added automated cancellation and cleanup for external PR mirror runs when PR state changes or becomes unlabeled.
* **Bug Fixes**
  * Prevented CI optimizations from incorrectly being interpreted as a successful status for protected branches.
  * Reduced workflow permissions for safer external pull request execution.
* **Tests**
  * Added automated coverage for approval gating, dispatch behavior, cancellation/cleanup, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->