### PR TITLE
feat: capture daily portfolio snapshots

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -588,6 +588,121 @@ as block zero. Its block lag is therefore absent, and the dashboard surfaces the
 latest unknown-cutoff sample as degraded instead of reporting a healthy zero
 lag.
 
+### Portfolio Capital and Return Tracking
+
+The `/pnl` report's realized-PnL figures say nothing about the capital deployed
+to earn them. To report a percentage return, the system needs a persisted daily
+snapshot of every balance under management, in USD terms.
+
+**Capture mechanism**: a `PortfolioSnapshot` aggregate, one instance per Eastern
+Time calendar day (`et_day`, `YYYY-MM-DD`), following the same event-sourced
+shape as the hedge-latency pipeline above: a `Captured` domain event (retained
+indefinitely, never compacted) is emitted through the CQRS framework by a
+self-rescheduling job, and a `PortfolioSnapshotProjection` reactor writes the
+flat `portfolio_snapshot` read-model table the `/pnl` capital calculation
+queries. The aggregate itself only tracks "has today been captured" -- routing a
+day's first `Capture` command through `initialize` (emits `Captured`) and any
+subsequent one through `transition` (rejected, idempotent by construction) -- so
+a scheduling bug that fires more than once a day cannot double-record it. Like
+the hedge-latency table above, `PortfolioSnapshotProjection` is forward-
+only/best-effort, not the rebuild-from-events invariant: a crash between the
+`Captured` event committing and this reactor's write can drop that day's
+read-model rows, and because the aggregate permanently rejects any further
+`Capture` for the same day, there is currently no automated path to recover a
+dropped row even though the event itself is retained forever. It must gain the
+same startup catch-up plus full rebuild described above before it can claim that
+invariant.
+
+**Capture scheduling**: the job wakes once per ET day, shortly after that day's
+`00:05` ET boundary, and labels the resulting snapshot with the ET day whose
+balances it is actually reading -- never a day other than the one just observed.
+In steady state this fires every day at the boundary. After a restart or a
+hydration retry that causes the job to wake up once its `target_et_day` has
+already passed (hydration stuck across a midnight boundary, or a late process
+wake), it CATCHES UP to a fresh reading for the CURRENT ET day rather than
+either back-dating a live read under the stale day's id or leaving that day's
+capital sample permanently absent: for a roughly delta-neutral book, deployed
+capital moves slowly and is dominated by deliberate flows, so a same-day reading
+remains a valid proxy for the missed day. A day the bot is down across entirely,
+with no wake before the next boundary, is simply absent from the series --
+coverage is sparse by design, not backfilled.
+
+**What is captured**: every balance the live in-memory inventory view has polled
+at least once that ET day, across both trading venues (onchain Raindex
+market-making, offchain Alpaca hedging) and the wallet-transit locations equity
+or cash may sit at in between (Ethereum wallet, Base wallet unwrapped, Base
+wallet wrapped). A venue never polled produces no row; a venue polled to a
+genuine zero balance still produces a `0` row. The capture only proceeds once
+every configured balance has been polled at least once that run -- a
+partially-hydrated view (e.g. equity seen onchain but not yet offchain) is
+skipped and retried shortly after, since a captured day can never be amended.
+This is a PRESENCE check, not a freshness check: a balance that is merely
+present (e.g. replayed from a persisted `InventorySnapshot` at startup, without
+ever being re-polled this run) still satisfies it. In steady state the capture
+job only wakes shortly after the `00:05` ET boundary, by which point the poller
+has already polled fresh this run, so the residual risk is narrow: a restart
+that hydrates stale data from a persisted snapshot and then captures before the
+poller gets a chance to poll again. A robust poll-driven freshness signal (an
+independent signal that records successful polls even when balances are
+unchanged) is accepted as out of scope for v1 and tracked as a follow-up.
+
+**Deployed capital definition**: a day's total USD capital is the sum of cash
+(USDC) balances across every location (both trading venues plus every
+wallet-transit point) plus positive equity holdings across every location,
+including the current Alpaca position at the hedging venue. Counter-trades
+consume or replenish that single broker position; they do not create a second,
+separately tracked hedge leg beside the broker inventory. Excluding Alpaca
+equity would therefore make reported capital change merely because inventory
+moved between Alpaca and Raindex, even when total equity under management was
+unchanged. A negative broker position, if present, does not contribute equity
+capital under this long-inventory definition: snapshots retain the signed broker
+position as observed for auditability, while the PnL capital read sums only
+positive equity quantities. The collateral or margin supporting shorts is not
+modeled. Hedging-venue USDC (cash) is included -- idle or reserved offchain cash
+is still capital under management.
+
+**USD marks**: USDC is treated as par (`1:1`), matching the reporting-currency
+assumption used elsewhere in `/pnl`. Equity balances are marked at the symbol's
+`last_price_usdc` (the same fill-derived price already tracked on the `Position`
+aggregate) as of capture time. A symbol with a balance but no observed price yet
+is recorded with `usd_mark = NULL` -- never a fabricated zero. Marks are fixed
+permanently at capture time as part of the immutable event payload: a later
+price correction does not retroactively change a previously reported day's
+capital. The persisted `mark_captured_at` is `Position.last_updated`, not a
+dedicated price-observation timestamp -- a precise one is a deferred follow-up.
+`last_updated` is the aggregate's last-touched time and is advanced by several
+non-price events too (offchain order placement/fill/cancel, threshold updates),
+so it is only an upper bound on how recently the price was actually observed:
+the staleness guard below reliably excludes a day once the _position_ has gone
+stale, but is not guaranteed to exclude every day with a genuinely stale price
+if that position was otherwise recently touched.
+
+**Derived `/pnl` fields**: for a queried date range, a day's total USD capital
+is computed only when every nonzero-balance row that day has a known, non-stale
+mark; a day with any missing or stale mark is excluded from the sample entirely
+(never partially), since per-row exclusion would understate capital and inflate
+the reported return. `average_deployed_capital_usd` is the mean of included
+days' totals; `annualized_return_pct` is the range's realized PnL divided by
+that average, annualized by `365 / coverage_days` -- reported only when at least
+two included days span at least two calendar days, AND snapshot coverage fully
+spans the queried date range (`first_snapshot_day` at or before the query's
+`fromDate`, `last_snapshot_day` at or after its `toDate`). The realized-PnL
+numerator is scoped to the whole query range, not to snapshot coverage, so a
+narrower coverage window annualizing a wider-range PnL figure would inflate the
+result -- exactly the dangerous direction this section's fail-fast rules exist
+to prevent. `average_deployed_capital_usd` is still reported (honestly labeled
+by `sample_days`) even when the annualized figure is omitted for this reason. A
+single included day still reports `average_deployed_capital_usd` and
+`coverage_days` (`1`), but `annualized_return_pct` stays `None`: extrapolating
+one day's return by `365x` is exactly the misleading-financial-number failure
+mode the fail-fast rules exist to prevent, so the system reports no annualized
+figure at all for that day rather than an unannualized raw return under the same
+field. Both capital fields are `None`, with an explicit warning, whenever no day
+qualifies, average capital is exactly zero, the query is symbol-filtered (a
+symbol-scoped slice of whole-portfolio capital is not a meaningful denominator),
+or an `as_of_rowid` in the past is requested (capital is always computed from
+the live snapshot table, not watermarked to a historical event position).
+
 ### Risk Management
 
 - Manual override capabilities for emergency situations with proper

--- a/migrations/20260720145025_portfolio_snapshot.sql
+++ b/migrations/20260720145025_portfolio_snapshot.sql
@@ -1,0 +1,34 @@
+-- Forward-only read model for the daily portfolio snapshot (RAI-1457).
+--
+-- Maintained exclusively by the PortfolioSnapshotProjection reactor from the
+-- PortfolioSnapshot aggregate's retained Captured events (one aggregate
+-- instance per ET day). The /pnl capital/return computation reads ONLY this
+-- table and never folds the events table. All timestamps are stored as
+-- RFC3339 TEXT (chrono `to_rfc3339`), which renders UTC values with the
+-- literal `+00:00` suffix -- the CHECK constraints below enforce that suffix
+-- so a non-UTC value can never corrupt lexicographic ordering.
+CREATE TABLE portfolio_snapshot (
+    et_day TEXT NOT NULL,
+    captured_at TEXT NOT NULL CHECK (captured_at LIKE '%+00:00'),
+    location TEXT NOT NULL CHECK (
+        location IN (
+            'market_making',
+            'hedging',
+            'ethereum_wallet',
+            'base_wallet_unwrapped',
+            'base_wallet_wrapped'
+        )
+    ),
+    -- 'USDC' or an equity symbol.
+    asset TEXT NOT NULL,
+    available_balance TEXT NOT NULL,
+    inflight_balance TEXT NOT NULL,
+    -- NULL when the symbol has a nonzero balance but no observed price yet.
+    usd_mark TEXT,
+    mark_captured_at TEXT CHECK (
+        mark_captured_at IS NULL OR mark_captured_at LIKE '%+00:00'
+    ),
+    PRIMARY KEY (et_day, location, asset)
+);
+
+CREATE INDEX idx_portfolio_snapshot_et_day ON portfolio_snapshot (et_day);

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -50,7 +50,7 @@ use st0x_raindex::{RaindexService, RaindexVaultId, RevokeOutcome};
 use st0x_registry::SymbolCache;
 use st0x_tokenization::AlpacaTokenizationService;
 use st0x_tokenization::Tokenizer;
-use st0x_wrapper::WrapperService;
+use st0x_wrapper::{Wrapper, WrapperService};
 
 use crate::alerts::{NoopNotifier, NotifierError, TelegramNotifier};
 use crate::conductor::exit::{ConductorExit, MonitorTaskError};
@@ -83,6 +83,7 @@ use crate::performance::HedgeLatencyProjection;
 use crate::performance::equity_timing::EquityTimingProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
 use crate::performance::reliability::LifecycleFailureProjection;
+use crate::portfolio_snapshot::{PortfolioSnapshot, PortfolioSnapshotProjection};
 use crate::position::{Position, PositionCommand, PositionError, PositionEvent, TradeId};
 use crate::rebalancing::equity::{
     CrossVenueEquityTransfer, EquityTransferServices, ResumeTokenizationAggregate,
@@ -611,6 +612,19 @@ where
     Ok((executor, provider, telemetry_writer, telemetry))
 }
 
