### PR TITLE
fix: bound the inconclusive-mint redrive with a deadline alert

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2369,13 +2369,26 @@ enum BridgeStage { Burn, Attestation, Mint }
   again; or `BridgingFailed` when recovering an already-failed post-burn
   transfer, whose next redrive re-attempts the mint directly instead
   (idempotency there comes from CCTP's nonce being authoritative, not from that
-  bounded scan). That redrive is deliberately unbounded and pages no operator:
-  each attempt re-reads authoritative on-chain state before minting, so
-  repeating it is harmless, whereas a false terminal failure strands the
-  rebalancing guard until an operator reconciles by hand. The cost is that a
-  PERSISTENTLY inconclusive recovery (a durably degraded RPC endpoint, not a
-  one-off blip) holds the guard with no alert. Bounding the redrive and alerting
-  on the bound is a tracked follow-up, not part of this rule
+  bounded scan).
+- **Inconclusive mint recovery: redrive and operator alert**: the job layer
+  schedules an unbounded delayed redrive (like the settlement-phase
+  RPC-transient case above) rather than consuming the apalis retry budget, since
+  the mint may already have landed and re-probing is idempotent. Once the
+  transfer's total age reaches 4 hours -- measured from the durable
+  `initiated_at` carried by whichever of
+  `Bridging`/`AwaitingAttestation`/`Attested`/`BridgingFailed` the transfer
+  resumed from, so the countdown survives restarts, and not from when mint
+  recovery itself became inconclusive -- the job begins paging the operator on
+  every redrive. A transfer that already exceeds the threshold can therefore
+  page on its first inconclusive mint-recovery probe. The redrive uses a slower
+  cadence after the deadline (30 minutes instead of 30 seconds, to avoid alert
+  fatigue) while still keeping the guard held and continuing to redrive -- the
+  funds are already burned, so the redrive never stops on its own; only manual
+  `transfer resume`/`transfer reconcile` ends it. The 4-hour threshold mirrors
+  the withdrawal-poll alert deadline, giving generous headroom above the
+  ~2-minute internal probe window while surfacing a durably degraded RPC
+  endpoint or a permanently unresolved nonce well before it becomes a multi-day
+  silent outage
 - Destination deposit must be confirmed to complete rebalancing (for
   AlpacaToBase) or before post-deposit conversion (for BaseToAlpaca)
 - Can mark failed from any non-terminal state

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -3912,9 +3912,11 @@ mod tests {
             cctp.base.message_transmitter,
             reverting_wallet,
         )
-        .with_node_sync_poll_interval(Duration::ZERO);
-
-        tokio::time::pause();
+        .with_node_sync_poll_interval(Duration::ZERO)
+        .with_mint_recovery_config(MintRecoveryConfig {
+            probe_interval: Duration::from_millis(5),
+            probes: NonZeroU32::new(2).unwrap(),
+        });
 
         let recovered = reverting_endpoint
             .recover_already_minted::<NoOpErrorRegistry>(
@@ -3994,9 +3996,11 @@ mod tests {
             cctp.base.message_transmitter,
             flaky_wallet,
         )
-        .with_node_sync_poll_interval(Duration::ZERO);
-
-        tokio::time::pause();
+        .with_node_sync_poll_interval(Duration::ZERO)
+        .with_mint_recovery_config(MintRecoveryConfig {
+            probe_interval: Duration::from_millis(5),
+            probes: NonZeroU32::new(2).unwrap(),
+        });
 
         let recovered = flaky_endpoint
             .recover_already_minted::<NoOpErrorRegistry>(

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -210,10 +210,12 @@ const CLI_ATTESTATION_REDRIVE_DELAY: Duration = Duration::from_secs(60);
 /// retry resumes the existing transfer instead of starting a second
 /// fund-moving one. The retryable set mirrors the worker: `AttestationTimedOut`,
 /// `WithdrawalPollInconclusive` (Alpaca API unreachable or returned a transient
-/// error), plus the settlement-wait errors (`WithdrawalTxUnderconfirmed`,
-/// `WalletUsdcInsufficient`, `SettlementCheckTransient`). Errors not in this set
-/// -- including `AttestationRetryDeadlineElapsed` and a previously-failed
-/// aggregate -- are terminal and returned to the caller.
+/// error), `MintRecoveryInconclusive` (CCTP mint recovery could not resolve a
+/// conclusive nonce/receipt), plus the settlement-wait errors
+/// (`WithdrawalTxUnderconfirmed`, `WalletUsdcInsufficient`,
+/// `SettlementCheckTransient`). Errors not in this set -- including
+/// `AttestationRetryDeadlineElapsed` and a previously-failed aggregate -- are
+/// terminal and returned to the caller.
 async fn redrive_transfer_until_settled<Resume, Fut>(
     redrive_delay: Duration,
     mut resume: Resume,
@@ -260,6 +262,26 @@ where
                     ?redrive_delay,
                     "Alpaca withdrawal poll inconclusive; Alpaca may be unreachable -- \
                      retrying after delay (aggregate stays in Withdrawing, guard held)"
+                );
+                tokio::time::sleep(redrive_delay).await;
+            }
+            // MintRecoveryInconclusive is non-terminal: the CCTP mint recovery
+            // window could not get a conclusive nonce/receipt read. The aggregate
+            // stays in whichever durable pre-mint state it was already in; the
+            // automatic delayed redrive continues in the background. Retry here
+            // so the CLI polls periodically without spinning, matching the
+            // behaviour of WithdrawalPollInconclusive -- otherwise a manual
+            // transfer would exit on this outcome, leaving the operator unable to
+            // drive the stuck transfer to completion via the CLI (the exact
+            // command the operator alert for this outcome recommends running).
+            Err(UsdcTransferError::MintRecoveryInconclusive { id, source, .. }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    %source,
+                    ?redrive_delay,
+                    "CCTP mint recovery inconclusive; retrying after delay \
+                     (aggregate stays in its durable pre-mint state, guard held)"
                 );
                 tokio::time::sleep(redrive_delay).await;
             }
