### PR TITLE
perf: accelerate CI test archive transfer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dorny/paths-filter@v3
         id: filter
@@ -106,7 +106,7 @@ jobs:
       CARGO_INCREMENTAL: "0"
       CARGO_TARGET_DIR: target/test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure Git fetch fail-fast
         run: |
@@ -127,7 +127,7 @@ jobs:
             keep-env-derivations = true
             keep-outputs = true
 
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         continue-on-error: true
         with:
           name: rainlanguage
@@ -162,13 +162,14 @@ jobs:
               -E "test(compile_fail_tests)"
           '
 
-      - name: Upload nextest archive
-        uses: actions/upload-artifact@v4
+      # Blacksmith transparently redirects the native Actions cache to
+      # colocated storage. GitHub artifacts still use remote Azure storage,
+      # which made each test shard spend ~20 minutes downloading this file.
+      - name: Save nextest archive
+        uses: actions/cache/save@v6
         with:
-          name: nextest-archive
           path: ${{ runner.temp }}/nextest-archive.tar.zst
-          retention-days: 1
-          if-no-files-found: error
+          key: ${{ runner.os }}-nextest-${{ github.run_id }}-${{ github.run_attempt }}
 
   backend-test:
     name: backend test ${{ matrix.partition }} of 4
@@ -182,7 +183,7 @@ jobs:
       matrix:
         partition: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure Git fetch fail-fast
         run: |
@@ -203,7 +204,7 @@ jobs:
             keep-env-derivations = true
             keep-outputs = true
 
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         continue-on-error: true
         with:
           name: rainlanguage
@@ -217,11 +218,12 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 8G
 
-      - name: Download nextest archive
-        uses: actions/download-artifact@v4
+      - name: Restore nextest archive
+        uses: actions/cache/restore@v6
         with:
-          name: nextest-archive
-          path: ${{ runner.temp }}
+          path: ${{ runner.temp }}/nextest-archive.tar.zst
+          key: ${{ runner.os }}-nextest-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
 
       # Test binaries come from the archive built in backend-build; no recompile.
       - name: test ${{ matrix.partition }} of 4
@@ -275,7 +277,7 @@ jobs:
         if: ${{ needs.changes.result == 'success' && needs.changes.outputs.code == 'false' }}
         run: echo "Docs-only change; skipping dashboard build."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
 
       - name: Configure Git fetch fail-fast
@@ -299,7 +301,7 @@ jobs:
             keep-env-derivations = true
             keep-outputs = true
 
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         continue-on-error: true
         with:
@@ -348,7 +350,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure Git fetch fail-fast
         run: |
@@ -369,7 +371,7 @@ jobs:
             keep-env-derivations = true
             keep-outputs = true
 
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         continue-on-error: true
         with:
           name: rainlanguage

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@v1.3.1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@v1.3.1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/external-pr-ci.yaml
+++ b/.github/workflows/external-pr-ci.yaml
@@ -175,7 +175,7 @@ jobs:
       # `pull_request_target` checks out the trusted base branch, never fork
       # code. Pin the action because this job's token can write refs, dispatch
       # workflows, and remove labels.
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
 
       # GitHub keeps `refs/pull/<number>/head` in this repository for every pull
       # request, fork ones included, so the mirror needs no fork remote.
@@ -340,7 +340,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
         with:
           persist-credentials: false
 
@@ -405,7 +405,7 @@ jobs:
       actions: write
       contents: write
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/rekey.yaml
+++ b/.github/workflows/rekey.yaml
@@ -15,7 +15,7 @@ jobs:
   tf-rekey:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
 


### PR DESCRIPTION
## What

[RAI-1517](https://linear.app/makeitrain/issue/RAI-1517/reduce-ci-action-deprecations-and-test-archive-transfer-time)

- Route the nextest archive through the Actions cache used by Blacksmith's colocated cache service.
- Update checkout to v6 and Cachix to v17.
- Add grouped weekly Dependabot updates for GitHub Actions.

## Why

The linked CI run spent about 20 minutes downloading a 1.42 GB nextest archive in each test shard, while the tests themselves took about 90 seconds. The older action runtimes also emitted Node.js deprecation warnings.

## How

The build job saves the archive under an exact OS, run ID, and run-attempt key. Test shards restore that key and fail immediately on a cache miss. Security-sensitive external PR jobs keep checkout pinned to the v6 commit SHA.

## Testing

- `cargo check --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo fmt -- --check`
- repository pre-commit hooks
- `nixfmt --check`

## Screenshots

Not applicable.

## Anything else

GitHub CI will provide the first end-to-end measurement of the colocated archive transfer.