+/// Resolves the rebalancing configuration, which is optional.
+///
+/// Standalone mode is a supported deployment, not a failure, so
+/// [`CtxError::NotRebalancing`] maps to `None`. Every other error is a real
+/// misconfiguration and propagates.
+fn optional_rebalancing_ctx(ctx: &Ctx) -> anyhow::Result<Option<RebalancingCtx>> {
+    match ctx.rebalancing_ctx() {
+        Ok(rebalancing) => Ok(Some(rebalancing.clone())),
+        Err(CtxError::NotRebalancing) => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
 impl Conductor {
     pub(crate) async fn run<E>(
         executor_ctx: impl TryIntoExecutor<Executor = E>,
@@ -670,18 +684,16 @@ impl Conductor {
         // deferred-upgrade conflicts), failing the whole boot.
         catch_up_lifecycle_failures(&pool).await?;
 
-        let rebalancing = match ctx.rebalancing_ctx() {
-            Ok(ctx) => Some(ctx.clone()),
-            Err(CtxError::NotRebalancing) => None,
-            Err(error) => return Err(error.into()),
-        };
+        let rebalancing = optional_rebalancing_ctx(&ctx)?;
 
         let PositionAndRebalancing {
             position,
             position_projection,
             snapshot,
+            portfolio_snapshot,
             wallet_polling,
             tokenizer,
+            wrapper,
             service: rebalancing_service,
             recovery_transfer,
             wrapped_equity_recovery_store,
@@ -754,6 +766,7 @@ impl Conductor {
             offchain_order_projection,
             vault_registry,
             snapshot,
+            portfolio_snapshot,
         };
 
         let TradingJobQueues {
@@ -766,6 +779,7 @@ impl Conductor {
             wrapped_equity_recovery_ctx,
             unwrapped_equity_recovery_ctx,
             check_positions_queue,
+            portfolio_snapshot_queue,
         } = setup_trading_job_queues(
             &apalis_pool,
             &job_queue,
@@ -797,9 +811,10 @@ impl Conductor {
             execution_threshold: ctx.execution_threshold,
             frameworks,
             pool,
-            wallet_polling,
             inventory: inventory.clone(),
+            wallet_polling,
             tokenizer,
+            wrapper,
             shutdown_token: shutdown_token.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector,
@@ -827,6 +842,7 @@ impl Conductor {
             .reconcile_queue(reconcile_queue)
             .rejection_queue(rejection_queue)
             .check_positions_queue(check_positions_queue)
+            .portfolio_snapshot_queue(portfolio_snapshot_queue)
             .wrapped_equity_recovery_queue(wrapped_equity_recovery_queue)
             .maybe_wrapped_equity_recovery_ctx(wrapped_equity_recovery_ctx)
             .unwrapped_equity_recovery_queue(unwrapped_equity_recovery_queue)
@@ -1039,10 +1055,7 @@ async fn grant_startup_token_approvals(ctx: &Ctx) -> anyhow::Result<()> {
         Err(error) => return Err(error.into()),
     };
 
-    let wrapper = WrapperService::new(
-        base_wallet.clone(),
-        to_wrapped_equities(&ctx.assets.equities.symbols),
-    );
+    let wrapper = build_wrapper(base_wallet.clone(), ctx);
 
     let symbols = ctx
         .assets
@@ -1054,7 +1067,7 @@ async fn grant_startup_token_approvals(ctx: &Ctx) -> anyhow::Result<()> {
         })
         .cloned();
 
-    let targets = build_approval_targets(&wrapper, symbols, ctx.evm.orderbook, USDC_BASE)?;
+    let targets = build_approval_targets(wrapper.as_ref(), symbols, ctx.evm.orderbook, USDC_BASE)?;
 
     grant_startup_approvals(&base_wallet, &targets).await?;
 
@@ -1244,6 +1257,7 @@ struct RebalancingInfrastructure {
     position_projection: Arc<Projection<Position>>,
     snapshot: Arc<Store<InventorySnapshot>>,
     tokenizer: Arc<dyn Tokenizer>,
+    wrapper: Arc<dyn Wrapper>,
     service: Arc<RebalancingService>,
     recovery_transfer: Arc<CrossVenueEquityTransfer>,
     wrapped_equity_recovery_store: Arc<Store<WrappedEquityRecovery>>,
@@ -1278,8 +1292,17 @@ struct PositionAndRebalancing {
     position: Arc<Store<Position>>,
     position_projection: Arc<Projection<Position>>,
     snapshot: Arc<Store<InventorySnapshot>>,
+    portfolio_snapshot: Arc<Store<PortfolioSnapshot>>,
     wallet_polling: Option<crate::inventory::WalletPollingCtx>,
     tokenizer: Option<Arc<dyn Tokenizer>>,
+    /// `None` only when no wallet is configured at all: without one, the bot
+    /// can never hold onchain (wrapped) equity in the first place, so the
+    /// portfolio-snapshot capture gate never actually needs to resolve a
+    /// vault ratio in that case (`crate::portfolio_snapshot::write`). `Some`
+    /// regardless of whether rebalancing itself is enabled -- a wallet can be
+    /// configured for trading alone (`TradingMode::Standalone`), and market
+    /// making still holds wrapped vault shares in that mode.
+    wrapper: Option<Arc<dyn Wrapper>>,
     service: Option<Arc<RebalancingService>>,
     recovery_transfer: Option<Arc<CrossVenueEquityTransfer>>,
     wrapped_equity_recovery_store: Option<Arc<Store<WrappedEquityRecovery>>>,
@@ -1293,11 +1316,35 @@ struct PositionAndRebalancing {
     resume_tokenization_queue: Option<ResumeTokenizationJobQueue>,
 }
 
+/// Builds the wrapper service from the single wallet/config source shared by
+/// startup approvals, portfolio snapshots, and rebalancing.
+fn build_wrapper<Chain: Wallet + Clone>(
+    base_wallet: Chain,
+    ctx: &Ctx,
+) -> Arc<WrapperService<Chain>> {
+    Arc::new(WrapperService::new(
+        base_wallet,
+        to_wrapped_equities(&ctx.assets.equities.symbols),
+    ))
+}
+
 impl PositionAndRebalancing {
     async fn setup(
         rebalancing: Option<RebalancingCtx>,
         deps: RebalancingDeps,
     ) -> anyhow::Result<Self> {
+        // Built exactly once, regardless of whether rebalancing is enabled:
+        // daily portfolio capture must happen independent of rebalancing
+        // mode, and the Single-Framework-Instance rule (docs/cqrs.md)
+        // forbids building a second Store<PortfolioSnapshot> in either
+        // branch below.
+        let portfolio_snapshot = StoreBuilder::<PortfolioSnapshot>::new(deps.pool.clone())
+            .with(Arc::new(PortfolioSnapshotProjection::new(
+                deps.pool.clone(),
+            )))
+            .build(())
+            .await?;
+
         if let Some(rebalancing_ctx) = rebalancing {
             let wallet_ctx = deps.ctx.wallet()?;
             let ethereum_wallet = wallet_ctx.ethereum_wallet().clone();
@@ -1331,8 +1378,10 @@ impl PositionAndRebalancing {
                 position: infra.position,
                 position_projection: infra.position_projection,
                 snapshot: infra.snapshot,
+                portfolio_snapshot,
                 wallet_polling: Some(wallet_polling),
                 tokenizer: Some(infra.tokenizer),
+                wrapper: Some(infra.wrapper),
                 service: Some(infra.service),
                 recovery_transfer: Some(infra.recovery_transfer),
                 wrapped_equity_recovery_store: Some(infra.wrapped_equity_recovery_store),
@@ -1350,6 +1399,7 @@ impl PositionAndRebalancing {
         } else {
             let RebalancingDeps {
                 pool,
+                ctx,
                 inventory,
                 broadcaster,
                 ..
@@ -1365,12 +1415,25 @@ impl PositionAndRebalancing {
                 .build(())
                 .await?;
 
+            // Rebalancing itself may be disabled (`TradingMode::Standalone`)
+            // while a wallet is still configured for trading alone -- market
+            // making then still holds wrapped vault shares onchain, so the
+            // portfolio-snapshot job still needs a ratio source. Mirrors
+            // `grant_startup_token_approvals`'s wallet-presence check.
+            let wrapper: Option<Arc<dyn Wrapper>> = match ctx.wallet() {
+                Ok(wallet_ctx) => Some(build_wrapper(wallet_ctx.base_wallet().clone(), &ctx)),
+                Err(CtxError::WalletNotConfigured) => None,
+                Err(error) => return Err(error.into()),
+            };
+
             Ok(Self {
                 position,
                 position_projection,
                 snapshot,
+                portfolio_snapshot,
                 wallet_polling: None,
                 tokenizer: None,
+                wrapper,
                 service: None,
                 recovery_transfer: None,
                 wrapped_equity_recovery_store: None,
@@ -1630,10 +1693,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
 
         let tokenizer: Arc<dyn Tokenizer> = tokenization;
 
-        let wrapper = Arc::new(WrapperService::new(
-            base_wallet.clone(),
-            to_wrapped_equities(&deps.ctx.assets.equities.symbols),
-        ));
+        let wrapper = build_wrapper(base_wallet.clone(), &deps.ctx);
 
         let equity_transfer_services = EquityTransferServices {
             raindex: raindex_service.clone(),
@@ -1806,6 +1866,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             position_projection: built.position_projection,
             snapshot: built.snapshot,
             tokenizer,
+            wrapper,
             service: rebalancing_service,
             recovery_transfer,
             wrapped_equity_recovery_store,
@@ -6065,6 +6126,12 @@ mod tests {
             .await
             .unwrap();
 
+        let portfolio_snapshot = StoreBuilder::<PortfolioSnapshot>::new(pool.clone())
+            .with(Arc::new(PortfolioSnapshotProjection::new(pool.clone())))
+            .build(())
+            .await
+            .unwrap();
+
         (
             CqrsFrameworks {
                 onchain_trade,
@@ -6074,6 +6141,7 @@ mod tests {
                 offchain_order_projection: offchain_order_projection.clone(),
                 vault_registry,
                 snapshot,
+                portfolio_snapshot,
             },
             offchain_order_projection,
         )

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -20,6 +20,7 @@ use st0x_finance::{HasZero, Positive, Usd};
 use st0x_raindex::RaindexService;
 use st0x_registry::SymbolCache;
 use st0x_tokenization::Tokenizer;
+use st0x_wrapper::Wrapper;
 
 use super::Conductor;
 use super::exit::MonitorTaskError;
@@ -53,6 +54,9 @@ use crate::offchain::order::{
 use crate::onchain::backfill::{BackfillJobQueue, BackfillRange};
 use crate::onchain::pyth::PythFeedIds;
 use crate::onchain_trade::OnChainTrade;
+use crate::portfolio_snapshot::{
+    PortfolioSnapshot, PortfolioSnapshotCtx, PortfolioSnapshotJob, PortfolioSnapshotJobQueue,
+};
 use crate::position::Position;
 use crate::position_check::{CheckPositions, CheckPositionsCtx, CheckPositionsJobQueue};
 use crate::rebalancing::equity::{
@@ -91,6 +95,7 @@ pub(crate) struct CqrsFrameworks {
     pub(crate) offchain_order_projection: Arc<Projection<OffchainOrder>>,
     pub(crate) vault_registry: Arc<Store<VaultRegistry>>,
     pub(crate) snapshot: Arc<Store<InventorySnapshot>>,
+    pub(crate) portfolio_snapshot: Arc<Store<PortfolioSnapshot>>,
 }
 
 /// Everything needed to construct a running [`Conductor`].
@@ -102,9 +107,19 @@ pub(crate) struct ConductorCtx<Prov, Exec> {
     pub(crate) execution_threshold: ExecutionThreshold,
     pub(crate) frameworks: CqrsFrameworks,
     pub(crate) pool: SqlitePool,
-    pub(crate) wallet_polling: Option<WalletPollingCtx>,
+    /// The live cross-venue inventory view. Not carried by [`CqrsFrameworks`]
+    /// (that struct holds only CQRS stores/projections) -- the
+    /// [`PortfolioSnapshotCtx`] job context reads it directly each tick, and
+    /// [`InventoryDivergenceRecoveryCtx`] verifies against it on divergence.
     pub(crate) inventory: Arc<BroadcastingInventory>,
+    pub(crate) wallet_polling: Option<WalletPollingCtx>,
     pub(crate) tokenizer: Option<Arc<dyn Tokenizer>>,
+    /// `None` only when no wallet is configured (the bot can then never hold
+    /// onchain wrapped equity in the first place). Independent of whether
+    /// rebalancing itself is enabled -- a wallet can be configured for
+    /// trading alone (`TradingMode::Standalone`), and market making still
+    /// holds wrapped vault shares onchain in that mode.
+    pub(crate) wrapper: Option<Arc<dyn Wrapper>>,
     pub(crate) shutdown_token: CancellationToken,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) failure_injector: FailureInjector,
@@ -168,6 +183,7 @@ pub(crate) fn spawn<Prov, Exec>(
     reconcile_queue: ReconcileOrderFillJobQueue,
     rejection_queue: HandleOrderRejectionJobQueue,
     check_positions_queue: CheckPositionsJobQueue,
+    portfolio_snapshot_queue: PortfolioSnapshotJobQueue,
     wrapped_equity_recovery_queue: WrappedEquityRecoveryJobQueue,
     wrapped_equity_recovery_ctx: Option<Arc<WrappedEquityRecoveryCtx>>,
     unwrapped_equity_recovery_queue: UnwrappedEquityRecoveryJobQueue,
@@ -226,6 +242,11 @@ where
     } = configured_inventory_vaults(&context.ctx);
 
     let wallet_polling = context.wallet_polling;
+    // Captured before `wallet_polling` moves into `InventoryPollingService`
+    // below: `PortfolioSnapshotCtx`'s hydration gate needs to know whether
+    // wallet-transit locations are polled at all, from the same source the
+    // live poller itself reads.
+    let wallet_polling_enabled = wallet_polling.is_some();
     let tokenizer = context.tokenizer;
 
     let mut polling_service = InventoryPollingService::new(
@@ -239,7 +260,7 @@ where
         tokenizer,
         reserved_cash,
     )
-    .with_configured_equity_symbols(configured_equity_symbols)
+    .with_configured_equity_symbols(configured_equity_symbols.clone())
     .with_configured_vaults(configured_equity_vaults, configured_usdc_vaults)
     .with_divergence_recovery(InventoryDivergenceRecoveryCtx {
         inventory: context.inventory.clone(),
@@ -330,6 +351,17 @@ where
         check_interval: std::time::Duration::from_secs(context.ctx.position_check_interval),
     });
 
+    let portfolio_snapshot_ctx = Arc::new(PortfolioSnapshotCtx {
+        inventory: context.inventory.clone(),
+        position_projection: context.frameworks.position_projection.clone(),
+        portfolio_snapshot: context.frameworks.portfolio_snapshot.clone(),
+        wrapper: context.wrapper.clone(),
+        configured_equity_symbols,
+        usdc_tracking_enabled: context.ctx.assets.cash.is_some(),
+        wallet_polling_enabled,
+        queue: portfolio_snapshot_queue.clone(),
+    });
+
     let trade_cqrs = super::TradeProcessingCqrs {
         pool: context.pool.clone(),
         onchain_trade: context.frameworks.onchain_trade,
@@ -410,6 +442,7 @@ where
         reconcile_ctx,
         rejection_ctx,
         check_positions_ctx,
+        portfolio_snapshot_ctx,
         rebalancing_check_ctx: rebalancing_service,
         seed_vault_registry_ctx,
         job_queue,
@@ -421,6 +454,7 @@ where
         reconcile_queue,
         rejection_queue,
         check_positions_queue,
+        portfolio_snapshot_queue,
         wrapped_equity_recovery_queue,
         wrapped_equity_recovery_ctx,
         unwrapped_equity_recovery_queue,
@@ -471,6 +505,7 @@ where
     reconcile_ctx: Arc<ReconcileOrderFillCtx>,
     rejection_ctx: Arc<HandleOrderRejectionCtx>,
     check_positions_ctx: Arc<CheckPositionsCtx<Exec>>,
+    portfolio_snapshot_ctx: Arc<PortfolioSnapshotCtx>,
     rebalancing_check_ctx: Option<Arc<RebalancingService>>,
     seed_vault_registry_ctx: Arc<SeedVaultRegistryCtx>,
     job_queue: DexTradeAccountingJobQueue,
@@ -482,6 +517,7 @@ where
     reconcile_queue: ReconcileOrderFillJobQueue,
     rejection_queue: HandleOrderRejectionJobQueue,
     check_positions_queue: CheckPositionsJobQueue,
+    portfolio_snapshot_queue: PortfolioSnapshotJobQueue,
     wrapped_equity_recovery_queue: WrappedEquityRecoveryJobQueue,
     wrapped_equity_recovery_ctx: Option<Arc<WrappedEquityRecoveryCtx>>,
     unwrapped_equity_recovery_queue: UnwrappedEquityRecoveryJobQueue,
@@ -520,6 +556,7 @@ where
             reconcile_ctx,
             rejection_ctx,
             check_positions_ctx,
+            portfolio_snapshot_ctx,
             rebalancing_check_ctx,
             seed_vault_registry_ctx,
             job_queue,
@@ -531,6 +568,7 @@ where
             reconcile_queue,
             rejection_queue,
             check_positions_queue,
+            portfolio_snapshot_queue,
             wrapped_equity_recovery_queue,
             wrapped_equity_recovery_ctx,
             unwrapped_equity_recovery_queue,
@@ -577,6 +615,8 @@ where
         let failure_injector_for_unwrapped_equity_recovery = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_check_positions = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_portfolio_snapshot = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_transfer_usdc_to_hedging = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
@@ -732,6 +772,21 @@ where
                         failure_notify_for_check_positions.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_check_positions.clone(),
+                    )
+                })
+                .register(move |index| {
+                    // Best-effort, not supervised (RAI-1457 review fix): a
+                    // daily reporting job must never trip the conductor-wide
+                    // fail-stop and halt trading over a transient capture
+                    // failure. Mirrors `ResumeTokenizationAggregate`'s
+                    // registration below.
+                    build_best_effort_worker!(
+                        ::<PortfolioSnapshotCtx, PortfolioSnapshotJob>,
+                        index,
+                        portfolio_snapshot_queue.clone(),
+                        portfolio_snapshot_ctx.clone(),
+                        #[cfg(any(test, feature = "test-support"))]
+                        failure_injector_for_portfolio_snapshot.clone(),
                     )
                 });
 

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -478,6 +478,7 @@ pub enum JobKind {
     TransferEquityToHedging,
     ResumeTokenizationAggregate,
     DashboardTradeDelivery,
+    PortfolioSnapshot,
 }
 
 /// Job execution error. Wraps the concrete `Job::Error` type at
@@ -520,6 +521,7 @@ pub struct FailureInjector {
     transfer_equity_to_hedging: Arc<Mutex<InjectionState>>,
     resume_tokenization_aggregate: Arc<Mutex<InjectionState>>,
     dashboard_trade_delivery: Arc<Mutex<InjectionState>>,
+    portfolio_snapshot: Arc<Mutex<InjectionState>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -560,6 +562,7 @@ impl FailureInjector {
             transfer_equity_to_hedging: Arc::new(Mutex::new(InjectionState::Idle)),
             resume_tokenization_aggregate: Arc::new(Mutex::new(InjectionState::Idle)),
             dashboard_trade_delivery: Arc::new(Mutex::new(InjectionState::Idle)),
+            portfolio_snapshot: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
@@ -612,6 +615,7 @@ impl FailureInjector {
             JobKind::TransferEquityToHedging => &self.transfer_equity_to_hedging,
             JobKind::ResumeTokenizationAggregate => &self.resume_tokenization_aggregate,
             JobKind::DashboardTradeDelivery => &self.dashboard_trade_delivery,
+            JobKind::PortfolioSnapshot => &self.portfolio_snapshot,
         };
 
         match mutex.lock() {

--- a/src/conductor/trading_queues.rs
+++ b/src/conductor/trading_queues.rs
@@ -10,6 +10,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use tracing::warn;
+
 use st0x_event_sorcery::{Projection, Store};
 use st0x_execution::SupportedExecutor;
 
@@ -23,6 +25,7 @@ use crate::offchain::order::{
     HandleOrderRejectionJobQueue, OffchainOrder, PollOrderStatusJobQueue,
     ReconcileOrderFillJobQueue, recover_submitted_offchain_orders,
 };
+use crate::portfolio_snapshot::{PortfolioSnapshotJobQueue, bootstrap_portfolio_snapshot};
 use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
 use crate::rebalancing::RebalancingService;
 use crate::tokenized_equity_mint::TokenizedEquityMint;
@@ -60,13 +63,14 @@ pub(super) struct TradingJobQueues {
     pub(super) wrapped_equity_recovery_ctx: Option<Arc<WrappedEquityRecoveryCtx>>,
     pub(super) unwrapped_equity_recovery_ctx: Option<Arc<UnwrappedEquityRecoveryCtx>>,
     pub(super) check_positions_queue: CheckPositionsJobQueue,
+    pub(super) portfolio_snapshot_queue: PortfolioSnapshotJobQueue,
 }
 
 /// Creates all trading-side and equity-recovery job queues, resets any orphaned
 /// `Running` rows left by a previous crash, recovers in-flight submitted orders,
-/// and bootstraps the position-check queue. Called once during conductor startup,
-/// before the apalis monitor spawns, so every `Running` row is orphaned by
-/// definition.
+/// and bootstraps the recurring position-check and portfolio-snapshot queues.
+/// Called once during conductor startup, before the apalis monitor spawns, so
+/// every `Running` row is orphaned by definition.
 pub(super) async fn setup_trading_job_queues(
     apalis_pool: &apalis_sqlite::SqlitePool,
     job_queue: &DexTradeAccountingJobQueue,
@@ -142,6 +146,9 @@ pub(super) async fn setup_trading_job_queues(
 
     bootstrap_check_positions(apalis_pool, &check_positions_queue).await?;
 
+    let portfolio_snapshot_queue = PortfolioSnapshotJobQueue::new(apalis_pool);
+    bootstrap_portfolio_snapshot_best_effort(apalis_pool, &portfolio_snapshot_queue).await;
+
     Ok(TradingJobQueues {
         hedge_queue,
         poll_status_queue,
@@ -152,5 +159,41 @@ pub(super) async fn setup_trading_job_queues(
         wrapped_equity_recovery_ctx,
         unwrapped_equity_recovery_ctx,
         check_positions_queue,
+        portfolio_snapshot_queue,
     })
+}
+
+/// Starts the reporting-only portfolio snapshot loop without making trading
+/// startup depend on it. Persistent failures remain observable in logs and on
+/// the next restart attempt.
+async fn bootstrap_portfolio_snapshot_best_effort(
+    apalis_pool: &apalis_sqlite::SqlitePool,
+    queue: &PortfolioSnapshotJobQueue,
+) {
+    if let Err(error) = bootstrap_portfolio_snapshot(apalis_pool, queue).await {
+        warn!(
+            ?error,
+            "Failed to bootstrap portfolio snapshot reporting; continuing trading startup"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn portfolio_snapshot_bootstrap_failure_does_not_fail_startup() {
+        let apalis_pool = apalis_sqlite::SqlitePool::connect(":memory:")
+            .await
+            .unwrap();
+        let queue = PortfolioSnapshotJobQueue::new(&apalis_pool);
+
+        bootstrap_portfolio_snapshot_best_effort(&apalis_pool, &queue).await;
+
+        assert!(logs_contain(
+            "Failed to bootstrap portfolio snapshot reporting; continuing trading startup"
+        ));
+    }
 }

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -23,5 +23,5 @@ pub(crate) use snapshot::{InventorySnapshot, InventorySnapshotId};
 pub(crate) use venue_balance::InventoryError;
 pub(crate) use view::{
     EquityImbalanceError, Imbalance, Inventory, InventoryView, InventoryViewError, Operator,
-    TransferOp, Venue,
+    PortfolioAsset, PortfolioBalanceRow, PortfolioLocation, TransferOp, Venue,
 };

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -548,6 +548,94 @@ pub(crate) enum InFlightEquityLocation {
     BaseWalletWrapped,
 }
 
+/// A destination for USD-denominated balances tracked in a daily portfolio
+/// snapshot (RAI-1457): the two live trading venues, plus the wallet-transit
+/// points equity or cash may sit at in between.
+///
+/// USDC observed in wallet transit is never "wrapped" (no wrapped-USDC
+/// concept exists onchain), so [`InFlightCashLocation::BaseWallet`] maps to
+/// `BaseWalletUnwrapped` here. The primary key `(et_day, location, asset)`
+/// prevents this from colliding with unwrapped equity at the same location,
+/// since `asset` still distinguishes them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum PortfolioLocation {
+    MarketMaking,
+    Hedging,
+    EthereumWallet,
+    BaseWalletUnwrapped,
+    BaseWalletWrapped,
+}
+
+impl std::fmt::Display for PortfolioLocation {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            Self::MarketMaking => "market_making",
+            Self::Hedging => "hedging",
+            Self::EthereumWallet => "ethereum_wallet",
+            Self::BaseWalletUnwrapped => "base_wallet_unwrapped",
+            Self::BaseWalletWrapped => "base_wallet_wrapped",
+        };
+        write!(formatter, "{label}")
+    }
+}
+
+/// The asset held at a [`PortfolioLocation`] in a daily portfolio snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum PortfolioAsset {
+    Usdc,
+    Equity(Symbol),
+}
+
+impl std::fmt::Display for PortfolioAsset {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Usdc => write!(formatter, "USDC"),
+            Self::Equity(symbol) => write!(formatter, "{symbol}"),
+        }
+    }
+}
+
+/// A single observed balance at a `(location, asset)` pair, ready to be
+/// marked with a USD price and captured into the daily portfolio snapshot's
+/// `Captured` event. `available` and `inflight` are kept as independent
+/// observed facts (per "No Denormalized Columns") -- nothing computed from
+/// them is persisted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct PortfolioBalanceRow {
+    pub(crate) location: PortfolioLocation,
+    pub(crate) asset: PortfolioAsset,
+    pub(crate) available: Float,
+    pub(crate) inflight: Float,
+}
+
+impl PartialEq for PortfolioBalanceRow {
+    fn eq(&self, other: &Self) -> bool {
+        self.location == other.location
+            && self.asset == other.asset
+            && self.available.eq(other.available).unwrap_or(false)
+            && self.inflight.eq(other.inflight).unwrap_or(false)
+    }
+}
+
+/// Venues paired with their [`PortfolioLocation`] counterpart, in the fixed
+/// order [`InventoryView::to_portfolio_snapshot_rows`] emits them.
+const PORTFOLIO_VENUES: [(Venue, PortfolioLocation); 2] = [
+    (Venue::MarketMaking, PortfolioLocation::MarketMaking),
+    (Venue::Hedging, PortfolioLocation::Hedging),
+];
+
+/// Wallet-transit cash locations in the fixed order rows are emitted.
+const PORTFOLIO_CASH_TRANSIT_LOCATIONS: [InFlightCashLocation; 2] = [
+    InFlightCashLocation::EthereumWallet,
+    InFlightCashLocation::BaseWallet,
+];
+
+/// Wallet-transit equity locations in the fixed order rows are emitted.
+const PORTFOLIO_EQUITY_TRANSIT_LOCATIONS: [InFlightEquityLocation; 2] = [
+    InFlightEquityLocation::BaseWalletUnwrapped,
+    InFlightEquityLocation::BaseWalletWrapped,
+];
+
 /// Cross-aggregate projection tracking inventory across venues.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct InventoryView {
@@ -836,6 +924,118 @@ impl InventoryView {
                 inflight_cash,
             },
         }
+    }
+
+    /// Extracts a flat list of observed balances for the daily portfolio
+    /// snapshot (RAI-1457). Mirrors [`Self::to_dto`]'s per-venue iteration,
+    /// but never merges wrapped/unwrapped equity or wallet-transit balances
+    /// -- each remains its own row so a persisted snapshot cannot silently
+    /// misstate a balance.
+    ///
+    /// Only locations that have actually been polled at least once are
+    /// emitted: a venue that was never polled produces no row, while a venue
+    /// polled to a genuine zero balance still produces a `0` row.
+    /// Wallet-transit amounts (`inflight_cash`/`inflight_equity`) are
+    /// point-in-time balances observed via wallet polling, not a venue
+    /// split, so they are recorded on the row's `inflight` field with
+    /// `available` at zero.
+    ///
+    /// Deployed capital counts the FULL book, including any configured cash
+    /// reserve: reserved cash held at the broker is still money under
+    /// management, not capital that has left the portfolio. The Hedging USDC
+    /// row therefore uses `offchain_gross_usd_cents` (the pre-reserve broker
+    /// balance) when known, falling back to the venue's own (reserve-adjusted
+    /// where a reserve is configured) `available` balance only when no gross
+    /// reading exists yet. An invalid gross reading is an error rather than a
+    /// fallback, matching
+    /// [`Self::check_usdc_imbalance_with_gross_offchain`]'s reasoning for why
+    /// gross, not net, is the right number here.
+    pub(crate) fn to_portfolio_snapshot_rows(
+        &self,
+    ) -> Result<Vec<PortfolioBalanceRow>, InventoryViewError> {
+        let mut rows = Vec::new();
+
+        for (symbol, inventory) in self.equities.iter().sorted_by_key(|(symbol, _)| *symbol) {
+            for (venue, location) in PORTFOLIO_VENUES {
+                if let Some(balance) = inventory.get_venue(venue) {
+                    rows.push(PortfolioBalanceRow {
+                        location,
+                        asset: PortfolioAsset::Equity(symbol.clone()),
+                        available: balance.available().into(),
+                        inflight: balance.inflight().into(),
+                    });
+                }
+            }
+        }
+
+        for (venue, location) in PORTFOLIO_VENUES {
+            if let Some(balance) = self.usdc.get_venue(venue) {
+                // Matches on `venue` (exactly 2 variants, `MarketMaking` and
+                // `Hedging`), not `location`: `PORTFOLIO_VENUES` can only ever
+                // produce those two `PortfolioLocation` values, so a wildcard
+                // over the 5-variant `PortfolioLocation` would silently cover
+                // wallet-transit variants this loop never actually sees.
+                let available = match venue {
+                    Venue::Hedging => match self.offchain_gross_usd_cents {
+                        Some(cents) => Float::from(
+                            Usdc::from_cents(cents)
+                                .ok_or(InventoryViewError::UsdBalanceConversion(cents))?,
+                        ),
+                        None => balance.available().into(),
+                    },
+                    Venue::MarketMaking => balance.available().into(),
+                };
+                rows.push(PortfolioBalanceRow {
+                    location,
+                    asset: PortfolioAsset::Usdc,
+                    available,
+                    inflight: balance.inflight().into(),
+                });
+            }
+        }
+
+        for cash_location in PORTFOLIO_CASH_TRANSIT_LOCATIONS {
+            if let Some(entry) = self.inflight_cash.get(&cash_location) {
+                rows.push(PortfolioBalanceRow {
+                    location: match cash_location {
+                        InFlightCashLocation::EthereumWallet => PortfolioLocation::EthereumWallet,
+                        InFlightCashLocation::BaseWallet => PortfolioLocation::BaseWalletUnwrapped,
+                    },
+                    asset: PortfolioAsset::Usdc,
+                    available: Usdc::ZERO.into(),
+                    inflight: entry.amount.into(),
+                });
+            }
+        }
+
+        let inflight_equity_symbols: std::collections::BTreeSet<&Symbol> = self
+            .inflight_equity
+            .keys()
+            .map(|(symbol, _)| symbol)
+            .collect();
+        for symbol in inflight_equity_symbols {
+            for equity_location in PORTFOLIO_EQUITY_TRANSIT_LOCATIONS {
+                let Some(entry) = self.inflight_equity.get(&(symbol.clone(), equity_location))
+                else {
+                    continue;
+                };
+                rows.push(PortfolioBalanceRow {
+                    location: match equity_location {
+                        InFlightEquityLocation::BaseWalletUnwrapped => {
+                            PortfolioLocation::BaseWalletUnwrapped
+                        }
+                        InFlightEquityLocation::BaseWalletWrapped => {
+                            PortfolioLocation::BaseWalletWrapped
+                        }
+                    },
+                    asset: PortfolioAsset::Equity(symbol.clone()),
+                    available: FractionalShares::ZERO.into(),
+                    inflight: entry.amount.into(),
+                });
+            }
+        }
+
+        Ok(rows)
     }
 }
 
@@ -4190,6 +4390,193 @@ mod tests {
             aapl.onchain_available,
             shares(40),
             "Available should reflect the transfer (50 - 10 moved to inflight)"
+        );
+    }
+
+    #[test]
+    fn to_portfolio_snapshot_rows_empty_view_produces_no_rows() {
+        let rows = InventoryView::default()
+            .to_portfolio_snapshot_rows()
+            .unwrap();
+
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn to_portfolio_snapshot_rows_populated_view_produces_correct_tuples() {
+        let aapl = Symbol::new("AAPL").unwrap();
+        let view = InventoryView::default()
+            .with_equity(aapl.clone(), shares(100), shares(50))
+            .with_usdc(Usdc::new(float!(10000)), Usdc::new(float!(5000)));
+
+        let rows = view.to_portfolio_snapshot_rows().unwrap();
+
+        assert_eq!(rows.len(), 4);
+        assert!(rows.contains(&PortfolioBalanceRow {
+            location: PortfolioLocation::MarketMaking,
+            asset: PortfolioAsset::Equity(aapl.clone()),
+            available: shares(100).into(),
+            inflight: FractionalShares::ZERO.into(),
+        }));
+        assert!(rows.contains(&PortfolioBalanceRow {
+            location: PortfolioLocation::Hedging,
+            asset: PortfolioAsset::Equity(aapl),
+            available: shares(50).into(),
+            inflight: FractionalShares::ZERO.into(),
+        }));
+        assert!(rows.contains(&PortfolioBalanceRow {
+            location: PortfolioLocation::MarketMaking,
+            asset: PortfolioAsset::Usdc,
+            available: Usdc::new(float!(10000)).into(),
+            inflight: Usdc::ZERO.into(),
+        }));
+        assert!(rows.contains(&PortfolioBalanceRow {
+            location: PortfolioLocation::Hedging,
+            asset: PortfolioAsset::Usdc,
+            available: Usdc::new(float!(5000)).into(),
+            inflight: Usdc::ZERO.into(),
+        }));
+    }
+
+    /// A symbol polled to a genuine zero balance at a venue must still
+    /// produce a `0` row -- only a venue that was never polled (`None`) is
+    /// skipped.
+    #[test]
+    fn to_portfolio_snapshot_rows_genuinely_zero_balance_still_produces_a_row() {
+        let aapl = Symbol::new("AAPL").unwrap();
+        let view =
+            InventoryView::default().with_equity(aapl.clone(), FractionalShares::ZERO, shares(10));
+
+        let rows = view.to_portfolio_snapshot_rows().unwrap();
+
+        assert!(rows.contains(&PortfolioBalanceRow {
+            location: PortfolioLocation::MarketMaking,
+            asset: PortfolioAsset::Equity(aapl),
+            available: FractionalShares::ZERO.into(),
+            inflight: FractionalShares::ZERO.into(),
+        }));
+    }
+
+    /// A venue that was never polled (`None`) must not appear as a row at
+    /// all -- distinct from a polled-to-zero balance.
+    #[test]
+    fn to_portfolio_snapshot_rows_never_polled_venue_produces_no_row() {
+        let spy = Symbol::new("SPY").unwrap();
+        let view = InventoryView {
+            equities: std::iter::once((
+                spy,
+                Inventory {
+                    onchain: Some(venue(75, 0)),
+                    offchain: None,
+                    last_rebalancing: None,
+                },
+            ))
+            .collect(),
+            ..InventoryView::default()
+        };
+
+        let rows = view.to_portfolio_snapshot_rows().unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].location, PortfolioLocation::MarketMaking);
+        assert!(
+            !rows
+                .iter()
+                .any(|row| row.location == PortfolioLocation::Hedging)
+        );
+    }
+
+    /// Wrapped and unwrapped equity balances for the same symbol must never
+    /// collapse into one row -- they are different units until normalized by
+    /// the vault ratio.
+    #[test]
+    fn to_portfolio_snapshot_rows_wrapped_and_unwrapped_equity_never_collapse() {
+        let aapl = Symbol::new("AAPL").unwrap();
+        let fetched_at = Utc::now();
+        let mut unwrapped = BTreeMap::new();
+        unwrapped.insert(aapl.clone(), shares(5));
+        let mut wrapped = BTreeMap::new();
+        wrapped.insert(aapl.clone(), shares(7));
+
+        let view = InventoryView::default()
+            .set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletUnwrapped,
+                &unwrapped,
+                fetched_at,
+                fetched_at,
+            )
+            .set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletWrapped,
+                &wrapped,
+                fetched_at,
+                fetched_at,
+            );
+
+        let rows = view.to_portfolio_snapshot_rows().unwrap();
+
+        assert_eq!(rows.len(), 2);
+        assert!(rows.contains(&PortfolioBalanceRow {
+            location: PortfolioLocation::BaseWalletUnwrapped,
+            asset: PortfolioAsset::Equity(aapl.clone()),
+            available: FractionalShares::ZERO.into(),
+            inflight: shares(5).into(),
+        }));
+        assert!(rows.contains(&PortfolioBalanceRow {
+            location: PortfolioLocation::BaseWalletWrapped,
+            asset: PortfolioAsset::Equity(aapl),
+            available: FractionalShares::ZERO.into(),
+            inflight: shares(7).into(),
+        }));
+    }
+
+    /// Wallet-transit USDC (`inflight_cash`) is emitted as its own row per
+    /// populated location, recorded on `inflight` with `available` at zero.
+    #[test]
+    fn to_portfolio_snapshot_rows_includes_inflight_cash() {
+        let fetched_at = Utc::now();
+        let view = InventoryView::default().set_inflight_cash(
+            InFlightCashLocation::EthereumWallet,
+            Usdc::new(float!(250)),
+            fetched_at,
+            fetched_at,
+        );
+
+        let rows = view.to_portfolio_snapshot_rows().unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].location, PortfolioLocation::EthereumWallet);
+        assert_eq!(rows[0].asset, PortfolioAsset::Usdc);
+        let expected_available: Float = Usdc::ZERO.into();
+        let expected_inflight: Float = Usdc::new(float!(250)).into();
+        assert!(rows[0].available.eq(expected_available).unwrap());
+        assert!(rows[0].inflight.eq(expected_inflight).unwrap());
+    }
+
+    /// A configured reserve makes `usdc.offchain.available` the
+    /// reserve-adjusted (net) balance -- deployed capital must still count
+    /// the full, pre-reserve broker cash, so the Hedging row uses
+    /// `offchain_gross_usd_cents`, not that net venue balance.
+    #[test]
+    fn to_portfolio_snapshot_rows_hedging_usdc_uses_gross_cash_not_reserve_adjusted() {
+        let view = InventoryView::default()
+            // The reserve-adjusted venue balance the poller stored after
+            // subtracting a configured reserve from the broker's real cash.
+            .with_usdc(Usdc::ZERO, Usdc::new(float!(800)))
+            .with_offchain_gross_usd_cents(100_000);
+
+        let rows = view.to_portfolio_snapshot_rows().unwrap();
+
+        let hedging_row = rows
+            .iter()
+            .find(|row| {
+                row.location == PortfolioLocation::Hedging && row.asset == PortfolioAsset::Usdc
+            })
+            .expect("Hedging USDC row must be present");
+        let expected_gross: Float = Usdc::new(float!(1000)).into();
+        assert!(
+            hedging_row.available.eq(expected_gross).unwrap(),
+            "Hedging USDC capital must use gross broker cash (1000), not the \
+             reserve-adjusted venue balance (800)"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ mod offchain;
 mod onchain;
 mod onchain_trade;
 mod performance;
+mod portfolio_snapshot;
 mod position;
 mod position_check;
 mod rebalancing;
@@ -82,6 +83,17 @@ pub use position::Position;
 #[cfg(any(test, feature = "test-support"))]
 pub fn check_positions_job_type() -> &'static str {
     std::any::type_name::<position_check::CheckPositions>()
+}
+
+/// Returns the apalis job type identifier for the `PortfolioSnapshot` job.
+///
+/// For use in tests when querying or asserting against the persistent job
+/// queue (the `Jobs.job_type` column). Like `CheckPositions`, this job
+/// reschedules itself and never terminates, so job-completion assertions
+/// must exclude it.
+#[cfg(any(test, feature = "test-support"))]
+pub fn portfolio_snapshot_job_type() -> &'static str {
+    std::any::type_name::<portfolio_snapshot::PortfolioSnapshotJob>()
 }
 #[cfg(any(test, feature = "test-support"))]
 pub use conductor::job::{FailureInjector, JobKind};

--- a/src/portfolio_snapshot/mod.rs
+++ b/src/portfolio_snapshot/mod.rs
@@ -1,0 +1,352 @@
+//! Daily portfolio snapshot: an event-sourced record of every balance under
+//! management, in USD terms, feeding `/pnl`'s capital and return-on-capital
+//! figures (RAI-1457, see SPEC.md "Portfolio Capital and Return Tracking").
+//!
+//! [`PortfolioSnapshot`] is one aggregate instance per Eastern Time calendar
+//! day (`et_day`): the day itself is the id, so "has today been captured" is
+//! a question the framework already answers -- `Uninitialized` routes a
+//! `Capture` command through [`EventSourced::initialize`] (emits `Captured`);
+//! `Live` routes it through [`EventSourced::transition`], which unconditionally
+//! rejects with [`PortfolioSnapshotError::AlreadyCaptured`] and emits no
+//! event. This makes per-day idempotency a property of the framework's
+//! lifecycle routing, not a `SELECT EXISTS` precheck.
+//!
+//! `Captured` events are retained forever (no `COMPACTION_POLICY` override):
+//! one event per ET day is a financial-audit record, not an observational
+//! stream eligible for compaction, and the storage volume is negligible.
+//! `type Materialized = Nil` -- the aggregate's own state only distinguishes
+//! `initialize` from `transition` routing; the queryable balances live in the
+//! plain `portfolio_snapshot` table maintained by the [`projection`] reactor,
+//! not on this aggregate.
+//!
+//! The write side splits into [`write`] (the self-rescheduling job that
+//! resolves USD marks and issues the `Capture` command) and [`projection`]
+//! (the reactor that maintains the flat read-model table from the retained
+//! `Captured` events).
+
+use std::fmt;
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use chrono::{DateTime, NaiveDate, Utc};
+use rain_math_float::Float;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tracing::info;
+
+use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
+
+use crate::inventory::PortfolioBalanceRow;
+use crate::position::option_float_eq;
+
+pub(crate) mod projection;
+pub(crate) mod write;
+
+pub(crate) use projection::PortfolioSnapshotProjection;
+pub(crate) use write::{
+    PortfolioSnapshotCtx, PortfolioSnapshotJob, PortfolioSnapshotJobQueue,
+    bootstrap_portfolio_snapshot,
+};
+
+/// Typed identifier for [`PortfolioSnapshot`] aggregates: one instance per
+/// Eastern Time calendar day. Using the day itself as the id gives
+/// "has today been captured" idempotency at the framework level -- no extra
+/// state is needed to route a `Capture` command to `initialize` (first
+/// capture) or `transition` (already captured, rejected).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub(crate) struct PortfolioSnapshotId(pub(crate) NaiveDate);
+
+impl fmt::Display for PortfolioSnapshotId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.0.format("%Y-%m-%d"))
+    }
+}
+
+/// Error parsing a [`PortfolioSnapshotId`] from its `YYYY-MM-DD` string form.
+#[derive(Debug, Error)]
+#[error("invalid portfolio snapshot id '{value}': expected YYYY-MM-DD: {source}")]
+pub(crate) struct ParsePortfolioSnapshotIdError {
+    value: String,
+    #[source]
+    source: chrono::ParseError,
+}
+
+impl FromStr for PortfolioSnapshotId {
+    type Err = ParsePortfolioSnapshotIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        NaiveDate::parse_from_str(value, "%Y-%m-%d")
+            .map(Self)
+            .map_err(|source| ParsePortfolioSnapshotIdError {
+                value: value.to_string(),
+                source,
+            })
+    }
+}
+
+/// A [`PortfolioBalanceRow`] with the USD mark resolved at capture time.
+/// Composes rather than duplicates `PortfolioBalanceRow`'s fields, so a field
+/// added there is inherited here automatically instead of needing to be
+/// mirrored by hand. Marks are fixed permanently once captured: because the
+/// aggregate's event is retained and immutable, a later price correction
+/// never retroactively changes a previously reported day's capital.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct PortfolioBalanceRowWithMark {
+    #[serde(flatten)]
+    pub(crate) row: PortfolioBalanceRow,
+    /// `None` when the balance is nonzero but no price has been observed
+    /// yet -- never a fabricated zero.
+    pub(crate) usd_mark: Option<Float>,
+    pub(crate) mark_captured_at: Option<DateTime<Utc>>,
+}
+
+impl PartialEq for PortfolioBalanceRowWithMark {
+    fn eq(&self, other: &Self) -> bool {
+        self.row == other.row
+            && option_float_eq(self.usd_mark, other.usd_mark)
+            && self.mark_captured_at == other.mark_captured_at
+    }
+}
+
+/// Domain events for [`PortfolioSnapshot`]. `Captured` is the only variant:
+/// one per ET day, retained forever.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) enum PortfolioSnapshotEvent {
+    Captured {
+        captured_at: DateTime<Utc>,
+        rows: Vec<PortfolioBalanceRowWithMark>,
+    },
+}
+
+impl DomainEvent for PortfolioSnapshotEvent {
+    fn event_type(&self) -> String {
+        match self {
+            Self::Captured { .. } => "PortfolioSnapshotEvent::Captured".to_string(),
+        }
+    }
+
+    fn event_version(&self) -> String {
+        "1.0".to_string()
+    }
+}
+
+/// Commands for [`PortfolioSnapshot`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) enum PortfolioSnapshotCommand {
+    Capture {
+        captured_at: DateTime<Utc>,
+        rows: Vec<PortfolioBalanceRowWithMark>,
+    },
+}
+
+/// Errors from [`PortfolioSnapshot`] command handling.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
+pub(crate) enum PortfolioSnapshotError {
+    #[error("portfolio already captured for this day")]
+    AlreadyCaptured,
+}
+
+/// One instance per ET day. Tracks only enough state to route a `Capture`
+/// command to `initialize` (not yet captured) or `transition` (already
+/// captured, rejected) -- the queryable balances live in the
+/// `portfolio_snapshot` table maintained by [`PortfolioSnapshotProjection`],
+/// not on this aggregate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct PortfolioSnapshot {
+    pub(crate) captured_at: DateTime<Utc>,
+    pub(crate) row_count: usize,
+}
+
+#[async_trait]
+impl EventSourced for PortfolioSnapshot {
+    type Id = PortfolioSnapshotId;
+    type Event = PortfolioSnapshotEvent;
+    type Command = PortfolioSnapshotCommand;
+    type Error = PortfolioSnapshotError;
+    type Services = ();
+    type Materialized = Nil;
+
+    const AGGREGATE_TYPE: &'static str = "PortfolioSnapshot";
+    const PROJECTION: Nil = Nil;
+    const SCHEMA_VERSION: u64 = 1;
+
+    fn originate(event: &Self::Event) -> Option<Self> {
+        match event {
+            PortfolioSnapshotEvent::Captured { captured_at, rows } => Some(Self {
+                captured_at: *captured_at,
+                row_count: rows.len(),
+            }),
+        }
+    }
+
+    fn evolve(entity: &Self, _event: &Self::Event) -> Result<Option<Self>, Self::Error> {
+        // Defensive, not expected: transition() below unconditionally
+        // rejects a second Capture for an already-Live aggregate, so a Live
+        // instance never actually observes a second Captured event in
+        // normal operation. Total but a no-op if it ever does.
+        Ok(Some(entity.clone()))
+    }
+
+    async fn initialize(
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        let PortfolioSnapshotCommand::Capture { captured_at, rows } = command;
+        // Logged here, not by the job that sent the command (AGENTS.md "Log
+        // in command handlers, not callers"): this handler has the full
+        // command in scope. `target_et_day` is derived from `captured_at`
+        // rather than threaded in separately -- the job always issues
+        // `Capture` under the id matching the ET day its balances were
+        // observed on, so the two agree by construction.
+        let target_et_day = write::et_day(captured_at);
+        info!(%target_et_day, row_count = rows.len(), "Portfolio snapshot captured");
+        Ok(vec![PortfolioSnapshotEvent::Captured { captured_at, rows }])
+    }
+
+    async fn transition(
+        &self,
+        _command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        // Expected, not a failure (decision 11): a scheduling bug that fires
+        // more than once a day is still visible via this log naming the day
+        // that was already captured, just not treated as retryable by the
+        // caller (`write.rs`'s `PortfolioSnapshotJob::perform`).
+        let existing_et_day = write::et_day(self.captured_at);
+        info!(%existing_et_day, "Portfolio already captured for this ET day");
+        Err(PortfolioSnapshotError::AlreadyCaptured)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use serde_json::json;
+
+    use st0x_event_sorcery::{LifecycleError, TestHarness, replay};
+    use st0x_execution::Symbol;
+    use st0x_float_macro::float;
+
+    use crate::inventory::{PortfolioAsset, PortfolioLocation};
+
+    use super::*;
+
+    fn test_row(symbol_available: i64) -> PortfolioBalanceRowWithMark {
+        PortfolioBalanceRowWithMark {
+            row: PortfolioBalanceRow {
+                location: PortfolioLocation::MarketMaking,
+                asset: PortfolioAsset::Usdc,
+                available: float!(&symbol_available.to_string()),
+                inflight: float!(0),
+            },
+            usd_mark: Some(float!(1)),
+            mark_captured_at: Some(Utc::now()),
+        }
+    }
+
+    #[tokio::test]
+    async fn first_capture_initializes_and_emits_captured() {
+        let captured_at = Utc.with_ymd_and_hms(2026, 7, 20, 4, 5, 0).unwrap();
+        let rows = vec![test_row(100)];
+
+        TestHarness::<PortfolioSnapshot>::with(())
+            .given_no_previous_events()
+            .when(PortfolioSnapshotCommand::Capture {
+                captured_at,
+                rows: rows.clone(),
+            })
+            .await
+            .then_expect_events(&[PortfolioSnapshotEvent::Captured { captured_at, rows }]);
+    }
+
+    #[tokio::test]
+    async fn second_capture_same_day_is_rejected_and_emits_no_event() {
+        let captured_at = Utc.with_ymd_and_hms(2026, 7, 20, 4, 5, 0).unwrap();
+        let rows = vec![test_row(100)];
+
+        let error = TestHarness::<PortfolioSnapshot>::with(())
+            .given(vec![PortfolioSnapshotEvent::Captured {
+                captured_at,
+                rows: rows.clone(),
+            }])
+            .when(PortfolioSnapshotCommand::Capture {
+                captured_at: captured_at + chrono::Duration::hours(1),
+                rows,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(PortfolioSnapshotError::AlreadyCaptured)
+        ));
+    }
+
+    #[test]
+    fn replay_reconstructs_captured_at_and_row_count() {
+        let captured_at = Utc.with_ymd_and_hms(2026, 7, 20, 4, 5, 0).unwrap();
+        let rows = vec![test_row(100), test_row(200)];
+
+        let snapshot = replay::<PortfolioSnapshot>(vec![PortfolioSnapshotEvent::Captured {
+            captured_at,
+            rows,
+        }])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(snapshot.captured_at, captured_at);
+        assert_eq!(snapshot.row_count, 2);
+    }
+
+    #[test]
+    fn portfolio_snapshot_id_roundtrips_through_display_and_parse() {
+        let id = PortfolioSnapshotId(NaiveDate::from_ymd_opt(2026, 7, 20).unwrap());
+
+        let parsed: PortfolioSnapshotId = id.to_string().parse().unwrap();
+
+        assert_eq!(parsed, id);
+        assert_eq!(id.to_string(), "2026-07-20");
+    }
+
+    #[test]
+    fn portfolio_snapshot_id_rejects_malformed_input() {
+        let error = "not-a-date".parse::<PortfolioSnapshotId>().unwrap_err();
+
+        assert_eq!(error.value, "not-a-date");
+    }
+
+    #[test]
+    fn marked_equity_row_json_shape_is_stable_and_roundtrips() {
+        let mark_captured_at = Utc.with_ymd_and_hms(2026, 7, 20, 4, 5, 0).unwrap();
+        let row = PortfolioBalanceRowWithMark {
+            row: PortfolioBalanceRow {
+                location: PortfolioLocation::MarketMaking,
+                asset: PortfolioAsset::Equity(Symbol::new("AAPL").unwrap()),
+                available: float!(0),
+                inflight: float!(0),
+            },
+            usd_mark: Some(float!(1)),
+            mark_captured_at: Some(mark_captured_at),
+        };
+
+        let encoded = serde_json::to_value(&row).unwrap();
+
+        assert_eq!(
+            encoded,
+            json!({
+                "location": "MarketMaking",
+                "asset": {"Equity": "AAPL"},
+                "available":
+                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "inflight":
+                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "usd_mark":
+                    "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "mark_captured_at": "2026-07-20T04:05:00Z",
+            })
+        );
+
+        let decoded: PortfolioBalanceRowWithMark = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded, row);
+    }
+}

--- a/src/portfolio_snapshot/projection.rs
+++ b/src/portfolio_snapshot/projection.rs
@@ -1,0 +1,244 @@
+//! Write side of the daily portfolio snapshot read model: the reactor that
+//! maintains the plain `portfolio_snapshot` table from retained
+//! `PortfolioSnapshot::Captured` events.
+//!
+//! **Durability model: forward-only, best-effort -- matching
+//! [`crate::performance::HedgeLatencyProjection`] exactly, NOT
+//! `QueryReplay::replay_all()`.** `QueryReplay` targets cqrs-es `Query`/`View`
+//! types; the bridge that would let a `Reactor` participate in that machinery
+//! is crate-private inside `event-sorcery`, and startup auto-catch-up is
+//! wired only for `Materialized = Table` entities. A crash between the
+//! `Captured` event committing and this reactor's write can therefore drop
+//! that day's read-model row. Because the `PortfolioSnapshot` aggregate
+//! permanently rejects any further `Capture` for the same `et_day`, there is
+//! currently no automated repair path for a dropped row -- accepted as the
+//! same best-effort risk `HedgeLatencyProjection` already carries in this
+//! codebase, not a regression introduced here.
+
+use sqlx::SqlitePool;
+use st0x_event_sorcery::{EntityList, Reactor, deps};
+use st0x_float_serde::format_float;
+use thiserror::Error;
+
+use super::{PortfolioSnapshot, PortfolioSnapshotEvent, PortfolioSnapshotId};
+
+/// Reactor maintaining the `portfolio_snapshot` read model from live
+/// `PortfolioSnapshot::Captured` events.
+pub(crate) struct PortfolioSnapshotProjection {
+    pool: SqlitePool,
+}
+
+deps!(PortfolioSnapshotProjection, [PortfolioSnapshot]);
+
+impl PortfolioSnapshotProjection {
+    pub(crate) fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    /// Writes every row of a `Captured` event for `id`'s ET day. Idempotent
+    /// under redelivery: the day's existing rows are deleted and reinserted
+    /// inside a single transaction, defense-in-depth beyond the aggregate's
+    /// own command-level idempotency (a second `Capture` for the same day is
+    /// rejected before it ever reaches this reactor).
+    async fn on_captured(
+        &self,
+        id: PortfolioSnapshotId,
+        event: PortfolioSnapshotEvent,
+    ) -> Result<(), ProjectionError> {
+        let PortfolioSnapshotEvent::Captured { captured_at, rows } = event;
+        let et_day = id.to_string();
+        let captured_at = captured_at.to_rfc3339();
+
+        let mut transaction = self.pool.begin().await?;
+
+        sqlx::query("DELETE FROM portfolio_snapshot WHERE et_day = ?")
+            .bind(&et_day)
+            .execute(&mut *transaction)
+            .await?;
+
+        for row in &rows {
+            let available_balance = format_float(&row.row.available)?;
+            let inflight_balance = format_float(&row.row.inflight)?;
+            let usd_mark = row.usd_mark.as_ref().map(format_float).transpose()?;
+            let mark_captured_at = row.mark_captured_at.map(|timestamp| timestamp.to_rfc3339());
+
+            sqlx::query(
+                "INSERT INTO portfolio_snapshot \
+                 (et_day, captured_at, location, asset, available_balance, \
+                  inflight_balance, usd_mark, mark_captured_at) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&et_day)
+            .bind(&captured_at)
+            .bind(row.row.location.to_string())
+            .bind(row.row.asset.to_string())
+            .bind(available_balance)
+            .bind(inflight_balance)
+            .bind(usd_mark)
+            .bind(mark_captured_at)
+            .execute(&mut *transaction)
+            .await?;
+        }
+
+        transaction.commit().await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ProjectionError {
+    #[error("portfolio-snapshot read-model write failed")]
+    Database(#[from] sqlx::Error),
+    #[error("failed to format a portfolio snapshot balance for persistence")]
+    Float(#[from] rain_math_float::FloatError),
+}
+
+#[async_trait::async_trait]
+impl Reactor for PortfolioSnapshotProjection {
+    type Error = ProjectionError;
+
+    async fn react(
+        &self,
+        event: <Self::Dependencies as EntityList>::Event,
+    ) -> Result<(), Self::Error> {
+        event
+            .on(|id, event| async move { self.on_captured(id, event).await })
+            .exhaustive()
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use sqlx::Row;
+    use st0x_event_sorcery::ReactorHarness;
+    use st0x_float_macro::float;
+
+    use crate::inventory::{PortfolioAsset, PortfolioBalanceRow, PortfolioLocation};
+    use crate::portfolio_snapshot::{PortfolioBalanceRowWithMark, PortfolioSnapshotId};
+    use crate::test_utils::setup_test_db;
+
+    use super::*;
+
+    fn captured_at() -> chrono::DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 20, 4, 5, 0).unwrap()
+    }
+
+    fn row(
+        location: PortfolioLocation,
+        available: i64,
+        usd_mark: Option<i64>,
+    ) -> PortfolioBalanceRowWithMark {
+        PortfolioBalanceRowWithMark {
+            row: PortfolioBalanceRow {
+                location,
+                asset: PortfolioAsset::Usdc,
+                available: float!(&available.to_string()),
+                inflight: float!(0),
+            },
+            usd_mark: usd_mark.map(|mark| float!(&mark.to_string())),
+            mark_captured_at: usd_mark.map(|_| captured_at()),
+        }
+    }
+
+    async fn row_count(pool: &SqlitePool, et_day: &str) -> i64 {
+        sqlx::query("SELECT COUNT(*) AS count FROM portfolio_snapshot WHERE et_day = ?")
+            .bind(et_day)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+            .get("count")
+    }
+
+    #[tokio::test]
+    async fn captured_event_with_n_rows_produces_n_rows_for_the_aggregate_id_day() {
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(PortfolioSnapshotProjection::new(pool.clone()));
+        let id = PortfolioSnapshotId(chrono::NaiveDate::from_ymd_opt(2026, 7, 20).unwrap());
+
+        harness
+            .receive::<PortfolioSnapshot>(
+                id,
+                PortfolioSnapshotEvent::Captured {
+                    captured_at: captured_at(),
+                    rows: vec![
+                        row(PortfolioLocation::MarketMaking, 100, Some(1)),
+                        row(PortfolioLocation::Hedging, 200, Some(1)),
+                    ],
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(row_count(&pool, "2026-07-20").await, 2);
+    }
+
+    #[tokio::test]
+    async fn null_mark_row_persists_sql_null_not_a_placeholder_string() {
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(PortfolioSnapshotProjection::new(pool.clone()));
+        let id = PortfolioSnapshotId(chrono::NaiveDate::from_ymd_opt(2026, 7, 20).unwrap());
+
+        harness
+            .receive::<PortfolioSnapshot>(
+                id,
+                PortfolioSnapshotEvent::Captured {
+                    captured_at: captured_at(),
+                    rows: vec![row(PortfolioLocation::MarketMaking, 100, None)],
+                },
+            )
+            .await
+            .unwrap();
+
+        let stored: (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT usd_mark, mark_captured_at FROM portfolio_snapshot WHERE et_day = ?",
+        )
+        .bind("2026-07-20")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(stored, (None, None));
+    }
+
+    #[tokio::test]
+    async fn redelivered_captured_event_leaves_exactly_one_row_set() {
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(PortfolioSnapshotProjection::new(pool.clone()));
+        let id = PortfolioSnapshotId(chrono::NaiveDate::from_ymd_opt(2026, 7, 20).unwrap());
+        let event = PortfolioSnapshotEvent::Captured {
+            captured_at: captured_at(),
+            rows: vec![
+                row(PortfolioLocation::MarketMaking, 100, Some(1)),
+                row(PortfolioLocation::Hedging, 200, Some(1)),
+            ],
+        };
+
+        harness
+            .receive::<PortfolioSnapshot>(id, event)
+            .await
+            .unwrap();
+        harness
+            .receive::<PortfolioSnapshot>(
+                id,
+                PortfolioSnapshotEvent::Captured {
+                    captured_at: captured_at(),
+                    rows: vec![row(PortfolioLocation::MarketMaking, 100, Some(1))],
+                },
+            )
+            .await
+            .unwrap();
+
+        let locations: Vec<String> = sqlx::query_scalar(
+            "SELECT location FROM portfolio_snapshot WHERE et_day = ? ORDER BY location",
+        )
+        .bind("2026-07-20")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(locations, vec!["market_making"]);
+    }
+}

--- a/src/portfolio_snapshot/write.rs
+++ b/src/portfolio_snapshot/write.rs
@@ -1,0 +1,1721 @@
+//! Periodic daily portfolio capture as a durable, self-rescheduling job.
+//!
+//! [`PortfolioSnapshotJob`] wakes once per Eastern Time day (delay-to-next-
+//! ET-midnight, decision 12 in the RAI-1457 plan), reads the live
+//! [`crate::inventory::InventoryView`], resolves each equity balance's USD
+//! mark from the `Position` aggregate, and issues a `Capture` command against
+//! the `PortfolioSnapshot` aggregate. Idempotency for a given ET day is the
+//! aggregate's job (see `crate::portfolio_snapshot`'s module doc); this job
+//! only decides *when* to try and what to skip when the view is not yet
+//! trustworthy.
+//!
+//! The job carries an explicit `target_et_day` rather than deriving the
+//! captured day from the wall clock at run time. In steady state,
+//! [`next_capture`] schedules it shortly after that day's ET midnight. After a
+//! restart past today's boundary, [`first_capture`] instead schedules today's
+//! `target_et_day` after [`HYDRATION_RETRY_BACKOFF`] and may persist the
+//! current hydrated view as today's snapshot.
+//!
+//! **Scheduling semantics (round-3 fix, see SPEC.md "Portfolio Capital and
+//! Return Tracking"):** one snapshot per ET day, labeled by the ET day it is
+//! captured on, taken at/after that day's `CAPTURE_BUFFER` boundary using
+//! same-day inventory ([`hydration_gap`] guarantees COMPLETE -- every
+//! required slot has been polled at least once this run; see that
+//! function's doc for the presence-vs-freshness tradeoff accepted for v1).
+//! In steady state this fires once a day, right after the
+//! boundary. If a restart or a stuck hydration retry causes `perform` to
+//! run after its `target_et_day` has already passed, it CATCHES UP to a
+//! fresh reading for the CURRENT ET day rather than either back-dating a live
+//! read under the stale day's id or leaving that day's capital sample
+//! permanently absent: for a roughly delta-neutral book, deployed capital
+//! moves slowly and is dominated by deliberate flows, so a same-day reading
+//! remains a valid proxy for the missed day. A snapshot is never labeled with
+//! a day other than the one its balances were actually observed on. A day the
+//! bot is down across entirely (no wake before the next boundary) is simply
+//! absent from the series -- coverage is sparse by design, not backfilled.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use apalis::prelude::Status;
+use chrono::{DateTime, Datelike, Days, NaiveDate, TimeZone, Utc};
+use chrono_tz::America::New_York;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tracing::warn;
+
+use st0x_event_sorcery::{AggregateError, LifecycleError, Projection, SendError, Store};
+use st0x_execution::{FractionalShares, Symbol};
+use st0x_float_macro::float;
+use st0x_wrapper::{RatioError, UnderlyingPerWrapped, Wrapper, WrapperError};
+
+use super::{
+    PortfolioBalanceRowWithMark, PortfolioSnapshot, PortfolioSnapshotCommand, PortfolioSnapshotId,
+};
+use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
+use crate::inventory::{
+    BroadcastingInventory, InventoryViewError, PortfolioAsset, PortfolioBalanceRow,
+    PortfolioLocation,
+};
+use crate::position::Position;
+
+pub(crate) type PortfolioSnapshotJobQueue = JobQueue<PortfolioSnapshotJob>;
+
+/// USDC is treated as par with USD, matching the reporting-currency
+/// assumption used elsewhere in `/pnl` (decision 7).
+const USDC_PAR: rain_math_float::Float = float!(1);
+
+/// Buffer added past ET midnight before capturing, so the last poll tick for
+/// the closing day has time to land in the read model.
+const CAPTURE_BUFFER: chrono::Duration = chrono::Duration::minutes(5);
+
+/// Retry backoff when the completeness gate fails (an incomplete
+/// `InventoryView`, expected during startup hydration).
+const HYDRATION_RETRY_BACKOFF: Duration = Duration::from_secs(5 * 60);
+
+/// Retry backoff when a job wakes before its own `target_et_day`'s boundary
+/// (a premature scheduler tick). Reuses the same short duration as
+/// [`HYDRATION_RETRY_BACKOFF`]: both cases want an uneventful, short retry
+/// rather than any change to `target_et_day`.
+const EARLY_WAKE_BACKOFF: Duration = HYDRATION_RETRY_BACKOFF;
+
+/// Shared dependencies for the [`PortfolioSnapshotJob`].
+pub(crate) struct PortfolioSnapshotCtx {
+    pub(crate) inventory: Arc<BroadcastingInventory>,
+    pub(crate) position_projection: Arc<Projection<Position>>,
+    pub(crate) portfolio_snapshot: Arc<Store<PortfolioSnapshot>>,
+    /// Resolves each configured equity's live vault ratio so wrapped onchain
+    /// balances (MarketMaking, BaseWalletWrapped) can be valued in
+    /// underlying-equivalent units before being persisted (see
+    /// [`convert_wrapped_equity_rows`]). `None` only when no wallet is
+    /// configured at all -- the bot can then never hold onchain wrapped
+    /// equity in the first place, so no row would ever need conversion.
+    pub(crate) wrapper: Option<Arc<dyn Wrapper>>,
+    /// Reused from `configured_inventory_vaults` (`src/conductor/builder.rs`)
+    /// rather than recomputed, so the completeness gate and the live
+    /// inventory poller always agree on what "fully hydrated" means.
+    pub(crate) configured_equity_symbols: HashSet<Symbol>,
+    pub(crate) usdc_tracking_enabled: bool,
+    /// Mirrors whether `[wallet_polling]` is configured (the same source the
+    /// live inventory poller reads, `crate::inventory::WalletPollingCtx`):
+    /// when `true`, [`hydration_gap`] also requires the wallet-transit
+    /// locations (Ethereum wallet, Base wallet unwrapped/wrapped) to have
+    /// been polled at least once before capture.
+    pub(crate) wallet_polling_enabled: bool,
+    pub(crate) queue: PortfolioSnapshotJobQueue,
+}
+
+/// Errors surfaced by [`PortfolioSnapshotJob::perform`]. Distinct from
+/// [`super::PortfolioSnapshotError`] (the aggregate's own command-rejection
+/// type) -- `AlreadyCaptured` is matched and consumed before it would ever
+/// reach this enum (decision 11).
+#[derive(Debug, Error)]
+pub(crate) enum PortfolioSnapshotJobError {
+    #[error("failed to enqueue follow-up portfolio snapshot job: {0}")]
+    Enqueue(#[from] QueuePushError),
+    #[error("failed to capture portfolio snapshot: {0}")]
+    Capture(#[from] SendError<PortfolioSnapshot>),
+    #[error("failed to load position for portfolio snapshot mark: {0}")]
+    PositionProjection(#[from] st0x_event_sorcery::ProjectionError<Position>),
+    #[error("apalis database error: {0}")]
+    ApalisDatabase(#[from] sqlx_apalis::Error),
+    #[error("failed to resolve vault ratio for portfolio snapshot: {0}")]
+    VaultRatio(#[from] WrapperError),
+    #[error("failed to convert wrapped equity balance to underlying units: {0}")]
+    WrappedEquityConversion(#[from] RatioError),
+    #[error("failed to read portfolio balances from inventory: {0}")]
+    Inventory(#[from] InventoryViewError),
+    #[error(
+        "wrapped equity balance present for {symbol} at {location} but no wallet/Wrapper is \
+         configured to resolve its vault ratio"
+    )]
+    MissingWrapper {
+        symbol: Symbol,
+        location: PortfolioLocation,
+    },
+}
+
+/// A durable, self-rescheduling job that captures one daily portfolio
+/// snapshot per ET day. Every input other than `target_et_day` is read fresh
+/// from the inventory view, the position projection, and the wall clock at
+/// run time, mirroring [`crate::position_check::CheckPositions`]'s shape.
+/// `target_et_day` is the one piece of state the job carries: the ET day it
+/// was scheduled to capture, fixed at enqueue time by [`next_capture`] so a
+/// hydration retry or a restart can never silently substitute a different
+/// day.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct PortfolioSnapshotJob {
+    pub(crate) target_et_day: NaiveDate,
+}
+
+impl Job<PortfolioSnapshotCtx> for PortfolioSnapshotJob {
+    type Output = ();
+    type Error = PortfolioSnapshotJobError;
+
+    const WORKER_NAME: &'static str = "portfolio-snapshot-worker";
+
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::PortfolioSnapshot;
+
+    fn label(&self) -> Label {
+        Label::new("PortfolioSnapshot")
+    }
+
+    async fn perform(&self, ctx: &PortfolioSnapshotCtx) -> Result<Self::Output, Self::Error> {
+        let now = Utc::now();
+        let today = et_day(now);
+
+        if self.target_et_day > today {
+            // Woke before this job's own boundary (e.g. a slightly early
+            // scheduler tick): wait for it rather than capturing under a day
+            // that has not started yet. `target_et_day` is unchanged, so the
+            // next attempt re-evaluates the same comparison.
+            let delay = et_midnight(self.target_et_day)
+                .and_then(|midnight| (midnight + CAPTURE_BUFFER - now).to_std().ok())
+                .unwrap_or(EARLY_WAKE_BACKOFF);
+            return ctx.reschedule(self.target_et_day, delay).await;
+        }
+
+        if self.target_et_day < today {
+            // The target day already passed: hydration stuck across a
+            // midnight boundary, or the process woke up late. Catch up to a
+            // fresh CURRENT-day reading instead of either back-dating a live
+            // read under the stale id or leaving the missed day's sample
+            // permanently absent (see this module's doc comment).
+            warn!(
+                missed_target_et_day = %self.target_et_day,
+                catching_up_to_et_day = %today,
+                "Portfolio snapshot capture missed its target ET day; catching up to a fresh \
+                 same-day reading instead of leaving that day's capital sample absent"
+            );
+        }
+        let target_et_day = today;
+
+        let rows = {
+            let view = ctx.inventory.read().await;
+            view.to_portfolio_snapshot_rows()?
+        };
+
+        if let Some(gap) = hydration_gap(&rows, ctx) {
+            warn!(
+                %gap,
+                %target_et_day,
+                "Portfolio snapshot capture skipped this tick: inventory view not fully \
+                 hydrated yet; retrying shortly"
+            );
+            // target_et_day (today), not self.target_et_day: a hydration
+            // retry that crosses midnight must keep catching up to the
+            // current day, never resume retrying under a day that has since
+            // passed.
+            return ctx.reschedule(target_et_day, HYDRATION_RETRY_BACKOFF).await;
+        }
+
+        let rows = convert_wrapped_equity_rows(rows, ctx.wrapper.as_deref()).await?;
+        let marked_rows = resolve_marks(&ctx.position_projection, now, rows).await?;
+
+        match ctx
+            .portfolio_snapshot
+            .send(
+                &PortfolioSnapshotId(target_et_day),
+                PortfolioSnapshotCommand::Capture {
+                    captured_at: now,
+                    rows: marked_rows,
+                },
+            )
+            .await
+        {
+            // Both the success and the AlreadyCaptured-rejection cases log
+            // from inside the aggregate's own `initialize`/`transition`
+            // handlers (mod.rs), not here: the handler has full state and
+            // keeps command-execution logs centralized (AGENTS.md "Log in
+            // command handlers, not callers"). AlreadyCaptured is expected,
+            // not a failure (decision 11): a scheduling bug that fires more
+            // than once a day is still visible via the handler's own info
+            // log naming the day, just not treated as retryable.
+            Ok(())
+            | Err(AggregateError::UserError(LifecycleError::Apply(
+                super::PortfolioSnapshotError::AlreadyCaptured,
+            ))) => {}
+            // Every other SendError, including AggregateConflict, is a real
+            // failure: propagate so apalis retries. A retried Capture against
+            // a now-Live aggregate simply resolves to AlreadyCaptured above
+            // on the next attempt.
+            Err(error) => return Err(PortfolioSnapshotJobError::Capture(error)),
+        }
+
+        let (delay, next_target_et_day) = next_capture_delay(now);
+        ctx.reschedule(next_target_et_day, delay).await
+    }
+}
+
+impl PortfolioSnapshotCtx {
+    /// Enqueues the follow-up job for `target_et_day` after `delay`. Used
+    /// both for hydration retries (same `target_et_day`, short backoff) and
+    /// for the next day's capture (the next `target_et_day`, computed by
+    /// [`next_capture_delay`]).
+    async fn reschedule(
+        &self,
+        target_et_day: NaiveDate,
+        delay: Duration,
+    ) -> Result<(), PortfolioSnapshotJobError> {
+        let mut queue = self.queue.clone();
+        queue
+            .push_with_delay(PortfolioSnapshotJob { target_et_day }, delay)
+            .await?;
+        Ok(())
+    }
+}
+
+/// The ET calendar day `now` falls on. DST-safe by construction: chrono_tz
+/// resolves the correct EST/EDT offset for the given instant, so no manual
+/// transition handling is needed. `pub(crate)` so integration tests (e.g.
+/// `api.rs`'s `/pnl` DST-boundary coverage) can derive the same day a real
+/// capture would, instead of assuming it.
+pub(crate) fn et_day(now: DateTime<Utc>) -> NaiveDate {
+    now.with_timezone(&New_York).date_naive()
+}
+
+/// The ET midnight instant (00:00:00 ET) for `day`, converted to UTC. `None`
+/// only on the vanishingly rare ET calendar day whose local midnight falls
+/// inside a DST spring-forward gap, where that local time is skipped
+/// entirely and `TimeZone::with_ymd_and_hms` has no single unambiguous
+/// answer.
+fn et_midnight(day: NaiveDate) -> Option<DateTime<Utc>> {
+    New_York
+        .with_ymd_and_hms(day.year(), day.month(), day.day(), 0, 0, 0)
+        .single()
+        .map(|midnight| midnight.with_timezone(&Utc))
+}
+
+/// The next capture instant at or after `now`, and the ET day it is labeled
+/// with. A capture that fires at 00:0X ET on day X is labeled `et_day = X`:
+/// because the job only ever wakes shortly after an ET midnight (never
+/// immediately on bootstrap), "day X" always means the freshly-hydrated view
+/// taken right after X's midnight, never an in-progress or stale mid-day
+/// read (round-2 fix for the original always-immediate bootstrap).
+fn next_capture(now: DateTime<Utc>) -> (DateTime<Utc>, NaiveDate) {
+    let today = et_day(now);
+
+    if let Some(midnight) = et_midnight(today) {
+        let candidate = midnight + CAPTURE_BUFFER;
+        if candidate > now {
+            return (candidate, today);
+        }
+    } else {
+        warn!(
+            %today,
+            "Ambiguous ET midnight while scheduling next portfolio snapshot capture; \
+             retrying shortly instead"
+        );
+        return (now + CAPTURE_BUFFER, today);
+    }
+
+    let tomorrow = today + Days::new(1);
+    let Some(midnight) = et_midnight(tomorrow) else {
+        warn!(
+            %tomorrow,
+            "Ambiguous ET midnight while scheduling next portfolio snapshot capture; \
+             retrying shortly instead"
+        );
+        return (now + CAPTURE_BUFFER, tomorrow);
+    };
+
+    (midnight + CAPTURE_BUFFER, tomorrow)
+}
+
+/// [`next_capture`]'s instant converted to a `push_with_delay` delay,
+/// alongside the target ET day it belongs to.
+fn next_capture_delay(now: DateTime<Utc>) -> (Duration, NaiveDate) {
+    let (target, target_et_day) = next_capture(now);
+    let delay = (target - now).to_std().unwrap_or_else(|error| {
+        // `next_capture` only ever returns instants at or after `now` by
+        // construction, so this branch guards the std-duration conversion
+        // itself (e.g. clock adjustments between the two `DateTime::now()`
+        // reads it is derived from), not a reachable scheduling bug.
+        warn!(
+            %error,
+            %target_et_day,
+            "Computed portfolio snapshot capture delay was not positive; retrying shortly \
+             instead"
+        );
+        HYDRATION_RETRY_BACKOFF
+    });
+    (delay, target_et_day)
+}
+
+/// Checks that every REQUIRED `(location, asset)` balance has been observed
+/// at least once this run -- i.e. is PRESENT in `rows`
+/// (`InventoryView::to_portfolio_snapshot_rows` only emits a row for a slot
+/// once it has actually been polled, distinguishing "never polled" from
+/// "polled to a genuine zero balance"; see that function's doc comment). A
+/// partially-hydrated view is just as dangerous as an empty one: once
+/// captured, a day can never be amended (the aggregate's `transition()`
+/// unconditionally rejects a second `Capture`). Returns a human-readable
+/// description of the first gap found, or `None` if fully hydrated.
+///
+/// **v1 accepted limitation** (see SPEC.md "Portfolio Capital and Return
+/// Tracking"): this is a PRESENCE gate, not a FRESHNESS gate -- it does not
+/// verify the observation happened recently, only that it happened at all
+/// this run (including via startup hydration replaying a persisted
+/// `InventorySnapshot`'s original readings). An earlier revision attempted a
+/// time-window freshness gate on top of presence, but `InventorySnapshot`
+/// suppresses events (and their watermarks) whenever a poll observes an
+/// unchanged balance, so the watermark freezes on a static book and the
+/// freshness window would eventually block every future capture, not just a
+/// stale-hydrated one. In steady state this job only wakes shortly after the
+/// ET-midnight `CAPTURE_BUFFER` boundary, by which point the poller has
+/// already polled fresh this run, so the residual risk is narrow: a restart
+/// that hydrates stale data from a persisted snapshot and then captures
+/// before the poller gets a chance to poll again. A robust poll-driven
+/// freshness signal (distinct from `InventorySnapshot`'s change-suppressed
+/// events) is a tracked follow-up, accepted as out of scope for v1.
+fn hydration_gap(rows: &[PortfolioBalanceRow], ctx: &PortfolioSnapshotCtx) -> Option<String> {
+    let present: HashSet<(PortfolioLocation, &PortfolioAsset)> =
+        rows.iter().map(|row| (row.location, &row.asset)).collect();
+
+    let is_polled = |location: PortfolioLocation, asset: &PortfolioAsset| -> bool {
+        present.contains(&(location, asset))
+    };
+
+    for symbol in &ctx.configured_equity_symbols {
+        for location in [PortfolioLocation::MarketMaking, PortfolioLocation::Hedging] {
+            let asset = PortfolioAsset::Equity(symbol.clone());
+            if !is_polled(location, &asset) {
+                return Some(format!("{symbol} not yet polled at {location}"));
+            }
+        }
+    }
+
+    if ctx.usdc_tracking_enabled {
+        for location in [PortfolioLocation::MarketMaking, PortfolioLocation::Hedging] {
+            if !is_polled(location, &PortfolioAsset::Usdc) {
+                return Some(format!("USDC not yet polled at {location}"));
+            }
+        }
+    }
+
+    if ctx.wallet_polling_enabled {
+        for location in [
+            PortfolioLocation::EthereumWallet,
+            PortfolioLocation::BaseWalletUnwrapped,
+        ] {
+            if !is_polled(location, &PortfolioAsset::Usdc) {
+                return Some(format!(
+                    "USDC wallet-transit balance not yet polled at {location}"
+                ));
+            }
+        }
+
+        for symbol in &ctx.configured_equity_symbols {
+            for location in [
+                PortfolioLocation::BaseWalletUnwrapped,
+                PortfolioLocation::BaseWalletWrapped,
+            ] {
+                let asset = PortfolioAsset::Equity(symbol.clone());
+                if !is_polled(location, &asset) {
+                    return Some(format!(
+                        "{symbol} wallet-transit balance not yet polled at {location}"
+                    ));
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Converts MarketMaking-venue and BaseWalletWrapped-transit equity balances
+/// from wrapped ERC-4626 vault-share units to underlying-equivalent units via
+/// the live vault ratio, mirroring `InventoryView::check_equity_imbalance`'s
+/// conversion (`src/inventory/view.rs`). Every other row (Hedging, USDC
+/// anywhere, BaseWalletUnwrapped, EthereumWallet) is already denominated in
+/// underlying units and is left untouched.
+///
+/// `evaluate_day` (`read.rs`) later multiplies each row's balance directly by
+/// `Position.last_price_usdc`, an UNDERLYING share price -- so a wrapped
+/// balance persisted without this conversion would be valued as if 1 wrapped
+/// share == 1 underlying share, silently wrong once a vault's ratio departs
+/// from 1:1 (dividends, splits, NAV accrual).
+///
+/// The ratio is resolved once per distinct symbol that actually needs
+/// conversion (not once per `configured_equity_symbols`), so a symbol with no
+/// MarketMaking/BaseWalletWrapped row this tick costs no RPC call.
+async fn convert_wrapped_equity_rows(
+    mut rows: Vec<PortfolioBalanceRow>,
+    wrapper: Option<&dyn Wrapper>,
+) -> Result<Vec<PortfolioBalanceRow>, PortfolioSnapshotJobError> {
+    let mut ratios: HashMap<Symbol, UnderlyingPerWrapped> = HashMap::new();
+
+    for row in &mut rows {
+        let PortfolioAsset::Equity(symbol) = &row.asset else {
+            continue;
+        };
+        if !matches!(
+            row.location,
+            PortfolioLocation::MarketMaking | PortfolioLocation::BaseWalletWrapped
+        ) {
+            continue;
+        }
+
+        let ratio = if let Some(ratio) = ratios.get(symbol) {
+            *ratio
+        } else {
+            let wrapper = wrapper.ok_or_else(|| PortfolioSnapshotJobError::MissingWrapper {
+                symbol: symbol.clone(),
+                location: row.location,
+            })?;
+            let ratio = wrapper.get_ratio_for_symbol(symbol).await?;
+            ratios.insert(symbol.clone(), ratio);
+            ratio
+        };
+
+        row.available = ratio
+            .to_underlying_fractional(FractionalShares::new(row.available))?
+            .into();
+        row.inflight = ratio
+            .to_underlying_fractional(FractionalShares::new(row.inflight))?
+            .into();
+    }
+
+    Ok(rows)
+}
+
+/// Resolves each row's USD mark (decision 7): USDC is par, equity is
+/// `Position.last_price_usdc` as of capture time. A symbol with a balance but
+/// no observed price yet gets `usd_mark: None, mark_captured_at: None` --
+/// never a fabricated zero.
+///
+/// `mark_captured_at` for an equity row is `Position.last_updated`, NOT a
+/// dedicated price-observation timestamp -- a precise one is a deferred
+/// follow-up. `last_updated` is the aggregate's last-touched time, advanced by
+/// several non-price events too (offchain order placement/fill/cancel,
+/// threshold updates), so it is only an UPPER BOUND on how recently
+/// `last_price_usdc` was actually observed: a symbol whose price hasn't moved
+/// in weeks but was otherwise recently touched still reports a "fresh"
+/// `mark_captured_at`. `read.rs`'s staleness guard (`is_stale_mark`) therefore
+/// reliably EXCLUDES a day once the position itself has gone stale, but is not
+/// guaranteed to exclude every day with a genuinely stale price -- a stale
+/// `last_price_usdc` can still pass the guard if its position was recently
+/// touched for an unrelated (non-price) reason. Known and accepted for this
+/// iteration; see SPEC.md "Portfolio Capital and Return Tracking".
+async fn resolve_marks(
+    position_projection: &Projection<Position>,
+    captured_at: DateTime<Utc>,
+    rows: Vec<PortfolioBalanceRow>,
+) -> Result<Vec<PortfolioBalanceRowWithMark>, PortfolioSnapshotJobError> {
+    let mut marked_rows = Vec::with_capacity(rows.len());
+    let mut equity_marks = HashMap::new();
+
+    for row in rows {
+        let (usd_mark, mark_captured_at) = match &row.asset {
+            PortfolioAsset::Usdc => (Some(USDC_PAR), Some(captured_at)),
+            PortfolioAsset::Equity(symbol) => {
+                if let Some(mark) = equity_marks.get(symbol) {
+                    *mark
+                } else {
+                    let mark = match position_projection.load(symbol).await? {
+                        Some(position) => match position.last_price_usdc {
+                            Some(mark) => (Some(mark), position.last_updated),
+                            None => (None, None),
+                        },
+                        None => (None, None),
+                    };
+                    equity_marks.insert(symbol.clone(), mark);
+                    mark
+                }
+            }
+        };
+
+        marked_rows.push(PortfolioBalanceRowWithMark {
+            row,
+            usd_mark,
+            mark_captured_at,
+        });
+    }
+
+    Ok(marked_rows)
+}
+
+/// The delay and ET day for the very FIRST job [`bootstrap_portfolio_snapshot`]
+/// pushes. Unlike [`next_capture`] (which always looks forward to the next
+/// boundary, appropriate right after a successful capture), this targets
+/// `today` even when `now` is already past today's boundary -- e.g. a restart
+/// at 9am ET -- so a boot never skips the current ET day's snapshot (round-3
+/// fix: a prior version deferred to `next_capture_delay(now)` unconditionally,
+/// which silently skipped "today" on any restart after the boundary).
+fn first_capture(now: DateTime<Utc>) -> (Duration, NaiveDate) {
+    let today = et_day(now);
+
+    let Some(midnight) = et_midnight(today) else {
+        warn!(
+            %today,
+            "Ambiguous ET midnight while bootstrapping today's portfolio snapshot capture; \
+             retrying shortly instead"
+        );
+        return (HYDRATION_RETRY_BACKOFF, today);
+    };
+
+    let boundary = midnight + CAPTURE_BUFFER;
+    if now >= boundary {
+        // Already past today's boundary: schedule almost immediately (a
+        // short backoff, giving the inventory poller a moment to warm up)
+        // rather than waiting for tomorrow -- `perform` itself still gates
+        // on `hydration_gap` before it ever captures anything.
+        return (HYDRATION_RETRY_BACKOFF, today);
+    }
+
+    let delay = (boundary - now).to_std().unwrap_or_else(|error| {
+        warn!(
+            %error,
+            %today,
+            "Computed bootstrap portfolio snapshot delay was not positive; retrying shortly \
+             instead"
+        );
+        HYDRATION_RETRY_BACKOFF
+    });
+    (delay, today)
+}
+
+/// Removes any non-terminal [`PortfolioSnapshotJob`] rows and pushes a fresh
+/// one targeting today (via [`first_capture`]), so a restart never leaves the
+/// current ET day permanently uncaptured. Each capture re-enqueues itself
+/// with a delay, so a still-scheduled job from a previous run remains in the
+/// queue across restarts. Without the purge, the number of concurrent capture
+/// loops would grow by one with every restart. Mirrors
+/// `bootstrap_check_positions`'s purge-then-push shape.
+pub(crate) async fn bootstrap_portfolio_snapshot(
+    apalis_pool: &apalis_sqlite::SqlitePool,
+    queue: &PortfolioSnapshotJobQueue,
+) -> Result<(), PortfolioSnapshotJobError> {
+    purge_pending_portfolio_snapshot_jobs(apalis_pool).await?;
+    let (delay, target_et_day) = first_capture(Utc::now());
+    queue
+        .clone()
+        .push_with_delay(PortfolioSnapshotJob { target_et_day }, delay)
+        .await?;
+    Ok(())
+}
+
+/// Removes every non-terminal [`PortfolioSnapshotJob`] row: `Pending`,
+/// `Queued` (apalis reserved the row for a worker but no `Running` lock has
+/// landed yet -- reachable whenever the process crashes between
+/// `fetch_next` and `lock`), `Running`, and any `Failed` row still within
+/// its retry budget. Matches the sibling `bootstrap_check_positions` purge's
+/// coverage of apalis's non-terminal statuses.
+async fn purge_pending_portfolio_snapshot_jobs(
+    apalis_pool: &apalis_sqlite::SqlitePool,
+) -> Result<u64, sqlx_apalis::Error> {
+    let job_type = std::any::type_name::<PortfolioSnapshotJob>();
+    let deleted = sqlx_apalis::query(
+        "DELETE FROM Jobs WHERE job_type = ? AND (status IN (?, ?, ?) \
+         OR (status = ? AND attempts < max_attempts))",
+    )
+    .bind(job_type)
+    .bind(Status::Pending.to_string())
+    .bind(Status::Queued.to_string())
+    .bind(Status::Running.to_string())
+    .bind(Status::Failed.to_string())
+    .execute(apalis_pool)
+    .await?
+    .rows_affected();
+
+    Ok(deleted)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use alloy::primitives::{TxHash, U256};
+    use chrono::TimeZone;
+    use sqlx::SqlitePool;
+    use tokio::sync::broadcast;
+
+    use st0x_config::ExecutionThreshold;
+    use st0x_dto::Statement;
+    use st0x_event_sorcery::StoreBuilder;
+    use st0x_execution::{Direction, FractionalShares, HasZero};
+    use st0x_finance::Usdc;
+    use st0x_wrapper::MockWrapper;
+
+    use crate::inventory::view::{InFlightCashLocation, InFlightEquityLocation};
+    use crate::inventory::{Inventory, InventoryView, Operator, Venue};
+    use crate::portfolio_snapshot::PortfolioSnapshotProjection;
+    use crate::position::{PositionCommand, TradeId};
+    use crate::test_utils::setup_test_pools;
+
+    use super::*;
+
+    fn aapl() -> Symbol {
+        Symbol::new("AAPL").unwrap()
+    }
+
+    fn broadcasting(inventory: InventoryView) -> Arc<BroadcastingInventory> {
+        let (sender, _receiver) = broadcast::channel::<Statement>(16);
+        Arc::new(BroadcastingInventory::new(inventory, sender))
+    }
+
+    async fn build_ctx(
+        pool: SqlitePool,
+        apalis_pool: apalis_sqlite::SqlitePool,
+        inventory: InventoryView,
+        configured_equity_symbols: HashSet<Symbol>,
+        usdc_tracking_enabled: bool,
+        wallet_polling_enabled: bool,
+        wrapper: Option<Arc<dyn Wrapper>>,
+    ) -> (PortfolioSnapshotCtx, Arc<Store<Position>>) {
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let portfolio_snapshot = StoreBuilder::<PortfolioSnapshot>::new(pool.clone())
+            .with(Arc::new(PortfolioSnapshotProjection::new(pool.clone())))
+            .build(())
+            .await
+            .unwrap();
+
+        let queue = PortfolioSnapshotJobQueue::new(&apalis_pool);
+
+        let ctx = PortfolioSnapshotCtx {
+            inventory: broadcasting(inventory),
+            position_projection,
+            portfolio_snapshot,
+            wrapper,
+            configured_equity_symbols,
+            usdc_tracking_enabled,
+            wallet_polling_enabled,
+            queue,
+        };
+
+        (ctx, position)
+    }
+
+    /// A view with equity and USDC balances present at both venues for
+    /// `symbol` -- `hydration_gap` is a PRESENCE gate (v1, see its doc
+    /// comment), so `with_equity`/`with_usdc` alone are sufficient; this
+    /// helper exists purely so callers can pass one `InventoryView` around
+    /// instead of chaining both builders inline at every call site.
+    fn freshly_polled_view(
+        symbol: Symbol,
+        onchain: FractionalShares,
+        offchain: FractionalShares,
+        onchain_usdc: Usdc,
+        offchain_usdc: Usdc,
+    ) -> InventoryView {
+        InventoryView::default()
+            .with_equity(symbol, onchain, offchain)
+            .with_usdc(onchain_usdc, offchain_usdc)
+    }
+
+    /// Convenience wrapper: full hydration for one configured symbol (AAPL)
+    /// plus USDC, both venues.
+    async fn build_fully_hydrated_ctx(
+        pool: SqlitePool,
+        apalis_pool: apalis_sqlite::SqlitePool,
+    ) -> (PortfolioSnapshotCtx, Arc<Store<Position>>) {
+        let view = freshly_polled_view(
+            aapl(),
+            FractionalShares::new(float!(10)),
+            FractionalShares::new(float!(5)),
+            Usdc::new(float!(1000)),
+            Usdc::new(float!(500)),
+        );
+
+        build_ctx(
+            pool,
+            apalis_pool,
+            view,
+            HashSet::from([aapl()]),
+            true,
+            false,
+            Some(Arc::new(MockWrapper::new())),
+        )
+        .await
+    }
+
+    async fn portfolio_snapshot_job_count(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {
+        sqlx_apalis::query_scalar::<_, i64>("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<PortfolioSnapshotJob>())
+            .fetch_one(apalis_pool)
+            .await
+            .unwrap()
+    }
+
+    async fn portfolio_snapshot_row_count(pool: &SqlitePool, et_day: &str) -> i64 {
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM portfolio_snapshot WHERE et_day = ?")
+            .bind(et_day)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    /// A job targeting today's ET day -- the common case for tests that
+    /// exercise the capture logic itself, not the day-scheduling logic.
+    fn job_for_today() -> PortfolioSnapshotJob {
+        PortfolioSnapshotJob {
+            target_et_day: et_day(Utc::now()),
+        }
+    }
+
+    #[tokio::test]
+    async fn first_capture_of_an_et_day_sends_capture_and_succeeds() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
+
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let et_day = et_day(Utc::now()).to_string();
+        assert_eq!(portfolio_snapshot_row_count(&pool, &et_day).await, 4);
+    }
+
+    #[tokio::test]
+    async fn second_capture_same_et_day_is_a_no_op_and_still_reschedules() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool.clone()).await;
+
+        job_for_today().perform(&ctx).await.unwrap();
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let et_day = et_day(Utc::now()).to_string();
+        // Still exactly the rows from the first capture -- the second
+        // Capture was rejected before it ever reached the reactor.
+        let first_count = portfolio_snapshot_row_count(&pool, &et_day).await;
+        assert_eq!(first_count, 4);
+
+        let run_at_count: i64 =
+            sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            run_at_count, 2,
+            "each perform() call reschedules exactly one follow-up job"
+        );
+    }
+
+    /// The catch-all `Err(error) => return Err(...)` arm (write.rs, distinct
+    /// from the expected `AlreadyCaptured` no-op): a genuine `Capture`
+    /// failure must propagate so apalis retries, never be swallowed. Forces
+    /// a real `SendError` by closing the pool backing the `PortfolioSnapshot`
+    /// event store before `perform()` runs. Uses a USDC-only view (no
+    /// configured equity symbols) so `resolve_marks` never touches
+    /// `position_projection`, isolating the failure to the `Capture` write
+    /// under test.
+    #[tokio::test]
+    async fn genuine_send_failure_propagates_as_err_not_swallowed() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let view =
+            InventoryView::default().with_usdc(Usdc::new(float!(1000)), Usdc::new(float!(500)));
+        let (ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool.clone(),
+            view,
+            HashSet::new(),
+            true,
+            false,
+            None,
+        )
+        .await;
+
+        pool.close().await;
+
+        let error = job_for_today().perform(&ctx).await.unwrap_err();
+
+        assert!(
+            matches!(error, PortfolioSnapshotJobError::Capture(_)),
+            "a genuine send failure must surface as PortfolioSnapshotJobError::Capture, got \
+             {error:?}"
+        );
+
+        let run_at_count: i64 =
+            sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            run_at_count, 0,
+            "perform() must return before the reschedule call when Capture genuinely fails, so \
+             apalis's own retry machinery drives the retry instead"
+        );
+    }
+
+    #[test]
+    fn est_boundary_04_59_and_05_01_utc_route_to_distinct_et_days() {
+        let before_midnight = Utc.with_ymd_and_hms(2026, 1, 15, 4, 59, 0).unwrap();
+        let after_midnight = Utc.with_ymd_and_hms(2026, 1, 15, 5, 1, 0).unwrap();
+
+        assert_ne!(et_day(before_midnight), et_day(after_midnight));
+        assert_eq!(
+            et_day(before_midnight),
+            NaiveDate::from_ymd_opt(2026, 1, 14).unwrap()
+        );
+        assert_eq!(
+            et_day(after_midnight),
+            NaiveDate::from_ymd_opt(2026, 1, 15).unwrap()
+        );
+    }
+
+    #[test]
+    fn edt_boundary_03_59_and_04_01_utc_route_to_distinct_et_days() {
+        let before_midnight = Utc.with_ymd_and_hms(2026, 7, 15, 3, 59, 0).unwrap();
+        let after_midnight = Utc.with_ymd_and_hms(2026, 7, 15, 4, 1, 0).unwrap();
+
+        assert_ne!(et_day(before_midnight), et_day(after_midnight));
+        assert_eq!(
+            et_day(before_midnight),
+            NaiveDate::from_ymd_opt(2026, 7, 14).unwrap()
+        );
+        assert_eq!(
+            et_day(after_midnight),
+            NaiveDate::from_ymd_opt(2026, 7, 15).unwrap()
+        );
+    }
+
+    /// `now` just after today's boundary (round-3 fix scenario (b)):
+    /// `first_capture` must target TODAY, not tomorrow -- the exact bug this
+    /// fix closes.
+    #[test]
+    fn first_capture_after_todays_boundary_targets_today_almost_immediately() {
+        let today = NaiveDate::from_ymd_opt(2026, 7, 15).unwrap();
+        let midnight = et_midnight(today).unwrap();
+        let now = midnight + CAPTURE_BUFFER + chrono::Duration::hours(9);
+
+        let (delay, target_et_day) = first_capture(now);
+
+        assert_eq!(target_et_day, today, "bootstrap must never skip today");
+        assert_eq!(delay, HYDRATION_RETRY_BACKOFF);
+    }
+
+    /// `now` before today's boundary (round-3 fix scenario (c)):
+    /// `first_capture` still targets today, just waits for the boundary
+    /// rather than capturing early.
+    #[test]
+    fn first_capture_before_todays_boundary_targets_today_at_the_boundary() {
+        let today = NaiveDate::from_ymd_opt(2026, 7, 15).unwrap();
+        let midnight = et_midnight(today).unwrap();
+        let now = midnight + chrono::Duration::minutes(1);
+
+        let (delay, target_et_day) = first_capture(now);
+
+        assert_eq!(target_et_day, today);
+        let boundary = midnight + CAPTURE_BUFFER;
+        let expected_delay = (boundary - now).to_std().unwrap();
+        assert_eq!(delay, expected_delay);
+    }
+
+    #[tokio::test]
+    async fn empty_inventory_view_fails_gate_and_never_calls_send() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool,
+            InventoryView::default(),
+            HashSet::from([aapl()]),
+            true,
+            false,
+            None,
+        )
+        .await;
+
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let et_day = et_day(Utc::now()).to_string();
+        assert_eq!(portfolio_snapshot_row_count(&pool, &et_day).await, 0);
+    }
+
+    #[tokio::test]
+    async fn wallet_locations_polled_to_zero_satisfy_hydration_gate() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let fetched_at = Utc::now();
+        let zero_equity = BTreeMap::from([(aapl(), FractionalShares::ZERO)]);
+        let view = InventoryView::default()
+            .with_equity(aapl(), FractionalShares::ZERO, FractionalShares::ZERO)
+            .set_inflight_cash(
+                InFlightCashLocation::EthereumWallet,
+                Usdc::ZERO,
+                fetched_at,
+                fetched_at,
+            )
+            .set_inflight_cash(
+                InFlightCashLocation::BaseWallet,
+                Usdc::ZERO,
+                fetched_at,
+                fetched_at,
+            )
+            .set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletUnwrapped,
+                &zero_equity,
+                fetched_at,
+                fetched_at,
+            )
+            .set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletWrapped,
+                &zero_equity,
+                fetched_at,
+                fetched_at,
+            );
+        let (ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool,
+            view,
+            HashSet::from([aapl()]),
+            false,
+            true,
+            Some(Arc::new(MockWrapper::new())),
+        )
+        .await;
+
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let et_day = et_day(Utc::now()).to_string();
+        assert_eq!(
+            portfolio_snapshot_row_count(&pool, &et_day).await,
+            6,
+            "two venue, two wallet-equity, and two wallet-USDC zero rows must be captured"
+        );
+    }
+
+    /// Regression for the round-2 blocker: the configured equity symbol is
+    /// polled at MarketMaking but NOT at Hedging (USDC tracking disabled so
+    /// only the equity gap is under test) -- the original "rows non-empty"
+    /// check would have wrongly let this through and permanently locked in
+    /// an incomplete day.
+    #[tokio::test]
+    async fn equity_polled_at_only_one_venue_fails_gate_and_never_calls_send() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let partial_view = InventoryView::default()
+            .update_equity(
+                &aapl(),
+                Inventory::available(
+                    Venue::MarketMaking,
+                    Operator::Add,
+                    FractionalShares::new(float!(10)),
+                ),
+                Utc::now(),
+            )
+            .unwrap();
+        let (ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool,
+            partial_view,
+            HashSet::from([aapl()]),
+            false,
+            false,
+            None,
+        )
+        .await;
+
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let et_day = et_day(Utc::now()).to_string();
+        assert_eq!(portfolio_snapshot_row_count(&pool, &et_day).await, 0);
+    }
+
+    /// Same regression, USDC side: polled at only one venue must also fail
+    /// the gate (no equity symbols configured, isolating the USDC gap).
+    #[tokio::test]
+    async fn usdc_polled_at_only_one_venue_fails_gate_and_never_calls_send() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let partial_view = InventoryView::default()
+            .update_usdc(
+                Inventory::available(Venue::MarketMaking, Operator::Add, Usdc::new(float!(1000))),
+                Utc::now(),
+            )
+            .unwrap();
+        let (ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool,
+            partial_view,
+            HashSet::new(),
+            true,
+            false,
+            None,
+        )
+        .await;
+
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let et_day = et_day(Utc::now()).to_string();
+        assert_eq!(portfolio_snapshot_row_count(&pool, &et_day).await, 0);
+    }
+
+    #[tokio::test]
+    async fn subsequent_tick_after_view_becomes_fully_hydrated_succeeds() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool,
+            InventoryView::default(),
+            HashSet::from([aapl()]),
+            true,
+            false,
+            Some(Arc::new(MockWrapper::new())),
+        )
+        .await;
+
+        job_for_today().perform(&ctx).await.unwrap();
+        let et_day_string = et_day(Utc::now()).to_string();
+        assert_eq!(portfolio_snapshot_row_count(&pool, &et_day_string).await, 0);
+
+        {
+            let mut view = ctx.inventory.write().await;
+            *view = freshly_polled_view(
+                aapl(),
+                FractionalShares::new(float!(10)),
+                FractionalShares::new(float!(5)),
+                Usdc::new(float!(1000)),
+                Usdc::new(float!(500)),
+            );
+        }
+
+        job_for_today().perform(&ctx).await.unwrap();
+        assert_eq!(portfolio_snapshot_row_count(&pool, &et_day_string).await, 4);
+    }
+
+    #[tokio::test]
+    async fn symbol_with_balance_but_no_price_yet_is_included_with_null_mark() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
+
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let et_day = et_day(Utc::now()).to_string();
+        let stored: Option<String> = sqlx::query_scalar(
+            "SELECT usd_mark FROM portfolio_snapshot \
+             WHERE et_day = ? AND asset = 'AAPL' AND location = 'market_making'",
+        )
+        .bind(&et_day)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(stored, None, "AAPL has never filled, so no mark is known");
+    }
+
+    /// Distinct from the "never touched" case above: the Position aggregate
+    /// IS initialized for AAPL, but no price-carrying event has landed on it
+    /// yet -- the inner `None` arm of `resolve_marks`'s equity match, not the
+    /// outer one.
+    #[tokio::test]
+    async fn symbol_with_position_initialized_but_no_price_yet_is_included_with_null_mark() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
+
+        position
+            .send(
+                &aapl(),
+                PositionCommand::ManuallyAdjustPosition {
+                    symbol: aapl(),
+                    target_net: FractionalShares::ZERO,
+                    reason: "test setup: initialize without a price".to_owned(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    expected_net: None,
+                    price_usdc: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let et_day = et_day(Utc::now()).to_string();
+        let stored: Option<String> = sqlx::query_scalar(
+            "SELECT usd_mark FROM portfolio_snapshot \
+             WHERE et_day = ? AND asset = 'AAPL' AND location = 'market_making'",
+        )
+        .bind(&et_day)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            stored, None,
+            "Position was initialized but no price-carrying event has landed on it yet"
+        );
+    }
+
+    /// The one branch of `resolve_marks` that reads a real fill-derived price
+    /// out of `Position` and pairs it with `position.last_updated`: this must
+    /// persist the position's OWN `last_updated`, never the job's `captured_at`
+    /// (an easy one-line regression, since both are `DateTime<Utc>` and
+    /// `captured_at` is in scope at that line).
+    #[tokio::test]
+    async fn equity_position_with_known_price_persists_that_price_and_its_own_last_updated() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
+
+        // Deliberately far from "now" so a regression that swapped in the
+        // job's own `captured_at` would be unmistakable in the assertion
+        // below, rather than accidentally matching by coincidence.
+        let seen_at = Utc.with_ymd_and_hms(2026, 7, 10, 12, 0, 0).unwrap();
+        position
+            .send(
+                &aapl(),
+                PositionCommand::AcknowledgeOnChainFillAt {
+                    symbol: aapl(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId {
+                        tx_hash: TxHash::ZERO,
+                        log_index: 0,
+                    },
+                    amount: FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: seen_at,
+                    seen_at,
+                },
+            )
+            .await
+            .unwrap();
+
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let et_day = et_day(Utc::now()).to_string();
+        let (usd_mark, mark_captured_at): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT usd_mark, mark_captured_at FROM portfolio_snapshot \
+             WHERE et_day = ? AND asset = 'AAPL' AND location = 'market_making'",
+        )
+        .bind(&et_day)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(usd_mark.as_deref(), Some("150"));
+        assert_eq!(
+            mark_captured_at.as_deref(),
+            Some(seen_at.to_rfc3339().as_str()),
+            "mark_captured_at must be Position.last_updated, not the job's own captured_at"
+        );
+    }
+
+    #[tokio::test]
+    async fn reschedules_at_next_et_midnight_plus_buffer_after_capture() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool.clone()).await;
+
+        let before = Utc::now();
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let (run_at, job_bytes): (i64, Vec<u8>) =
+            sqlx_apalis::query_as("SELECT run_at, job FROM Jobs WHERE job_type = ? LIMIT 1")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+
+        let expected_target_et_day = et_day(before) + Days::new(1);
+        let expected = (et_midnight(expected_target_et_day).unwrap() + CAPTURE_BUFFER).timestamp();
+        assert!(
+            (run_at - expected).abs() <= 5,
+            "expected run_at near {expected}, got {run_at}"
+        );
+        // The reschedule after a successful capture always targets the day
+        // AFTER the one just captured -- `job_for_today()` captured today,
+        // so the follow-up must never target today again.
+        let scheduled: PortfolioSnapshotJob = serde_json::from_slice(&job_bytes).unwrap();
+        assert_eq!(scheduled.target_et_day, expected_target_et_day);
+    }
+
+    #[tokio::test]
+    async fn reschedules_with_short_backoff_after_failed_completeness_gate() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool.clone(),
+            InventoryView::default(),
+            HashSet::from([aapl()]),
+            true,
+            false,
+            None,
+        )
+        .await;
+
+        let before = Utc::now();
+        let job = job_for_today();
+        job.clone().perform(&ctx).await.unwrap();
+
+        let run_at: i64 =
+            sqlx_apalis::query_scalar("SELECT run_at FROM Jobs WHERE job_type = ? LIMIT 1")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+
+        let expected =
+            before.timestamp() + i64::try_from(HYDRATION_RETRY_BACKOFF.as_secs()).unwrap();
+        assert!(
+            (run_at - expected).abs() <= 5,
+            "expected run_at near {expected}, got {run_at}"
+        );
+
+        let rescheduled_job: Vec<u8> =
+            sqlx_apalis::query_scalar("SELECT job FROM Jobs WHERE job_type = ? LIMIT 1")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        let rescheduled: PortfolioSnapshotJob = serde_json::from_slice(&rescheduled_job).unwrap();
+        assert_eq!(
+            rescheduled.target_et_day, job.target_et_day,
+            "a hydration retry must keep the same target_et_day, never recompute it"
+        );
+    }
+
+    /// Round-3 fix scenario (a): a job whose `target_et_day` is yesterday
+    /// (hydration stuck past midnight, or a very late wake) must capture
+    /// TODAY's fresh balances under TODAY's id -- never back-date a live read
+    /// under yesterday's stale id.
+    #[tokio::test]
+    async fn perform_past_its_target_day_catches_up_and_captures_under_today() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
+
+        let today = et_day(Utc::now());
+        let stale_job = PortfolioSnapshotJob {
+            target_et_day: today - Days::new(1),
+        };
+
+        stale_job.perform(&ctx).await.unwrap();
+
+        assert_eq!(
+            portfolio_snapshot_row_count(&pool, &(today - Days::new(1)).to_string()).await,
+            0,
+            "the stale target day must never be captured"
+        );
+        assert_eq!(
+            portfolio_snapshot_row_count(&pool, &today.to_string()).await,
+            4,
+            "the catch-up must contain the complete four-row fixture under today"
+        );
+    }
+
+    /// Compounds the round-3 catch-up fix with a hydration-gap failure: a
+    /// job whose `target_et_day` has already passed (yesterday) AND whose
+    /// inventory is still incompletely hydrated must reschedule under TODAY
+    /// (the local `target_et_day` `perform` computes), never resume
+    /// retrying under the stale `self.target_et_day`. Neither the stale day
+    /// nor today may be captured -- the completeness gate fails before any
+    /// `Capture` is attempted.
+    #[tokio::test]
+    async fn hydration_retry_compounded_with_stale_target_day_never_captures_under_stale_id() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool.clone(),
+            InventoryView::default(),
+            HashSet::from([aapl()]),
+            true,
+            false,
+            None,
+        )
+        .await;
+
+        let today = et_day(Utc::now());
+        let stale_job = PortfolioSnapshotJob {
+            target_et_day: today - Days::new(1),
+        };
+
+        stale_job.perform(&ctx).await.unwrap();
+
+        assert_eq!(
+            portfolio_snapshot_row_count(&pool, &(today - Days::new(1)).to_string()).await,
+            0,
+            "the stale target day must never be captured"
+        );
+        assert_eq!(
+            portfolio_snapshot_row_count(&pool, &today.to_string()).await,
+            0,
+            "an incomplete view must not capture today either"
+        );
+
+        let rescheduled_job: Vec<u8> =
+            sqlx_apalis::query_scalar("SELECT job FROM Jobs WHERE job_type = ? LIMIT 1")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        let rescheduled: PortfolioSnapshotJob = serde_json::from_slice(&rescheduled_job).unwrap();
+        assert_eq!(
+            rescheduled.target_et_day, today,
+            "a hydration-gap retry on a stale job must reschedule under today, never resume \
+             retrying under the day that has already passed"
+        );
+    }
+
+    /// A job that wakes before its own `target_et_day`'s boundary must wait
+    /// for it rather than capturing early: `target_et_day` stays unchanged on
+    /// the rescheduled follow-up.
+    #[tokio::test]
+    async fn perform_before_its_target_day_reschedules_without_capturing() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool.clone()).await;
+
+        let future_day = et_day(Utc::now()) + Days::new(1);
+        let early_job = PortfolioSnapshotJob {
+            target_et_day: future_day,
+        };
+
+        early_job.perform(&ctx).await.unwrap();
+
+        assert_eq!(
+            portfolio_snapshot_row_count(&pool, &future_day.to_string()).await,
+            0
+        );
+
+        let (run_at, rescheduled_job): (i64, Vec<u8>) =
+            sqlx_apalis::query_as("SELECT run_at, job FROM Jobs WHERE job_type = ? LIMIT 1")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        let rescheduled: PortfolioSnapshotJob = serde_json::from_slice(&rescheduled_job).unwrap();
+        assert_eq!(rescheduled.target_et_day, future_day);
+        let expected = (et_midnight(future_day).unwrap() + CAPTURE_BUFFER).timestamp();
+        assert!(
+            (run_at - expected).abs() <= 5,
+            "expected early wake to reschedule once at {expected}, got {run_at}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_purges_stale_pending_row_and_leaves_exactly_one() {
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let queue = PortfolioSnapshotJobQueue::new(&apalis_pool);
+
+        sqlx_apalis::query(
+            "INSERT INTO Jobs (job, id, job_type, status, attempts, max_attempts) \
+             VALUES (?, ?, ?, ?, 0, 25)",
+        )
+        .bind("{}")
+        .bind("stale-pending")
+        .bind(std::any::type_name::<PortfolioSnapshotJob>())
+        .bind(Status::Pending.to_string())
+        .execute(&apalis_pool)
+        .await
+        .unwrap();
+
+        let before = Utc::now();
+        bootstrap_portfolio_snapshot(&apalis_pool, &queue)
+            .await
+            .unwrap();
+
+        assert_eq!(portfolio_snapshot_job_count(&apalis_pool).await, 1);
+
+        // Round-2 fix: bootstrap must never enqueue a truly-immediate
+        // (zero-delay) capture -- it always waits at least
+        // HYDRATION_RETRY_BACKOFF, giving the inventory poller a moment to
+        // warm up, even when (round-3 fix) it is catching up to today rather
+        // than deferring to tomorrow's boundary.
+        let run_at: i64 =
+            sqlx_apalis::query_scalar("SELECT run_at FROM Jobs WHERE job_type = ? LIMIT 1")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        assert!(
+            run_at > before.timestamp() + 60,
+            "bootstrap must not schedule an immediate capture: run_at {run_at}, now {}",
+            before.timestamp()
+        );
+
+        let job_bytes: Vec<u8> =
+            sqlx_apalis::query_scalar("SELECT job FROM Jobs WHERE job_type = ? LIMIT 1")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        let job: PortfolioSnapshotJob = serde_json::from_slice(&job_bytes).unwrap();
+        assert_eq!(
+            job.target_et_day,
+            et_day(before),
+            "bootstrap must target today, never skip it"
+        );
+    }
+
+    #[tokio::test]
+    async fn purge_removes_pending_queued_running_and_retryable_failed_but_keeps_terminal() {
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_type = std::any::type_name::<PortfolioSnapshotJob>();
+
+        async fn insert(
+            apalis_pool: &apalis_sqlite::SqlitePool,
+            job_type: &str,
+            id: &str,
+            status: &str,
+            attempts: i64,
+        ) {
+            sqlx_apalis::query(
+                "INSERT INTO Jobs (job, id, job_type, status, attempts, max_attempts) \
+                 VALUES (?, ?, ?, ?, ?, 25)",
+            )
+            .bind("{}")
+            .bind(id)
+            .bind(job_type)
+            .bind(status)
+            .bind(attempts)
+            .execute(apalis_pool)
+            .await
+            .unwrap();
+        }
+
+        insert(
+            &apalis_pool,
+            job_type,
+            "pending-1",
+            &Status::Pending.to_string(),
+            0,
+        )
+        .await;
+        insert(
+            &apalis_pool,
+            job_type,
+            "queued-1",
+            &Status::Queued.to_string(),
+            0,
+        )
+        .await;
+        insert(
+            &apalis_pool,
+            job_type,
+            "running-1",
+            &Status::Running.to_string(),
+            0,
+        )
+        .await;
+        insert(
+            &apalis_pool,
+            job_type,
+            "failed-retryable",
+            &Status::Failed.to_string(),
+            3,
+        )
+        .await;
+        insert(
+            &apalis_pool,
+            job_type,
+            "failed-exhausted",
+            &Status::Failed.to_string(),
+            25,
+        )
+        .await;
+        insert(
+            &apalis_pool,
+            job_type,
+            "done-1",
+            &Status::Done.to_string(),
+            1,
+        )
+        .await;
+        insert(
+            &apalis_pool,
+            job_type,
+            "killed-1",
+            &Status::Killed.to_string(),
+            1,
+        )
+        .await;
+
+        let deleted = purge_pending_portfolio_snapshot_jobs(&apalis_pool)
+            .await
+            .unwrap();
+        assert_eq!(deleted, 4);
+
+        let remaining: Vec<String> =
+            sqlx_apalis::query_scalar("SELECT id FROM Jobs WHERE job_type = ?")
+                .bind(job_type)
+                .fetch_all(&apalis_pool)
+                .await
+                .unwrap();
+        assert_eq!(remaining.len(), 3);
+        assert!(remaining.contains(&"failed-exhausted".to_string()));
+        assert!(remaining.contains(&"done-1".to_string()));
+        assert!(remaining.contains(&"killed-1".to_string()));
+    }
+
+    /// With wallet polling configured (`wallet_polling_enabled: true`), the
+    /// wallet-transit locations must themselves have been polled at least
+    /// once before capture, even when every venue balance is present. Before
+    /// the first successful wallet poll, `inflight_cash`/`inflight_equity`
+    /// are simply empty -- indistinguishable from "no balance" unless the
+    /// gate explicitly requires them.
+    #[tokio::test]
+    async fn wallet_transit_not_yet_polled_fails_gate_when_wallet_polling_enabled() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let view = freshly_polled_view(
+            aapl(),
+            FractionalShares::new(float!(10)),
+            FractionalShares::new(float!(5)),
+            Usdc::new(float!(1000)),
+            Usdc::new(float!(500)),
+        );
+        let (ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool,
+            view,
+            HashSet::from([aapl()]),
+            true,
+            true,
+            Some(Arc::new(MockWrapper::new())),
+        )
+        .await;
+
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let et_day = et_day(Utc::now()).to_string();
+        assert_eq!(
+            portfolio_snapshot_row_count(&pool, &et_day).await,
+            0,
+            "wallet polling is enabled but no wallet-transit balance has ever been polled"
+        );
+    }
+
+    /// `convert_wrapped_equity_rows`'s `MissingWrapper` fail-fast guard: a
+    /// nonzero MarketMaking equity balance (a WRAPPED ERC-4626 vault-share
+    /// balance) requires a live vault ratio to value in underlying-equivalent
+    /// units. With no `Wrapper` configured, capture must fail outright --
+    /// never silently persist the wrapped balance as if it were already
+    /// underlying-denominated (a 1:1 valuation that is only correct by
+    /// coincidence, and silently wrong once a vault's ratio departs from
+    /// 1:1).
+    #[tokio::test]
+    async fn missing_wrapper_with_nonzero_market_making_balance_fails_fast() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let view = freshly_polled_view(
+            aapl(),
+            FractionalShares::new(float!(10)),
+            FractionalShares::new(float!(5)),
+            Usdc::new(float!(1000)),
+            Usdc::new(float!(500)),
+        );
+        let (ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool,
+            view,
+            HashSet::from([aapl()]),
+            true,
+            false,
+            None,
+        )
+        .await;
+
+        let error = job_for_today().perform(&ctx).await.unwrap_err();
+
+        match error {
+            PortfolioSnapshotJobError::MissingWrapper { symbol, location } => {
+                assert_eq!(symbol, aapl());
+                assert_eq!(location, PortfolioLocation::MarketMaking);
+            }
+            other => panic!("expected MissingWrapper, got {other:?}"),
+        }
+
+        let et_day = et_day(Utc::now()).to_string();
+        assert_eq!(
+            portfolio_snapshot_row_count(&pool, &et_day).await,
+            0,
+            "a failed capture must never persist a partial or incorrectly-valued row"
+        );
+    }
+
+    /// Onchain MarketMaking equity and BaseWalletWrapped-transit equity are
+    /// WRAPPED ERC-4626 vault shares, not underlying shares. With a non-1:1
+    /// ratio (1.5, simulating vault NAV accrual from dividends/splits), both
+    /// must be persisted as underlying-EQUIVALENT balances (raw * ratio), the
+    /// same conversion `InventoryView::check_equity_imbalance` already
+    /// applies. Hedging (already underlying) and BaseWalletUnwrapped
+    /// (already underlying) must be persisted unconverted.
+    #[tokio::test]
+    async fn wrapped_equity_rows_are_valued_as_underlying_equivalent_with_non_1_to_1_ratio() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let now = Utc::now();
+
+        let wrapped_market_making = FractionalShares::new(float!(10));
+        let unwrapped_offchain = FractionalShares::new(float!(5));
+        let wrapped_transit = FractionalShares::new(float!(2));
+        let unwrapped_transit = FractionalShares::new(float!(3));
+
+        let view = InventoryView::default()
+            .with_equity(aapl(), wrapped_market_making, unwrapped_offchain)
+            .record_equity_snapshot_watermarks(Venue::MarketMaking, [&aapl()], now)
+            .record_equity_snapshot_watermarks(Venue::Hedging, [&aapl()], now)
+            .set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletWrapped,
+                &BTreeMap::from([(aapl(), wrapped_transit)]),
+                now,
+                now,
+            )
+            .set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletUnwrapped,
+                &BTreeMap::from([(aapl(), unwrapped_transit)]),
+                now,
+                now,
+            )
+            .set_inflight_cash(InFlightCashLocation::EthereumWallet, Usdc::ZERO, now, now)
+            .set_inflight_cash(InFlightCashLocation::BaseWallet, Usdc::ZERO, now, now);
+
+        let ratio_1_5 = U256::from(1_500_000_000_000_000_000u64);
+        let (ctx, _position) = build_ctx(
+            pool.clone(),
+            apalis_pool,
+            view,
+            HashSet::from([aapl()]),
+            false,
+            true,
+            Some(Arc::new(MockWrapper::with_ratio(ratio_1_5))),
+        )
+        .await;
+
+        job_for_today().perform(&ctx).await.unwrap();
+
+        let et_day = et_day(Utc::now()).to_string();
+
+        async fn available_balance(pool: &SqlitePool, et_day: &str, location: &str) -> String {
+            sqlx::query_scalar(
+                "SELECT available_balance FROM portfolio_snapshot \
+                 WHERE et_day = ? AND asset = 'AAPL' AND location = ?",
+            )
+            .bind(et_day)
+            .bind(location)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+        }
+
+        async fn inflight_balance(pool: &SqlitePool, et_day: &str, location: &str) -> String {
+            sqlx::query_scalar(
+                "SELECT inflight_balance FROM portfolio_snapshot \
+                 WHERE et_day = ? AND asset = 'AAPL' AND location = ?",
+            )
+            .bind(et_day)
+            .bind(location)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+        }
+
+        assert_eq!(
+            available_balance(&pool, &et_day, "market_making").await,
+            "15",
+            "10 wrapped shares * 1.5 ratio = 15 underlying-equivalent shares"
+        );
+        assert_eq!(
+            available_balance(&pool, &et_day, "hedging").await,
+            "5",
+            "offchain balance is already underlying units and must stay unconverted"
+        );
+        assert_eq!(
+            inflight_balance(&pool, &et_day, "base_wallet_wrapped").await,
+            "3",
+            "2 wrapped shares * 1.5 ratio = 3 underlying-equivalent shares"
+        );
+        assert_eq!(
+            inflight_balance(&pool, &et_day, "base_wallet_unwrapped").await,
+            "3",
+            "unwrapped transit balance is already underlying units and must stay unconverted"
+        );
+    }
+}