@@ -1630,10 +1652,12 @@ pub(crate) async fn resume_interrupted_transfers_command<W: Write>(
 mod tests {
     use alloy::primitives::{Address, B256, address, b256};
     use alloy::providers::ProviderBuilder;
+    use chrono::Utc;
     use rain_math_float::Float;
     use url::Url;
     use uuid::uuid;
 
+    use st0x_bridge::cctp::CctpError;
     use st0x_config::ExecutionThreshold;
     use st0x_config::RebalancingCtx;
     use st0x_config::create_test_issuance_ctx;
@@ -1787,6 +1811,41 @@ mod tests {
             calls.get(),
             2,
             "the loop must retry exactly once after the inconclusive poll, then succeed",
+        );
+    }
+
+    /// The manual redrive loop must also retry `MintRecoveryInconclusive` --
+    /// otherwise a manual `stox transfer resume --kind usdc` invocation (the
+    /// exact command the operator alert for this outcome recommends running)
+    /// would exit immediately instead of continuing to drive the stuck mint
+    /// recovery to completion via the CLI.
+    #[tokio::test]
+    async fn redrive_loop_retries_mint_recovery_inconclusive_then_succeeds() {
+        let calls = std::cell::Cell::new(0u32);
+
+        let result = redrive_transfer_until_settled(Duration::from_millis(0), || {
+            let attempt = calls.get() + 1;
+            calls.set(attempt);
+            async move {
+                if attempt == 1 {
+                    Err(UsdcTransferError::MintRecoveryInconclusive {
+                        id: UsdcRebalanceId(Uuid::from_u128(43)),
+                        initiated_at: Utc::now(),
+                        source: Box::new(CctpError::ScanInconclusive { from_block: 99 }),
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await;
+
+        result.expect("redrive must succeed once the mint recovery resolves");
+        assert_eq!(
+            calls.get(),
+            2,
+            "the loop must retry exactly once after the inconclusive mint recovery, \
+             then succeed",
         );
     }
 

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -21,10 +21,12 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{error, warn};
 
+use st0x_bridge::cctp::CctpError;
 use st0x_evm::Wallet;
 use st0x_execution::AlpacaWalletError;
 use st0x_finance::Usdc;
@@ -90,6 +92,32 @@ const WITHDRAWAL_POLL_ALERT_DEADLINE: Duration = Duration::from_secs(4 * 60 * 60
 /// so a slower post-deadline cadence is harmless for funds in transit.
 const WITHDRAWAL_POLL_POST_DEADLINE_REDRIVE_DELAY: Duration = Duration::from_secs(30 * 60);
 
+/// Duration after which repeated `MintRecoveryInconclusive` redrives page the
+/// operator via the notifier. Mirrors `WITHDRAWAL_POLL_ALERT_DEADLINE`: the
+/// deadline is durable, derived from whichever durable aggregate state the
+/// transfer resumed from (`Bridging`, `AwaitingAttestation`, `Attested`, or a
+/// post-burn `BridgingFailed`, all of which persist `initiated_at`), so the
+/// countdown survives restarts.
+///
+/// 4 hours gives generous headroom above the ~2-minute internal probe window
+/// (`MINT_RECOVERY_PROBES` x `MINT_RECOVERY_PROBE_INTERVAL` in the
+/// `st0x-bridge` crate) that `recover_already_minted` runs per attempt, while
+/// ensuring a durably degraded RPC endpoint or a nonce that never resolves
+/// surfaces well before it becomes a multi-day silent outage.
+const MINT_RECOVERY_ALERT_DEADLINE: Duration = Duration::from_secs(4 * 60 * 60);
+
+/// Delay before re-probing an inconclusive CCTP mint recovery. It currently
+/// matches `SETTLEMENT_REDRIVE_DELAY` (30 s), but remains distinct because
+/// CCTP nonce polling and Ethereum settlement timing may evolve independently.
+const MINT_RECOVERY_REDRIVE_DELAY: Duration = Duration::from_secs(30);
+
+/// Redrive delay used AFTER the mint-recovery alert deadline has elapsed.
+/// Mirrors `WITHDRAWAL_POLL_POST_DEADLINE_REDRIVE_DELAY`: slows the cadence
+/// from `MINT_RECOVERY_REDRIVE_DELAY` (30 s) to prevent alert fatigue on the
+/// shared Telegram channel, while the guard stays held and the re-probe --
+/// idempotent against the same CCTP nonce -- keeps running.
+const MINT_RECOVERY_POST_DEADLINE_REDRIVE_DELAY: Duration = Duration::from_secs(30 * 60);
+
 /// Returns the warn-threshold attempt count at which an early operator alert
 /// fires, or `None` when there is no room for a distinct early warning.
 ///
@@ -106,8 +134,123 @@ fn warn_threshold(max_redrives: u32) -> Option<u32> {
     (threshold < max_redrives).then_some(threshold)
 }
 
-fn withdrawal_poll_deadline_elapsed(elapsed: Option<Duration>) -> Option<Duration> {
-    elapsed.filter(|elapsed| *elapsed >= WITHDRAWAL_POLL_ALERT_DEADLINE)
+/// Returns `elapsed` unchanged when it has reached or passed `deadline`, or
+/// `None` otherwise. Shared by both the withdrawal-poll and mint-recovery
+/// alert deadlines (`WITHDRAWAL_POLL_ALERT_DEADLINE` /
+/// `MINT_RECOVERY_ALERT_DEADLINE`): each call site passes its own deadline
+/// constant so the alert-triggering logic is written once.
+fn deadline_elapsed(elapsed: Option<Duration>, deadline: Duration) -> Option<Duration> {
+    elapsed.filter(|elapsed| *elapsed >= deadline)
+}
+
+/// Which cross-venue USDC transfer direction hit a post-burn CCTP mint
+/// recovery that stayed inconclusive. The deadline math, notifier message
+/// template, and redrive enqueue are identical between directions; only the
+/// log label and the `stox transfer resume --direction` hint differ, so this
+/// enum carries those two differences as data instead of duplicating the
+/// surrounding logic per direction.
+#[derive(Debug, Clone, Copy)]
+enum MintRecoveryDirection {
+    /// Base -> Alpaca (hedging).
+    BaseToAlpaca,
+    /// Alpaca -> Base (market making).
+    AlpacaToBase,
+}
+
+impl MintRecoveryDirection {
+    /// Human-readable label for the `warn!` log and operator alert, e.g.
+    /// "Base->Alpaca".
+    fn label(self) -> &'static str {
+        match self {
+            Self::BaseToAlpaca => "Base->Alpaca",
+            Self::AlpacaToBase => "Alpaca->Base",
+        }
+    }
+
+    /// The `stox transfer resume --direction` flag value naming this
+    /// direction, for the manual-intervention hint in the alert message.
+    fn cli_flag(self) -> &'static str {
+        match self {
+            Self::BaseToAlpaca => "to-alpaca",
+            Self::AlpacaToBase => "to-raindex",
+        }
+    }
+}
+
+/// Reschedules a post-burn CCTP mint recovery that stayed inconclusive:
+/// unbounded and budget-free, escalating to an operator alert once
+/// `initiated_at` is past `MINT_RECOVERY_ALERT_DEADLINE`. Shared by
+/// `TransferUsdcToHedging::handle_mint_recovery_inconclusive` and
+/// `TransferUsdcToMarketMaking::handle_mint_recovery_inconclusive`, whose
+/// logic was otherwise byte-for-byte identical between the two directions
+/// (see `MintRecoveryDirection`'s doc for what actually differs).
+///
+/// The alert message reports `elapsed` as the transfer's total age since
+/// `initiated_at`, NOT as "time the mint has been inconclusive": `initiated_at`
+/// is stamped once at transfer start and carried unchanged through every
+/// earlier phase (withdrawal, burn, attestation), so a transfer that spent
+/// hours in an earlier phase before ever reaching mint recovery would
+/// otherwise report a misleadingly large "inconclusive" duration on its very
+/// first inconclusive probe. Phrasing it as total transfer age (with mint
+/// recovery named as the CURRENT stuck stage) keeps the message honest while
+/// still using `initiated_at` as the alert deadline -- anchoring the deadline
+/// to when the mint phase itself began would need a new durable timestamp,
+/// which is out of scope here (see the finding this addresses).
+async fn schedule_mint_recovery_redrive<Task>(
+    notifier: &Arc<dyn Notifier>,
+    job_queue: &mut JobQueue<Task>,
+    redriven_job: Task,
+    direction: MintRecoveryDirection,
+    id: UsdcRebalanceId,
+    initiated_at: DateTime<Utc>,
+    source: Box<CctpError>,
+) -> Result<(), QueuePushError>
+where
+    Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static,
+{
+    // Mirror the `.ok()` pattern used for the withdrawal-poll deadline: a
+    // future `initiated_at` (clock skew after restart) makes `to_std()`
+    // return `Err`, treated as `None` so no spurious alert fires.
+    let elapsed = Utc::now().signed_duration_since(initiated_at).to_std().ok();
+    let alert_deadline_elapsed = deadline_elapsed(elapsed, MINT_RECOVERY_ALERT_DEADLINE);
+    let redrive_delay = if alert_deadline_elapsed.is_some() {
+        MINT_RECOVERY_POST_DEADLINE_REDRIVE_DELAY
+    } else {
+        MINT_RECOVERY_REDRIVE_DELAY
+    };
+
+    let label = direction.label();
+    warn!(
+        target: "rebalance",
+        %id,
+        %source,
+        ?elapsed,
+        delay = ?redrive_delay,
+        "{label} USDC transfer: CCTP mint recovery inconclusive; rescheduling \
+         (guard held, redrive continues)"
+    );
+
+    if let Some(elapsed) = alert_deadline_elapsed {
+        let cli_flag = direction.cli_flag();
+        let message = format!(
+            "USDC transfer {id} ({label}): running for {elapsed:?} since it started \
+             (>{MINT_RECOVERY_ALERT_DEADLINE:?}); currently stuck at CCTP mint recovery \
+             -- nonce state unknown or mint receipt unreconstructible ({source}), the \
+             mint may already have landed. Transfer stays mid-flight (guard held), \
+             automatic redrive continues. Verify on-chain nonce/mint status before \
+             acting; use `stox transfer resume --kind usdc --id {id} --direction \
+             {cli_flag}` if the automatic redrive appears stuck."
+        );
+        if let Err(notify_err) = notifier.notify(&message).await {
+            warn!(
+                target: "rebalance",
+                ?notify_err,
+                "Failed to deliver mint-recovery-deadline-elapsed alert"
+            );
+        }
+    }
+
+    job_queue.push_with_delay(redriven_job, redrive_delay).await
 }
 
 /// Apalis queue type for [`TransferUsdcToHedging`].
@@ -304,21 +447,12 @@ impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
             // for slow on-chain settlement would be wrong. Mirrors the
             // market-making settlement-wait arm.
             //
-            // When `source` wraps a `CctpError::MintRecoveryInconclusive` (see
-            // `CrossVenueCashTransfer::redrive_on_mint_recovery_inconclusive` in
-            // manager.rs), this redrive is UNBOUNDED with NO operator alert: a
-            // durably degraded RPC endpoint redrives here forever at
-            // `SETTLEMENT_REDRIVE_DELAY`, holding the `usdc_in_progress` guard the
-            // whole time, with only this `warn!` (never `ctx.notifier.notify`) to
-            // observe it. A deadline-based alert mirroring
-            // `WithdrawalPollInconclusive` is a deliberate, tracked follow-up (see
-            // `redrive_on_mint_recovery_inconclusive`'s doc for why it is not
-            // included here), not an oversight.
+            // A post-burn CCTP mint recovery whose outcome could not be
+            // determined is a DIFFERENT, dedicated variant --
+            // `UsdcTransferError::MintRecoveryInconclusive` (see the arm below)
+            // -- not wrapped in this one, so it gets its own deadline-based
+            // operator alert instead of redriving here silently forever.
             Err(UsdcTransferError::SettlementCheckTransient { id, source }) => {
-                // `source` is logged (not just the generic reason) so an
-                // operator watching this redrive can see, e.g., a
-                // `CctpError::MintRecoveryInconclusive` probe error directly,
-                // rather than only "settlement-phase RPC check failed".
                 warn!(
                     target: "rebalance",
                     %id,
@@ -330,6 +464,23 @@ impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
                 let mut job_queue = ctx.job_queue.clone();
                 job_queue
                     .push_with_delay(self.clone(), SETTLEMENT_REDRIVE_DELAY)
+                    .await?;
+            }
+            // Post-burn CCTP mint recovery inconclusive: the nonce state is
+            // unknown or the mint receipt could not be reconstructed (see
+            // `CrossVenueCashTransfer::redrive_on_mint_recovery_inconclusive` in
+            // manager.rs). The aggregate stays in whatever durable pre-mint
+            // state it was already in, so this redrives unbounded and
+            // budget-free BEFORE the deadline; at or after
+            // `MINT_RECOVERY_ALERT_DEADLINE` the operator is paged on every
+            // redrive while the guard stays held and redriving continues (at a
+            // slower cadence, to avoid alert fatigue).
+            Err(UsdcTransferError::MintRecoveryInconclusive {
+                id,
+                initiated_at,
+                source,
+            }) => {
+                self.handle_mint_recovery_inconclusive(ctx, id, initiated_at, source)
                     .await?;
             }
             // Revert-class burn failures: safe to redrive because
@@ -663,6 +814,30 @@ impl TransferUsdcToHedging {
             .await?;
         Ok(())
     }
+
+    /// Handles a post-burn CCTP mint recovery that stayed inconclusive: reschedule
+    /// unbounded and budget-free, escalating to an operator alert once
+    /// `initiated_at` is past `MINT_RECOVERY_ALERT_DEADLINE`. Symmetric to
+    /// [`TransferUsdcToMarketMaking::handle_mint_recovery_inconclusive`].
+    async fn handle_mint_recovery_inconclusive(
+        &self,
+        ctx: &TransferUsdcToHedgingCtx,
+        id: UsdcRebalanceId,
+        initiated_at: DateTime<Utc>,
+        source: Box<CctpError>,
+    ) -> Result<(), TransferUsdcToHedgingJobError> {
+        schedule_mint_recovery_redrive(
+            &ctx.notifier,
+            &mut ctx.job_queue.clone(),
+            self.clone(),
+            MintRecoveryDirection::BaseToAlpaca,
+            id,
+            initiated_at,
+            source,
+        )
+        .await?;
+        Ok(())
+    }
 }
 
 /// Dependencies the Alpaca->Base job needs. Symmetric to
@@ -787,21 +962,16 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
                     // This arm is unreachable; it exists only to satisfy exhaustiveness.
                     _ => unreachable!("outer or-pattern limits to settlement variants"),
                 };
-                // `settlement_err` (which for `SettlementCheckTransient` carries
-                // the boxed `CctpError` source, e.g. a
-                // `MintRecoveryInconclusive` probe error) is logged in full so
-                // an operator watching this redrive sees the underlying cause,
-                // not just the generic `reason` string.
+                // `settlement_err` is logged in full (not just the generic
+                // `reason` string) so an operator watching this redrive sees
+                // the underlying cause.
                 //
-                // When that source is `CctpError::MintRecoveryInconclusive` (see
-                // `CrossVenueCashTransfer::redrive_on_mint_recovery_inconclusive`
-                // in manager.rs), this redrive is UNBOUNDED with NO operator
-                // alert: a durably degraded RPC endpoint redrives here forever at
-                // `SETTLEMENT_REDRIVE_DELAY`, holding the `usdc_in_progress` guard
-                // the whole time, with only this `warn!` (never
-                // `ctx.notifier.notify`) to observe it. A deadline-based alert
-                // mirroring `WithdrawalPollInconclusive` is a deliberate, tracked
-                // follow-up, not an oversight.
+                // A post-burn CCTP mint recovery whose outcome could not be
+                // determined is a DIFFERENT, dedicated variant --
+                // `UsdcTransferError::MintRecoveryInconclusive` (see the arm
+                // below) -- not wrapped in this one, so it gets its own
+                // deadline-based operator alert instead of redriving here
+                // silently forever.
                 warn!(
                     target: "rebalance",
                     %id,
@@ -812,6 +982,23 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
                 let mut job_queue = ctx.job_queue.clone();
                 job_queue
                     .push_with_delay(self.clone(), SETTLEMENT_REDRIVE_DELAY)
+                    .await?;
+            }
+            // Post-burn CCTP mint recovery inconclusive: the nonce state is
+            // unknown or the mint receipt could not be reconstructed (see
+            // `CrossVenueCashTransfer::redrive_on_mint_recovery_inconclusive` in
+            // manager.rs). The aggregate stays in whatever durable pre-mint
+            // state it was already in, so this redrives unbounded and
+            // budget-free BEFORE the deadline; at or after
+            // `MINT_RECOVERY_ALERT_DEADLINE` the operator is paged on every
+            // redrive while the guard stays held and redriving continues (at a
+            // slower cadence, to avoid alert fatigue).
+            Err(UsdcTransferError::MintRecoveryInconclusive {
+                id,
+                initiated_at,
+                source,
+            }) => {
+                self.handle_mint_recovery_inconclusive(ctx, id, initiated_at, source)
                     .await?;
             }
             Err(UsdcTransferError::AttestationRetryDeadlineElapsed { id }) => {
@@ -1001,8 +1188,8 @@ impl TransferUsdcToMarketMaking {
         // Once past the deadline, slow the redrive cadence from 30 s to 30 min
         // so the operator page repeats at ~2/hour rather than ~120/hour. The
         // re-poll is idempotent so a slower cadence is safe.
-        let deadline_elapsed = withdrawal_poll_deadline_elapsed(elapsed);
-        let redrive_delay = if deadline_elapsed.is_some() {
+        let alert_deadline_elapsed = deadline_elapsed(elapsed, WITHDRAWAL_POLL_ALERT_DEADLINE);
+        let redrive_delay = if alert_deadline_elapsed.is_some() {
             WITHDRAWAL_POLL_POST_DEADLINE_REDRIVE_DELAY
         } else {
             WITHDRAWAL_POLL_REDRIVE_DELAY
@@ -1018,7 +1205,7 @@ impl TransferUsdcToMarketMaking {
              (aggregate stays in Withdrawing, guard held)"
         );
 
-        if let Some(elapsed) = deadline_elapsed {
+        if let Some(elapsed) = alert_deadline_elapsed {
             let message = format!(
                 "Alpaca->Base USDC transfer {id}: withdrawal polling inconclusive \
                  for {elapsed:?} (>{WITHDRAWAL_POLL_ALERT_DEADLINE:?}). Alpaca may \
@@ -1040,6 +1227,30 @@ impl TransferUsdcToMarketMaking {
             .clone()
             .push_with_delay(self.clone(), redrive_delay)
             .await?;
+        Ok(())
+    }
+
+    /// Handles a post-burn CCTP mint recovery that stayed inconclusive: reschedule
+    /// unbounded and budget-free, escalating to an operator alert once
+    /// `initiated_at` is past `MINT_RECOVERY_ALERT_DEADLINE`. Symmetric to
+    /// [`TransferUsdcToHedging::handle_mint_recovery_inconclusive`].
+    async fn handle_mint_recovery_inconclusive(
+        &self,
+        ctx: &TransferUsdcToMarketMakingCtx,
+        id: UsdcRebalanceId,
+        initiated_at: DateTime<Utc>,
+        source: Box<CctpError>,
+    ) -> Result<(), TransferUsdcToMarketMakingJobError> {
+        schedule_mint_recovery_redrive(
+            &ctx.notifier,
+            &mut ctx.job_queue.clone(),
+            self.clone(),
+            MintRecoveryDirection::AlpacaToBase,
+            id,
+            initiated_at,
+            source,
+        )
+        .await?;
         Ok(())
     }
 
@@ -1155,7 +1366,6 @@ mod tests {
     use reqwest::StatusCode;
     use uuid::Uuid;
 
-    use st0x_bridge::cctp::CctpError;
     use st0x_evm::EvmError;
     use st0x_execution::{AlpacaTransferId, AlpacaWalletError};
     use st0x_float_macro::float;
@@ -1169,9 +1379,29 @@ mod tests {
         let elapsed = Some(WITHDRAWAL_POLL_ALERT_DEADLINE);
 
         assert_eq!(
-            withdrawal_poll_deadline_elapsed(elapsed),
+            deadline_elapsed(elapsed, WITHDRAWAL_POLL_ALERT_DEADLINE),
             Some(WITHDRAWAL_POLL_ALERT_DEADLINE),
             "the alert deadline comparison must be inclusive"
+        );
+    }
+
+    #[test]
+    fn mint_recovery_deadline_elapsed_includes_exact_boundary() {
+        let elapsed = Some(MINT_RECOVERY_ALERT_DEADLINE);
+
+        assert_eq!(
+            deadline_elapsed(elapsed, MINT_RECOVERY_ALERT_DEADLINE),
+            Some(MINT_RECOVERY_ALERT_DEADLINE),
+            "the alert deadline comparison must be inclusive"
+        );
+    }
+
+    #[test]
+    fn mint_recovery_deadline_elapsed_none_input_stays_none() {
+        assert_eq!(
+            deadline_elapsed(None, MINT_RECOVERY_ALERT_DEADLINE),
+            None,
+            "a None elapsed (e.g. future initiated_at from clock skew) must not elapse"
         );
     }
 
@@ -1369,6 +1599,60 @@ mod tests {
                     elapsed: Duration::from_secs(1800),
                 },
             })
+        }
+    }
+
+    /// Stub that returns `MintRecoveryInconclusive` for every resume call in
+    /// either direction. `initiated_at` controls whether the deadline check in
+    /// the job handler fires an operator alert (past deadline) or only logs a
+    /// warning (before).
+    struct MintRecoveryInconclusiveStub {
+        initiated_at: DateTime<Utc>,
+    }
+
+    impl MintRecoveryInconclusiveStub {
+        fn before_deadline() -> Self {
+            Self {
+                initiated_at: Utc::now(),
+            }
+        }
+
+        fn after_deadline() -> Self {
+            Self {
+                initiated_at: Utc::now()
+                    - chrono::Duration::from_std(MINT_RECOVERY_ALERT_DEADLINE).unwrap()
+                    - chrono::Duration::seconds(1),
+            }
+        }
+
+        fn error(&self, id: &UsdcRebalanceId) -> UsdcTransferError {
+            UsdcTransferError::MintRecoveryInconclusive {
+                id: id.clone(),
+                initiated_at: self.initiated_at,
+                source: Box::new(CctpError::ScanInconclusive { from_block: 99 }),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ResumeAlpacaToBase for MintRecoveryInconclusiveStub {
+        async fn resume_alpaca_to_base(
+            &self,
+            id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(self.error(id))
+        }
+    }
+
+    #[async_trait]
+    impl ResumeBaseToAlpaca for MintRecoveryInconclusiveStub {
+        async fn resume_base_to_alpaca(
+            &self,
+            id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(self.error(id))
         }
     }
 
@@ -1672,7 +1956,7 @@ mod tests {
         let after = Utc::now().timestamp();
 
         assert_eq!(
-            withdrawal_poll_deadline_elapsed(None),
+            deadline_elapsed(None, WITHDRAWAL_POLL_ALERT_DEADLINE),
             None,
             "future initiated_at maps to elapsed=None, so the deadline is not elapsed"
         );
@@ -1822,6 +2106,276 @@ mod tests {
             1,
             "WithdrawalPollInconclusive at exact deadline boundary must fire the operator alert \
              (>= comparison); got: {messages:?}"
+        );
+    }
+
+    /// `MintRecoveryInconclusive` before the alert deadline must schedule a
+    /// delayed redrive (one Pending row with `MINT_RECOVERY_REDRIVE_DELAY`) and
+    /// return `Ok` so the apalis retry budget is not consumed -- warn log
+    /// only, no operator alert. `revert_redrive_attempts` must not be
+    /// incremented (the redrive is unbounded and independent of the
+    /// burn-revert budget). Market-making (Alpaca->Base) direction.
+    #[tokio::test]
+    async fn market_making_job_redrives_on_mint_recovery_inconclusive() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(MintRecoveryInconclusiveStub::before_deadline()),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let before = Utc::now().timestamp();
+        job.perform(&ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "MintRecoveryInconclusive must enqueue exactly one delayed redrive job"
+        );
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        let rescheduled: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.id, job.id,
+            "the rescheduled job must resume the same aggregate id"
+        );
+        assert!(
+            run_at >= before + i64::try_from(MINT_RECOVERY_REDRIVE_DELAY.as_secs()).unwrap() - 5
+                && run_at
+                    <= after + i64::try_from(MINT_RECOVERY_REDRIVE_DELAY.as_secs()).unwrap() + 5,
+            "redrive must be delayed by ~{MINT_RECOVERY_REDRIVE_DELAY:?} -- \
+             run_at={run_at} before={before} after={after}"
+        );
+        assert!(
+            notifier.messages().is_empty(),
+            "MintRecoveryInconclusive before deadline must not fire an operator alert, got: {:?}",
+            notifier.messages()
+        );
+        assert_eq!(
+            rescheduled.revert_redrive_attempts, 0,
+            "MintRecoveryInconclusive must not increment revert_redrive_attempts: the redrive \
+             is unbounded and independent of the burn-revert budget"
+        );
+    }
+
+    /// `MintRecoveryInconclusive` at or after the alert deadline must fire an
+    /// operator alert via the notifier while STILL scheduling the delayed
+    /// redrive (at the slower post-deadline cadence) and returning `Ok`. The
+    /// guard stays held and redriving continues -- funds are already burned,
+    /// so silently giving up is not an option. Market-making (Alpaca->Base)
+    /// direction.
+    #[tokio::test]
+    async fn market_making_job_fires_alert_on_mint_recovery_deadline_elapsed() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(MintRecoveryInconclusiveStub::after_deadline()),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let before = Utc::now().timestamp();
+        job.perform(&ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "deadline-elapsed must still enqueue a delayed redrive job (guard stays held, \
+             redriving does not stop)"
+        );
+        let (_payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        assert!(
+            run_at
+                >= before
+                    + i64::try_from(MINT_RECOVERY_POST_DEADLINE_REDRIVE_DELAY.as_secs()).unwrap()
+                    - 5
+                && run_at
+                    <= after
+                        + i64::try_from(MINT_RECOVERY_POST_DEADLINE_REDRIVE_DELAY.as_secs())
+                            .unwrap()
+                        + 5,
+            "post-deadline redrive must use the longer {MINT_RECOVERY_POST_DEADLINE_REDRIVE_DELAY:?} \
+             delay to prevent alert fatigue -- run_at={run_at} before={before} after={after}"
+        );
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "MintRecoveryInconclusive past deadline must fire exactly one operator alert, \
+             got: {messages:?}"
+        );
+        let alert = &messages[0];
+        assert!(
+            alert.contains(&job.id.to_string()),
+            "alert must contain the transfer id so the operator can act on it; got: {alert:?}"
+        );
+        assert!(
+            alert.contains("stox transfer resume"),
+            "alert must contain the recovery command; got: {alert:?}"
+        );
+        assert!(
+            alert.contains("to-raindex"),
+            "alert must contain the --direction flag; got: {alert:?}"
+        );
+        let expected_source = CctpError::ScanInconclusive { from_block: 99 }.to_string();
+        assert!(
+            alert.contains(&expected_source),
+            "alert must contain the underlying CctpError source {expected_source:?}; \
+             got: {alert:?}"
+        );
+        // `initiated_at` is the transfer's START, carried unchanged through every
+        // earlier phase, NOT the moment mint recovery became inconclusive -- mint
+        // recovery is the LAST phase, so `elapsed` can already exceed the alert
+        // deadline on the very first inconclusive probe. The message must report
+        // it honestly as total transfer age with mint recovery named as the
+        // current stuck stage, not as "mint recovery inconclusive for {elapsed}"
+        // (which would overstate how long the mint itself has been stuck).
+        assert!(
+            alert.contains("running for")
+                && alert.contains("currently stuck at CCTP mint recovery"),
+            "alert must report elapsed as total transfer age (mint recovery is the current \
+             stage), not as the duration the mint itself has been inconclusive; got: {alert:?}"
+        );
+    }
+
+    /// Mirrors `market_making_job_redrives_on_mint_recovery_inconclusive` for the
+    /// hedging (Base->Alpaca) direction: a `MintRecoveryInconclusive` before the
+    /// deadline must redrive budget-free with no alert.
+    #[tokio::test]
+    async fn hedging_job_redrives_on_mint_recovery_inconclusive() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(MintRecoveryInconclusiveStub::before_deadline()),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let before = Utc::now().timestamp();
+        Job::perform(&job, &ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            1,
+            "MintRecoveryInconclusive must enqueue exactly one delayed redrive job"
+        );
+        assert!(
+            notifier.messages().is_empty(),
+            "MintRecoveryInconclusive before deadline must not fire an operator alert, got: {:?}",
+            notifier.messages()
+        );
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToHedging>(&pool).await;
+        let rescheduled: TransferUsdcToHedging = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.id, job.id,
+            "the rescheduled job must resume the same aggregate id"
+        );
+        assert_eq!(
+            rescheduled.revert_redrive_attempts, 0,
+            "MintRecoveryInconclusive must not increment revert_redrive_attempts"
+        );
+        assert!(
+            run_at >= before + i64::try_from(MINT_RECOVERY_REDRIVE_DELAY.as_secs()).unwrap() - 5
+                && run_at
+                    <= after + i64::try_from(MINT_RECOVERY_REDRIVE_DELAY.as_secs()).unwrap() + 5,
+            "redrive must be delayed by ~{MINT_RECOVERY_REDRIVE_DELAY:?} -- \
+             run_at={run_at} before={before} after={after}"
+        );
+    }
+
+    /// Mirrors `market_making_job_fires_alert_on_mint_recovery_deadline_elapsed`
+    /// for the hedging (Base->Alpaca) direction.
+    #[tokio::test]
+    async fn hedging_job_fires_alert_on_mint_recovery_deadline_elapsed() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(MintRecoveryInconclusiveStub::after_deadline()),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+        };
+
+        let before = Utc::now().timestamp();
+        Job::perform(&job, &ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            1,
+            "deadline-elapsed must still enqueue a delayed redrive job (guard stays held, \
+             redriving does not stop)"
+        );
+        let (_payload, run_at) = pending_job_row::<TransferUsdcToHedging>(&pool).await;
+        assert!(
+            run_at
+                >= before
+                    + i64::try_from(MINT_RECOVERY_POST_DEADLINE_REDRIVE_DELAY.as_secs()).unwrap()
+                    - 5
+                && run_at
+                    <= after
+                        + i64::try_from(MINT_RECOVERY_POST_DEADLINE_REDRIVE_DELAY.as_secs())
+                            .unwrap()
+                        + 5,
+            "post-deadline redrive must use the longer {MINT_RECOVERY_POST_DEADLINE_REDRIVE_DELAY:?} \
+             delay -- run_at={run_at} before={before} after={after}"
+        );
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "MintRecoveryInconclusive past deadline must fire exactly one operator alert, \
+             got: {messages:?}"
+        );
+        let alert = &messages[0];
+        assert!(
+            alert.contains(&job.id.to_string()),
+            "alert must contain the transfer id so the operator can act on it; got: {alert:?}"
+        );
+        assert!(
+            alert.contains("to-alpaca"),
+            "alert must contain the --direction flag; got: {alert:?}"
+        );
+        // See the matching assertion in
+        // `market_making_job_fires_alert_on_mint_recovery_deadline_elapsed` for why
+        // this must be phrased as total transfer age, not mint-inconclusive duration.
+        assert!(
+            alert.contains("running for")
+                && alert.contains("currently stuck at CCTP mint recovery"),
+            "alert must report elapsed as total transfer age (mint recovery is the current \
+             stage), not as the duration the mint itself has been inconclusive; got: {alert:?}"
         );
     }
 

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -171,6 +171,17 @@ fn classify_vault_withdrawal_error(error: RaindexError) -> UsdcTransferError {
     }
 }
 
+/// The two durable timestamps carried by `AwaitingAttestation`: when the
+/// attestation retry gives up, and when the transfer originally started.
+/// Both are `DateTime<Utc>`, so passing them as adjacent positional
+/// parameters would let a call site swap the retry deadline for the
+/// transfer's start time without a compile error; bundling them as named
+/// fields removes that risk.
+struct AwaitingAttestationTimestamps {
+    retry_deadline_at: DateTime<Utc>,
+    initiated_at: DateTime<Utc>,
+}
+
 /// Orchestrates USDC rebalancing between Alpaca (Ethereum) and Rain (Base).
 ///
 /// # Type Parameters
@@ -211,6 +222,29 @@ enum MintCallSite {
     /// `recover_from_bridging_failed`, reached from an already-terminal
     /// `BridgingFailed`.
     RecoverFromBridgingFailed,
+}
+
+/// Identifies which of the two `Bridge::find_recent_mint` scan call sites hit
+/// a transport-class failure while resuming from `Attested`, so
+/// `CrossVenueCashTransfer::redrive_on_mint_scan_failure`'s `warn!` log names
+/// the direction without a hand-maintained string fragment.
+#[derive(Debug, Clone, Copy)]
+enum MintScanCallSite {
+    /// `continue_alpaca_to_base_from_attested`, scanning Base for an
+    /// already-submitted mint.
+    AlpacaToBase,
+    /// `continue_from_attested`, scanning Ethereum for an already-submitted
+    /// mint.
+    BaseToAlpaca,
+}
+
+impl std::fmt::Display for MintScanCallSite {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlpacaToBase => write!(formatter, "Alpaca->Base"),
+            Self::BaseToAlpaca => write!(formatter, "Base->Alpaca"),
+        }
+    }
 }
 
 impl<
@@ -733,11 +767,13 @@ impl<
             Some(ConversionComplete {
                 direction: AlpacaToBase,
                 conversion,
+                initiated_at,
                 ..
             }) => {
                 self.continue_alpaca_to_base_from_conversion_complete(
                     id,
                     conversion.received_amount,
+                    initiated_at,
                 )
                 .await
             }
@@ -758,26 +794,38 @@ impl<
                     .await?;
                 // Thread the confirmed withdrawal_tx so the burn-scan lower bound
                 // is derived from the withdrawal tx block (not the raw chain head).
-                self.continue_alpaca_to_base_from_withdrawal_complete(id, amount, withdrawal_tx)
-                    .await
+                self.continue_alpaca_to_base_from_withdrawal_complete(
+                    id,
+                    amount,
+                    withdrawal_tx,
+                    initiated_at,
+                )
+                .await
             }
 
             Some(WithdrawalComplete {
                 direction: AlpacaToBase,
                 amount,
                 withdrawal_tx,
+                initiated_at,
                 ..
             }) => {
                 // Thread the persisted withdrawal_tx so the durable re-check fires
                 // on apalis redrive (primary gate does not re-run from this arm).
-                self.continue_alpaca_to_base_from_withdrawal_complete(id, amount, withdrawal_tx)
-                    .await
+                self.continue_alpaca_to_base_from_withdrawal_complete(
+                    id,
+                    amount,
+                    withdrawal_tx,
+                    initiated_at,
+                )
+                .await
             }
 
             Some(Bridging {
                 direction: AlpacaToBase,
                 amount,
                 burn_tx_hash,
+                initiated_at,
                 ..
             }) => {
                 // The `Bridging` state carries only the nominal `amount`; it does
@@ -787,8 +835,13 @@ impl<
                 // `continue_alpaca_to_base_from_bridging` only uses `burn_amount`
                 // for `BurnReceipt`; the actual minted amount comes from the
                 // on-chain mint receipt, so supplying the nominal here is harmless.
-                self.continue_alpaca_to_base_from_bridging(id, usdc_to_u256(amount)?, burn_tx_hash)
-                    .await
+                self.continue_alpaca_to_base_from_bridging(
+                    id,
+                    usdc_to_u256(amount)?,
+                    burn_tx_hash,
+                    initiated_at,
+                )
+                .await
             }
 
             Some(UsdcRebalance::AwaitingAttestation {
@@ -796,13 +849,17 @@ impl<
                 amount,
                 burn_tx_hash,
                 retry_deadline_at,
+                initiated_at,
                 ..
             }) => {
                 self.continue_alpaca_to_base_from_awaiting_attestation(
                     id,
                     amount,
                     burn_tx_hash,
-                    retry_deadline_at,
+                    AwaitingAttestationTimestamps {
+                        retry_deadline_at,
+                        initiated_at,
+                    },
                 )
                 .await
             }
