### PR TITLE
fix: align return coverage when snapshot marks are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ repaired exposure could never be valued and would never hedge.
 `position set` is rejected while the symbol still has a pending offchain hedge
 order; resolve it first with `position release-hedge`, then retry.
 
+After verifying a missing daily snapshot mark against a historical-price source,
+set the preceding regular-session close through the audited CQRS repair command:
+
+```bash
+cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml portfolio-snapshot set --day 2026-07-20 --symbol AAPL --usd-mark 211.18 --observed-at 2026-07-17T20:00:00Z --source "Nasdaq historical close" --reason "repair missing snapshot mark"
+```
+
+The repair updates every captured location for that symbol and day without
+changing the live position price. If the read model needs recovery, stop the bot
+first (the rebuild replays events read at its start; concurrent captures would
+force it to be re-run), then replay all captured balances and corrections with:
+
+```bash
+cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml view rebuild --aggregate portfolio-snapshot --all
+```
+
 ### Brokerage Setup
 
 **Alpaca Broker API** (managed accounts, supports auto-rebalancing):

--- a/SPEC.md
+++ b/SPEC.md
@@ -702,48 +702,66 @@ short-sale proceeds would inflate the counted cash, and posted maintenance
 margin would become genuinely uncounted capital.
 
 **USD marks**: USDC is treated as par (`1:1`), matching the reporting-currency
-assumption used elsewhere in `/pnl`. Equity balances are marked at the symbol's
-`last_price_usdc` (the same fill-derived price already tracked on the `Position`
-aggregate) as of capture time. A symbol with a balance but no observed price yet
-is recorded with `usd_mark = NULL` -- never a fabricated zero. Marks are fixed
-permanently at capture time as part of the immutable event payload: a later
-price correction does not retroactively change a previously reported day's
-capital. The persisted `mark_captured_at` is `Position.last_price_observed_at`,
-a dedicated price-observation timestamp set only by the events that also set
-`last_price_usdc` (`OnChainOrderFilled`, using the fill's `block_timestamp`, and
-priced `ManualPositionAdjusted`, using `adjusted_at`). This is distinct from
-`last_updated`, the aggregate's last-touched time, which is also advanced by
-non-price events (offchain order placement/fill/cancel, threshold updates) that
-leave `last_price_observed_at` untouched. So the staleness guard below keys off
-how recently the price itself was actually observed, and does exclude a day with
-a genuinely stale price even when the position was otherwise recently touched by
-a non-price event.
+assumption used elsewhere in `/pnl`. Equity balances are marked from the
+symbol's `Position.last_price: Option<PriceObservation>` as of capture time. A
+`PriceObservation` carries the fill-derived USD price and the time that price
+was economically observed: `OnChainOrderFilled` uses the fill's
+`block_timestamp`, and a priced `ManualPositionAdjusted` uses `adjusted_at`.
+This is distinct from `last_updated`, which is also advanced by non-price
+events. A symbol with a balance but no observed price is recorded with
+`usd_mark = NULL` -- never a fabricated zero. A missing or stale mark does not
+block the immutable balance capture; it immediately emits an error, increments
+an operational counter, and begins sending an operator alert through the
+configured alerting channel. Alert delivery is at-least-once: successful
+per-symbol delivery is recorded as a retained aggregate event, while failures
+enqueue an alert-only retry without blocking the next day's capture. Alert
+retries survive process restarts; a crash in the narrow interval after Telegram
+accepts a message but before the delivery event commits may produce a duplicate
+rather than lose the incident.
+
+Captured marks are immutable facts, but operators may correct a missing or stale
+historical mark through the portfolio-snapshot `set` recovery command. The
+command requires the ET day, symbol, strictly-positive USD mark, economic
+observation timestamp, price source, and non-blank operator reason. The
+historical-price convention is the last regular-session closing price available
+before that ET day's `00:05` capture boundary (the preceding trading day's
+close, including across weekends and exchange holidays). The supplied economic
+timestamp names that close. The command enforces that the timestamp is from an
+earlier ET day and remains within the report's mark-usability window; the
+operator and recorded source attest the exchange-calendar close because the CLI
+does not independently fetch a historical market calendar. The correction is an
+append-only `PortfolioSnapshot` CQRS event and updates every location row for
+the symbol on that day in the read model; repeated corrections remain auditable
+and the most recent event wins. It never updates the live `Position.last_price`.
+The snapshot projection replays all retained capture and correction events at
+startup and can be rebuilt on demand, so a reactor failure cannot permanently
+discard a correction.
 
 **Derived `/pnl` fields**: for a queried date range, a day's total USD capital
 is computed only when every nonzero-balance row that day has a known, non-stale
-mark; a day with any missing or stale mark is excluded from the sample entirely
-(never partially), since per-row exclusion would understate capital and inflate
-the reported return. `average_deployed_capital_usd` is the mean of included
-days' totals; `annualized_return_pct` is the range's realized PnL divided by
-that average, annualized by `365 / coverage_days` -- reported only when at least
-two included days span at least two calendar days, AND snapshot coverage fully
-spans the queried date range (`first_snapshot_day` at or before the query's
-`fromDate`, `last_snapshot_day` at or after its `toDate`). The realized-PnL
-numerator is scoped to the whole query range, not to snapshot coverage, so a
-narrower coverage window annualizing a wider-range PnL figure would inflate the
-result -- exactly the dangerous direction this section's fail-fast rules exist
-to prevent. `average_deployed_capital_usd` is still reported (honestly labeled
-by `sample_days`) even when the annualized figure is omitted for this reason. A
-single included day still reports `average_deployed_capital_usd` and
-`coverage_days` (`1`), but `annualized_return_pct` stays `None`: extrapolating
-one day's return by `365x` is exactly the misleading-financial-number failure
-mode the fail-fast rules exist to prevent, so the system reports no annualized
-figure at all for that day rather than an unannualized raw return under the same
-field. Both capital fields are `None`, with an explicit warning, whenever no day
-qualifies, average capital is exactly zero, the query is symbol-filtered (a
-symbol-scoped slice of whole-portfolio capital is not a meaningful denominator),
-or an `as_of_rowid` in the past is requested (capital is always computed from
-the live snapshot table, not watermarked to a historical event position).
+mark; a day with any missing or stale mark is excluded entirely (never
+partially), since per-row exclusion would understate capital and inflate the
+reported return. The response lists each excluded ET day and its reason. The
+ordinary `/pnl` totals remain scoped to the full requested range.
+
+Return on capital uses only the usable ET days for both sides of the ratio.
+`average_deployed_capital_usd` is the mean of those days' capital. The return
+numerator is net realized PnL whose accounting date is one of those same days;
+PnL from an excluded or absent snapshot day remains in the ordinary report but
+does not enter return on capital. Each daily return is therefore weighted by
+that day's capital, equivalently:
+
+`annualized_return_pct = 100 * 365 * sum(usable-day net realized PnL) /
+sum(usable-day deployed capital)`.
+
+The annualized percentage is reported only when at least two usable days are
+available. A single included day still reports average capital but not an
+annualized percentage. Both capital fields are `None`, with an explicit warning,
+whenever no day qualifies, average capital is exactly zero, the query is
+symbol-filtered (a symbol-scoped slice of whole-portfolio capital is not a
+meaningful denominator), or an `as_of_rowid` in the past is requested (capital
+is always computed from the live snapshot table, not watermarked to a historical
+event position).
 
 ### Risk Management
 

--- a/dashboard/src/lib/pnl/report.ts
+++ b/dashboard/src/lib/pnl/report.ts
@@ -233,6 +233,11 @@ export type PnlCapitalSummary = {
   sampleDays: number
   firstSnapshotDay: string | null
   lastSnapshotDay: string | null
+  excludedDays: Array<{
+    etDay: string
+    kind: 'missingSnapshot' | 'missingMark' | 'staleMark'
+    reason: string
+  }>
 }
 
 export type PnlResponse = {

--- a/migrations/20260720145025_portfolio_snapshot.sql
+++ b/migrations/20260720145025_portfolio_snapshot.sql
@@ -1,4 +1,4 @@
--- Forward-only read model for the daily portfolio snapshot (RAI-1457).
+-- Replayable read model for the daily portfolio snapshot (RAI-1457).
 --
 -- Maintained exclusively by the PortfolioSnapshotProjection reactor from the
 -- PortfolioSnapshot aggregate's retained Captured events (one aggregate

--- a/src/api.rs
+++ b/src/api.rs
@@ -192,7 +192,7 @@ async fn pnl(
         Vec::new()
     };
 
-    build_pnl_report(&state.pool, &query, activities)
+    build_pnl_report(&state.pool, &query, activities, Utc::now())
         .await
         .map(Json)
         .map_err(pnl_error_response)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,7 @@ mod wrapper;
 
 use alloy::primitives::{Address, B256, TxHash};
 use alloy::providers::ProviderBuilder;
+use chrono::{DateTime, NaiveDate, Utc};
 use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 use rain_math_float::Float;
 use sqlx::SqlitePool;
@@ -31,6 +32,7 @@ use crate::offchain::order::{OffchainOrder, OffchainOrderId, OrderPlacer};
 use crate::performance::equity_timing::EquityTimingProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
 use crate::performance::reliability::LifecycleFailureProjection;
+use crate::portfolio_snapshot::PortfolioSnapshotProjection;
 use crate::position::Position;
 use crate::vault_registry::VaultRegistry;
 
@@ -125,6 +127,9 @@ pub enum AggregateView {
     /// failure across all four subscribed streams through the reactor fold.
     /// Supports `--all` only.
     LifecycleFailure,
+    /// Daily portfolio snapshot read model. Replays captures and every audited
+    /// historical-mark correction. Supports `--all` only.
+    PortfolioSnapshot,
 }
 
 /// CCTP chain identifier for specifying source chain.
@@ -187,6 +192,31 @@ pub enum PositionRecoveryCommand {
     },
 }
 
+#[derive(Debug, Subcommand)]
+pub enum PortfolioSnapshotRecoveryCommand {
+    /// Set the audited historical closing-price mark for one captured ET day.
+    Set {
+        /// ET day of the immutable balance snapshot (YYYY-MM-DD).
+        #[arg(long = "day")]
+        day: NaiveDate,
+        /// Equity symbol whose mark applies at every captured location.
+        #[arg(short = 's', long = "symbol")]
+        symbol: Symbol,
+        /// Strictly-positive historical USD closing price per share.
+        #[arg(long = "usd-mark", value_parser = parse_positive_mark)]
+        usd_mark: Positive<Float>,
+        /// Sourced economic timestamp; must be an earlier ET day and remain usable.
+        #[arg(long = "observed-at")]
+        observed_at: DateTime<Utc>,
+        /// Source used to verify the historical price.
+        #[arg(long = "source", value_parser = parse_non_empty_source)]
+        source: String,
+        /// Operator reason persisted with the correction event.
+        #[arg(short = 'r', long = "reason", value_parser = parse_non_empty_reason)]
+        reason: String,
+    },
+}
+
 fn parse_float(input: &str) -> Result<Float, String> {
     Float::parse(input.to_string()).map_err(|err| format!("{err}"))
 }
@@ -201,6 +231,18 @@ fn parse_positive_price(input: &str) -> Result<Float, String> {
         return Err(format!("--price must be strictly positive, got {value:?}"));
     }
     Ok(value)
+}
+
+fn parse_positive_mark(input: &str) -> Result<Positive<Float>, String> {
+    Positive::new(parse_positive_price(input)?).map_err(|error| format!("{error}"))
+}
+
+fn parse_non_empty_source(input: &str) -> Result<String, String> {
+    if input.trim().is_empty() {
+        return Err("--source must not be blank; it is persisted as audit provenance".to_string());
+    }
+
+    Ok(input.to_string())
 }
 
 fn parse_positive_shares(input: &str) -> Result<Positive<FractionalShares>, String> {
@@ -656,6 +698,12 @@ pub enum Commands {
         command: PositionRecoveryCommand,
     },
 
+    /// Repair historical daily portfolio snapshot marks through CQRS events.
+    PortfolioSnapshot {
+        #[command(subcommand)]
+        command: PortfolioSnapshotRecoveryCommand,
+    },
+
     /// Recover stuck asset transfers (USDC rebalances, mints, redemptions).
     Transfer {
         #[command(subcommand)]
@@ -949,6 +997,9 @@ enum SimpleCommand {
     },
     Position {
         command: PositionRecoveryCommand,
+    },
+    PortfolioSnapshot {
+        command: PortfolioSnapshotRecoveryCommand,
     },
     FailTransfer {
         transfer_type: TransferType,
@@ -1323,6 +1374,7 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         }
         Commands::OrderStatus { order_id } => Ok(SimpleCommand::OrderStatus { order_id }),
         Commands::Position { command } => Ok(SimpleCommand::Position { command }),
+        Commands::PortfolioSnapshot { command } => Ok(SimpleCommand::PortfolioSnapshot { command }),
         Commands::FailUsdcTransfer { id, reason } => {
             Ok(SimpleCommand::FailUsdcTransfer { id, reason })
         }
@@ -1544,6 +1596,9 @@ async fn run_simple_command<W: Write>(
         SimpleCommand::Position { command } => {
             run_position_command(stdout, pool, command, ctx.execution_threshold).await
         }
+        SimpleCommand::PortfolioSnapshot { command } => {
+            repair::set_portfolio_snapshot_mark_command(stdout, pool, command).await
+        }
         SimpleCommand::FailTransfer {
             transfer_type,
             id,
@@ -1681,6 +1736,27 @@ async fn rebuild_view<W: Write>(
             writeln!(
                 stdout,
                 "Rebuilt lifecycle-failure read model ({replayed} events replayed)"
+            )?;
+        }
+        AggregateView::PortfolioSnapshot => {
+            if id.is_some() {
+                anyhow::bail!(
+                    "portfolio-snapshot rebuild replays the whole read model; pass --all, not --id"
+                );
+            }
+
+            if !all {
+                anyhow::bail!(
+                    "portfolio-snapshot rebuild replays the whole read model; pass --all"
+                );
+            }
+
+            let replayed = PortfolioSnapshotProjection::new(pool.clone())
+                .rebuild_all()
+                .await?;
+            writeln!(
+                stdout,
+                "Rebuilt portfolio-snapshot read model ({replayed} events replayed)"
             )?;
         }
     }
@@ -2293,6 +2369,62 @@ mod tests {
             error.to_string().contains("must not be blank"),
             "unexpected error: {error}",
         );
+    }
+
+    #[test]
+    fn portfolio_snapshot_set_rejects_nonpositive_mark_and_blank_provenance() {
+        for (flag, value) in [("--usd-mark", "0"), ("--source", "   "), ("--reason", "")] {
+            let mut args = vec![
+                "st0x-cli",
+                "portfolio-snapshot",
+                "set",
+                "--day",
+                "2026-07-20",
+                "--symbol",
+                "AAPL",
+                "--usd-mark",
+                "150",
+                "--observed-at",
+                "2026-07-17T20:00:00Z",
+                "--source",
+                "Nasdaq historical close",
+                "--reason",
+                "repair missing mark",
+            ];
+            let value_index = args.iter().position(|arg| *arg == flag).unwrap() + 1;
+            args[value_index] = value;
+            let error = Cli::try_parse_from(args).unwrap_err();
+            assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        }
+    }
+
+    #[test]
+    fn portfolio_snapshot_set_parses_audited_historical_mark() {
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "portfolio-snapshot",
+            "set",
+            "--day",
+            "2026-07-20",
+            "--symbol",
+            "AAPL",
+            "--usd-mark",
+            "150.25",
+            "--observed-at",
+            "2026-07-17T20:00:00Z",
+            "--source",
+            "Nasdaq historical close",
+            "--reason",
+            "repair missing mark",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            classify_command(cli.command),
+            Ok(SimpleCommand::PortfolioSnapshot {
+                command: PortfolioSnapshotRecoveryCommand::Set { .. }
+            })
+        ));
     }
 
     #[test]

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -2,22 +2,116 @@
 
 use anyhow::{Context, bail};
 use async_trait::async_trait;
+use chrono::{TimeZone, Utc};
+use chrono_tz::America::New_York;
 use rain_math_float::Float;
 use sqlx::SqlitePool;
 use std::io::Write;
 use std::sync::Arc;
 
 use st0x_config::ExecutionThreshold;
-use st0x_event_sorcery::{AggregateError, LifecycleError, StoreBuilder};
+use st0x_event_sorcery::{AggregateError, LifecycleError, RetryOnBusy, StoreBuilder, load_entity};
 use st0x_execution::{
     CancellationOutcome, ExecutorOrderId, FractionalShares, LimitOrder, MarketOrder, Symbol,
 };
+use st0x_float_serde::format_float;
 
+use super::PortfolioSnapshotRecoveryCommand;
 use crate::offchain::order::{
     OffchainOrder, OffchainOrderCommand, OffchainOrderError, OffchainOrderId, OrderPlacementResult,
     OrderPlacer,
 };
+use crate::portfolio_snapshot::{
+    PortfolioSnapshot, PortfolioSnapshotCommand, PortfolioSnapshotId, PortfolioSnapshotProjection,
+};
 use crate::position::{Position, PositionCommand};
+
+pub(super) async fn set_portfolio_snapshot_mark_command<W: Write>(
+    stdout: &mut W,
+    pool: &SqlitePool,
+    command: PortfolioSnapshotRecoveryCommand,
+) -> anyhow::Result<()> {
+    let PortfolioSnapshotRecoveryCommand::Set {
+        day,
+        symbol,
+        usd_mark,
+        observed_at,
+        source,
+        reason,
+    } = command;
+
+    let capture_boundary = New_York
+        .from_local_datetime(
+            &day.and_hms_opt(0, 5, 0)
+                .context("invalid ET capture time")?,
+        )
+        .single()
+        .context("ambiguous ET capture boundary")?
+        .with_timezone(&Utc);
+    if observed_at >= capture_boundary {
+        bail!(
+            "--observed-at must identify the regular-session close before the {day} 00:05 ET \
+             capture boundary ({capture_boundary})"
+        );
+    }
+
+    let store = StoreBuilder::<PortfolioSnapshot>::new(pool.clone())
+        .with(Arc::new(RetryOnBusy {
+            inner: PortfolioSnapshotProjection::new(pool.clone()),
+        }))
+        .build(())
+        .await
+        .context("failed to build portfolio snapshot store")?;
+
+    store
+        .send(
+            &PortfolioSnapshotId(day),
+            PortfolioSnapshotCommand::SetEquityMark {
+                symbol: symbol.clone(),
+                usd_mark,
+                observed_at,
+                source: source.clone(),
+                reason: reason.clone(),
+                corrected_at: Utc::now(),
+            },
+        )
+        .await
+        .context("failed to set historical portfolio snapshot mark")?;
+
+    let formatted_mark = format_float(&usd_mark.inner()).context("failed to format USD mark")?;
+    let snapshot = load_entity::<PortfolioSnapshot>(pool, &PortfolioSnapshotId(day))
+        .await
+        .context("failed to reload corrected portfolio snapshot")?
+        .context("corrected portfolio snapshot aggregate is missing")?;
+    let expected_row_count = i64::try_from(snapshot.captured_equity_row_count(&symbol))
+        .context("captured equity row count exceeds SQLite integer range")?;
+    let (row_count, corrected_count): (i64, i64) = sqlx::query_as(
+        "SELECT COUNT(*), COUNT(CASE WHEN usd_mark = ? AND mark_captured_at = ? THEN 1 END) \
+         FROM portfolio_snapshot WHERE et_day = ? AND asset = ?",
+    )
+    .bind(&formatted_mark)
+    .bind(observed_at.to_rfc3339())
+    .bind(day.to_string())
+    .bind(symbol.to_string())
+    .fetch_one(pool)
+    .await
+    .context("failed to verify historical portfolio snapshot mark")?;
+    if row_count != expected_row_count || corrected_count != expected_row_count {
+        bail!(
+            "historical mark event committed, but the portfolio-snapshot read model did not \
+             update every {day} {symbol} row; run `view rebuild --aggregate \
+             portfolio-snapshot --all` before retrying"
+        );
+    }
+
+    writeln!(
+        stdout,
+        "Set {day} {symbol} portfolio mark to ${formatted_mark} observed at {observed_at} from \
+         {source} because \"{reason}\""
+    )?;
+
+    Ok(())
+}
 
 /// An [`OrderPlacer`] for repair commands that must never place or cancel an
 /// order: `MarkFailed` is a pure terminal transition that never touches the