--- a/src/position.rs
+++ b/src/position.rs
@@ -1238,7 +1238,9 @@ impl PositionEvent {
 
 /// Compares two optional `Float` prices, treating both-absent as equal.
 /// `Float` has no `PartialEq`, so this routes through its fallible `eq`.
-fn option_float_eq(left: Option<Float>, right: Option<Float>) -> bool {
+/// `pub(crate)` so other modules with the same need (e.g.
+/// `portfolio_snapshot`) reuse this instead of redefining it.
+pub(crate) fn option_float_eq(left: Option<Float>, right: Option<Float>) -> bool {
     match (left, right) {
         (None, None) => true,
         (Some(left), Some(right)) => left.eq(right).unwrap_or(false),

--- a/tests/e2e/poll.rs
+++ b/tests/e2e/poll.rs
@@ -412,9 +412,9 @@ pub async fn poll_for_hedge_completion(
 /// conflicts) may still be in-flight after higher-level conditions are met.
 /// Use this instead of an immediate done-count assertion.
 ///
-/// The self-rescheduling `CheckPositions` job is excluded from both totals,
-/// since it always leaves exactly one `Pending` row in the queue waiting for
-/// the next tick and is not "in-flight work".
+/// The self-rescheduling `CheckPositions` and `PortfolioSnapshot` jobs are
+/// excluded from both totals, since each always leaves exactly one non-`Done`
+/// row in the queue waiting for the next tick and is not "in-flight work".
 pub async fn poll_for_all_jobs_done(
     bot: &mut JoinHandle<anyhow::Result<()>>,
     db_path: &std::path::Path,
@@ -437,15 +437,19 @@ pub async fn poll_for_all_jobs_done(
         };
 
         let check_positions = st0x_hedge::check_positions_job_type();
-        let total = sqlx::query_as::<_, (i64,)>("SELECT COUNT(*) FROM Jobs WHERE job_type != ?")
-            .bind(check_positions)
-            .fetch_one(&pool)
-            .await;
+        let portfolio_snapshot = st0x_hedge::portfolio_snapshot_job_type();
+        let total =
+            sqlx::query_as::<_, (i64,)>("SELECT COUNT(*) FROM Jobs WHERE job_type NOT IN (?, ?)")
+                .bind(check_positions)
+                .bind(portfolio_snapshot)
+                .fetch_one(&pool)
+                .await;
 
         let done = sqlx::query_as::<_, (i64,)>(
-            "SELECT COUNT(*) FROM Jobs WHERE status = 'Done' AND job_type != ?",
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Done' AND job_type NOT IN (?, ?)",
         )
         .bind(check_positions)
+        .bind(portfolio_snapshot)
         .fetch_one(&pool)
         .await;
 


### PR DESCRIPTION
## What

[RAI-1457](https://linear.app/makeitrain/issue/RAI-1457/persist-daily-portfolio-snapshots-so-pnl-can-report-return-on-capital), part 1 of 2.

- Add one event-sourced `PortfolioSnapshot` per Eastern Time calendar day.
- Project each `Captured` event into the new `portfolio_snapshot` table.
- Capture venue and wallet balances through a daily, self-rescheduling job.
- Add typed inventory rows for each `(location, asset)` balance.

## Why

- `/pnl` has realized profit and loss, but it has no historical capital series.
- `BroadcastingInventory` only keeps the latest poll, so there is nothing durable to average.

## How

- The ET day is the aggregate ID. The first `Capture` emits an event, and later captures for that day fail idempotently.
- The job targets `00:05` ET and handles Eastern Standard Time and Eastern Daylight Time through `chrono_tz`.
- A hydration gate requires every configured inventory slot before capture.
- Wrapped equity converts to underlying units through the live vault ratio.
- Equity marks use `Position.last_price_usdc`. USDC uses a fixed `1:1` mark.
- The best-effort worker never stops trading when reporting fails.
- Startup removes old non-terminal snapshot jobs before it starts one fresh loop.

## Testing

- 39 focused aggregate, projection, inventory, scheduling, hydration, mark, and bootstrap tests pass.
- Workspace check, Clippy, formatting, nixfmt, and changed-file hooks pass.

## Screenshots

None, this PR only adds backend persistence.

## Anything else

- Adds `migrations/20260720145025_portfolio_snapshot.sql`.
- A crash between the event commit and reactor write can still lose a projected day.
- The hydration gate checks presence, not poll freshness. The next PR stack already tracks that follow-up.
- The next PR reads this series and adds return on capital to `/pnl`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily portfolio snapshots covering cash, equities, and wallet-transit balances across supported locations.
  * Added deployed-capital and USD return tracking for `/pnl`, including average capital and annualized returns when complete, current marks are available.
  * Added automatic scheduling, catch-up handling, hydration checks, and duplicate-capture protection.
  * Added support for wrapped-equity valuation and configurable wallet polling.

* **Documentation**
  * Documented portfolio capital definitions, valuation rules, snapshot timing, and return calculation coverage requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->