@@ -819,6 +876,7 @@ impl<
                 attestation,
                 message,
                 mint_scan_from_block,
+                initiated_at,
                 ..
             }) => {
                 self.continue_alpaca_to_base_from_attested(
@@ -828,6 +886,7 @@ impl<
                     cctp_nonce,
                     message,
                     mint_scan_from_block,
+                    initiated_at,
                 )
                 .await
             }
@@ -956,6 +1015,7 @@ impl<
                 from_block,
                 burn_amount,
                 pending_burn_tx,
+                initiated_at,
                 ..
             }) => {
                 let nominal_u256 = usdc_to_u256(amount)?;
@@ -981,8 +1041,13 @@ impl<
                     .await?;
                 // Pass burn_receipt.amount (what was actually burned, per the scan)
                 // so BurnReceipt records the real amount, not the nominal.
-                self.continue_alpaca_to_base_from_bridging(id, burn_receipt.amount, burn_receipt.tx)
-                    .await
+                self.continue_alpaca_to_base_from_bridging(
+                    id,
+                    burn_receipt.amount,
+                    burn_receipt.tx,
+                    initiated_at,
+                )
+                .await
             }
 
             // `WithdrawalSubmitting` is produced only by the BaseToAlpaca flow
@@ -1016,21 +1081,30 @@ impl<
         &self,
         id: &UsdcRebalanceId,
         filled_amount: Usdc,