@@ -455,16 +549,137 @@ mod tests {
 
     use st0x_config::ExecutionThreshold;
     use st0x_execution::{ClientOrderId, Direction, ExecutorOrderId, FractionalShares};
-    use st0x_finance::Usd;
+    use st0x_finance::{Positive, Usd};
     use st0x_float_macro::float;
     use uuid::Uuid;
 
     use super::*;
+    use crate::inventory::{PortfolioAsset, PortfolioBalanceRow, PortfolioLocation};
+    use crate::portfolio_snapshot::{PortfolioBalanceRowWithMark, PortfolioSnapshotId};
     use crate::position::TradeId;
     use crate::test_utils::{positive_shares, setup_test_db};
 
     fn repair_order_placer() -> Arc<dyn OrderPlacer> {
         Arc::new(RepairOrderPlacer)
+    }
+
+    async fn seed_missing_portfolio_marks(
+        pool: &SqlitePool,
+        day: chrono::NaiveDate,
+        symbol: &Symbol,
+    ) {
+        let captured_at = Utc.with_ymd_and_hms(2026, 7, 20, 4, 5, 0).unwrap();
+        let rows = [PortfolioLocation::MarketMaking, PortfolioLocation::Hedging]
+            .into_iter()
+            .map(|location| PortfolioBalanceRowWithMark {
+                row: PortfolioBalanceRow {
+                    location,
+                    asset: PortfolioAsset::Equity(symbol.clone()),
+                    available: float!(10),
+                    inflight: float!(0),
+                },
+                usd_mark: None,
+                mark_captured_at: None,
+            })
+            .collect::<Vec<_>>();
+        let store = StoreBuilder::<PortfolioSnapshot>::new(pool.clone())
+            .with(Arc::new(PortfolioSnapshotProjection::new(pool.clone())))
+            .build(())
+            .await
+            .unwrap();
+        store
+            .send(
+                &PortfolioSnapshotId(day),
+                PortfolioSnapshotCommand::Capture { captured_at, rows },
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn portfolio_snapshot_repair_updates_all_symbol_rows_without_touching_position() {
+        let pool = setup_test_db().await;
+        let day = chrono::NaiveDate::from_ymd_opt(2026, 7, 20).unwrap();
+        let symbol = Symbol::new("AAPL").unwrap();
+        seed_missing_portfolio_marks(&pool, day, &symbol).await;
+
+        let mut output = Vec::new();
+        set_portfolio_snapshot_mark_command(
+            &mut output,
+            &pool,
+            PortfolioSnapshotRecoveryCommand::Set {
+                day,
+                symbol: symbol.clone(),
+                usd_mark: Positive::new(float!(150)).unwrap(),
+                observed_at: Utc.with_ymd_and_hms(2026, 7, 17, 20, 0, 0).unwrap(),
+                source: "Nasdaq historical close".to_owned(),
+                reason: "repair missing mark".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let marks: Vec<String> = sqlx::query_scalar(
+            "SELECT usd_mark FROM portfolio_snapshot WHERE et_day = ? AND asset = 'AAPL'",
+        )
+        .bind(day.to_string())
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(marks, vec!["150", "150"]);
+        assert!(
+            st0x_event_sorcery::load_entity::<Position>(&pool, &symbol)
+                .await
+                .unwrap()
+                .is_none(),
+            "historical repair must not create or update live Position state"
+        );
+        let event_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM events WHERE aggregate_type = 'PortfolioSnapshot' \
+             AND aggregate_id = ? AND event_type = 'PortfolioSnapshotEvent::EquityMarkSet'",
+        )
+        .bind(day.to_string())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(event_count, 1);
+    }
+
+    #[tokio::test]
+    async fn portfolio_snapshot_repair_rejects_partial_projection_rows() {
+        let pool = setup_test_db().await;
+        let day = chrono::NaiveDate::from_ymd_opt(2026, 7, 20).unwrap();
+        let symbol = Symbol::new("AAPL").unwrap();
+        seed_missing_portfolio_marks(&pool, day, &symbol).await;
+        sqlx::query(
+            "DELETE FROM portfolio_snapshot WHERE et_day = ? AND asset = ? AND location = ?",
+        )
+        .bind(day.to_string())
+        .bind(symbol.to_string())
+        .bind(PortfolioLocation::Hedging.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let error = set_portfolio_snapshot_mark_command(
+            &mut Vec::new(),
+            &pool,
+            PortfolioSnapshotRecoveryCommand::Set {
+                day,
+                symbol,
+                usd_mark: Positive::new(float!(150)).unwrap(),
+                observed_at: Utc.with_ymd_and_hms(2026, 7, 17, 20, 0, 0).unwrap(),
+                source: "Nasdaq historical close".to_owned(),
+                reason: "repair missing mark".to_owned(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("did not update every"),
+            "unexpected error: {error:#}"
+        );
     }
 
     /// Seeds a standalone OffchainOrder aggregate for `order_id` into the

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -625,6 +625,31 @@ fn optional_rebalancing_ctx(ctx: &Ctx) -> anyhow::Result<Option<RebalancingCtx>>
     }
 }
 
+/// Publishes the recovery handle that backs `/transfers/resume`.
+///
+/// Called only after all startup work (inventory hydration, orphan recovery,
+/// store builds) completes, so the endpoint returns 503 until the conductor is
+/// ready. Both halves exist only when rebalancing is enabled; the tuple match
+/// makes that dual-Some requirement explicit, so the compiler flags any arm
+/// accidentally set without the other. A losing `set` race is ignored: the
+/// cell is written once per boot, so an already-populated cell holds an
+/// equivalent handle.
+fn publish_recovery_handle(
+    recovery_cell: &tokio::sync::OnceCell<crate::api::RecoveryHandle>,
+    transfer: Option<Arc<CrossVenueEquityTransfer>>,
+    rebalancing_service: Option<Arc<RebalancingService>>,
+) {
+    let (Some(transfer), Some(rebalancing_service)) = (transfer, rebalancing_service) else {
+        debug!("Rebalancing disabled: /transfers/resume stays unavailable");
+        return;
+    };
+
+    let _ = recovery_cell.set(crate::api::RecoveryHandle {
+        transfer,
+        rebalancing_service,
+    });
+}
+
 impl Conductor {
     pub(crate) async fn run<E>(
         executor_ctx: impl TryIntoExecutor<Executor = E>,
@@ -685,6 +710,7 @@ impl Conductor {
         catch_up_lifecycle_failures(&pool).await?;
 
         let rebalancing = optional_rebalancing_ctx(&ctx)?;
+        let notifier = build_notifier(ctx.alerts.as_ref())?;
 
         let PositionAndRebalancing {
             position,
@@ -717,6 +743,7 @@ impl Conductor {
                 vault_registry_projection,
                 schedulers: schedulers.clone(),
                 telemetry: telemetry.clone(),
+                notifier: notifier.clone(),
             },
         )
         .await?;
@@ -781,6 +808,7 @@ impl Conductor {
             check_positions_queue,
             portfolio_snapshot_queue,
         } = setup_trading_job_queues(
+            &pool,
             &apalis_pool,
             &job_queue,
             EquityRecoveryInputs {
@@ -822,7 +850,7 @@ impl Conductor {
 
         // Clone before the builder consumes it; the recovery handle needs the
         // rebalancing service to rebuild tracking during recheck recovery.
-        let recovery_rebalancing_service = rebalancing_service.clone();
+        let recovery_service = rebalancing_service.clone();
 
         let (resume_tokenization_queue, resume_tokenization_ctx) = resolve_resume_tokenization(
             resume_tokenization_queue,
@@ -843,6 +871,7 @@ impl Conductor {
             .rejection_queue(rejection_queue)
             .check_positions_queue(check_positions_queue)
             .portfolio_snapshot_queue(portfolio_snapshot_queue)
+            .notifier(notifier)
             .wrapped_equity_recovery_queue(wrapped_equity_recovery_queue)
             .maybe_wrapped_equity_recovery_ctx(wrapped_equity_recovery_ctx)
             .unwrapped_equity_recovery_queue(unwrapped_equity_recovery_queue)
@@ -866,17 +895,7 @@ impl Conductor {
             .telemetry_writer(telemetry_writer)
             .call();
 
-        // Publish the recovery handle only after all startup work
-        // (inventory hydration, orphan recovery, store builds) completes
-        // so /transfers/resume returns 503 until the conductor is ready.
-        if let (Some(transfer), Some(rebalancing_service)) =
-            (recovery_transfer, recovery_rebalancing_service)
-        {
-            let _ = recovery_cell.set(crate::api::RecoveryHandle {
-                transfer,
-                rebalancing_service,
-            });
-        }
+        publish_recovery_handle(&recovery_cell, recovery_transfer, recovery_service);
 
         info!("Conductor is running");
         let result = conductor.wait_for_completion().await;
@@ -1282,6 +1301,7 @@ struct RebalancingDeps {
     vault_registry_projection: Arc<Projection<VaultRegistry>>,
     schedulers: RebalancingSchedulers,
     telemetry: TelemetrySender,
+    notifier: Arc<dyn crate::alerts::Notifier>,
 }
 
 /// Position + rebalancing-adjacent infrastructure produced during conductor
@@ -1338,10 +1358,12 @@ impl PositionAndRebalancing {
         // mode, and the Single-Framework-Instance rule (docs/cqrs.md)
         // forbids building a second Store<PortfolioSnapshot> in either
         // branch below.
+        let portfolio_snapshot_projection = PortfolioSnapshotProjection::new(deps.pool.clone());
+        portfolio_snapshot_projection.rebuild_all().await?;
         let portfolio_snapshot = StoreBuilder::<PortfolioSnapshot>::new(deps.pool.clone())
-            .with(Arc::new(PortfolioSnapshotProjection::new(
-                deps.pool.clone(),
-            )))
+            .with(Arc::new(RetryOnBusy {
+                inner: portfolio_snapshot_projection,
+            }))
             .build(())
             .await?;
 
@@ -1450,7 +1472,7 @@ impl PositionAndRebalancing {
     }
 }
 
-/// Builds the USDC alerting notifier.
+/// Builds the shared operational-alerting notifier.
 ///
 /// Returns `Ok(Arc<NoopNotifier>)` when `[alerts]` is absent — silence is
 /// the correct behaviour for an unconfigured optional channel.
@@ -1460,16 +1482,16 @@ impl PositionAndRebalancing {
 /// an operator who configured `[alerts]` believes alerts are active; silently
 /// falling back to Noop would suppress all redrive-limit and terminal-error
 /// pages with no runtime indication.
-fn build_usdc_notifier(
+fn build_notifier(
     alerts: Option<&st0x_config::AlertsCtx>,
 ) -> Result<Arc<dyn crate::alerts::Notifier>, NotifierError> {
     let Some(alerts) = alerts else {
-        debug!("USDC alerting: [alerts] section absent, using NoopNotifier");
+        debug!("Alerting: [alerts] section absent, using NoopNotifier");
         return Ok(Arc::new(NoopNotifier));
     };
     let notifier =
         TelegramNotifier::new(&alerts.bot_token, alerts.chat_id, alerts.message_thread_id)?;
-    info!("USDC alerting: Telegram notifier configured");
+    info!("Telegram notifier configured");
     Ok(Arc::new(notifier))
 }
 
@@ -1706,7 +1728,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         let transfer_usdc_to_market_making_queue =
             deps.schedulers.transfer_usdc_to_market_making.clone();
 
-        let usdc_notifier = build_usdc_notifier(deps.ctx.alerts.as_ref())?;
+        let notifier = deps.notifier.clone();
 
         let rebalancing_service = Arc::new(RebalancingService::new(
             RebalancingServiceConfig {
@@ -1720,7 +1742,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             deps.inventory.clone(),
             wrapper.clone(),
             deps.schedulers,
-            usdc_notifier.clone(),
+            notifier.clone(),
         ));
 
         wire_freeze_guard(
@@ -1839,7 +1861,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             transfer: usdc_handles.resume_alpaca_to_base,
             job_queue: transfer_usdc_to_market_making_queue,
             max_burn_revert_redrives: rebalancing_ctx.max_burn_revert_redrives,
-            notifier: usdc_notifier.clone(),
+            notifier: notifier.clone(),
         });
 
         let transfer_usdc_to_hedging_ctx = Arc::new(TransferUsdcToHedgingCtx {
@@ -1847,7 +1869,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             timeout: rebalancing_ctx.transfer_attempt_timeout,
             job_queue: transfer_usdc_to_hedging_queue,
             max_burn_revert_redrives: rebalancing_ctx.max_burn_revert_redrives,
-            notifier: usdc_notifier,
+            notifier,
         });
 
         let transfer_equity_to_market_making_ctx = Arc::new(TransferEquityToMarketMakingCtx {
@@ -9109,6 +9131,7 @@ mod tests {
                 vault_registry_projection,
                 schedulers: RebalancingSchedulers::new(&apalis_pool),
                 telemetry: TelemetrySender::disabled(),
+                notifier: Arc::new(NoopNotifier),
             },
         )
         .await
@@ -11395,18 +11418,18 @@ mod tests {
         );
     }
 
-    /// When `[alerts]` is absent, `build_usdc_notifier` returns a `NoopNotifier`
+    /// When `[alerts]` is absent, `build_notifier` returns a `NoopNotifier`
     /// that silently discards notifications without error.
     #[tokio::test]
-    async fn build_usdc_notifier_returns_ok_noop_when_alerts_absent() {
-        let notifier = build_usdc_notifier(None).unwrap();
+    async fn build_notifier_returns_ok_noop_when_alerts_absent() {
+        let notifier = build_notifier(None).unwrap();
         notifier
             .notify("test message")
             .await
             .expect("NoopNotifier must not error on notify");
     }
 
-    /// When `[alerts]` IS present, `build_usdc_notifier` constructs a real
+    /// When `[alerts]` IS present, `build_notifier` constructs a real
     /// Telegram notifier and returns `Ok` -- it must NOT fail startup for a
     /// well-formed config, and it must NOT silently fall back to `NoopNotifier`
     /// (which would suppress every redrive-limit and terminal-error page).
@@ -11418,7 +11441,7 @@ mod tests {
     /// `notify()` is deliberately not exercised: the present-branch notifier posts
     /// to the live Telegram API, which a unit test must never reach.
     #[tokio::test]
-    async fn build_usdc_notifier_returns_ok_telegram_when_alerts_present() {
+    async fn build_notifier_returns_ok_telegram_when_alerts_present() {
         let alerts = st0x_config::AlertsCtx {
             chat_id: 123,
             bot_token: "test-bot-token".to_string(),
@@ -11428,7 +11451,7 @@ mod tests {
             message_thread_id: Some(42),
         };
 
-        build_usdc_notifier(Some(&alerts))
+        build_notifier(Some(&alerts))
             .expect("a well-formed [alerts] config must yield a notifier, not a startup error");
     }
 }

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use task_supervisor::SupervisorBuilder;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use st0x_config::{BrokerCtx, Ctx, ExecutionThreshold};
 use st0x_event_sorcery::{Projection, Store};
@@ -34,7 +34,7 @@ use super::monitor::executor_maintenance::ExecutorMaintenance;
 use super::monitor::gas::{GasMonitor, ProviderBalanceReader};
 use super::monitor::inventory::InventoryMonitor;
 use super::monitor::order_fills::OrderFillMonitor;
-use crate::alerts::TelegramNotifier;
+use crate::alerts::Notifier;
 use crate::dashboard::{
     DashboardTradeDeliveryCtx, DashboardTradeDeliveryJobQueue, DashboardTradeHandoffMonitor,
     DeliverDashboardTrade,
@@ -184,6 +184,7 @@ pub(crate) fn spawn<Prov, Exec>(
     rejection_queue: HandleOrderRejectionJobQueue,
     check_positions_queue: CheckPositionsJobQueue,
     portfolio_snapshot_queue: PortfolioSnapshotJobQueue,
+    notifier: Arc<dyn Notifier>,
     wrapped_equity_recovery_queue: WrappedEquityRecoveryJobQueue,
     wrapped_equity_recovery_ctx: Option<Arc<WrappedEquityRecoveryCtx>>,
     unwrapped_equity_recovery_queue: UnwrappedEquityRecoveryJobQueue,
@@ -294,7 +295,7 @@ where
     // Build the gas monitor before `context.provider` is consumed by the
     // order-fill monitor / accountant below. `None` when `[alerts]` is
     // unconfigured -- the monitor is then simply not spawned.
-    let gas_monitor = build_gas_monitor(&context.ctx, context.provider.clone());
+    let gas_monitor = build_gas_monitor(&context.ctx, context.provider.clone(), notifier.clone());
 
     let poll_interval = context.ctx.order_polling_interval();
     info!("Constructing order-job context with poll interval: {poll_interval:?}");
@@ -366,6 +367,7 @@ where
         usdc_tracking_enabled: context.ctx.assets.cash.is_some(),
         wallet_polling_enabled,
         poll_freshness,
+        notifier,
         queue: portfolio_snapshot_queue.clone(),
     });
 
@@ -929,28 +931,19 @@ where
 /// when alerting is unconfigured. The monitor watches the order-owner wallet
 /// on the orderbook chain (Base in production), which is the same provider the
 /// conductor already uses for fill polling and contract reads.
-fn build_gas_monitor<Prov>(ctx: &Ctx, provider: Prov) -> Option<GasMonitor>
+fn build_gas_monitor<Prov>(
+    ctx: &Ctx,
+    provider: Prov,
+    notifier: Arc<dyn Notifier>,
+) -> Option<GasMonitor>
 where
     Prov: Provider + Send + Sync + 'static,
 {
     let alerts = ctx.alerts.as_ref()?;
 
-    let notifier =
-        match TelegramNotifier::new(&alerts.bot_token, alerts.chat_id, alerts.message_thread_id) {
-            Ok(notifier) => notifier,
-            Err(error) => {
-                error!(
-                    target: "gas",
-                    ?error,
-                    "Failed to build Telegram notifier; gas monitor will not be started"
-                );
-                return None;
-            }
-        };
-
     Some(GasMonitor {
         balance_reader: Arc::new(ProviderBalanceReader::new(provider)),
-        notifier: Arc::new(notifier),
+        notifier,
         wallet: ctx.order_owner(),
         chain: "base",
         threshold_wei: alerts.low_balance_threshold_wei,

--- a/src/conductor/trading_queues.rs
+++ b/src/conductor/trading_queues.rs
@@ -72,6 +72,7 @@ pub(super) struct TradingJobQueues {
 /// Called once during conductor startup, before the apalis monitor spawns, so
 /// every `Running` row is orphaned by definition.
 pub(super) async fn setup_trading_job_queues(
+    cqrs_pool: &sqlx::SqlitePool,
     apalis_pool: &apalis_sqlite::SqlitePool,
     job_queue: &DexTradeAccountingJobQueue,
     equity_recovery: EquityRecoveryInputs,
@@ -147,7 +148,8 @@ pub(super) async fn setup_trading_job_queues(
     bootstrap_check_positions(apalis_pool, &check_positions_queue).await?;
 
     let portfolio_snapshot_queue = PortfolioSnapshotJobQueue::new(apalis_pool);
-    bootstrap_portfolio_snapshot_best_effort(apalis_pool, &portfolio_snapshot_queue).await;
+    bootstrap_portfolio_snapshot_best_effort(cqrs_pool, apalis_pool, &portfolio_snapshot_queue)
+        .await;
 
     Ok(TradingJobQueues {
         hedge_queue,
@@ -167,10 +169,11 @@ pub(super) async fn setup_trading_job_queues(
 /// startup depend on it. Persistent failures remain observable in logs and on
 /// the next restart attempt.
 async fn bootstrap_portfolio_snapshot_best_effort(
+    cqrs_pool: &sqlx::SqlitePool,
     apalis_pool: &apalis_sqlite::SqlitePool,
     queue: &PortfolioSnapshotJobQueue,
 ) {
-    if let Err(error) = bootstrap_portfolio_snapshot(apalis_pool, queue).await {
+    if let Err(error) = bootstrap_portfolio_snapshot(cqrs_pool, apalis_pool, queue).await {
         warn!(
             ?error,
             "Failed to bootstrap portfolio snapshot reporting; continuing trading startup"
@@ -185,12 +188,13 @@ mod tests {
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn portfolio_snapshot_bootstrap_failure_does_not_fail_startup() {
+        let cqrs_pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
         let apalis_pool = apalis_sqlite::SqlitePool::connect(":memory:")
             .await
             .unwrap();
         let queue = PortfolioSnapshotJobQueue::new(&apalis_pool);
 
-        bootstrap_portfolio_snapshot_best_effort(&apalis_pool, &queue).await;
+        bootstrap_portfolio_snapshot_best_effort(&cqrs_pool, &apalis_pool, &queue).await;
 
         assert!(logs_contain(
             "Failed to bootstrap portfolio snapshot reporting; continuing trading startup"

--- a/src/dashboard/pnl/builder.rs
+++ b/src/dashboard/pnl/builder.rs
@@ -1,5 +1,6 @@
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
+use chrono::NaiveDate;
 use num_decimal::Num;
 
 use st0x_execution::alpaca_broker_api::AccountActivity;
@@ -23,7 +24,7 @@ use super::replay::{
 use super::response::{PnlCapitalSummary, PnlCostEntry, PnlResponse};
 use super::samples::{build_available_range, build_sample_stats, parse_position_view};
 use super::sessions::{
-    date_key, matches_cost_date_filter, matches_cost_symbol_filter, matches_date_filter,
+    date_key, et_day_key, matches_cost_date_filter, matches_cost_symbol_filter, matches_date_filter,
 };
 use super::state::{CostEventRow, PositionEventRow, PositionViewRow, SummaryAcc, SymbolBook};
 use super::windows::build_windows;
@@ -80,11 +81,8 @@ fn remove_tokenization_fee_overlaps(
         .collect()
 }
 
-/// Builds the `/pnl` response from already-loaded rows. Returns the DTO
-/// alongside the internal numeric net realized PnL total for the queried
-/// range. Callers needing that total for the capital/return-on-capital
-/// computation read it from here rather than re-parsing
-/// `PnlResponse.summary.net_realized_pnl_usd`'s formatted string.
+/// Builds the `/pnl` response from already-loaded rows and returns net realized
+/// PnL bucketed by ET accounting day for the aligned capital calculation.
 pub(crate) fn build_pnl_response_from_rows(
     event_rows: Vec<PositionEventRow>,
     position_rows: &[PositionViewRow],
@@ -93,7 +91,7 @@ pub(crate) fn build_pnl_response_from_rows(
     query: &PnlQuery,
     symbols: &BTreeSet<String>,
     mut warnings: Vec<String>,
-) -> Result<(PnlResponse, Num), PnlError> {
+) -> Result<(PnlResponse, BTreeMap<NaiveDate, Num>), PnlError> {
     let event_rows = if symbols.is_empty() {
         event_rows
     } else {
@@ -227,9 +225,29 @@ pub(crate) fn build_pnl_response_from_rows(
         &filtered_cost_entries,
         cost_replay.missing_cost_observation_count,
     );
+    let mut daily_net_realized_pnl_usd = BTreeMap::<NaiveDate, Num>::new();
+    for entry in &filtered_entries {
+        let day = et_day_key(&entry.closed_at).ok_or_else(|| PnlError::InvalidDate {
+            field: "closedAt",
+            value: entry.closed_at.clone(),
+        })?;
+        *daily_net_realized_pnl_usd.entry(day).or_default() += &entry.realized_pnl_usd;
+    }
+    for entry in &filtered_cost_entries {
+        let amount = match entry.effect {
+            AccountingEffect::Cost => -entry.amount_usd.clone(),
+            AccountingEffect::Revenue => entry.amount_usd.clone(),
+            AccountingEffect::None => Num::default(),
+        };
+        let day = et_day_key(&entry.occurred_at).ok_or_else(|| PnlError::InvalidDate {
+            field: "occurredAt",
+            value: entry.occurred_at.clone(),
+        })?;
+        *daily_net_realized_pnl_usd.entry(day).or_default() += amount;
+    }
     let filtered = summary_from_entries(&filtered_entries);
     let replay_summary = summary_to_dto(&full_total);
-    let (summary, net_realized_pnl_usd) = with_costs(
+    let (summary, _net_realized_pnl_usd) = with_costs(
         with_replay_exposure(filtered.summary, replay_summary),
         &cost_summary,
     )?;
@@ -269,6 +287,6 @@ pub(crate) fn build_pnl_response_from_rows(
             has_more: end < total,
             windows,
         },
-        net_realized_pnl_usd,
+        daily_net_realized_pnl_usd,
     ))
 }

--- a/src/dashboard/pnl/response.rs
+++ b/src/dashboard/pnl/response.rs
@@ -81,6 +81,18 @@ pub(crate) struct PnlCapitalSummary {
     pub(crate) sample_days: usize,
     pub(crate) first_snapshot_day: Option<String>,
     pub(crate) last_snapshot_day: Option<String>,
+    pub(crate) excluded_days: Vec<PnlCapitalExcludedDay>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PnlCapitalExcludedDay {
+    pub(crate) et_day: String,
+    /// Stable discriminant ("missingSnapshot" | "missingMark" | "staleMark")
+    /// so consumers can group or badge exclusions without parsing the prose
+    /// `reason`.
+    pub(crate) kind: &'static str,
+    pub(crate) reason: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/dashboard/pnl/sessions.rs
+++ b/src/dashboard/pnl/sessions.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use chrono::{Datelike, Timelike, Weekday};
+use chrono::{Datelike, NaiveDate, Timelike, Weekday};
 use chrono_tz::America::New_York;
 
 use super::costs::CostEntryInternal;
@@ -30,10 +30,22 @@ impl MarketSession {
 }
 
 pub(crate) fn date_key(iso: &str) -> String {
-    parse_timestamp(iso).map_or_else(
+    et_day_key(iso).map_or_else(
         || iso.get(..10).unwrap_or(iso).to_owned(),
-        |parsed| parsed.with_timezone(&New_York).date_naive().to_string(),
+        |day| day.to_string(),
     )
+}
+
+/// The ET accounting day of an ISO timestamp, as a typed date. Date-only
+/// values (e.g. Alpaca account activities stamped `2026-05-15`) are taken as
+/// already naming their accounting day. `None` when the value is neither --
+/// callers joining on accounting days must treat that as an error rather
+/// than falling back to a prefix of the raw string (see [`date_key`] for the
+/// display-oriented fallback).
+pub(crate) fn et_day_key(iso: &str) -> Option<NaiveDate> {
+    parse_timestamp(iso)
+        .map(|parsed| parsed.with_timezone(&New_York).date_naive())
+        .or_else(|| NaiveDate::parse_from_str(iso, "%Y-%m-%d").ok())
 }
 
 pub(crate) fn market_session_for_iso(iso: &str) -> MarketSession {

--- a/src/dashboard/pnl/source.rs
+++ b/src/dashboard/pnl/source.rs
@@ -1,12 +1,14 @@
 //! SQLite and broker-backed source loading for backend PnL reports.
+use chrono::{DateTime, Days, NaiveDate, NaiveTime, Utc};
+use chrono_tz::America::New_York;
 use rain_math_float::Float;
 use sqlx::{QueryBuilder, Sqlite, SqlitePool, Transaction};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use st0x_execution::alpaca_broker_api::AccountActivity;
 use st0x_float_serde::format_float;
 
-use crate::portfolio_snapshot::{capital_summary, load_portfolio_days};
+use crate::portfolio_snapshot::{CAPTURE_BUFFER, EtDayRange, capital_summary, load_portfolio_days};
 
 use super::builder::build_pnl_response_from_rows;
 use super::parsing::{fmt_decimal, parse_payload_string};
@@ -22,6 +24,7 @@ pub(crate) async fn build_pnl_report(
     pool: &SqlitePool,
     query: &PnlQuery,
     alpaca_activities: Vec<AccountActivity>,
+    now: DateTime<Utc>,
 ) -> Result<PnlResponse, PnlError> {
     let mut warnings = vec![
         ATTRIBUTION_WARNING.to_owned(),
@@ -41,7 +44,7 @@ pub(crate) async fn build_pnl_report(
     let cost_rows = load_cost_events(&mut tx, resolved_rowid.resolved).await?;
     tx.commit().await?;
 
-    let (mut response, net_realized_pnl_usd) = build_pnl_response_from_rows(
+    let (mut response, daily_net_realized_pnl_usd) = build_pnl_response_from_rows(
         event_rows,
         &position_rows,
         &cost_rows,
@@ -56,8 +59,9 @@ pub(crate) async fn build_pnl_report(
         query,
         &resolved_rowid,
         &symbols,
-        &fmt_decimal(&net_realized_pnl_usd),
+        &daily_net_realized_pnl_usd,
         &mut response,
+        now,
     )
     .await?;
 
@@ -79,8 +83,9 @@ async fn apply_capital_summary(
     query: &PnlQuery,
     resolved_rowid: &ResolvedRowid,
     symbols: &BTreeSet<String>,
-    net_realized_pnl_usd_decimal: &str,
+    daily_net_realized_pnl_usd: &BTreeMap<NaiveDate, num_decimal::Num>,
     response: &mut PnlResponse,
+    now: DateTime<Utc>,
 ) -> Result<(), PnlError> {
     if resolved_rowid.resolved != resolved_rowid.max {
         response.warnings.push(format!(
@@ -104,10 +109,19 @@ async fn apply_capital_summary(
         return Ok(());
     }
 
-    let et_day_range = query.et_day_range()?;
+    let et_day_range = complete_capital_range(
+        pool,
+        query.et_day_range()?,
+        daily_net_realized_pnl_usd,
+        latest_capture_day(now)?,
+    )
+    .await?;
     let days = load_portfolio_days(pool, et_day_range).await?;
-    let net_realized_pnl_usd = Float::parse(net_realized_pnl_usd_decimal.to_owned())?;
-    let capital = capital_summary(&days, net_realized_pnl_usd, et_day_range)?;
+    let daily_net_realized_pnl_usd = daily_net_realized_pnl_usd
+        .iter()
+        .map(|(day, pnl)| Ok((*day, Float::parse(fmt_decimal(pnl))?)))
+        .collect::<Result<BTreeMap<_, _>, PnlError>>()?;
+    let capital = capital_summary(&days, &daily_net_realized_pnl_usd)?;
 
     response.warnings.extend(capital.warnings);
     response.warnings.push(
@@ -134,9 +148,61 @@ async fn apply_capital_summary(
         sample_days: capital.sample_days,
         first_snapshot_day: capital.first_snapshot_day.map(|day| day.to_string()),
         last_snapshot_day: capital.last_snapshot_day.map(|day| day.to_string()),
+        excluded_days: capital
+            .excluded_days
+            .into_iter()
+            .map(|day| super::response::PnlCapitalExcludedDay {
+                et_day: day.et_day.to_string(),
+                kind: day.reason.kind(),
+                reason: day.reason.describe(),
+            })
+            .collect(),
     };
 
     Ok(())
+}
+
+pub(crate) fn latest_capture_day(now: DateTime<Utc>) -> Result<NaiveDate, PnlError> {
+    let now_et = now.with_timezone(&New_York);
+    let day = now_et.date_naive();
+    if now_et.time() < NaiveTime::MIN + CAPTURE_BUFFER {
+        day.checked_sub_days(Days::new(1))
+            .ok_or_else(|| PnlError::InvalidDate {
+                field: "reportThrough",
+                value: day.to_string(),
+            })
+    } else {
+        Ok(day)
+    }
+}
+
+async fn complete_capital_range(
+    pool: &SqlitePool,
+    mut range: EtDayRange,
+    daily_net_realized_pnl_usd: &BTreeMap<NaiveDate, num_decimal::Num>,
+    report_through: NaiveDate,
+) -> Result<EtDayRange, PnlError> {
+    if range.from.is_none() {
+        let first_snapshot: Option<String> =
+            sqlx::query_scalar("SELECT MIN(et_day) FROM portfolio_snapshot")
+                .fetch_one(pool)
+                .await?;
+        let first_snapshot = first_snapshot
+            .map(|day| {
+                NaiveDate::parse_from_str(&day, "%Y-%m-%d").map_err(|_| PnlError::InvalidDate {
+                    field: "portfolioSnapshotDay",
+                    value: day,
+                })
+            })
+            .transpose()?;
+        let first_pnl = daily_net_realized_pnl_usd.keys().next().copied();
+        range.from = first_snapshot.into_iter().chain(first_pnl).min();
+    }
+    if range.to.is_none() {
+        range.to = Some(report_through);
+    }
+
+    Ok(range)
 }
 
 pub(crate) async fn validate_pnl_snapshot_rowid(

--- a/src/dashboard/pnl/tests.rs
+++ b/src/dashboard/pnl/tests.rs
@@ -590,7 +590,7 @@ fn report_with_result(
             COST_WARNING.to_owned(),
         ],
     )
-    .map(|(response, _net_realized_pnl_usd)| response)
+    .map(|(response, _daily_net_realized_pnl_usd)| response)
 }
 
 async fn pnl_test_pool(
@@ -699,7 +699,7 @@ fn report_result(events: Vec<PositionEventRow>) -> Result<PnlResponse, PnlError>
             COST_WARNING.to_owned(),
         ],
     )
-    .map(|(response, _net_realized_pnl_usd)| response)
+    .map(|(response, _daily_net_realized_pnl_usd)| response)
 }
 
 fn report(events: Vec<PositionEventRow>) -> PnlResponse {
@@ -957,7 +957,9 @@ async fn source_loader_includes_manual_position_adjustments() {
     )
     .await;
 
-    let report = build_pnl_report(&pool, &query(), Vec::new()).await.unwrap();
+    let report = build_pnl_report(&pool, &query(), Vec::new(), Utc::now())
+        .await
+        .unwrap();
 
     assert_eq!(report.summary.gross_realized_pnl_usd, "0");
     assert_eq!(report.summary.open_long_shares, "1");
@@ -976,7 +978,7 @@ async fn source_loader_rejects_malformed_persisted_payload_text() {
     .await
     .unwrap();
 
-    let error = build_pnl_report(&pool, &query(), Vec::new())
+    let error = build_pnl_report(&pool, &query(), Vec::new(), Utc::now())
         .await
         .unwrap_err();
 
@@ -1003,7 +1005,9 @@ async fn source_loader_includes_persisted_cost_events() {
     )
     .await;
 
-    let report = build_pnl_report(&pool, &query(), Vec::new()).await.unwrap();
+    let report = build_pnl_report(&pool, &query(), Vec::new(), Utc::now())
+        .await
+        .unwrap();
 
     assert_eq!(report.summary.tracked_costs_usd, "0.25");
     assert_eq!(report.costs.tokenization_fees_usd, "0.25");
@@ -1035,6 +1039,7 @@ async fn source_loader_respects_as_of_rowid_for_position_and_cost_events() {
             ..query()
         },
         Vec::new(),
+        Utc::now(),
     )
     .await
     .unwrap();
@@ -1061,6 +1066,7 @@ async fn source_loader_rejects_future_as_of_rowid() {
             ..query()
         },
         Vec::new(),
+        Utc::now(),
     )
     .await
     .unwrap_err();
@@ -2566,7 +2572,9 @@ async fn build_pnl_report_populates_capital_when_snapshots_exist() {
     )
     .await;
 
-    let report = build_pnl_report(&pool, &query(), Vec::new()).await.unwrap();
+    let report = build_pnl_report(&pool, &query(), Vec::new(), Utc::now())
+        .await
+        .unwrap();
 
     assert_eq!(
         report.capital.average_deployed_capital_usd,
@@ -2589,10 +2597,130 @@ async fn build_pnl_report_populates_capital_when_snapshots_exist() {
 }
 
 #[tokio::test]
+async fn return_uses_only_pnl_from_days_with_usable_capital() {
+    let pool = pnl_test_pool(
+        vec![
+            onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
+            offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
+            onchain_sell(3, "110", "2026-05-16T14:00:00Z"),
+            offchain_buy(4, "2026-05-16T14:01:00Z", "10", "1"),
+            onchain_sell(5, "10", "2026-05-17T14:00:00Z"),
+            offchain_buy(6, "2026-05-17T14:01:00Z", "8", "1"),
+        ],
+        position_rows(),
+    )
+    .await;
+    for et_day in ["2026-05-15", "2026-05-17"] {
+        insert_portfolio_snapshot_row(
+            &pool,
+            et_day,
+            "market_making",
+            "USDC",
+            "1000",
+            Some("1"),
+            Some("2026-05-15T04:05:00+00:00"),
+        )
+        .await;
+    }
+    insert_portfolio_snapshot_row(
+        &pool,
+        "2026-05-16",
+        "market_making",
+        "AAPL",
+        "10",
+        None,
+        None,
+    )
+    .await;
+
+    let report = build_pnl_report(
+        &pool,
+        &PnlQuery {
+            from_date: Some("2026-05-15".to_owned()),
+            to_date: Some("2026-05-17".to_owned()),
+            ..query()
+        },
+        Vec::new(),
+        Utc::now(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(report.summary.net_realized_pnl_usd, "104");
+    assert_eq!(report.capital.annualized_return_pct.as_deref(), Some("73"));
+    assert_eq!(report.capital.excluded_days.len(), 1);
+    assert_eq!(report.capital.excluded_days[0].et_day, "2026-05-16");
+}
+
+#[tokio::test]
+async fn return_excludes_signed_cost_effects_from_days_without_usable_capital() {
+    let pool = pnl_test_pool_with_costs(
+        Vec::new(),
+        position_rows(),
+        vec![
+            tokenized_mint_requested(1, "mint-excluded-day", "RKLB"),
+            tokenized_tokens_received(2, "mint-excluded-day", "100", "2026-05-16T14:02:00Z"),
+        ],
+    )
+    .await;
+    for et_day in ["2026-05-15", "2026-05-17"] {
+        insert_portfolio_snapshot_row(
+            &pool,
+            et_day,
+            "market_making",
+            "USDC",
+            "1000",
+            Some("1"),
+            Some("2026-05-15T04:05:00+00:00"),
+        )
+        .await;
+    }
+    insert_portfolio_snapshot_row(
+        &pool,
+        "2026-05-16",
+        "market_making",
+        "AAPL",
+        "10",
+        None,
+        None,
+    )
+    .await;
+
+    let report = build_pnl_report(
+        &pool,
+        &PnlQuery {
+            from_date: Some("2026-05-15".to_owned()),
+            to_date: Some("2026-05-17".to_owned()),
+            ..query()
+        },
+        vec![account_activity(
+            "usable-day-revenue",
+            "FEE",
+            "2",
+            None,
+            "2026-05-15T14:02:00Z",
+        )],
+        Utc::now(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(report.summary.net_realized_pnl_usd, "-98");
+    assert_eq!(
+        report.capital.annualized_return_pct.as_deref(),
+        Some("36.5")
+    );
+    assert_eq!(report.capital.excluded_days.len(), 1);
+    assert_eq!(report.capital.excluded_days[0].et_day, "2026-05-16");
+}
+
+#[tokio::test]
 async fn build_pnl_report_omits_capital_with_warning_when_no_snapshots_exist() {
     let pool = pnl_test_pool(Vec::new(), position_rows()).await;
 
-    let report = build_pnl_report(&pool, &query(), Vec::new()).await.unwrap();
+    let report = build_pnl_report(&pool, &query(), Vec::new(), Utc::now())
+        .await
+        .unwrap();
 
     assert_eq!(report.capital.average_deployed_capital_usd, None);
     assert_eq!(report.capital.annualized_return_pct, None);
@@ -2604,6 +2732,43 @@ async fn build_pnl_report_omits_capital_with_warning_when_no_snapshots_exist() {
     );
     assert!(!report.warnings.contains(&CAPITAL_AVAILABLE_NOTE.to_owned()));
     assert!(report.warnings.contains(&BASELINE_WARNING.to_owned()));
+}
+
+#[tokio::test]
+async fn from_only_range_exposes_missing_day_after_last_snapshot() {
+    let pool = pnl_test_pool(Vec::new(), position_rows()).await;
+    // One second past the 00:05 ET capture boundary: the instant is pinned
+    // (and shared with the report call below) so the derived day is stable
+    // no matter when the test runs.
+    let now = Utc.with_ymd_and_hms(2026, 5, 23, 4, 5, 1).single().unwrap();
+    let report_through = super::source::latest_capture_day(now).unwrap();
+
+    let report = build_pnl_report(
+        &pool,
+        &PnlQuery {
+            from_date: Some(report_through.to_string()),
+            to_date: None,
+            ..query()
+        },
+        Vec::new(),
+        now,
+    )
+    .await
+    .unwrap();
+
+    let excluded = report
+        .capital
+        .excluded_days
+        .iter()
+        .find(|day| day.et_day == report_through.to_string())
+        .unwrap_or_else(|| {
+            panic!(
+                "the explicit fromDate must be represented even across the capture boundary: {:?}",
+                report.capital.excluded_days
+            )
+        });
+    assert_eq!(excluded.kind, "missingSnapshot");
+    assert_eq!(excluded.reason, "no portfolio snapshot was captured");
 }
 
 #[tokio::test]
@@ -2627,6 +2792,7 @@ async fn build_pnl_report_symbol_filtered_query_omits_capital_with_warning() {
             ..query()
         },
         Vec::new(),
+        Utc::now(),
     )
     .await
     .unwrap();
@@ -2668,6 +2834,7 @@ async fn build_pnl_report_empty_symbol_param_preserves_capital() {
             ..query()
         },
         Vec::new(),
+        Utc::now(),
     )
     .await
     .unwrap();
@@ -2711,6 +2878,7 @@ async fn build_pnl_report_as_of_rowid_non_current_omits_capital_with_warning() {
             ..query()
         },
         Vec::new(),
+        Utc::now(),
     )
     .await
     .unwrap();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -50,6 +50,10 @@ pub(crate) fn setup() -> Result<PrometheusHandle, BuildError> {
         "Inventory OperatorDeposit/OperatorWithdraw legs with no same-tx counterpart in the \
          batch, by leg"
     );
+    metrics::describe_counter!(
+        "portfolio_snapshot_unusable_mark_total",
+        "Nonzero equity balances captured with a missing or stale USD mark, by symbol and reason"
+    );
 
     let _ = HANDLE.set(handle.clone());
     Ok(handle)

--- a/src/portfolio_snapshot/mod.rs
+++ b/src/portfolio_snapshot/mod.rs
@@ -9,10 +9,11 @@
 //! `Live` routes it through [`EventSourced::transition`], which unconditionally
 //! rejects with [`PortfolioSnapshotError::AlreadyCaptured`] and emits no
 //! event. This makes per-day idempotency a property of the framework's
-//! lifecycle routing, not a `SELECT EXISTS` precheck.
+//! lifecycle routing, not a `SELECT EXISTS` precheck. A live aggregate also
+//! accepts audited `SetEquityMark` corrections for equities captured that day.
 //!
-//! `Captured` events are retained forever (no `COMPACTION_POLICY` override):
-//! one event per ET day is a financial-audit record, not an observational
+//! Snapshot events are retained forever (no `COMPACTION_POLICY` override):
+//! captures and operator corrections are financial-audit records, not observational
 //! stream eligible for compaction, and the storage volume is negligible.
 //! `type Materialized = Nil` -- the aggregate's own state only distinguishes
 //! `initialize` from `transition` routing; the queryable balances live in the
@@ -25,6 +26,7 @@
 //! `Captured` events). The [`read`] module computes the capital and return
 //! figures exposed by `/pnl` from that read model.
 
+use std::collections::HashSet;
 use std::fmt;
 use std::str::FromStr;
 
@@ -36,6 +38,7 @@ use thiserror::Error;
 use tracing::info;
 
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
+use st0x_finance::{Positive, Symbol};
 
 use crate::inventory::PortfolioBalanceRow;
 use crate::position::option_float_eq;
@@ -47,7 +50,7 @@ pub(crate) mod write;
 pub(crate) use projection::PortfolioSnapshotProjection;
 pub(crate) use read::{EtDayRange, ReadError, capital_summary, load_portfolio_days};
 pub(crate) use write::{
-    PortfolioSnapshotCtx, PortfolioSnapshotJob, PortfolioSnapshotJobQueue,
+    CAPTURE_BUFFER, PortfolioSnapshotCtx, PortfolioSnapshotJob, PortfolioSnapshotJobQueue,
     bootstrap_portfolio_snapshot,
 };
 // Only consumed by api.rs's `#[cfg(test)]` DST-boundary /pnl test, which
@@ -95,9 +98,8 @@ impl FromStr for PortfolioSnapshotId {
 /// A [`PortfolioBalanceRow`] with the USD mark resolved at capture time.
 /// Composes rather than duplicates `PortfolioBalanceRow`'s fields, so a field
 /// added there is inherited here automatically instead of needing to be
-/// mirrored by hand. Marks are fixed permanently once captured: because the
-/// aggregate's event is retained and immutable, a later price correction
-/// never retroactively changes a previously reported day's capital.
+/// mirrored by hand. The captured value remains immutable in its event; an
+/// audited correction is a later event whose projection value supersedes it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct PortfolioBalanceRowWithMark {
     #[serde(flatten)]
@@ -116,20 +118,105 @@ impl PartialEq for PortfolioBalanceRowWithMark {
     }
 }
 
-/// Domain events for [`PortfolioSnapshot`]. `Captured` is the only variant:
-/// one per ET day, retained forever.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// Domain events for [`PortfolioSnapshot`], retained forever.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum PortfolioSnapshotEvent {
     Captured {
         captured_at: DateTime<Utc>,
         rows: Vec<PortfolioBalanceRowWithMark>,
     },
+    EquityMarkSet {
+        symbol: Symbol,
+        usd_mark: Positive<Float>,
+        observed_at: DateTime<Utc>,
+        source: String,
+        reason: String,
+        corrected_at: DateTime<Utc>,
+    },
+    UnusableMarkAlerted {
+        symbol: Symbol,
+        alerted_at: DateTime<Utc>,
+    },
+    UnusableMarkDetected {
+        symbol: Symbol,
+        detected_at: DateTime<Utc>,
+    },
+}
+
+impl PartialEq for PortfolioSnapshotEvent {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                Self::Captured {
+                    captured_at: left_at,
+                    rows: left_rows,
+                },
+                Self::Captured {
+                    captured_at: right_at,
+                    rows: right_rows,
+                },
+            ) => left_at == right_at && left_rows == right_rows,
+            (
+                Self::EquityMarkSet {
+                    symbol: left_symbol,
+                    usd_mark: left_mark,
+                    observed_at: left_observed,
+                    source: left_source,
+                    reason: left_reason,
+                    corrected_at: left_corrected,
+                },
+                Self::EquityMarkSet {
+                    symbol: right_symbol,
+                    usd_mark: right_mark,
+                    observed_at: right_observed,
+                    source: right_source,
+                    reason: right_reason,
+                    corrected_at: right_corrected,
+                },
+            ) => {
+                left_symbol == right_symbol
+                    && left_mark.inner().eq(right_mark.inner()).unwrap_or(false)
+                    && left_observed == right_observed
+                    && left_source == right_source
+                    && left_reason == right_reason
+                    && left_corrected == right_corrected
+            }
+            (
+                Self::UnusableMarkAlerted {
+                    symbol: left_symbol,
+                    alerted_at: left_at,
+                },
+                Self::UnusableMarkAlerted {
+                    symbol: right_symbol,
+                    alerted_at: right_at,
+                },
+            )
+            | (
+                Self::UnusableMarkDetected {
+                    symbol: left_symbol,
+                    detected_at: left_at,
+                },
+                Self::UnusableMarkDetected {
+                    symbol: right_symbol,
+                    detected_at: right_at,
+                },
+            ) => left_symbol == right_symbol && left_at == right_at,
+            _ => false,
+        }
+    }
 }
 
 impl DomainEvent for PortfolioSnapshotEvent {
     fn event_type(&self) -> String {
         match self {
             Self::Captured { .. } => "PortfolioSnapshotEvent::Captured".to_string(),
+            Self::EquityMarkSet { .. } => "PortfolioSnapshotEvent::EquityMarkSet".to_string(),
+            Self::UnusableMarkAlerted { .. } => {
+                "PortfolioSnapshotEvent::UnusableMarkAlerted".to_string()
+            }
+            Self::UnusableMarkDetected { .. } => {
+                "PortfolioSnapshotEvent::UnusableMarkDetected".to_string()
+            }
         }
     }
 
@@ -145,6 +232,22 @@ pub(crate) enum PortfolioSnapshotCommand {
         captured_at: DateTime<Utc>,
         rows: Vec<PortfolioBalanceRowWithMark>,
     },
+    SetEquityMark {
+        symbol: Symbol,
+        usd_mark: Positive<Float>,
+        observed_at: DateTime<Utc>,
+        source: String,
+        reason: String,
+        corrected_at: DateTime<Utc>,
+    },
+    RecordUnusableMarkAlerted {
+        symbol: Symbol,
+        alerted_at: DateTime<Utc>,
+    },
+    RecordUnusableMarkDetected {
+        symbol: Symbol,
+        detected_at: DateTime<Utc>,
+    },
 }
 
 /// Errors from [`PortfolioSnapshot`] command handling.
@@ -152,17 +255,47 @@ pub(crate) enum PortfolioSnapshotCommand {
 pub(crate) enum PortfolioSnapshotError {
     #[error("portfolio already captured for this day")]
     AlreadyCaptured,
+    #[error("portfolio has not been captured for this day")]
+    NotCaptured,
+    #[error("portfolio snapshot does not contain equity {symbol}")]
+    EquityNotCaptured { symbol: Symbol },
+    #[error("historical price source must not be blank")]
+    BlankSource,
+    #[error("operator reason must not be blank")]
+    BlankReason,
+    #[error("historical mark for {symbol} must be observed before ET day {et_day}")]
+    MarkNotBeforeCaptureDay { symbol: Symbol, et_day: NaiveDate },
+    #[error("historical mark for {symbol} is too stale to make ET day {et_day} usable")]
+    MarkTooStale { symbol: Symbol, et_day: NaiveDate },
 }
 
-/// One instance per ET day. Tracks only enough state to route a `Capture`
-/// command to `initialize` (not yet captured) or `transition` (already
-/// captured, rejected) -- the queryable balances live in the
-/// `portfolio_snapshot` table maintained by [`PortfolioSnapshotProjection`],
-/// not on this aggregate.
+/// One instance per ET day. Alongside capture idempotency it retains original
+/// rows and per-symbol correction/alert state so durable job retries neither
+/// lose nor repeatedly send unusable-mark alerts. Queryable balances still
+/// live in the `portfolio_snapshot` projection.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct PortfolioSnapshot {
     pub(crate) captured_at: DateTime<Utc>,
-    pub(crate) row_count: usize,
+    captured_rows: Vec<PortfolioBalanceRowWithMark>,
+    alerted_symbols: HashSet<Symbol>,
+    detected_symbols: HashSet<Symbol>,
+    corrected_symbols: HashSet<Symbol>,
+}
+
+impl PortfolioSnapshot {
+    pub(crate) fn captured_equity_row_count(&self, symbol: &Symbol) -> usize {
+        self.captured_rows
+            .iter()
+            .filter(|row| match &row.row.asset {
+                crate::inventory::PortfolioAsset::Equity(captured) => captured == symbol,
+                crate::inventory::PortfolioAsset::Usdc => false,
+            })
+            .count()
+    }
+
+    fn has_captured_equity(&self, symbol: &Symbol) -> bool {
+        self.captured_equity_row_count(symbol) > 0
+    }
 }
 
 #[async_trait]
@@ -176,30 +309,47 @@ impl EventSourced for PortfolioSnapshot {
 
     const AGGREGATE_TYPE: &'static str = "PortfolioSnapshot";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 1;
+    const SCHEMA_VERSION: u64 = 2;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         match event {
             PortfolioSnapshotEvent::Captured { captured_at, rows } => Some(Self {
                 captured_at: *captured_at,
-                row_count: rows.len(),
+                captured_rows: rows.clone(),
+                alerted_symbols: HashSet::new(),
+                detected_symbols: HashSet::new(),
+                corrected_symbols: HashSet::new(),
             }),
+            PortfolioSnapshotEvent::EquityMarkSet { .. }
+            | PortfolioSnapshotEvent::UnusableMarkAlerted { .. }
+            | PortfolioSnapshotEvent::UnusableMarkDetected { .. } => None,
         }
     }
 
-    fn evolve(entity: &Self, _event: &Self::Event) -> Result<Option<Self>, Self::Error> {
-        // Defensive, not expected: transition() below unconditionally
-        // rejects a second Capture for an already-Live aggregate, so a Live
-        // instance never actually observes a second Captured event in
-        // normal operation. Total but a no-op if it ever does.
-        Ok(Some(entity.clone()))
+    fn evolve(entity: &Self, event: &Self::Event) -> Result<Option<Self>, Self::Error> {
+        let mut next = entity.clone();
+        match event {
+            PortfolioSnapshotEvent::Captured { .. } => {}
+            PortfolioSnapshotEvent::EquityMarkSet { symbol, .. } => {
+                next.corrected_symbols.insert(symbol.clone());
+            }
+            PortfolioSnapshotEvent::UnusableMarkAlerted { symbol, .. } => {
+                next.alerted_symbols.insert(symbol.clone());
+            }
+            PortfolioSnapshotEvent::UnusableMarkDetected { symbol, .. } => {
+                next.detected_symbols.insert(symbol.clone());
+            }
+        }
+        Ok(Some(next))
     }
 
     async fn initialize(
         command: Self::Command,
         _services: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
-        let PortfolioSnapshotCommand::Capture { captured_at, rows } = command;
+        let PortfolioSnapshotCommand::Capture { captured_at, rows } = command else {
+            return Err(PortfolioSnapshotError::NotCaptured);
+        };
         // Logged here, not by the job that sent the command (AGENTS.md "Log
         // in command handlers, not callers"): this handler has the full
         // command in scope. `target_et_day` is derived from `captured_at`
@@ -213,16 +363,79 @@ impl EventSourced for PortfolioSnapshot {
 
     async fn transition(
         &self,
-        _command: Self::Command,
+        command: Self::Command,
         _services: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         // Expected, not a failure (decision 11): a scheduling bug that fires
         // more than once a day is still visible via this log naming the day
         // that was already captured, just not treated as retryable by the
         // caller (`write.rs`'s `PortfolioSnapshotJob::perform`).
-        let existing_et_day = write::et_day(self.captured_at);
-        info!(%existing_et_day, "Portfolio already captured for this ET day");
-        Err(PortfolioSnapshotError::AlreadyCaptured)
+        match command {
+            PortfolioSnapshotCommand::Capture { .. } => {
+                let existing_et_day = write::et_day(self.captured_at);
+                info!(%existing_et_day, "Portfolio already captured for this ET day");
+                Err(PortfolioSnapshotError::AlreadyCaptured)
+            }
+            PortfolioSnapshotCommand::SetEquityMark {
+                symbol,
+                usd_mark,
+                observed_at,
+                source,
+                reason,
+                corrected_at,
+            } => {
+                if !self.has_captured_equity(&symbol) {
+                    return Err(PortfolioSnapshotError::EquityNotCaptured { symbol });
+                }
+                if source.trim().is_empty() {
+                    return Err(PortfolioSnapshotError::BlankSource);
+                }
+                if reason.trim().is_empty() {
+                    return Err(PortfolioSnapshotError::BlankReason);
+                }
+
+                let et_day = write::et_day(self.captured_at);
+                if write::et_day(observed_at) >= et_day {
+                    return Err(PortfolioSnapshotError::MarkNotBeforeCaptureDay { symbol, et_day });
+                }
+                let asset = crate::inventory::PortfolioAsset::Equity(symbol.clone());
+                if read::is_stale_mark(&asset, observed_at, et_day) {
+                    return Err(PortfolioSnapshotError::MarkTooStale { symbol, et_day });
+                }
+                info!(%et_day, %symbol, ?usd_mark, %observed_at, %source, %reason, %corrected_at, "Portfolio snapshot equity mark set");
+                Ok(vec![PortfolioSnapshotEvent::EquityMarkSet {
+                    symbol,
+                    usd_mark,
+                    observed_at,
+                    source,
+                    reason,
+                    corrected_at,
+                }])
+            }
+            PortfolioSnapshotCommand::RecordUnusableMarkAlerted { symbol, alerted_at } => {
+                if !self.has_captured_equity(&symbol) {
+                    return Err(PortfolioSnapshotError::EquityNotCaptured { symbol });
+                }
+                info!(%symbol, %alerted_at, "Portfolio snapshot unusable-mark alert delivered");
+                Ok(vec![PortfolioSnapshotEvent::UnusableMarkAlerted {
+                    symbol,
+                    alerted_at,
+                }])
+            }
+            PortfolioSnapshotCommand::RecordUnusableMarkDetected {
+                symbol,
+                detected_at,
+            } => {
+                if !self.has_captured_equity(&symbol) {
+                    return Err(PortfolioSnapshotError::EquityNotCaptured { symbol });
+                }
+                info!(%symbol, %detected_at, "Portfolio snapshot unusable mark detected");
+                Ok(vec![PortfolioSnapshotEvent::UnusableMarkDetected {
+                    symbol,
+                    detected_at,
+                }])
+            }
+        }
     }
 }
 
@@ -249,6 +462,19 @@ mod tests {
             },
             usd_mark: Some(float!(1)),
             mark_captured_at: Some(Utc::now()),
+        }
+    }
+
+    fn equity_row(symbol: &str) -> PortfolioBalanceRowWithMark {
+        PortfolioBalanceRowWithMark {
+            row: PortfolioBalanceRow {
+                location: PortfolioLocation::MarketMaking,
+                asset: PortfolioAsset::Equity(Symbol::new(symbol).unwrap()),
+                available: float!(10),
+                inflight: float!(0),
+            },
+            usd_mark: None,
+            mark_captured_at: None,
         }
     }
 
@@ -290,6 +516,100 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn captured_equity_mark_can_be_set_repeatedly_as_append_only_events() {
+        let captured_at = Utc.with_ymd_and_hms(2026, 7, 20, 4, 5, 0).unwrap();
+        let observed_at = Utc.with_ymd_and_hms(2026, 7, 17, 20, 0, 0).unwrap();
+        let corrected_at = Utc.with_ymd_and_hms(2026, 7, 22, 15, 0, 0).unwrap();
+        let symbol = Symbol::new("AAPL").unwrap();
+        let command = |mark| PortfolioSnapshotCommand::SetEquityMark {
+            symbol: symbol.clone(),
+            usd_mark: Positive::new(mark).unwrap(),
+            observed_at,
+            source: "Nasdaq historical close".to_owned(),
+            reason: "repair missing capture mark".to_owned(),
+            corrected_at,
+        };
+
+        let first_event = PortfolioSnapshotEvent::EquityMarkSet {
+            symbol: symbol.clone(),
+            usd_mark: Positive::new(float!(150)).unwrap(),
+            observed_at,
+            source: "Nasdaq historical close".to_owned(),
+            reason: "repair missing capture mark".to_owned(),
+            corrected_at,
+        };
+        TestHarness::<PortfolioSnapshot>::with(())
+            .given(vec![PortfolioSnapshotEvent::Captured {
+                captured_at,
+                rows: vec![equity_row("AAPL")],
+            }])
+            .when(command(float!(150)))
+            .await
+            .then_expect_events(std::slice::from_ref(&first_event));
+
+        TestHarness::<PortfolioSnapshot>::with(())
+            .given(vec![
+                PortfolioSnapshotEvent::Captured {
+                    captured_at,
+                    rows: vec![equity_row("AAPL")],
+                },
+                first_event,
+            ])
+            .when(command(float!(151)))
+            .await
+            .then_expect_events(&[PortfolioSnapshotEvent::EquityMarkSet {
+                symbol,
+                usd_mark: Positive::new(float!(151)).unwrap(),
+                observed_at,
+                source: "Nasdaq historical close".to_owned(),
+                reason: "repair missing capture mark".to_owned(),
+                corrected_at,
+            }]);
+    }
+
+    #[tokio::test]
+    async fn correction_rejects_same_day_or_stale_observation() {
+        let captured_at = Utc.with_ymd_and_hms(2026, 7, 20, 4, 5, 0).unwrap();
+        let symbol = Symbol::new("AAPL").unwrap();
+        let command = |observed_at| PortfolioSnapshotCommand::SetEquityMark {
+            symbol: symbol.clone(),
+            usd_mark: Positive::new(float!(150)).unwrap(),
+            observed_at,
+            source: "Nasdaq historical close".to_owned(),
+            reason: "repair missing capture mark".to_owned(),
+            corrected_at: captured_at + chrono::Duration::days(2),
+        };
+        let given = || {
+            vec![PortfolioSnapshotEvent::Captured {
+                captured_at,
+                rows: vec![equity_row("AAPL")],
+            }]
+        };
+
+        let same_day = TestHarness::<PortfolioSnapshot>::with(())
+            .given(given())
+            .when(command(Utc.with_ymd_and_hms(2026, 7, 20, 4, 1, 0).unwrap()))
+            .await
+            .then_expect_error();
+        assert!(matches!(
+            same_day,
+            LifecycleError::Apply(PortfolioSnapshotError::MarkNotBeforeCaptureDay { .. })
+        ));
+
+        let stale = TestHarness::<PortfolioSnapshot>::with(())
+            .given(given())
+            .when(command(
+                Utc.with_ymd_and_hms(2026, 7, 10, 20, 0, 0).unwrap(),
+            ))
+            .await
+            .then_expect_error();
+        assert!(matches!(
+            stale,
+            LifecycleError::Apply(PortfolioSnapshotError::MarkTooStale { .. })
+        ));
+    }
+
     #[test]
     fn replay_reconstructs_captured_at_and_row_count() {
         let captured_at = Utc.with_ymd_and_hms(2026, 7, 20, 4, 5, 0).unwrap();
@@ -303,7 +623,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(snapshot.captured_at, captured_at);
-        assert_eq!(snapshot.row_count, 2);
+        assert_eq!(snapshot.captured_rows.len(), 2);
     }
 
     #[test]

--- a/src/portfolio_snapshot/projection.rs
+++ b/src/portfolio_snapshot/projection.rs
@@ -1,26 +1,24 @@
 //! Write side of the daily portfolio snapshot read model: the reactor that
 //! maintains the plain `portfolio_snapshot` table from retained
-//! `PortfolioSnapshot::Captured` events.
+//! `PortfolioSnapshot` capture and historical-mark correction events.
 //!
-//! **Durability model: forward-only, best-effort -- matching
-//! [`crate::performance::HedgeLatencyProjection`] exactly, NOT
-//! `QueryReplay::replay_all()`.** `QueryReplay` targets cqrs-es `Query`/`View`
-//! types; the bridge that would let a `Reactor` participate in that machinery
-//! is crate-private inside `event-sorcery`, and startup auto-catch-up is
-//! wired only for `Materialized = Table` entities. A crash between the
-//! `Captured` event committing and this reactor's write can therefore drop
-//! that day's read-model row. Because the `PortfolioSnapshot` aggregate
-//! permanently rejects any further `Capture` for the same `et_day`, there is
-//! currently no automated repair path for a dropped row -- accepted as the
-//! same best-effort risk `HedgeLatencyProjection` already carries in this
-//! codebase, not a regression introduced here.
+//! The live reactor is forward-only, but the retained event stream remains the
+//! source of truth: [`PortfolioSnapshotProjection::rebuild_all`] truncates and
+//! replays the read model in one transaction. This gives operators a durable
+//! recovery path for a reactor failure and guarantees manual mark corrections
+//! survive projection rebuilds.
 
-use sqlx::SqlitePool;
-use st0x_event_sorcery::{EntityList, Reactor, deps};
+use chrono::{DateTime, Utc};
+use rain_math_float::Float;
+use sqlx::{Sqlite, SqlitePool, Transaction};
+use st0x_event_sorcery::{EntityList, EventSourced, IdempotentReactor, Reactor, deps};
+use st0x_finance::{Positive, Symbol};
 use st0x_float_serde::format_float;
 use thiserror::Error;
 
-use super::{PortfolioSnapshot, PortfolioSnapshotEvent, PortfolioSnapshotId};
+use super::{
+    PortfolioBalanceRowWithMark, PortfolioSnapshot, PortfolioSnapshotEvent, PortfolioSnapshotId,
+};
 
 /// Reactor maintaining the `portfolio_snapshot` read model from live
 /// `PortfolioSnapshot::Captured` events.
@@ -40,20 +38,18 @@ impl PortfolioSnapshotProjection {
     /// inside a single transaction, defense-in-depth beyond the aggregate's
     /// own command-level idempotency (a second `Capture` for the same day is
     /// rejected before it ever reaches this reactor).
-    async fn on_captured(
-        &self,
+    async fn on_captured_tx(
+        transaction: &mut Transaction<'_, Sqlite>,
         id: PortfolioSnapshotId,
-        event: PortfolioSnapshotEvent,
+        captured_at: DateTime<Utc>,
+        rows: Vec<PortfolioBalanceRowWithMark>,
     ) -> Result<(), ProjectionError> {
-        let PortfolioSnapshotEvent::Captured { captured_at, rows } = event;
         let et_day = id.to_string();
         let captured_at = captured_at.to_rfc3339();
 
-        let mut transaction = self.pool.begin().await?;
-
         sqlx::query("DELETE FROM portfolio_snapshot WHERE et_day = ?")
             .bind(&et_day)
-            .execute(&mut *transaction)
+            .execute(&mut **transaction)
             .await?;
 
         for row in &rows {
@@ -76,13 +72,101 @@ impl PortfolioSnapshotProjection {
             .bind(inflight_balance)
             .bind(usd_mark)
             .bind(mark_captured_at)
-            .execute(&mut *transaction)
+            .execute(&mut **transaction)
             .await?;
         }
 
-        transaction.commit().await?;
+        Ok(())
+    }
+
+    async fn on_equity_mark_set_tx(
+        transaction: &mut Transaction<'_, Sqlite>,
+        id: PortfolioSnapshotId,
+        symbol: Symbol,
+        usd_mark: Positive<Float>,
+        observed_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), ProjectionError> {
+        let et_day = id.to_string();
+        let mark = format_float(&usd_mark.inner())?;
+        let result = sqlx::query(
+            "UPDATE portfolio_snapshot SET usd_mark = ?, mark_captured_at = ? \
+             WHERE et_day = ? AND asset = ?",
+        )
+        .bind(mark)
+        .bind(observed_at.to_rfc3339())
+        .bind(&et_day)
+        .bind(symbol.to_string())
+        .execute(&mut **transaction)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(ProjectionError::EquityRowsMissing { et_day, symbol });
+        }
 
         Ok(())
+    }
+
+    async fn on_event(
+        &self,
+        id: PortfolioSnapshotId,
+        event: PortfolioSnapshotEvent,
+    ) -> Result<(), ProjectionError> {
+        let mut transaction = self.pool.begin().await?;
+        Self::apply_event_tx(&mut transaction, id, event).await?;
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    async fn apply_event_tx(
+        transaction: &mut Transaction<'_, Sqlite>,
+        id: PortfolioSnapshotId,
+        event: PortfolioSnapshotEvent,
+    ) -> Result<(), ProjectionError> {
+        match event {
+            PortfolioSnapshotEvent::Captured { captured_at, rows } => {
+                Self::on_captured_tx(transaction, id, captured_at, rows).await
+            }
+            PortfolioSnapshotEvent::EquityMarkSet {
+                symbol,
+                usd_mark,
+                observed_at,
+                ..
+            } => Self::on_equity_mark_set_tx(transaction, id, symbol, usd_mark, observed_at).await,
+            PortfolioSnapshotEvent::UnusableMarkAlerted { .. }
+            | PortfolioSnapshotEvent::UnusableMarkDetected { .. } => Ok(()),
+        }
+    }
+
+    /// Rebuilds the complete read model from retained aggregate events in one
+    /// transaction, so a parse or write failure leaves the prior table intact.
+    ///
+    /// Operator constraint: run with the conductor stopped. The event list is
+    /// read once at the start of the transaction; an event the live reactor
+    /// commits mid-rebuild is not replayed. Under WAL the rebuild's write-lock
+    /// upgrade then fails (`SQLITE_BUSY_SNAPSHOT`) rather than committing a
+    /// read model missing that day, but the rebuild itself must be re-run.
+    pub(crate) async fn rebuild_all(&self) -> Result<u64, ProjectionError> {
+        let mut transaction = self.pool.begin().await?;
+        let events: Vec<(String, String)> = sqlx::query_as(
+            "SELECT aggregate_id, payload FROM events WHERE aggregate_type = ? \
+             ORDER BY aggregate_id, sequence ASC",
+        )
+        .bind(PortfolioSnapshot::AGGREGATE_TYPE)
+        .fetch_all(&mut *transaction)
+        .await?;
+
+        sqlx::query("DELETE FROM portfolio_snapshot")
+            .execute(&mut *transaction)
+            .await?;
+
+        for (aggregate_id, payload) in &events {
+            let id = aggregate_id.parse()?;
+            let event = serde_json::from_str(payload)?;
+            Self::apply_event_tx(&mut transaction, id, event).await?;
+        }
+
+        transaction.commit().await?;
+        u64::try_from(events.len()).map_err(|source| ProjectionError::EventCount { source })
     }
 }
 
@@ -92,6 +176,17 @@ pub(crate) enum ProjectionError {
     Database(#[from] sqlx::Error),
     #[error("failed to format a portfolio snapshot balance for persistence")]
     Float(#[from] rain_math_float::FloatError),
+    #[error("failed to deserialize a portfolio-snapshot event")]
+    Event(#[from] serde_json::Error),
+    #[error("failed to parse portfolio-snapshot aggregate id")]
+    AggregateId(#[from] super::ParsePortfolioSnapshotIdError),
+    #[error("portfolio-snapshot event count exceeded u64")]
+    EventCount {
+        #[source]
+        source: std::num::TryFromIntError,
+    },
+    #[error("portfolio-snapshot read model has no rows for {symbol} on {et_day}")]
+    EquityRowsMissing { et_day: String, symbol: Symbol },
 }
 
 #[async_trait::async_trait]
@@ -103,17 +198,21 @@ impl Reactor for PortfolioSnapshotProjection {
         event: <Self::Dependencies as EntityList>::Event,
     ) -> Result<(), Self::Error> {
         event
-            .on(|id, event| async move { self.on_captured(id, event).await })
+            .on(|id, event| async move { self.on_event(id, event).await })
             .exhaustive()
             .await
     }
 }
 
+impl IdempotentReactor for PortfolioSnapshotProjection {}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use chrono::{TimeZone, Utc};
     use sqlx::Row;
-    use st0x_event_sorcery::ReactorHarness;
+    use st0x_event_sorcery::{ReactorHarness, StoreBuilder};
     use st0x_float_macro::float;
 
     use crate::inventory::{PortfolioAsset, PortfolioBalanceRow, PortfolioLocation};
@@ -140,6 +239,19 @@ mod tests {
             },
             usd_mark: usd_mark.map(|mark| float!(&mark.to_string())),
             mark_captured_at: usd_mark.map(|_| captured_at()),
+        }
+    }
+
+    fn equity_row(location: PortfolioLocation) -> PortfolioBalanceRowWithMark {
+        PortfolioBalanceRowWithMark {
+            row: PortfolioBalanceRow {
+                location,
+                asset: PortfolioAsset::Equity(Symbol::new("AAPL").unwrap()),
+                available: float!(10),
+                inflight: float!(0),
+            },
+            usd_mark: None,
+            mark_captured_at: None,
         }
     }
 
@@ -240,5 +352,108 @@ mod tests {
         .unwrap();
 
         assert_eq!(locations, vec!["market_making"]);
+    }
+
+    #[tokio::test]
+    async fn equity_mark_set_updates_every_location_and_latest_event_wins() {
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(PortfolioSnapshotProjection::new(pool.clone()));
+        let id = PortfolioSnapshotId(chrono::NaiveDate::from_ymd_opt(2026, 7, 20).unwrap());
+        harness
+            .receive::<PortfolioSnapshot>(
+                id,
+                PortfolioSnapshotEvent::Captured {
+                    captured_at: captured_at(),
+                    rows: vec![
+                        equity_row(PortfolioLocation::MarketMaking),
+                        equity_row(PortfolioLocation::Hedging),
+                    ],
+                },
+            )
+            .await
+            .unwrap();
+
+        for mark in [float!(150), float!(151)] {
+            harness
+                .receive::<PortfolioSnapshot>(
+                    id,
+                    PortfolioSnapshotEvent::EquityMarkSet {
+                        symbol: Symbol::new("AAPL").unwrap(),
+                        usd_mark: Positive::new(mark).unwrap(),
+                        observed_at: captured_at() - chrono::Duration::days(3),
+                        source: "Nasdaq historical close".to_owned(),
+                        reason: "operator correction".to_owned(),
+                        corrected_at: captured_at() + chrono::Duration::days(2),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        let marks: Vec<String> = sqlx::query_scalar(
+            "SELECT usd_mark FROM portfolio_snapshot \
+             WHERE et_day = '2026-07-20' AND asset = 'AAPL' ORDER BY location",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(marks, vec!["151", "151"]);
+    }
+
+    #[tokio::test]
+    async fn rebuild_replays_capture_and_latest_mark_correction() {
+        let pool = setup_test_db().await;
+        let projection = Arc::new(PortfolioSnapshotProjection::new(pool.clone()));
+        let store = StoreBuilder::<PortfolioSnapshot>::new(pool.clone())
+            .with(projection.clone())
+            .build(())
+            .await
+            .unwrap();
+        let id = PortfolioSnapshotId(chrono::NaiveDate::from_ymd_opt(2026, 7, 20).unwrap());
+
+        store
+            .send(
+                &id,
+                super::super::PortfolioSnapshotCommand::Capture {
+                    captured_at: captured_at(),
+                    rows: vec![
+                        equity_row(PortfolioLocation::MarketMaking),
+                        equity_row(PortfolioLocation::Hedging),
+                    ],
+                },
+            )
+            .await
+            .unwrap();
+        for mark in [float!(150), float!(151)] {
+            store
+                .send(
+                    &id,
+                    super::super::PortfolioSnapshotCommand::SetEquityMark {
+                        symbol: Symbol::new("AAPL").unwrap(),
+                        usd_mark: Positive::new(mark).unwrap(),
+                        observed_at: captured_at() - chrono::Duration::days(3),
+                        source: "Nasdaq historical close".to_owned(),
+                        reason: "operator correction".to_owned(),
+                        corrected_at: captured_at() + chrono::Duration::days(2),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        sqlx::query("DELETE FROM portfolio_snapshot")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert_eq!(projection.rebuild_all().await.unwrap(), 3);
+
+        let marks: Vec<String> = sqlx::query_scalar(
+            "SELECT usd_mark FROM portfolio_snapshot \
+             WHERE et_day = '2026-07-20' AND asset = 'AAPL' ORDER BY location",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(marks, vec!["151", "151"]);
     }
 }

--- a/src/portfolio_snapshot/read.rs
+++ b/src/portfolio_snapshot/read.rs
@@ -16,7 +16,7 @@
 
 use std::collections::BTreeMap;
 
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Days, NaiveDate, Utc};
 use rain_math_float::Float;
 use sqlx::{QueryBuilder, Sqlite, SqlitePool};
 use thiserror::Error;
@@ -32,7 +32,7 @@ use crate::inventory::{PortfolioAsset, PortfolioLocation};
 /// the whole day from the capital sample. Only equity marks are
 /// staleness-checked -- USDC's mark is a fixed par assumption captured fresh
 /// at capture time.
-const MARK_STALENESS_THRESHOLD_DAYS: i64 = 7;
+pub(crate) const MARK_STALENESS_THRESHOLD_DAYS: i64 = 7;
 
 /// Minimum included snapshot days, spanning at least this many calendar
 /// days, before an annualized return is computed. A single day's return
@@ -43,6 +43,14 @@ const MIN_COVERAGE_DAYS_FOR_ANNUALIZATION: i64 = 2;
 
 const DAYS_PER_YEAR: Float = float!(365);
 const PERCENT: Float = float!(100);
+
+/// Caps how many excluded days are individually reported (as
+/// `excluded_days` entries and per-day warnings). An open-ended query over a
+/// long PnL history with sparse snapshot coverage would otherwise synthesize
+/// one excluded day per calendar day -- thousands of rows of noise in a
+/// single response. The most recent days are kept; older ones are summarized
+/// in one warning.
+const MAX_REPORTED_EXCLUDED_DAYS: usize = 90;
 
 /// Errors loading and interpreting persisted `portfolio_snapshot` rows.
 #[derive(Debug, Error)]
@@ -73,13 +81,40 @@ pub(crate) enum ReadError {
     },
     #[error("sample day count {sample_days} does not fit in i64 for the coverage-gap check")]
     SampleDaysOverflow { sample_days: usize },
+    #[error("portfolio snapshot date range overflowed after {day}")]
+    DateRangeOverflow { day: NaiveDate },
 }
 
 /// Why a day was excluded from the capital sample.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum DayExclusionReason {
+    MissingSnapshot,
     MissingMark(PortfolioAsset),
     StaleMark(PortfolioAsset, DateTime<Utc>),
+}
+
+impl DayExclusionReason {
+    /// Stable machine-readable discriminant for API consumers, decoupled
+    /// from the human-readable [`describe`](Self::describe) prose.
+    pub(crate) const fn kind(&self) -> &'static str {
+        match self {
+            Self::MissingSnapshot => "missingSnapshot",
+            Self::MissingMark(_) => "missingMark",
+            Self::StaleMark(..) => "staleMark",
+        }
+    }
+
+    pub(crate) fn describe(&self) -> String {
+        match self {
+            Self::MissingSnapshot => "no portfolio snapshot was captured".to_owned(),
+            Self::MissingMark(asset) => {
+                format!("no USD mark observed yet for {asset}")
+            }
+            Self::StaleMark(asset, mark_captured_at) => {
+                format!("USD mark for {asset} is stale (last observed {mark_captured_at})")
+            }
+        }
+    }
 }
 
 /// A day's deployed capital, or the reason it could not be computed. Mutually
@@ -133,7 +168,14 @@ pub(crate) struct CapitalSummary {
     pub(crate) sample_days: usize,
     pub(crate) first_snapshot_day: Option<NaiveDate>,
     pub(crate) last_snapshot_day: Option<NaiveDate>,
+    pub(crate) excluded_days: Vec<CapitalExcludedDay>,
     pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CapitalExcludedDay {
+    pub(crate) et_day: NaiveDate,
+    pub(crate) reason: DayExclusionReason,
 }
 
 /// A single `(location, asset)` balance row loaded from `portfolio_snapshot`
@@ -212,27 +254,71 @@ pub(crate) async fn load_portfolio_days(
         });
     }
 
-    by_day
+    let mut evaluated = by_day
         .into_iter()
-        .map(|(et_day, rows)| evaluate_day(et_day, rows))
-        .collect()
+        .map(|(et_day, rows)| evaluate_day(et_day, rows).map(|day| (et_day, day)))
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+
+    // Complete the finite report window even when one or both query bounds are
+    // open. An explicit bound anchors that edge; an open edge resolves to the
+    // first/last available snapshot. This exposes interior gaps and a missing
+    // explicit edge without inventing an unbounded calendar range.
+    let first_loaded_day = evaluated.first_key_value().map(|(day, _)| *day);
+    let last_loaded_day = evaluated.last_key_value().map(|(day, _)| *day);
+    let effective_from = from.or(first_loaded_day);
+    let effective_to = to.or(last_loaded_day);
+    let (Some(mut day), Some(last_day)) = (effective_from, effective_to) else {
+        return Ok(evaluated.into_values().collect());
+    };
+    let mut complete_range = Vec::new();
+    while day <= last_day {
+        complete_range.push(evaluated.remove(&day).unwrap_or(PortfolioDay {
+            et_day: day,
+            capital: DayCapital::Excluded(DayExclusionReason::MissingSnapshot),
+        }));
+        if day == last_day {
+            break;
+        }
+        day = day
+            .checked_add_days(Days::new(1))
+            .ok_or(ReadError::DateRangeOverflow { day })?;
+    }
+
+    Ok(complete_range)
 }
 
-/// Computes [`CapitalSummary`] from already-loaded [`PortfolioDay`]s and the
-/// range's numeric net realized PnL accumulator, not a re-parsed response
-/// string.
-///
-/// `query_et_day_range` has the same `(from, to)` bounds that scope
-/// `net_realized_pnl_usd`: the PnL numerator is computed over the caller's
-/// whole query range, not over snapshot coverage, so annualizing by
-/// `365 / coverage_days` is only valid when snapshot coverage fully spans that
-/// range. See [`coverage_spans_query_range`].
+/// Computes [`CapitalSummary`] from already-loaded [`PortfolioDay`]s and net
+/// realized PnL bucketed by ET accounting day. Only PnL whose day has usable
+/// capital enters the return numerator; full-range PnL remains unchanged in
+/// the ordinary report.
 pub(crate) fn capital_summary(
     days: &[PortfolioDay],
-    net_realized_pnl_usd: Float,
-    query_et_day_range: EtDayRange,
+    daily_net_realized_pnl_usd: &BTreeMap<NaiveDate, Float>,
 ) -> Result<CapitalSummary, ReadError> {
-    let mut warnings = exclusion_warnings(days);
+    let mut excluded_days = days
+        .iter()
+        .filter_map(|day| match &day.capital {
+            DayCapital::Included(_) => None,
+            DayCapital::Excluded(reason) => Some(CapitalExcludedDay {
+                et_day: day.et_day,
+                reason: reason.clone(),
+            }),
+        })
+        .collect::<Vec<_>>();
+    let omitted_excluded_days = excluded_days
+        .len()
+        .saturating_sub(MAX_REPORTED_EXCLUDED_DAYS);
+    let excluded_days = excluded_days.split_off(omitted_excluded_days);
+    let mut warnings = excluded_days
+        .iter()
+        .map(|day| describe_exclusion(day.et_day, &day.reason))
+        .collect::<Vec<_>>();
+    if omitted_excluded_days > 0 {
+        warnings.push(format!(
+            "Portfolio capital sample excludes {omitted_excluded_days} additional earlier \
+             day(s) not listed individually"
+        ));
+    }
 
     let included: Vec<(NaiveDate, Float)> = days
         .iter()
@@ -251,6 +337,7 @@ pub(crate) fn capital_summary(
             sample_days: 0,
             first_snapshot_day: None,
             last_snapshot_day: None,
+            excluded_days,
             warnings,
         });
     }
@@ -291,6 +378,7 @@ pub(crate) fn capital_summary(
             sample_days,
             first_snapshot_day: Some(first_snapshot_day),
             last_snapshot_day: Some(last_snapshot_day),
+            excluded_days,
             warnings,
         });
     }
@@ -298,7 +386,15 @@ pub(crate) fn capital_summary(
     let meets_sample_and_coverage_minimums = sample_days >= MIN_SAMPLE_DAYS_FOR_ANNUALIZATION
         && coverage_days >= MIN_COVERAGE_DAYS_FOR_ANNUALIZATION;
 
-    let annualized_return_pct = if !meets_sample_and_coverage_minimums {
+    let annualized_return_pct = if meets_sample_and_coverage_minimums {
+        let mut usable_pnl = Float::zero()?;
+        for (day, _) in &included {
+            if let Some(day_pnl) = daily_net_realized_pnl_usd.get(day) {
+                usable_pnl = (usable_pnl + *day_pnl)?;
+            }
+        }
+        Some(((((usable_pnl / total)? * DAYS_PER_YEAR)?) * PERCENT)?)
+    } else {
         warnings.push(format!(
             "Annualized return on capital requires at least \
              {MIN_SAMPLE_DAYS_FOR_ANNUALIZATION} included snapshot days spanning at least \
@@ -306,19 +402,6 @@ pub(crate) fn capital_summary(
              covering {coverage_days} calendar day(s) are available"
         ));
         None
-    } else if !coverage_spans_query_range(first_snapshot_day, last_snapshot_day, query_et_day_range)
-    {
-        warnings.push(
-            "Snapshot coverage does not span the full query range; annualized return omitted \
-             to avoid conflating a partial-coverage denominator with full-range realized PnL"
-                .to_owned(),
-        );
-        None
-    } else {
-        let coverage_days_float = Float::parse(coverage_days.to_string())?;
-        let annual_factor = (DAYS_PER_YEAR / coverage_days_float)?;
-        let period_return = (net_realized_pnl_usd / average)?;
-        Some(((period_return * annual_factor)? * PERCENT)?)
     };
 
     Ok(CapitalSummary {
@@ -328,51 +411,16 @@ pub(crate) fn capital_summary(
         sample_days,
         first_snapshot_day: Some(first_snapshot_day),
         last_snapshot_day: Some(last_snapshot_day),
+        excluded_days,
         warnings,
     })
 }
 
-/// Whether `[first_snapshot_day, last_snapshot_day]` fully covers
-/// `query_et_day_range`: the realized-PnL numerator passed into
-/// [`capital_summary`] is scoped to the caller's query range, not to
-/// snapshot coverage, so annualizing by `365 / coverage_days` is only valid
-/// when the two line up. An unbounded query side (`None`, "load every
-/// captured day") can never be proven spanned by a finite snapshot range --
-/// `portfolio_snapshot` does not backfill history -- so it conservatively
-/// counts as not spanning rather than assuming the coverage happens to reach
-/// back to the true start of history.
-fn coverage_spans_query_range(
-    first_snapshot_day: NaiveDate,
-    last_snapshot_day: NaiveDate,
-    query_et_day_range: EtDayRange,
-) -> bool {
-    let EtDayRange {
-        from: query_from,
-        to: query_to,
-    } = query_et_day_range;
-    query_from.is_some_and(|from| first_snapshot_day <= from)
-        && query_to.is_some_and(|to| last_snapshot_day >= to)
-}
-
-fn exclusion_warnings(days: &[PortfolioDay]) -> Vec<String> {
-    days.iter()
-        .filter_map(|day| match &day.capital {
-            DayCapital::Included(_) => None,
-            DayCapital::Excluded(reason) => Some(describe_exclusion(day.et_day, reason)),
-        })
-        .collect()
-}
-
 fn describe_exclusion(et_day: NaiveDate, reason: &DayExclusionReason) -> String {
-    match reason {
-        DayExclusionReason::MissingMark(asset) => format!(
-            "Portfolio capital sample excludes {et_day}: no USD mark observed yet for {asset}"
-        ),
-        DayExclusionReason::StaleMark(asset, mark_captured_at) => format!(
-            "Portfolio capital sample excludes {et_day}: USD mark for {asset} is stale \
-             (last observed {mark_captured_at})"
-        ),
-    }
+    format!(
+        "Portfolio capital sample excludes {et_day}: {}",
+        reason.describe()
+    )
 }
 
 fn evaluate_day(et_day: NaiveDate, rows: Vec<RawBalanceRow>) -> Result<PortfolioDay, ReadError> {
@@ -435,7 +483,7 @@ fn evaluate_day(et_day: NaiveDate, rows: Vec<RawBalanceRow>) -> Result<Portfolio
     })
 }
 
-fn is_stale_mark(
+pub(crate) fn is_stale_mark(
     asset: &PortfolioAsset,
     mark_captured_at: DateTime<Utc>,
     et_day: NaiveDate,
@@ -719,8 +767,45 @@ mod tests {
         );
     }
 
-    /// An open-ended range (only `from` set) must include every day at or
-    /// after it, with no upper bound.
+    #[tokio::test]
+    async fn bounded_range_surfaces_a_day_with_no_snapshot_as_excluded() {
+        let pool = setup_test_db().await;
+        for et_day in ["2026-07-17", "2026-07-19"] {
+            insert_row(
+                &pool,
+                et_day,
+                "market_making",
+                "USDC",
+                "1000",
+                Some("1"),
+                Some("2026-07-17T04:05:00+00:00"),
+            )
+            .await;
+        }
+
+        let days = load_portfolio_days(
+            &pool,
+            EtDayRange {
+                from: Some(NaiveDate::from_ymd_opt(2026, 7, 17).unwrap()),
+                to: Some(NaiveDate::from_ymd_opt(2026, 7, 19).unwrap()),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(days.len(), 3);
+        assert_eq!(
+            days[1].et_day,
+            NaiveDate::from_ymd_opt(2026, 7, 18).unwrap()
+        );
+        assert_eq!(
+            days[1].capital,
+            DayCapital::Excluded(DayExclusionReason::MissingSnapshot)
+        );
+    }
+
+    /// A lower-bounded range resolves its open upper edge to the latest
+    /// available snapshot and still exposes a missing requested edge day.
     #[tokio::test]
     async fn load_portfolio_days_respects_open_ended_lower_bound() {
         let pool = setup_test_db().await;
@@ -751,10 +836,49 @@ mod tests {
         };
         let days = load_portfolio_days(&pool, range).await.unwrap();
 
-        assert_eq!(days.len(), 1);
+        assert_eq!(days.len(), 2);
         assert_eq!(
             days[0].et_day,
+            NaiveDate::from_ymd_opt(2026, 7, 18).unwrap()
+        );
+        assert_eq!(
+            days[0].capital,
+            DayCapital::Excluded(DayExclusionReason::MissingSnapshot)
+        );
+        assert_eq!(
+            days[1].et_day,
             NaiveDate::from_ymd_opt(2026, 7, 19).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn upper_bounded_range_exposes_missing_upper_edge() {
+        let pool = setup_test_db().await;
+        insert_row(
+            &pool,
+            "2026-07-17",
+            "market_making",
+            "USDC",
+            "1000",
+            Some("1"),
+            Some("2026-07-17T04:05:00+00:00"),
+        )
+        .await;
+
+        let days = load_portfolio_days(
+            &pool,
+            EtDayRange {
+                from: None,
+                to: Some(NaiveDate::from_ymd_opt(2026, 7, 18).unwrap()),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(days.len(), 2);
+        assert_eq!(
+            days[1].capital,
+            DayCapital::Excluded(DayExclusionReason::MissingSnapshot)
         );
     }
 
@@ -963,15 +1087,45 @@ mod tests {
             .unwrap()
     }
 
+    fn daily_pnl(values: &[(u64, i64)]) -> BTreeMap<NaiveDate, Float> {
+        values
+            .iter()
+            .map(|(offset, amount)| (day(*offset), usd(*amount)))
+            .collect()
+    }
+
+    #[test]
+    fn capital_summary_caps_reported_excluded_days_to_the_most_recent() {
+        let excluded_count = MAX_REPORTED_EXCLUDED_DAYS + 2;
+        let mut days: Vec<_> = (0..excluded_count as u64)
+            .map(|offset| PortfolioDay {
+                et_day: day(offset),
+                capital: DayCapital::Excluded(DayExclusionReason::MissingSnapshot),
+            })
+            .collect();
+        days.push(included_day(day(excluded_count as u64), 1000));
+
+        let summary = capital_summary(&days, &daily_pnl(&[])).unwrap();
+
+        assert_eq!(summary.excluded_days.len(), MAX_REPORTED_EXCLUDED_DAYS);
+        assert_eq!(summary.excluded_days[0].et_day, day(2));
+        assert_eq!(
+            summary.excluded_days[MAX_REPORTED_EXCLUDED_DAYS - 1].et_day,
+            day(excluded_count as u64 - 1)
+        );
+        assert!(
+            summary.warnings.contains(
+                &"Portfolio capital sample excludes 2 additional earlier day(s) not listed \
+              individually"
+                    .to_owned()
+            )
+        );
+    }
+
     #[test]
     fn capital_summary_hand_computed_two_day_average_and_annualized_return() {
         let days = vec![included_day(day(0), 1000), included_day(day(1), 2000)];
-        let query_range = EtDayRange {
-            from: Some(day(0)),
-            to: Some(day(1)),
-        };
-
-        let summary = capital_summary(&days, usd(30), query_range).unwrap();
+        let summary = capital_summary(&days, &daily_pnl(&[(0, 10), (1, 20)])).unwrap();
 
         assert_eq!(summary.sample_days, 2);
         assert_eq!(summary.coverage_days, Some(2));
@@ -996,12 +1150,11 @@ mod tests {
             .enumerate()
             .map(|(offset, total)| included_day(day(offset as u64), *total))
             .collect();
-        let query_range = EtDayRange {
-            from: Some(day(0)),
-            to: Some(day(4)),
-        };
-
-        let summary = capital_summary(&days, usd(50), query_range).unwrap();
+        let summary = capital_summary(
+            &days,
+            &daily_pnl(&[(0, 10), (1, 10), (2, 10), (3, 10), (4, 10)]),
+        )
+        .unwrap();
 
         assert_eq!(summary.sample_days, 5);
         assert_eq!(summary.coverage_days, Some(5));
@@ -1021,7 +1174,7 @@ mod tests {
     /// test does not exercise.
     #[test]
     fn capital_summary_zero_included_days_returns_none_without_a_warning() {
-        let summary = capital_summary(&[], usd(0), EtDayRange::default()).unwrap();
+        let summary = capital_summary(&[], &BTreeMap::new()).unwrap();
 
         assert!(summary.average_deployed_capital_usd.is_none());
         assert!(summary.annualized_return_pct.is_none());
@@ -1036,7 +1189,7 @@ mod tests {
     fn capital_summary_single_included_day_reports_average_but_no_annualized_figure() {
         let days = vec![included_day(day(0), 1000)];
 
-        let summary = capital_summary(&days, usd(10), EtDayRange::default()).unwrap();
+        let summary = capital_summary(&days, &daily_pnl(&[(0, 10)])).unwrap();
 
         assert_eq!(summary.sample_days, 1);
         assert_eq!(summary.coverage_days, Some(1));
@@ -1056,7 +1209,7 @@ mod tests {
     fn capital_summary_average_capital_zero_returns_none_without_dividing() {
         let days = vec![included_day(day(0), 0), included_day(day(1), 0)];
 
-        let summary = capital_summary(&days, usd(10), EtDayRange::default()).unwrap();
+        let summary = capital_summary(&days, &daily_pnl(&[(0, 10)])).unwrap();
 
         assert!(summary.average_deployed_capital_usd.is_none());
         assert!(summary.annualized_return_pct.is_none());
@@ -1085,7 +1238,7 @@ mod tests {
             },
         ];
 
-        let summary = capital_summary(&days, usd(0), EtDayRange::default()).unwrap();
+        let summary = capital_summary(&days, &BTreeMap::new()).unwrap();
 
         assert_eq!(summary.sample_days, 0);
         assert_eq!(summary.warnings.len(), 2);
@@ -1096,12 +1249,7 @@ mod tests {
     #[test]
     fn capital_summary_gap_in_coverage_adds_warning_but_still_annualizes() {
         let days = vec![included_day(day(0), 1000), included_day(day(4), 2000)];
-        let query_range = EtDayRange {
-            from: Some(day(0)),
-            to: Some(day(4)),
-        };
-
-        let summary = capital_summary(&days, usd(30), query_range).unwrap();
+        let summary = capital_summary(&days, &daily_pnl(&[(0, 10), (4, 20)])).unwrap();
 
         assert_eq!(summary.sample_days, 2);
         assert_eq!(summary.coverage_days, Some(5));
@@ -1112,7 +1260,7 @@ mod tests {
                 .eq(usd(1500))
                 .unwrap()
         );
-        assert!(summary.annualized_return_pct.unwrap().eq(usd(146)).unwrap());
+        assert!(summary.annualized_return_pct.unwrap().eq(usd(365)).unwrap());
         assert!(
             summary
                 .warnings
@@ -1121,54 +1269,23 @@ mod tests {
         );
     }
 
-    /// The realized-PnL numerator is scoped to the caller's whole query
-    /// range, not to snapshot coverage: when the query range extends beyond
-    /// what was actually captured, annualizing by `365 / coverage_days`
-    /// would conflate a wider-period PnL figure with a narrower capital
-    /// sample. Average capital is still reported honestly.
     #[test]
-    fn capital_summary_omits_annualized_when_query_range_exceeds_snapshot_coverage() {
-        let days = vec![included_day(day(0), 1000), included_day(day(1), 2000)];
-        // Query spans a month before the earliest captured day: realized PnL
-        // over that whole month must not be annualized against the 2-day
-        // coverage denominator.
-        let query_range = EtDayRange {
-            from: Some(day(0).checked_sub_days(Days::new(30)).unwrap()),
-            to: Some(day(1)),
-        };
-
-        let summary = capital_summary(&days, usd(30), query_range).unwrap();
-
-        assert!(
-            summary
-                .average_deployed_capital_usd
-                .unwrap()
-                .eq(usd(1500))
-                .unwrap(),
-            "average deployed capital must still be reported"
-        );
-        assert!(summary.annualized_return_pct.is_none());
-        assert!(
-            summary
-                .warnings
-                .iter()
-                .any(|warning| warning.contains("does not span the full query range"))
-        );
-    }
-
-    /// The mirror case: when snapshot coverage fully spans the query range,
-    /// annualization proceeds as usual.
-    #[test]
-    fn capital_summary_annualizes_when_coverage_fully_spans_query_range() {
-        let days = vec![included_day(day(0), 1000), included_day(day(1), 2000)];
-        let query_range = EtDayRange {
-            from: Some(day(0)),
-            to: Some(day(1)),
-        };
-
-        let summary = capital_summary(&days, usd(30), query_range).unwrap();
+    fn capital_summary_excludes_pnl_from_a_day_with_an_unusable_mark() {
+        let days = vec![
+            included_day(day(0), 1000),
+            PortfolioDay {
+                et_day: day(1),
+                capital: DayCapital::Excluded(DayExclusionReason::MissingMark(
+                    PortfolioAsset::Equity(Symbol::new("AAPL").unwrap()),
+                )),
+            },
+            included_day(day(2), 2000),
+        ];
+        let summary = capital_summary(&days, &daily_pnl(&[(0, 10), (1, 1_000), (2, 20)])).unwrap();
 
         assert!(summary.annualized_return_pct.unwrap().eq(usd(365)).unwrap());
+        assert_eq!(summary.excluded_days.len(), 1);
+        assert_eq!(summary.excluded_days[0].et_day, day(1));
     }
 
     /// Boundary of `is_stale_mark`: exactly `MARK_STALENESS_THRESHOLD_DAYS`

--- a/src/portfolio_snapshot/write.rs
+++ b/src/portfolio_snapshot/write.rs
@@ -43,25 +43,31 @@
 //! across entirely (no wake before the next boundary) is simply absent from
 //! the series -- coverage is sparse by design, not backfilled.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
 use apalis::prelude::Status;
 use chrono::{DateTime, Datelike, Days, NaiveDate, TimeZone, Utc};
 use chrono_tz::America::New_York;
+use metrics::counter;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{error, warn};
 
-use st0x_event_sorcery::{AggregateError, LifecycleError, Projection, SendError, Store};
-use st0x_execution::{FractionalShares, Symbol};
+use st0x_event_sorcery::{
+    AggregateError, LifecycleError, LoadAllIdsError, Projection, SendError, Store, load_all_ids,
+};
+use st0x_execution::{FractionalShares, HasZero, Symbol};
 use st0x_float_macro::float;
+use st0x_float_serde::format_float;
 use st0x_wrapper::{RatioError, UnderlyingPerWrapped, Wrapper, WrapperError};
 
+use super::read::is_stale_mark;
 use super::{
     PortfolioBalanceRowWithMark, PortfolioSnapshot, PortfolioSnapshotCommand, PortfolioSnapshotId,
 };
+use crate::alerts::{Notifier, NotifierError};
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::inventory::{
     BroadcastingInventory, InventoryViewError, PollFreshness, PortfolioAsset, PortfolioBalanceRow,
@@ -76,12 +82,23 @@ pub(crate) type PortfolioSnapshotJobQueue = JobQueue<PortfolioSnapshotJob>;
 const USDC_PAR: rain_math_float::Float = float!(1);
 
 /// Buffer added past ET midnight before capturing, so the last poll tick for
-/// the closing day has time to land in the read model.
-const CAPTURE_BUFFER: chrono::Duration = chrono::Duration::minutes(5);
+/// the closing day has time to land in the read model. `pub(crate)` because
+/// the /pnl capital report (`crate::dashboard::pnl`) anchors its
+/// latest-complete-day cutoff to the same boundary.
+pub(crate) const CAPTURE_BUFFER: chrono::Duration = chrono::Duration::minutes(5);
 
 /// Retry backoff when the completeness gate fails (an incomplete
 /// `InventoryView`, expected during startup hydration).
 const HYDRATION_RETRY_BACKOFF: Duration = Duration::from_secs(5 * 60);
+const ALERT_RETRY_BACKOFF: Duration = Duration::from_secs(5 * 60);
+
+/// How many ET days back [`bootstrap_portfolio_snapshot`] reconstructs
+/// alert-only jobs for. The recovery exists to close the crash window between
+/// a committed capture and its original alert enqueue -- a window measured in
+/// seconds -- so a week is already generous. Without a bound, every restart
+/// would fan out one job per snapshot day ever captured, growing by one per
+/// day forever.
+const BOOTSTRAP_ALERT_WINDOW_DAYS: i64 = 7;
 
 /// Retry backoff when a job wakes before its own `target_et_day`'s boundary
 /// (a premature scheduler tick). Reuses the same short duration as
@@ -131,6 +148,7 @@ pub(crate) struct PortfolioSnapshotCtx {
     /// what this process has actually polled -- closing the restart-stale
     /// hole [`hydration_gap`] alone cannot see (see that function's doc).
     pub(crate) poll_freshness: PollFreshness,
+    pub(crate) notifier: Arc<dyn Notifier>,
     pub(crate) queue: PortfolioSnapshotJobQueue,
 }
 
@@ -154,6 +172,16 @@ pub(crate) enum PortfolioSnapshotJobError {
     WrappedEquityConversion(#[from] RatioError),
     #[error("failed to read portfolio balances from inventory: {0}")]
     Inventory(#[from] InventoryViewError),
+    #[error("failed to evaluate portfolio snapshot mark usability: {0}")]
+    MarkEvaluation(#[from] rain_math_float::FloatError),
+    #[error("failed to load an already-captured portfolio snapshot: {0}")]
+    SnapshotLoad(#[source] SendError<PortfolioSnapshot>),
+    #[error("portfolio snapshot was already captured but its aggregate state is missing")]
+    MissingCapturedState,
+    #[error("failed to deliver portfolio snapshot alert: {0}")]
+    AlertDelivery(#[from] NotifierError),
+    #[error("failed to load portfolio-snapshot ids for alert recovery: {0}")]
+    SnapshotIds(#[from] LoadAllIdsError),
     #[error(
         "wrapped equity balance present for {symbol} at {location} but no wallet/Wrapper is \
          configured to resolve its vault ratio"
@@ -175,6 +203,8 @@ pub(crate) enum PortfolioSnapshotJobError {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PortfolioSnapshotJob {
     pub(crate) target_et_day: NaiveDate,
+    #[serde(default)]
+    alert_only: bool,
 }
 
 impl Job<PortfolioSnapshotCtx> for PortfolioSnapshotJob {
@@ -197,6 +227,20 @@ impl Job<PortfolioSnapshotCtx> for PortfolioSnapshotJob {
 }
 
 impl PortfolioSnapshotJob {
+    fn capture(target_et_day: NaiveDate) -> Self {
+        Self {
+            target_et_day,
+            alert_only: false,
+        }
+    }
+
+    fn alert(target_et_day: NaiveDate) -> Self {
+        Self {
+            target_et_day,
+            alert_only: true,
+        }
+    }
+
     /// The full body of [`Job::perform`], with `now` taken as a parameter
     /// instead of read from the wall clock, so tests can deterministically
     /// exercise time-dependent branches (the freshness-defer escape hatch in
@@ -207,6 +251,10 @@ impl PortfolioSnapshotJob {
         ctx: &PortfolioSnapshotCtx,
         now: DateTime<Utc>,
     ) -> Result<(), PortfolioSnapshotJobError> {
+        if self.alert_only {
+            return self.retry_alert(ctx, now).await;
+        }
+
         let today = et_day(now);
 
         if self.target_et_day > today {
@@ -217,7 +265,7 @@ impl PortfolioSnapshotJob {
             let delay = et_midnight(self.target_et_day)
                 .and_then(|midnight| (midnight + CAPTURE_BUFFER - now).to_std().ok())
                 .unwrap_or(EARLY_WAKE_BACKOFF);
-            return ctx.reschedule(self.target_et_day, delay).await;
+            return ctx.reschedule_capture(self.target_et_day, delay).await;
         }
 
         if self.target_et_day < today {
@@ -258,7 +306,7 @@ impl PortfolioSnapshotJob {
                 target_et_day,
                 "capture-window wait",
             );
-            return ctx.reschedule(target_et_day, delay).await;
+            return ctx.reschedule_capture(target_et_day, delay).await;
         }
 
         // Upper bound: a tick landing more than MAX_FRESHNESS_DEFER past the
@@ -291,7 +339,7 @@ impl PortfolioSnapshotJob {
                 );
             }
             let (delay, next_target_et_day) = next_capture_delay(now);
-            return ctx.reschedule(next_target_et_day, delay).await;
+            return ctx.reschedule_capture(next_target_et_day, delay).await;
         }
 
         // Freshness is checked BEFORE the inventory view is read: the live
@@ -318,7 +366,7 @@ impl PortfolioSnapshotJob {
             // the day on the next tick even if freshness recovers in the
             // skipped interval).
             return ctx
-                .reschedule(target_et_day, capped_retry_backoff(boundary, now))
+                .reschedule_capture(target_et_day, capped_retry_backoff(boundary, now))
                 .await;
         }
 
@@ -340,7 +388,7 @@ impl PortfolioSnapshotJob {
             // passed. Capped the same way as the freshness-gap retry above,
             // for the same reason.
             return ctx
-                .reschedule(target_et_day, capped_retry_backoff(boundary, now))
+                .reschedule_capture(target_et_day, capped_retry_backoff(boundary, now))
                 .await;
         }
 
@@ -353,7 +401,7 @@ impl PortfolioSnapshotJob {
                 &PortfolioSnapshotId(target_et_day),
                 PortfolioSnapshotCommand::Capture {
                     captured_at: now,
-                    rows: marked_rows,
+                    rows: marked_rows.clone(),
                 },
             )
             .await
@@ -377,9 +425,172 @@ impl PortfolioSnapshotJob {
             Err(error) => return Err(PortfolioSnapshotJobError::Capture(error)),
         }
 
+        ctx.reschedule_alert(target_et_day, Duration::ZERO).await?;
         let (delay, next_target_et_day) = next_capture_delay(now);
-        ctx.reschedule(next_target_et_day, delay).await
+        ctx.reschedule_capture(next_target_et_day, delay).await
     }
+
+    /// Defers only failed notification sends ([`AlertDelivery`]): delivery is
+    /// at-least-once and a Telegram outage is expected to heal on its own, so
+    /// the job retries itself on a fixed backoff. Every other failure
+    /// (missing aggregate state, load/command errors, mark evaluation) is
+    /// propagated so apalis's bounded retry and dead-letter machinery sees it
+    /// instead of an unbounded self-reschedule loop.
+    ///
+    /// [`AlertDelivery`]: PortfolioSnapshotJobError::AlertDelivery
+    async fn retry_alert(
+        &self,
+        ctx: &PortfolioSnapshotCtx,
+        now: DateTime<Utc>,
+    ) -> Result<(), PortfolioSnapshotJobError> {
+        match self.deliver_alert(ctx, now).await {
+            Ok(()) => Ok(()),
+            Err(PortfolioSnapshotJobError::AlertDelivery(error)) => {
+                error!(
+                    %error,
+                    et_day = %self.target_et_day,
+                    "Portfolio snapshot alert delivery deferred"
+                );
+                ctx.reschedule_alert(self.target_et_day, ALERT_RETRY_BACKOFF)
+                    .await
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn deliver_alert(
+        &self,
+        ctx: &PortfolioSnapshotCtx,
+        now: DateTime<Utc>,
+    ) -> Result<(), PortfolioSnapshotJobError> {
+        let id = PortfolioSnapshotId(self.target_et_day);
+        let snapshot = ctx
+            .portfolio_snapshot
+            .load(&id)
+            .await
+            .map_err(PortfolioSnapshotJobError::SnapshotLoad)?
+            .ok_or(PortfolioSnapshotJobError::MissingCapturedState)?;
+        alert_unusable_marks(ctx, &id, &snapshot, now).await
+    }
+}
+
+/// Why a captured equity row's USD mark cannot value the day. Mutually
+/// exclusive by construction; the metric label and the alert prose both
+/// derive from it, so neither can drift from the other.
+enum UnusableMark {
+    Missing,
+    Stale { observed_at: DateTime<Utc> },
+}
+
+impl UnusableMark {
+    const fn metric_label(&self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::Stale { .. } => "stale",
+        }
+    }
+}
+
+impl std::fmt::Display for UnusableMark {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Missing => write!(formatter, "missing"),
+            Self::Stale { observed_at } => {
+                write!(formatter, "stale (last observed {observed_at})")
+            }
+        }
+    }
+}
+
+async fn alert_unusable_marks(
+    ctx: &PortfolioSnapshotCtx,
+    id: &PortfolioSnapshotId,
+    snapshot: &PortfolioSnapshot,
+    now: DateTime<Utc>,
+) -> Result<(), PortfolioSnapshotJobError> {
+    let target_et_day = id.0;
+    let mut unusable = BTreeMap::<Symbol, (rain_math_float::Float, UnusableMark)>::new();
+    for row in &snapshot.captured_rows {
+        let PortfolioAsset::Equity(symbol) = &row.row.asset else {
+            continue;
+        };
+        let balance = (row.row.available + row.row.inflight)?;
+        if balance.is_zero()? {
+            continue;
+        }
+        if balance.is_negative()? {
+            warn!(
+                %target_et_day,
+                %symbol,
+                "Captured equity row has a negative aggregate balance; skipping mark evaluation"
+            );
+            continue;
+        }
+
+        let reason = match (row.usd_mark, row.mark_captured_at) {
+            (Some(_), Some(observed_at))
+                if is_stale_mark(&row.row.asset, observed_at, target_et_day) =>
+            {
+                UnusableMark::Stale { observed_at }
+            }
+            (Some(_), Some(_)) => continue,
+            _ => UnusableMark::Missing,
+        };
+
+        if let Some((total_balance, _)) = unusable.get_mut(symbol) {
+            *total_balance = (*total_balance + balance)?;
+        } else {
+            unusable.insert(symbol.clone(), (balance, reason));
+        }
+    }
+
+    for (symbol, (balance, reason)) in unusable {
+        if snapshot.alerted_symbols.contains(&symbol)
+            || snapshot.corrected_symbols.contains(&symbol)
+        {
+            continue;
+        }
+        let formatted_balance = format_float(&balance)?;
+        if !snapshot.detected_symbols.contains(&symbol) {
+            error!(
+                %target_et_day,
+                %symbol,
+                balance = %formatted_balance,
+                %reason,
+                "Portfolio snapshot captured nonzero equity with an unusable USD mark"
+            );
+            ctx.portfolio_snapshot
+                .send(
+                    id,
+                    PortfolioSnapshotCommand::RecordUnusableMarkDetected {
+                        symbol: symbol.clone(),
+                        detected_at: now,
+                    },
+                )
+                .await?;
+            counter!(
+                "portfolio_snapshot_unusable_mark_total",
+                "symbol" => symbol.to_string(),
+                "reason" => reason.metric_label()
+            )
+            .increment(1);
+        }
+        let message = format!(
+            "🚨 Portfolio snapshot mark {reason}\nET day: {target_et_day}\nSymbol: {symbol}\nTotal contributing balance: {formatted_balance}\nRepair: st0x-cli portfolio-snapshot set --day {target_et_day} --symbol {symbol} ..."
+        );
+        ctx.notifier.notify(&message).await?;
+        ctx.portfolio_snapshot
+            .send(
+                id,
+                PortfolioSnapshotCommand::RecordUnusableMarkAlerted {
+                    symbol: symbol.clone(),
+                    alerted_at: now,
+                },
+            )
+            .await?;
+    }
+
+    Ok(())
 }
 
 impl PortfolioSnapshotCtx {
@@ -387,14 +598,26 @@ impl PortfolioSnapshotCtx {
     /// both for hydration retries (same `target_et_day`, short backoff) and
     /// for the next day's capture (the next `target_et_day`, computed by
     /// [`next_capture_delay`]).
-    async fn reschedule(
+    async fn reschedule_capture(
         &self,
         target_et_day: NaiveDate,
         delay: Duration,
     ) -> Result<(), PortfolioSnapshotJobError> {
         let mut queue = self.queue.clone();
         queue
-            .push_with_delay(PortfolioSnapshotJob { target_et_day }, delay)
+            .push_with_delay(PortfolioSnapshotJob::capture(target_et_day), delay)
+            .await?;
+        Ok(())
+    }
+
+    async fn reschedule_alert(
+        &self,
+        target_et_day: NaiveDate,
+        delay: Duration,
+    ) -> Result<(), PortfolioSnapshotJobError> {
+        let mut queue = self.queue.clone();
+        queue
+            .push_with_delay(PortfolioSnapshotJob::alert(target_et_day), delay)
             .await?;
         Ok(())
     }
@@ -768,11 +991,9 @@ async fn resolve_marks(
                     *mark
                 } else {
                     let mark = match position_projection.load(symbol).await? {
-                        Some(position) => {
-                            position.last_price.map_or((None, None), |observation| {
-                                (Some(observation.price), Some(observation.observed_at))
-                            })
-                        }
+                        Some(position) => position.last_price.map_or((None, None), |observation| {
+                            (Some(observation.price), Some(observation.observed_at))
+                        }),
                         None => (None, None),
                     };
                     equity_marks.insert(symbol.clone(), mark);
@@ -835,9 +1056,13 @@ fn first_capture(now: DateTime<Utc>) -> (Duration, NaiveDate) {
     (delay, today)
 }
 
-/// Removes any non-terminal [`PortfolioSnapshotJob`] rows and pushes a fresh
-/// one targeting today (via [`first_capture`]), so a restart never silently
-/// skips queuing an attempt at the current ET day. Whether that attempt
+/// Reconstructs alert-only work from retained snapshot aggregates captured
+/// within the last [`BOOTSTRAP_ALERT_WINDOW_DAYS`] ET days, removes stale
+/// capture-loop rows, and pushes a fresh capture targeting today (via
+/// [`first_capture`]). Reconstructing alerts closes the crash window between a
+/// committed capture and its original alert-job enqueue; older days are
+/// outside any plausible crash window and re-enqueuing the whole history
+/// would fan out one job per captured day on every restart. Whether today's attempt
 /// actually captures today depends on `perform_at`'s boundary-anchored
 /// lateness cap ([`exceeds_lateness_cap`]) -- a sufficiently late
 /// restart still leaves today a gap, by design (see this module's doc
@@ -847,19 +1072,50 @@ fn first_capture(now: DateTime<Utc>) -> (Duration, NaiveDate) {
 /// grow by one with every restart. Mirrors `bootstrap_check_positions`'s
 /// purge-then-push shape.
 pub(crate) async fn bootstrap_portfolio_snapshot(
+    cqrs_pool: &sqlx::SqlitePool,
     apalis_pool: &apalis_sqlite::SqlitePool,
     queue: &PortfolioSnapshotJobQueue,
 ) -> Result<(), PortfolioSnapshotJobError> {
     purge_pending_portfolio_snapshot_jobs(apalis_pool).await?;
+    purge_portfolio_snapshot_alert_jobs(apalis_pool).await?;
+    let today = et_day(Utc::now());
+    let snapshot_ids = load_all_ids::<PortfolioSnapshot>(cqrs_pool).await?;
+    for id in snapshot_ids {
+        if today.signed_duration_since(id.0).num_days() > BOOTSTRAP_ALERT_WINDOW_DAYS {
+            continue;
+        }
+        queue
+            .clone()
+            .push_with_delay(PortfolioSnapshotJob::alert(id.0), Duration::ZERO)
+            .await?;
+    }
     let (delay, target_et_day) = first_capture(Utc::now());
     queue
         .clone()
-        .push_with_delay(PortfolioSnapshotJob { target_et_day }, delay)
+        .push_with_delay(PortfolioSnapshotJob::capture(target_et_day), delay)
         .await?;
     Ok(())
 }
 
-/// Removes every non-terminal [`PortfolioSnapshotJob`] row: `Pending`,
+async fn purge_portfolio_snapshot_alert_jobs(
+    apalis_pool: &apalis_sqlite::SqlitePool,
+) -> Result<u64, sqlx_apalis::Error> {
+    let deleted = sqlx_apalis::query(
+        "DELETE FROM Jobs WHERE job_type = ? \
+         AND COALESCE(json_extract(CAST(job AS TEXT), '$.alert_only'), 0) = 1 \
+         AND status NOT IN (?, ?)",
+    )
+    .bind(std::any::type_name::<PortfolioSnapshotJob>())
+    .bind(Status::Done.to_string())
+    .bind(Status::Killed.to_string())
+    .execute(apalis_pool)
+    .await?
+    .rows_affected();
+    Ok(deleted)
+}
+
+/// Removes every non-terminal capture-mode [`PortfolioSnapshotJob`] row:
+/// `Pending`,
 /// `Queued` (apalis reserved the row for a worker but no `Running` lock has
 /// landed yet -- reachable whenever the process crashes between
 /// `fetch_next` and `lock`), `Running`, and any `Failed` row still within
@@ -870,8 +1126,9 @@ async fn purge_pending_portfolio_snapshot_jobs(
 ) -> Result<u64, sqlx_apalis::Error> {
     let job_type = std::any::type_name::<PortfolioSnapshotJob>();
     let deleted = sqlx_apalis::query(
-        "DELETE FROM Jobs WHERE job_type = ? AND (status IN (?, ?, ?) \
-         OR (status = ? AND attempts < max_attempts))",
+        "DELETE FROM Jobs WHERE job_type = ? \
+         AND COALESCE(json_extract(CAST(job AS TEXT), '$.alert_only'), 0) = 0 \
+         AND (status IN (?, ?, ?) OR (status = ? AND attempts < max_attempts))",
     )
     .bind(job_type)
     .bind(Status::Pending.to_string())
@@ -888,6 +1145,7 @@ async fn purge_pending_portfolio_snapshot_jobs(
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use alloy::primitives::{TxHash, U256};
     use chrono::TimeZone;
@@ -902,6 +1160,7 @@ mod tests {
     use st0x_finance::Usdc;
     use st0x_wrapper::MockWrapper;
 
+    use crate::alerts::CapturingNotifier;
     use crate::inventory::view::{InFlightCashLocation, InFlightEquityLocation};
     use crate::inventory::{Inventory, InventoryView, Operator, Venue};
     use crate::portfolio_snapshot::read::{DayCapital, DayExclusionReason};
@@ -913,6 +1172,26 @@ mod tests {
 
     fn aapl() -> Symbol {
         Symbol::new("AAPL").unwrap()
+    }
+
+    #[derive(Default)]
+    struct FailOnceNotifier {
+        attempts: AtomicUsize,
+        delivered: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl Notifier for FailOnceNotifier {
+        async fn notify(&self, _message: &str) -> Result<(), NotifierError> {
+            if self.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(NotifierError::ApiError {
+                    status: reqwest::StatusCode::SERVICE_UNAVAILABLE,
+                    body: "temporary outage".to_owned(),
+                });
+            }
+            self.delivered.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
     }
 
     fn broadcasting(inventory: InventoryView) -> Arc<BroadcastingInventory> {
@@ -955,6 +1234,7 @@ mod tests {
             // `mark_all_required_fresh` explicitly, the same way they mutate
             // `ctx.inventory` to simulate a poll landing.
             poll_freshness: PollFreshness::new(),
+            notifier: Arc::new(crate::alerts::NoopNotifier),
             queue,
         };
 
@@ -1041,9 +1321,7 @@ mod tests {
     /// A job targeting today's ET day -- the common case for tests that
     /// exercise the capture logic itself, not the day-scheduling logic.
     fn job_for_today() -> PortfolioSnapshotJob {
-        PortfolioSnapshotJob {
-            target_et_day: et_day(Utc::now()),
-        }
+        PortfolioSnapshotJob::capture(et_day(Utc::now()))
     }
 
     /// A deterministic instant just past today's capture boundary, safely
@@ -1093,16 +1371,17 @@ mod tests {
         let first_count = portfolio_snapshot_row_count(&pool, &et_day).await;
         assert_eq!(first_count, 4);
 
-        let run_at_count: i64 =
-            sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
-                .bind(std::any::type_name::<PortfolioSnapshotJob>())
-                .fetch_one(&apalis_pool)
-                .await
-                .unwrap();
-        assert_eq!(
-            run_at_count, 2,
-            "each perform() call reschedules exactly one follow-up job"
-        );
+        let (capture_jobs, alert_jobs): (i64, i64) = sqlx_apalis::query_as(
+            "SELECT \
+             COUNT(CASE WHEN COALESCE(json_extract(CAST(job AS TEXT), '$.alert_only'), 0) = 0 THEN 1 END), \
+             COUNT(CASE WHEN json_extract(CAST(job AS TEXT), '$.alert_only') = 1 THEN 1 END) \
+             FROM Jobs WHERE job_type = ?",
+        )
+        .bind(std::any::type_name::<PortfolioSnapshotJob>())
+        .fetch_one(&apalis_pool)
+        .await
+        .unwrap();
+        assert_eq!((capture_jobs, alert_jobs), (2, 2));
     }
 
     /// The catch-all `Err(error) => return Err(...)` arm (write.rs, distinct
@@ -1543,9 +1822,15 @@ mod tests {
     #[tokio::test]
     async fn symbol_with_balance_but_no_price_yet_is_included_with_null_mark() {
         let (pool, apalis_pool) = setup_test_pools().await;
-        let (ctx, _position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
+        let (mut ctx, _position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        ctx.notifier = notifier.clone();
 
         job_for_today()
+            .perform_at(&ctx, safe_capture_now())
+            .await
+            .unwrap();
+        PortfolioSnapshotJob::alert(et_day(Utc::now()))
             .perform_at(&ctx, safe_capture_now())
             .await
             .unwrap();
@@ -1561,6 +1846,97 @@ mod tests {
         .unwrap();
 
         assert_eq!(stored, None, "AAPL has never filled, so no mark is known");
+        let alerts = notifier.messages();
+        assert_eq!(alerts.len(), 1);
+        assert!(alerts[0].contains("mark missing"));
+        assert!(alerts[0].contains("Symbol: AAPL"));
+    }
+
+    #[tokio::test]
+    async fn failed_alert_is_retried_from_the_captured_event_rows() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (mut ctx, _position) =
+            build_fully_hydrated_ctx(pool.clone(), apalis_pool.clone()).await;
+        let notifier = Arc::new(FailOnceNotifier::default());
+        ctx.notifier = notifier.clone();
+        let job = job_for_today();
+        let now = safe_capture_now();
+
+        job.perform_at(&ctx, now).await.unwrap();
+        assert_eq!(notifier.attempts.load(Ordering::SeqCst), 0);
+        assert_eq!(notifier.delivered.load(Ordering::SeqCst), 0);
+        let queued_jobs: Vec<Vec<u8>> =
+            sqlx_apalis::query_scalar("SELECT job FROM Jobs WHERE job_type = ? ORDER BY run_at")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_all(&apalis_pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            queued_jobs.len(),
+            2,
+            "next capture and alert retry must both survive"
+        );
+        let alert_retry = queued_jobs
+            .iter()
+            .map(|job| serde_json::from_slice::<PortfolioSnapshotJob>(job).unwrap())
+            .find(|job| job.alert_only)
+            .expect("failed notification must enqueue an alert-only retry");
+
+        alert_retry.perform_at(&ctx, now).await.unwrap();
+        assert_eq!(notifier.attempts.load(Ordering::SeqCst), 1);
+        let detection_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM events WHERE aggregate_type = 'PortfolioSnapshot' \
+             AND event_type = 'PortfolioSnapshotEvent::UnusableMarkDetected'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            detection_count, 1,
+            "detection is persisted despite Telegram failure"
+        );
+
+        PortfolioSnapshotJob::alert(job.target_et_day)
+            .perform_at(&ctx, now)
+            .await
+            .unwrap();
+        assert_eq!(notifier.attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(notifier.delivered.load(Ordering::SeqCst), 1);
+
+        PortfolioSnapshotJob::alert(job.target_et_day)
+            .perform_at(&ctx, now)
+            .await
+            .unwrap();
+        assert_eq!(
+            notifier.attempts.load(Ordering::SeqCst),
+            2,
+            "delivery event deduplicates retries"
+        );
+    }
+
+    #[tokio::test]
+    async fn alert_for_uncaptured_day_propagates_instead_of_rescheduling() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (ctx, _position) = build_fully_hydrated_ctx(pool, apalis_pool.clone()).await;
+
+        let error = PortfolioSnapshotJob::alert(et_day(Utc::now()))
+            .perform_at(&ctx, safe_capture_now())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            PortfolioSnapshotJobError::MissingCapturedState
+        ));
+        let queued: i64 = sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<PortfolioSnapshotJob>())
+            .fetch_one(&apalis_pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            queued, 0,
+            "non-transient alert failures must reach apalis, not self-reschedule"
+        );
     }
 
     /// Distinct from the "never touched" case above: the Position aggregate
@@ -1693,7 +2069,9 @@ mod tests {
     #[tokio::test]
     async fn stale_price_with_recent_non_price_touch_excludes_the_day() {
         let (pool, apalis_pool) = setup_test_pools().await;
-        let (ctx, position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
+        let (mut ctx, position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        ctx.notifier = notifier.clone();
 
         let block_timestamp = Utc::now() - chrono::Duration::days(10);
         position
@@ -1732,6 +2110,10 @@ mod tests {
             .perform_at(&ctx, safe_capture_now())
             .await
             .unwrap();
+        PortfolioSnapshotJob::alert(et_day(Utc::now()))
+            .perform_at(&ctx, safe_capture_now())
+            .await
+            .unwrap();
 
         let today = et_day(Utc::now());
         let days = load_portfolio_days(
@@ -1753,6 +2135,9 @@ mod tests {
             )),
             "a stale price must exclude the day even though the position was touched today"
         );
+        let alerts = notifier.messages();
+        assert_eq!(alerts.len(), 1);
+        assert!(alerts[0].contains("mark stale"));
     }
 
     /// `resolve_marks` must key staleness off `block_timestamp` (the
@@ -1828,12 +2213,14 @@ mod tests {
         let real_before = Utc::now();
         job_for_today().perform_at(&ctx, now).await.unwrap();
 
-        let (run_at, job_bytes): (i64, Vec<u8>) =
-            sqlx_apalis::query_as("SELECT run_at, job FROM Jobs WHERE job_type = ? LIMIT 1")
-                .bind(std::any::type_name::<PortfolioSnapshotJob>())
-                .fetch_one(&apalis_pool)
-                .await
-                .unwrap();
+        let (run_at, job_bytes): (i64, Vec<u8>) = sqlx_apalis::query_as(
+            "SELECT run_at, job FROM Jobs WHERE job_type = ? \
+                 AND COALESCE(json_extract(CAST(job AS TEXT), '$.alert_only'), 0) = 0 LIMIT 1",
+        )
+        .bind(std::any::type_name::<PortfolioSnapshotJob>())
+        .fetch_one(&apalis_pool)
+        .await
+        .unwrap();
 
         let tomorrow = et_day(now) + Days::new(1);
         let expected_boundary = et_midnight(tomorrow).unwrap() + CAPTURE_BUFFER;
@@ -1912,9 +2299,7 @@ mod tests {
         let (ctx, _position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool).await;
 
         let today = et_day(Utc::now());
-        let stale_job = PortfolioSnapshotJob {
-            target_et_day: today - Days::new(1),
-        };
+        let stale_job = PortfolioSnapshotJob::capture(today - Days::new(1));
 
         stale_job
             .perform_at(&ctx, safe_capture_now())
@@ -1962,9 +2347,7 @@ mod tests {
         // this run.
 
         let today = et_day(Utc::now());
-        let stale_job = PortfolioSnapshotJob {
-            target_et_day: today - Days::new(1),
-        };
+        let stale_job = PortfolioSnapshotJob::capture(today - Days::new(1));
 
         stale_job
             .perform_at(&ctx, safe_capture_now())
@@ -1999,9 +2382,7 @@ mod tests {
         .await;
 
         let today = et_day(Utc::now());
-        let stale_job = PortfolioSnapshotJob {
-            target_et_day: today - Days::new(1),
-        };
+        let stale_job = PortfolioSnapshotJob::capture(today - Days::new(1));
 
         stale_job
             .perform_at(&ctx, safe_capture_now())
@@ -2042,9 +2423,7 @@ mod tests {
         let (ctx, _position) = build_fully_hydrated_ctx(pool.clone(), apalis_pool.clone()).await;
 
         let future_day = et_day(Utc::now()) + Days::new(1);
-        let early_job = PortfolioSnapshotJob {
-            target_et_day: future_day,
-        };
+        let early_job = PortfolioSnapshotJob::capture(future_day);
 
         // `reschedule` (via apalis's `push_with_delay`) anchors `run_at` to
         // the REAL wall clock at insertion time, not `now` -- only the
@@ -2079,7 +2458,7 @@ mod tests {
 
     #[tokio::test]
     async fn bootstrap_purges_stale_pending_row_and_leaves_exactly_one() {
-        let (_pool, apalis_pool) = setup_test_pools().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let queue = PortfolioSnapshotJobQueue::new(&apalis_pool);
 
         sqlx_apalis::query(
@@ -2104,7 +2483,7 @@ mod tests {
         // to run within that capped window.
         let (expected_delay, _) = first_capture(before);
 
-        bootstrap_portfolio_snapshot(&apalis_pool, &queue)
+        bootstrap_portfolio_snapshot(&pool, &apalis_pool, &queue)
             .await
             .unwrap();
 
@@ -2149,6 +2528,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bootstrap_recovers_alert_work_after_capture_commit() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let queue = PortfolioSnapshotJobQueue::new(&apalis_pool);
+        let now = Utc::now();
+        let recent_day = et_day(now);
+        let stale_day = recent_day - Days::new(30);
+        let store = StoreBuilder::<PortfolioSnapshot>::new(pool.clone())
+            .with(Arc::new(PortfolioSnapshotProjection::new(pool.clone())))
+            .build(())
+            .await
+            .unwrap();
+        let seeded_row = PortfolioBalanceRowWithMark {
+            row: PortfolioBalanceRow {
+                location: PortfolioLocation::MarketMaking,
+                asset: PortfolioAsset::Equity(aapl()),
+                available: float!(10),
+                inflight: float!(0),
+            },
+            usd_mark: None,
+            mark_captured_at: None,
+        };
+        for (day, captured_at) in [(recent_day, now), (stale_day, now - Days::new(30))] {
+            store
+                .send(
+                    &PortfolioSnapshotId(day),
+                    PortfolioSnapshotCommand::Capture {
+                        captured_at,
+                        rows: vec![seeded_row.clone()],
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        bootstrap_portfolio_snapshot(&pool, &apalis_pool, &queue)
+            .await
+            .unwrap();
+
+        let jobs: Vec<Vec<u8>> =
+            sqlx_apalis::query_scalar("SELECT job FROM Jobs WHERE job_type = ?")
+                .bind(std::any::type_name::<PortfolioSnapshotJob>())
+                .fetch_all(&apalis_pool)
+                .await
+                .unwrap();
+        let jobs = jobs
+            .iter()
+            .map(|job| serde_json::from_slice::<PortfolioSnapshotJob>(job).unwrap())
+            .collect::<Vec<_>>();
+        let alert_days = jobs
+            .iter()
+            .filter(|job| job.alert_only)
+            .map(|job| job.target_et_day)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            alert_days,
+            vec![recent_day],
+            "only days inside the bootstrap alert window get an alert job"
+        );
+        assert_eq!(jobs.iter().filter(|job| !job.alert_only).count(), 1);
+    }
+
+    #[tokio::test]
     async fn purge_removes_pending_queued_running_and_retryable_failed_but_keeps_terminal() {
         let (_pool, apalis_pool) = setup_test_pools().await;
         let job_type = std::any::type_name::<PortfolioSnapshotJob>();
@@ -2182,6 +2623,21 @@ mod tests {
             0,
         )
         .await;
+        sqlx_apalis::query(
+            "INSERT INTO Jobs (job, id, job_type, status, attempts, max_attempts) \
+             VALUES (?, 'alert-pending', ?, ?, 0, 25)",
+        )
+        .bind(
+            serde_json::to_vec(&PortfolioSnapshotJob::alert(
+                NaiveDate::from_ymd_opt(2026, 7, 20).unwrap(),
+            ))
+            .unwrap(),
+        )
+        .bind(job_type)
+        .bind(Status::Pending.to_string())
+        .execute(&apalis_pool)
+        .await
+        .unwrap();
         insert(
             &apalis_pool,
             job_type,
@@ -2242,7 +2698,8 @@ mod tests {
                 .fetch_all(&apalis_pool)
                 .await
                 .unwrap();
-        assert_eq!(remaining.len(), 3);
+        assert_eq!(remaining.len(), 4);
+        assert!(remaining.contains(&"alert-pending".to_string()));
         assert!(remaining.contains(&"failed-exhausted".to_string()));
         assert!(remaining.contains(&"done-1".to_string()));
         assert!(remaining.contains(&"killed-1".to_string()));
@@ -2697,7 +3154,7 @@ mod tests {
         let boundary = et_midnight(target_et_day).unwrap() + CAPTURE_BUFFER;
         let now = boundary + chrono::Duration::minutes(1);
 
-        let job = PortfolioSnapshotJob { target_et_day };
+        let job = PortfolioSnapshotJob::capture(target_et_day);
         job.perform_at(&ctx, now).await.unwrap();
 
         assert_eq!(
@@ -2759,7 +3216,7 @@ mod tests {
         let first_tick_now = cap - chrono::Duration::minutes(2);
 
         let real_before = Utc::now();
-        let job = PortfolioSnapshotJob { target_et_day };
+        let job = PortfolioSnapshotJob::capture(target_et_day);
         job.perform_at(&ctx, first_tick_now).await.unwrap();
 
         assert_eq!(
@@ -2786,7 +3243,7 @@ mod tests {
         // have skipped over. The rescheduled job's second tick lands exactly
         // at the cap.
         mark_all_required_fresh(&ctx);
-        let rescheduled = PortfolioSnapshotJob { target_et_day };
+        let rescheduled = PortfolioSnapshotJob::capture(target_et_day);
         rescheduled.perform_at(&ctx, cap).await.unwrap();
 
         assert!(
@@ -2812,7 +3269,7 @@ mod tests {
         let now = boundary - chrono::Duration::seconds(1);
 
         let real_before = Utc::now();
-        let job = PortfolioSnapshotJob { target_et_day };
+        let job = PortfolioSnapshotJob::capture(target_et_day);
         job.perform_at(&ctx, now).await.unwrap();
 
         assert_eq!(
@@ -2861,7 +3318,7 @@ mod tests {
         let boundary = et_midnight(target_et_day).unwrap() + CAPTURE_BUFFER;
         let cap = boundary + MAX_FRESHNESS_DEFER;
 
-        let job = PortfolioSnapshotJob { target_et_day };
+        let job = PortfolioSnapshotJob::capture(target_et_day);
         job.perform_at(&ctx, cap).await.unwrap();
 
         assert!(
@@ -2887,7 +3344,7 @@ mod tests {
         let boundary = et_midnight(target_et_day).unwrap() + CAPTURE_BUFFER;
         let now = boundary + MAX_FRESHNESS_DEFER + chrono::Duration::seconds(1);
 
-        let job = PortfolioSnapshotJob { target_et_day };
+        let job = PortfolioSnapshotJob::capture(target_et_day);
         job.perform_at(&ctx, now).await.unwrap();
 
         assert_eq!(
@@ -2943,7 +3400,7 @@ mod tests {
         let boundary = et_midnight(target_et_day).unwrap() + CAPTURE_BUFFER;
         let now = boundary + MAX_FRESHNESS_DEFER + chrono::Duration::minutes(1);
 
-        let job = PortfolioSnapshotJob { target_et_day };
+        let job = PortfolioSnapshotJob::capture(target_et_day);
         // `reschedule` (via apalis's `push_with_delay`) anchors `run_at` to
         // the REAL wall clock at insertion time, not the fictitious injected
         // `now` -- only the delay's LENGTH is derived from `now`.
@@ -3012,9 +3469,7 @@ mod tests {
         let today_boundary = et_midnight(today).unwrap() + CAPTURE_BUFFER;
         let now = today_boundary + MAX_FRESHNESS_DEFER + chrono::Duration::minutes(1);
 
-        let stale_job = PortfolioSnapshotJob {
-            target_et_day: yesterday,
-        };
+        let stale_job = PortfolioSnapshotJob::capture(yesterday);
         stale_job.perform_at(&ctx, now).await.unwrap();
 
         assert_eq!(
@@ -3060,9 +3515,7 @@ mod tests {
         let today_boundary = et_midnight(today).unwrap() + CAPTURE_BUFFER;
         let now = today_boundary - chrono::Duration::seconds(1);
 
-        let stale_job = PortfolioSnapshotJob {
-            target_et_day: yesterday,
-        };
+        let stale_job = PortfolioSnapshotJob::capture(yesterday);
         stale_job.perform_at(&ctx, now).await.unwrap();
 
         assert_eq!(


### PR DESCRIPTION
## What

[RAI-1514](https://linear.app/makeitrain/issue/RAI-1514/keep-return-on-capital-usable-when-daily-snapshot-marks-are-missing)

- Keep full-range PnL totals while limiting return on capital to days with usable capital.
- Expose every excluded ET day and its reason, including missing snapshot days at open range edges.
- Add an audited CLI command to repair a historical equity mark without changing the live position price.
- Send durable Telegram alerts when a captured nonzero equity balance has a missing or stale mark.

## Why

A missing or stale snapshot mark previously let return on capital combine PnL from more days than its capital denominator covered. Operators also had no audited way to repair the historical mark after verifying the close.

## How

- Bucket trade PnL, costs, and revenue by ET day, then use only days with usable capital in both the return numerator and denominator.
- Persist repairs as append-only `PortfolioSnapshot` events and project the latest correction to every captured location for that symbol and day.
- Rebuild the snapshot projection from retained events at startup and through `view rebuild --aggregate portfolio-snapshot --all`.
- Persist mark detection and successful alert delivery separately. Alert-only jobs retry Telegram failures and are reconstructed from retained snapshots after restart.
- Keep the existing 00:05 ET capture boundary.

## Testing

- Added coverage for missing and stale marks, finite/open date-range gaps, and aligned trade/cost/revenue return calculations.
- Added aggregate, CLI, projection rebuild, repeated-repair, alert retry/deduplication, and startup recovery tests.
- `nix run .#ci`

## Screenshots

Not applicable.

## Anything else

Telegram delivery is at-least-once. A crash after Telegram accepts a message but before the delivery event commits can produce a duplicate rather than lose the alert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved PnL reporting with daily realized PnL alignment and clearer annualized return calculations.
  - Reports now identify excluded days and explain missing or unusable portfolio data.
  - Added operational alerts for missing or stale historical price marks.
  - Added audited tools to correct historical marks and rebuild portfolio snapshot data.

- **Bug Fixes**
  - Corrected historical marks update all applicable snapshot records without changing live position prices.
  - Improved snapshot recovery, replay, and alert retry behavior for more reliable reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->