+        initiated_at: DateTime<Utc>,
     ) -> Result<(), UsdcTransferError> {
         let transfer = self.initiate_alpaca_withdrawal(id, filled_amount).await?;
 
-        // Approximate initiated_at: the aggregate's initiated_at was just set
-        // moments ago by the Initiate command handler. Reading it back from the
-        // aggregate is not worth an extra DB round-trip; on any re-poll redrive,
-        // resume_alpaca_to_base reads the exact aggregate value anyway. The
-        // 4-hour operator-alert deadline absorbs any sub-second discrepancy here.
+        // Approximate initiated_at for the withdrawal poll: the aggregate's
+        // initiated_at was just set moments ago by the Initiate command handler.
+        // Reading it back from the aggregate is not worth an extra DB round-trip;
+        // on any re-poll redrive, resume_alpaca_to_base reads the exact aggregate
+        // value anyway. The 4-hour operator-alert deadline absorbs any sub-second
+        // discrepancy here. The mint-recovery deadline below uses the REAL
+        // `initiated_at` threaded in from the caller's aggregate state, since it
+        // is already available with no extra round-trip.
         let withdrawal_tx = self
             .poll_and_confirm_withdrawal(id, &transfer.id, Utc::now())
             .await?;
         // Thread the confirmed withdrawal_tx so the burn-scan lower bound
         // is derived from the withdrawal tx block (not the raw chain head).
-        self.continue_alpaca_to_base_from_withdrawal_complete(id, filled_amount, withdrawal_tx)
-            .await
+        self.continue_alpaca_to_base_from_withdrawal_complete(
+            id,
+            filled_amount,
+            withdrawal_tx,
+            initiated_at,
+        )
+        .await
     }
 
     /// Drives an Alpaca->Base transfer from `WithdrawalComplete` through to
@@ -1040,6 +1114,7 @@ impl<
         id: &UsdcRebalanceId,
         amount: Usdc,
         withdrawal_tx: Option<TxHash>,
+        initiated_at: DateTime<Utc>,
     ) -> Result<(), UsdcTransferError> {
         // DURABLE confirmation re-check: fires on the redrive path
         // (`WithdrawalComplete` -> resume) when the primary gate in
@@ -1240,8 +1315,13 @@ impl<
 
         // Pass the actual (capped) burn amount through so BurnReceipt records
         // what was truly burned, not the nominal requested amount.
-        self.continue_alpaca_to_base_from_bridging(id, burn_receipt.amount, burn_receipt.tx)
-            .await
+        self.continue_alpaca_to_base_from_bridging(
+            id,
+            burn_receipt.amount,
+            burn_receipt.tx,
+            initiated_at,
+        )
+        .await
     }
 
     /// Drives an Alpaca->Base transfer from `Bridging`/`Attested` through to
@@ -1259,6 +1339,7 @@ impl<
         // or usdc_to_u256 output) so no conversion is needed here.
         burn_amount: U256,
         burn_tx_hash: TxHash,
+        initiated_at: DateTime<Utc>,
     ) -> Result<(), UsdcTransferError> {
         let burn_receipt = BurnReceipt {
             tx: burn_tx_hash,
@@ -1280,7 +1361,9 @@ impl<
             }
         };
 
-        let mint_receipt = self.execute_cctp_mint(id, attestation_response).await?;
+        let mint_receipt = self
+            .execute_cctp_mint(id, attestation_response, initiated_at)
+            .await?;
 
         self.continue_alpaca_to_base_from_bridged(id, u256_to_usdc(mint_receipt.amount)?)
             .await
@@ -1294,8 +1377,12 @@ impl<
         id: &UsdcRebalanceId,
         amount: Usdc,
         burn_tx_hash: TxHash,
-        retry_deadline_at: DateTime<Utc>,
+        timestamps: AwaitingAttestationTimestamps,
     ) -> Result<(), UsdcTransferError> {
+        let AwaitingAttestationTimestamps {
+            retry_deadline_at,
+            initiated_at,
+        } = timestamps;
         let burn_receipt = BurnReceipt {
             tx: burn_tx_hash,
             amount: usdc_to_u256(amount)?,
@@ -1320,7 +1407,9 @@ impl<
             }
         };
 
-        let mint_receipt = self.execute_cctp_mint(id, attestation_response).await?;
+        let mint_receipt = self
+            .execute_cctp_mint(id, attestation_response, initiated_at)
+            .await?;
 
         self.continue_alpaca_to_base_from_bridged(id, u256_to_usdc(mint_receipt.amount)?)
             .await
@@ -1346,6 +1435,7 @@ impl<
         cctp_nonce: B256,
         message: Option<Vec<u8>>,
         mint_scan_from_block: Option<u64>,
+        initiated_at: DateTime<Utc>,
     ) -> Result<(), UsdcTransferError> {
         // Events persisted before crash-safe resume carry no scan bound. Scanning
         // from genesis could adopt an unrelated mint to the same wallet, so refuse
@@ -1363,7 +1453,14 @@ impl<
                 mint_scan_from_block,
             )
             .await
-            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?
+            .map_err(|error| {
+                Self::redrive_on_mint_scan_failure(
+                    id,
+                    error,
+                    MintScanCallSite::AlpacaToBase,
+                    initiated_at,
+                )
+            })?
         {
             let amount_received = u256_to_usdc(mint_receipt.amount)?;
 
@@ -1400,7 +1497,9 @@ impl<
                 message,
             )
             .await?;
-        let mint_receipt = self.execute_cctp_mint(id, attestation_response).await?;
+        let mint_receipt = self
+            .execute_cctp_mint(id, attestation_response, initiated_at)
+            .await?;
 
         self.continue_alpaca_to_base_from_bridged(id, u256_to_usdc(mint_receipt.amount)?)
             .await
@@ -1436,15 +1535,21 @@ impl<
         // Approximate initiated_at: same reasoning as
         // continue_alpaca_to_base_from_conversion_complete -- the aggregate's value
         // was set moments ago; resume_alpaca_to_base uses the exact stored value on
-        // any re-poll redrive.
+        // any re-poll redrive. Reused below for the mint-recovery deadline too.
+        let initiated_at = Utc::now();
         let withdrawal_tx = self
-            .poll_and_confirm_withdrawal(id, &transfer.id, Utc::now())
+            .poll_and_confirm_withdrawal(id, &transfer.id, initiated_at)
             .await?;
 
         // Thread the confirmed withdrawal_tx so the burn-scan lower bound is
         // derived from the withdrawal tx block (not the raw chain head).
-        self.continue_alpaca_to_base_from_withdrawal_complete(id, usdc_amount, withdrawal_tx)
-            .await?;
+        self.continue_alpaca_to_base_from_withdrawal_complete(
+            id,
+            usdc_amount,
+            withdrawal_tx,
+            initiated_at,
+        )
+        .await?;
 
         info!(target: "rebalance", "Alpaca to Base rebalance completed successfully");
         Ok(())
@@ -1721,43 +1826,27 @@ impl<
     /// codebase has a documented history of them) or a manual/external mint
     /// landing in the window would let a redrive adopt the wrong mint.
     ///
-    /// UNBOUNDED BY DESIGN, with NO operator alert: every call site redrives
-    /// via `UsdcTransferError::SettlementCheckTransient` for as long as
-    /// `CctpEndpoint::recover_already_minted`'s probe loop keeps returning
-    /// `MintRecoveryInconclusive` (e.g. a durably degraded RPC endpoint),
-    /// with no attempt limit and no `ctx.notifier.notify` call anywhere on
-    /// this path -- see `job.rs`'s handling of `SettlementCheckTransient`,
-    /// which is deliberately silent and unbounded here (unlike the generic
-    /// terminal arm below, which pages on `FailBridging`). The
-    /// `usdc_in_progress` rebalancing guard stays held for the entire
-    /// redrive, exactly as it would for a genuine in-flight transfer, so a
-    /// PERSISTENTLY inconclusive mint recovery (not a one-off RPC blip) is
-    /// currently invisible to an operator until someone notices inventory
-    /// drift or inspects the Jobs table directly.
-    ///
-    /// This is a known, deliberately deferred gap, not an oversight: adding
-    /// a `WithdrawalPollInconclusive`-style deadline-based alert here
-    /// requires a durable counter or timestamp that survives redrives and
-    /// restarts, which this error's `SettlementCheckTransient` mapping does
-    /// not carry. The two available anchors both have a blast radius well
-    /// beyond this fix: (1) `WithdrawalPollInconclusive`'s own
-    /// `initiated_at` comes from the single aggregate state that reaches its
-    /// one call site (`Withdrawing`); this error's three call sites are
-    /// reached from FOUR different aggregate states (`Bridging`,
-    /// `AwaitingAttestation`, `Attested`, `BridgingFailed`) across BOTH
-    /// transfer directions, so threading an equivalent timestamp means
-    /// plumbing it through every one of those call chains; (2) tracking it
-    /// instead as a counter on the job payload (mirroring
-    /// `revert_redrive_attempts`) means adding a new mandatory field to
-    /// `TransferUsdcToHedging`/`TransferUsdcToMarketMaking`, which are
-    /// constructed at roughly 90 call sites across `job.rs`'s own tests and
-    /// `rebalancing/trigger/mod.rs`. Either is real, scoped work -- tracked
-    /// as a deliberate follow-up (mirroring `WithdrawalPollInconclusive`'s
-    /// deadline alert), not something to invent ad hoc inside this fix.
+    /// BOUNDED BY A DEADLINE, mirroring `WithdrawalPollInconclusive`: every call
+    /// site redrives via `UsdcTransferError::MintRecoveryInconclusive` for as
+    /// long as `CctpEndpoint::recover_already_minted`'s probe loop keeps
+    /// returning `MintRecoveryInconclusive` (e.g. a durably degraded RPC
+    /// endpoint). The redrive itself stays unbounded and budget-free -- the
+    /// `usdc_in_progress` rebalancing guard stays held exactly as it would for
+    /// a genuine in-flight transfer, since declaring a terminal failure on
+    /// unobserved state (or on funds that may have already moved) would be
+    /// wrong. What bounds it is the alert: `initiated_at`, threaded here from
+    /// whichever of the four durable states (`Bridging`, `AwaitingAttestation`,
+    /// `Attested`, `BridgingFailed`) the caller resumed from, lets the job
+    /// layer (`job.rs`'s `handle_mint_recovery_inconclusive`) compute elapsed
+    /// time since the transfer started. Before the deadline only a warn log
+    /// fires; at or after it the operator is paged on every redrive via
+    /// `ctx.notifier.notify`, while the guard stays held and redriving
+    /// continues at a slower cadence to avoid alert fatigue.
     fn redrive_on_mint_recovery_inconclusive(
         id: &UsdcRebalanceId,
         error: CctpError,
         call_site: MintCallSite,
+        initiated_at: DateTime<Utc>,
     ) -> UsdcTransferError {
         warn!(
             target: "rebalance",
@@ -1766,8 +1855,62 @@ impl<
             "CCTP mint recovery inconclusive: the nonce state is unknown, or the nonce read \
              consumed but its receipt could not be reconstructed; will retry: {error}"
         );
-        UsdcTransferError::SettlementCheckTransient {
+        UsdcTransferError::MintRecoveryInconclusive {
             id: id.clone(),
+            initiated_at,
+            source: Box::new(error),
+        }
+    }
+
+    /// Classifies a `Bridge::find_recent_mint` scan failure hit while resuming
+    /// from `Attested` (`continue_alpaca_to_base_from_attested` /
+    /// `continue_from_attested`), BEFORE any mint is attempted.
+    ///
+    /// `find_recent_mint` never submits a transaction -- it only reads
+    /// `MintAndWithdraw` logs via `eth_getLogs` -- so it structurally cannot
+    /// fail with a revert-class error; every failure it can actually produce
+    /// (`RpcTransport`, `SolType` decode) is a transport/RPC hiccup on the
+    /// destination chain. That is exactly the "durably degraded RPC endpoint"
+    /// case `MintRecoveryInconclusive` exists to tolerate: the USDC is already
+    /// burned, so declaring this terminal via `UsdcTransferError::Cctp` would
+    /// consume the apalis retry budget and open the circuit instead of
+    /// continuing the unbounded, deadline-gated redrive, stranding the
+    /// transfer on exactly the incident this feature was built to survive.
+    ///
+    /// Reuses `CctpError::is_revert()` (rather than a parallel hand-maintained
+    /// variant list) to draw the line: a non-revert error redrives via
+    /// `MintRecoveryInconclusive` carrying `initiated_at` unchanged, so the job
+    /// layer's deadline-gated alert (`handle_mint_recovery_inconclusive`) still
+    /// applies. A revert-class error would mean this scan somehow observed a
+    /// reverted transaction -- not reachable through `find_recent_mint` today,
+    /// but classified as structurally terminal for defense in depth should the
+    /// scan's implementation ever change.
+    fn redrive_on_mint_scan_failure(
+        id: &UsdcRebalanceId,
+        error: CctpError,
+        call_site: MintScanCallSite,
+        initiated_at: DateTime<Utc>,
+    ) -> UsdcTransferError {
+        if error.is_revert() {
+            warn!(
+                target: "rebalance",
+                %id,
+                %call_site,
+                "CCTP mint scan reverted while resuming from Attested: {error}"
+            );
+            return UsdcTransferError::Cctp(Box::new(error));
+        }
+
+        warn!(
+            target: "rebalance",
+            %id,
+            %call_site,
+            "CCTP mint scan failed transiently while resuming from Attested; \
+             nonce state unknown, will retry: {error}"
+        );
+        UsdcTransferError::MintRecoveryInconclusive {
+            id: id.clone(),
+            initiated_at,
             source: Box::new(error),
         }
     }
@@ -1777,6 +1920,7 @@ impl<
         &self,
         id: &UsdcRebalanceId,
         attestation_response: AttestationResponse,
+        initiated_at: DateTime<Utc>,
     ) -> Result<MintReceipt, UsdcTransferError> {
         let mint_receipt = match self
             .cctp_bridge
@@ -1797,13 +1941,14 @@ impl<
             // adopts an already-landed mint via a bounded scan before minting
             // again, so a redrive cannot double-mint.
             //
-            // See `redrive_on_mint_recovery_inconclusive`'s doc for why this
-            // is unbounded and deliberately pages no operator.
+            // See `redrive_on_mint_recovery_inconclusive`'s doc for the
+            // deadline-based operator alert bounding this redrive.
             Err(error @ CctpError::MintRecoveryInconclusive { .. }) => {
                 return Err(Self::redrive_on_mint_recovery_inconclusive(
                     id,
                     error,
                     MintCallSite::ExecuteCctpMint,
+                    initiated_at,
                 ));
             }
             Err(error) => {
@@ -1929,13 +2074,20 @@ impl<
 
         let amount_u256 = usdc_to_u256(amount)?;
 
+        // Approximate initiated_at: captured before the vault withdrawal and
+        // CCTP burn. The aggregate records its durable value after withdrawal
+        // succeeds, so this can err early by the withdrawal duration but never
+        // delays paging by the two on-chain operations. Any redrive reads the
+        // exact aggregate value via resume_base_to_alpaca.
+        let initiated_at = Utc::now();
+
         self.withdraw_from_vault(id, amount, amount_u256).await?;
 
         let burn_receipt = self.execute_cctp_burn_on_base(id, amount_u256).await?;
 
         // From Bridging onward the fresh-start and resume paths are identical:
         // poll Circle, record the attestation, mint, deposit, and convert.
-        self.continue_from_bridging(id, amount, burn_receipt.tx)
+        self.continue_from_bridging(id, amount, burn_receipt.tx, initiated_at)
             .await?;
 
         info!(target: "rebalance", "Base to Alpaca rebalance completed successfully");
@@ -1975,17 +2127,22 @@ impl<
                 direction,
                 amount,
                 from_block,
+                initiated_at,
                 ..
             }) => {
                 Self::require_base_to_alpaca(id, direction)?;
                 let amount_u256 = usdc_to_u256(amount)?;
                 self.resume_withdrawal_submitting(id, amount, amount_u256, from_block)
                     .await?;
-                self.continue_from_withdrawal_complete(id, amount).await
+                self.continue_from_withdrawal_complete(id, amount, initiated_at)
+                    .await
             }
 
             Some(UsdcRebalance::Withdrawing {
-                direction, amount, ..
+                direction,
+                amount,
+                initiated_at,
+                ..
             }) => {
                 Self::require_base_to_alpaca(id, direction)?;
                 self.cqrs
@@ -1996,14 +2153,19 @@ impl<
                         },
                     )
                     .await?;
-                self.continue_from_withdrawal_complete(id, amount).await
+                self.continue_from_withdrawal_complete(id, amount, initiated_at)
+                    .await
             }
 
             Some(UsdcRebalance::WithdrawalComplete {
-                direction, amount, ..
+                direction,
+                amount,
+                initiated_at,
+                ..
             }) => {
                 Self::require_base_to_alpaca(id, direction)?;
-                self.continue_from_withdrawal_complete(id, amount).await
+                self.continue_from_withdrawal_complete(id, amount, initiated_at)
+                    .await
             }
 
             Some(UsdcRebalance::BridgingSubmitting {
@@ -2011,6 +2173,7 @@ impl<
                 amount,
                 from_block,
                 pending_burn_tx,
+                initiated_at,
                 ..
             }) => {
                 Self::require_base_to_alpaca(id, direction)?;
@@ -2018,7 +2181,7 @@ impl<
                 let burn_receipt = self
                     .resume_bridging_submitting(id, amount_u256, from_block, pending_burn_tx)
                     .await?;
-                self.continue_from_bridging(id, amount, burn_receipt.tx)
+                self.continue_from_bridging(id, amount, burn_receipt.tx, initiated_at)
                     .await
             }
 
@@ -2026,10 +2189,12 @@ impl<
                 direction,
                 amount,
                 burn_tx_hash,
+                initiated_at,
                 ..
             }) => {
                 Self::require_base_to_alpaca(id, direction)?;
-                self.continue_from_bridging(id, amount, burn_tx_hash).await
+                self.continue_from_bridging(id, amount, burn_tx_hash, initiated_at)
+                    .await
             }
 
             Some(UsdcRebalance::AwaitingAttestation {
@@ -2037,11 +2202,20 @@ impl<
                 amount,
                 burn_tx_hash,
                 retry_deadline_at,
+                initiated_at,
                 ..
             }) => {
                 Self::require_base_to_alpaca(id, direction)?;
-                self.continue_from_awaiting_attestation(id, amount, burn_tx_hash, retry_deadline_at)
-                    .await
+                self.continue_from_awaiting_attestation(
+                    id,
+                    amount,
+                    burn_tx_hash,
+                    AwaitingAttestationTimestamps {
+                        retry_deadline_at,
+                        initiated_at,
+                    },
+                )
+                .await
             }
 
             Some(UsdcRebalance::Attested {
@@ -2051,17 +2225,18 @@ impl<
                 attestation,
                 message,
                 mint_scan_from_block,
+                initiated_at,
                 ..
             }) => {
                 Self::require_base_to_alpaca(id, direction)?;
                 self.continue_from_attested(
                     id,
-                    direction,
                     burn_tx_hash,
                     attestation,
                     cctp_nonce,
                     message,
                     mint_scan_from_block,
+                    initiated_at,
                 )
                 .await
             }
@@ -2139,10 +2314,12 @@ impl<
             Some(UsdcRebalance::BridgingFailed {
                 direction,
                 burn_tx_hash,
+                initiated_at,
                 ..
             }) => {
                 Self::require_base_to_alpaca(id, direction)?;
-                self.recover_from_bridging_failed(id, burn_tx_hash).await
+                self.recover_from_bridging_failed(id, burn_tx_hash, initiated_at)
+                    .await
             }
 
             Some(
@@ -2170,6 +2347,7 @@ impl<
         &self,
         id: &UsdcRebalanceId,
         burn_tx_hash: Option<TxHash>,
+        initiated_at: DateTime<Utc>,
     ) -> Result<(), UsdcTransferError> {
         let Some(burn_tx_hash) = burn_tx_hash else {
             warn!(
@@ -2245,6 +2423,7 @@ impl<
                     id,
                     error,
                     MintCallSite::RecoverFromBridgingFailed,
+                    initiated_at,
                 ));
             }
             Err(error) => return Err(UsdcTransferError::Cctp(Box::new(error))),
@@ -2382,10 +2561,11 @@ impl<
         &self,
         id: &UsdcRebalanceId,
         amount: Usdc,
+        initiated_at: DateTime<Utc>,
     ) -> Result<(), UsdcTransferError> {
         let amount_u256 = usdc_to_u256(amount)?;
         let burn_receipt = self.execute_cctp_burn_on_base(id, amount_u256).await?;
-        self.continue_from_bridging(id, amount, burn_receipt.tx)
+        self.continue_from_bridging(id, amount, burn_receipt.tx, initiated_at)
             .await
     }
 
@@ -2396,6 +2576,7 @@ impl<
         id: &UsdcRebalanceId,
         amount: Usdc,
         burn_tx_hash: TxHash,
+        initiated_at: DateTime<Utc>,
     ) -> Result<(), UsdcTransferError> {
         let burn_receipt = BurnReceipt {
             tx: burn_tx_hash,
@@ -2417,7 +2598,8 @@ impl<
         };
 
         info!(target: "rebalance", "Circle attestation received for Base burn");
-        self.mint_and_continue(id, attestation_response).await
+        self.mint_and_continue(id, attestation_response, initiated_at)
+            .await
     }
 
     /// Drives the transfer from `AwaitingAttestation`: re-poll Circle until the
@@ -2428,8 +2610,12 @@ impl<
         id: &UsdcRebalanceId,
         amount: Usdc,
         burn_tx_hash: TxHash,
-        retry_deadline_at: DateTime<Utc>,
+        timestamps: AwaitingAttestationTimestamps,
     ) -> Result<(), UsdcTransferError> {
+        let AwaitingAttestationTimestamps {
+            retry_deadline_at,
+            initiated_at,
+        } = timestamps;
         let burn_receipt = BurnReceipt {
             tx: burn_tx_hash,
             amount: usdc_to_u256(amount)?,
@@ -2454,7 +2640,8 @@ impl<
             }
         };
 
-        self.mint_and_continue(id, attestation_response).await
+        self.mint_and_continue(id, attestation_response, initiated_at)
+            .await
     }
 
     /// Drives the transfer from `Attested` through to terminal.
@@ -2479,12 +2666,12 @@ impl<
     async fn continue_from_attested(
         &self,
         id: &UsdcRebalanceId,
-        direction: RebalanceDirection,
         burn_tx_hash: TxHash,
         attestation: Vec<u8>,
         cctp_nonce: B256,
         message: Option<Vec<u8>>,
         mint_scan_from_block: Option<u64>,
+        initiated_at: DateTime<Utc>,
     ) -> Result<(), UsdcTransferError> {
         // Events persisted before crash-safe resume carry no scan bound. Scanning
         // from genesis could adopt an unrelated mint to the same wallet, so refuse
@@ -2494,13 +2681,13 @@ impl<
             return Err(UsdcTransferError::ResumeWithoutMintScanBound { id: id.clone() });
         };
 
-        // The mint lands on the destination chain of `direction`; scanning the
-        // wrong chain would miss the already-submitted mint and fall through to a
-        // double-mint that reverts on the used CCTP nonce.
-        let mint_direction = match direction {
-            RebalanceDirection::BaseToAlpaca => BridgeDirection::BaseToEthereum,
-            RebalanceDirection::AlpacaToBase => BridgeDirection::EthereumToBase,
-        };
+        // This function is only reached via `resume_base_to_alpaca`'s `Attested`
+        // arm, which already validated the direction through
+        // `require_base_to_alpaca`, so the mint direction (destination chain)
+        // is always Base->Ethereum here. There is no `AlpacaToBase` equivalent
+        // to make this generic over: `continue_alpaca_to_base_from_attested`
+        // is the separate, dedicated function for that direction.
+        let mint_direction = BridgeDirection::BaseToEthereum;
 
         if let Some(mint_receipt) = self
             .cctp_bridge
@@ -2510,7 +2697,14 @@ impl<
                 mint_scan_from_block,
             )
             .await
-            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?
+            .map_err(|error| {
+                Self::redrive_on_mint_scan_failure(
+                    id,
+                    error,
+                    MintScanCallSite::BaseToAlpaca,
+                    initiated_at,
+                )
+            })?
         {
             let amount_received = u256_to_usdc(mint_receipt.amount)?;
 
@@ -2542,7 +2736,8 @@ impl<
                 message,
             )
             .await?;
-        self.mint_and_continue(id, attestation_response).await
+        self.mint_and_continue(id, attestation_response, initiated_at)
+            .await
     }
 
     /// Mints on the destination chain from a fresh attestation and continues to
@@ -2551,9 +2746,10 @@ impl<
         &self,
         id: &UsdcRebalanceId,
         attestation_response: AttestationResponse,
+        initiated_at: DateTime<Utc>,
     ) -> Result<(), UsdcTransferError> {
         let mint_receipt = self
-            .execute_cctp_mint_on_ethereum(id, attestation_response)
+            .execute_cctp_mint_on_ethereum(id, attestation_response, initiated_at)
             .await?;
         self.continue_from_bridged_fresh(id, u256_to_usdc(mint_receipt.amount)?)
             .await
@@ -3514,6 +3710,7 @@ impl<
         &self,
         id: &UsdcRebalanceId,
         attestation_response: AttestationResponse,
+        initiated_at: DateTime<Utc>,
     ) -> Result<MintReceipt, UsdcTransferError> {
         // The final `Err` arm below records a durable, terminal `FailBridging`.
         // What it implies about the CCTP nonce depends on which `mint()` error
@@ -3538,7 +3735,7 @@ impl<
         // not be reconstructed (a lagging log scan, a mismatched log, a
         // reverted mint tx) -- is distinguished by
         // `CctpError::MintRecoveryInconclusive` and handled by the first
-        // match arm: it redrives via `SettlementCheckTransient` instead of
+        // match arm: it redrives via `MintRecoveryInconclusive` instead of
         // declaring a false terminal failure on unobserved state, or on funds
         // we already know moved.
         //
@@ -3561,13 +3758,14 @@ impl<
             // resume adopts an already-landed mint via a bounded scan before
             // minting again, so a redrive cannot double-mint.
             //
-            // See `redrive_on_mint_recovery_inconclusive`'s doc for why this
-            // is unbounded and deliberately pages no operator.
+            // See `redrive_on_mint_recovery_inconclusive`'s doc for the
+            // deadline-based operator alert bounding this redrive.
             Err(error @ CctpError::MintRecoveryInconclusive { .. }) => {
                 return Err(Self::redrive_on_mint_recovery_inconclusive(
                     id,
                     error,
                     MintCallSite::ExecuteCctpMintOnEthereum,
+                    initiated_at,
                 ));
             }
             Err(error) => {
@@ -3936,8 +4134,9 @@ mod tests {
     /// `CctpError::MintRecoveryInconclusive`, forwarding every other `Bridge`
     /// and `UsdcBridgeHelper` method to a wrapped real bridge. Used to test
     /// that `execute_cctp_mint`/`execute_cctp_mint_on_ethereum`/
-    /// `recover_from_bridging_failed` redrive via `SettlementCheckTransient`
-    /// instead of declaring `FailBridging` on that error class.
+    /// `recover_from_bridging_failed` redrive via
+    /// `UsdcTransferError::MintRecoveryInconclusive` instead of declaring
+    /// `FailBridging` on that error class.
     ///
     /// Generic over `InnerBridge` (rather than a unit struct with
     /// `unimplemented!()` methods) because `recover_from_bridging_failed`
@@ -4053,6 +4252,161 @@ mod tests {
 
     #[async_trait::async_trait]
     impl<InnerBridge> UsdcBridgeHelper for MintErrorBridge<InnerBridge>
+    where
+        InnerBridge: UsdcBridgeHelper,
+    {
+        async fn ethereum_tx_confirmations(
+            &self,
+            tx_hash: TxHash,
+        ) -> Result<Option<u64>, CctpError> {
+            self.inner.ethereum_tx_confirmations(tx_hash).await
+        }
+
+        async fn ethereum_tx_block(&self, tx_hash: TxHash) -> Result<u64, CctpError> {
+            self.inner.ethereum_tx_block(tx_hash).await
+        }
+
+        async fn ethereum_usdc_balance(&self, holder: Address) -> Result<U256, CctpError> {
+            self.inner.ethereum_usdc_balance(holder).await
+        }
+
+        async fn send_usdc_on_ethereum(
+            &self,
+            to: Address,
+            amount: U256,
+        ) -> Result<TxHash, CctpError> {
+            self.inner.send_usdc_on_ethereum(to, amount).await
+        }
+
+        async fn find_recent_usdc_transfer(
+            &self,
+            from: Address,
+            to: Address,
+            amount: U256,
+            from_block: u64,
+        ) -> Result<Option<TxHash>, CctpError> {
+            self.inner
+                .find_recent_usdc_transfer(from, to, amount, from_block)
+                .await
+        }
+    }
+
+    /// A `Bridge` decorator whose `find_recent_mint` always returns a canned
+    /// non-revert `CctpError`, forwarding every other `Bridge` and
+    /// `UsdcBridgeHelper` method to a wrapped real bridge. Used to test that
+    /// `continue_alpaca_to_base_from_attested`/`continue_from_attested`
+    /// redrive via `UsdcTransferError::MintRecoveryInconclusive` on a
+    /// transport-class pre-mint scan failure instead of declaring the
+    /// transfer terminally `Cctp`-failed -- the exact "durably degraded RPC"
+    /// case this redrive path exists to tolerate.
+    struct FindRecentMintErrorBridge<InnerBridge> {
+        inner: InnerBridge,
+    }
+
+    #[async_trait::async_trait]
+    impl<InnerBridge> st0x_bridge::Bridge for FindRecentMintErrorBridge<InnerBridge>
+    where
+        InnerBridge: st0x_bridge::Bridge<Error = CctpError, Attestation = AttestationResponse>,
+    {
+        type Error = CctpError;
+        type Attestation = AttestationResponse;
+
+        async fn burn(
+            &self,
+            direction: BridgeDirection,
+            amount: U256,
+            recipient: Address,
+        ) -> Result<BurnReceipt, CctpError> {
+            self.inner.burn(direction, amount, recipient).await
+        }
+
+        async fn submit_burn(
+            &self,
+            direction: BridgeDirection,
+            amount: U256,
+            recipient: Address,
+        ) -> Result<TxHash, CctpError> {
+            self.inner.submit_burn(direction, amount, recipient).await
+        }
+
+        async fn confirm_burn(
+            &self,
+            direction: BridgeDirection,
+            tx_hash: TxHash,
+            amount: U256,
+        ) -> Result<BurnReceipt, CctpError> {
+            self.inner.confirm_burn(direction, tx_hash, amount).await
+        }
+
+        async fn burn_status(
+            &self,
+            direction: BridgeDirection,
+            tx_hash: TxHash,
+        ) -> Result<st0x_bridge::BurnTxStatus, CctpError> {
+            self.inner.burn_status(direction, tx_hash).await
+        }
+
+        async fn poll_attestation(
+            &self,
+            direction: BridgeDirection,
+            burn_tx: TxHash,
+        ) -> Result<AttestationResponse, CctpError> {
+            self.inner.poll_attestation(direction, burn_tx).await
+        }
+
+        async fn mint(
+            &self,
+            direction: BridgeDirection,
+            attestation: &AttestationResponse,
+        ) -> Result<st0x_bridge::MintReceipt, CctpError> {
+            self.inner.mint(direction, attestation).await
+        }
+
+        fn reconstruct_attestation(
+            &self,
+            message: Vec<u8>,
+            attestation: Vec<u8>,
+        ) -> Result<AttestationResponse, CctpError> {
+            self.inner.reconstruct_attestation(message, attestation)
+        }
+
+        async fn find_recent_burn(
+            &self,
+            direction: BridgeDirection,
+            amount: U256,
+            recipient: Address,
+            from_block: u64,
+        ) -> Result<Option<TxHash>, CctpError> {
+            self.inner
+                .find_recent_burn(direction, amount, recipient, from_block)
+                .await
+        }
+
+        // The method under test: a canned non-revert error, regardless of
+        // direction/recipient/from_block. `ScanInconclusive` is a
+        // representative non-revert `CctpError` (mirrors the sentinel used by
+        // `CctpError::is_revert()`'s own unit tests); the specific variant is
+        // not what's under test, only that `is_revert()` classifies it `false`.
+        async fn find_recent_mint(
+            &self,
+            _direction: BridgeDirection,
+            _recipient: Address,
+            _from_block: u64,
+        ) -> Result<Option<st0x_bridge::MintReceipt>, CctpError> {
+            Err(CctpError::ScanInconclusive { from_block: 0 })
+        }
+
+        async fn destination_block(&self, direction: BridgeDirection) -> Result<u64, CctpError> {
+            self.inner.destination_block(direction).await
+        }
+
+        async fn source_block(&self, direction: BridgeDirection) -> Result<u64, CctpError> {
+            self.inner.source_block(direction).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<InnerBridge> UsdcBridgeHelper for FindRecentMintErrorBridge<InnerBridge>
     where
         InnerBridge: UsdcBridgeHelper,
     {
@@ -9227,7 +9581,7 @@ mod tests {
         // The burn attempt fails (Cctp error from the fee query or the REVERT
         // contract). Either way the error must not be a balance-gate wedge.
         let error = manager
-            .continue_alpaca_to_base_from_withdrawal_complete(&id, nominal, None)
+            .continue_alpaca_to_base_from_withdrawal_complete(&id, nominal, None, Utc::now())
             .await
             .unwrap_err();
 
@@ -9286,7 +9640,7 @@ mod tests {
         advance_to_withdrawal_complete_alpaca_to_base(&cqrs, &id, amount).await;
 
         let error = manager
-            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, None)
+            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, None, Utc::now())
             .await
             .unwrap_err();
 
@@ -9365,7 +9719,7 @@ mod tests {
         // tx-confirmation endpoint registered), producing SettlementCheckTransient.
         // A BurnRevert error proves the gate was skipped and the burn was attempted.
         let error = manager
-            .continue_alpaca_to_base_from_withdrawal_complete(&id, nominal, None)
+            .continue_alpaca_to_base_from_withdrawal_complete(&id, nominal, None, Utc::now())
             .await
             .unwrap_err();
 
@@ -9417,7 +9771,7 @@ mod tests {
         advance_to_withdrawal_complete_alpaca_to_base(&cqrs, &id, nominal).await;
 
         let error = manager
-            .continue_alpaca_to_base_from_withdrawal_complete(&id, nominal, None)
+            .continue_alpaca_to_base_from_withdrawal_complete(&id, nominal, None, Utc::now())
             .await
             .unwrap_err();
 
@@ -9489,7 +9843,12 @@ mod tests {
         // the balance read returns zero (RPC node lag).
         let confirmed_tx = chain.mint_tx;
         let error = manager
-            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, Some(confirmed_tx))
+            .continue_alpaca_to_base_from_withdrawal_complete(
+                &id,
+                amount,
+                Some(confirmed_tx),
+                Utc::now(),
+            )
             .await
             .unwrap_err();
 
@@ -9567,7 +9926,7 @@ mod tests {
         // emitted before the burn attempt; the REVERT leaves the aggregate at
         // BridgingSubmitting with no FailBridging.
         let error = manager
-            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, None)
+            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, None, Utc::now())
             .await
             .unwrap_err();
 
@@ -10126,7 +10485,7 @@ mod tests {
         // zero USDC. No FailBridging is emitted; the aggregate stays in
         // WithdrawalComplete for the next delayed-redrive attempt.
         let error = manager
-            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, None)
+            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, None, Utc::now())
             .await
             .unwrap_err();
 
@@ -10869,7 +11228,7 @@ mod tests {
         advance_to_withdrawal_complete_alpaca_to_base(&cqrs, &id, amount).await;
 
         let error = manager
-            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, None)
+            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, None, Utc::now())
             .await
             .unwrap_err();
 
@@ -11289,7 +11648,12 @@ mod tests {
         advance_to_withdrawal_complete_alpaca_to_base(&cqrs, &id, amount).await;
 
         let error = manager
-            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, Some(under_confirmed_tx))
+            .continue_alpaca_to_base_from_withdrawal_complete(
+                &id,
+                amount,
+                Some(under_confirmed_tx),
+                Utc::now(),
+            )
             .await
             .unwrap_err();
 
@@ -11342,7 +11706,7 @@ mod tests {
         advance_to_withdrawal_complete_alpaca_to_base(&cqrs, &id, amount).await;
 
         let error = manager
-            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, None)
+            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, None, Utc::now())
             .await
             .unwrap_err();
 
@@ -11502,7 +11866,12 @@ mod tests {
         advance_to_withdrawal_complete_alpaca_to_base(&cqrs, &id, amount).await;
 
         let error = manager
-            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, Some(withdrawal_tx))
+            .continue_alpaca_to_base_from_withdrawal_complete(
+                &id,
+                amount,
+                Some(withdrawal_tx),
+                Utc::now(),
+            )
             .await
             .unwrap_err();
 
@@ -11866,9 +12235,11 @@ mod tests {
     /// read) must NOT be treated the same as a decided mint failure: declaring
     /// `FailBridging` would strand the rebalancing guard on state the probe
     /// loop never actually observed. `execute_cctp_mint` must instead return
-    /// `SettlementCheckTransient` so the job delayed-redrives, leaving the
+    /// `MintRecoveryInconclusive` so the job delayed-redrives, leaving the
     /// aggregate at `Attested` (whose resume adopts an already-landed mint via
-    /// a bounded scan before minting again, so the redrive is safe).
+    /// a bounded scan before minting again, so the redrive is safe). The
+    /// `initiated_at` passed in must be threaded through unchanged so the job
+    /// layer can compute the alert deadline from it.
     #[tokio::test]
     async fn mint_recovery_inconclusive_redrives_instead_of_failing_bridging() {
         let (_anvil, endpoint, private_key) = setup_anvil();
@@ -11908,18 +12279,29 @@ mod tests {
             &test_settlement_params(),
         );
 
+        let initiated_at = Utc::now() - chrono::Duration::minutes(30);
         let error = manager
-            .execute_cctp_mint(&id, attestation_response)
+            .execute_cctp_mint(&id, attestation_response, initiated_at)
             .await
             .unwrap_err();
 
-        let UsdcTransferError::SettlementCheckTransient { id: err_id, .. } = error else {
+        let UsdcTransferError::MintRecoveryInconclusive {
+            id: err_id,
+            initiated_at: err_initiated_at,
+            ..
+        } = error
+        else {
             panic!(
                 "a mint recovery window that expired inconclusively must redrive via \
-                 SettlementCheckTransient, not fail the bridge; got: {error:?}"
+                 MintRecoveryInconclusive, not fail the bridge; got: {error:?}"
             );
         };
         assert_eq!(err_id, id);
+        assert_eq!(
+            err_initiated_at, initiated_at,
+            "initiated_at must be threaded through unchanged so the job layer can \
+             compute the alert deadline from it"
+        );
 
         // No FailBridging must have been emitted: the aggregate stays at
         // Attested so the next redrive can adopt a late mint or retry cleanly.
@@ -11933,7 +12315,7 @@ mod tests {
     /// Mirrors `mint_recovery_inconclusive_redrives_instead_of_failing_bridging`
     /// for the BaseToAlpaca (Ethereum-side) mint direction: a `mint()` failure
     /// classified `CctpError::MintRecoveryInconclusive` must redrive via
-    /// `SettlementCheckTransient` from `execute_cctp_mint_on_ethereum` too, not
+    /// `MintRecoveryInconclusive` from `execute_cctp_mint_on_ethereum` too, not
     /// just from the AlpacaToBase `execute_cctp_mint`. This is the direction
     /// described as the actual production incident (a stranded post-burn
     /// `BridgingFailed` blocking USDC rebalancing for hours), so it needs its
@@ -11977,18 +12359,29 @@ mod tests {
             &test_settlement_params(),
         );
 
+        let initiated_at = Utc::now() - chrono::Duration::minutes(30);
         let error = manager
-            .execute_cctp_mint_on_ethereum(&id, attestation_response)
+            .execute_cctp_mint_on_ethereum(&id, attestation_response, initiated_at)
             .await
             .unwrap_err();
 
-        let UsdcTransferError::SettlementCheckTransient { id: err_id, .. } = error else {
+        let UsdcTransferError::MintRecoveryInconclusive {
+            id: err_id,
+            initiated_at: err_initiated_at,
+            ..
+        } = error
+        else {
             panic!(
                 "a mint recovery window that expired inconclusively must redrive via \
-                 SettlementCheckTransient, not fail the bridge; got: {error:?}"
+                 MintRecoveryInconclusive, not fail the bridge; got: {error:?}"
             );
         };
         assert_eq!(err_id, id);
+        assert_eq!(
+            err_initiated_at, initiated_at,
+            "initiated_at must be threaded through unchanged so the job layer can \
+             compute the alert deadline from it"
+        );
 
         // No FailBridging must have been emitted: the aggregate stays at
         // Attested so the next redrive can adopt a late mint or retry cleanly.
@@ -12034,6 +12427,10 @@ mod tests {
         // shape `recover_from_bridging_failed` attempts to recover.
         let burn_tx =
             fixed_bytes!("0xaaaa000000000000000000000000000000000000000000000000000000000003");
+        // Bracket the Initiate handler's `Utc::now()` stamp so the durable
+        // initiated_at threaded through to MintRecoveryInconclusive can be
+        // pinned to a tight window, not merely bounded above.
+        let before_initiate = Utc::now();
         cqrs.send(
             &id,
             UsdcRebalanceCommand::Initiate {
@@ -12044,6 +12441,7 @@ mod tests {
         )
         .await
         .unwrap();
+        let after_initiate = Utc::now();
         cqrs.send(
             &id,
             UsdcRebalanceCommand::ConfirmWithdrawal {
@@ -12082,14 +12480,29 @@ mod tests {
             .await
             .unwrap_err();
 
-        let UsdcTransferError::SettlementCheckTransient { id: err_id, .. } = error else {
+        let UsdcTransferError::MintRecoveryInconclusive {
+            id: err_id,
+            initiated_at: err_initiated_at,
+            ..
+        } = error
+        else {
             panic!(
                 "a post-burn BridgingFailed recovery whose mint recovery window expired \
-                 inconclusively must redrive via SettlementCheckTransient, not stay \
+                 inconclusively must redrive via MintRecoveryInconclusive, not stay \
                  terminally mapped to Cctp; got: {error:?}"
             );
         };
         assert_eq!(err_id, id);
+        // `BridgingFailed` carries its own durable `initiated_at`, stamped by the
+        // aggregate's `Initiate` handler at `before_initiate..after_initiate`, not
+        // a fresh `Utc::now()` taken at recovery time. Bracketing the Initiate
+        // send pins the exact expected window rather than only bounding above.
+        assert!(
+            err_initiated_at >= before_initiate && err_initiated_at <= after_initiate,
+            "initiated_at must be the durable timestamp recorded when the transfer began \
+             ({before_initiate:?}..={after_initiate:?}), not a fresh Utc::now() call at \
+             recovery time; got {err_initiated_at:?}"
+        );
 
         // The aggregate must remain BridgingFailed (no further command
         // emitted): the next redrive re-polls the attestation and idempotently
@@ -12098,6 +12511,156 @@ mod tests {
         assert!(
             matches!(state, UsdcRebalance::BridgingFailed { .. }),
             "aggregate must remain BridgingFailed (no re-fail, no false recovery); got: {state:?}"
+        );
+    }
+
+    /// A transport-class `find_recent_mint` failure hit while scanning for an
+    /// already-submitted mint on `Attested` resume (BEFORE any mint is even
+    /// attempted) must NOT be blanket-mapped to `UsdcTransferError::Cctp`: that
+    /// lands in the job's generic terminal arm, consuming the apalis retry
+    /// budget and opening the circuit on exactly the "durably degraded
+    /// destination RPC" case the mint-recovery redrive exists to survive, even
+    /// though the USDC is already burned. `continue_alpaca_to_base_from_attested`
+    /// must instead redrive via `MintRecoveryInconclusive`, carrying
+    /// `initiated_at` unchanged, exactly like a `Bridge::mint` recovery-probe
+    /// failure.
+    #[tokio::test]
+    async fn find_recent_mint_scan_transport_failure_redrives_alpaca_to_base() {
+        let (_anvil, endpoint, private_key) = setup_anvil();
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (real_cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+
+        let server = MockServer::start();
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+
+        let cqrs = create_test_store_instance().await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        advance_to_attested_alpaca_to_base(&cqrs, &id, amount).await;
+
+        let expected_initiated_at = match cqrs.load(&id).await.unwrap().expect("aggregate exists") {
+            UsdcRebalance::Attested { initiated_at, .. } => initiated_at,
+            other => panic!("expected Attested state, got: {other:?}"),
+        };
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(FindRecentMintErrorBridge {
+                inner: real_cctp_bridge,
+            }),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            address!("0x2222222222222222222222222222222222222222"),
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        let UsdcTransferError::MintRecoveryInconclusive {
+            id: err_id,
+            initiated_at: err_initiated_at,
+            ..
+        } = error
+        else {
+            panic!(
+                "a transport-class find_recent_mint scan failure must redrive via \
+                 MintRecoveryInconclusive, not terminally fail via Cctp; got: {error:?}"
+            );
+        };
+        assert_eq!(err_id, id);
+        assert_eq!(
+            err_initiated_at, expected_initiated_at,
+            "initiated_at must be threaded through unchanged so the job layer can \
+             compute the alert deadline from it"
+        );
+
+        // No FailBridging must have been emitted: the aggregate stays at
+        // Attested so the next redrive can retry the scan or adopt a late mint.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::Attested { .. }),
+            "aggregate must remain at Attested (no FailBridging emitted); got: {state:?}"
+        );
+    }
+
+    /// Mirrors `find_recent_mint_scan_transport_failure_redrives_alpaca_to_base`
+    /// for the BaseToAlpaca (Ethereum-side) mint direction: a transport-class
+    /// `find_recent_mint` failure during `continue_from_attested`'s pre-mint
+    /// scan must also redrive via `MintRecoveryInconclusive`, not `Cctp`.
+    #[tokio::test]
+    async fn find_recent_mint_scan_transport_failure_redrives_base_to_alpaca() {
+        let (_anvil, endpoint, private_key) = setup_anvil();
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (real_cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+
+        let server = MockServer::start();
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+
+        let cqrs = create_test_store_instance().await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        advance_to_attested_base_to_alpaca(&cqrs, &id, amount).await;
+
+        let expected_initiated_at = match cqrs.load(&id).await.unwrap().expect("aggregate exists") {
+            UsdcRebalance::Attested { initiated_at, .. } => initiated_at,
+            other => panic!("expected Attested state, got: {other:?}"),
+        };
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(FindRecentMintErrorBridge {
+                inner: real_cctp_bridge,
+            }),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            address!("0x2222222222222222222222222222222222222222"),
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        let UsdcTransferError::MintRecoveryInconclusive {
+            id: err_id,
+            initiated_at: err_initiated_at,
+            ..
+        } = error
+        else {
+            panic!(
+                "a transport-class find_recent_mint scan failure must redrive via \
+                 MintRecoveryInconclusive, not terminally fail via Cctp; got: {error:?}"
+            );
+        };
+        assert_eq!(err_id, id);
+        assert_eq!(
+            err_initiated_at, expected_initiated_at,
+            "initiated_at must be threaded through unchanged so the job layer can \
+             compute the alert deadline from it"
+        );
+
+        // No FailBridging must have been emitted: the aggregate stays at
+        // Attested so the next redrive can retry the scan or adopt a late mint.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::Attested { .. }),
+            "aggregate must remain at Attested (no FailBridging emitted); got: {state:?}"
         );
     }
 
@@ -14045,7 +14608,12 @@ mod tests {
         let fake_tx = TxHash::from_slice(&[0xabu8; 32]);
 
         let error = manager
-            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, Some(fake_tx))
+            .continue_alpaca_to_base_from_withdrawal_complete(
+                &id,
+                amount,
+                Some(fake_tx),
+                Utc::now(),
+            )
             .await
             .unwrap_err();
 

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -242,6 +242,33 @@ pub(crate) enum UsdcTransferError {
         #[source]
         source: Box<CctpError>,
     },
+    /// A post-burn CCTP mint whose recovery could not be resolved: the recovery
+    /// window expired without ever getting a conclusive `usedNonces()` read, the
+    /// nonce read consumed but its receipt could not be reconstructed, or the
+    /// pre-mint scan for an already-submitted mint (`find_recent_mint`, run on
+    /// `Attested` resume before minting is attempted) failed on a transport-class
+    /// error. The aggregate stays in whichever durable pre-mint state it was
+    /// already in (`Bridging`, `AwaitingAttestation`, `Attested`, or a post-burn
+    /// `BridgingFailed`), so this is safe to delayed-redrive: declaring a
+    /// terminal failure here would strand the rebalancing guard on state that
+    /// was never actually observed, or on funds that may have already moved.
+    ///
+    /// Mirrors `WithdrawalPollInconclusive` in redrive semantics: unbounded,
+    /// returns `Ok` from the job. `initiated_at` is threaded from the
+    /// aggregate's current state (all four reachable states persist it) so the
+    /// job handler can compute a durable deadline: before the deadline only a
+    /// warn log fires; at or after the deadline the operator is paged on every
+    /// redrive while the guard stays held and redriving continues.
+    #[error(
+        "USDC rebalance {id}: CCTP mint recovery inconclusive (nonce state \
+         unknown or receipt unreconstructible); mint may already have landed"
+    )]
+    MintRecoveryInconclusive {
+        id: UsdcRebalanceId,
+        initiated_at: DateTime<Utc>,
+        #[source]
+        source: Box<CctpError>,
+    },
     /// The detached submit-and-record burn task (spawned so a cancelling job
     /// timeout cannot drop the broadcast->record critical section) panicked and
     /// failed to join. The burn may or may not have broadcast. TERMINAL and


### PR DESCRIPTION
## What

[RAI-1498](https://linear.app/makeitrain/issue/RAI-1498/bound-the-inconclusive-mint-redrive-with-a-deadline-alert)

- A post-burn CCTP mint that stays inconclusive now pages an operator after 4 hours instead of redriving silently forever.
- The redrive itself is unchanged before the deadline: still budget-free, still the default.

## Why

- `CctpError::MintRecoveryInconclusive` exists so an undecidable mint outcome does not become a terminal `BridgingFailed`, because declaring failure on unobserved state strands the rebalancing guard on a false negative.
- But the redrive it maps to is budget-free by design, so nothing ever ends it and nothing ever alerts. A persistently inconclusive mint would hold the `usdc_in_progress` guard indefinitely with no operator told. That trades a loud false failure for a silent indefinite hold, which is not obviously better.

## How

- `UsdcTransferError::MintRecoveryInconclusive` carries a durable `initiated_at`, threaded from all four aggregate states (`Bridging`, `AwaitingAttestation`, `Attested`, `BridgingFailed`) through the single `redrive_on_mint_recovery_inconclusive` choke point that all three `Bridge::mint` call sites already share.
- `job.rs` gains a dedicated match arm for it in both job types, mirroring `handle_withdrawal_poll_inconclusive`. Before `MINT_RECOVERY_ALERT_DEADLINE` (4h, matching `WITHDRAWAL_POLL_ALERT_DEADLINE`) it redrives on the normal delay with a warn. At or past it, every redrive also notifies through the existing notifier, with a `stox transfer resume` hint.
- Redriving never stops after the alert, because the funds are already burned and silence is not an option. The cadence slows from 30s to 30min to avoid alert fatigue, matching the withdrawal-poll precedent.

## Testing

- 6 new tests: before and after the deadline, for both the hedging and market-making directions, plus the pre-existing test corrected to expect the new variant.
- 183 tests pass in `rebalancing::usdc::`. Clippy clean under `-D clippy::pedantic` with no suppressions.
- SPEC.md updated with the deadline alert, mirroring the withdrawal-poll write-up.

## Anything else

- `continue_from_attested` lost its `direction` parameter. Threading `initiated_at` pushed it to 9 arguments and tripped clippy's `too_many_arguments`; the parameter had one call site with a compile-time-constant value that the caller already validates, so removing it was the honest fix rather than a suppression.
- Worth knowing for review: an earlier partial attempt added the error variant without a `job.rs` match arm. It compiled, because the generic terminal arm satisfied exhaustiveness, but that arm consumes the retry budget and alerts immediately, so the fix was a no-op in exactly the case it targets. The dedicated arm is the substance of this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability Improvements**
  - USDC rebalancing now continues retrying when post-burn mint recovery is inconclusive, rather than failing immediately.
  - Recovery attempts preserve the original transfer timeline and continue until manually resumed or reconciled.
  - Retry frequency slows after four hours to support longer-running recovery scenarios.

- **Operator Alerts**
  - Operators are alerted when recovery exceeds the four-hour threshold, with instructions for manual intervention.

- **CLI Improvements**
  - Manual rebalancing now waits and retries automatically for inconclusive mint recovery results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->