### PR TITLE
fix: back off on Alpaca 429 instead of failing the job terminally

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4117,6 +4117,61 @@ poll chain exists per order regardless of which path pushed it. A `Running` poll
 row and its delayed `Pending` successor may temporarily coexist within that one
 chain.
 
+##### Broker rate-limit (429) backpressure
+
+A `429 Too Many Requests` from Alpaca is not a bug and must not consume a job's
+terminal retry budget or open its circuit breaker. Three call-site shapes, each
+handled differently:
+
+- **Apalis jobs**: on a classified 429, the job's `perform()` catches the error
+  before it ever becomes an `Err`, computes a delay from the broker's
+  `Retry-After` header (or an escalating fallback when absent, floored to a
+  minimum sleep so a `Retry-After: 0` cannot cause a hot loop), pushes a fresh
+  copy of itself back onto its own queue after that delay, and returns `Ok(())`.
+  The row acks `Done` immediately and the worker is free on the very next poll
+  tick to pick up any other pending work -- the row is never held in place
+  waiting out the backoff. A per-job `backpressure_streak` counter travels in
+  the job's own payload (there is no live retry object between separate
+  dispatches) and bounds this to a large but finite reschedule budget; once
+  exhausted, a supervised job (e.g. `Order status
+  poll`) logs loudly and
+  dead-letters cleanly (`Ok(())`, not `Err`) rather than opening its circuit
+  breaker, since a persistent 429 there signals a structurally-dead integration
+  (suspended account, revoked key), not a process fault. An exhausted
+  `Order status poll` retains its completed queue row as a durable dead-letter
+  marker so periodic submitted-order recovery cannot reset the budget and
+  immediately re-arm it. `Order status poll` reads and idempotent hedge-order
+  placement are the jobs whose successors genuinely re-drive the broker call;
+  other jobs' 429s can land after their own idempotency guard already committed,
+  in which case the reschedule still frees the worker and preserves the retry
+  budget but the guard itself (not the reschedule) is what makes the eventual
+  retry safe.
+  - **Exception -- equity recovery jobs**: wrapped/unwrapped equity recovery
+    currently records provider failures as terminal aggregate events carrying
+    display text, so the job never receives a typed 429 to classify or
+    reschedule. Those recovery paths retain their existing terminal behavior
+    until their aggregate error contracts preserve typed provider failures.
+  - **Exception -- USDC conversion order placement**: the USD->USDC and
+    USDC->USD conversion placements (inside the USDC hedging/market-making
+    transfer jobs) are NOT rescheduled on a 429, unlike every other call site
+    above. Placement commits the aggregate to `Converting` before the broker
+    call, but a 429 (or any other placement error) still fails fast: the
+    aggregate terminalizes (`ConversionFailed`) and the error propagates as an
+    ordinary terminal failure, exactly as before this backpressure mechanism
+    existed. This is unchanged from prod today, and is a deliberate choice, not
+    an oversight -- retrying a rejected/ambiguous placement risks submitting the
+    order twice against real money. Making conversion placement reschedule-safe
+    needs a place-then-commit reorder of the conversion aggregate (defer
+    recording intent until after a successful placement, or have the resume path
+    re-place idempotently by `client_order_id` instead of only looking the order
+    up) and is a documented follow-up, not part of this mechanism.
+- **Synchronous (CLI) call sites**: no queue row and no sibling job waiting on a
+  shared worker, so a classified 429 is retried in place with a small bounded
+  attempt budget instead.
+- **Supervised, non-job tasks** (e.g. `Executor maintenance`): already correct
+  with no change -- a tick error of any kind, backpressure included, is logged
+  and the loop simply waits for the next tick.
+
 **Lifecycle workflows** (stepped, durable, future):
 
 | Workflow           | Steps                                                                                  |

--- a/crates/execution/src/alpaca_broker_api/client.rs
+++ b/crates/execution/src/alpaca_broker_api/client.rs
@@ -15,6 +15,7 @@ use super::journal::{JournalRequest, JournalResponse};
 use super::order::{
     CryptoOrderRequest, CryptoOrderResponse, LimitOrderRequest, OrderRequest, OrderResponse,
 };
+use crate::rate_limit::retry_after_from_response_headers;
 use crate::{CancellationOutcome, ClientOrderId, FractionalShares, Positive, Symbol};
 
 /// Request timeout applied to every Alpaca Broker API HTTP call.
@@ -357,9 +358,10 @@ impl AlpacaBrokerApiClient {
             return Ok(());
         }
 
+        let retry_after = retry_after_from_response_headers(response.headers());
         let bytes = response.bytes().await?;
 
-        Err(parse_api_error(status, &bytes))
+        Err(parse_api_error(status, &bytes, retry_after))
     }
 
     /// Perform a POST request with JSON body
@@ -380,6 +382,9 @@ impl AlpacaBrokerApiClient {
     ) -> Result<T, AlpacaBrokerApiError> {
         let status = response.status();
         let url = response.url().clone();
+        // Captured before `response.bytes()` consumes the response --
+        // headers are no longer readable afterward.
+        let retry_after = retry_after_from_response_headers(response.headers());
         // Read raw bytes and parse successful responses with `from_slice` so
         // invalid UTF-8 fails fast (matching the prior `response.json()`),
         // rather than being silently replaced by `response.text()`'s lossy
@@ -399,14 +404,18 @@ impl AlpacaBrokerApiClient {
             return Ok(serde_json::from_slice(&bytes)?);
         }
 
-        Err(parse_api_error(status, &bytes))
+        Err(parse_api_error(status, &bytes, retry_after))
     }
 }
 
 /// Parse an Alpaca error response body into an `ApiError`, falling back to the
 /// raw (lossy-decoded) body when it does not match `AlpacaApiErrorBody`. Shared
 /// by `delete` and `handle_response` so both error paths stay in sync.
-fn parse_api_error(status: reqwest::StatusCode, bytes: &[u8]) -> AlpacaBrokerApiError {
+fn parse_api_error(
+    status: reqwest::StatusCode,
+    bytes: &[u8],
+    retry_after: Option<Duration>,
+) -> AlpacaBrokerApiError {
     let (alpaca_code, message) = match serde_json::from_slice::<AlpacaApiErrorBody>(bytes) {
         Ok(parsed) => (parsed.code, parsed.message),
         Err(_) => (None, String::from_utf8_lossy(bytes).into_owned()),
@@ -416,6 +425,7 @@ fn parse_api_error(status: reqwest::StatusCode, bytes: &[u8]) -> AlpacaBrokerApi
         status,
         alpaca_code,
         message,
+        retry_after,
     }
 }
 
@@ -569,6 +579,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancel_order_captures_retry_after_on_429() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let order_id = uuid!("44444444-4444-4444-4444-444444444444");
+
+        let mock = server.mock(|when, then| {
+            when.method(DELETE).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("retry-after", "15")
+                .json_body(serde_json::json!({ "message": "rate limited" }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let error = client.cancel_order(order_id).await.unwrap_err();
+
+        mock.assert();
+        let AlpacaBrokerApiError::ApiError { retry_after, .. } = error else {
+            panic!("expected ApiError, got {error:?}");
+        };
+        assert_eq!(retry_after, Some(Duration::from_secs(15)));
+    }
+
+    #[tokio::test]
     async fn test_verify_account_success() {
         let server = MockServer::start();
         let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
@@ -652,6 +688,53 @@ mod tests {
         assert!(
             matches!(err, AlpacaBrokerApiError::ApiError { status, .. } if status.as_u16() == 401)
         );
+    }
+
+    #[tokio::test]
+    async fn handle_response_captures_retry_after_seconds_header_on_429() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("retry-after", "30")
+                .json_body(serde_json::json!({ "message": "rate limited" }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let error = client.verify_account().await.unwrap_err();
+
+        mock.assert();
+        let AlpacaBrokerApiError::ApiError { retry_after, .. } = error else {
+            panic!("expected ApiError, got {error:?}");
+        };
+        assert_eq!(retry_after, Some(Duration::from_secs(30)));
+    }
+
+    #[tokio::test]
+    async fn handle_response_has_no_retry_after_when_header_absent() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(429)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({ "message": "rate limited" }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let error = client.verify_account().await.unwrap_err();
+
+        mock.assert();
+        let AlpacaBrokerApiError::ApiError { retry_after, .. } = error else {
+            panic!("expected ApiError, got {error:?}");
+        };
+        assert_eq!(retry_after, None);
     }
 
     #[tracing_test::traced_test]

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -5,12 +5,14 @@ use serde::Deserialize;
 use st0x_float_serde::format_float_with_fallback;
 use std::fmt;
 use std::str::FromStr;
+use std::time::Duration;
 use thiserror::Error;
 use uuid::Uuid;
 
 use crate::alpaca_market_data::AlpacaMarketDataError;
 use crate::{
-    ClientOrderId, CounterTradeCostError, ExecutorOrderId, FractionalShares, Positive, Symbol, Usd,
+    Backpressure, ClientOrderId, CounterTradeCostError, ExecutorOrderId, FractionalShares,
+    Positive, Symbol, Usd,
 };
 
 /// Time-in-force specifies how long an order remains active before it expires.
@@ -165,6 +167,11 @@ pub enum AlpacaBrokerApiError {
         alpaca_code: Option<u64>,
         /// Human-readable error message from Alpaca
         message: String,
+        /// Parsed `Retry-After` header from the response, when the broker
+        /// sent one. Only meaningful when `status == 429 Too Many Requests`;
+        /// captured unconditionally regardless of status since it costs
+        /// nothing to carry and keeps `parse_api_error` a single call site.
+        retry_after: Option<Duration>,
     },
 
     #[error("Invalid order ID: {0}")]
@@ -300,4 +307,128 @@ fn format_api_error(
         || format!("Alpaca API error ({status}): {message}"),
         |code| format!("Alpaca API error {code} ({status}): {message}"),
     )
+}
+
+impl AlpacaBrokerApiError {
+    /// Classifies this error as broker rate-limiting (HTTP 429), returning
+    /// its `Retry-After` hint when the broker sent one. Every other variant
+    /// returns `None` -- an exhaustive match so a new variant added later
+    /// forces a conscious decision here rather than silently classifying as
+    /// "not backpressure".
+    ///
+    /// The bare-429 assumption is not a guess: it is the classification
+    /// RAI-1492's actual incident (a `PollOrderStatus` job's persisted
+    /// `last_result`) recorded, and matches RFC 6585's standard status code
+    /// for rate limiting that Alpaca (like virtually every REST API) uses.
+    /// The `Retry-After` hint carried alongside it is a separate, softer
+    /// assumption -- see `rate_limit::parse_retry_after`'s doc comment and
+    /// its fixture test for that one, since Alpaca's own SDKs do not trust
+    /// the header even when present.
+    pub fn backpressure(&self) -> Option<Backpressure> {
+        match self {
+            Self::ApiError {
+                status,
+                retry_after,
+                ..
+            } if *status == reqwest::StatusCode::TOO_MANY_REQUESTS => Some(Backpressure {
+                retry_after: *retry_after,
+            }),
+
+            Self::ApiError { .. }
+            | Self::HttpClient(_)
+            | Self::JsonParse(_)
+            | Self::InvalidHeader(_)
+            | Self::InvalidOrderId(_)
+            | Self::IncompleteOrder { .. }
+            | Self::AccountNotActive { .. }
+            | Self::CryptoOrderFailed { .. }
+            | Self::DuplicateOrderNotFound { .. }
+            | Self::CalendarIterationInvariantViolation
+            | Self::CalendarDateMismatch { .. }
+            | Self::CalendarLocalTimeUnresolvable { .. }
+            | Self::InvalidAccountActivitiesUrl { .. }
+            | Self::AccountActivitiesPaginationInvariantViolation
+            | Self::AccountActivitiesPageLimitExceeded { .. }
+            | Self::AssetNotActive { .. }
+            | Self::AssetNotTradable { .. }
+            | Self::InvalidLimitPricePrecision { .. }
+            | Self::UsdBalanceConversion(_)
+            | Self::FractionalCents(_)
+            | Self::InvalidSymbol(_)
+            | Self::MissingPositionQuantity
+            | Self::BelowPrecision { .. }
+            | Self::UsdcBelowPrecision { .. }
+            | Self::UsdcPrecisionExceeded { .. }
+            | Self::NotPositive(_)
+            | Self::NotPositiveLimitPrice(_)
+            | Self::FloatConversion(_)
+            | Self::CounterTradeCost(_) => None,
+
+            // Delegate rather than returning `None`: `find_backpressure`'s
+            // chain-walk downcasts `AlpacaBrokerApiError` before it ever
+            // reaches the wrapped `AlpacaMarketDataError`, so classifying
+            // here means a 429 from `fetch_latest_trade_price` (e.g. the
+            // extended-hours limit-price lookup) is caught at this first
+            // hop instead of relying on a second, separate
+            // `AlpacaMarketDataError` downcast one level further down the
+            // chain.
+            Self::LatestTrade(source) => source.backpressure(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backpressure_some_for_429_with_retry_after() {
+        let error = AlpacaBrokerApiError::ApiError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            alpaca_code: None,
+            message: "rate limited".to_string(),
+            retry_after: Some(Duration::from_secs(20)),
+        };
+
+        assert_eq!(
+            error.backpressure(),
+            Some(Backpressure {
+                retry_after: Some(Duration::from_secs(20))
+            })
+        );
+    }
+
+    #[test]
+    fn backpressure_some_with_none_retry_after_for_429_without_header() {
+        let error = AlpacaBrokerApiError::ApiError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            alpaca_code: None,
+            message: "rate limited".to_string(),
+            retry_after: None,
+        };
+
+        assert_eq!(
+            error.backpressure(),
+            Some(Backpressure { retry_after: None })
+        );
+    }
+
+    #[test]
+    fn backpressure_none_for_non_429_api_error() {
+        let error = AlpacaBrokerApiError::ApiError {
+            status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            alpaca_code: None,
+            message: "boom".to_string(),
+            retry_after: None,
+        };
+
+        assert_eq!(error.backpressure(), None);
+    }
+
+    #[test]
+    fn backpressure_none_for_a_non_api_error_variant() {
+        let error = AlpacaBrokerApiError::MissingPositionQuantity;
+
+        assert_eq!(error.backpressure(), None);
+    }
 }

--- a/crates/execution/src/alpaca_broker_api/order.rs
+++ b/crates/execution/src/alpaca_broker_api/order.rs
@@ -2659,6 +2659,7 @@ mod tests {
             status,
             alpaca_code: None,
             message: message.into(),
+            retry_after: None,
         }
     }
 

--- a/crates/execution/src/alpaca_market_data.rs
+++ b/crates/execution/src/alpaca_market_data.rs
@@ -3,11 +3,13 @@
 use rain_math_float::Float;
 use reqwest::{Client, RequestBuilder, StatusCode};
 use serde::Deserialize;
+use std::time::Duration;
 use tracing::trace;
 
+use crate::rate_limit::retry_after_from_response_headers;
 use crate::{
-    LatestQuote, LatestQuoteError, Positive, Symbol, Usd, deserialize_float_from_number_or_string,
-    deserialize_option_float_from_number_or_string,
+    Backpressure, LatestQuote, LatestQuoteError, Positive, Symbol, Usd,
+    deserialize_float_from_number_or_string, deserialize_option_float_from_number_or_string,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -15,7 +17,11 @@ pub enum AlpacaMarketDataError {
     #[error("HTTP request failed: {0}")]
     Http(#[from] reqwest::Error),
     #[error("API error (status {status}): {body}")]
-    ApiError { status: StatusCode, body: String },
+    ApiError {
+        status: StatusCode,
+        body: String,
+        retry_after: Option<Duration>,
+    },
     #[error("failed to parse latest trade response: {0}")]
     JsonParse(#[from] serde_json::Error),
     #[error("latest trade response for {symbol} did not include a price")]
@@ -41,6 +47,37 @@ pub enum AlpacaMarketDataError {
         #[source]
         source: LatestQuoteError,
     },
+}
+
+impl AlpacaMarketDataError {
+    /// Classifies this error as broker rate-limiting (HTTP 429), returning
+    /// its `Retry-After` hint when the broker sent one. Every other variant
+    /// returns `None` -- an exhaustive match so a new variant added later
+    /// forces a conscious decision here rather than silently classifying as
+    /// "not backpressure".
+    pub fn backpressure(&self) -> Option<Backpressure> {
+        match self {
+            Self::ApiError {
+                status,
+                retry_after,
+                ..
+            } if *status == StatusCode::TOO_MANY_REQUESTS => Some(Backpressure {
+                retry_after: *retry_after,
+            }),
+
+            Self::ApiError { .. }
+            | Self::Http(_)
+            | Self::JsonParse(_)
+            | Self::MissingPrice { .. }
+            | Self::NonPositivePrice { .. }
+            | Self::MissingQuote { .. }
+            | Self::MissingBid { .. }
+            | Self::MissingAsk { .. }
+            | Self::NonPositiveBid { .. }
+            | Self::NonPositiveAsk { .. }
+            | Self::InvalidQuote { .. } => None,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -97,6 +134,7 @@ async fn get_market_data_bytes(request: RequestBuilder) -> Result<Vec<u8>, Alpac
     let response = request.send().await?;
     let status = response.status();
     let url = response.url().clone();
+    let retry_after = retry_after_from_response_headers(response.headers());
     let bytes = response.bytes().await?;
 
     trace!(
@@ -111,6 +149,7 @@ async fn get_market_data_bytes(request: RequestBuilder) -> Result<Vec<u8>, Alpac
         return Err(AlpacaMarketDataError::ApiError {
             status,
             body: String::from_utf8_lossy(&bytes).into_owned(),
+            retry_after,
         });
     }
 
@@ -453,6 +492,7 @@ mod tests {
             when.method(GET).path("/v2/stocks/AAPL/trades/latest");
             then.status(429)
                 .header("content-type", "application/json")
+                .header("Retry-After", "30")
                 .json_body(json!({
                     "message": "rate limited",
                     "market_data_marker": "error-body"
@@ -463,11 +503,16 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(matches!(
-            error,
-            AlpacaMarketDataError::ApiError { status, .. }
-                if status == StatusCode::TOO_MANY_REQUESTS
-        ));
+        let AlpacaMarketDataError::ApiError {
+            status,
+            retry_after,
+            ..
+        } = error
+        else {
+            panic!("expected ApiError");
+        };
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(retry_after, Some(Duration::from_secs(30)));
         assert!(logs_contain("Alpaca market data response body received"));
         assert!(logs_contain("market_data_marker"));
         assert!(logs_contain("error-body"));
@@ -503,5 +548,74 @@ mod tests {
             AlpacaMarketDataError::ApiError { status, .. }
                 if status == StatusCode::FORBIDDEN
         ));
+    }
+
+    #[tokio::test]
+    async fn fetch_latest_trade_price_backpressure_some_for_429_with_header() {
+        let server = MockServer::start();
+        let client = Client::new();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v2/stocks/AAPL/trades/latest");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("Retry-After", "12")
+                .json_body(json!({ "message": "rate limited" }));
+        });
+
+        let error = fetch_latest_trade_price(&client, &server.base_url(), &symbol)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.backpressure(),
+            Some(Backpressure {
+                retry_after: Some(Duration::from_secs(12))
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_latest_trade_price_backpressure_some_with_none_without_header() {
+        let server = MockServer::start();
+        let client = Client::new();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v2/stocks/AAPL/trades/latest");
+            then.status(429)
+                .header("content-type", "application/json")
+                .json_body(json!({ "message": "rate limited" }));
+        });
+
+        let error = fetch_latest_trade_price(&client, &server.base_url(), &symbol)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.backpressure(),
+            Some(Backpressure { retry_after: None })
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_latest_trade_price_backpressure_none_for_non_429() {
+        let server = MockServer::start();
+        let client = Client::new();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v2/stocks/AAPL/trades/latest");
+            then.status(500)
+                .header("content-type", "application/json")
+                .json_body(json!({ "message": "boom" }));
+        });
+
+        let error = fetch_latest_trade_price(&client, &server.base_url(), &symbol)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.backpressure(), None);
     }
 }

--- a/crates/execution/src/alpaca_wallet/client.rs
+++ b/crates/execution/src/alpaca_wallet/client.rs
@@ -1,6 +1,7 @@
 //! Authenticated HTTP transport for Alpaca Broker API wallet modules.
 
 use std::borrow::Cow;
+use std::time::Duration;
 
 use alloy::primitives::{Address, TxHash, hex::FromHexError};
 use reqwest::{Client, Method, Response, StatusCode};
@@ -9,14 +10,19 @@ use tracing::{trace, warn};
 
 use super::transfer::{AlpacaTransferId, Network, TokenSymbol, TransferStatus};
 use super::whitelist::{TravelRuleInfo, WhitelistEntry, WhitelistStatus};
-use crate::AlpacaAccountId;
+use crate::rate_limit::retry_after_from_response_headers;
+use crate::{AlpacaAccountId, Backpressure};
 
 #[derive(Debug, Error)]
 pub enum AlpacaWalletError {
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
     #[error("API error (status {status}): {message}")]
-    ApiError { status: StatusCode, message: String },
+    ApiError {
+        status: StatusCode,
+        message: String,
+        retry_after: Option<Duration>,
+    },
     #[error("Failed to parse response")]
     ParseError(#[from] serde_json::Error),
     #[error("response body was not valid UTF-8: {0}")]
@@ -63,6 +69,39 @@ pub enum AlpacaWalletError {
         previous: TransferStatus,
         next: TransferStatus,
     },
+}
+
+impl AlpacaWalletError {
+    /// Classifies this error as broker rate-limiting (HTTP 429), returning
+    /// its `Retry-After` hint when the broker sent one. Every other variant
+    /// returns `None` -- an exhaustive match so a new variant added later
+    /// forces a conscious decision here rather than silently classifying as
+    /// "not backpressure".
+    pub fn backpressure(&self) -> Option<Backpressure> {
+        match self {
+            Self::ApiError {
+                status,
+                retry_after,
+                ..
+            } if *status == StatusCode::TOO_MANY_REQUESTS => Some(Backpressure {
+                retry_after: *retry_after,
+            }),
+
+            Self::ApiError { .. }
+            | Self::Reqwest(_)
+            | Self::ParseError(_)
+            | Self::Utf8(_)
+            | Self::FromHex(_)
+            | Self::TransferNotFound { .. }
+            | Self::FailedTransferHasTx { .. }
+            | Self::TransferTimeout { .. }
+            | Self::InvalidStatusTransition { .. }
+            | Self::AddressNotWhitelisted { .. }
+            | Self::NoWhitelistEntries { .. }
+            | Self::DepositTimeout { .. }
+            | Self::InvalidDepositTransition { .. } => None,
+        }
+    }
 }
 
 pub struct AlpacaWalletClient {
@@ -277,6 +316,7 @@ async fn read_response_body(
 ) -> Result<String, AlpacaWalletError> {
     let status = response.status();
     let url = response.url().clone();
+    let retry_after = retry_after_from_response_headers(response.headers());
     // Read raw bytes and convert the success body with `String::from_utf8` so
     // invalid UTF-8 fails fast (matching the prior `response.json()` at the call
     // sites) instead of being silently replaced by `response.text()`'s lossy
@@ -291,6 +331,7 @@ async fn read_response_body(
             return Err(AlpacaWalletError::ApiError {
                 status,
                 message: "Unknown error".to_string(),
+                retry_after,
             });
         }
         Err(error) => return Err(error.into()),
@@ -312,6 +353,7 @@ async fn read_response_body(
         return Err(AlpacaWalletError::ApiError {
             status,
             message: redact_beneficiary_for_logging(&String::from_utf8_lossy(&bytes)).into_owned(),
+            retry_after,
         });
     }
 
@@ -484,6 +526,80 @@ mod tests {
         ));
 
         error_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn alpaca_wallet_backpressure_some_for_429_with_retry_after() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v1/rate_limited");
+            then.status(429)
+                .header("Retry-After", "25")
+                .json_body(json!({ "message": "rate limited" }));
+        });
+
+        let client = AlpacaWalletClient::new(
+            server.base_url(),
+            TEST_ACCOUNT_ID,
+            "test_key_id".to_string(),
+            "test_secret_key".to_string(),
+        );
+
+        let error = client.get("/v1/rate_limited").await.unwrap_err();
+
+        assert_eq!(
+            error.backpressure(),
+            Some(Backpressure {
+                retry_after: Some(Duration::from_secs(25))
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_wallet_backpressure_some_with_none_without_header() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v1/rate_limited");
+            then.status(429)
+                .json_body(json!({ "message": "rate limited" }));
+        });
+
+        let client = AlpacaWalletClient::new(
+            server.base_url(),
+            TEST_ACCOUNT_ID,
+            "test_key_id".to_string(),
+            "test_secret_key".to_string(),
+        );
+
+        let error = client.get("/v1/rate_limited").await.unwrap_err();
+
+        assert_eq!(
+            error.backpressure(),
+            Some(Backpressure { retry_after: None })
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_wallet_backpressure_none_for_non_429() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v1/server_error");
+            then.status(500).body("Internal Server Error");
+        });
+
+        let client = AlpacaWalletClient::new(
+            server.base_url(),
+            TEST_ACCOUNT_ID,
+            "test_key_id".to_string(),
+            "test_secret_key".to_string(),
+        );
+
+        let error = client.get("/v1/server_error").await.unwrap_err();
+
+        assert_eq!(error.backpressure(), None);
     }
 
     #[tokio::test]
@@ -703,7 +819,9 @@ mod tests {
             "test_secret_key".to_string(),
         );
 
-        let AlpacaWalletError::ApiError { status, message } = client
+        let AlpacaWalletError::ApiError {
+            status, message, ..
+        } = client
             .post("/v1/whitelists", &json!({"any": "body"}))
             .await
             .unwrap_err()

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -23,18 +23,28 @@ mod alpaca_wallet;
 pub mod error;
 pub mod mock;
 pub mod order;
+mod rate_limit;
 
 pub use alpaca_broker_api::{
     AlpacaAccountId, AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiError,
     AlpacaBrokerApiMode, ConversionDirection, CryptoOrderOutcome, JournalResponse, JournalStatus,
     TimeInForce,
 };
+// `AlpacaMarketDataError` is wrapped by `AlpacaBrokerApiError::LatestTrade`,
+// which delegates its own `backpressure()` classification straight to the
+// wrapped error (RAI-1494), so the parent app never needs to name or
+// downcast this type in production -- test-only, so tests can still
+// construct the exact wrapped shape (`LatestTrade(AlpacaMarketDataError::
+// ApiError { .. })`) that `fetch_latest_trade_price` produces.
+#[cfg(any(test, feature = "test-support"))]
+pub use alpaca_market_data::AlpacaMarketDataError;
 pub use error::PersistenceError;
 pub use mock::{MockExecutor, MockExecutorCtx};
 pub use order::{
     CancellationOutcome, ClientOrderId, ClientOrderIdError, LimitOrder, MarketOrder,
     OrderPlacement, OrderState, OrderStatus, OrderUpdate,
 };
+pub use rate_limit::retry_after_from_response_headers;
 
 #[cfg(any(test, feature = "test-support"))]
 pub use alpaca_wallet::AlpacaWalletClient;
@@ -162,6 +172,28 @@ pub enum LatestQuoteError {
         bid: Positive<Usd>,
         ask: Positive<Usd>,
     },
+}
+
+/// A classified rate-limit (HTTP 429) response from an Alpaca API, carrying
+/// the broker's `Retry-After` hint when it sent one.
+///
+/// Each Alpaca error type (`AlpacaBrokerApiError`, `AlpacaMarketDataError`,
+/// `AlpacaWalletError`, and `st0x-tokenization`'s `AlpacaTokenizationError`)
+/// exposes an inherent `.backpressure() -> Option<Backpressure>` method
+/// rather than a free classifier function: these error types are already
+/// `pub` domain types call sites match on directly, so a free function would
+/// only relocate the "know about these concrete types" fact, not remove it
+/// (see RAI-1494's plan). `None` inside `retry_after` already means "429, no
+/// usable `Retry-After` header" -- a caller does not need a separate
+/// enum case for that, only `Option`'s existing `None`.
+///
+/// Lives at this crate's root (rather than nested under `alpaca_broker_api`)
+/// because `AlpacaWalletError` and `st0x-tokenization`'s
+/// `AlpacaTokenizationError` (a downstream crate that already depends on
+/// `st0x-execution`) both need to return it too.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Backpressure {
+    pub retry_after: Option<Duration>,
 }
 
 #[async_trait]

--- a/crates/execution/src/rate_limit.rs
+++ b/crates/execution/src/rate_limit.rs
@@ -1,0 +1,179 @@
+//! Shared `Retry-After` header parsing for Alpaca's broker, wallet, and
+//! market-data HTTP clients (RAI-1494). A single parser so every client
+//! captures the header the same way instead of duplicating the delay-seconds
+//! vs. HTTP-date branching per call site.
+
+use std::str::FromStr;
+use std::time::{Duration, SystemTime};
+
+use chrono::{DateTime, Utc};
+use reqwest::header::{HeaderMap, RETRY_AFTER};
+
+/// Parses an HTTP `Retry-After` header value into a [`Duration`] relative to
+/// `now`.
+///
+/// Tries the delay-seconds form (`"120"`) first, then falls back to the
+/// HTTP-date form (RFC 7231's preferred IMF-fixdate, e.g.
+/// `"Sun, 06 Nov 1994 08:49:37 GMT"`).
+///
+/// **Not pinned to a confirmed real Alpaca 429 response** (RAI-1494 review
+/// finding): every 429 test in this codebase synthesizes the header via
+/// `httpmock` rather than replaying a captured live response, and Alpaca's
+/// own official SDKs are, if anything, evidence AGAINST relying on it --
+/// neither `alpacahq/alpaca-py`'s `RetryHTTPAdapter`
+/// (`alpaca/common/rest.py`, `DEFAULT_RETRY_WAIT_SECONDS`) nor
+/// `alpacahq/alpaca-trade-api-go`'s `ClientOpts.RetryDelay`
+/// (`marketdata/rest_test.go`'s `TestDefaultDo_TooMany429s`) read ANY
+/// response header on a 429 -- both just sleep a fixed configured delay and
+/// retry, blind to whatever the server sent. This does not prove Alpaca
+/// never sends `Retry-After`, only that neither official SDK trusts one.
+/// This is exactly why the caller (`decide_backpressure`) must degrade
+/// gracefully when this parser returns `None`: an absent or unparseable
+/// header falls back to a tested escalating backoff, so a wrong assumption
+/// here only makes the backoff sub-optimal, never breaks correctness.
+///
+/// `"0"` parses to `Some(Duration::ZERO)` -- a legitimate broker value.
+/// Flooring a near-zero delay to a minimum sleep is the caller's concern
+/// (`decide_backpressure`), not this parser's.
+///
+/// Returns `None` for a malformed value, a date at or before `now`, or a date
+/// `SystemTime` cannot represent the difference for. A parse failure here is
+/// not a financial value -- falling back to the caller's escalating backoff
+/// is the correct, intentionally soft behavior, unlike this codebase's
+/// fail-fast rule for financial data.
+///
+/// `pub` (re-exported from the crate root, module itself stays private) so
+/// `st0x-tokenization`'s Alpaca client can reuse the same parser for its own
+/// `Retry-After` capture rather than duplicating the delay-seconds/HTTP-date
+/// branching a second time.
+///
+/// Alpaca's documented 429 error body carries a numeric `code` and `message`,
+/// no `Retry-After` header -- the header-absence case is already pinned by
+/// `retry_after_from_response_headers_returns_none_when_absent` below (this
+/// parser only ever reads headers, so a documented-body fixture would assert
+/// nothing that case doesn't already cover), and
+/// `decide_backpressure_escalates_the_fallback_when_retry_after_is_absent`
+/// (`st0x-hedge`'s `conductor::job` tests) asserts the caller's escalating
+/// fallback is what actually runs in that case. Alpaca not sending the
+/// header is the expected case, not an edge case this code merely tolerates.
+pub fn parse_retry_after(header_value: &str, now: SystemTime) -> Option<Duration> {
+    let trimmed = header_value.trim();
+
+    if let Ok(delay_seconds) = u64::from_str(trimmed) {
+        return Some(Duration::from_secs(delay_seconds));
+    }
+
+    let parsed_date = DateTime::parse_from_rfc2822(trimmed).ok()?;
+    let parsed_system_time: SystemTime = parsed_date.with_timezone(&Utc).into();
+
+    parsed_system_time.duration_since(now).ok()
+}
+
+/// Reads and parses the `Retry-After` header from a response's headers, if
+/// present, using [`parse_retry_after`].
+///
+/// Returns `None` for a missing header, a header value that is not valid
+/// ASCII/visible-text, or a value the parser cannot interpret.
+///
+/// `pub` (re-exported from the crate root) so every Alpaca client
+/// (broker, wallet, market-data, and `st0x-tokenization`'s client) captures
+/// the header the same way instead of duplicating this
+/// `get -> to_str -> parse_retry_after` chain per call site.
+pub fn retry_after_from_response_headers(headers: &HeaderMap) -> Option<Duration> {
+    let header_value = headers.get(RETRY_AFTER)?.to_str().ok()?;
+
+    parse_retry_after(header_value, SystemTime::now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_retry_after_reads_delay_seconds() {
+        let now = SystemTime::now();
+
+        assert_eq!(
+            parse_retry_after("120", now),
+            Some(Duration::from_secs(120))
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_reads_zero_delay_seconds() {
+        let now = SystemTime::now();
+
+        assert_eq!(parse_retry_after("0", now), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn parse_retry_after_reads_http_date() {
+        // "Sun, 06 Nov 1994 08:49:37 GMT" is exactly unix second 784111777.
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(784_111_777 - 60);
+
+        assert_eq!(
+            parse_retry_after("Sun, 06 Nov 1994 08:49:37 GMT", now),
+            Some(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_trims_surrounding_whitespace() {
+        let now = SystemTime::now();
+
+        assert_eq!(
+            parse_retry_after("  45  ", now),
+            Some(Duration::from_secs(45))
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_returns_none_for_a_past_http_date() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(784_111_777 + 60);
+
+        assert_eq!(
+            parse_retry_after("Sun, 06 Nov 1994 08:49:37 GMT", now),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_returns_none_for_garbage_input() {
+        let now = SystemTime::now();
+
+        assert_eq!(parse_retry_after("not-a-retry-after-value", now), None);
+    }
+
+    #[test]
+    fn parse_retry_after_returns_none_for_empty_string() {
+        let now = SystemTime::now();
+
+        assert_eq!(parse_retry_after("", now), None);
+    }
+
+    #[test]
+    fn retry_after_from_response_headers_reads_a_present_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, "30".parse().unwrap());
+
+        assert_eq!(
+            retry_after_from_response_headers(&headers),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn retry_after_from_response_headers_returns_none_when_absent() {
+        let headers = HeaderMap::new();
+
+        assert_eq!(retry_after_from_response_headers(&headers), None);
+    }
+
+    #[test]
+    fn retry_after_from_response_headers_returns_none_for_unparseable_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, "not-a-value".parse().unwrap());
+
+        assert_eq!(retry_after_from_response_headers(&headers), None);
+    }
+}

--- a/crates/tokenization/src/alpaca.rs
+++ b/crates/tokenization/src/alpaca.rs
@@ -41,7 +41,10 @@ use st0x_evm::{
     EvmError, IERC20, IntoErrorRegistry, NODE_SYNC_MAX_ATTEMPTS, NODE_SYNC_POLL_INTERVAL,
     OpenChainErrorRegistry, Wallet, wait_for_node_sync,
 };
-use st0x_execution::{AlpacaAccountId, FractionalShares, Network, PollingConfig, Symbol};
+use st0x_execution::{
+    AlpacaAccountId, Backpressure, FractionalShares, Network, PollingConfig, Symbol,
+    retry_after_from_response_headers,
+};
 
 use super::{
     IssuerRequestId, MintVerificationError, TokenizationRequestId, Tokenizer, TokenizerError,
@@ -427,6 +430,7 @@ pub enum AlpacaTokenizationError {
     ApiError {
         status: StatusCode,
         message: AlpacaApiErrorMessage,
+        retry_after: Option<Duration>,
     },
 
     #[error("Insufficient position for symbol: {symbol}")]
@@ -470,6 +474,18 @@ impl AlpacaApiErrorMessage {
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
+impl AlpacaApiErrorMessage {
+    /// Test-only constructor so downstream crates can build a classified
+    /// `AlpacaTokenizationError::ApiError` (e.g. RAI-1494's `find_backpressure`
+    /// tests) without depending on the production `from_response` path, which
+    /// stays crate-private since it is only ever built from a real HTTP
+    /// response body.
+    pub fn for_test(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
 impl std::fmt::Display for AlpacaApiErrorMessage {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(formatter, "{}", self.0)
@@ -505,9 +521,43 @@ impl AlpacaTokenizationError {
             _ => None,
         }
     }
+
+    /// Classifies this error as broker rate-limiting (HTTP 429), returning
+    /// its `Retry-After` hint when the broker sent one. Every other variant
+    /// returns `None` -- an exhaustive match so a new variant added later
+    /// forces a conscious decision here rather than silently classifying as
+    /// "not backpressure".
+    pub fn backpressure(&self) -> Option<Backpressure> {
+        match self {
+            Self::ApiError {
+                status,
+                retry_after,
+                ..
+            } if *status == StatusCode::TOO_MANY_REQUESTS => Some(Backpressure {
+                retry_after: *retry_after,
+            }),
+
+            Self::ApiError { .. }
+            | Self::Reqwest(_)
+            | Self::JsonParse(_)
+            | Self::Utf8(_)
+            | Self::InsufficientPosition { .. }
+            | Self::UnsupportedAccount
+            | Self::InvalidParameters { .. }
+            | Self::RequestNotFound { .. }
+            | Self::Evm(_)
+            | Self::PollTimeout { .. }
+            | Self::MissingRedemptionWallet => None,
+        }
+    }
 }
 
-fn map_mint_error(status: StatusCode, message: String, symbol: Symbol) -> AlpacaTokenizationError {
+fn map_mint_error(
+    status: StatusCode,
+    message: String,
+    symbol: Symbol,
+    retry_after: Option<Duration>,
+) -> AlpacaTokenizationError {
     match status {
         StatusCode::FORBIDDEN => {
             if message.contains("insufficient") || message.contains("position") {
@@ -522,6 +572,7 @@ fn map_mint_error(status: StatusCode, message: String, symbol: Symbol) -> Alpaca
         _ => AlpacaTokenizationError::ApiError {
             status,
             message: AlpacaApiErrorMessage::from_response(message),
+            retry_after,
         },
     }
 }
@@ -594,6 +645,7 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
             .await?;
 
         let status = response.status();
+        let retry_after = retry_after_from_response_headers(response.headers());
 
         if status.is_success() {
             // Read raw bytes and parse with `from_slice` so invalid UTF-8 fails
@@ -631,7 +683,12 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
             "Alpaca tokenization mint error response body received"
         );
         warn!(target: "tokenization", status = %status, message = %message, "Tokenization request failed");
-        Err(map_mint_error(status, message, request.underlying_symbol))
+        Err(map_mint_error(
+            status,
+            message,
+            request.underlying_symbol,
+            retry_after,
+        ))
     }
 
     /// List tokenization requests with optional filtering.
@@ -907,6 +964,7 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
         let response = request.send().await?;
 
         let status = response.status();
+        let retry_after = retry_after_from_response_headers(response.headers());
         // Read raw bytes; convert the success body with strict `String::from_utf8`
         // so invalid UTF-8 fails fast for the caller's parse. Lossy decoding is
         // used only for the trace line and the error-body message.
@@ -930,6 +988,7 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
             message: AlpacaApiErrorMessage::from_response(
                 String::from_utf8_lossy(&bytes).into_owned(),
             ),
+            retry_after,
         })
     }
 }
@@ -1300,6 +1359,78 @@ pub(crate) mod tests {
         );
 
         mint_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_request_mint_rate_limited_captures_retry_after() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, key) = setup_anvil();
+        let client = create_test_client(&server, &endpoint, &key, TEST_REDEMPTION_WALLET).await;
+
+        let mint_mock = server.mock(|when, then| {
+            when.method(POST).path(tokenization_mint_path());
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("Retry-After", "18")
+                .json_body(json!({ "message": "rate limited" }));
+        });
+
+        let request = create_mint_request();
+
+        let err = client.request_mint(request).await.unwrap_err();
+        let AlpacaTokenizationError::ApiError {
+            status,
+            retry_after,
+            ..
+        } = err
+        else {
+            panic!("expected ApiError");
+        };
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(retry_after, Some(Duration::from_secs(18)));
+
+        mint_mock.assert();
+    }
+
+    #[test]
+    fn tokenization_backpressure_some_for_429_with_retry_after() {
+        let error = AlpacaTokenizationError::ApiError {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            message: AlpacaApiErrorMessage::from_response("rate limited".to_string()),
+            retry_after: Some(Duration::from_secs(18)),
+        };
+
+        assert_eq!(
+            error.backpressure(),
+            Some(Backpressure {
+                retry_after: Some(Duration::from_secs(18))
+            })
+        );
+    }
+
+    #[test]
+    fn tokenization_backpressure_some_with_none_without_header() {
+        let error = AlpacaTokenizationError::ApiError {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            message: AlpacaApiErrorMessage::from_response("rate limited".to_string()),
+            retry_after: None,
+        };
+
+        assert_eq!(
+            error.backpressure(),
+            Some(Backpressure { retry_after: None })
+        );
+    }
+
+    #[test]
+    fn tokenization_backpressure_none_for_non_429() {
+        let error = AlpacaTokenizationError::ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: AlpacaApiErrorMessage::from_response("boom".to_string()),
+            retry_after: None,
+        };
+
+        assert_eq!(error.backpressure(), None);
     }
 
     fn sample_tokenization_request_json(

--- a/crates/tokenization/src/lib.rs
+++ b/crates/tokenization/src/lib.rs
@@ -22,10 +22,10 @@ use std::str::FromStr;
 use uuid::Uuid;
 
 use st0x_evm::EvmError;
-use st0x_execution::{FractionalShares, Symbol};
+use st0x_execution::{Backpressure, FractionalShares, Symbol};
 
 pub use alpaca::{
-    AlpacaTokenizationError, AlpacaTokenizationService, TokenizationRequest,
+    AlpacaApiErrorMessage, AlpacaTokenizationError, AlpacaTokenizationService, TokenizationRequest,
     TokenizationRequestStatus, TokenizationRequestType,
 };
 
@@ -138,6 +138,27 @@ pub enum TokenizerError {
     Alpaca(#[from] AlpacaTokenizationError),
     #[error(transparent)]
     MintVerification(#[from] MintVerificationError),
+}
+
+impl TokenizerError {
+    /// Classifies this error as broker rate-limiting (HTTP 429), returning
+    /// its `Retry-After` hint when the broker sent one.
+    ///
+    /// Needed because `#[error(transparent)]` (used above so `TokenizerError`
+    /// forwards `Display`/`source()` straight through to the wrapped error)
+    /// makes `.source()` skip the wrapped `AlpacaTokenizationError` entirely
+    /// -- it forwards to the wrapped error's OWN source, not the wrapped
+    /// error itself. A generic `.source()`-chain walker (RAI-1494's
+    /// `find_backpressure`) can therefore never see the `AlpacaTokenizationError`
+    /// to classify it when it arrives wrapped in a `TokenizerError`; this
+    /// inherent method delegates directly instead of relying on the source
+    /// chain.
+    pub fn backpressure(&self) -> Option<Backpressure> {
+        match self {
+            Self::Alpaca(source) => source.backpressure(),
+            Self::MintVerification(_) => None,
+        }
+    }
 }
 
 /// Errors from verifying a mint transaction onchain.

--- a/crates/tokenization/src/mock.rs
+++ b/crates/tokenization/src/mock.rs
@@ -270,6 +270,7 @@ impl Tokenizer for MockTokenizer {
                     message: AlpacaApiErrorMessage::from_response(
                         "mock mint request error".to_string(),
                     ),
+                    retry_after: None,
                 }))
             }
         }
@@ -358,6 +359,7 @@ impl Tokenizer for MockTokenizer {
                     message: AlpacaApiErrorMessage::from_response(
                         "mock send_for_redemption failure".to_string(),
                     ),
+                    retry_after: None,
                 }))
             }
             MockSendOutcome::Succeed => Ok(self.redemption_tx),
@@ -384,6 +386,7 @@ impl Tokenizer for MockTokenizer {
                     message: AlpacaApiErrorMessage::from_response(
                         "mock detection API error".to_string(),
                     ),
+                    retry_after: None,
                 }))
             }
         }
@@ -466,6 +469,7 @@ impl Tokenizer for MockTokenizer {
                     message: AlpacaApiErrorMessage::from_response(
                         "mock list_pending_requests failure".to_string(),
                     ),
+                    retry_after: None,
                 }));
             }
             MockListPendingOutcome::Succeed => {}

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -299,6 +299,244 @@ would fail the guard query -- and, on the boot path, propagate through
 `recover_submitted_offchain_orders` to fail `Conductor::run()` -- for every
 order sharing this job type, not just the corrupt row's own.
 
+### Broker rate-limit (429) backpressure: reschedule, don't retry in place (RAI-1494)
+
+**Problem this fixes**: before RAI-1494, a classified or unclassified error from
+an Alpaca call inside `Job::perform()` -- including an HTTP 429 -- went through
+the unmodified `RetryPolicy::retries(3)` path. Three quick in-place retries
+exhaust in seconds against a sustained rate-limit condition, tripping the
+supervised circuit breaker and reproducing RAI-1492's "hedging silently stops"
+incident. Retrying _in place_ for longer (a naive fix) is worse: it would hold
+the job's `concurrency(1)` worker slot for the whole backoff window, blocking
+every other pending item behind it -- the same "one item monopolizes the worker"
+failure shape, just invisible instead of a visible circuit-breaker trip.
+
+**Mechanism**: a 429 is intercepted _before_ `perform()` returns `Err` at all.
+The job classifies the error, computes a delay, pushes a fresh copy of itself
+onto its own queue after that delay via `push_with_delay`, and returns `Ok(())`.
+The row acks `Done` immediately and the worker is free on the very next poll
+tick to pick up any other pending item. The pushed successor is a brand-new
+`Pending` row apalis dispatches when its `run_at` arrives. Because the error
+never reaches `RetryPolicy`/`calculate_status`/the circuit breaker, a pure-429
+sequence can never produce apalis's `Event::Error` and can never open the
+circuit breaker -- RAI-1494 is fully decoupled from RAI-1495 (the
+circuit-breaker latch-with-no-wakeup bug) by construction, not by scoping
+discipline.
+
+**Shared building blocks** (`src/conductor/job.rs`, `crates/execution/src/`):
+
+- `st0x_execution::Backpressure { retry_after: Option<Duration> }` -- crate root
+  of `st0x-execution`, re-exported since `st0x-tokenization` also needs it.
+  `None` inside `retry_after` already means "429, no usable `Retry-After`
+  header"; there is no separate enum case for that.
+- An inherent `pub fn backpressure(&self) -> Option<Backpressure>` on each of
+  the four Alpaca error types (`AlpacaBrokerApiError`, `AlpacaMarketDataError`,
+  `AlpacaWalletError`, `st0x_tokenization::AlpacaTokenizationError`) --
+  exhaustive `match`, `Some` only for the `ApiError`-shaped variant with
+  `status == 429`. An inherent method per type, not a free classifier function:
+  these are already `pub` domain types call sites match on directly, so a free
+  function would only relocate the "know about these four types" fact, not
+  remove it.
+- `crate::rate_limit::parse_retry_after(header_value: &str, now: SystemTime)
+  -> Option<Duration>`
+  (`crates/execution/src/rate_limit.rs`, re-exported from that crate's root) --
+  the one parser every Alpaca client's response-handling path calls to capture
+  `Retry-After` **before** consuming the response body. Tries delay-seconds
+  first, falls back to the HTTP-date form. `"0"` parses to
+  `Some(Duration::ZERO)` -- a legitimate broker value; flooring a near-zero
+  delay is `decide_backpressure`'s job, not the parser's.
+- `crate::conductor::job::find_backpressure(error: &(dyn std::error::Error +
+  'static)) -> Option<Backpressure>`
+  -- walks the `.source()` chain, trying a `downcast_ref` against each of the
+  four error types in turn at every link, short-circuiting on the first `Some`.
+  This is the one place that "knows about" all four concrete types.
+- `crate::conductor::job::decide_backpressure(backpressure: &Backpressure,
+  streak: u32) -> BackpressureDecision { delay: Duration, exhausted: bool }`
+  -- pure, no apalis/tokio types. Honours `Retry-After` when present (clamped to
+  `[MIN_BACKPRESSURE_DELAY (1s), MAX_RETRY_AFTER (5min)]`); otherwise escalates
+  a fallback backoff (`BACKPRESSURE_FALLBACK_BASE` 1s up to
+  `BACKPRESSURE_FALLBACK_CAP` 60s) keyed off `streak`. `exhausted` is `true`
+  once `streak >= BACKPRESSURE_RESCHEDULE_LIMIT` (500) -- a persistently-429ing
+  item is eventually treated as a structurally-dead integration (suspended
+  account, revoked key), not endless transient rate-limiting. This function does
+  not log; each job logs its own every-10th-streak visibility line and its own
+  exhaustion line, mirroring
+  `PollOrderStatus::
+  handle_get_order_status_error`.
+
+**Per-job streak counter, not a stateful `Policy`**: because each reschedule is
+a brand-new apalis dispatch (a fresh `Pending` row), there is no live in-memory
+object to carry a retry count between attempts. Every participating job's
+payload gains a `backpressure_streak: u32` field, `#[serde(default)]` so an
+already-enqueued row under the pre-this-change shape still deserializes (to `0`,
+the correct "no streak yet" value) instead of crashing the poll stream's
+`sqlx::Decode` -- a decode failure there surfaces as `WorkerError::StreamError`,
+a worker-crashing fault, not a clean per-row dead-letter, so `#[serde(default)]`
+is mandatory on every one of these fields, not optional polish.
+
+**Reschedule reuses `reschedule_self`'s shape, not `push_poll_job_if_absent`'s
+guard**: the 429 reschedule is a single in-perform self-replacement point --
+exactly one `Running` row acking `Done` while pushing exactly one `Pending`
+successor -- the same invariant `reschedule_self` (above) already relies on for
+its own ordinary Pending/Submitted reschedule. It is not one of the five
+external push sites `push_poll_job_if_absent` exists to guard, so it does not
+need that guard. **A reschedule push's own failure must propagate as `Err`,
+never be swallowed into `Ok(())`**: `push_with_delay` returns
+`Result<(), QueuePushError>`; if that push itself fails (e.g. a transient SQLite
+write error), silently returning `Ok(())` anyway would ack the current row
+`Done` with no live successor, dropping the item. Every participating job's
+error enum has a `#[from] QueuePushError` arm precisely so `?` handles this
+correctly.
+
+**Crash-window duplicate risk: shared with, not introduced by, this mechanism.**
+If the process crashes between the reschedule push committing and the current
+job's `Ok(())` ack landing, both the old `Running` row (reset to `Pending` by
+`requeue_orphaned` at next boot) and the new `Pending` successor exist. This is
+`reschedule_self`'s existing pre-RAI-1494 characteristic, not a new one --
+RAI-1493's dedup guard covers the _external push site_ layer, not the in-perform
+self-replacement point, before or after this change. Also note: **orphan-reaping
+cannot reap or shorten a reschedule delay.** A rescheduled successor is inserted
+as a `Pending` row with a future `run_at`; it is never `Running` and holds no
+worker lock, and both `requeue_orphaned` (this repo) and apalis-core's own
+`reenqueue_orphaned_after` operate only on locked `Running` rows past a
+heartbeat timeout. Even the widest delay this mechanism produces
+(`MAX_RETRY_AFTER`, 5 minutes) cannot be shortened by orphan-reaping.
+
+**Terminal behavior at `BACKPRESSURE_RESCHEDULE_LIMIT` exhaustion depends on
+worker supervision.** For a job registered on a _supervised_ worker
+(`build_supervised_worker!`), propagating a bare `Err` at exhaustion would open
+the circuit breaker for a cause that is not a genuine bug -- reproducing the
+parent incident, just delayed by up to 500 reschedules instead of happening
+immediately. So a supervised job instead dead-letters at exhaustion: log a loud,
+distinct `error!` naming the item and the exhausted streak, then return
+`Ok(())`, so the row acks `Done` and the worker's shared circuit breaker never
+observes an `Event::Error` for this cause. A genuine _non-backpressure_ `Err` on
+these jobs is completely untouched by this decision and still fail-stops exactly
+as before. A best-effort-worker job (`build_best_effort_worker!`) is already
+log-only-and-continue on any terminal failure (RAI-1110), so exhaustion there
+needs no special case: the existing best-effort terminal handling already covers
+it.
+
+**True retry vs. reschedule-then-backstop -- not every job's reschedule
+re-drives the Alpaca call.** Whether a reschedule's successor attempt actually
+re-hits Alpaca, or instead short-circuits past it, depends on where the 429
+lands relative to that job's own committed idempotency guard:
+
+- **True retry**: no guard commits ahead of the Alpaca call, so every reschedule
+  genuinely re-attempts it. `PollOrderStatus`'s `get_order_status` is a pure
+  read with no committed state ahead of it -- the one job the parent RAI-1492
+  incident actually exercised. `PlaceHedge` also genuinely retries a
+  rate-limited broker placement: its position claim has committed, but the
+  durable offchain order remains `Pending`, so `recover_pending_poll_status`
+  re-drives the placement with the same deterministic `client_order_id`.
+- **Reschedule-then-backstop**: a guard commits _before_ the Alpaca touch, so
+  once that guard commits, a 429 later in the same attempt reschedules, but the
+  pushed successor short-circuits past the Alpaca call entirely.
+  `AccountForDexTrade` commits `account_for_onchain_fill` keyed on
+  `(tx_hash, log_index)` before any Alpaca call, so a rescheduled successor hits
+  `FillAccountingOutcome::AlreadyAcknowledged` and never re-attempts the hedge.
+  Its reschedule's value is narrower than for a true-retry job: it still
+  prevents burning the terminal retry budget and still frees the worker, but
+  actual completion is delegated to the existing `CheckPositions` backstop, not
+  the reschedule itself, and the streak structurally caps at 1 (a guard that
+  already committed cannot un-commit on a later attempt).
+
+This distinction matters for what a job's own tests can honestly claim: a test
+asserting "the reschedule completes the work" for a reschedule-then-backstop job
+would pass by coincidence of the short-circuit while proving nothing about the
+actual hedge/fill outcome.
+
+An exhausted `PollOrderStatus` row is acknowledged as `Done`, but it is not
+ordinary cleanup fodder: the finished-job cleanup retains rows whose serialized
+`backpressure_streak` reached the limit. `push_poll_job_if_absent` checks that
+durable marker before both periodic recovery and every other poll push site, so
+recovery cannot replace a finite dead letter with a fresh zero-streak chain.
+Once the broker order is reconciled to a terminal aggregate state, it naturally
+falls out of submitted-order recovery and the marker becomes inert.
+
+**Quarantined: USDC conversion order placement is not rescheduled at all.**
+`TransferUsdcToHedging`/`TransferUsdcToMarketMaking` are "true retry" jobs for
+their deposit-poll and withdrawal-poll sub-steps, but the conversion placement
+sub-step (`execute_usd_to_usdc_conversion`/`execute_usdc_to_usd_conversion`,
+called from inside `resume_alpaca_to_base`/`resume_base_to_alpaca`) is an
+explicit exception: a 429 (or any other placement error) still fails fast,
+exactly as before this mechanism existed. `InitiateConversion`/
+`InitiatePostDepositConversion` commits the aggregate to `Converting` before the
+broker call, but placement failure unconditionally sends `FailConversion` and
+returns `UsdcTransferError::ConversionPlacementFailed` -- a variant with no
+`#[source]`, so `find_backpressure` can never classify it and the job's generic
+terminal path (alert + propagate `Err`) runs instead of a reschedule. An earlier
+pass tried making a placement 429 reschedule-safe by leaving the aggregate in
+`Converting` and routing the redrive through the order-lookup resume path
+(`resume_converting`); that broke down because a 429 rejects the HTTP request,
+so the order was never created, the lookup 404s, and the redrive still ended in
+a terminal failure -- just one hop further away and harder to diagnose. Retrying
+a placement in place carries a real double-order risk against actual money, so
+this was reverted rather than iterated on further. Making it safe needs a
+place-then-commit reorder of the conversion aggregate (defer
+`InitiateConversion` until after a successful placement, or have the resume path
+re-place idempotently by `client_order_id` instead of only looking the order up)
+-- tracked as a follow-up, not part of this mechanism.
+
+**Known gap: several equity mint/redemption/recovery jobs cannot classify a 429
+at all today.** `WrappedEquityRecoveryJob`, `UnwrappedEquityRecoveryJob`,
+`TransferEquityToMarketMaking`, `TransferEquityToHedging`, and
+`ResumeTokenizationAggregate` all gained a `backpressure_streak` field (so their
+payload schema is ready), but none has a working reschedule wired to its actual
+Alpaca-touching failure path:
+
+- `WrappedEquityRecoveryJob`/`UnwrappedEquityRecoveryJob`: the aggregate's own
+  command handler (`resume_mint_or_fail`/`resume_redemption_or_fail` in each
+  `aggregate.rs`) catches a `resume_mint`/`resume_redemption` failure and
+  records it as a terminal `RecoveryFailed` **event** with only a
+  Display-formatted `String` reason -- `ctx.store.send()` returns `Ok(())`
+  regardless, so `perform()` never observes an `Err` to classify at all. A 429
+  here has always immediately terminalized the recovery with zero retries,
+  before and after RAI-1494.
+- `TransferEquityToMarketMaking`/`TransferEquityToHedging`/
+  `ResumeTokenizationAggregate`: these DO propagate a genuine `Err` (today's
+  `retries(3)` already applies), but
+  `TokenizedEquityMintError::RequestFailed
+  { error_message: String }`
+  (`error.to_string()` in `tokenized_equity_mint.rs`) and the mirrored
+  `EquityRedemption` error variants discard the original error type before it
+  ever reaches the job -- `find_backpressure`'s downcast-based classification
+  has nothing to walk to.
+
+Closing this needs the mint/redemption/recovery aggregates' error types to
+preserve the classified error (not just its `Display` string), and for the two
+recovery jobs, `transition()` to return `Err` instead of `Ok(RecoveryFailed)` on
+a classified 429 plus threading a streak into the `Command` (the aggregate has
+no visibility into the job's own payload today). This is a redesign of those
+aggregates' error-handling contracts, out of scope for RAI-1494's per-job wiring
+-- tracked as a follow-up, not silently left unaddressed.
+
+**Synchronous (CLI) call sites get bounded in-call retry, not the reschedule
+mechanism.** A CLI command is not a durable job: there is no queue row to
+reschedule and no sibling work waiting behind a shared `concurrency(1)` worker
+-- the "worker" is the one-shot process the operator is already waiting on, so
+retrying in place cannot reproduce the incident.
+`src/cli/backpressure_retry.rs`'s `retry_on_backpressure` reuses the same
+`find_backpressure`/`decide_backpressure` building blocks: on a classified 429
+within a small bounded attempt budget (`BACKPRESSURE_RETRY_MAX_ATTEMPTS`), it
+sleeps for the classified delay and retries in place; otherwise
+(non-backpressure error, or budget exhausted) it propagates to the CLI's
+existing `anyhow` error path unchanged. Wired into `cli/trading.rs`
+(market/limit order placement, order-status), `cli/alpaca_wallet.rs` (deposit
+address lookup, whitelist reads), and `cli/rebalancing.rs` (`transfer-usdc`).
+Not wired into `cli/repair.rs` (its commands never call the broker --
+`RepairOrderPlacer` always errors by design) or `transfer-equity` (same
+stringified-error gap as
+`TransferEquityToMarketMaking`/`TransferEquityToHedging` above).
+
+**`ExecutorMaintenance` (`src/conductor/monitor/executor_maintenance.rs`) needs
+no change.** It is a `SupervisedTask`, not a job or CLI command; its tick errors
+are already logged and swallowed unconditionally by the supervisor lifecycle --
+there is no retry budget to burn and no circuit breaker layer to interact with.
+A 429 there behaves today exactly like the reschedule mechanism this section
+documents: wait, log, try again next tick. Pinned by a regression test rather
+than left as an unverified assumption.
+
 ### Job trait
 
 Defined in `src/conductor/job.rs`. Wraps apalis's function-based handler API

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -15,6 +15,7 @@ use st0x_finance::Usdc;
 use st0x_float_serde::format_float_with_fallback;
 
 use super::ConvertDirection;
+use super::backpressure_retry::{BACKPRESSURE_RETRY_MAX_ATTEMPTS, retry_on_backpressure};
 use st0x_config::{BrokerCtx, Ctx};
 
 pub(super) async fn alpaca_deposit_command<Registry: IntoErrorRegistry, W: Write>(
@@ -44,9 +45,11 @@ pub(super) async fn alpaca_deposit_command<Registry: IntoErrorRegistry, W: Write
     writeln!(stdout, "   Fetching Alpaca deposit address...")?;
     let usdc_symbol = TokenSymbol::new("USDC");
     let ethereum = Network::new("ethereum");
-    let deposit_address = alpaca_wallet
-        .get_wallet_address(&usdc_symbol, &ethereum)
-        .await?;
+    let deposit_address = retry_on_backpressure(
+        || alpaca_wallet.get_wallet_address(&usdc_symbol, &ethereum),
+        BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+    )
+    .await?;
     writeln!(stdout, "   Alpaca deposit address: {deposit_address}")?;
 
     let amount_u256 = amount.to_u256_6_decimals()?;
@@ -224,7 +227,11 @@ pub(super) async fn alpaca_withdraw_command<Registry: IntoErrorRegistry, W: Writ
     // Check whitelist before on-chain balance to fail fast on invalid destinations.
     // Chain comparison intentionally omitted -- Alpaca returns inconsistent chain
     // values ("ETH" vs "ethereum"). Matches is_address_whitelisted_and_approved.
-    let whitelist = alpaca_wallet.get_whitelisted_addresses().await?;
+    let whitelist = retry_on_backpressure(
+        || alpaca_wallet.get_whitelisted_addresses(),
+        BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+    )
+    .await?;
     let is_whitelisted = whitelist.iter().any(|entry| {
         entry.address == to_address
             && entry.asset == usdc_asset
@@ -364,7 +371,11 @@ pub(super) async fn alpaca_whitelist_command<W: Write>(
     );
 
     writeln!(stdout, "   Checking existing whitelist entries...")?;
-    let existing = alpaca_wallet.get_whitelisted_addresses().await?;
+    let existing = retry_on_backpressure(
+        || alpaca_wallet.get_whitelisted_addresses(),
+        BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+    )
+    .await?;
 
     for entry in &existing {
         if entry.address == target_address && entry.asset.as_ref() == "USDC" {

--- a/src/cli/backpressure_retry.rs
+++ b/src/cli/backpressure_retry.rs
@@ -1,0 +1,195 @@
+//! Bounded in-call retry for synchronous CLI Alpaca calls (RAI-1494).
+//!
+//! A CLI command is not a durable job: there is no apalis queue row to
+//! reschedule and no sibling work waiting behind a shared
+//! `concurrency(1)` worker. Retrying a classified broker rate-limit (429)
+//! in place with a small bounded budget cannot reproduce the parent
+//! RAI-1492 incident's "one job monopolizes the single worker" shape --
+//! the "worker" here is the one-shot CLI process the operator is already
+//! waiting on. This mirrors the job-path reschedule mechanism's
+//! classification (`crate::conductor::job::find_backpressure`/
+//! `decide_backpressure`) but retries synchronously instead of pushing a
+//! delayed successor job.
+
+use std::future::Future;
+use tracing::warn;
+
+use crate::conductor::job::{BackpressureStreak, decide_backpressure, find_backpressure};
+
+/// Default bounded retry budget for CLI Alpaca calls: a handful of attempts
+/// is enough to ride out a brief rate-limit window without turning a CLI
+/// invocation into a long-running process an operator did not expect.
+pub(crate) const BACKPRESSURE_RETRY_MAX_ATTEMPTS: u32 = 3;
+
+/// Retries `call` up to `max_attempts` times when its error is classified as
+/// broker rate-limiting (429), sleeping for the same delay the job-path
+/// reschedule mechanism would honour (`Retry-After` when present, else an
+/// escalating fallback). Any non-backpressure error, or a backpressure error
+/// once `max_attempts` is exhausted, propagates unchanged to the caller's
+/// existing `anyhow` error path.
+///
+/// `call` is a closure returning a fresh future per attempt (an `FnMut`, not
+/// a bare `Future`) since a future can only be polled to completion once.
+pub(crate) async fn retry_on_backpressure<Value, ErrorType, Fut>(
+    mut call: impl FnMut() -> Fut,
+    max_attempts: u32,
+) -> Result<Value, ErrorType>
+where
+    ErrorType: std::error::Error + 'static,
+    Fut: Future<Output = Result<Value, ErrorType>>,
+{
+    let mut attempt: u32 = 0;
+
+    loop {
+        match call().await {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                let Some(backpressure) = find_backpressure(&error) else {
+                    return Err(error);
+                };
+
+                attempt = attempt.saturating_add(1);
+                if attempt >= max_attempts {
+                    return Err(error);
+                }
+
+                // `decide_backpressure`'s `streak` parameter is a consecutive
+                // reschedule count; `attempt - 1` (0-indexed) plays the same
+                // role here, escalating the fallback delay identically to
+                // the job path when `Retry-After` is absent.
+                let decision = decide_backpressure(&backpressure, BackpressureStreak(attempt - 1));
+                warn!(
+                    target: "broker",
+                    attempts_remaining = max_attempts - attempt,
+                    delay = ?decision.delay,
+                    "Broker rate-limited the CLI request; retrying after delay"
+                );
+                tokio::time::sleep(decision.delay).await;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    use super::*;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("test error")]
+    struct TestError {
+        #[source]
+        source: Option<st0x_execution::AlpacaBrokerApiError>,
+    }
+
+    fn backpressure_429(retry_after: Duration) -> TestError {
+        TestError {
+            source: Some(st0x_execution::AlpacaBrokerApiError::ApiError {
+                status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                alpaca_code: None,
+                message: "rate limited".to_string(),
+                retry_after: Some(retry_after),
+            }),
+        }
+    }
+
+    fn non_backpressure_error() -> TestError {
+        TestError { source: None }
+    }
+
+    #[tokio::test]
+    async fn retry_on_backpressure_retries_within_budget_then_succeeds() {
+        let call_count = AtomicU32::new(0);
+
+        let result = retry_on_backpressure(
+            || {
+                let attempt = call_count.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if attempt < 2 {
+                        Err(backpressure_429(Duration::from_millis(1)))
+                    } else {
+                        Ok::<_, TestError>("success")
+                    }
+                }
+            },
+            5,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, "success");
+        assert_eq!(call_count.load(Ordering::SeqCst), 3);
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn retry_on_backpressure_logs_the_delay_and_remaining_budget() {
+        let call_count = AtomicU32::new(0);
+
+        retry_on_backpressure(
+            || {
+                let attempt = call_count.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if attempt == 0 {
+                        Err(backpressure_429(Duration::from_millis(1)))
+                    } else {
+                        Ok::<_, TestError>(())
+                    }
+                }
+            },
+            3,
+        )
+        .await
+        .unwrap();
+
+        assert!(logs_contain("Broker rate-limited the CLI request"));
+        assert!(logs_contain("attempts_remaining=2"));
+        assert!(logs_contain("delay=1s"));
+    }
+
+    #[tokio::test]
+    async fn retry_on_backpressure_gives_up_after_max_attempts() {
+        let call_count = AtomicU32::new(0);
+
+        let error = retry_on_backpressure(
+            || {
+                call_count.fetch_add(1, Ordering::SeqCst);
+                async move { Err::<(), _>(backpressure_429(Duration::from_millis(1))) }
+            },
+            3,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.source.is_some());
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            3,
+            "must stop after exactly max_attempts calls"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_on_backpressure_does_not_retry_a_non_backpressure_error() {
+        let call_count = AtomicU32::new(0);
+
+        let error = retry_on_backpressure(
+            || {
+                call_count.fetch_add(1, Ordering::SeqCst);
+                async move { Err::<(), _>(non_backpressure_error()) }
+            },
+            5,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.source.is_none());
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "a non-backpressure error must fail on the first attempt, not retry"
+        );
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 //! CLI commands for trading, asset transfers, and authentication.
 
 mod alpaca_wallet;
+mod backpressure_retry;
 mod cctp;
 mod dividend;
 mod rebalancing;

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -26,6 +26,7 @@ use st0x_tokenization::{
 };
 use st0x_wrapper::{Wrapper, WrapperService};
 
+use super::backpressure_retry::{BACKPRESSURE_RETRY_MAX_ATTEMPTS, retry_on_backpressure};
 use super::{TransferDirection, TransferType};
 use crate::api::ResumeResponse;
 use crate::bot_gas::BotGasReceiptCostEnqueuer;
@@ -227,7 +228,7 @@ where
     Fut: Future<Output = Result<(), UsdcTransferError>>,
 {
     loop {
-        match resume().await {
+        match retry_on_backpressure(&mut resume, BACKPRESSURE_RETRY_MAX_ATTEMPTS).await {
             Ok(()) => return Ok(()),
             Err(UsdcTransferError::AttestationTimedOut { id }) => {
                 warn!(
@@ -252,42 +253,53 @@ where
                 );
                 tokio::time::sleep(redrive_delay).await;
             }
-            // WithdrawalPollInconclusive is non-terminal: Alpaca was unreachable or
-            // returned an error. The aggregate stays in Withdrawing (guard held);
-            // the automatic delayed redrive continues in the background. Retry here
-            // so the CLI polls periodically without spinning, matching the behaviour
-            // of AttestationTimedOut for Circle unavailability.
-            Err(UsdcTransferError::WithdrawalPollInconclusive { id, .. }) => {
-                warn!(
-                    target: "rebalance",
-                    %id,
-                    ?redrive_delay,
-                    "Alpaca withdrawal poll inconclusive; Alpaca may be unreachable -- \
-                     retrying after delay (aggregate stays in Withdrawing, guard held)"
-                );
-                tokio::time::sleep(redrive_delay).await;
+            // WithdrawalPollInconclusive and MintRecoveryInconclusive are
+            // non-terminal: Alpaca was unreachable or returned an error, or the
+            // CCTP mint recovery window could not get a conclusive nonce/receipt
+            // read. The aggregate stays in its durable pre-terminal state (guard
+            // held); the automatic delayed redrive continues in the background.
+            // Retry here so the CLI polls periodically without spinning, matching
+            // the behaviour of AttestationTimedOut for Circle unavailability --
+            // otherwise a manual transfer would exit on this outcome, leaving the
+            // operator unable to drive the stuck transfer to completion via the CLI
+            // (the exact command the operator alert for this outcome recommends
+            // running).
+            Err(error) => {
+                let withdrawal_poll_backpressure = match &error {
+                    UsdcTransferError::WithdrawalPollInconclusive { source, .. } => {
+                        source.backpressure().is_some()
+                    }
+                    _ => false,
+                };
+                if withdrawal_poll_backpressure {
+                    return Err(error);
+                }
+
+                match error {
+                    UsdcTransferError::WithdrawalPollInconclusive { id, .. } => {
+                        warn!(
+                            target: "rebalance",
+                            %id,
+                            ?redrive_delay,
+                            "Alpaca withdrawal poll inconclusive; Alpaca may be unreachable -- \
+                             retrying after delay (aggregate stays in Withdrawing, guard held)"
+                        );
+                        tokio::time::sleep(redrive_delay).await;
+                    }
+                    UsdcTransferError::MintRecoveryInconclusive { id, source, .. } => {
+                        warn!(
+                            target: "rebalance",
+                            %id,
+                            %source,
+                            ?redrive_delay,
+                            "CCTP mint recovery inconclusive; retrying after delay \
+                             (aggregate stays in its durable pre-mint state, guard held)"
+                        );
+                        tokio::time::sleep(redrive_delay).await;
+                    }
+                    error => return Err(error),
+                }
             }
-            // MintRecoveryInconclusive is non-terminal: the CCTP mint recovery
-            // window could not get a conclusive nonce/receipt read. The aggregate
-            // stays in whichever durable pre-mint state it was already in; the
-            // automatic delayed redrive continues in the background. Retry here
-            // so the CLI polls periodically without spinning, matching the
-            // behaviour of WithdrawalPollInconclusive -- otherwise a manual
-            // transfer would exit on this outcome, leaving the operator unable to
-            // drive the stuck transfer to completion via the CLI (the exact
-            // command the operator alert for this outcome recommends running).
-            Err(UsdcTransferError::MintRecoveryInconclusive { id, source, .. }) => {
-                warn!(
-                    target: "rebalance",
-                    %id,
-                    %source,
-                    ?redrive_delay,
-                    "CCTP mint recovery inconclusive; retrying after delay \
-                     (aggregate stays in its durable pre-mint state, guard held)"
-                );
-                tokio::time::sleep(redrive_delay).await;
-            }
-            Err(error) => return Err(error),
         }
     }
 }
@@ -533,16 +545,26 @@ async fn run_usdc_transfer<Writer: Write>(
     // re-enters from the persisted state on the same id -- so this single
     // invocation covers both the first run and every redrive without ever
     // minting a second `UsdcRebalanceId` against the already-burned funds.
-    redrive_transfer_until_settled(CLI_ATTESTATION_REDRIVE_DELAY, || async {
-        match direction {
-            TransferDirection::ToRaindex => {
-                rebalance_manager.resume_alpaca_to_base(&id, amount).await
-            }
-            TransferDirection::ToAlpaca => {
-                rebalance_manager.resume_base_to_alpaca(&id, amount).await
-            }
-        }
-    })
+    // Bounded in-call retry (RAI-1494): a classified broker rate-limit (429)
+    // retries the whole redrive-until-settled attempt (bounded), rather than
+    // surfacing immediately as a CLI failure. Re-invoking `resume_*` on the
+    // same `id` is exactly as safe as `redrive_transfer_until_settled`'s own
+    // existing redrives -- both re-enter the same persisted aggregate state.
+    retry_on_backpressure(
+        || {
+            redrive_transfer_until_settled(CLI_ATTESTATION_REDRIVE_DELAY, || async {
+                match direction {
+                    TransferDirection::ToRaindex => {
+                        rebalance_manager.resume_alpaca_to_base(&id, amount).await
+                    }
+                    TransferDirection::ToAlpaca => {
+                        rebalance_manager.resume_base_to_alpaca(&id, amount).await
+                    }
+                }
+            })
+        },
+        BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+    )
     .await?;
 
     let completion = match direction {
@@ -1063,15 +1085,24 @@ pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clon
 
     writeln!(stdout, "   Sending mint request to Alpaca...")?;
 
+    // Bounded in-call retry (RAI-1494): a classified broker rate-limit (429)
+    // retries in place instead of failing this CLI command immediately. The
+    // `issuer_request_id` is generated once, outside the retry closure, and
+    // reused across placement retries so a redelivered 429 cannot mint
+    // against a second issuer-side idempotency key.
     let issuer_request_id = IssuerRequestId::generate();
-    let request = tokenization_service
-        .request_mint(
-            symbol.clone(),
-            quantity,
-            receiving_wallet,
-            issuer_request_id,
-        )
-        .await?;
+    let request = retry_on_backpressure(
+        || {
+            tokenization_service.request_mint(
+                symbol.clone(),
+                quantity,
+                receiving_wallet,
+                issuer_request_id.clone(),
+            )
+        },
+        BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+    )
+    .await?;
 
     writeln!(stdout, "   Request ID: {}", request.id)?;
     writeln!(stdout, "   Status: {:?}", request.status)?;
@@ -1079,9 +1110,11 @@ pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clon
     if request.status == TokenizationRequestStatus::Pending {
         writeln!(stdout, "   Polling Alpaca until completion...")?;
 
-        let completed = tokenization_service
-            .poll_mint_until_complete(&request.id)
-            .await?;
+        let completed = retry_on_backpressure(
+            || tokenization_service.poll_mint_until_complete(&request.id),
+            BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+        )
+        .await?;
 
         writeln!(stdout, "   Alpaca status: {:?}", completed.status)?;
 
@@ -1181,12 +1214,23 @@ pub(super) async fn alpaca_redeem_command<Writer: Write>(
 
     writeln!(stdout, "   Sending tokens to redemption wallet...")?;
 
+    // `send_for_redemption` is a raw ERC20 transfer with no issuer-side
+    // idempotency key (unlike `request_mint`'s `IssuerRequestId`), and its
+    // error path never crosses the Alpaca API, so it cannot classify as
+    // broker rate-limiting -- retrying it here would risk a double on-chain
+    // send for no possible backpressure benefit. Left unwrapped
+    // intentionally (RAI-1494); only the two Alpaca API polls below are
+    // bounded-retried.
     let tx_hash = Tokenizer::send_for_redemption(&tokenization_service, token, amount).await?;
 
     writeln!(stdout, "   Transfer tx: {tx_hash}")?;
     writeln!(stdout, "   Waiting for Alpaca to detect transfer...")?;
 
-    let request = Tokenizer::poll_for_redemption(&tokenization_service, &tx_hash).await?;
+    let request = retry_on_backpressure(
+        || Tokenizer::poll_for_redemption(&tokenization_service, &tx_hash),
+        BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+    )
+    .await?;
 
     writeln!(stdout, "   Request ID: {}", request.id)?;
     writeln!(stdout, "   Status: {:?}", request.status)?;
@@ -1194,8 +1238,11 @@ pub(super) async fn alpaca_redeem_command<Writer: Write>(
     if request.status == TokenizationRequestStatus::Pending {
         writeln!(stdout, "   Polling until completion...")?;
 
-        let completed =
-            Tokenizer::poll_redemption_until_complete(&tokenization_service, &request.id).await?;
+        let completed = retry_on_backpressure(
+            || Tokenizer::poll_redemption_until_complete(&tokenization_service, &request.id),
+            BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+        )
+        .await?;
 
         writeln!(stdout, "   Final status: {:?}", completed.status)?;
 
@@ -1676,7 +1723,7 @@ mod tests {
     use st0x_finance::Usdc;
     use st0x_float_macro::float;
     use st0x_tokenization::mock::MockTokenizer;
-    use st0x_tokenization::{issuer_request_id, tokenization_request_id};
+    use st0x_tokenization::{TokenizerError, issuer_request_id, tokenization_request_id};
     use st0x_wrapper::MockWrapper;
 
     use super::*;
@@ -1848,6 +1895,44 @@ mod tests {
             2,
             "the loop must retry exactly once after the inconclusive mint recovery, \
              then succeed",
+        );
+    }
+
+    #[tokio::test]
+    async fn redrive_loop_bounds_withdrawal_poll_backpressure_retries() {
+        let calls = std::cell::Cell::new(0u32);
+
+        let error = redrive_transfer_until_settled(Duration::from_millis(0), || {
+            calls.set(calls.get() + 1);
+            async move {
+                Err(UsdcTransferError::WithdrawalPollInconclusive {
+                    id: UsdcRebalanceId(Uuid::from_u128(43)),
+                    initiated_at: chrono::Utc::now(),
+                    source: AlpacaWalletError::ApiError {
+                        status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                        message: "rate limited".to_string(),
+                        retry_after: Some(Duration::from_millis(1)),
+                    },
+                })
+            }
+        })
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            UsdcTransferError::WithdrawalPollInconclusive {
+                source: AlpacaWalletError::ApiError {
+                    status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                    ..
+                },
+                ..
+            }
+        ));
+        assert_eq!(
+            calls.get(),
+            BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+            "a sustained withdrawal-poll 429 must stop at the shared CLI retry budget"
         );
     }
 
@@ -3729,6 +3814,108 @@ mod tests {
                 .contains("equity COIN is not configured in [assets.equities]"),
             "an unconfigured symbol must fail before any network call, got: {error}"
         );
+    }
+
+    /// A classified broker rate-limit (429) on the tokenization mint request
+    /// must be retried in place (RAI-1494), not surfaced on the first
+    /// attempt. Drives a real `httpmock` 429 through `AlpacaTokenizationService`
+    /// exactly as `alpaca_tokenize_command` calls it -- if the
+    /// `retry_on_backpressure` wrapping around `request_mint` were ever
+    /// removed, this test would fail after exactly one call instead of the
+    /// full bounded budget.
+    #[tokio::test]
+    async fn alpaca_tokenize_mint_request_retries_a_429_up_to_the_bounded_budget() {
+        let server = httpmock::MockServer::start_async().await;
+        let account_id = AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
+        let mint_path = format!("/v1/accounts/{account_id}/tokenization/mint");
+
+        let mint_mock = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST).path(mint_path);
+                then.status(429)
+                    .header("content-type", "application/json")
+                    .header("Retry-After", "0")
+                    .json_body(serde_json::json!({ "message": "rate limited" }));
+            })
+            .await;
+
+        let tokenization_service = AlpacaTokenizationService::new(
+            server.base_url(),
+            account_id,
+            "test_key".to_string(),
+            "test_secret".to_string(),
+            st0x_evm::StubWallet::stub(Address::ZERO),
+            None,
+        );
+        let issuer_request_id = IssuerRequestId::generate();
+
+        let error = retry_on_backpressure(
+            || {
+                tokenization_service.request_mint(
+                    Symbol::new("AAPL").unwrap(),
+                    FractionalShares::new(float!(10)),
+                    Address::ZERO,
+                    issuer_request_id.clone(),
+                )
+            },
+            BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(error, TokenizerError::Alpaca(_)),
+            "a persistent 429 must still surface as a real failure once the \
+             bounded budget is exhausted, got: {error}"
+        );
+        mint_mock
+            .assert_calls_async(BACKPRESSURE_RETRY_MAX_ATTEMPTS as usize)
+            .await;
+    }
+
+    /// Same regression as the mint case, for the redemption detection poll
+    /// (`alpaca_redeem_command`'s `poll_for_redemption`).
+    #[tokio::test]
+    async fn alpaca_redeem_poll_for_redemption_retries_a_429_up_to_the_bounded_budget() {
+        let server = httpmock::MockServer::start_async().await;
+        let account_id = AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
+        let requests_path = format!("/v1/accounts/{account_id}/tokenization/requests");
+
+        let list_mock = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET).path(requests_path);
+                then.status(429)
+                    .header("content-type", "application/json")
+                    .header("Retry-After", "0")
+                    .json_body(serde_json::json!({ "message": "rate limited" }));
+            })
+            .await;
+
+        let tokenization_service = AlpacaTokenizationService::new(
+            server.base_url(),
+            account_id,
+            "test_key".to_string(),
+            "test_secret".to_string(),
+            st0x_evm::StubWallet::stub(Address::ZERO),
+            None,
+        );
+        let tx_hash = alloy::primitives::TxHash::ZERO;
+
+        let error = retry_on_backpressure(
+            || Tokenizer::poll_for_redemption(&tokenization_service, &tx_hash),
+            BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(error, TokenizerError::Alpaca(_)),
+            "a persistent 429 must still surface as a real failure once the \
+             bounded budget is exhausted, got: {error}"
+        );
+        list_mock
+            .assert_calls_async(BACKPRESSURE_RETRY_MAX_ATTEMPTS as usize)
+            .await;
     }
 
     fn redemption_services() -> EquityTransferServices {

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -20,6 +20,7 @@ use st0x_execution::{
 };
 use st0x_float_serde::format_float_with_fallback;
 
+use super::backpressure_retry::{BACKPRESSURE_RETRY_MAX_ATTEMPTS, retry_on_backpressure};
 use crate::conductor::{
     FillAccountingOutcome, account_for_onchain_fill, execute_mark_acknowledged,
     execute_settle_fill, is_expected_place_offchain_order_rejection,
@@ -259,7 +260,12 @@ async fn get_broker_order_status<W: Write>(
     match &ctx.broker {
         BrokerCtx::AlpacaBrokerApi(alpaca_auth) => {
             let broker = alpaca_auth.clone().try_into_executor().await?;
-            Ok(broker.get_order_status(&order_id.to_string()).await?)
+            let order_id = order_id.to_string();
+            Ok(retry_on_backpressure(
+                || broker.get_order_status(&order_id),
+                BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+            )
+            .await?)
         }
         BrokerCtx::DryRun => {
             let broker = MockExecutorCtx.try_into_executor().await?;
@@ -364,16 +370,19 @@ async fn execute_alpaca_limit_order<W: Write>(
     writeln!(stdout, "🔄 Executing Alpaca Broker API limit order...")?;
 
     let broker = alpaca_auth.clone().try_into_executor().await?;
-    let placement = broker
-        .place_alpaca_limit_order(AlpacaLimitOrder {
-            symbol: request.symbol.clone(),
-            shares: request.shares,
-            direction: request.direction,
-            limit_price,
-            extended_hours,
-            client_order_id: ClientOrderId::cli(Uuid::new_v4()),
-        })
-        .await?;
+    let order = AlpacaLimitOrder {
+        symbol: request.symbol.clone(),
+        shares: request.shares,
+        direction: request.direction,
+        limit_price,
+        extended_hours,
+        client_order_id: ClientOrderId::cli(Uuid::new_v4()),
+    };
+    let placement = retry_on_backpressure(
+        || broker.place_alpaca_limit_order(order.clone()),
+        BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+    )
+    .await?;
 
     writeln!(
         stdout,
@@ -495,7 +504,11 @@ pub(super) async fn execute_broker_order<W: Write>(
                 auth.time_in_force = tif;
             }
             let broker = auth.try_into_executor().await?;
-            let placement = broker.place_market_order(market_order).await?;
+            let placement = retry_on_backpressure(
+                || broker.place_market_order(market_order.clone()),
+                BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+            )
+            .await?;
             writeln!(
                 stdout,
                 "✅ Alpaca Broker API order placed with ID: {}",
@@ -563,11 +576,20 @@ async fn place_market_order_until_filled<Exec: Executor, W: Write>(
     market_order: MarketOrder,
     stdout: &mut W,
 ) -> anyhow::Result<()> {
-    let placement = broker.place_market_order(market_order).await?;
+    let placement = retry_on_backpressure(
+        || broker.place_market_order(market_order.clone()),
+        BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+    )
+    .await?;
     writeln!(stdout, "   Buy order placed: {}", placement.order_id)?;
 
     for attempt in 1..=BUY_FILL_MAX_ATTEMPTS {
-        match broker.get_order_status(&placement.order_id).await? {
+        let order_state = retry_on_backpressure(
+            || broker.get_order_status(&placement.order_id),
+            BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+        )
+        .await?;
+        match order_state {
             OrderState::Filled { order_id, .. } => {
                 writeln!(stdout, "   Buy filled (order {order_id})")?;
                 return Ok(());
@@ -1888,6 +1910,217 @@ mod tests {
         assert!(
             error.to_string().contains("buy order failed"),
             "a rejected order must fail the buy-fill wait, got: {error}"
+        );
+    }
+
+    /// Executor error carrying an optional Alpaca 429 as its `source`, so
+    /// `find_backpressure` classifies it exactly like a real
+    /// `AlpacaBrokerApiError` -- used to pin that
+    /// `place_market_order_until_filled` retries a classified 429 in place
+    /// (RAI-1494) instead of failing the buy-fill wait immediately.
+    #[derive(Debug, thiserror::Error)]
+    #[error("test executor error")]
+    struct BackpressureTestError {
+        #[source]
+        source: Option<st0x_execution::AlpacaBrokerApiError>,
+    }
+
+    fn backpressure_429_error() -> BackpressureTestError {
+        BackpressureTestError {
+            source: Some(st0x_execution::AlpacaBrokerApiError::ApiError {
+                status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                alpaca_code: None,
+                message: "rate limited".to_string(),
+                retry_after: Some(std::time::Duration::from_millis(1)),
+            }),
+        }
+    }
+
+    /// Executor whose `place_market_order` returns a classified 429 for the
+    /// first `placement_429s` calls before succeeding, and whose
+    /// `get_order_status` returns a classified 429 for the first
+    /// `status_429s` calls before reporting `Filled`.
+    #[derive(Clone)]
+    struct BackpressureThenFilledExecutor {
+        placement_429s: usize,
+        status_429s: usize,
+        placement_calls: Arc<AtomicUsize>,
+        status_calls: Arc<AtomicUsize>,
+    }
+
+    impl BackpressureThenFilledExecutor {
+        fn new(placement_429s: usize, status_429s: usize) -> Self {
+            Self {
+                placement_429s,
+                status_429s,
+                placement_calls: Arc::new(AtomicUsize::new(0)),
+                status_calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Executor for BackpressureThenFilledExecutor {
+        type Error = BackpressureTestError;
+        type OrderId = String;
+        type Ctx = ();
+
+        async fn try_from_ctx(_ctx: Self::Ctx) -> Result<Self, Self::Error> {
+            Ok(Self::new(0, 0))
+        }
+
+        async fn is_market_open(&self) -> Result<bool, Self::Error> {
+            Ok(true)
+        }
+
+        async fn place_market_order(
+            &self,
+            order: MarketOrder,
+        ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
+            let call_index = self.placement_calls.fetch_add(1, Ordering::SeqCst);
+            if call_index < self.placement_429s {
+                return Err(backpressure_429_error());
+            }
+            Ok(OrderPlacement {
+                order_id: "backpressure-order-id".to_string(),
+                symbol: order.symbol,
+                shares: order.shares,
+                direction: order.direction,
+                placed_at: Utc::now(),
+                extended_hours: false,
+                limit_price: None,
+            })
+        }
+
+        async fn get_order_status(
+            &self,
+            _order_id: &Self::OrderId,
+        ) -> Result<OrderState, Self::Error> {
+            let call_index = self.status_calls.fetch_add(1, Ordering::SeqCst);
+            if call_index < self.status_429s {
+                return Err(backpressure_429_error());
+            }
+            Ok(OrderState::Filled {
+                executed_at: Utc::now(),
+                order_id: ExecutorOrderId::new("backpressure-order-id"),
+                price: st0x_execution::Usd::new(Float::parse("195.30".to_string()).unwrap()),
+            })
+        }
+
+        fn to_supported_executor(&self) -> SupportedExecutor {
+            SupportedExecutor::DryRun
+        }
+
+        fn parse_order_id(&self, order_id_str: &str) -> Result<Self::OrderId, Self::Error> {
+            Ok(order_id_str.to_string())
+        }
+
+        async fn get_inventory(&self) -> Result<InventoryResult, Self::Error> {
+            Ok(InventoryResult::Unimplemented)
+        }
+
+        async fn place_limit_order(
+            &self,
+            _order: LimitOrder,
+        ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
+            unimplemented!("not exercised by the buy-fill backpressure tests")
+        }
+
+        async fn cancel_order(
+            &self,
+            _order_id: &Self::OrderId,
+        ) -> Result<CancellationOutcome, Self::Error> {
+            unimplemented!("not exercised by the buy-fill backpressure tests")
+        }
+
+        async fn preflight_counter_trade_at_price(
+            &self,
+            order: MarketOrder,
+            _reference_price: Positive<Usd>,
+        ) -> Result<CounterTradePreflight, Self::Error> {
+            self.preflight_counter_trade(order).await
+        }
+    }
+
+    #[tokio::test]
+    async fn market_buy_retries_placement_after_a_429_then_succeeds() {
+        let broker = BackpressureThenFilledExecutor::new(2, 0);
+        let order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: positive_shares("10"),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::cli(Uuid::new_v4()),
+        };
+        let mut stdout = Vec::new();
+
+        place_market_order_until_filled(&broker, order, &mut stdout)
+            .await
+            .expect("a classified 429 on placement must be retried, not fail the buy-fill wait");
+
+        assert_eq!(
+            broker.placement_calls.load(Ordering::SeqCst),
+            3,
+            "must retry placement exactly twice after the first two 429s before succeeding"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_buy_retries_status_poll_after_a_429_then_succeeds() {
+        let broker = BackpressureThenFilledExecutor::new(0, 2);
+        let order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: positive_shares("10"),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::cli(Uuid::new_v4()),
+        };
+        let mut stdout = Vec::new();
+
+        place_market_order_until_filled(&broker, order, &mut stdout)
+            .await
+            .expect(
+                "a classified 429 on the status poll must be retried, not fail the buy-fill wait",
+            );
+
+        assert_eq!(
+            broker.status_calls.load(Ordering::SeqCst),
+            3,
+            "must retry the status poll exactly twice after the first two 429s before succeeding"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_buy_placement_fails_when_429s_exceed_the_retry_budget() {
+        let broker =
+            BackpressureThenFilledExecutor::new(BACKPRESSURE_RETRY_MAX_ATTEMPTS as usize, 0);
+        let order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: positive_shares("10"),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::cli(Uuid::new_v4()),
+        };
+        let mut stdout = Vec::new();
+
+        let error = place_market_order_until_filled(&broker, order, &mut stdout)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            broker.placement_calls.load(Ordering::SeqCst),
+            BACKPRESSURE_RETRY_MAX_ATTEMPTS as usize,
+            "must stop retrying after exactly the bounded attempt budget"
+        );
+        let backpressure_error = error
+            .downcast_ref::<BackpressureTestError>()
+            .expect("the exhausted 429 must surface as the executor's own error type unwrapped");
+        assert!(
+            matches!(
+                backpressure_error.source,
+                Some(st0x_execution::AlpacaBrokerApiError::ApiError {
+                    status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                    ..
+                })
+            ),
+            "the exhausted 429 must retain its classified source, got: {backpressure_error:?}"
         );
     }
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -58,6 +58,7 @@ use crate::bot_gas::{
     RecordBotGasReceiptCostJobQueue,
 };
 use crate::conductor::exit::{ConductorExit, MonitorTaskError};
+use crate::conductor::job::{BACKPRESSURE_RESCHEDULE_LIMIT, BackpressureStreak};
 use crate::conductor::monitor::order_fills::{CutoffProbe, probe_cutoff_block_support};
 use crate::dashboard::{Broadcaster, DashboardTradeDelivery};
 use crate::equity_redemption::{
@@ -68,12 +69,13 @@ use crate::inventory::{
 };
 use crate::offchain::order::{
     ExecutorOrderPlacer, OffchainOrder, OffchainOrderId, OffchainOrderPlacement, OrderPlacer,
-    PollOrderStatusJobQueue, TerminalPositionFinalization, client_order_id_for_placement,
-    finalize_cancelled_position_or_log_unpriced, place_offchain_order_at_broker,
-    position_command_for_finalization, push_poll_job_if_absent, terminal_position_finalization,
+    PollOrderStatus, PollOrderStatusJobQueue, TerminalPositionFinalization,
+    client_order_id_for_placement, finalize_cancelled_position_or_log_unpriced,
+    place_offchain_order_at_broker, position_command_for_finalization, push_poll_job_if_absent,
+    terminal_position_finalization,
 };
 #[cfg(test)]
-use crate::offchain::order::{OffchainOrderCommand, PollOrderStatus, noop_order_placer};
+use crate::offchain::order::{OffchainOrderCommand, noop_order_placer};
 use crate::onchain::OnchainTrade;
 #[cfg(test)]
 use crate::onchain::accumulator::check_all_positions;
@@ -1292,9 +1294,19 @@ fn spawn_finished_job_cleanup(
             // prevent generic tokenization recovery from racing a requeued
             // transfer job or resurrecting a terminal dead letter. Transfer
             // jobs are low-volume, so retaining their finished rows is cheap.
+            //
+            // A completed PollOrderStatus row at the backpressure limit is
+            // likewise a durable dead-letter marker. Retain only that narrow
+            // subset; ordinary completed poll rows remain disposable.
             let cleanup_result = sqlx_apalis::query(
                 "DELETE FROM Jobs \
                  WHERE job_type NOT IN (?, ?, ?, ?) \
+                 AND NOT ( \
+                     job_type = ? \
+                     AND status = ? \
+                     AND json_valid(CAST(job AS TEXT)) \
+                     AND json_extract(CAST(job AS TEXT), '$.backpressure_streak') >= ? \
+                 ) \
                  AND ( \
                      status = ? \
                      OR status = ? \
@@ -1305,6 +1317,9 @@ fn spawn_finished_job_cleanup(
             .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
             .bind(std::any::type_name::<TransferEquityToHedging>())
             .bind(std::any::type_name::<TransferEquityToMarketMaking>())
+            .bind(std::any::type_name::<PollOrderStatus>())
+            .bind(Status::Done.to_string())
+            .bind(i64::from(BACKPRESSURE_RESCHEDULE_LIMIT))
             .bind(Status::Done.to_string())
             .bind(Status::Killed.to_string())
             .bind(Status::Failed.to_string())
@@ -2293,6 +2308,7 @@ async fn recover_interrupted_tokenization_aggregates(
             resume_queue
                 .push(ResumeTokenizationAggregate {
                     target: ResumeTokenizationTarget::Mint(mint_id.clone()),
+                    backpressure_streak: BackpressureStreak::default(),
                 })
                 .await?;
         }
@@ -2319,6 +2335,7 @@ async fn recover_interrupted_tokenization_aggregates(
             resume_queue
                 .push(ResumeTokenizationAggregate {
                     target: ResumeTokenizationTarget::Redemption(redemption_id.clone()),
+                    backpressure_streak: BackpressureStreak::default(),
                 })
                 .await?;
         }
@@ -3179,6 +3196,7 @@ where
             threshold: cqrs.execution_threshold,
             offchain_order_id,
             market_session: execution.market_session,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         if let Err(error) = cqrs.hedge_queue.clone().push(job).await {
@@ -4717,6 +4735,7 @@ mod tests {
             .push(UnwrappedEquityRecoveryJob {
                 symbol: Symbol::new("AAPL").unwrap(),
                 recovery_id: UnwrappedEquityRecoveryId(uuid::Uuid::new_v4()),
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -5058,6 +5077,8 @@ mod tests {
                 symbol: Symbol::new("AAPL").unwrap(),
                 quantity: FractionalShares::new(float!(1)),
                 generation: 1,
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -5068,6 +5089,8 @@ mod tests {
                 aggregate_id: redemption_id,
                 symbol: Symbol::new("AAPL").unwrap(),
                 quantity: FractionalShares::new(float!(1)),
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -5135,6 +5158,8 @@ mod tests {
                 symbol: Symbol::new("AAPL").unwrap(),
                 quantity: FractionalShares::new(float!(1)),
                 generation: 1,
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -5145,6 +5170,8 @@ mod tests {
                 aggregate_id: redemption_id,
                 symbol: Symbol::new("AAPL").unwrap(),
                 quantity: FractionalShares::new(float!(1)),
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -5642,10 +5669,33 @@ mod tests {
         let market_making_type = std::any::type_name::<TransferUsdcToMarketMaking>();
         let equity_to_hedging_type = std::any::type_name::<TransferEquityToHedging>();
         let equity_to_market_making_type = std::any::type_name::<TransferEquityToMarketMaking>();
+        let poll_order_status_type = std::any::type_name::<PollOrderStatus>();
 
         // Non-transfer finished rows must be pruned (Done and exhausted Failed).
         insert_job_row(&apalis_pool, "other-done", "test", Status::Done, 1, 25).await;
         insert_job_row(&apalis_pool, "other-failed", "test", Status::Failed, 25, 25).await;
+
+        let mut poll_queue = PollOrderStatusJobQueue::new(&apalis_pool);
+        poll_queue
+            .push(PollOrderStatus {
+                offchain_order_id: OffchainOrderId::from_uuid(uuid::Uuid::from_u128(1)),
+                backpressure_streak: BackpressureStreak::default(),
+            })
+            .await
+            .unwrap();
+        poll_queue
+            .push(PollOrderStatus {
+                offchain_order_id: OffchainOrderId::from_uuid(uuid::Uuid::from_u128(2)),
+                backpressure_streak: BackpressureStreak(BACKPRESSURE_RESCHEDULE_LIMIT),
+            })
+            .await
+            .unwrap();
+        sqlx_apalis::query("UPDATE Jobs SET status = ? WHERE job_type = ?")
+            .bind(Status::Done.to_string())
+            .bind(poll_order_status_type)
+            .execute(&apalis_pool)
+            .await
+            .unwrap();
 
         // USDC transfer finished rows must survive cleanup: they are the durable
         // startup re-arm idempotency + redrive-budget signal.
@@ -5689,8 +5739,9 @@ mod tests {
         let handle =
             spawn_finished_job_cleanup(pool.clone(), apalis_pool.clone(), Duration::from_secs(60));
 
-        // The two non-transfer finished rows are pruned; all transfer rows remain.
-        wait_for_job_count(&apalis_pool, 4).await;
+        // The two non-transfer rows and ordinary completed poll row are pruned;
+        // transfer rows and the exhausted poll dead-letter marker remain.
+        wait_for_job_count(&apalis_pool, 5).await;
         handle.abort();
 
         let mut remaining: Vec<String> = sqlx_apalis::query_scalar("SELECT job_type FROM Jobs")
@@ -5703,11 +5754,12 @@ mod tests {
             market_making_type.to_string(),
             equity_to_hedging_type.to_string(),
             equity_to_market_making_type.to_string(),
+            poll_order_status_type.to_string(),
         ];
         expected.sort();
         assert_eq!(
             remaining, expected,
-            "transfer finished rows must survive cleanup regardless of direction or Done/Failed status"
+            "transfer rows and the exhausted poll marker must survive cleanup"
         );
     }
 
@@ -11519,7 +11571,10 @@ mod tests {
         // duplicate.
         cqrs.poll_status_queue
             .clone()
-            .push(PollOrderStatus { offchain_order_id })
+            .push(PollOrderStatus {
+                offchain_order_id,
+                backpressure_streak: BackpressureStreak::default(),
+            })
             .await
             .unwrap();
         assert_eq!(

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -350,6 +350,7 @@ where
         offchain_order: context.frameworks.offchain_order.clone(),
         order_placer: order_placer.clone(),
         poll_status_queue: poll_status_queue.clone(),
+        hedge_queue: hedge_queue.clone(),
         assets: context.ctx.assets.clone(),
         counter_trade_submission_lock: counter_trade_submission_lock.clone(),
         counter_trade_slippage_bps: match &context.ctx.broker {
@@ -1278,6 +1279,7 @@ mod tests {
     use st0x_wrapper::{MockWrapper, Wrapper};
 
     use super::*;
+    use crate::conductor::job::BackpressureStreak;
     use crate::equity_redemption::RedemptionAggregateId;
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::{
@@ -1395,6 +1397,8 @@ mod tests {
                 aggregate_id: poison_id.clone(),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -1423,6 +1427,8 @@ mod tests {
                 aggregate_id: healthy_id,
                 symbol,
                 quantity: FractionalShares::new(float!(1)),
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -1462,6 +1468,8 @@ mod tests {
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
                 generation: 0,
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -1491,6 +1499,8 @@ mod tests {
                 symbol,
                 quantity: FractionalShares::new(float!(1)),
                 generation: 0,
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -12,14 +12,17 @@ use apalis_core::backend::poll_strategy::{BackoffConfig, IntervalStrategy, Strat
 use apalis_core::worker::context::WorkerContext;
 use apalis_core::worker::event::Event;
 use apalis_sqlite::{Config, SqliteContext, SqlitePool, SqliteStorage, SqlxError};
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::sync::Arc;
 #[cfg(any(test, feature = "test-support"))]
 use std::sync::Mutex;
 use std::time::Duration;
 use tracing::{debug, error, warn};
+
+use st0x_execution::{AlpacaBrokerApiError, AlpacaWalletError, Backpressure};
+use st0x_tokenization::{AlpacaTokenizationError, TokenizerError};
 
 /// Recovery timeout for the fail-stop circuit breaker. Effectively
 /// infinite for any plausible bot uptime; chosen to be finite so
@@ -63,6 +66,246 @@ impl Backoff for ExponentialBackoff {
 /// Sequence for `RetryPolicy::retries(3)`: 1s, 2s, 4s.
 pub(crate) const RETRY_BACKOFF: ExponentialBackoff =
     ExponentialBackoff::new(Duration::from_secs(1), Duration::from_secs(30));
+
+/// Minimum delay before a backpressure reschedule fires (RAI-1494). Floors a
+/// `Retry-After: 0` (or a malformed near-zero value) so a broker signal
+/// meant to be honoured cannot produce a hot reschedule loop against an
+/// already-rate-limited endpoint. Not a financial clamp -- rate-limit
+/// hygiene, distinct from this codebase's fail-fast rule for financial
+/// values.
+pub(crate) const MIN_BACKPRESSURE_DELAY: Duration = Duration::from_secs(1);
+
+/// Ceiling on an exact `Retry-After` value, guarding only against a
+/// malformed or bogus huge header. A legitimate broker-specified wait within
+/// this bound is always honoured exactly.
+pub(crate) const MAX_RETRY_AFTER: Duration = Duration::from_secs(5 * 60);
+
+/// Escalating fallback when the broker signals backpressure without a usable
+/// `Retry-After`. Same base as [`RETRY_BACKOFF`] so a single 429 is no more
+/// aggressive than today's non-backpressure backoff; capped higher (60s vs
+/// 30s) since sustained backpressure, now that rescheduling frees the worker
+/// between tries, can afford a longer per-attempt ceiling.
+pub(crate) const BACKPRESSURE_FALLBACK_BASE: Duration = Duration::from_secs(1);
+pub(crate) const BACKPRESSURE_FALLBACK_CAP: Duration = Duration::from_secs(60);
+
+/// Reschedule budget before a persistently-429ing item is treated as a
+/// structurally-dead integration (suspended account, revoked key) rather
+/// than transient rate-limiting. ~8.3h worst case when the fallback
+/// escalation is in play (60s cap); up to ~41.6h if every reschedule honours
+/// a broker-specified `Retry-After` at the [`MAX_RETRY_AFTER`] ceiling. A
+/// judgment call, revisited once real sustained-429 durations are observed
+/// in production.
+pub(crate) const BACKPRESSURE_RESCHEDULE_LIMIT: u32 = 500;
+
+/// Streak count at which sustained backpressure should page an operator
+/// (RAI-1494 pass 3), rather than staying silent until the full
+/// [`BACKPRESSURE_RESCHEDULE_LIMIT`] dead-letter. Before this PR, a stuck
+/// Alpaca withdrawal poll paged at `WITHDRAWAL_POLL_ALERT_DEADLINE` (4h);
+/// routing a classified 429 through this reschedule machinery instead must
+/// not silently drop that SLA. Halfway to the limit (mirrors the
+/// `warn_threshold` pattern used for redrive budgets elsewhere) lands close
+/// to the pre-existing 4h bar under the escalating fallback delay (capped at
+/// [`BACKPRESSURE_FALLBACK_CAP`] = 60s): 250 reschedules * 60s = ~4.17h. With
+/// a broker-specified `Retry-After` at the [`MAX_RETRY_AFTER`] ceiling this
+/// extends to ~20.9h -- still far tighter than the ~41.6h a dead-letter-only
+/// page would allow.
+pub(crate) const BACKPRESSURE_ALERT_STREAK: u32 = BACKPRESSURE_RESCHEDULE_LIMIT / 2 + 1;
+
+/// Durable count of consecutive broker rate-limit (429) reschedules leading
+/// up to a job's current attempt (RAI-1494). Every participating job payload
+/// carries this in the same field name (`backpressure_streak`), distinct at
+/// the type level from unrelated durable counters like
+/// `revert_redrive_attempts` -- a copy-paste swap between the two at a
+/// construction site is now a compile error instead of a silent behaviour
+/// bug. `#[serde(transparent)]` keeps the wire format an unadorned integer,
+/// so no schema migration is implied and pre-existing rows still decode.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct BackpressureStreak(pub(crate) u32);
+
+/// Outcome of [`decide_backpressure`]: the delay before a rescheduled
+/// successor should run, and whether the streak has exhausted
+/// [`BACKPRESSURE_RESCHEDULE_LIMIT`].
+pub(crate) struct BackpressureDecision {
+    pub(crate) delay: Duration,
+    /// `true` once `streak` has reached [`BACKPRESSURE_RESCHEDULE_LIMIT`] --
+    /// the caller must not reschedule again. Per the RAI-1494 plan's binding
+    /// M2 decision, a supervised job's `perform()` treats this as its own
+    /// self-contained terminal event (a loud `error!` log, then `Ok(())`)
+    /// rather than propagating the original `Err` into the shared
+    /// supervised on-event path, so a persistently-429ing item cannot
+    /// re-open the circuit breaker RAI-1495 already knows how to latch.
+    pub(crate) exhausted: bool,
+}
+
+/// Pure: computes the reschedule delay and whether the budget is exhausted
+/// for a given consecutive-backpressure streak. No apalis/tower types, no
+/// I/O, no `Job` bound -- trivially unit-testable and shared by every
+/// participating job. Logging (the every-10th-streak visibility line, and
+/// the loud exhaustion log) is the caller's responsibility, keeping this
+/// function a plain computation.
+pub(crate) fn decide_backpressure(
+    backpressure: &Backpressure,
+    streak: BackpressureStreak,
+) -> BackpressureDecision {
+    let BackpressureStreak(streak) = streak;
+
+    let delay = backpressure.retry_after.map_or_else(
+        || {
+            let factor = 2u32.saturating_pow(streak);
+            BACKPRESSURE_FALLBACK_BASE
+                .saturating_mul(factor)
+                .clamp(MIN_BACKPRESSURE_DELAY, BACKPRESSURE_FALLBACK_CAP)
+        },
+        |retry_after| retry_after.clamp(MIN_BACKPRESSURE_DELAY, MAX_RETRY_AFTER),
+    );
+
+    BackpressureDecision {
+        delay,
+        exhausted: streak >= BACKPRESSURE_RESCHEDULE_LIMIT,
+    }
+}
+
+/// Outcome of [`advance_backpressure`]: either the reschedule budget is
+/// exhausted (the caller should dead-letter) or a successor should be
+/// pushed after `delay` with `next_streak`. Centralizes the
+/// exhaustion/streak-increment/every-10th-visibility decision that was
+/// previously copy-pasted verbatim across every participating job's error
+/// handler; each job still owns its own log message fields and successor
+/// struct construction, since both are job-specific.
+pub(crate) enum BackpressureStep {
+    /// `streak` has reached [`BACKPRESSURE_RESCHEDULE_LIMIT`] -- the caller
+    /// must log its own dead-letter message and return `Ok(())` rather than
+    /// propagate the original `Err` (see [`BackpressureDecision::exhausted`]).
+    DeadLetter,
+    /// Reschedule a successor with `next_streak` after `delay`. `visible`
+    /// is `true` on every 10th consecutive reschedule (1-indexed), telling
+    /// the caller to also emit its own "still rescheduling" visibility log.
+    Reschedule {
+        next_streak: BackpressureStreak,
+        delay: Duration,
+        visible: bool,
+    },
+}
+
+/// Combines [`decide_backpressure`]'s pure delay/exhaustion computation with
+/// the streak-increment and every-10th visibility decision every
+/// participating job repeats verbatim. Still pure and unit-testable; logging
+/// text and successor construction stay with each job's own handler because
+/// both carry job-specific fields.
+pub(crate) fn advance_backpressure(
+    backpressure: &Backpressure,
+    streak: BackpressureStreak,
+) -> BackpressureStep {
+    let decision = decide_backpressure(backpressure, streak);
+
+    if decision.exhausted {
+        return BackpressureStep::DeadLetter;
+    }
+
+    let BackpressureStreak(streak) = streak;
+    let next_streak = BackpressureStreak(streak.saturating_add(1));
+    let BackpressureStreak(next_streak_value) = next_streak;
+    BackpressureStep::Reschedule {
+        next_streak,
+        delay: decision.delay,
+        visible: next_streak_value % 10 == 0,
+    }
+}
+
+/// Outcome of [`apply_backpressure_step`]: which branch of a
+/// [`BackpressureStep`] was taken. `next_streak` and `visible` are threaded
+/// back through the `Rescheduled` variant so the caller can still log its own
+/// "still rescheduling" message with the actual scheduled streak; both
+/// branches' message text stay job-specific and are not centralized here.
+pub(crate) enum BackpressureOutcome {
+    /// The reschedule budget was exhausted; no successor was pushed. The
+    /// caller logs its own dead-letter message and returns `Ok(())`.
+    DeadLettered,
+    /// A successor was pushed after the computed delay.
+    Rescheduled {
+        next_streak: BackpressureStreak,
+        visible: bool,
+    },
+}
+
+/// Executes a [`BackpressureStep`] against `queue`: a no-op for
+/// [`BackpressureStep::DeadLetter`], or builds the successor via
+/// `build_successor` and pushes it after the computed delay for
+/// [`BackpressureStep::Reschedule`]. Centralizes the
+/// push-then-return-the-outcome boilerplate that was copy-pasted verbatim
+/// across every participating job's error handler; each job still owns its
+/// own tracing text and successor struct construction, since both are
+/// job-specific.
+pub(crate) async fn apply_backpressure_step<
+    Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static,
+>(
+    step: BackpressureStep,
+    queue: &mut JobQueue<Task>,
+    build_successor: impl FnOnce(BackpressureStreak) -> Task,
+) -> Result<BackpressureOutcome, QueuePushError> {
+    match step {
+        BackpressureStep::DeadLetter => Ok(BackpressureOutcome::DeadLettered),
+        BackpressureStep::Reschedule {
+            next_streak,
+            delay,
+            visible,
+        } => {
+            queue
+                .push_with_delay(build_successor(next_streak), delay)
+                .await?;
+            Ok(BackpressureOutcome::Rescheduled {
+                next_streak,
+                visible,
+            })
+        }
+    }
+}
+
+/// Walks the `.source()` chain of a job error looking for a classified
+/// broker rate-limit (429) response, checking the error itself before
+/// descending into its sources. Tries each of four known error types in
+/// turn, short-circuiting on the first `Some` -- this is the one place that
+/// needs to "know about" all of them (RAI-1494).
+///
+/// `AlpacaMarketDataError` (market-data 429s, e.g. from
+/// `fetch_latest_trade_price`) is NOT one of the four: it only ever reaches
+/// the wider app wrapped in `AlpacaBrokerApiError::LatestTrade`, and that
+/// variant's `backpressure()` delegates straight to the wrapped error, so
+/// classification happens at the `AlpacaBrokerApiError` hop already --
+/// naming `AlpacaMarketDataError` here would be a redundant, leaky second
+/// downcast (`st0x-execution`'s `AGENTS.md` keeps it test-only).
+///
+/// `TokenizerError` needs its own downcast (not just `AlpacaTokenizationError`):
+/// `TokenizerError::Alpaca` is `#[error(transparent)]`, which makes `.source()`
+/// forward straight through to the WRAPPED error's own source rather than
+/// returning the wrapped error itself -- so a chain-walk alone would skip
+/// right past an `AlpacaTokenizationError` arriving wrapped in a
+/// `TokenizerError` (as every `Tokenizer` trait method returns) without ever
+/// downcasting it. `TokenizerError::backpressure()` delegates internally
+/// instead of relying on `.source()`.
+pub(crate) fn find_backpressure(error: &(dyn std::error::Error + 'static)) -> Option<Backpressure> {
+    std::iter::successors(Some(error), |error| error.source()).find_map(|error| {
+        error
+            .downcast_ref::<AlpacaBrokerApiError>()
+            .and_then(AlpacaBrokerApiError::backpressure)
+            .or_else(|| {
+                error
+                    .downcast_ref::<AlpacaWalletError>()
+                    .and_then(AlpacaWalletError::backpressure)
+            })
+            .or_else(|| {
+                error
+                    .downcast_ref::<AlpacaTokenizationError>()
+                    .and_then(AlpacaTokenizationError::backpressure)
+            })
+            .or_else(|| {
+                error
+                    .downcast_ref::<TokenizerError>()
+                    .and_then(TokenizerError::backpressure)
+            })
+    })
+}
 
 type Storage<Task> = SqliteStorage<
     Task,
@@ -741,6 +984,321 @@ mod tests {
 
     use super::*;
     use crate::test_utils::setup_test_apalis_pool;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("intermediate wrapper: {0}")]
+    struct IntermediateTestError(#[source] AlpacaBrokerApiError);
+
+    fn api_error_429(retry_after: Option<Duration>) -> AlpacaBrokerApiError {
+        AlpacaBrokerApiError::ApiError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            alpaca_code: None,
+            message: "rate limited".to_string(),
+            retry_after,
+        }
+    }
+
+    #[test]
+    fn find_backpressure_walks_multiple_hops_to_a_wrapped_429() {
+        let error = IntermediateTestError(api_error_429(Some(Duration::from_secs(7))));
+
+        let backpressure = find_backpressure(&error).expect("expected a classified 429");
+        assert_eq!(backpressure.retry_after, Some(Duration::from_secs(7)));
+    }
+
+    #[test]
+    fn find_backpressure_none_for_an_unrelated_error_chain() {
+        let io_error = std::io::Error::other("boom");
+
+        assert_eq!(find_backpressure(&io_error), None);
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("intermediate wrapper: {0}")]
+    struct IntermediateWalletTestError(#[source] AlpacaWalletError);
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("intermediate wrapper: {0}")]
+    struct IntermediateTokenizationTestError(#[source] AlpacaTokenizationError);
+
+    /// Pins the REAL production wrapping shape (not a synthetic intermediate
+    /// wrapper): `fetch_latest_trade_price` failures surface as
+    /// `AlpacaBrokerApiError::LatestTrade(AlpacaMarketDataError)`, and
+    /// `AlpacaBrokerApiError::backpressure()` delegates straight to the
+    /// wrapped market-data error (RAI-1494) instead of `find_backpressure`
+    /// needing its own separate `AlpacaMarketDataError` downcast.
+    #[test]
+    fn find_backpressure_classifies_a_market_data_429_wrapped_in_latest_trade() {
+        let error =
+            AlpacaBrokerApiError::LatestTrade(st0x_execution::AlpacaMarketDataError::ApiError {
+                status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                body: "rate limited".to_string(),
+                retry_after: Some(Duration::from_secs(9)),
+            });
+
+        let backpressure = find_backpressure(&error).expect("expected a classified 429");
+        assert_eq!(backpressure.retry_after, Some(Duration::from_secs(9)));
+    }
+
+    #[test]
+    fn find_backpressure_walks_multiple_hops_to_a_wrapped_wallet_429() {
+        let error = IntermediateWalletTestError(AlpacaWalletError::ApiError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            message: "rate limited".to_string(),
+            retry_after: Some(Duration::from_secs(11)),
+        });
+
+        let backpressure = find_backpressure(&error).expect("expected a classified 429");
+        assert_eq!(backpressure.retry_after, Some(Duration::from_secs(11)));
+    }
+
+    #[test]
+    fn find_backpressure_walks_multiple_hops_to_a_wrapped_tokenization_429() {
+        let error = IntermediateTokenizationTestError(AlpacaTokenizationError::ApiError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            message: st0x_tokenization::AlpacaApiErrorMessage::for_test("rate limited"),
+            retry_after: Some(Duration::from_secs(13)),
+        });
+
+        let backpressure = find_backpressure(&error).expect("expected a classified 429");
+        assert_eq!(backpressure.retry_after, Some(Duration::from_secs(13)));
+    }
+
+    /// Pins the `#[error(transparent)]` gotcha `TokenizerError::backpressure()`
+    /// exists to work around: every `Tokenizer` trait method returns
+    /// `TokenizerError`, not `AlpacaTokenizationError` directly, and
+    /// `#[error(transparent)]` makes `.source()` skip straight past the
+    /// wrapped `AlpacaTokenizationError` to ITS OWN source (`None` for
+    /// `ApiError`) instead of returning the wrapped error itself. Without the
+    /// dedicated `TokenizerError` downcast in `find_backpressure`, a 429 from
+    /// any `Tokenizer` call site (e.g. `retry_on_backpressure`-wrapped CLI
+    /// tokenization calls) would never classify -- this regressed silently
+    /// once during this change (a `TokenizerError`-typed 429 produced zero
+    /// retries against a real mocked response) and must not regress again.
+    #[test]
+    fn find_backpressure_classifies_a_tokenizer_error_wrapped_429_despite_transparent_forwarding() {
+        let error: st0x_tokenization::TokenizerError = AlpacaTokenizationError::ApiError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            message: st0x_tokenization::AlpacaApiErrorMessage::for_test("rate limited"),
+            retry_after: Some(Duration::from_secs(21)),
+        }
+        .into();
+
+        let backpressure = find_backpressure(&error).expect("expected a classified 429");
+        assert_eq!(backpressure.retry_after, Some(Duration::from_secs(21)));
+    }
+
+    #[test]
+    fn decide_backpressure_floors_a_zero_retry_after() {
+        let backpressure = Backpressure {
+            retry_after: Some(Duration::ZERO),
+        };
+
+        let decision = decide_backpressure(&backpressure, BackpressureStreak(0));
+
+        assert_eq!(decision.delay, MIN_BACKPRESSURE_DELAY);
+        assert!(!decision.exhausted);
+    }
+
+    #[test]
+    fn decide_backpressure_honours_a_large_retry_after_within_the_ceiling() {
+        let backpressure = Backpressure {
+            retry_after: Some(Duration::from_secs(120)),
+        };
+
+        let decision = decide_backpressure(&backpressure, BackpressureStreak(0));
+
+        assert_eq!(decision.delay, Duration::from_secs(120));
+    }
+
+    #[test]
+    fn decide_backpressure_caps_a_retry_after_above_the_ceiling() {
+        let backpressure = Backpressure {
+            retry_after: Some(Duration::from_secs(10 * 60)),
+        };
+
+        let decision = decide_backpressure(&backpressure, BackpressureStreak(0));
+
+        assert_eq!(decision.delay, MAX_RETRY_AFTER);
+    }
+
+    #[test]
+    fn decide_backpressure_escalates_the_fallback_when_retry_after_is_absent() {
+        let backpressure = Backpressure { retry_after: None };
+
+        let delays: Vec<Duration> = (0..8)
+            .map(|streak| decide_backpressure(&backpressure, BackpressureStreak(streak)).delay)
+            .collect();
+
+        for window in delays.windows(2) {
+            assert!(
+                window[1] >= window[0],
+                "the fallback delay must never decrease as the streak grows: {delays:?}"
+            );
+        }
+        assert_eq!(
+            delays.last().copied().unwrap(),
+            BACKPRESSURE_FALLBACK_CAP,
+            "the fallback must plateau at its cap for a long streak: {delays:?}"
+        );
+        assert!(
+            delays[0] < delays[3],
+            "the fallback must actually escalate, not start already at the cap: {delays:?}"
+        );
+    }
+
+    #[test]
+    fn decide_backpressure_is_not_exhausted_below_the_limit() {
+        let backpressure = Backpressure {
+            retry_after: Some(Duration::from_secs(1)),
+        };
+
+        let decision = decide_backpressure(
+            &backpressure,
+            BackpressureStreak(BACKPRESSURE_RESCHEDULE_LIMIT - 1),
+        );
+
+        assert!(!decision.exhausted);
+    }
+
+    #[test]
+    fn decide_backpressure_is_exhausted_at_the_limit() {
+        let backpressure = Backpressure {
+            retry_after: Some(Duration::from_secs(1)),
+        };
+
+        let decision = decide_backpressure(
+            &backpressure,
+            BackpressureStreak(BACKPRESSURE_RESCHEDULE_LIMIT),
+        );
+
+        assert!(decision.exhausted);
+    }
+
+    #[test]
+    fn advance_backpressure_reschedules_with_incremented_streak_below_the_limit() {
+        let backpressure = Backpressure {
+            retry_after: Some(Duration::from_secs(5)),
+        };
+
+        let step = advance_backpressure(&backpressure, BackpressureStreak(3));
+
+        match step {
+            BackpressureStep::Reschedule {
+                next_streak,
+                delay,
+                visible,
+            } => {
+                assert_eq!(next_streak, BackpressureStreak(4));
+                assert_eq!(delay, Duration::from_secs(5));
+                assert!(!visible);
+            }
+            BackpressureStep::DeadLetter => panic!("expected a reschedule step, got DeadLetter"),
+        }
+    }
+
+    #[test]
+    fn advance_backpressure_marks_every_tenth_streak_visible() {
+        let backpressure = Backpressure {
+            retry_after: Some(Duration::from_secs(1)),
+        };
+
+        let step = advance_backpressure(&backpressure, BackpressureStreak(9));
+
+        match step {
+            BackpressureStep::Reschedule {
+                next_streak,
+                visible,
+                ..
+            } => {
+                assert_eq!(next_streak, BackpressureStreak(10));
+                assert!(visible);
+            }
+            BackpressureStep::DeadLetter => panic!("expected a reschedule step, got DeadLetter"),
+        }
+    }
+
+    #[test]
+    fn advance_backpressure_dead_letters_at_the_limit() {
+        let backpressure = Backpressure {
+            retry_after: Some(Duration::from_secs(1)),
+        };
+
+        let step = advance_backpressure(
+            &backpressure,
+            BackpressureStreak(BACKPRESSURE_RESCHEDULE_LIMIT),
+        );
+
+        match step {
+            BackpressureStep::DeadLetter => {}
+            BackpressureStep::Reschedule { .. } => {
+                panic!("expected DeadLetter at the reschedule limit")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_backpressure_step_dead_letter_pushes_nothing() {
+        let apalis_pool = setup_test_apalis_pool().await;
+        let mut queue = JobQueue::<u32>::new(&apalis_pool);
+
+        let outcome = apply_backpressure_step(BackpressureStep::DeadLetter, &mut queue, |_| {
+            panic!("build_successor must not be called on the DeadLetter branch")
+        })
+        .await
+        .unwrap();
+
+        match outcome {
+            BackpressureOutcome::DeadLettered => {}
+            BackpressureOutcome::Rescheduled { .. } => {
+                panic!("expected DeadLettered, got Rescheduled")
+            }
+        }
+        assert!(
+            !queue.has_in_flight().await.unwrap(),
+            "DeadLetter must not push a successor"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_backpressure_step_reschedule_pushes_the_built_successor() {
+        let apalis_pool = setup_test_apalis_pool().await;
+        let mut queue = JobQueue::<u32>::new(&apalis_pool);
+
+        let step = BackpressureStep::Reschedule {
+            next_streak: BackpressureStreak(7),
+            delay: Duration::from_millis(1),
+            visible: true,
+        };
+
+        let outcome =
+            apply_backpressure_step(step, &mut queue, |BackpressureStreak(streak)| streak)
+                .await
+                .unwrap();
+
+        match outcome {
+            BackpressureOutcome::Rescheduled {
+                next_streak,
+                visible,
+            } => {
+                assert_eq!(next_streak, BackpressureStreak(7));
+                assert!(visible);
+            }
+            BackpressureOutcome::DeadLettered => panic!("expected Rescheduled, got DeadLettered"),
+        }
+
+        let pushed_payload = sqlx_apalis::query_scalar::<_, String>(
+            "SELECT CAST(job AS TEXT) FROM Jobs WHERE job_type = ?",
+        )
+        .bind(std::any::type_name::<u32>())
+        .fetch_one(&apalis_pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            pushed_payload, "7",
+            "the pushed successor must be built from the step's next_streak"
+        );
+    }
 
     #[tokio::test]
     async fn has_in_flight_detects_pending_and_ignores_terminal() {

--- a/src/conductor/monitor/executor_maintenance.rs
+++ b/src/conductor/monitor/executor_maintenance.rs
@@ -12,6 +12,15 @@
 //! aborted on shutdown but never restarted: if token refresh died, the
 //! executor silently stopped working. Wrapping the tick in a supervised
 //! task closes that gap.
+//!
+//! RAI-1494: a broker rate-limit (429) error from [`Executor::maintenance_tick`]
+//! needs no special handling here. This is a [`SupervisedTask`], not an apalis
+//! job or a synchronous call site -- every tick error, backpressure included,
+//! is already logged and swallowed unconditionally by the `loop` above, with
+//! no terminal retry budget to burn and no circuit breaker layer to
+//! interact with. A 429 today behaves exactly like the reschedule mechanism
+//! RAI-1494 adds elsewhere: wait, log, try again next tick. Pinned by
+//! `keeps_ticking_after_a_429_maintenance_tick_error` below.
 
 use std::time::Duration;
 use task_supervisor::{SupervisedTask, TaskResult};
@@ -60,8 +69,8 @@ mod tests {
     use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 
     use st0x_execution::{
-        CounterTradePreflight, ExecutionError, InventoryResult, LimitOrder, MarketOrder,
-        OrderPlacement, OrderState, SupportedExecutor, TryIntoExecutor,
+        AlpacaBrokerApiError, CounterTradePreflight, ExecutionError, InventoryResult, LimitOrder,
+        MarketOrder, OrderPlacement, OrderState, SupportedExecutor, TryIntoExecutor,
     };
 
     use super::*;
@@ -188,6 +197,137 @@ mod tests {
                 .await
                 .unwrap_or_else(|| panic!("maintenance failed to tick on iteration {tick}"));
         }
+
+        handle.abort();
+    }
+
+    /// Executor whose `Error` is `AlpacaBrokerApiError` so its
+    /// `maintenance_tick` can return a genuine broker rate-limit (429)
+    /// error, letting `keeps_ticking_after_a_429_maintenance_tick_error`
+    /// pin the RAI-1494 "no special handling needed here" claim against a
+    /// real classified error type rather than only a generic one.
+    #[derive(Clone)]
+    struct NotifyingAlpacaExecutor {
+        tx: UnboundedSender<()>,
+    }
+
+    #[derive(Debug, Clone, Default)]
+    struct NotifyingAlpacaExecutorCtx;
+
+    #[async_trait]
+    impl TryIntoExecutor for NotifyingAlpacaExecutorCtx {
+        type Executor = NotifyingAlpacaExecutor;
+        async fn try_into_executor(
+            self,
+        ) -> Result<Self::Executor, <Self::Executor as Executor>::Error> {
+            unreachable!("test executor is constructed directly")
+        }
+    }
+
+    #[async_trait]
+    impl Executor for NotifyingAlpacaExecutor {
+        type Error = AlpacaBrokerApiError;
+        type OrderId = String;
+        type Ctx = NotifyingAlpacaExecutorCtx;
+
+        async fn try_from_ctx(_ctx: Self::Ctx) -> Result<Self, Self::Error> {
+            unreachable!("test executor is constructed directly")
+        }
+
+        async fn is_market_open(&self) -> Result<bool, Self::Error> {
+            Ok(true)
+        }
+
+        async fn place_market_order(
+            &self,
+            _order: MarketOrder,
+        ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
+            unreachable!("not used in maintenance tests")
+        }
+
+        async fn place_limit_order(
+            &self,
+            _order: LimitOrder,
+        ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
+            unreachable!("not used in maintenance tests")
+        }
+
+        async fn cancel_order(
+            &self,
+            _order_id: &Self::OrderId,
+        ) -> Result<st0x_execution::CancellationOutcome, Self::Error> {
+            unreachable!("not used in maintenance tests")
+        }
+
+        async fn get_order_status(
+            &self,
+            _order_id: &Self::OrderId,
+        ) -> Result<OrderState, Self::Error> {
+            unreachable!("not used in maintenance tests")
+        }
+
+        fn to_supported_executor(&self) -> SupportedExecutor {
+            SupportedExecutor::AlpacaBrokerApi
+        }
+
+        fn parse_order_id(&self, order_id_str: &str) -> Result<Self::OrderId, Self::Error> {
+            Ok(order_id_str.to_string())
+        }
+
+        async fn maintenance_tick(&self) -> Result<(), Self::Error> {
+            self.tx.send(()).unwrap();
+
+            Err(AlpacaBrokerApiError::ApiError {
+                status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                alpaca_code: None,
+                message: "rate limited".to_string(),
+                retry_after: Some(Duration::from_millis(1)),
+            })
+        }
+
+        async fn get_inventory(&self) -> Result<InventoryResult, Self::Error> {
+            Ok(InventoryResult::Unimplemented)
+        }
+
+        async fn preflight_counter_trade(
+            &self,
+            _order: MarketOrder,
+        ) -> Result<CounterTradePreflight, Self::Error> {
+            Ok(CounterTradePreflight::Allowed { reservation: None })
+        }
+
+        async fn preflight_counter_trade_at_price(
+            &self,
+            _order: MarketOrder,
+            _reference_price: st0x_execution::Positive<st0x_execution::Usd>,
+        ) -> Result<CounterTradePreflight, Self::Error> {
+            Ok(CounterTradePreflight::Allowed { reservation: None })
+        }
+    }
+
+    /// Pins the doc comment's claim above: a 429-shaped `AlpacaBrokerApiError`
+    /// from `maintenance_tick` is already handled correctly by the existing
+    /// "log and continue to the next tick" behavior, with no RAI-1494
+    /// reschedule/dead-letter machinery needed on this `SupervisedTask`.
+    #[tokio::test(start_paused = true)]
+    async fn keeps_ticking_after_a_429_maintenance_tick_error() {
+        let (tx, mut rx) = unbounded_channel();
+        let mut maintenance =
+            ExecutorMaintenance::new(NotifyingAlpacaExecutor { tx }, Duration::from_secs(10));
+
+        let handle = tokio::spawn(async move { maintenance.run().await });
+
+        for tick in 0..3 {
+            rx.recv().await.unwrap_or_else(|| {
+                panic!("maintenance stopped ticking after a 429 error on tick {tick}")
+            });
+        }
+
+        assert!(
+            !handle.is_finished(),
+            "maintenance must keep running after a 429 tick error, exactly as it does for \
+             any other transient tick error"
+        );
 
         handle.abort();
     }

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -46,7 +46,7 @@ use super::{
 };
 use crate::bindings::TestERC20;
 use crate::bot_gas::BotGasReceiptCostEnqueuer;
-use crate::conductor::job::Job;
+use crate::conductor::job::{BackpressureStreak, Job};
 use crate::equity_redemption::{
     EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,
 };
@@ -2702,6 +2702,7 @@ async fn wrapped_recovery_reschedules_when_held_for_recovery_but_no_balance() {
     let job = WrappedEquityRecoveryJob {
         symbol: symbol.clone(),
         recovery_id: recovery_id.clone(),
+        backpressure_streak: BackpressureStreak::default(),
     };
 
     // The job claims HeldForRecovery, finds no wrapped balance, and reschedules
@@ -2835,6 +2836,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_landed_wrapped_equity_recovery()
     let job = WrappedEquityRecoveryJob {
         symbol: symbol.clone(),
         recovery_id: recovery_id.clone(),
+        backpressure_streak: BackpressureStreak::default(),
     };
 
     // The job must claim HeldForRecovery and run to completion.
@@ -2975,6 +2977,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_unwrapped_equity_recovery
     let job = UnwrappedEquityRecoveryJob {
         symbol: symbol.clone(),
         recovery_id: recovery_id.clone(),
+        backpressure_streak: BackpressureStreak::default(),
     };
 
     // The job must claim HeldForRecovery and run to completion.
@@ -3128,6 +3131,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_dispatches_active_mint() 
     let job = UnwrappedEquityRecoveryJob {
         symbol: symbol.clone(),
         recovery_id: recovery_id.clone(),
+        backpressure_streak: BackpressureStreak::default(),
     };
 
     // The job must claim HeldForRecovery and dispatch through the ActiveMint path.

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -51,7 +51,7 @@ use st0x_execution::{
 };
 use st0x_finance::{NonNegative, NotNonNegative, Usd};
 
-use crate::conductor::job::QueuePushError;
+use crate::conductor::job::{QueuePushError, find_backpressure};
 use crate::onchain::OnChainError;
 use crate::position::{Position, PositionCommand};
 
@@ -89,6 +89,23 @@ pub(crate) enum JobError {
     IntConversion(#[from] std::num::TryFromIntError),
     #[error("Poll interval overflowed while computing the stranded-row staleness bound")]
     StaleAfterOverflow,
+}
+
+/// Failures from the durable broker-placement boundary.
+///
+/// Aggregate persistence failures and classified broker backpressure must both
+/// retain their typed source chains. In particular, a 429 response leaves the
+/// order in [`OffchainOrder::Pending`] so the owning durable job can reschedule
+/// the idempotent placement with the same broker `client_order_id`.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PlaceOffchainOrderError {
+    #[error("Offchain order command failed: {0}")]
+    Command(#[from] SendError<OffchainOrder>),
+    #[error("Broker placement was rate-limited")]
+    Backpressure {
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -151,6 +168,13 @@ impl OffchainOrderPlacement {
 /// so callers can react (roll the position back on `Failed`, poll on
 /// `Submitted`).
 ///
+/// A classified broker 429 is the exception to the ordinary placement-error
+/// outcome: it is returned with its typed source intact and the aggregate stays
+/// `Pending`. The owning durable job can then reschedule and re-drive the same
+/// `client_order_id`; stringifying it into `MarkPlacementFailed` would
+/// terminalize a retryable throttle and make job-level classification
+/// impossible.
+///
 /// **Concurrency invariant:** a placement-failure outcome is recorded via
 /// `MarkPlacementFailed`, which the aggregate honours only while the order is
 /// still `Pending`. A stale attempt whose broker call errored after a concurrent
@@ -165,7 +189,7 @@ pub(crate) async fn place_offchain_order_at_broker(
     order_placer: &dyn OrderPlacer,
     offchain_order_id: &OffchainOrderId,
     placement: OffchainOrderPlacement,
-) -> Result<Option<OffchainOrder>, SendError<OffchainOrder>> {
+) -> Result<Option<OffchainOrder>, PlaceOffchainOrderError> {
     let OffchainOrderPlacement {
         symbol,
         shares,
@@ -276,6 +300,10 @@ pub(crate) async fn place_offchain_order_at_broker(
             )
             .increment(1);
 
+            if find_backpressure(error.as_ref()).is_some() {
+                return Err(PlaceOffchainOrderError::Backpressure { source: error });
+            }
+
             OffchainOrderCommand::MarkPlacementFailed {
                 error: error.to_string(),
             }
@@ -283,7 +311,7 @@ pub(crate) async fn place_offchain_order_at_broker(
     };
 
     store.send(offchain_order_id, outcome).await?;
-    store.load(offchain_order_id).await
+    Ok(store.load(offchain_order_id).await?)
 }
 
 /// Derives the broker-side [`ClientOrderId`] for a placement attempt.
@@ -3034,6 +3062,43 @@ mod tests {
         Arc::new(Failing)
     }
 
+    fn rate_limited_order_placer() -> Arc<dyn OrderPlacer> {
+        struct RateLimited;
+
+        #[async_trait]
+        impl OrderPlacer for RateLimited {
+            async fn place_market_order(
+                &self,
+                _order: MarketOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err(Box::new(AlpacaBrokerApiError::ApiError {
+                    status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                    alpaca_code: None,
+                    message: "rate limited".to_string(),
+                    retry_after: Some(std::time::Duration::from_millis(1)),
+                }))
+            }
+
+            async fn place_limit_order(
+                &self,
+                _order: LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                unimplemented!("test uses a market order")
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &ExecutorOrderId,
+            ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(CancellationOutcome::Requested)
+            }
+        }
+
+        Arc::new(RateLimited)
+    }
+
     fn limit_failing_order_placer() -> Arc<dyn OrderPlacer> {
         struct LimitFailing;
 
@@ -3904,6 +3969,38 @@ mod tests {
             ),
             "expected Failed with the broker error, got {order:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn place_at_broker_preserves_a_rate_limited_order_as_pending() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let (store, _) = StoreBuilder::<OffchainOrder>::new(pool)
+            .build(noop_order_placer())
+            .await
+            .unwrap();
+        let id = OffchainOrderId::new();
+        let placer = rate_limited_order_placer();
+
+        let error = place_offchain_order_at_broker(
+            &store,
+            placer.as_ref(),
+            &id,
+            OffchainOrderPlacement::market(
+                Symbol::new("AAPL").unwrap(),
+                Positive::new(FractionalShares::new(float!(100))).unwrap(),
+                Direction::Buy,
+                SupportedExecutor::DryRun,
+                ClientOrderId::from_uuid(id.as_uuid()),
+            ),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(find_backpressure(&error).is_some());
+        assert!(matches!(
+            store.load(&id).await.unwrap(),
+            Some(OffchainOrder::Pending { .. })
+        ));
     }
 
     #[tokio::test]

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -20,7 +20,10 @@ use st0x_execution::{
 };
 use st0x_finance::{NonNegative, Usd};
 
-use crate::conductor::job::{Job, JobQueue, Label};
+use crate::conductor::job::{
+    BACKPRESSURE_RESCHEDULE_LIMIT, BackpressureOutcome, BackpressureStreak, Job, JobQueue, Label,
+    advance_backpressure, apply_backpressure_step, find_backpressure,
+};
 use crate::offchain::order::handle_rejection::{
     HandleOrderRejection, HandleOrderRejectionJobQueue,
 };
@@ -81,6 +84,16 @@ pub(crate) struct PollOrderStatusCtx<E: Executor + Clone + Send + Sync + 'static
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PollOrderStatus {
     pub(crate) offchain_order_id: OffchainOrderId,
+    /// Count of consecutive broker rate-limit (429) reschedules leading up
+    /// to this attempt (RAI-1494). `#[serde(default)]` so a row enqueued
+    /// under the pre-this-change payload shape (no field at all) still
+    /// deserializes -- to `0`, the correct "no streak yet" value -- instead
+    /// of crashing the poll stream's `sqlx::Decode` (see
+    /// `poll_order_status_payload_without_backpressure_streak_deserializes_to_zero`).
+    /// Reset to `0` on every non-backpressure reschedule (`reschedule_self`);
+    /// incremented by one on each backpressure reschedule's pushed successor.
+    #[serde(default)]
+    pub(crate) backpressure_streak: BackpressureStreak,
 }
 
 impl<E> Job<PollOrderStatusCtx<E>> for PollOrderStatus
@@ -157,10 +170,87 @@ impl PollOrderStatus {
         JobError: From<E::Error>,
     {
         let parsed_order_id = ctx.executor.parse_order_id(executor_order_id.as_ref())?;
-        let order_state = ctx.executor.get_order_status(&parsed_order_id).await?;
+
+        let order_state = match ctx.executor.get_order_status(&parsed_order_id).await {
+            Ok(order_state) => order_state,
+            Err(error) => return self.handle_get_order_status_error(ctx, error).await,
+        };
 
         self.dispatch_for_broker_state(ctx, order, &executor_order_id, order_state)
             .await
+    }
+
+    /// Handles a `get_order_status` failure: reschedules with a classified
+    /// delay on broker rate-limiting (429) instead of consuming the terminal
+    /// retry budget, or propagates any other error through the normal,
+    /// unmodified retry/circuit-breaker path.
+    ///
+    /// `get_order_status` is a pure read with no committed guard ahead of
+    /// it, so every rescheduled successor genuinely re-hits the broker --
+    /// this is the one "true retry" job RAI-1494's parent incident
+    /// (RAI-1492) actually exercised (see the RAI-1494 plan's per-job
+    /// classification table; contrast `AccountForDexTrade`/`PlaceHedge`,
+    /// whose committed guards make their own reschedules short-circuit
+    /// instead of re-driving the broker call).
+    async fn handle_get_order_status_error<E>(
+        &self,
+        ctx: &PollOrderStatusCtx<E>,
+        error: E::Error,
+    ) -> Result<(), JobError>
+    where
+        E: Executor + Clone + Send + Sync + 'static,
+        JobError: From<E::Error>,
+    {
+        let Some(backpressure) = find_backpressure(&error) else {
+            return Err(error.into());
+        };
+
+        let step = advance_backpressure(&backpressure, self.backpressure_streak);
+        let mut queue = ctx.poll_status_queue.clone();
+        let outcome = apply_backpressure_step(step, &mut queue, |next_streak| Self {
+            offchain_order_id: self.offchain_order_id,
+            backpressure_streak: next_streak,
+        })
+        .await?;
+
+        match outcome {
+            BackpressureOutcome::DeadLettered => {
+                // Per the RAI-1494 plan's binding M2 decision: PollOrderStatus is
+                // a supervised worker, so propagating this as a bare `Err` would
+                // exhaust `RetryPolicy::retries(3)` and open the circuit breaker
+                // for a cause that is not a genuine bug -- reproducing RAI-1492's
+                // "hedging silently stops" outcome, just delayed by
+                // BACKPRESSURE_RESCHEDULE_LIMIT reschedules instead of happening
+                // immediately. Dead-letter instead: log loudly and ack `Done`.
+                let BackpressureStreak(streak) = self.backpressure_streak;
+                error!(
+                    target: "broker",
+                    offchain_order_id = %self.offchain_order_id,
+                    streak,
+                    limit = BACKPRESSURE_RESCHEDULE_LIMIT,
+                    "PollOrderStatus: broker rate-limiting exceeded the reschedule \
+                     budget; dead-lettering this poll instead of opening the \
+                     circuit breaker -- treat as a structurally-dead Alpaca \
+                     integration (suspended account, revoked key) needing manual \
+                     reconciliation"
+                );
+            }
+            BackpressureOutcome::Rescheduled {
+                next_streak: BackpressureStreak(streak),
+                visible,
+            } => {
+                if visible {
+                    error!(
+                        target: "broker",
+                        offchain_order_id = %self.offchain_order_id,
+                        streak,
+                        "PollOrderStatus: still rescheduling after sustained broker rate-limiting"
+                    );
+                }
+            }
+        }
+
+        Ok(())
     }
 
     async fn dispatch_for_broker_state<E>(
@@ -971,7 +1061,13 @@ where
 {
     let mut queue = ctx.poll_status_queue.clone();
     queue
-        .push_with_delay(PollOrderStatus { offchain_order_id }, ctx.poll_interval)
+        .push_with_delay(
+            PollOrderStatus {
+                offchain_order_id,
+                backpressure_streak: BackpressureStreak::default(),
+            },
+            ctx.poll_interval,
+        )
         .await?;
 
     Ok(())
@@ -1075,6 +1171,19 @@ const STRANDED_POLL_JOB_INTERVAL_MULTIPLIER: u32 = 5;
 /// `killed` counter (`status = 'Killed' AND attempts < max_attempts`) exists
 /// to surface the latter.
 ///
+/// The collapse also zeroes the loser's `backpressure_streak` (via
+/// `json_set`): [`has_exhausted_backpressure_marker`] reads any `Done` row
+/// with `backpressure_streak >= BACKPRESSURE_RESCHEDULE_LIMIT` as a
+/// deliberate dead-letter marker, and a collapsed `Pending` successor
+/// legitimately carrying the limit (pushed by a run one short of it) would
+/// otherwise become a permanent false marker -- no dead-letter ever happened,
+/// yet every future re-arm for the order would be silently blocked. Zeroing
+/// on collapse makes `Done` + streak-at-limit mean exactly one thing: a run
+/// that exhausted its budget and acked itself `Done` (apalis's `ack.sql`
+/// never rewrites the payload, so a genuine marker keeps its streak). Pinned
+/// by `collapsed_duplicate_carrying_the_streak_limit_does_not_become_a_dead_`
+/// `letter_marker`.
+///
 /// `json_extract` requires `CAST(job AS TEXT)` -- `Jobs.job` is a `BLOB`
 /// (apalis's `JsonCodec`), and a bare BLOB argument is not guaranteed to be
 /// read as JSON text on every SQLite build. `json_extract` also raises a hard
@@ -1093,7 +1202,8 @@ async fn reconcile_live_poll_jobs(
     let stale_after_secs = i64::try_from(stale_after.as_secs())?;
 
     let collapsed = sqlx_apalis::query(
-        "UPDATE Jobs SET status = 'Done', done_at = strftime('%s', 'now') \
+        "UPDATE Jobs SET status = 'Done', done_at = strftime('%s', 'now'), \
+             job = CAST(json_set(CAST(job AS TEXT), '$.backpressure_streak', 0) AS BLOB) \
          WHERE job_type = ? \
            AND json_valid(CAST(job AS TEXT)) \
            AND json_extract(CAST(job AS TEXT), '$.offchain_order_id') = ? \
@@ -1185,24 +1295,54 @@ async fn reconcile_and_check_live_poll_job(
 }
 
 /// Outcome of [`push_poll_job_if_absent`]: whether a new [`PollOrderStatus`]
-/// job was pushed, or one was already live and the push was skipped.
+/// job was pushed, one was already live, or a retained exhausted-budget marker
+/// made another push unsafe.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum PollJobPushOutcome {
     AlreadyLive,
+    BackpressureExhausted,
     Pushed,
+}
+
+/// Returns whether this order has a retained, completed
+/// [`PollOrderStatus`] row whose durable backpressure budget is exhausted.
+///
+/// The finished-job cleanup deliberately retains these rows as dead-letter
+/// markers. Without consulting the marker here, the periodic submitted-order
+/// recovery would immediately replace the exhausted job with a fresh
+/// `backpressure_streak = 0` payload, making the finite budget unbounded.
+async fn has_exhausted_backpressure_marker(
+    apalis_pool: &apalis_sqlite::SqlitePool,
+    offchain_order_id: OffchainOrderId,
+) -> Result<bool, JobError> {
+    let exhausted: bool = sqlx_apalis::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM Jobs \
+         WHERE job_type = ? \
+           AND status = 'Done' \
+           AND json_valid(CAST(job AS TEXT)) \
+           AND json_extract(CAST(job AS TEXT), '$.offchain_order_id') = ? \
+           AND json_extract(CAST(job AS TEXT), '$.backpressure_streak') >= ?)",
+    )
+    .bind(std::any::type_name::<PollOrderStatus>())
+    .bind(offchain_order_id.to_string())
+    .bind(i64::from(BACKPRESSURE_RESCHEDULE_LIMIT))
+    .fetch_one(apalis_pool)
+    .await?;
+
+    Ok(exhausted)
 }
 
 /// Pushes a [`PollOrderStatus`] job for `offchain_order_id` unless one is
 /// already live ([`reconcile_and_check_live_poll_job`], which may also
 /// collapse pre-existing duplicate `Pending` rows for this order to `Done`
-/// as a side effect first). Consolidates the check-then-push shape every
-/// `PollOrderStatus` push site shares so a future change to the push step (a
-/// metric, different logging, another guard condition) only needs to land
-/// once instead of being replicated by hand at every call site -- exactly
-/// the class of gap that originally left the fifth push site
-/// (`route_placement_outcome`) unguarded. The process-local lock covers both
-/// the check and push; without it, concurrent callers can all observe no live
-/// row before any caller's push commits and fork one chain each.
+/// as a side effect first) or a retained exhausted-budget marker proves that
+/// polling this order was deliberately dead-lettered. Consolidates every
+/// guard around the push so a future change only needs to land once instead
+/// of being replicated by hand at every call site -- exactly the class of gap
+/// that originally left the fifth push site (`route_placement_outcome`)
+/// unguarded. The process-local lock covers every guard and the push; without
+/// it, concurrent callers can all observe no live row before any caller's push
+/// commits and fork one chain each.
 pub(crate) async fn push_poll_job_if_absent(
     mut queue: PollOrderStatusJobQueue,
     offchain_order_id: OffchainOrderId,
@@ -1210,11 +1350,20 @@ pub(crate) async fn push_poll_job_if_absent(
 ) -> Result<PollJobPushOutcome, JobError> {
     let _push_guard = POLL_JOB_PUSH_LOCK.lock().await;
 
+    if has_exhausted_backpressure_marker(queue.pool(), offchain_order_id).await? {
+        return Ok(PollJobPushOutcome::BackpressureExhausted);
+    }
+
     if reconcile_and_check_live_poll_job(queue.pool(), offchain_order_id, poll_interval).await? {
         return Ok(PollJobPushOutcome::AlreadyLive);
     }
 
-    queue.push(PollOrderStatus { offchain_order_id }).await?;
+    queue
+        .push(PollOrderStatus {
+            offchain_order_id,
+            backpressure_streak: BackpressureStreak::default(),
+        })
+        .await?;
 
     Ok(PollJobPushOutcome::Pushed)
 }
@@ -1318,6 +1467,7 @@ async fn recover_submitted_offchain_orders_with_policy(
     let candidate_count = pending_poll.len();
     let mut pushed = 0usize;
     let mut skipped = 0usize;
+    let mut dead_lettered = 0usize;
     let mut failed = 0usize;
 
     for offchain_order_id in pending_poll {
@@ -1347,6 +1497,9 @@ async fn recover_submitted_offchain_orders_with_policy(
             PollJobPushOutcome::AlreadyLive => {
                 skipped += 1;
             }
+            PollJobPushOutcome::BackpressureExhausted => {
+                dead_lettered += 1;
+            }
             PollJobPushOutcome::Pushed => {
                 pushed += 1;
 
@@ -1363,6 +1516,7 @@ async fn recover_submitted_offchain_orders_with_policy(
         candidate_count,
         pushed,
         skipped,
+        dead_lettered,
         failed,
         "Periodic submitted-order poll recovery swept offchain orders awaiting broker fill"
     );
@@ -1375,19 +1529,28 @@ mod tests {
     use std::sync::OnceLock;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use apalis::prelude::Monitor;
+    use apalis_core::worker::ext::circuit_breaker::config::CircuitBreakerConfig;
     use chrono::Utc;
     use futures_util::future::join_all;
+    use httpmock::prelude::*;
     use sqlx_apalis::ConnectOptions;
     use tokio::sync::Barrier;
+    use uuid::uuid;
 
     use st0x_config::ExecutionThreshold;
     use st0x_event_sorcery::StoreBuilder;
     use st0x_execution::{
-        ClientOrderId, Direction, ExecutionError, FractionalShares, MockExecutor, Positive, Symbol,
+        AlpacaAccountId, AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, ClientOrderId,
+        DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS, Direction, ExecutionError, FractionalShares,
+        MockExecutor, Positive, Symbol, TimeInForce,
     };
     use st0x_float_macro::float;
 
     use super::*;
+    use crate::conductor::job::{
+        FAIL_STOP_RECOVERY_TIMEOUT, FailureInjector, build_supervised_worker, build_worker_inner,
+    };
     use crate::offchain::order::{
         NoFillOutcome, OffchainOrderCommand, TerminalPositionFinalization, noop_order_placer,
         terminal_position_finalization,
@@ -1439,6 +1602,47 @@ mod tests {
         }
     }
 
+    const TEST_ALPACA_ACCOUNT_ID: AlpacaAccountId =
+        AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
+
+    fn mock_alpaca_account(server: &MockServer) -> httpmock::Mock<'_> {
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({
+                    "id": "904837e3-3b76-47ec-b432-046db621571b",
+                    "status": "ACTIVE"
+                }));
+        })
+    }
+
+    /// Builds real `PollOrderStatusCtx<AlpacaBrokerApi>` test infra backed by
+    /// `httpmock` rather than `MockExecutor`, so a 429's `Retry-After` header
+    /// and status code flow through the real `AlpacaBrokerApiClient` --
+    /// `MockExecutor`'s `Error` type (`ExecutionError`) cannot carry a
+    /// classified `AlpacaBrokerApiError`.
+    async fn build_test_infra_alpaca(server: &MockServer) -> TestInfra<AlpacaBrokerApi> {
+        let _account_mock = mock_alpaca_account(server);
+
+        let auth = AlpacaBrokerApiCtx {
+            api_key: "test_key".to_string(),
+            api_secret: "test_secret".to_string(),
+            account_id: TEST_ALPACA_ACCOUNT_ID,
+            mode: Some(AlpacaBrokerApiMode::Mock(server.base_url())),
+            asset_cache_ttl: Duration::from_secs(3600),
+            time_in_force: TimeInForce::default(),
+            counter_trade_slippage_bps: DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,
+        };
+
+        let executor = AlpacaBrokerApi::try_from_ctx(auth)
+            .await
+            .expect("failed to build test AlpacaBrokerApi executor");
+
+        build_test_infra(executor).await
+    }
+
     async fn submit_offchain_order<E: Executor + Clone + Send + Sync + 'static>(
         infra: &TestInfra<E>,
         symbol: &Symbol,
@@ -1464,6 +1668,35 @@ mod tests {
         shares: Positive<FractionalShares>,
         direction: Direction,
         order_executor: SupportedExecutor,
+    ) -> OffchainOrderId {
+        submit_offchain_order_with_executor_and_accepted_id(
+            infra,
+            symbol,
+            tokenized_symbol,
+            shares,
+            direction,
+            order_executor,
+            ExecutorOrderId::new("test-accept"),
+        )
+        .await
+    }
+
+    /// Like [`submit_offchain_order_with_executor`], but lets the caller pick
+    /// the broker order id `MarkAccepted` records. Needed for a real
+    /// [`st0x_execution::AlpacaBrokerApi`] executor, whose `parse_order_id`
+    /// requires a valid UUID string (unlike `MockExecutor`, which accepts any
+    /// string) -- the plain `"test-accept"` placeholder every other test uses
+    /// would fail to parse before `get_order_status` is ever called.
+    async fn submit_offchain_order_with_executor_and_accepted_id<
+        E: Executor + Clone + Send + Sync + 'static,
+    >(
+        infra: &TestInfra<E>,
+        symbol: &Symbol,
+        tokenized_symbol: &str,
+        shares: Positive<FractionalShares>,
+        direction: Direction,
+        order_executor: SupportedExecutor,
+        accepted_executor_order_id: ExecutorOrderId,
     ) -> OffchainOrderId {
         let onchain = OnchainTradeBuilder::new()
             .with_symbol(tokenized_symbol)
@@ -1529,7 +1762,7 @@ mod tests {
             .send(
                 &offchain_order_id,
                 OffchainOrderCommand::MarkAccepted {
-                    executor_order_id: ExecutorOrderId::new("test-accept"),
+                    executor_order_id: accepted_executor_order_id,
                     placed_shares: shares,
                     submitted_at: Utc::now(),
                     market_session: st0x_execution::MarketSession::Regular,
@@ -1607,6 +1840,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -1647,6 +1881,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -1746,6 +1981,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -1793,6 +2029,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -1834,6 +2071,7 @@ mod tests {
 
         let error = PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -1892,6 +2130,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -1942,6 +2181,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2010,6 +2250,7 @@ mod tests {
         );
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2053,6 +2294,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2094,6 +2336,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2153,6 +2396,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2193,6 +2437,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2222,6 +2467,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2289,6 +2535,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2351,6 +2598,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2407,6 +2655,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2538,6 +2787,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2574,6 +2824,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2638,6 +2889,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2686,6 +2938,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2732,6 +2985,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -2875,6 +3129,7 @@ mod tests {
 
         let first_result = PollOrderStatus {
             offchain_order_id: failing_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await;
@@ -2888,6 +3143,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: succeeding_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -3250,6 +3506,7 @@ mod tests {
 
         PollOrderStatus {
             offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
         }
         .perform(&infra.ctx)
         .await
@@ -3278,7 +3535,10 @@ mod tests {
         let offchain_order_id = OffchainOrderId::new();
         let mut queue = infra.ctx.poll_status_queue.clone();
         queue
-            .push(PollOrderStatus { offchain_order_id })
+            .push(PollOrderStatus {
+                offchain_order_id,
+                backpressure_streak: BackpressureStreak::default(),
+            })
             .await
             .unwrap();
 
@@ -3313,7 +3573,10 @@ mod tests {
         let offchain_order_id = OffchainOrderId::new();
         let mut queue = infra.ctx.poll_status_queue.clone();
         queue
-            .push(PollOrderStatus { offchain_order_id })
+            .push(PollOrderStatus {
+                offchain_order_id,
+                backpressure_streak: BackpressureStreak::default(),
+            })
             .await
             .unwrap();
 
@@ -3371,8 +3634,11 @@ mod tests {
         lock_at: Option<i64>,
     ) -> String {
         let id = uuid::Uuid::new_v4().to_string();
-        let payload = serde_json::to_vec(&PollOrderStatus { offchain_order_id })
-            .expect("serialize PollOrderStatus payload");
+        let payload = serde_json::to_vec(&PollOrderStatus {
+            offchain_order_id,
+            backpressure_streak: BackpressureStreak::default(),
+        })
+        .expect("serialize PollOrderStatus payload");
         sqlx_apalis::query(
             "INSERT INTO Jobs (id, job_type, job, status, attempts, max_attempts, run_at, lock_at) \
              VALUES (?, ?, ?, ?, ?, 25, strftime('%s', 'now'), ?)",
@@ -3398,8 +3664,11 @@ mod tests {
         run_at: i64,
     ) -> String {
         let id = uuid::Uuid::new_v4().to_string();
-        let payload = serde_json::to_vec(&PollOrderStatus { offchain_order_id })
-            .expect("serialize PollOrderStatus payload");
+        let payload = serde_json::to_vec(&PollOrderStatus {
+            offchain_order_id,
+            backpressure_streak: BackpressureStreak::default(),
+        })
+        .expect("serialize PollOrderStatus payload");
         sqlx_apalis::query(
             "INSERT INTO Jobs (id, job_type, job, status, attempts, max_attempts, run_at) \
              VALUES (?, ?, ?, 'Pending', 0, 25, ?)",
@@ -3429,8 +3698,11 @@ mod tests {
         done_at: i64,
     ) -> String {
         let id = uuid::Uuid::new_v4().to_string();
-        let payload = serde_json::to_vec(&PollOrderStatus { offchain_order_id })
-            .expect("serialize PollOrderStatus payload");
+        let payload = serde_json::to_vec(&PollOrderStatus {
+            offchain_order_id,
+            backpressure_streak: BackpressureStreak::default(),
+        })
+        .expect("serialize PollOrderStatus payload");
         sqlx_apalis::query(
             "INSERT INTO Jobs (id, job_type, job, status, attempts, max_attempts, run_at, done_at) \
              VALUES (?, ?, ?, 'Failed', 1, 25, strftime('%s', 'now'), ?)",
@@ -3457,8 +3729,11 @@ mod tests {
         priority: i64,
     ) -> String {
         let id = uuid::Uuid::new_v4().to_string();
-        let payload = serde_json::to_vec(&PollOrderStatus { offchain_order_id })
-            .expect("serialize PollOrderStatus payload");
+        let payload = serde_json::to_vec(&PollOrderStatus {
+            offchain_order_id,
+            backpressure_streak: BackpressureStreak::default(),
+        })
+        .expect("serialize PollOrderStatus payload");
         sqlx_apalis::query(
             "INSERT INTO Jobs (id, job_type, job, status, attempts, max_attempts, run_at, priority) \
              VALUES (?, ?, ?, 'Pending', 0, 25, ?, ?)",
@@ -3627,7 +3902,10 @@ mod tests {
         // point (apalis's re-dispatch contract), not because of it.
         let mut queue = infra.ctx.poll_status_queue.clone();
         queue
-            .push(PollOrderStatus { offchain_order_id })
+            .push(PollOrderStatus {
+                offchain_order_id,
+                backpressure_streak: BackpressureStreak::default(),
+            })
             .await
             .unwrap();
         sqlx_apalis::query("UPDATE Jobs SET status = 'Failed', attempts = 1 WHERE job_type = ?")
@@ -3674,7 +3952,10 @@ mod tests {
         let offchain_order_id = OffchainOrderId::new();
         let mut queue = infra.ctx.poll_status_queue.clone();
         queue
-            .push(PollOrderStatus { offchain_order_id })
+            .push(PollOrderStatus {
+                offchain_order_id,
+                backpressure_streak: BackpressureStreak::default(),
+            })
             .await
             .unwrap();
 
@@ -3856,7 +4137,11 @@ mod tests {
         // `reschedule_self`'s legitimate successor: not yet due, pushed one
         // poll interval in the future -- committed under the lock the
         // blocked collapse above is waiting to acquire.
-        let successor_payload = serde_json::to_vec(&PollOrderStatus { offchain_order_id }).unwrap();
+        let successor_payload = serde_json::to_vec(&PollOrderStatus {
+            offchain_order_id,
+            backpressure_streak: BackpressureStreak::default(),
+        })
+        .unwrap();
         sqlx_apalis::query(
             "INSERT INTO Jobs (id, job_type, job, status, attempts, max_attempts, run_at) \
              VALUES (?, ?, ?, 'Pending', 0, 25, ?)",
@@ -4145,6 +4430,118 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn push_poll_job_if_absent_preserves_an_exhausted_backpressure_dead_letter() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let mut queue = infra.ctx.poll_status_queue.clone();
+        queue
+            .push(PollOrderStatus {
+                offchain_order_id,
+                backpressure_streak: BackpressureStreak(BACKPRESSURE_RESCHEDULE_LIMIT),
+            })
+            .await
+            .unwrap();
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE job_type = ?")
+            .bind(poll_order_status_job_type())
+            .execute(&infra.apalis_pool)
+            .await
+            .unwrap();
+
+        let outcome = push_poll_job_if_absent(queue, offchain_order_id, TEST_POLL_INTERVAL)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, PollJobPushOutcome::BackpressureExhausted);
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            1,
+            "recovery must retain the dead-letter marker without pushing a zero-streak successor"
+        );
+    }
+
+    /// A duplicate `Pending` successor legitimately carrying
+    /// `BACKPRESSURE_RESCHEDULE_LIMIT` (pushed by a run one short of the
+    /// limit) that loses the dedup collapse must not read back as a
+    /// dead-letter marker: the collapse zeroes the loser's
+    /// `backpressure_streak`, so a later re-arm for the order still pushes
+    /// instead of being silently blocked forever by a dead-letter that never
+    /// happened.
+    #[tokio::test]
+    async fn collapsed_duplicate_carrying_the_streak_limit_does_not_become_a_dead_letter_marker() {
+        let infra = build_test_infra(MockExecutor::new()).await;
+        let offchain_order_id = OffchainOrderId::new();
+        let now = Utc::now().timestamp();
+
+        let survivor_id =
+            seed_pending_poll_job_row_at(&infra.apalis_pool, offchain_order_id, now - 10).await;
+
+        let loser_id = uuid::Uuid::new_v4().to_string();
+        let loser_payload = serde_json::to_vec(&PollOrderStatus {
+            offchain_order_id,
+            backpressure_streak: BackpressureStreak(BACKPRESSURE_RESCHEDULE_LIMIT),
+        })
+        .unwrap();
+        sqlx_apalis::query(
+            "INSERT INTO Jobs (id, job_type, job, status, attempts, max_attempts, run_at) \
+             VALUES (?, ?, ?, 'Pending', 0, 25, ?)",
+        )
+        .bind(&loser_id)
+        .bind(poll_order_status_job_type())
+        .bind(loser_payload)
+        .bind(now + 60)
+        .execute(&infra.apalis_pool)
+        .await
+        .unwrap();
+
+        let outcome = push_poll_job_if_absent(
+            infra.ctx.poll_status_queue.clone(),
+            offchain_order_id,
+            TEST_POLL_INTERVAL,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outcome,
+            PollJobPushOutcome::AlreadyLive,
+            "the due survivor must keep the chain live while the duplicate collapses"
+        );
+
+        let loser_streak: i64 = sqlx_apalis::query_scalar(
+            "SELECT json_extract(CAST(job AS TEXT), '$.backpressure_streak') \
+             FROM Jobs WHERE id = ?",
+        )
+        .bind(&loser_id)
+        .fetch_one(&infra.apalis_pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            loser_streak, 0,
+            "the collapse must zero the loser's streak so it cannot read as a dead-letter"
+        );
+
+        // Simulate the surviving chain finishing normally, then re-arm: the
+        // collapsed duplicate must not block the push as a false marker.
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+            .bind(&survivor_id)
+            .execute(&infra.apalis_pool)
+            .await
+            .unwrap();
+
+        let outcome = push_poll_job_if_absent(
+            infra.ctx.poll_status_queue.clone(),
+            offchain_order_id,
+            TEST_POLL_INTERVAL,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outcome,
+            PollJobPushOutcome::Pushed,
+            "a collapsed duplicate must not mint a permanent BackpressureExhausted marker"
+        );
+    }
+
+    #[tokio::test]
     async fn recover_submitted_offchain_orders_is_a_noop_when_a_live_poll_job_already_exists() {
         let infra = build_test_infra(MockExecutor::new()).await;
         let symbol = Symbol::new("AAPL").unwrap();
@@ -4188,6 +4585,7 @@ mod tests {
         queue
             .push(PollOrderStatus {
                 offchain_order_id: order_id,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -4387,5 +4785,537 @@ mod tests {
             "an oversized order_polling_interval must fail fast with a typed overflow error \
              rather than panicking inside Duration's checked_mul"
         );
+    }
+
+    // RAI-1494: a 429 from `get_order_status` reschedules instead of
+    // consuming the terminal retry budget. `MockExecutor`'s `Error`
+    // (`ExecutionError`) cannot carry a classified `AlpacaBrokerApiError`, so
+    // these tests drive a real `AlpacaBrokerApi` executor against
+    // `httpmock`.
+
+    fn current_unix_time_secs() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .try_into()
+            .unwrap()
+    }
+
+    async fn successor_backpressure_streak(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {
+        let streaks: Vec<i64> = sqlx_apalis::query_scalar(
+            "SELECT json_extract(CAST(job AS TEXT), '$.backpressure_streak') FROM Jobs \
+             WHERE job_type = ?",
+        )
+        .bind(poll_order_status_job_type())
+        .fetch_all(apalis_pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            streaks.len(),
+            1,
+            "a 429 must enqueue exactly one PollOrderStatus successor"
+        );
+        streaks.into_iter().next().unwrap()
+    }
+
+    #[tokio::test]
+    async fn poll_with_429_broker_response_reschedules_with_the_classified_delay_and_does_not_fail()
+    {
+        let server = MockServer::start();
+        let infra = build_test_infra_alpaca(&server).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let accepted_order_id = uuid!("11111111-1111-1111-1111-111111111111");
+        let order_id = submit_offchain_order_with_executor_and_accepted_id(
+            &infra,
+            &symbol,
+            "wtAAPL",
+            shares,
+            Direction::Sell,
+            SupportedExecutor::AlpacaBrokerApi,
+            ExecutorOrderId::new(&accepted_order_id),
+        )
+        .await;
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{accepted_order_id}"
+            ));
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("retry-after", "5")
+                .json_body(serde_json::json!({ "message": "rate limited" }));
+        });
+
+        let before_now = current_unix_time_secs();
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        mock.assert();
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            1,
+            "a 429 must reschedule exactly one successor poll job rather than fail the job"
+        );
+        assert_eq!(
+            successor_backpressure_streak(&infra.apalis_pool).await,
+            1,
+            "the pushed successor must carry an incremented backpressure streak"
+        );
+
+        let scheduled_at = min_run_at(&infra.apalis_pool, poll_order_status_job_type()).await;
+        assert!(
+            scheduled_at >= before_now + 5,
+            "the reschedule must honour the broker's Retry-After (5s); got {scheduled_at}s, \
+             before_now={before_now}s"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_with_429_and_no_retry_after_uses_the_escalating_fallback() {
+        let server = MockServer::start();
+        let infra = build_test_infra_alpaca(&server).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let accepted_order_id = uuid!("11111111-1111-1111-1111-111111111112");
+        let order_id = submit_offchain_order_with_executor_and_accepted_id(
+            &infra,
+            &symbol,
+            "wtAAPL",
+            shares,
+            Direction::Sell,
+            SupportedExecutor::AlpacaBrokerApi,
+            ExecutorOrderId::new(&accepted_order_id),
+        )
+        .await;
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{accepted_order_id}"
+            ));
+            then.status(429)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({ "message": "rate limited" }));
+        });
+
+        let before_now = current_unix_time_secs();
+
+        // Start at streak 3 so the escalating fallback (base 1s, doubling)
+        // produces a delay (8s) clearly distinct from the flooring/ceiling
+        // boundary values the other tests pin.
+        PollOrderStatus {
+            offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak(3),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        mock.assert();
+        assert_eq!(
+            successor_backpressure_streak(&infra.apalis_pool).await,
+            4,
+            "the pushed successor must carry streak 3 + 1"
+        );
+
+        let scheduled_at = min_run_at(&infra.apalis_pool, poll_order_status_job_type()).await;
+        assert!(
+            scheduled_at >= before_now + 8,
+            "with no Retry-After header, streak 3 must escalate to an 8s fallback delay \
+             (1s * 2^3); got {scheduled_at}s, before_now={before_now}s"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_with_429_retry_after_zero_still_floors_the_delay() {
+        let server = MockServer::start();
+        let infra = build_test_infra_alpaca(&server).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let accepted_order_id = uuid!("11111111-1111-1111-1111-111111111113");
+        let order_id = submit_offchain_order_with_executor_and_accepted_id(
+            &infra,
+            &symbol,
+            "wtAAPL",
+            shares,
+            Direction::Sell,
+            SupportedExecutor::AlpacaBrokerApi,
+            ExecutorOrderId::new(&accepted_order_id),
+        )
+        .await;
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{accepted_order_id}"
+            ));
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("retry-after", "0")
+                .json_body(serde_json::json!({ "message": "rate limited" }));
+        });
+
+        let before_now = current_unix_time_secs();
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        mock.assert();
+
+        let scheduled_at = min_run_at(&infra.apalis_pool, poll_order_status_job_type()).await;
+        assert!(
+            scheduled_at > before_now,
+            "a Retry-After: 0 must be floored to MIN_BACKPRESSURE_DELAY (1s), not honoured \
+             literally as an immediate re-dispatch; got {scheduled_at}s, before_now={before_now}s"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_with_429_reschedule_does_not_fork_a_duplicate_poll_chain() {
+        let server = MockServer::start();
+        let infra = build_test_infra_alpaca(&server).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let accepted_order_id = uuid!("11111111-1111-1111-1111-111111111114");
+        let order_id = submit_offchain_order_with_executor_and_accepted_id(
+            &infra,
+            &symbol,
+            "wtAAPL",
+            shares,
+            Direction::Sell,
+            SupportedExecutor::AlpacaBrokerApi,
+            ExecutorOrderId::new(&accepted_order_id),
+        )
+        .await;
+
+        server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{accepted_order_id}"
+            ));
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("retry-after", "30")
+                .json_body(serde_json::json!({ "message": "rate limited" }));
+        });
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        // Simulates an external push site (e.g. the periodic recovery sweep)
+        // landing at the same moment as the backpressure reschedule's own
+        // pushed successor.
+        let outcome = push_poll_job_if_absent(
+            infra.ctx.poll_status_queue.clone(),
+            order_id,
+            infra.ctx.poll_interval,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            matches!(outcome, PollJobPushOutcome::AlreadyLive),
+            "an external push racing the backpressure reschedule's own future-run_at successor \
+             must see it as already live, not push a second chain"
+        );
+        assert_eq!(
+            live_poll_job_ids(&infra.apalis_pool, order_id).await.len(),
+            1,
+            "exactly one live PollOrderStatus row must exist for the order after the race"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_with_429_reschedule_push_failure_propagates_err_not_ok() {
+        let server = MockServer::start();
+        let infra = build_test_infra_alpaca(&server).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let accepted_order_id = uuid!("11111111-1111-1111-1111-111111111115");
+        let order_id = submit_offchain_order_with_executor_and_accepted_id(
+            &infra,
+            &symbol,
+            "wtAAPL",
+            shares,
+            Direction::Sell,
+            SupportedExecutor::AlpacaBrokerApi,
+            ExecutorOrderId::new(&accepted_order_id),
+        )
+        .await;
+
+        server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{accepted_order_id}"
+            ));
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("retry-after", "1")
+                .json_body(serde_json::json!({ "message": "rate limited" }));
+        });
+
+        // Force the reschedule's own push to fail: the projection/aggregate
+        // pool is untouched, so only the queue write fails.
+        infra.ctx.poll_status_queue.pool().close().await;
+
+        let error = PollOrderStatus {
+            offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(error, JobError::Enqueue(_)),
+            "a reschedule push that itself fails must propagate as Err, never be swallowed \
+             into Ok(()); got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_with_429_past_the_reschedule_limit_dead_letters_without_opening_the_circuit_breaker()
+     {
+        let server = MockServer::start();
+        let infra = build_test_infra_alpaca(&server).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let accepted_order_id = uuid!("11111111-1111-1111-1111-111111111116");
+        let order_id = submit_offchain_order_with_executor_and_accepted_id(
+            &infra,
+            &symbol,
+            "wtAAPL",
+            shares,
+            Direction::Sell,
+            SupportedExecutor::AlpacaBrokerApi,
+            ExecutorOrderId::new(&accepted_order_id),
+        )
+        .await;
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{accepted_order_id}"
+            ));
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("retry-after", "1")
+                .json_body(serde_json::json!({ "message": "rate limited" }));
+        });
+
+        // Per the RAI-1494 plan's binding M2 decision, PollOrderStatus is one
+        // of the five supervised jobs whose exhaustion must dead-letter (loud
+        // log + `Ok(())`) rather than propagate `Err` -- a bare `Err` here
+        // would exhaust `RetryPolicy::retries(3)` and open the circuit
+        // breaker for a cause that is not a genuine bug, reproducing
+        // RAI-1492's outcome just delayed by the reschedule budget.
+        PollOrderStatus {
+            offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak(BACKPRESSURE_RESCHEDULE_LIMIT),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        mock.assert();
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
+            0,
+            "exhaustion must dead-letter cleanly: no successor is pushed and the current row \
+             simply acks Done"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_order_status_payload_without_backpressure_streak_deserializes_to_zero() {
+        let offchain_order_id = OffchainOrderId::new();
+        let old_payload = serde_json::json!({
+            "offchain_order_id": offchain_order_id,
+        });
+
+        let job: PollOrderStatus =
+            serde_json::from_value(old_payload).expect("pre-field payload must still deserialize");
+
+        assert_eq!(job.offchain_order_id, offchain_order_id);
+        assert_eq!(job.backpressure_streak, BackpressureStreak::default());
+    }
+
+    #[test]
+    fn poll_order_status_new_payload_deserializes_under_a_struct_lacking_the_field() {
+        #[derive(serde::Deserialize)]
+        struct PreRai1494PollOrderStatus {
+            offchain_order_id: OffchainOrderId,
+        }
+
+        let offchain_order_id = OffchainOrderId::new();
+        let new_payload = serde_json::to_value(PollOrderStatus {
+            offchain_order_id,
+            backpressure_streak: BackpressureStreak(3),
+        })
+        .unwrap();
+
+        let job: PreRai1494PollOrderStatus = serde_json::from_value(new_payload)
+            .expect("a rolled-back binary must ignore the new backpressure_streak field");
+
+        assert_eq!(job.offchain_order_id, offchain_order_id);
+    }
+
+    #[tokio::test]
+    async fn poll_with_repeated_429_never_reaches_terminal_failure_end_to_end() {
+        let server = MockServer::start();
+        let infra = build_test_infra_alpaca(&server).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let accepted_order_id = uuid!("11111111-1111-1111-1111-111111111117");
+        let order_id = submit_offchain_order_with_executor_and_accepted_id(
+            &infra,
+            &symbol,
+            "wtAAPL",
+            shares,
+            Direction::Sell,
+            SupportedExecutor::AlpacaBrokerApi,
+            ExecutorOrderId::new(&accepted_order_id),
+        )
+        .await;
+
+        let status_path = format!(
+            "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{accepted_order_id}"
+        );
+
+        let mut rate_limited_mock = server.mock(|when, then| {
+            when.method(GET).path(status_path.clone());
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("retry-after", "1")
+                .json_body(serde_json::json!({ "message": "rate limited" }));
+        });
+
+        let TestInfra {
+            ctx, apalis_pool, ..
+        } = infra;
+
+        let mut push_queue = ctx.poll_status_queue.clone();
+        push_queue
+            .push(PollOrderStatus {
+                offchain_order_id: order_id,
+                backpressure_streak: BackpressureStreak::default(),
+            })
+            .await
+            .unwrap();
+
+        let ctx = Arc::new(ctx);
+        let failure_notify = Arc::new(tokio::sync::Notify::new());
+        let fail_stop = CircuitBreakerConfig::default()
+            .with_failure_threshold(1)
+            .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
+
+        let monitor_handle = tokio::spawn({
+            let failure_notify = failure_notify.clone();
+            let ctx = ctx.clone();
+            let queue = ctx.poll_status_queue.clone();
+            let monitor = Monitor::new()
+                .should_restart(|_ctx, _error, _attempt| false)
+                .register(move |index| {
+                    build_supervised_worker!(
+                        ::<PollOrderStatusCtx<AlpacaBrokerApi>, PollOrderStatus>,
+                        index,
+                        queue.clone(),
+                        ctx.clone(),
+                        fail_stop.clone(),
+                        failure_notify.clone(),
+                        FailureInjector::new(),
+                    )
+                });
+
+            async move {
+                let _ = monitor.run().await;
+            }
+        });
+
+        // N > 3 (the old, no-longer-used retries(3) bound this reschedule
+        // mechanism replaces) rate-limited attempts before the broker
+        // reports a terminal fill.
+        let rate_limit_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        while rate_limited_mock.calls() < 4 {
+            assert!(
+                tokio::time::Instant::now() < rate_limit_deadline,
+                "expected at least 4 rate-limited attempts within 30s"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        rate_limited_mock.delete();
+        server.mock(|when, then| {
+            when.method(GET).path(status_path.clone());
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({
+                    "id": accepted_order_id.to_string(),
+                    "symbol": "AAPL",
+                    "qty": "2",
+                    "side": "sell",
+                    "status": "filled",
+                    "filled_avg_price": "100.00",
+                    "updated_at": "2025-01-06T14:32:05.000000Z",
+                    "filled_at": "2025-01-06T14:32:01.111111Z"
+                }));
+        });
+
+        let reconcile_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            if count_jobs(&apalis_pool, reconcile_order_fill_job_type()).await >= 1 {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < reconcile_deadline,
+                "job should eventually reach terminal dispatch once backpressure clears; \
+                 job rows: {:?}",
+                sqlx_apalis::query_as::<_, (String, String, i64, i64)>(
+                    "SELECT id, status, attempts, max_attempts FROM Jobs WHERE job_type = ?"
+                )
+                .bind(poll_order_status_job_type())
+                .fetch_all(&apalis_pool)
+                .await
+                .unwrap()
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        assert!(
+            !matches!(
+                tokio::time::timeout(Duration::from_millis(50), failure_notify.notified()).await,
+                Ok(())
+            ),
+            "repeated 429s must never open the circuit breaker or signal a terminal job failure"
+        );
+
+        let terminally_failed: i64 = sqlx_apalis::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE job_type = ? AND status IN ('Failed', 'Killed')",
+        )
+        .bind(poll_order_status_job_type())
+        .fetch_one(&apalis_pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            terminally_failed, 0,
+            "no PollOrderStatus row must ever land Failed/Killed behind a latched circuit \
+             breaker while backpressure was in play"
+        );
+
+        monitor_handle.abort();
     }
 }

--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -29,7 +29,7 @@ use st0x_execution::Executor;
 use super::OnChainError;
 use crate::bindings::IRaindexInventory::{OperatorDeposit, OperatorWithdraw};
 use crate::bindings::IRaindexV6::{ClearV3, TakeOrderV3};
-use crate::conductor::job::{Job, Label};
+use crate::conductor::job::{BackpressureStreak, Job, Label};
 use crate::onchain::trade::{BotOperator, InventoryTrade, RaindexTradeEvent};
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::{
@@ -738,7 +738,10 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
         // "ClearV3"/"TakeOrderV3"/"InventoryTrade".
         counter!("onchain_events_total", "event_type" => trade_event.event.kind()).increment(1);
         job_queue
-            .push(AccountForDexTrade { trade: trade_event })
+            .push(AccountForDexTrade {
+                trade: trade_event,
+                backpressure_streak: BackpressureStreak::default(),
+            })
             .await?;
     }
 

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -23,7 +23,7 @@ use st0x_execution::{
     ClientOrderId, CounterTradePreflight, Direction, Executor, MarketOrder, MarketSession, Symbol,
 };
 
-use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
+use crate::conductor::job::{BackpressureStreak, Job, JobQueue, Label, QueuePushError};
 use crate::conductor::{clamp_shares_to_reservation, recover_orphaned_pending_offchain_orders};
 use crate::equity_redemption::symbols_with_active_transfers;
 use crate::offchain::order::{
@@ -320,6 +320,7 @@ where
             threshold: self.ctx.execution_threshold,
             offchain_order_id: OffchainOrderId::new(),
             market_session: ready.market_session,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let mut queue = self.hedge_queue.clone();

--- a/src/rebalancing/equity/job.rs
+++ b/src/rebalancing/equity/job.rs
@@ -37,7 +37,7 @@ use super::{CrossVenueEquityTransfer, MintTransferError, RedemptionError};
 #[cfg(test)]
 use crate::bot_gas::BotGasReceiptCostEnqueuer;
 use crate::bot_gas::redrive::{BotGasFailureClassifier, redrive_on_bot_gas_failure};
-use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
+use crate::conductor::job::{BackpressureStreak, Job, JobQueue, Label, QueuePushError};
 use crate::equity_redemption::RedemptionAggregateId;
 use crate::rebalancing::trigger::GuardState;
 use crate::tokenized_equity_mint::TokenizedEquityMint;
@@ -149,6 +149,28 @@ pub(crate) struct TransferEquityToMarketMaking {
     /// `GenerationMismatch -> Ok(())` rather than overwriting a new transfer's slot.
     #[serde(default)]
     pub(crate) generation: u64,
+    /// Count of consecutive broker rate-limit (429) reschedules leading up to
+    /// this attempt (RAI-1494). `#[serde(default)]` so a row enqueued under
+    /// the pre-this-change payload shape still deserializes to `0` instead of
+    /// crashing the poll stream's `sqlx::Decode`.
+    ///
+    /// NOT YET wired to a reschedule: `TokenizedEquityMint`'s command handler
+    /// converts a `request_mint`/tokenizer failure to
+    /// `TokenizedEquityMintError::RequestFailed { error_message: String }`
+    /// (`error.to_string()`), discarding the original error type before it
+    /// ever reaches this job -- `find_backpressure`'s downcast-based
+    /// classification has nothing to walk to. This is the same root cause as
+    /// `WrappedEquityRecoveryJob`'s gap (see its field doc), but one layer
+    /// removed: here the error DOES propagate as a genuine `Err` (apalis's
+    /// `retries(3)` already applies today), it is just untyped by the time it
+    /// arrives. Closing this needs `TokenizedEquityMintError` (and the
+    /// mirrored `EquityRedemption`/`RedemptionError` path for
+    /// `TransferEquityToHedging`) to preserve the classified error, not just
+    /// its `Display` string -- out of scope for this task's per-job wiring.
+    /// Field added now so the payload schema is ready when that follow-up
+    /// lands.
+    #[serde(default)]
+    pub(crate) backpressure_streak: BackpressureStreak,
 }
 
 impl Job<TransferEquityToMarketMakingCtx> for TransferEquityToMarketMaking {
@@ -468,6 +490,19 @@ pub(crate) struct TransferEquityToHedging {
     pub(crate) aggregate_id: RedemptionAggregateId,
     pub(crate) symbol: Symbol,
     pub(crate) quantity: FractionalShares,
+    /// Count of consecutive broker rate-limit (429) reschedules leading up to
+    /// this attempt (RAI-1494). `#[serde(default)]` so a row enqueued under
+    /// the pre-this-change payload shape still deserializes to `0` instead of
+    /// crashing the poll stream's `sqlx::Decode`.
+    ///
+    /// NOT YET wired to a reschedule: mirrors `TransferEquityToMarketMaking`'s
+    /// identical gap (see its field doc) -- `EquityRedemption`'s command
+    /// handlers convert tokenizer failures to `{ error_message: String }`
+    /// fields via `error.to_string()`, discarding the original error type
+    /// before it reaches this job. Field added now so the payload schema is
+    /// ready when that follow-up lands.
+    #[serde(default)]
+    pub(crate) backpressure_streak: BackpressureStreak,
 }
 
 impl Job<TransferEquityToHedgingCtx> for TransferEquityToHedging {
@@ -665,6 +700,7 @@ mod tests {
                     symbol: symbol.clone(),
                     quantity,
                     generation: 0,
+                    backpressure_streak: BackpressureStreak::default(),
                 })
                 .await
                 .expect_err("push to a closed pool must fail");
@@ -699,6 +735,7 @@ mod tests {
             symbol: symbol.clone(),
             quantity: FractionalShares::new(float!(5)),
             generation: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = chrono::Utc::now().timestamp();
@@ -758,6 +795,7 @@ mod tests {
                     symbol: symbol.clone(),
                     quantity,
                     generation: 0,
+                    backpressure_streak: BackpressureStreak::default(),
                 })
                 .await
                 .expect_err("push to a closed pool must fail");
@@ -789,6 +827,7 @@ mod tests {
             symbol: symbol.clone(),
             quantity: FractionalShares::new(float!(5)),
             generation: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx)
@@ -817,6 +856,8 @@ mod tests {
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: FractionalShares::new(float!(10)),
             generation: 0,
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap();
@@ -837,6 +878,8 @@ mod tests {
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: FractionalShares::new(float!(10)),
             generation: 0,
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -865,6 +908,8 @@ mod tests {
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: FractionalShares::new(float!(10)),
             generation: 0,
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -949,6 +994,8 @@ mod tests {
             symbol: symbol.clone(),
             quantity: FractionalShares::new(float!(5)),
             generation: 0,
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // TokensWrapped propagates Err: apalis retries resume_mint (idempotent
@@ -1009,6 +1056,8 @@ mod tests {
             symbol: symbol.clone(),
             quantity: FractionalShares::new(float!(5)),
             generation: 0,
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // VaultDepositSubmitted propagates Err so apalis retries the transfer job,
@@ -1075,6 +1124,8 @@ mod tests {
             symbol: symbol.clone(),
             quantity: FractionalShares::new(float!(5)),
             generation: 0,
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Must return Ok(()) — apalis does not retry; UnwrappedEquityRecovery takes over.
@@ -1138,6 +1189,8 @@ mod tests {
             symbol: symbol.clone(),
             quantity: FractionalShares::new(float!(5)),
             generation: 0,
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Must return Ok(()) — apalis does not retry; UnwrappedEquityRecovery takes over.
@@ -1200,6 +1253,8 @@ mod tests {
             symbol: symbol.clone(),
             quantity: FractionalShares::new(float!(5)),
             generation: 0,
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Must return Ok(()) so apalis marks the stale job Done -- no retry.
@@ -1258,6 +1313,8 @@ mod tests {
             symbol: symbol.clone(),
             quantity: FractionalShares::new(float!(5)),
             generation: 0,
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -1333,6 +1390,8 @@ mod tests {
             symbol: symbol.clone(),
             quantity: FractionalShares::new(float!(5)),
             generation: 0,
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Terminal aggregate must propagate Err — it is not a recoverable state.
@@ -1396,6 +1455,8 @@ mod tests {
             symbol: symbol.clone(),
             quantity: FractionalShares::new(float!(5)),
             generation: 0,
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Idempotent: guard already held, state is recoverable -> still Ok(()).
@@ -1443,6 +1504,8 @@ mod tests {
             symbol: symbol.clone(),
             quantity: FractionalShares::new(float!(5)),
             generation: 0,
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -1467,6 +1530,7 @@ mod tests {
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: FractionalShares::new(float!(2.5)),
             generation: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let expected = json!({
@@ -1474,6 +1538,7 @@ mod tests {
             "symbol": "AAPL",
             "quantity": "2.5",
             "generation": 0_u64,
+            "backpressure_streak": 0_u32,
         });
 
         assert_eq!(serde_json::to_value(&job).unwrap(), expected);
@@ -1484,8 +1549,12 @@ mod tests {
         assert_eq!(roundtripped.symbol, job.symbol);
         assert_eq!(roundtripped.quantity, job.quantity);
         assert_eq!(roundtripped.generation, job.generation);
+        assert_eq!(roundtripped.backpressure_streak, job.backpressure_streak);
 
-        // Old rows without the generation field must deserialize to generation=0.
+        // Old rows without the generation/backpressure_streak fields must
+        // deserialize to 0 for both (RAI-1494's
+        // `transfer_equity_to_market_making_payload_without_backpressure_streak_
+        // deserializes_to_zero` mandate).
         let legacy_payload = json!({
             "issuer_request_id": issuer_request_id("mint-roundtrip").to_string(),
             "symbol": "AAPL",
@@ -1493,6 +1562,33 @@ mod tests {
         });
         let legacy: TransferEquityToMarketMaking = serde_json::from_value(legacy_payload).unwrap();
         assert_eq!(legacy.generation, 0, "missing generation must default to 0");
+        assert_eq!(
+            legacy.backpressure_streak,
+            BackpressureStreak::default(),
+            "missing backpressure_streak must default to 0"
+        );
+    }
+
+    #[test]
+    fn transfer_equity_to_market_making_payload_without_backpressure_streak_deserializes_to_zero() {
+        let legacy_payload = json!({
+            "issuer_request_id": issuer_request_id("legacy-mint").to_string(),
+            "symbol": "AAPL",
+            "quantity": "2.5",
+        });
+        let job: TransferEquityToMarketMaking = serde_json::from_value(legacy_payload).unwrap();
+        assert_eq!(job.backpressure_streak, BackpressureStreak::default());
+    }
+
+    #[test]
+    fn transfer_equity_to_hedging_payload_without_backpressure_streak_deserializes_to_zero() {
+        let legacy_payload = json!({
+            "aggregate_id": redemption_aggregate_id("legacy-redemption").to_string(),
+            "symbol": "AAPL",
+            "quantity": "2.5",
+        });
+        let job: TransferEquityToHedging = serde_json::from_value(legacy_payload).unwrap();
+        assert_eq!(job.backpressure_streak, BackpressureStreak::default());
     }
 
     /// Records the redemption resume call and returns a configurable outcome.
@@ -1565,6 +1661,7 @@ mod tests {
             aggregate_id: redemption_aggregate_id("redeem-bot-gas-enqueue-failure"),
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: FractionalShares::new(float!(10)),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = chrono::Utc::now().timestamp();
@@ -1609,6 +1706,8 @@ mod tests {
             aggregate_id: redemption_aggregate_id("redeem-forward"),
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: FractionalShares::new(float!(10)),
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap();
@@ -1634,6 +1733,8 @@ mod tests {
             aggregate_id: redemption_aggregate_id("redeem-fail"),
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: FractionalShares::new(float!(10)),
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -1656,6 +1757,8 @@ mod tests {
             aggregate_id: redemption_aggregate_id("redeem-roundtrip"),
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: FractionalShares::new(float!(2.5)),
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let serialized = serde_json::to_vec(&job).unwrap();

--- a/src/rebalancing/equity/resume_job.rs
+++ b/src/rebalancing/equity/resume_job.rs
@@ -27,7 +27,7 @@ use super::{CrossVenueEquityTransfer, MintError, RedemptionError};
 #[cfg(test)]
 use crate::bot_gas::BotGasReceiptCostEnqueuer;
 use crate::bot_gas::redrive::{BotGasFailureClassifier, redrive_on_bot_gas_failure};
-use crate::conductor::job::{Job, JobQueue, Label};
+use crate::conductor::job::{BackpressureStreak, Job, JobQueue, Label};
 use crate::equity_redemption::RedemptionAggregateId;
 
 /// Apalis queue type for [`ResumeTokenizationAggregate`].
@@ -51,6 +51,20 @@ pub(crate) enum ResumeTokenizationTarget {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct ResumeTokenizationAggregate {
     pub(crate) target: ResumeTokenizationTarget,
+    /// Count of consecutive broker rate-limit (429) reschedules leading up to
+    /// this attempt (RAI-1494). `#[serde(default)]` so a row enqueued under
+    /// the pre-this-change payload shape still deserializes to `0` instead of
+    /// crashing the poll stream's `sqlx::Decode`.
+    ///
+    /// NOT YET wired to a reschedule: mirrors `TransferEquityToMarketMaking`'s
+    /// identical gap (see its field doc) -- `resume_mint`/`resume_redemption`
+    /// dispatch to the same `TokenizedEquityMint`/`EquityRedemption` command
+    /// handlers, which convert tokenizer failures to
+    /// `{ error_message: String }` fields via `error.to_string()`, discarding
+    /// the original error type before it reaches this job. Field added now
+    /// so the payload schema is ready when that follow-up lands.
+    #[serde(default)]
+    pub(crate) backpressure_streak: BackpressureStreak,
 }
 
 /// Dependencies the job needs.
@@ -265,6 +279,8 @@ mod tests {
 
         let job = ResumeTokenizationAggregate {
             target: ResumeTokenizationTarget::Mint(id),
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Terminal aggregate: resume_mint returns Ok(()) immediately.
@@ -316,6 +332,8 @@ mod tests {
 
         let job = ResumeTokenizationAggregate {
             target: ResumeTokenizationTarget::Mint(id),
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let calls_before = tokenizer.call_count();
@@ -396,6 +414,8 @@ mod tests {
 
         let job = ResumeTokenizationAggregate {
             target: ResumeTokenizationTarget::Redemption(id),
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Completed aggregate is terminal: resume_redemption returns Ok(()).
@@ -444,6 +464,8 @@ mod tests {
 
         let job = ResumeTokenizationAggregate {
             target: ResumeTokenizationTarget::Mint(id.clone()),
+
+            backpressure_streak: BackpressureStreak::default(),
         };
         Job::perform(&job, &ctx).await.unwrap();
 
@@ -557,6 +579,7 @@ mod tests {
         };
         let job = ResumeTokenizationAggregate {
             target: ResumeTokenizationTarget::Mint(id),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx)
@@ -584,6 +607,8 @@ mod tests {
 
         let job = ResumeTokenizationAggregate {
             target: ResumeTokenizationTarget::Mint(id),
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -605,6 +630,8 @@ mod tests {
 
         let job = ResumeTokenizationAggregate {
             target: ResumeTokenizationTarget::Redemption(id),
+
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -671,6 +698,8 @@ mod tests {
 
         let job = ResumeTokenizationAggregate {
             target: ResumeTokenizationTarget::Redemption(id.clone()),
+
+            backpressure_streak: BackpressureStreak::default(),
         };
         Job::perform(&job, &ctx).await.unwrap();
 
@@ -697,9 +726,13 @@ mod tests {
 
         let mint_job = ResumeTokenizationAggregate {
             target: ResumeTokenizationTarget::Mint(mint_id.clone()),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
-        let expected_mint = json!({ "target": { "Mint": mint_id.to_string() } });
+        let expected_mint = json!({
+            "target": { "Mint": mint_id.to_string() },
+            "backpressure_streak": 0_u32,
+        });
         assert_eq!(serde_json::to_value(&mint_job).unwrap(), expected_mint);
 
         let roundtripped_mint: ResumeTokenizationAggregate =
@@ -709,12 +742,20 @@ mod tests {
             ResumeTokenizationTarget::Mint(mint_id),
             "roundtripped mint target must match original"
         );
+        assert_eq!(
+            roundtripped_mint.backpressure_streak,
+            BackpressureStreak::default()
+        );
 
         let redemption_job = ResumeTokenizationAggregate {
             target: ResumeTokenizationTarget::Redemption(redemption_id.clone()),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
-        let expected_redemption = json!({ "target": { "Redemption": redemption_id.to_string() } });
+        let expected_redemption = json!({
+            "target": { "Redemption": redemption_id.to_string() },
+            "backpressure_streak": 0_u32,
+        });
         assert_eq!(
             serde_json::to_value(&redemption_job).unwrap(),
             expected_redemption
@@ -727,5 +768,20 @@ mod tests {
             ResumeTokenizationTarget::Redemption(redemption_id),
             "roundtripped redemption target must match original"
         );
+        assert_eq!(
+            roundtripped_redemption.backpressure_streak,
+            BackpressureStreak::default()
+        );
+    }
+
+    /// Mandatory RAI-1494 test (M1): a row enqueued before `backpressure_streak`
+    /// existed must still deserialize, defaulting the field to `0`.
+    #[test]
+    fn resume_tokenization_aggregate_payload_without_backpressure_streak_deserializes_to_zero() {
+        let mint_id = issuer_request_id("legacy-mint");
+        let legacy_payload = json!({ "target": { "Mint": mint_id.to_string() } });
+
+        let job: ResumeTokenizationAggregate = serde_json::from_value(legacy_payload).unwrap();
+        assert_eq!(job.backpressure_streak, BackpressureStreak::default());
     }
 }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -34,7 +34,7 @@ use self::freeze::FreezeStatusReader;
 use self::usdc::UsdcRebalanceOperation;
 #[cfg(test)]
 use crate::bot_gas::BotGasReceiptCostEnqueuer;
-use crate::conductor::job::QueuePushError;
+use crate::conductor::job::{BackpressureStreak, QueuePushError};
 use crate::equity_redemption::{
     EquityRedemption, EquityRedemptionCommand, EquityRedemptionEvent, RedemptionAggregateId,
 };
@@ -1130,6 +1130,7 @@ impl RebalancingService {
                             id: id.clone(),
                             amount,
                             revert_redrive_attempts: 0,
+                            backpressure_streak: BackpressureStreak::default(),
                         })
                         .await?;
                     self.usdc_in_progress.store(true, Ordering::SeqCst);
@@ -1931,6 +1932,7 @@ impl RebalancingService {
                         .push(WrappedEquityRecoveryJob {
                             symbol: symbol.clone(),
                             recovery_id: recovery_id.clone(),
+                            backpressure_streak: BackpressureStreak::default(),
                         })
                         .await
                     {
@@ -2008,6 +2010,7 @@ impl RebalancingService {
                         .push(UnwrappedEquityRecoveryJob {
                             symbol: symbol.clone(),
                             recovery_id: recovery_id.clone(),
+                            backpressure_streak: BackpressureStreak::default(),
                         })
                         .await
                     {
@@ -3094,6 +3097,7 @@ impl RebalancingService {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await;
 
@@ -3164,6 +3168,7 @@ impl RebalancingService {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await;
 
@@ -3487,6 +3492,7 @@ impl RebalancingService {
                 symbol: symbol.clone(),
                 quantity,
                 generation,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await;
 
@@ -3583,6 +3589,7 @@ impl RebalancingService {
                 aggregate_id: aggregate_id.clone(),
                 symbol: symbol.clone(),
                 quantity,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await;
 
@@ -4142,6 +4149,7 @@ impl RebalancingService {
                             id: id.clone(),
                             amount,
                             revert_redrive_attempts: 0,
+                            backpressure_streak: BackpressureStreak::default(),
                         })
                         .await?;
                 }
@@ -4152,6 +4160,7 @@ impl RebalancingService {
                             id: id.clone(),
                             amount,
                             revert_redrive_attempts: 0,
+                            backpressure_streak: BackpressureStreak::default(),
                         })
                         .await?;
                 }
@@ -12594,6 +12603,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(400),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -12724,6 +12734,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(400),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -12758,6 +12769,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(400),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -12787,6 +12799,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(400),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -12837,6 +12850,7 @@ mod tests {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -12867,6 +12881,7 @@ mod tests {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -12894,6 +12909,7 @@ mod tests {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -12930,6 +12946,7 @@ mod tests {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13026,6 +13043,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13074,6 +13092,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13125,6 +13144,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13168,6 +13188,7 @@ mod tests {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13207,6 +13228,7 @@ mod tests {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13250,6 +13272,7 @@ mod tests {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13296,6 +13319,7 @@ mod tests {
                     id: zombie_id.clone(),
                     amount: usdc(100),
                     revert_redrive_attempts: 0,
+                    backpressure_streak: BackpressureStreak::default(),
                 })
                 .await
                 .unwrap();
@@ -13339,6 +13363,7 @@ mod tests {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13373,6 +13398,7 @@ mod tests {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13404,6 +13430,7 @@ mod tests {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13445,6 +13472,7 @@ mod tests {
                 id: zombie_id.clone(),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13468,6 +13496,7 @@ mod tests {
                 id: live_id.clone(),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13509,6 +13538,7 @@ mod tests {
                 id: UsdcRebalanceId(Uuid::new_v4()),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13563,6 +13593,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(100),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13743,6 +13774,8 @@ mod tests {
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
                 generation: 0,
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13781,6 +13814,8 @@ mod tests {
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
                 generation: 0,
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13816,6 +13851,8 @@ mod tests {
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
                 generation: 0,
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13874,6 +13911,8 @@ mod tests {
                 aggregate_id: redemption_id,
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13932,6 +13971,8 @@ mod tests {
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
                 generation: 0,
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -13986,6 +14027,8 @@ mod tests {
                 aggregate_id: redemption_id,
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -14040,6 +14083,8 @@ mod tests {
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
                 generation: 0,
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -14079,6 +14124,8 @@ mod tests {
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
                 generation: 0,
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -14130,6 +14177,8 @@ mod tests {
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
                 generation: 0,
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -14186,6 +14235,8 @@ mod tests {
                 aggregate_id: redemption_aggregate_id("corrupt-redemption-payload"),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -14243,6 +14294,8 @@ mod tests {
                     symbol: symbol.clone(),
                     quantity: FractionalShares::new(float!(1)),
                     generation: 0,
+
+                    backpressure_streak: BackpressureStreak::default(),
                 })
                 .await
                 .unwrap();
@@ -14308,6 +14361,8 @@ mod tests {
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
                 generation: 0,
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -14328,6 +14383,8 @@ mod tests {
                 aggregate_id: live_redemption_id,
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(float!(1)),
+
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -14389,6 +14446,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(400),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -15490,6 +15548,7 @@ mod tests {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -16683,6 +16742,7 @@ mod tests {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -16724,6 +16784,7 @@ mod tests {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -16773,6 +16834,7 @@ mod tests {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -16824,6 +16886,7 @@ mod tests {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -17146,6 +17209,7 @@ mod tests {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -17182,6 +17246,7 @@ mod tests {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -17234,6 +17299,7 @@ mod tests {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -17304,6 +17370,7 @@ mod tests {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -17377,6 +17444,7 @@ mod tests {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -17435,6 +17503,7 @@ mod tests {
                 id: id.clone(),
                 amount,
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -17698,6 +17767,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(400),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -17746,6 +17816,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(400),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -17843,6 +17914,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(400),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -17895,6 +17967,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(400),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -17941,6 +18014,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(400),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -17989,6 +18063,7 @@ mod tests {
                 id: id.clone(),
                 amount: usdc(400),
                 revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -29,14 +29,18 @@ use tracing::{error, warn};
 
 use st0x_bridge::cctp::CctpError;
 use st0x_evm::Wallet;
-use st0x_execution::AlpacaWalletError;
+use st0x_execution::{AlpacaWalletError, Backpressure};
 use st0x_finance::Usdc;
 
 use super::UsdcTransferError;
 use super::manager::CrossVenueCashTransfer;
 use crate::alerts::Notifier;
 use crate::bot_gas::redrive::{BotGasFailureClassifier, redrive_on_bot_gas_failure};
-use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
+use crate::conductor::job::{
+    BACKPRESSURE_ALERT_STREAK, BACKPRESSURE_RESCHEDULE_LIMIT, BackpressureOutcome,
+    BackpressureStep, BackpressureStreak, Job, JobQueue, Label, QueuePushError,
+    advance_backpressure, apply_backpressure_step, find_backpressure,
+};
 use crate::usdc_rebalance::UsdcRebalanceId;
 
 const ATTESTATION_REDRIVE_DELAY: Duration = Duration::from_secs(60);
@@ -292,6 +296,161 @@ where
     }
 }
 
+#[derive(Clone, Copy)]
+enum BackpressureSite {
+    Hedging,
+    MarketMaking,
+    WithdrawalPoll { deadline_elapsed: bool },
+}
+
+struct BackpressureLabels {
+    direction: &'static str,
+    context: &'static str,
+    state: &'static str,
+    alert: &'static str,
+}
+
+impl BackpressureSite {
+    const fn labels(self) -> BackpressureLabels {
+        match self {
+            Self::Hedging => BackpressureLabels {
+                direction: "Base->Alpaca",
+                context: "broker rate-limiting",
+                state: "mid-flight",
+                alert: "hedging",
+            },
+            Self::MarketMaking => BackpressureLabels {
+                direction: "Alpaca->Base",
+                context: "broker rate-limiting",
+                state: "mid-flight",
+                alert: "market-making",
+            },
+            Self::WithdrawalPoll { .. } => BackpressureLabels {
+                direction: "Alpaca->Base",
+                context: "withdrawal poll broker rate-limiting",
+                state: "in Withdrawing",
+                alert: "withdrawal-poll",
+            },
+        }
+    }
+
+    const fn should_page_at_streak(self) -> bool {
+        !matches!(
+            self,
+            Self::WithdrawalPoll {
+                deadline_elapsed: true
+            }
+        )
+    }
+}
+
+/// Shared log-and-notify tail for a backpressure `outcome`, used by every
+/// call site that routes a classified 429 through `advance_backpressure`/
+/// `apply_backpressure_step`: logs a loud, distinct `error!` and pages the
+/// operator once on `DeadLettered` (unconditionally), or once when the
+/// reschedule streak first crosses `BACKPRESSURE_ALERT_STREAK` on
+/// `Rescheduled`. The typed `site` selects the direction, rate-limited
+/// operation, held aggregate state, and alert-delivery label as one coherent
+/// set so callers cannot accidentally combine labels from different transfer
+/// stages. `streak_before_this_attempt` is only read on `DeadLettered` -- that
+/// variant carries no streak of its own, so the caller's already-known
+/// `backpressure_streak` (the value that made this attempt exhaust the budget)
+/// is what gets logged.
+async fn log_and_alert_backpressure_outcome(
+    id: &UsdcRebalanceId,
+    site: BackpressureSite,
+    streak_before_this_attempt: BackpressureStreak,
+    outcome: BackpressureOutcome,
+    notifier: &Arc<dyn Notifier>,
+) {
+    let BackpressureLabels {
+        direction,
+        context,
+        state,
+        alert,
+    } = site.labels();
+
+    match outcome {
+        BackpressureOutcome::DeadLettered => {
+            let BackpressureStreak(streak) = streak_before_this_attempt;
+            error!(
+                target: "rebalance",
+                %id,
+                streak,
+                limit = BACKPRESSURE_RESCHEDULE_LIMIT,
+                "{direction} USDC transfer: {context} exceeded the reschedule \
+                 budget; dead-lettering instead of opening the circuit breaker -- \
+                 treat as a structurally-dead Alpaca integration needing manual \
+                 reconciliation"
+            );
+            let message = format!(
+                "USDC transfer {id}: {context} exceeded the \
+                 {BACKPRESSURE_RESCHEDULE_LIMIT}-reschedule budget. Aggregate stays \
+                 {state} (guard held); likely a structurally-dead Alpaca \
+                 integration (suspended account, revoked key) needing manual \
+                 reconciliation."
+            );
+            if let Err(error) = notifier.notify(&message).await {
+                warn!(
+                    target: "rebalance", ?error,
+                    "Failed to deliver USDC {alert} backpressure dead-letter alert"
+                );
+            }
+        }
+        BackpressureOutcome::Rescheduled {
+            next_streak: BackpressureStreak(streak),
+            visible,
+        } => {
+            if visible {
+                error!(
+                    target: "rebalance",
+                    %id,
+                    streak,
+                    "{direction} USDC transfer: {context} still rescheduling after \
+                     sustained broker rate-limiting"
+                );
+            }
+            if streak == BACKPRESSURE_ALERT_STREAK && site.should_page_at_streak() {
+                let message = format!(
+                    "USDC transfer {id}: {context} has persisted for {streak} consecutive \
+                     reschedules. Aggregate stays {state} (guard held); investigate \
+                     Alpaca connectivity/rate limits before the \
+                     {BACKPRESSURE_RESCHEDULE_LIMIT}-attempt budget is exhausted."
+                );
+                if let Err(error) = notifier.notify(&message).await {
+                    warn!(
+                        target: "rebalance", ?error,
+                        "Failed to deliver USDC {alert} sustained-backpressure alert"
+                    );
+                }
+            }
+        }
+    }
+}
+
+async fn alert_withdrawal_poll_deadline_elapsed(
+    id: &UsdcRebalanceId,
+    elapsed: Duration,
+    source: &AlpacaWalletError,
+    notifier: &Arc<dyn Notifier>,
+) {
+    let message = format!(
+        "Alpaca->Base USDC transfer {id}: withdrawal polling inconclusive \
+         for {elapsed:?} (>{WITHDRAWAL_POLL_ALERT_DEADLINE:?}). Alpaca may \
+         be unreachable or credentials may have changed ({source}). Aggregate stays in \
+         Withdrawing (guard held). Use `stox transfer resume --kind usdc --id \
+         {id} --direction to-raindex` to manually re-poll, or investigate \
+         Alpaca connectivity."
+    );
+    if let Err(notify_err) = notifier.notify(&message).await {
+        warn!(
+            target: "rebalance",
+            ?notify_err,
+            "Failed to deliver withdrawal-poll-deadline-elapsed alert"
+        );
+    }
+}
+
 /// Apalis queue type for [`TransferUsdcToHedging`].
 pub(crate) type TransferUsdcToHedgingJobQueue = JobQueue<TransferUsdcToHedging>;
 
@@ -408,6 +567,13 @@ pub(crate) struct TransferUsdcToHedging {
     /// so the bound is durable across restarts.
     #[serde(default)]
     pub(crate) revert_redrive_attempts: u32,
+    /// Count of consecutive broker rate-limit (429) reschedules leading up to
+    /// this attempt (RAI-1494). `#[serde(default)]` so a row enqueued under
+    /// the pre-this-change payload shape still deserializes to `0` instead of
+    /// crashing the poll stream's `sqlx::Decode`. Independent of
+    /// `revert_redrive_attempts`, which covers a different failure class.
+    #[serde(default)]
+    pub(crate) backpressure_streak: BackpressureStreak,
 }
 
 impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
@@ -634,35 +800,7 @@ impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
                     warn!(target: "rebalance", ?error, "Failed to deliver USDC hedging vault-liquidity alert");
                 }
             }
-            Err(error) => {
-                // Terminal non-redriven error: fire notifier before surfacing
-                // to apalis so the operator is alerted before the circuit opens.
-                //
-                // KNOWN LIMITATION: this arm fires on every apalis attempt (up
-                // to 4x with the default RetryPolicy::retries(3)). Because the
-                // apalis retry uses the same serialized payload and `perform`
-                // has no visibility into the current attempt number, suppressing
-                // duplicates here is not feasible without threading apalis
-                // attempt context through. The bounded-limit path
-                // (BurnRevertLimitReached / TimeoutLimitReached) already fires
-                // exactly once via the Ok-return redrive pattern; this generic
-                // terminal arm is a best-effort alert that may duplicate.
-                let id = &self.id;
-                error!(
-                    target: "rebalance",
-                    %id,
-                    %error,
-                    "Base->Alpaca USDC transfer failed terminally; circuit will open"
-                );
-                let message = format!(
-                    "USDC transfer {id} failed: {error}. \
-                     Check if apalis will retry before acting."
-                );
-                if let Err(error) = ctx.notifier.notify(&message).await {
-                    warn!(target: "rebalance", ?error, "Failed to deliver USDC hedging terminal-error alert");
-                }
-                return Err(error.into());
-            }
+            Err(error) => return self.handle_terminal_or_backpressure_error(ctx, error).await,
         }
 
         Ok(())
@@ -670,6 +808,81 @@ impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
 }
 
 impl TransferUsdcToHedging {
+    /// Handles the generic (unclassified-by-name) terminal error arm:
+    /// reschedules with a classified delay on broker rate-limiting (429)
+    /// instead of consuming the terminal retry budget and alerting, or falls
+    /// through to the pre-existing terminal alert+propagate path for any
+    /// other error. `TransferUsdcToHedging` is a "true retry" job (RAI-1494
+    /// plan): `resume_base_to_alpaca` re-drives from the top on every attempt
+    /// with no committed guard specific to this failure class, so every
+    /// reschedule genuinely re-attempts the resume. Exception: the USDC->USD
+    /// conversion placement sub-step never reaches this arm on a 429 -- it
+    /// fails fast unconditionally (see `execute_usdc_to_usd_conversion`) and
+    /// returns `ConversionPlacementFailed`, which `find_backpressure` never
+    /// classifies, so it falls through to the plain terminal path below.
+    async fn handle_terminal_or_backpressure_error(
+        &self,
+        ctx: &TransferUsdcToHedgingCtx,
+        error: UsdcTransferError,
+    ) -> Result<(), TransferUsdcToHedgingJobError> {
+        if let Some(backpressure) = find_backpressure(&error) {
+            let step = advance_backpressure(&backpressure, self.backpressure_streak);
+            let mut job_queue = ctx.job_queue.clone();
+            let outcome = apply_backpressure_step(step, &mut job_queue, |next_streak| Self {
+                id: self.id.clone(),
+                amount: self.amount,
+                revert_redrive_attempts: self.revert_redrive_attempts,
+                backpressure_streak: next_streak,
+            })
+            .await?;
+
+            // Per the RAI-1494 plan's binding M2 decision: this is a
+            // supervised worker, so dead-letter instead of propagating `Err`
+            // into the shared supervised on-event path. RAI-1494 pass 3:
+            // both dead-lettering and sustained rescheduling must page the
+            // operator -- rerouting a 429 through this reschedule machinery
+            // must not silently drop the alerting the pre-existing terminal
+            // path gave every sustained failure.
+            log_and_alert_backpressure_outcome(
+                &self.id,
+                BackpressureSite::Hedging,
+                self.backpressure_streak,
+                outcome,
+                &ctx.notifier,
+            )
+            .await;
+
+            return Ok(());
+        }
+
+        // Terminal non-redriven error: fire notifier before surfacing
+        // to apalis so the operator is alerted before the circuit opens.
+        //
+        // KNOWN LIMITATION: this arm fires on every apalis attempt (up
+        // to 4x with the default RetryPolicy::retries(3)). Because the
+        // apalis retry uses the same serialized payload and `perform`
+        // has no visibility into the current attempt number, suppressing
+        // duplicates here is not feasible without threading apalis
+        // attempt context through. The bounded-limit path
+        // (BurnRevertLimitReached / TimeoutLimitReached) already fires
+        // exactly once via the Ok-return redrive pattern; this generic
+        // terminal arm is a best-effort alert that may duplicate.
+        let id = &self.id;
+        error!(
+            target: "rebalance",
+            %id,
+            %error,
+            "Base->Alpaca USDC transfer failed terminally; circuit will open"
+        );
+        let message = format!(
+            "USDC transfer {id} failed: {error}. Check if apalis will retry before acting."
+        );
+        if let Err(error) = ctx.notifier.notify(&message).await {
+            warn!(target: "rebalance", ?error, "Failed to deliver USDC hedging terminal-error alert");
+        }
+        Err(error.into())
+    }
+
     /// Handles a per-attempt timeout by either opening the circuit (when the
     /// redrive limit is reached) or scheduling a delayed redrive attempt.
     /// Extracted from `Job::perform` to mirror the market-making extraction and
@@ -759,6 +972,7 @@ impl TransferUsdcToHedging {
 
         let updated = Self {
             revert_redrive_attempts: next_attempts,
+            backpressure_streak: BackpressureStreak::default(),
             ..self.clone()
         };
         ctx.job_queue
@@ -861,6 +1075,7 @@ impl TransferUsdcToHedging {
 
         let updated = Self {
             revert_redrive_attempts: next_attempts,
+            backpressure_streak: BackpressureStreak::default(),
             ..self.clone()
         };
         ctx.job_queue
@@ -943,6 +1158,13 @@ pub(crate) struct TransferUsdcToMarketMaking {
     /// the apalis payload so the bound is durable across restarts.
     #[serde(default)]
     pub(crate) revert_redrive_attempts: u32,
+    /// Count of consecutive broker rate-limit (429) reschedules leading up to
+    /// this attempt (RAI-1494). `#[serde(default)]` so a row enqueued under
+    /// the pre-this-change payload shape still deserializes to `0` instead of
+    /// crashing the poll stream's `sqlx::Decode`. Independent of
+    /// `revert_redrive_attempts`, which covers a different failure class.
+    #[serde(default)]
+    pub(crate) backpressure_streak: BackpressureStreak,
 }
 
 impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
@@ -1116,14 +1338,35 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
             // the same transfer ID is re-polled. Before the alert deadline only
             // a warn log fires; at or after the deadline the operator is paged on
             // every redrive while the guard stays held and re-polling continues.
+            // A classified broker rate-limit (429) on the withdrawal poll must
+            // route through the same bounded backpressure machinery as every
+            // other call site (RAI-1494), not the old unbounded inconclusive
+            // redrive: without this, a sustained 429 here would never
+            // increment `backpressure_streak`, honour `Retry-After`, or ever
+            // dead-letter at `BACKPRESSURE_RESCHEDULE_LIMIT`. Any other
+            // inconclusive poll error (timeout, network, non-429 API error)
+            // keeps the pre-existing unbounded redrive via
+            // `handle_withdrawal_poll_inconclusive`.
             Err(UsdcTransferError::WithdrawalPollInconclusive {
                 id,
                 initiated_at,
                 source,
-            }) => {
-                self.handle_withdrawal_poll_inconclusive(ctx, id, initiated_at, source)
+            }) => match source.backpressure() {
+                None => {
+                    self.handle_withdrawal_poll_inconclusive(ctx, id, initiated_at, source)
+                        .await?;
+                }
+                Some(backpressure) => {
+                    self.handle_withdrawal_poll_backpressure(
+                        ctx,
+                        id,
+                        initiated_at,
+                        source,
+                        backpressure,
+                    )
                     .await?;
-            }
+                }
+            },
             // Revert-class burn failures: safe to redrive because
             // `resume_bridging_submitting` scans for an existing burn before
             // re-burning (the scan lower bound is durably recorded). The safety
@@ -1193,35 +1436,7 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
                     warn!(target: "rebalance", ?error, "Failed to deliver USDC market-making inconclusive-burn alert");
                 }
             }
-            Err(error) => {
-                // Terminal non-redriven error: fire notifier before surfacing
-                // to apalis so the operator is alerted before the circuit opens.
-                //
-                // KNOWN LIMITATION: this arm fires on every apalis attempt (up
-                // to 4x with the default RetryPolicy::retries(3)). Because the
-                // apalis retry uses the same serialized payload and `perform`
-                // has no visibility into the current attempt number, suppressing
-                // duplicates here is not feasible without threading apalis
-                // attempt context through. The bounded-limit path
-                // (BurnRevertLimitReached) already fires exactly once via the
-                // Ok-return redrive pattern; this generic terminal arm is a
-                // best-effort alert that may duplicate.
-                let id = &self.id;
-                error!(
-                    target: "rebalance",
-                    %id,
-                    %error,
-                    "Alpaca->Base USDC transfer failed terminally; circuit will open"
-                );
-                let message = format!(
-                    "USDC transfer {id} failed: {error}. \
-                     Check if apalis will retry before acting."
-                );
-                if let Err(error) = ctx.notifier.notify(&message).await {
-                    warn!(target: "rebalance", ?error, "Failed to deliver USDC market-making terminal-error alert");
-                }
-                return Err(error.into());
-            }
+            Err(error) => return self.handle_terminal_or_backpressure_error(ctx, error).await,
         }
 
         Ok(())
@@ -1264,6 +1479,139 @@ impl TransferUsdcToMarketMaking {
         Ok(())
     }
 
+    /// Handles the generic (unclassified-by-name) terminal error arm:
+    /// reschedules with a classified delay on broker rate-limiting (429)
+    /// instead of consuming the terminal retry budget and alerting, or falls
+    /// through to the pre-existing terminal alert+propagate path for any
+    /// other error. `TransferUsdcToMarketMaking` is a "true retry" job
+    /// (RAI-1494 plan): `resume_alpaca_to_base` re-drives from the top on
+    /// every attempt with no committed guard specific to this failure class,
+    /// so every reschedule genuinely re-attempts the resume. Exception: the
+    /// USD->USDC conversion placement sub-step never reaches this arm on a
+    /// 429 -- it fails fast unconditionally (see
+    /// `execute_usd_to_usdc_conversion`) and returns
+    /// `ConversionPlacementFailed`, which `find_backpressure` never
+    /// classifies, so it falls through to the plain terminal path below.
+    async fn handle_terminal_or_backpressure_error(
+        &self,
+        ctx: &TransferUsdcToMarketMakingCtx,
+        error: UsdcTransferError,
+    ) -> Result<(), TransferUsdcToMarketMakingJobError> {
+        if let Some(backpressure) = find_backpressure(&error) {
+            let step = advance_backpressure(&backpressure, self.backpressure_streak);
+            let mut job_queue = ctx.job_queue.clone();
+            let outcome = apply_backpressure_step(step, &mut job_queue, |next_streak| Self {
+                id: self.id.clone(),
+                amount: self.amount,
+                revert_redrive_attempts: self.revert_redrive_attempts,
+                backpressure_streak: next_streak,
+            })
+            .await?;
+
+            // Per the RAI-1494 plan's binding M2 decision: this is a
+            // supervised worker, so dead-letter instead of propagating `Err`
+            // into the shared supervised on-event path. RAI-1494 pass 3:
+            // both dead-lettering and sustained rescheduling must page the
+            // operator -- rerouting a 429 through this reschedule machinery
+            // must not silently drop the alerting the pre-existing terminal
+            // path gave every sustained failure.
+            log_and_alert_backpressure_outcome(
+                &self.id,
+                BackpressureSite::MarketMaking,
+                self.backpressure_streak,
+                outcome,
+                &ctx.notifier,
+            )
+            .await;
+
+            return Ok(());
+        }
+
+        // Terminal non-redriven error: fire notifier before surfacing
+        // to apalis so the operator is alerted before the circuit opens.
+        //
+        // KNOWN LIMITATION: this arm fires on every apalis attempt (up
+        // to 4x with the default RetryPolicy::retries(3)). Because the
+        // apalis retry uses the same serialized payload and `perform`
+        // has no visibility into the current attempt number, suppressing
+        // duplicates here is not feasible without threading apalis
+        // attempt context through. The bounded-limit path
+        // (BurnRevertLimitReached) already fires exactly once via the
+        // Ok-return redrive pattern; this generic terminal arm is a
+        // best-effort alert that may duplicate.
+        let id = &self.id;
+        error!(
+            target: "rebalance",
+            %id,
+            %error,
+            "Alpaca->Base USDC transfer failed terminally; circuit will open"
+        );
+        let message = format!(
+            "USDC transfer {id} failed: {error}. Check if apalis will retry before acting."
+        );
+        if let Err(error) = ctx.notifier.notify(&message).await {
+            warn!(target: "rebalance", ?error, "Failed to deliver USDC market-making terminal-error alert");
+        }
+        Err(error.into())
+    }
+
+    /// Bounded backpressure path for a CLASSIFIED broker rate-limit (429) on the
+    /// withdrawal poll. Routes through the same machinery as every other call
+    /// site (RAI-1494) rather than the unbounded inconclusive redrive in
+    /// [`Self::handle_withdrawal_poll_inconclusive`]: without this, a sustained
+    /// 429 here would never increment `backpressure_streak`, honour
+    /// `Retry-After`, or ever dead-letter at `BACKPRESSURE_RESCHEDULE_LIMIT`.
+    async fn handle_withdrawal_poll_backpressure(
+        &self,
+        ctx: &TransferUsdcToMarketMakingCtx,
+        id: UsdcRebalanceId,
+        initiated_at: DateTime<Utc>,
+        source: AlpacaWalletError,
+        backpressure: Backpressure,
+    ) -> Result<(), TransferUsdcToMarketMakingJobError> {
+        let elapsed = Utc::now().signed_duration_since(initiated_at).to_std().ok();
+        let deadline_elapsed = deadline_elapsed(elapsed, WITHDRAWAL_POLL_ALERT_DEADLINE);
+        let mut step = advance_backpressure(&backpressure, self.backpressure_streak);
+        if deadline_elapsed.is_some()
+            && let BackpressureStep::Reschedule { delay, .. } = &mut step
+        {
+            *delay = (*delay).max(WITHDRAWAL_POLL_POST_DEADLINE_REDRIVE_DELAY);
+        }
+        let mut job_queue = ctx.job_queue.clone();
+        let outcome = apply_backpressure_step(step, &mut job_queue, |next_streak| Self {
+            id: id.clone(),
+            amount: self.amount,
+            revert_redrive_attempts: self.revert_redrive_attempts,
+            backpressure_streak: next_streak,
+        })
+        .await?;
+
+        if let Some(elapsed) = deadline_elapsed {
+            alert_withdrawal_poll_deadline_elapsed(&id, elapsed, &source, &ctx.notifier).await;
+        }
+
+        // Per the RAI-1494 plan's binding M2 decision: dead-letter instead of
+        // propagating `Err` into the shared supervised on-event path. The
+        // aggregate stays in Withdrawing (guard held); the pre-existing 4-hour
+        // alert deadline path (`handle_withdrawal_poll_inconclusive`) does not
+        // run on this bounded backpressure path, so this pages the operator
+        // directly instead (RAI-1494 pass 3) rather than staying silent until a
+        // manual restart is noticed, and pages once more when sustained
+        // backpressure crosses a deadline comparable to that same 4h alert.
+        log_and_alert_backpressure_outcome(
+            &id,
+            BackpressureSite::WithdrawalPoll {
+                deadline_elapsed: deadline_elapsed.is_some(),
+            },
+            self.backpressure_streak,
+            outcome,
+            &ctx.notifier,
+        )
+        .await;
+
+        Ok(())
+    }
+
     async fn handle_withdrawal_poll_inconclusive(
         &self,
         ctx: &TransferUsdcToMarketMakingCtx,
@@ -1298,26 +1646,20 @@ impl TransferUsdcToMarketMaking {
         );
 
         if let Some(elapsed) = alert_deadline_elapsed {
-            let message = format!(
-                "Alpaca->Base USDC transfer {id}: withdrawal polling inconclusive \
-                 for {elapsed:?} (>{WITHDRAWAL_POLL_ALERT_DEADLINE:?}). Alpaca may \
-                 be unreachable or credentials may have changed ({source}). Aggregate stays in \
-                 Withdrawing (guard held). Use `stox transfer resume --kind usdc --id \
-                 {id} --direction to-raindex` to manually re-poll, or investigate \
-                 Alpaca connectivity."
-            );
-            if let Err(notify_err) = ctx.notifier.notify(&message).await {
-                warn!(
-                    target: "rebalance",
-                    ?notify_err,
-                    "Failed to deliver withdrawal-poll-deadline-elapsed alert"
-                );
-            }
+            alert_withdrawal_poll_deadline_elapsed(&id, elapsed, &source, &ctx.notifier).await;
         }
 
+        // Reset backpressure_streak: this arm now only handles NON-backpressure
+        // inconclusive polls (a classified 429 is routed through the bounded
+        // backpressure machinery before reaching here), so any prior streak is
+        // unrelated to this redrive cause.
+        let updated = Self {
+            backpressure_streak: BackpressureStreak::default(),
+            ..self.clone()
+        };
         ctx.job_queue
             .clone()
-            .push_with_delay(self.clone(), redrive_delay)
+            .push_with_delay(updated, redrive_delay)
             .await?;
         Ok(())
     }
@@ -1441,6 +1783,7 @@ impl TransferUsdcToMarketMaking {
 
         let updated = Self {
             revert_redrive_attempts: next_attempts,
+            backpressure_streak: BackpressureStreak::default(),
             ..self.clone()
         };
         ctx.job_queue
@@ -1614,6 +1957,74 @@ mod tests {
             _amount: Usdc,
         ) -> Result<(), UsdcTransferError> {
             Err(UsdcTransferError::AttestationTimedOut { id: id.clone() })
+        }
+    }
+
+    fn wallet_429() -> UsdcTransferError {
+        UsdcTransferError::AlpacaWallet(AlpacaWalletError::ApiError {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            message: "rate limited".to_string(),
+            retry_after: Some(Duration::from_millis(1)),
+        })
+    }
+
+    fn wallet_500() -> UsdcTransferError {
+        UsdcTransferError::AlpacaWallet(AlpacaWalletError::ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: "boom".to_string(),
+            retry_after: None,
+        })
+    }
+
+    struct RateLimitedBaseToAlpaca;
+
+    #[async_trait]
+    impl ResumeBaseToAlpaca for RateLimitedBaseToAlpaca {
+        async fn resume_base_to_alpaca(
+            &self,
+            _id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(wallet_429())
+        }
+    }
+
+    struct RateLimitedAlpacaToBase;
+
+    #[async_trait]
+    impl ResumeAlpacaToBase for RateLimitedAlpacaToBase {
+        async fn resume_alpaca_to_base(
+            &self,
+            _id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(wallet_429())
+        }
+    }
+
+    struct FailingBaseToAlpaca;
+
+    #[async_trait]
+    impl ResumeBaseToAlpaca for FailingBaseToAlpaca {
+        async fn resume_base_to_alpaca(
+            &self,
+            _id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(wallet_500())
+        }
+    }
+
+    struct FailingAlpacaToBase;
+
+    #[async_trait]
+    impl ResumeAlpacaToBase for FailingAlpacaToBase {
+        async fn resume_alpaca_to_base(
+            &self,
+            _id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(wallet_500())
         }
     }
 
@@ -1827,6 +2238,49 @@ mod tests {
         }
     }
 
+    /// Withdrawal poll returning a CLASSIFIED broker rate-limit (429), unlike
+    /// [`InconclusiveAlpacaToBase`]'s unclassifiable timeout -- pins that a
+    /// 429 here routes through the bounded backpressure machinery
+    /// (RAI-1494), not the old unbounded `WITHDRAWAL_POLL_REDRIVE_DELAY` path.
+    struct RateLimitedWithdrawalPollAlpacaToBase {
+        initiated_at: DateTime<Utc>,
+    }
+
+    impl RateLimitedWithdrawalPollAlpacaToBase {
+        fn before_deadline() -> Self {
+            Self {
+                initiated_at: Utc::now(),
+            }
+        }
+
+        fn after_deadline() -> Self {
+            Self {
+                initiated_at: Utc::now()
+                    - chrono::Duration::from_std(WITHDRAWAL_POLL_ALERT_DEADLINE).unwrap()
+                    - chrono::Duration::seconds(1),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ResumeAlpacaToBase for RateLimitedWithdrawalPollAlpacaToBase {
+        async fn resume_alpaca_to_base(
+            &self,
+            id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(UsdcTransferError::WithdrawalPollInconclusive {
+                id: id.clone(),
+                initiated_at: self.initiated_at,
+                source: AlpacaWalletError::ApiError {
+                    status: StatusCode::TOO_MANY_REQUESTS,
+                    message: "rate limited".to_string(),
+                    retry_after: Some(Duration::from_millis(1)),
+                },
+            })
+        }
+    }
+
     async fn setup_queue_pool() -> apalis_sqlite::SqlitePool {
         setup_test_apalis_pool().await
     }
@@ -1864,6 +2318,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -1916,6 +2371,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -1968,6 +2424,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 3,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -2007,6 +2464,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -2038,6 +2496,300 @@ mod tests {
         );
     }
 
+    #[test]
+    fn transfer_usdc_to_hedging_payload_without_backpressure_streak_deserializes_to_zero() {
+        let payload = serde_json::json!({
+            "id": UsdcRebalanceId(Uuid::new_v4()),
+            "amount": Usdc::new(float!(100)),
+            "revert_redrive_attempts": 0,
+        });
+
+        let job: TransferUsdcToHedging = serde_json::from_value(payload).unwrap();
+        assert_eq!(job.backpressure_streak, BackpressureStreak::default());
+    }
+
+    #[tokio::test]
+    async fn hedging_job_429_reschedules_with_incremented_streak() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(RateLimitedBaseToAlpaca),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        // `revert_redrive_attempts` starts nonzero and distinct from
+        // `backpressure_streak` so a copy-paste swap of which counter
+        // receives which value at the `handle_terminal_or_backpressure_error`
+        // struct-literal construction site would fail this assertion instead
+        // of passing coincidentally (both fields would otherwise start at the
+        // same value, 0, and a swap would be invisible).
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 2,
+            backpressure_streak: BackpressureStreak::default(),
+        };
+
+        job.perform(&ctx).await.unwrap();
+
+        let (payload, _run_at) = pending_job_row::<TransferUsdcToHedging>(&pool).await;
+        let rescheduled: TransferUsdcToHedging = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(rescheduled.backpressure_streak, BackpressureStreak(1));
+        assert_eq!(
+            rescheduled.revert_redrive_attempts, 2,
+            "a backpressure reschedule must not touch the unrelated revert-redrive budget"
+        );
+        // RAI-1494 pass 3: a lone 429, far below BACKPRESSURE_ALERT_STREAK,
+        // must not page the operator.
+        assert!(
+            notifier.messages().is_empty(),
+            "a single 429 far below the alert streak must not fire an operator alert, got: {:?}",
+            notifier.messages()
+        );
+    }
+
+    #[tokio::test]
+    async fn hedging_job_429_past_reschedule_limit_dead_letters_without_propagating_err() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(RateLimitedBaseToAlpaca),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak(BACKPRESSURE_RESCHEDULE_LIMIT),
+        };
+
+        job.perform(&ctx).await.unwrap();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            0,
+            "an exhausted backpressure streak must dead-letter, not reschedule"
+        );
+        // RAI-1494 pass 3: dead-lettering after exhausting the reschedule
+        // budget must page the operator -- rerouting a 429 through this
+        // machinery must not silently drop the alerting a terminal failure
+        // used to always get.
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "dead-lettering a sustained 429 must page the operator exactly once, got: {:?}",
+            notifier.messages()
+        );
+    }
+
+    /// Sustained backpressure crossing `BACKPRESSURE_ALERT_STREAK` must page
+    /// the operator once, well before the full `BACKPRESSURE_RESCHEDULE_LIMIT`
+    /// dead-letter -- otherwise a sustained 429 silently degrades the
+    /// pre-existing paging SLA a terminal failure used to get on every
+    /// attempt (RAI-1494 pass 3).
+    #[tokio::test]
+    async fn hedging_job_429_crossing_alert_streak_pages_operator_once() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(RateLimitedBaseToAlpaca),
+            timeout: Duration::from_secs(3600),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak(BACKPRESSURE_ALERT_STREAK - 1),
+        };
+
+        job.perform(&ctx).await.unwrap();
+
+        let (payload, _run_at) = pending_job_row::<TransferUsdcToHedging>(&pool).await;
+        let rescheduled: TransferUsdcToHedging = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.backpressure_streak,
+            BackpressureStreak(BACKPRESSURE_ALERT_STREAK)
+        );
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "crossing BACKPRESSURE_ALERT_STREAK must page the operator exactly once, got: {:?}",
+            notifier.messages()
+        );
+    }
+
+    #[tokio::test]
+    async fn hedging_job_non_backpressure_error_still_fails_terminally() {
+        let pool = setup_queue_pool().await;
+        let ctx = hedging_ctx(Arc::new(FailingBaseToAlpaca), &pool);
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
+        };
+
+        let error = job.perform(&ctx).await.unwrap_err();
+        let TransferUsdcToHedgingJobError::Transfer(UsdcTransferError::AlpacaWallet(
+            AlpacaWalletError::ApiError { status, .. },
+        )) = error
+        else {
+            panic!("expected the non-backpressure error to propagate unchanged, got {error:?}");
+        };
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn transfer_usdc_to_market_making_payload_without_backpressure_streak_deserializes_to_zero() {
+        let payload = serde_json::json!({
+            "id": UsdcRebalanceId(Uuid::new_v4()),
+            "amount": Usdc::new(float!(100)),
+            "revert_redrive_attempts": 0,
+        });
+
+        let job: TransferUsdcToMarketMaking = serde_json::from_value(payload).unwrap();
+        assert_eq!(job.backpressure_streak, BackpressureStreak::default());
+    }
+
+    #[tokio::test]
+    async fn market_making_job_429_reschedules_with_incremented_streak() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(RateLimitedAlpacaToBase),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        // See the hedging-direction sibling test: a nonzero, distinct
+        // `revert_redrive_attempts` closes the swap-risk gap between the two
+        // same-typed counters (RAI-1494 review finding).
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 3,
+            backpressure_streak: BackpressureStreak::default(),
+        };
+
+        job.perform(&ctx).await.unwrap();
+
+        let (payload, _run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        let rescheduled: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(rescheduled.backpressure_streak, BackpressureStreak(1));
+        assert_eq!(
+            rescheduled.revert_redrive_attempts, 3,
+            "a backpressure reschedule must not touch the unrelated revert-redrive budget"
+        );
+        // RAI-1494 pass 3: a lone 429, far below BACKPRESSURE_ALERT_STREAK,
+        // must not page the operator.
+        assert!(
+            notifier.messages().is_empty(),
+            "a single 429 far below the alert streak must not fire an operator alert, got: {:?}",
+            notifier.messages()
+        );
+    }
+
+    #[tokio::test]
+    async fn market_making_job_429_past_reschedule_limit_dead_letters_without_propagating_err() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(RateLimitedAlpacaToBase),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak(BACKPRESSURE_RESCHEDULE_LIMIT),
+        };
+
+        job.perform(&ctx).await.unwrap();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            0,
+            "an exhausted backpressure streak must dead-letter, not reschedule"
+        );
+        // RAI-1494 pass 3: dead-lettering after exhausting the reschedule
+        // budget must page the operator -- rerouting a 429 through this
+        // machinery must not silently drop the alerting a terminal failure
+        // used to always get.
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "dead-lettering a sustained 429 must page the operator exactly once, got: {:?}",
+            notifier.messages()
+        );
+    }
+
+    /// Sustained backpressure crossing `BACKPRESSURE_ALERT_STREAK` must page
+    /// the operator once, well before the full `BACKPRESSURE_RESCHEDULE_LIMIT`
+    /// dead-letter (RAI-1494 pass 3), mirroring the hedging-direction sibling.
+    #[tokio::test]
+    async fn market_making_job_429_crossing_alert_streak_pages_operator_once() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(RateLimitedAlpacaToBase),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak(BACKPRESSURE_ALERT_STREAK - 1),
+        };
+
+        job.perform(&ctx).await.unwrap();
+
+        let (payload, _run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        let rescheduled: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.backpressure_streak,
+            BackpressureStreak(BACKPRESSURE_ALERT_STREAK)
+        );
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "crossing BACKPRESSURE_ALERT_STREAK must page the operator exactly once, got: {:?}",
+            notifier.messages()
+        );
+    }
+
+    #[tokio::test]
+    async fn market_making_job_non_backpressure_error_still_fails_terminally() {
+        let pool = setup_queue_pool().await;
+        let ctx = market_making_ctx(Arc::new(FailingAlpacaToBase), &pool);
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
+        };
+
+        let error = job.perform(&ctx).await.unwrap_err();
+        let TransferUsdcToMarketMakingJobError::Transfer(UsdcTransferError::AlpacaWallet(
+            AlpacaWalletError::ApiError { status, .. },
+        )) = error
+        else {
+            panic!("expected the non-backpressure error to propagate unchanged, got {error:?}");
+        };
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
     /// `WithdrawalPollInconclusive` before the alert deadline must schedule a
     /// delayed redrive (one Pending job row with `WITHDRAWAL_POLL_REDRIVE_DELAY`) and
     /// return `Ok` so the apalis retry budget is not consumed -- warn log only,
@@ -2053,10 +2805,16 @@ mod tests {
             max_burn_revert_redrives: 5,
             notifier: notifier.clone(),
         };
+        // `backpressure_streak` starts nonzero: this non-429 inconclusive
+        // poll error routes through `handle_withdrawal_poll_inconclusive`
+        // (not the backpressure branch), which must reset the streak since
+        // it is now unrelated (RAI-1494 review finding: closes the
+        // swap-risk gap between the two same-typed counters).
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak(4),
         };
 
         let before = Utc::now().timestamp();
@@ -2101,6 +2859,193 @@ mod tests {
             "WithdrawalPollInconclusive must not increment revert_redrive_attempts: \
              the re-poll redrive is unbounded and independent of the burn-revert budget"
         );
+        assert_eq!(
+            rescheduled.backpressure_streak,
+            BackpressureStreak::default(),
+            "a non-429 inconclusive poll redrive is unrelated to backpressure and must \
+             reset the streak"
+        );
+    }
+
+    /// A classified 429 on the withdrawal poll (unlike the plain-timeout
+    /// `InconclusiveAlpacaToBase` case above) must route through the bounded
+    /// backpressure machinery (RAI-1494): increment `backpressure_streak`
+    /// and use `decide_backpressure`'s delay, not the old unbounded
+    /// `WITHDRAWAL_POLL_REDRIVE_DELAY` redrive.
+    #[tokio::test]
+    async fn market_making_job_withdrawal_poll_429_reschedules_through_backpressure_machinery() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(RateLimitedWithdrawalPollAlpacaToBase::before_deadline()),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
+        };
+
+        // `RateLimitedWithdrawalPollAlpacaToBase` returns `retry_after:
+        // Some(Duration::from_millis(1))`, which `decide_backpressure`
+        // deterministically floors to exactly `MIN_BACKPRESSURE_DELAY` (1s) --
+        // captured before the call so the assertion below can pin an exact
+        // window, not just a one-sided upper bound that would also pass for
+        // an unintended zero-delay reschedule.
+        let before_now = Utc::now().timestamp();
+
+        job.perform(&ctx).await.unwrap();
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        let rescheduled: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.backpressure_streak,
+            BackpressureStreak(1),
+            "a classified 429 on the withdrawal poll must route through the bounded \
+             backpressure machinery (incrementing the streak), not the old unbounded \
+             inconclusive redrive"
+        );
+        assert!(
+            notifier.messages().is_empty(),
+            "a single 429 below the reschedule limit must not fire an operator alert, got: {:?}",
+            notifier.messages()
+        );
+        // `decide_backpressure` floors the delay at MIN_BACKPRESSURE_DELAY (1s),
+        // far below the old unbounded WITHDRAWAL_POLL_REDRIVE_DELAY (30s) --
+        // pin the exact expected window (not just "somewhere under 30s") so a
+        // regression to a different delay computation would fail this test.
+        assert!(
+            (before_now + 1..before_now + 3).contains(&run_at),
+            "a classified 429 must use the deterministic MIN_BACKPRESSURE_DELAY (1s) \
+             floor, not the old {WITHDRAWAL_POLL_REDRIVE_DELAY:?} unbounded redrive \
+             delay or any other value; got run_at={run_at}, before_now={before_now}"
+        );
+    }
+
+    /// Once the withdrawal-poll 429 streak exhausts `BACKPRESSURE_RESCHEDULE_LIMIT`,
+    /// the job must dead-letter (loud log, `Ok(())`) instead of rescheduling
+    /// again or propagating `Err` -- symmetric with every other backpressure
+    /// call site.
+    #[tokio::test]
+    async fn market_making_job_withdrawal_poll_429_past_reschedule_limit_dead_letters_without_propagating_err()
+     {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(RateLimitedWithdrawalPollAlpacaToBase::before_deadline()),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak(BACKPRESSURE_RESCHEDULE_LIMIT),
+        };
+
+        job.perform(&ctx).await.unwrap();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            0,
+            "an exhausted backpressure streak on the withdrawal poll must dead-letter, \
+             not reschedule"
+        );
+        // RAI-1494 pass 3: dead-lettering the withdrawal-poll backpressure path
+        // must page the operator directly -- the pre-existing 4h
+        // `handle_withdrawal_poll_inconclusive` alert path does not run here,
+        // so this arm must not silently drop paging altogether.
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "dead-lettering a sustained withdrawal-poll 429 must page the operator \
+             exactly once, got: {:?}",
+            notifier.messages()
+        );
+    }
+
+    /// Sustained withdrawal-poll backpressure crossing `BACKPRESSURE_ALERT_STREAK`
+    /// must page the operator once, well before the full
+    /// `BACKPRESSURE_RESCHEDULE_LIMIT` dead-letter (RAI-1494 pass 3) --
+    /// otherwise the bounded backpressure path silently degrades the
+    /// pre-existing 4h withdrawal-poll paging SLA to ~8-42h.
+    #[tokio::test]
+    async fn market_making_job_withdrawal_poll_429_crossing_alert_streak_pages_operator_once() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(RateLimitedWithdrawalPollAlpacaToBase::before_deadline()),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak(BACKPRESSURE_ALERT_STREAK - 1),
+        };
+
+        job.perform(&ctx).await.unwrap();
+
+        let (payload, _run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        let rescheduled: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.backpressure_streak,
+            BackpressureStreak(BACKPRESSURE_ALERT_STREAK)
+        );
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "crossing BACKPRESSURE_ALERT_STREAK on the withdrawal poll must page the \
+             operator exactly once, got: {:?}",
+            notifier.messages()
+        );
+    }
+
+    #[tokio::test]
+    async fn market_making_job_withdrawal_poll_429_preserves_wall_clock_alert_and_cadence() {
+        let pool = setup_queue_pool().await;
+        let notifier = Arc::new(CapturingNotifier::default());
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(RateLimitedWithdrawalPollAlpacaToBase::after_deadline()),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
+            max_burn_revert_redrives: 5,
+            notifier: notifier.clone(),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+            revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak(BACKPRESSURE_ALERT_STREAK - 1),
+        };
+        let before_now = Utc::now().timestamp();
+
+        job.perform(&ctx).await.unwrap();
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        let rescheduled: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.backpressure_streak,
+            BackpressureStreak(BACKPRESSURE_ALERT_STREAK)
+        );
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "the wall-clock page must replace, not duplicate, the streak-threshold page"
+        );
+
+        let expected_delay =
+            i64::try_from(WITHDRAWAL_POLL_POST_DEADLINE_REDRIVE_DELAY.as_secs()).unwrap();
+        assert!(
+            (before_now + expected_delay..before_now + expected_delay + 2).contains(&run_at),
+            "post-deadline backpressure must preserve the 30-minute alert cadence; \
+             got run_at={run_at}, before_now={before_now}"
+        );
     }
 
     /// A future `initiated_at` can happen after clock skew on restart. The
@@ -2120,6 +3065,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -2170,6 +3116,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // perform must still return Ok: deadline-elapsed does NOT consume the
@@ -2243,6 +3190,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // perform must return Ok even at the exact boundary.
@@ -2300,6 +3248,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -2357,6 +3306,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -2443,6 +3393,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -2496,6 +3447,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -2561,6 +3513,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)
@@ -2585,6 +3538,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx).await.expect(
@@ -2609,6 +3563,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)
@@ -2633,6 +3588,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx).await.expect(
@@ -2657,6 +3613,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)
@@ -2694,6 +3651,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap_or_else(|error| {
@@ -2743,6 +3701,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap_or_else(|error| {
@@ -2908,6 +3867,7 @@ mod tests {
             id: id.clone(),
             amount,
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap();
@@ -2934,6 +3894,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap();
@@ -2953,6 +3914,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -3055,6 +4017,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -3098,6 +4061,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -3159,6 +4123,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -3233,6 +4198,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -3295,6 +4261,7 @@ mod tests {
                     id: id.clone(),
                     amount,
                     revert_redrive_attempts: 0,
+                    backpressure_streak: BackpressureStreak::default(),
                 })
                 .await
                 .expect_err("push to a closed pool must fail");
@@ -3321,6 +4288,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -3371,6 +4339,7 @@ mod tests {
                     id: id.clone(),
                     amount,
                     revert_redrive_attempts: 0,
+                    backpressure_streak: BackpressureStreak::default(),
                 })
                 .await
                 .expect_err("push to a closed pool must fail");
@@ -3399,6 +4368,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let before = Utc::now().timestamp();
@@ -3471,6 +4441,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // A failing notifier must not prevent the redrive from being enqueued
@@ -3534,10 +4505,16 @@ mod tests {
     async fn hedging_job_redrives_burn_revert_first_attempt() {
         let pool = setup_queue_pool().await;
         let ctx = hedging_ctx(Arc::new(BurnRevertResume), &pool);
+        // `backpressure_streak` starts nonzero (a prior 429 streak that this
+        // unrelated burn-revert redrive must clear) so a copy-paste swap of
+        // which counter gets reset vs incremented at this struct-literal
+        // construction site would fail the assertion below instead of
+        // passing coincidentally (RAI-1494 review finding).
         let job = TransferUsdcToHedging {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak(4),
         };
 
         let before = Utc::now().timestamp();
@@ -3564,6 +4541,11 @@ mod tests {
             rescheduled.revert_redrive_attempts, 1,
             "revert_redrive_attempts must be incremented to 1 in the redrive payload"
         );
+        assert_eq!(
+            rescheduled.backpressure_streak,
+            BackpressureStreak::default(),
+            "a burn-revert redrive is unrelated to backpressure and must reset the streak"
+        );
         assert!(
             run_at >= before + i64::try_from(BURN_REVERT_REDRIVE_DELAY.as_secs()).unwrap() - 5
                 && run_at
@@ -3589,6 +4571,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 3,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -3618,6 +4601,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -3650,6 +4634,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap_err();
@@ -3686,6 +4671,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 2,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap();
@@ -3732,6 +4718,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 2,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Returns Ok (last redrive enqueued), NOT Err
@@ -3777,6 +4764,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 3,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -3819,6 +4807,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap();
@@ -3860,6 +4849,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 1,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap();
@@ -3896,6 +4886,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 2,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Returns Ok (last redrive enqueued), NOT Err
@@ -3941,6 +4932,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 3,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -3982,6 +4974,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 2,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap();
@@ -4030,10 +5023,14 @@ mod tests {
     async fn market_making_job_redrives_burn_revert_first_attempt() {
         let pool = setup_queue_pool().await;
         let ctx = market_making_ctx(Arc::new(BurnRevertAlpacaToBase), &pool);
+        // See the hedging-direction sibling test: a nonzero starting
+        // `backpressure_streak` closes the swap-risk gap between the two
+        // same-typed counters (RAI-1494 review finding).
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak(4),
         };
 
         let before = Utc::now().timestamp();
@@ -4060,6 +5057,11 @@ mod tests {
             rescheduled.revert_redrive_attempts, 1,
             "revert_redrive_attempts must be incremented to 1 in the redrive payload"
         );
+        assert_eq!(
+            rescheduled.backpressure_streak,
+            BackpressureStreak::default(),
+            "a burn-revert redrive is unrelated to backpressure and must reset the streak"
+        );
         assert!(
             run_at >= before + i64::try_from(BURN_REVERT_REDRIVE_DELAY.as_secs()).unwrap() - 5
                 && run_at
@@ -4084,6 +5086,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 3,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -4120,6 +5123,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 2,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap();
@@ -4164,6 +5168,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 2,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Returns Ok (last redrive enqueued), NOT Err
@@ -4208,6 +5213,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 3,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -4261,6 +5267,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         Job::perform(&job, &ctx).await.unwrap_err();
@@ -4295,6 +5302,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)
@@ -4329,6 +5337,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)
@@ -4388,6 +5397,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Must error (terminal), not Ok (redrive)
@@ -4448,6 +5458,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = Job::perform(&job, &ctx).await.unwrap_err();
@@ -4489,6 +5500,7 @@ mod tests {
             id: UsdcRebalanceId(Uuid::new_v4()),
             amount: Usdc::new(float!(100)),
             revert_redrive_attempts: 0,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -641,6 +641,20 @@ impl<
         {
             Ok(order) => order,
             Err(error) => {
+                // Conversion placement fails fast on ANY error (RAI-1494:
+                // deliberately NOT rescheduled, unlike the deposit/withdrawal
+                // polls) -- retrying a placement risks submitting the order
+                // twice against real money. A classified 429 must not reach
+                // the job's backpressure classifier though:
+                // `find_backpressure` walks the `.source()` chain, so
+                // returning `AlpacaBrokerApi` here would let it downcast into
+                // the underlying 429 and mistakenly reschedule an
+                // already-terminalized aggregate. Return the
+                // non-classifiable `ConversionPlacementFailed` only for that
+                // case; every other placement failure (e.g. a terminally
+                // rejected/canceled/expired order) keeps surfacing the
+                // original `AlpacaBrokerApi` variant so its specific reason
+                // is preserved for callers/tests that match on it.
                 warn!(target: "rebalance", "USD to USDC conversion failed: {error}");
                 self.cqrs
                     .send(
@@ -650,6 +664,9 @@ impl<
                         },
                     )
                     .await?;
+                if error.backpressure().is_some() {
+                    return Err(UsdcTransferError::ConversionPlacementFailed { id: id.clone() });
+                }
                 return Err(UsdcTransferError::AlpacaBrokerApi(error));
             }
         };
@@ -726,6 +743,11 @@ impl<
         {
             Ok(order) => order,
             Err(error) => {
+                // Conversion placement fails fast on ANY error (RAI-1494):
+                // same rationale as `execute_usd_to_usdc_conversion` above --
+                // only a classified 429 returns the non-classifiable
+                // `ConversionPlacementFailed`; every other placement failure
+                // keeps surfacing the original `AlpacaBrokerApi` variant.
                 warn!(target: "rebalance", "USDC to USD conversion failed: {error}");
                 self.cqrs
                     .send(
@@ -735,6 +757,9 @@ impl<
                         },
                     )
                     .await?;
+                if error.backpressure().is_some() {
+                    return Err(UsdcTransferError::ConversionPlacementFailed { id: id.clone() });
+                }
                 return Err(UsdcTransferError::AlpacaBrokerApi(error));
             }
         };
@@ -800,6 +825,11 @@ impl<
                 direction: AlpacaToBase,
                 ..
             }) => {
+                // Conversion placement fails fast unconditionally (RAI-1494:
+                // see `execute_usd_to_usdc_conversion`), so the aggregate
+                // never survives an error in `Converting` -- reaching this
+                // arm means a crash occurred between `InitiateConversion` and
+                // the terminal Fail/Confirm. Fails for manual reconciliation.
                 self.cqrs
                     .send(
                         id,
@@ -3973,6 +4003,25 @@ impl<
         let transfer = match self.alpaca_wallet.poll_deposit_by_tx_hash(&send_tx).await {
             Ok(transfer) => transfer,
             Err(error) => {
+                // Classify BEFORE emitting FailDeposit (RAI-1494): a broker
+                // rate-limit (429) is not a determinate "deposit failed"
+                // signal, only a transient throttle on the polling request
+                // itself. Leave the aggregate in DepositInitiated so the
+                // job's backpressure reschedule can re-poll the same send_tx
+                // once the delay elapses, mirroring
+                // `poll_and_confirm_withdrawal`'s conservative fail-closed
+                // pattern for indeterminate poll errors.
+                if error.backpressure().is_some() {
+                    warn!(
+                        target: "rebalance",
+                        %error,
+                        "Alpaca deposit polling hit broker rate-limiting; keeping \
+                         DepositInitiated state for delayed reschedule (will re-poll \
+                         the same send_tx)"
+                    );
+                    return Err(UsdcTransferError::AlpacaWallet(error));
+                }
+
                 warn!(target: "rebalance", "Alpaca deposit polling failed: {error}");
                 self.cqrs
                     .send(
@@ -5956,6 +6005,172 @@ mod tests {
         );
     }
 
+    /// RAI-1494 (quarantined): a classified broker rate-limit (429) on the
+    /// conversion placement fails FAST, exactly like any other placement
+    /// error -- `FailConversion` fires and the aggregate terminalizes to
+    /// `ConversionFailed`, never staying in `Converting`. Retrying a
+    /// conversion placement risks submitting the order twice against real
+    /// money, so this leg intentionally does not participate in the
+    /// reschedule/backpressure machinery the deposit and withdrawal legs use.
+    /// Sibling of `test_usd_to_usdc_conversion_emits_fail_conversion_on_api_error`
+    /// (a non-429 API error), which already asserted this same fail-fast
+    /// shape -- this pins that a 429 gets no special treatment either.
+    #[tokio::test]
+    async fn test_usd_to_usdc_conversion_429_fails_fast_to_conversion_failed() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let order_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("Retry-After", "5")
+                .json_body(json!({ "message": "rate limited" }));
+        });
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1000");
+
+        let error = manager
+            .execute_usd_to_usdc_conversion(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                &error,
+                UsdcTransferError::ConversionPlacementFailed { id: errored }
+                    if *errored == id
+            ),
+            "expected ConversionPlacementFailed (not a source-preserving \
+             AlpacaBrokerApi wrapper), got: {error:?}"
+        );
+
+        // CRITICAL contract: the job's backpressure classifier must not be
+        // able to downcast into this error, or an already-terminalized
+        // ConversionFailed aggregate would get rescheduled.
+        assert_eq!(
+            crate::conductor::job::find_backpressure(&error),
+            None,
+            "a conversion placement failure must never classify as \
+             backpressure at the job level, even when caused by a 429"
+        );
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::ConversionFailed { .. }),
+            "a 429 on conversion placement must fail fast to ConversionFailed \
+             (not stay Converting); got: {state:?}"
+        );
+        assert_eq!(
+            order_mock.calls(),
+            1,
+            "the order must be placed exactly once"
+        );
+    }
+
+    /// RAI-1494 (quarantined): proves the fail-fast conversion path is safe
+    /// even if something external re-drives the transfer after a placement
+    /// 429 -- `resume_alpaca_to_base` must see the aggregate already
+    /// terminalized (`ConversionFailed`) and refuse to redrive rather than
+    /// re-placing the order, since a placement 429 no longer leaves the
+    /// aggregate in a resumable `Converting` state.
+    #[tokio::test]
+    async fn test_usd_to_usdc_conversion_429_resume_does_not_reattempt_placement() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let order_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("Retry-After", "5")
+                .json_body(json!({ "message": "rate limited" }));
+        });
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1000");
+
+        manager
+            .execute_usd_to_usdc_conversion(&id, amount)
+            .await
+            .unwrap_err();
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::ConversionFailed { .. }),
+            "expected ConversionFailed after the 429, got {state:?}"
+        );
+
+        let resume_error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                &resume_error,
+                UsdcTransferError::PreviouslyFailedAggregate { id: errored }
+                    if *errored == id
+            ),
+            "resuming a fail-fast-terminated conversion must surface \
+             PreviouslyFailedAggregate, not redrive placement; got: {resume_error:?}"
+        );
+        assert_eq!(
+            order_mock.calls(),
+            1,
+            "resume must NOT place a second conversion order"
+        );
+    }
+
     /// AlpacaToBase workflow MUST call USD-to-USDC conversion before
     /// withdrawal.
     ///
@@ -6615,6 +6830,170 @@ mod tests {
             proceeds,
             usdc("998.3"),
             "Should return actual USD proceeds, not the USDC sold amount"
+        );
+    }
+
+    /// RAI-1494 (quarantined): a classified broker rate-limit (429) on the
+    /// post-deposit USDC->USD conversion placement fails FAST, same rationale
+    /// and shape as
+    /// `test_usd_to_usdc_conversion_429_fails_fast_to_conversion_failed`.
+    #[tokio::test]
+    async fn usdc_to_usd_conversion_429_fails_fast_to_conversion_failed() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let rebalance_amount = usdc("1000");
+        let deposited_amount = usdc("1000");
+
+        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, rebalance_amount, deposited_amount)
+            .await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let order_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("Retry-After", "5")
+                .json_body(json!({ "message": "rate limited" }));
+        });
+
+        let error = manager
+            .execute_usdc_to_usd_conversion(&id, deposited_amount)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                &error,
+                UsdcTransferError::ConversionPlacementFailed { id: errored }
+                    if *errored == id
+            ),
+            "expected ConversionPlacementFailed (not a source-preserving \
+             AlpacaBrokerApi wrapper), got: {error:?}"
+        );
+
+        // CRITICAL contract: the job's backpressure classifier must not be
+        // able to downcast into this error.
+        assert_eq!(
+            crate::conductor::job::find_backpressure(&error),
+            None,
+            "a conversion placement failure must never classify as \
+             backpressure at the job level, even when caused by a 429"
+        );
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::ConversionFailed { .. }),
+            "a 429 on conversion placement must fail fast to ConversionFailed \
+             (not stay Converting); got: {state:?}"
+        );
+        assert_eq!(
+            order_mock.calls(),
+            1,
+            "the order must be placed exactly once"
+        );
+    }
+
+    /// RAI-1494 (quarantined): mirrors
+    /// `test_usd_to_usdc_conversion_429_resume_does_not_reattempt_placement`
+    /// for the BaseToAlpaca post-deposit leg -- `resume_base_to_alpaca` must
+    /// see the aggregate already terminalized (`ConversionFailed`) and refuse
+    /// to redrive rather than re-placing the order.
+    #[tokio::test]
+    async fn usdc_to_usd_conversion_429_resume_does_not_reattempt_placement() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let rebalance_amount = usdc("1000");
+        let deposited_amount = usdc("1000");
+
+        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, rebalance_amount, deposited_amount)
+            .await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let order_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("Retry-After", "5")
+                .json_body(json!({ "message": "rate limited" }));
+        });
+
+        manager
+            .execute_usdc_to_usd_conversion(&id, deposited_amount)
+            .await
+            .unwrap_err();
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::ConversionFailed { .. }),
+            "expected ConversionFailed after the 429, got {state:?}"
+        );
+
+        let resume_error = manager
+            .resume_base_to_alpaca(&id, rebalance_amount)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                &resume_error,
+                UsdcTransferError::PreviouslyFailedAggregate { id: errored }
+                    if *errored == id
+            ),
+            "resuming a fail-fast-terminated conversion must surface \
+             PreviouslyFailedAggregate, not redrive placement; got: {resume_error:?}"
+        );
+        assert_eq!(
+            order_mock.calls(),
+            1,
+            "resume must NOT place a second conversion order"
         );
     }
 
@@ -8096,6 +8475,66 @@ mod tests {
         assert!(
             matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
             "Expected ConversionComplete after resume from DepositInitiated, got: {final_state:?}"
+        );
+    }
+
+    /// RAI-1494: a classified broker rate-limit (429) on the deposit poll
+    /// must NOT emit `FailDeposit` -- the aggregate stays in
+    /// `DepositInitiated` so the job's backpressure reschedule can re-poll
+    /// the same `send_tx`. Sibling of
+    /// `resume_base_to_alpaca_from_deposit_initiated_polls_and_converts`
+    /// (the happy path), with the transfers-poll mocked to 429 instead of a
+    /// successful `COMPLETE` transfer.
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_deposit_initiated_429_keeps_deposit_initiated_state() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let (_burn_tx, mint_tx) =
+            advance_to_bridged_base_to_alpaca(&cqrs, &id, amount, amount_received).await;
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateDeposit {
+                deposit: TransferRef::OnchainTx(mint_tx),
+            },
+        )
+        .await
+        .unwrap();
+
+        let _transfers_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("Retry-After", "5")
+                .json_body(json!({ "message": "rate limited" }));
+        });
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::AlpacaWallet(AlpacaWalletError::ApiError {
+                    status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                    ..
+                })
+            ),
+            "expected a classified 429 to surface unchanged, got: {error:?}"
+        );
+
+        let final_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(final_state, UsdcRebalance::DepositInitiated { .. }),
+            "a classified 429 must leave the aggregate in DepositInitiated (not \
+             DepositFailed) so a backpressure reschedule can re-poll the same send_tx; \
+             got: {final_state:?}"
         );
     }
 

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -114,6 +114,27 @@ pub(crate) enum UsdcTransferError {
          operator reconciliation"
     )]
     ResumeIndeterminateConversion { id: UsdcRebalanceId },
+    /// A USDC conversion order placement (`convert_usdc_usd`) failed with a
+    /// classified broker rate-limit (429). Conversion placement fails fast
+    /// unconditionally on ANY error -- `FailConversion` has already been sent
+    /// (recorded in the event's `reason`) by the time this is returned --
+    /// but a 429 specifically must not surface as `AlpacaBrokerApi` (which
+    /// would keep the underlying error as a downcastable `#[source]`): the
+    /// job's backpressure classifier (`find_backpressure`, which walks the
+    /// `.source()` chain) would then reschedule an already-terminalized
+    /// aggregate instead of treating this as the terminal failure it is.
+    /// Retrying a conversion placement risks submitting the order twice
+    /// against real money, so this variant deliberately carries no
+    /// `#[source]`. Every other placement failure (a non-429 broker error, a
+    /// terminally rejected/canceled/expired order, ...) keeps surfacing the
+    /// original `AlpacaBrokerApi` variant instead, since `find_backpressure`
+    /// already classifies those as non-backpressure and preserving the
+    /// specific failure reason is useful for operators and callers.
+    #[error(
+        "USDC rebalance {id} conversion order placement failed; recorded as \
+         ConversionFailed for operator reconciliation (not retriable)"
+    )]
+    ConversionPlacementFailed { id: UsdcRebalanceId },
     #[error(
         "USDC rebalance {id} cannot resume from Attested state: no mint scan \
          bound was captured (pre-resume-hardening event); manual reconciliation \
@@ -350,6 +371,7 @@ impl BotGasFailureClassifier for UsdcTransferError {
             | Self::WithdrawalFailed { .. }
             | Self::DepositFailed { .. }
             | Self::UsdcConversion(_)
+            | Self::ConversionPlacementFailed { .. }
             | Self::Float(_)
             | Self::InvalidShares(_)
             | Self::NotPositive(_)

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -22,7 +22,10 @@ use st0x_execution::{
     Positive, PostCloseGap, SupportedExecutor, Symbol, Usd,
 };
 
-use crate::conductor::job::{Job, JobQueue, Label};
+use crate::conductor::job::{
+    BACKPRESSURE_RESCHEDULE_LIMIT, BackpressureOutcome, BackpressureStreak, Job, JobQueue, Label,
+    advance_backpressure, apply_backpressure_step, find_backpressure,
+};
 #[cfg(test)]
 use crate::offchain::order::PollOrderStatus;
 use crate::offchain::order::{
@@ -106,6 +109,11 @@ pub(crate) struct HedgeCtx {
     /// `OffchainOrder::Place` handler.
     pub(crate) order_placer: Arc<dyn OrderPlacer>,
     pub(crate) poll_status_queue: PollOrderStatusJobQueue,
+    /// This job's own queue, so a classified broker rate-limit (429) can
+    /// reschedule itself (RAI-1494) instead of consuming the terminal retry
+    /// budget. Previously missing -- `HedgeCtx` held `poll_status_queue` for
+    /// `recover_pending_poll_status` but no handle to its own job type.
+    pub(crate) hedge_queue: HedgeJobQueue,
     /// Per-symbol asset config. Gates the extended-hours limit path: only a
     /// symbol with `extended_hours_counter_trading = enabled` may place a limit
     /// order during an Extended session. A disabled symbol skips (the
@@ -155,6 +163,20 @@ pub(crate) struct PlaceHedge {
     /// live session before selecting the broker order kind.
     #[serde(default = "default_market_session")]
     pub(crate) market_session: MarketSession,
+    /// Count of consecutive broker rate-limit (429) reschedules leading up to
+    /// this attempt (RAI-1494). `#[serde(default)]` so a row enqueued under
+    /// the pre-this-change payload shape still deserializes to `0` instead of
+    /// crashing the poll stream's `sqlx::Decode`.
+    ///
+    /// A 429 before the position claim (for example, during the
+    /// extended-hours price lookup) simply retries that read. A 429 from the
+    /// broker placement happens after the position claim, but the durable
+    /// offchain order remains `Pending`; the successor hits
+    /// `PositionError::PendingExecution`, enters
+    /// `recover_pending_poll_status`, and safely re-drives the placement with
+    /// the same deterministic broker `client_order_id`.
+    #[serde(default)]
+    pub(crate) backpressure_streak: BackpressureStreak,
 }
 
 fn default_market_session() -> MarketSession {
@@ -602,6 +624,15 @@ impl Job<HedgeCtx> for PlaceHedge {
     }
 
     async fn perform(&self, ctx: &HedgeCtx) -> Result<Self::Output, Self::Error> {
+        match self.perform_body(ctx).await {
+            Ok(output) => Ok(output),
+            Err(error) => self.handle_place_hedge_error(ctx, error).await,
+        }
+    }
+}
+
+impl PlaceHedge {
+    async fn perform_body(&self, ctx: &HedgeCtx) -> Result<(), TradeAccountingError> {
         // Residual TOCTOU: the session read, the limit-price fetch, and the
         // broker submission are three separate awaits, so the venue clock can
         // cross a 9:30/16:00 boundary between them. This is inherent (the clock
@@ -734,17 +765,90 @@ impl Job<HedgeCtx> for PlaceHedge {
 
         route_placement_outcome(ctx, &self.symbol, self.offchain_order_id, placed).await
     }
+
+    /// Handles a `perform_body` failure: reschedules with a classified delay
+    /// on broker rate-limiting (429) instead of consuming the terminal retry
+    /// budget, or propagates any other error through the normal, unmodified
+    /// retry/circuit-breaker path.
+    ///
+    /// `PositionCommand::PlaceOffChainOrder` claims the position before the
+    /// broker call. A rescheduled successor therefore enters
+    /// `recover_pending_poll_status`; when the 429 came from placement, the
+    /// offchain order is still `Pending` and that recovery safely re-drives
+    /// the idempotent broker call. A 429 before the claim commits (e.g. during
+    /// the extended-hours price lookup) is likewise safe to reschedule.
+    async fn handle_place_hedge_error(
+        &self,
+        ctx: &HedgeCtx,
+        error: TradeAccountingError,
+    ) -> Result<(), TradeAccountingError> {
+        let Some(backpressure) = find_backpressure(&error) else {
+            return Err(error);
+        };
+
+        let step = advance_backpressure(&backpressure, self.backpressure_streak);
+        let mut queue = ctx.hedge_queue.clone();
+        let outcome = apply_backpressure_step(step, &mut queue, |next_streak| Self {
+            symbol: self.symbol.clone(),
+            direction: self.direction,
+            shares: self.shares,
+            executor: self.executor,
+            threshold: self.threshold,
+            offchain_order_id: self.offchain_order_id,
+            market_session: self.market_session,
+            backpressure_streak: next_streak,
+        })
+        .await?;
+
+        match outcome {
+            BackpressureOutcome::DeadLettered => {
+                // Per the RAI-1494 plan's binding M2 decision (applied uniformly
+                // to every supervised job): dead-letter instead of propagating
+                // `Err` into the shared supervised on-event path.
+                let BackpressureStreak(streak) = self.backpressure_streak;
+                error!(
+                    target: "hedge",
+                    symbol = %self.symbol,
+                    offchain_order_id = %self.offchain_order_id,
+                    streak,
+                    limit = BACKPRESSURE_RESCHEDULE_LIMIT,
+                    "PlaceHedge: broker rate-limiting exceeded the reschedule budget; \
+                     dead-lettering this hedge instead of opening the circuit breaker \
+                     -- treat as a structurally-dead Alpaca integration needing manual \
+                     reconciliation"
+                );
+            }
+            BackpressureOutcome::Rescheduled {
+                next_streak: BackpressureStreak(streak),
+                visible,
+            } => {
+                if visible {
+                    error!(
+                        target: "hedge",
+                        symbol = %self.symbol,
+                        offchain_order_id = %self.offchain_order_id,
+                        streak,
+                        "PlaceHedge: still rescheduling after sustained broker rate-limiting"
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::any::type_name;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex as StdMutex};
+
     use alloy::primitives::{Address, TxHash};
     use proptest::prelude::*;
-    use std::any::type_name;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use uuid::Uuid;
 
+    use st0x_config::{EquitiesConfig, EquityAssetConfig, ExecutionThreshold, OperationMode};
     use st0x_event_sorcery::StoreBuilder;
     use st0x_execution::{
         ClientOrderId, Direction, ExecutorOrderId, FractionalShares, Positive, SupportedExecutor,
@@ -760,7 +864,6 @@ mod tests {
     };
     use crate::position::{Position, PositionCommand, TradeId};
     use crate::test_utils::TEST_POLL_INTERVAL;
-    use st0x_config::{EquitiesConfig, EquityAssetConfig, ExecutionThreshold, OperationMode};
 
     /// Builds an [`AssetsConfig`] with a single equity whose extended-hours
     /// counter-trading flag is set as given. Used to drive the per-symbol
@@ -900,6 +1003,7 @@ mod tests {
             position: position.clone(),
             offchain_order,
             poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
+            hedge_queue: HedgeJobQueue::new(&apalis_pool),
             // The placer doubles as the session source; the default stubs
             // report a Regular session, so these ctxs exercise the regular
             // market-order path. AAPL is enabled for extended hours so the
@@ -955,6 +1059,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             offchain_order_id: OffchainOrderId::new(),
             market_session: MarketSession::Regular,
+            backpressure_streak: BackpressureStreak::default(),
         }
     }
 
@@ -977,6 +1082,398 @@ mod tests {
             job.market_session,
             MarketSession::Regular,
             "legacy PlaceHedge jobs without market_session must deserialize as Regular"
+        );
+    }
+
+    #[test]
+    fn place_hedge_payload_without_backpressure_streak_deserializes_to_zero() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let payload = serde_json::json!({
+            "symbol": symbol,
+            "direction": Direction::Sell,
+            "shares": Positive::new(FractionalShares::new(float!(2.0))).unwrap(),
+            "executor": SupportedExecutor::DryRun,
+            "threshold": ExecutionThreshold::whole_share(),
+            "offchain_order_id": offchain_order_id,
+            "market_session": MarketSession::Regular,
+        });
+
+        let job: PlaceHedge = serde_json::from_value(payload).unwrap();
+
+        assert_eq!(job.backpressure_streak, BackpressureStreak::default());
+    }
+
+    fn place_hedge_job_type() -> &'static str {
+        std::any::type_name::<PlaceHedge>()
+    }
+
+    async fn successor_backpressure_streak(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {
+        let streaks: Vec<i64> = sqlx_apalis::query_scalar(
+            "SELECT json_extract(CAST(job AS TEXT), '$.backpressure_streak') FROM Jobs \
+             WHERE job_type = ?",
+        )
+        .bind(place_hedge_job_type())
+        .fetch_all(apalis_pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            streaks.len(),
+            1,
+            "a 429 must enqueue exactly one PlaceHedge successor"
+        );
+        streaks.into_iter().next().unwrap()
+    }
+
+    fn alpaca_429(retry_after_millis: u64) -> TradeAccountingError {
+        TradeAccountingError::AlpacaBrokerApi(st0x_execution::AlpacaBrokerApiError::ApiError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            alpaca_code: None,
+            message: "rate limited".to_string(),
+            retry_after: Some(Duration::from_millis(retry_after_millis)),
+        })
+    }
+
+    /// Exercises the shared handler directly; end-to-end placement
+    /// backpressure is covered separately below.
+    #[tokio::test]
+    async fn place_hedge_429_reschedules_with_incremented_streak_and_does_not_propagate_err() {
+        let TestInfra {
+            ctx, apalis_pool, ..
+        } = create_hedge_ctx(succeeding_order_placer()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let job = hedge_job(&symbol, 2.0, Direction::Sell);
+
+        job.handle_place_hedge_error(&ctx, alpaca_429(1))
+            .await
+            .unwrap();
+
+        assert_eq!(successor_backpressure_streak(&apalis_pool).await, 1);
+    }
+
+    #[tokio::test]
+    async fn place_hedge_429_past_reschedule_limit_dead_letters_without_propagating_err() {
+        let TestInfra {
+            ctx, apalis_pool, ..
+        } = create_hedge_ctx(succeeding_order_placer()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let mut job = hedge_job(&symbol, 2.0, Direction::Sell);
+        job.backpressure_streak = BackpressureStreak(BACKPRESSURE_RESCHEDULE_LIMIT);
+
+        job.handle_place_hedge_error(&ctx, alpaca_429(1))
+            .await
+            .unwrap();
+
+        let job_count: i64 =
+            sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                .bind(place_hedge_job_type())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            job_count, 0,
+            "an exhausted backpressure streak must dead-letter, not reschedule"
+        );
+    }
+
+    #[tokio::test]
+    async fn place_hedge_non_backpressure_error_propagates_unchanged() {
+        let TestInfra { ctx, .. } = create_hedge_ctx(succeeding_order_placer()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let job = hedge_job(&symbol, 2.0, Direction::Sell);
+        let error =
+            TradeAccountingError::AlpacaBrokerApi(st0x_execution::AlpacaBrokerApiError::ApiError {
+                status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                alpaca_code: None,
+                message: "boom".to_string(),
+                retry_after: None,
+            });
+
+        let result = job.handle_place_hedge_error(&ctx, error).await;
+        let Err(TradeAccountingError::AlpacaBrokerApi(
+            st0x_execution::AlpacaBrokerApiError::ApiError { status, .. },
+        )) = result
+        else {
+            panic!("expected the non-backpressure error to propagate unchanged");
+        };
+        assert_eq!(status, reqwest::StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    /// `OrderPlacer` whose extended-hours price lookup fails with a classified
+    /// broker rate-limit (429) wrapped exactly as the real Alpaca executor
+    /// produces it: `AlpacaBrokerApiError::LatestTrade(AlpacaMarketDataError)`,
+    /// a two-hop boxed source (`TradeAccountingError::LimitPriceFetch` boxes
+    /// a `dyn Error`, which itself wraps the market-data error). Used to pin
+    /// the extended-hours reschedule path `handle_place_hedge_error`'s doc
+    /// comment claims handles (RAI-1494).
+    fn rate_limited_price_fetch_placer() -> Arc<dyn OrderPlacer> {
+        struct RateLimitedPricePlacer;
+
+        #[async_trait::async_trait]
+        impl OrderPlacer for RateLimitedPricePlacer {
+            async fn place_market_order(
+                &self,
+                _order: st0x_execution::MarketOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err(
+                    "place_market_order must not be called when the price fetch is rate-limited"
+                        .into(),
+                )
+            }
+
+            async fn place_limit_order(
+                &self,
+                _order: st0x_execution::LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err(
+                    "place_limit_order must not be called when the price fetch is rate-limited"
+                        .into(),
+                )
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &st0x_execution::ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
+            }
+
+            async fn fetch_latest_trade_price(
+                &self,
+                _symbol: &Symbol,
+            ) -> Result<
+                Option<st0x_execution::Positive<Usd>>,
+                Box<dyn std::error::Error + Send + Sync>,
+            > {
+                Err(Box::new(st0x_execution::AlpacaBrokerApiError::LatestTrade(
+                    st0x_execution::AlpacaMarketDataError::ApiError {
+                        status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                        body: "rate limited".to_string(),
+                        retry_after: Some(Duration::from_millis(1)),
+                    },
+                )))
+            }
+
+            async fn market_session(
+                &self,
+            ) -> Result<MarketSession, Box<dyn std::error::Error + Send + Sync>> {
+                Ok(MarketSession::Extended)
+            }
+        }
+
+        Arc::new(RateLimitedPricePlacer)
+    }
+
+    #[derive(Default)]
+    struct RateLimitedPlacementState {
+        attempts: AtomicUsize,
+        client_order_ids: StdMutex<Vec<ClientOrderId>>,
+    }
+
+    /// Rate-limits the first broker placement, then accepts the successor's
+    /// idempotent retry. The shared state lets the test prove both calls used
+    /// the same broker `client_order_id`.
+    fn rate_limited_once_order_placer() -> (Arc<dyn OrderPlacer>, Arc<RateLimitedPlacementState>) {
+        struct RateLimitedOncePlacer {
+            state: Arc<RateLimitedPlacementState>,
+        }
+
+        #[async_trait::async_trait]
+        impl OrderPlacer for RateLimitedOncePlacer {
+            async fn place_market_order(
+                &self,
+                order: st0x_execution::MarketOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                self.state
+                    .client_order_ids
+                    .lock()
+                    .unwrap()
+                    .push(order.client_order_id);
+                let attempt = self.state.attempts.fetch_add(1, Ordering::SeqCst);
+                if attempt == 0 {
+                    return Err(Box::new(st0x_execution::AlpacaBrokerApiError::ApiError {
+                        status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                        alpaca_code: None,
+                        message: "rate limited".to_string(),
+                        retry_after: Some(Duration::from_millis(1)),
+                    }));
+                }
+
+                Ok(OrderPlacementResult {
+                    executor_order_id: ExecutorOrderId::new("accepted-after-rate-limit"),
+                    placed_shares: order.shares,
+                    is_extended_hours: false,
+                    limit_price: None,
+                })
+            }
+
+            async fn place_limit_order(
+                &self,
+                _order: st0x_execution::LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err("regular-session test must not place a limit order".into())
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
+            }
+        }
+
+        let state = Arc::new(RateLimitedPlacementState::default());
+        (
+            Arc::new(RateLimitedOncePlacer {
+                state: state.clone(),
+            }),
+            state,
+        )
+    }
+
+    #[tokio::test]
+    async fn place_hedge_extended_hours_price_fetch_429_reschedules_through_perform_without_claiming_position()
+     {
+        let TestInfra {
+            ctx,
+            apalis_pool,
+            position_projection,
+            ..
+        } = create_hedge_ctx_with(
+            rate_limited_price_fetch_placer(),
+            extended_hours_assets("AAPL", true),
+        )
+        .await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let job = PlaceHedge {
+            symbol: symbol.clone(),
+            direction: Direction::Sell,
+            shares: Positive::new(FractionalShares::new(float!(2.0))).unwrap(),
+            executor: SupportedExecutor::DryRun,
+            threshold: ExecutionThreshold::whole_share(),
+            offchain_order_id: OffchainOrderId::new(),
+            market_session: MarketSession::Extended,
+            backpressure_streak: BackpressureStreak::default(),
+        };
+
+        // Driven through the REAL `Job::perform` entry point (not
+        // `handle_place_hedge_error` called directly): the two-hop boxed 429
+        // must reschedule (`Ok(())`), not propagate as `Err`.
+        job.perform(&ctx).await.unwrap();
+
+        assert_eq!(successor_backpressure_streak(&apalis_pool).await, 1);
+
+        let position = position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "a 429 raised before the position claim must not claim the position"
+        );
+    }
+
+    #[tokio::test]
+    async fn place_hedge_placement_429_retries_same_client_order_id_and_submits() {
+        let (placer, placement_state) = rate_limited_once_order_placer();
+        let TestInfra {
+            ctx,
+            apalis_pool,
+            offchain_order_projection,
+            ..
+        } = create_hedge_ctx(placer).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let job = hedge_job(&symbol, 2.0, Direction::Sell);
+
+        job.perform(&ctx).await.unwrap();
+
+        assert_eq!(placement_state.attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(successor_backpressure_streak(&apalis_pool).await, 1);
+        let pending = offchain_order_projection
+            .load(&job.offchain_order_id)
+            .await
+            .unwrap()
+            .expect("rate-limited placement must retain its offchain order");
+        assert!(
+            matches!(pending, OffchainOrder::Pending { .. }),
+            "a placement 429 must leave the durable order Pending, got {pending:?}"
+        );
+
+        let (successor_id, successor_payload): (String, Vec<u8>) = sqlx_apalis::query_as(
+            "SELECT id, job FROM Jobs WHERE job_type = ? AND status = 'Pending'",
+        )
+        .bind(place_hedge_job_type())
+        .fetch_one(&apalis_pool)
+        .await
+        .unwrap();
+        let successor: PlaceHedge =
+            serde_json::from_slice(&successor_payload).expect("deserialize PlaceHedge successor");
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Running' WHERE id = ?")
+            .bind(&successor_id)
+            .execute(&apalis_pool)
+            .await
+            .unwrap();
+
+        successor.perform(&ctx).await.unwrap();
+
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+            .bind(&successor_id)
+            .execute(&apalis_pool)
+            .await
+            .unwrap();
+        assert_eq!(placement_state.attempts.load(Ordering::SeqCst), 2);
+        let client_order_ids = placement_state.client_order_ids.lock().unwrap().clone();
+        let expected_client_order_id = ClientOrderId::from_uuid(job.offchain_order_id.as_uuid());
+        assert_eq!(
+            client_order_ids,
+            [expected_client_order_id.clone(), expected_client_order_id,],
+            "the retry must reuse the first attempt's broker idempotency key"
+        );
+
+        let submitted = offchain_order_projection
+            .load(&job.offchain_order_id)
+            .await
+            .unwrap()
+            .expect("successful retry must retain its offchain order");
+        assert!(
+            matches!(submitted, OffchainOrder::Submitted { .. }),
+            "the successful retry must advance the order to Submitted, got {submitted:?}"
+        );
+        let poll_jobs: i64 =
+            sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                .bind(type_name::<PollOrderStatus>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            poll_jobs, 1,
+            "the successful retry must enqueue exactly one PollOrderStatus job"
         );
     }
 
@@ -1666,6 +2163,7 @@ mod tests {
             position: position.clone(),
             offchain_order,
             poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
+            hedge_queue: HedgeJobQueue::new(&apalis_pool),
             order_placer: placer,
             assets: extended_hours_assets("AAPL", true),
             counter_trade_slippage_bps: 100,
@@ -1747,6 +2245,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             offchain_order_id: OffchainOrderId::new(),
             market_session: MarketSession::Extended,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx).await.unwrap();
@@ -2068,6 +2567,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             offchain_order_id: OffchainOrderId::new(),
             market_session: MarketSession::Extended,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx).await.unwrap();
@@ -2140,6 +2640,7 @@ mod tests {
             offchain_order_id: OffchainOrderId::new(),
             // Stale: enqueued during regular hours, retried during Extended.
             market_session: MarketSession::Regular,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)
@@ -2203,6 +2704,7 @@ mod tests {
             offchain_order_id: OffchainOrderId::new(),
             // Stale serialized session: enqueued during regular hours.
             market_session: MarketSession::Regular,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)
@@ -2317,6 +2819,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             offchain_order_id: OffchainOrderId::new(),
             market_session: MarketSession::Extended,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // The job fails with a retryable error (it propagates, so apalis
@@ -2457,6 +2960,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             offchain_order_id: OffchainOrderId::new(),
             market_session: MarketSession::Extended,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)
@@ -2503,6 +3007,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             offchain_order_id: OffchainOrderId::new(),
             market_session: MarketSession::Extended,
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx).await.unwrap();
@@ -2618,6 +3123,7 @@ mod tests {
             position: position.clone(),
             offchain_order,
             poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
+            hedge_queue: HedgeJobQueue::new(&apalis_pool),
             order_placer: placer,
             assets,
             counter_trade_slippage_bps: 100,

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -24,10 +24,14 @@ use st0x_registry::{SymbolCache, get_symbol_lock};
 
 use super::inclusion::EmittedOnChain;
 use super::skipped_fill::{SkipReason, record_skipped_fill};
-use crate::conductor::job::{Job, JobQueue, Label};
+use crate::conductor::job::{
+    BACKPRESSURE_RESCHEDULE_LIMIT, BackpressureOutcome, BackpressureStreak, Job, JobQueue, Label,
+    advance_backpressure, apply_backpressure_step, find_backpressure,
+};
 use crate::conductor::{
     TradeProcessingCqrs, VaultDiscoveryCtx, discover_vaults_for_trade, process_queued_trade,
 };
+use crate::offchain::order::PlaceOffchainOrderError;
 use crate::onchain::pyth::PythFeedIds;
 use crate::onchain::trade::{RaindexTradeEvent, TradeValidationError};
 use crate::onchain::{OnChainError, OnchainTrade};
@@ -43,6 +47,22 @@ pub(crate) type DexTradeAccountingJobQueue = JobQueue<AccountForDexTrade>;
 pub struct AccountForDexTrade {
     /// Raindex trade event with block inclusion metadata
     pub(crate) trade: EmittedOnChain<RaindexTradeEvent>,
+    /// Count of consecutive broker rate-limit (429) reschedules leading up to
+    /// this attempt (RAI-1494). `#[serde(default)]` so a row enqueued under
+    /// the pre-this-change payload shape still deserializes to `0` instead of
+    /// crashing the poll stream's `sqlx::Decode`.
+    ///
+    /// This job is "reschedule-then-backstop", not "true retry":
+    /// `account_for_onchain_fill` commits on `(tx_hash, log_index)` before
+    /// any Alpaca touch, so once that guard commits, a 429 later in the same
+    /// attempt reschedules, but the pushed successor's
+    /// `account_for_onchain_fill` hits `FillAccountingOutcome::
+    /// AlreadyAcknowledged` and never re-attempts the hedge -- the streak
+    /// structurally caps at 1 and never approaches
+    /// `BACKPRESSURE_RESCHEDULE_LIMIT`. Actual completion of the hedge is
+    /// delegated to the existing `CheckPositions` backstop.
+    #[serde(default)]
+    pub(crate) backpressure_streak: BackpressureStreak,
 }
 
 /// Bundles the shared dependencies needed by the trade accounting job.
@@ -309,14 +329,92 @@ where
 
         let trading_enabled = ctx.ctx.assets.is_trading_enabled(trade.symbol.base());
 
-        process_queued_trade(
+        match process_queued_trade(
             &ctx.executor,
             trade_event,
             trade,
             &ctx.cqrs,
             trading_enabled,
         )
+        .await
+        {
+            Ok(_) => Ok(()),
+            Err(error) => self.handle_process_queued_trade_error(ctx, error).await,
+        }
+    }
+}
+
+impl AccountForDexTrade {
+    /// Handles a `process_queued_trade` failure: reschedules with a
+    /// classified delay on broker rate-limiting (429) instead of consuming
+    /// the terminal retry budget, or propagates any other error through the
+    /// normal, unmodified retry/circuit-breaker path.
+    ///
+    /// `account_for_onchain_fill` commits its `(tx_hash, log_index)` guard
+    /// before any Alpaca touch, so a rescheduled successor short-circuits to
+    /// `AlreadyAcknowledged` rather than re-driving the hedge -- this job is
+    /// "reschedule-then-backstop", not "true retry" (see the RAI-1494 plan's
+    /// per-job classification table). The reschedule's value here is only:
+    /// don't burn the terminal retry budget, don't latch the worker; actual
+    /// completion is `CheckPositions`' job, unchanged by this plan.
+    async fn handle_process_queued_trade_error<Node, Exec>(
+        &self,
+        ctx: &AccountantCtx<Node, Exec>,
+        error: TradeAccountingError,
+    ) -> Result<(), TradeAccountingError>
+    where
+        Node: Provider + Clone + Send + Sync + 'static,
+        Exec: Executor + Clone + Send + 'static,
+        TradeAccountingError: From<Exec::Error>,
+    {
+        let Some(backpressure) = find_backpressure(&error) else {
+            return Err(error);
+        };
+
+        let step = advance_backpressure(&backpressure, self.backpressure_streak);
+        let mut queue = ctx.job_queue.clone();
+        let outcome = apply_backpressure_step(step, &mut queue, |next_streak| Self {
+            trade: self.trade.clone(),
+            backpressure_streak: next_streak,
+        })
         .await?;
+
+        match outcome {
+            BackpressureOutcome::DeadLettered => {
+                // Per the RAI-1494 plan's binding M2 decision (applied uniformly
+                // to every supervised job, not just the five that can sustain a
+                // genuine streak): dead-letter instead of propagating `Err` into
+                // the shared supervised on-event path, so a persistently-429ing
+                // item cannot re-open the circuit breaker RAI-1495 already knows
+                // how to latch.
+                let BackpressureStreak(streak) = self.backpressure_streak;
+                error!(
+                    target: "hedge",
+                    tx_hash = ?self.trade.tx_hash,
+                    log_index = self.trade.log_index,
+                    streak,
+                    limit = BACKPRESSURE_RESCHEDULE_LIMIT,
+                    "AccountForDexTrade: broker rate-limiting exceeded the reschedule \
+                     budget; dead-lettering this fill instead of opening the circuit \
+                     breaker -- treat as a structurally-dead Alpaca integration needing \
+                     manual reconciliation"
+                );
+            }
+            BackpressureOutcome::Rescheduled {
+                next_streak: BackpressureStreak(streak),
+                visible,
+            } => {
+                if visible {
+                    error!(
+                        target: "hedge",
+                        tx_hash = ?self.trade.tx_hash,
+                        log_index = self.trade.log_index,
+                        streak,
+                        "AccountForDexTrade: still rescheduling after sustained broker rate-limiting"
+                    );
+                }
+            }
+        }
 
         Ok(())
     }
@@ -403,6 +501,8 @@ pub(crate) enum TradeAccountingError {
     PositionCommand(#[from] SendError<crate::position::Position>),
     #[error("Offchain order command failed: {0}")]
     OffchainOrderCommand(#[from] SendError<crate::offchain::order::OffchainOrder>),
+    #[error("Offchain order placement failed: {0}")]
+    OffchainOrderPlacement(#[from] PlaceOffchainOrderError),
     #[error("Execution error: {0}")]
     Execution(#[from] ExecutionError),
     // TODO: TradeAccountingError should not be coupled to a concrete executor error type.
@@ -467,6 +567,7 @@ pub(crate) enum TradeAccountingError {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::time::Duration;
 
     use alloy::primitives::{Address, B256, U256, address};
     use alloy::providers::mock::Asserter;
@@ -480,7 +581,8 @@ mod tests {
     use st0x_event_sorcery::StoreBuilder;
     use st0x_evm::IERC20::{decimalsCall, symbolCall};
     use st0x_execution::{
-        FractionalShares, MockExecutor, MockExecutorCtx, Positive, Symbol, TryIntoExecutor,
+        CancellationOutcome, FractionalShares, InventoryResult, MockExecutor, MockExecutorCtx,
+        Positive, SupportedExecutor, Symbol, TryIntoExecutor,
     };
     use st0x_float_macro::float;
 
@@ -588,6 +690,7 @@ mod tests {
 
         AccountForDexTrade {
             trade: EmittedOnChain::from_log(event, &log).unwrap(),
+            backpressure_streak: BackpressureStreak::default(),
         }
     }
 
@@ -663,6 +766,7 @@ mod tests {
         let event = RaindexTradeEvent::TakeOrderV3(Box::new(take_event));
         let job = AccountForDexTrade {
             trade: EmittedOnChain::from_log(event, &log).unwrap(),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Mock EVM responses: receipt first, then decimals()+symbol() for each token.
@@ -764,6 +868,7 @@ mod tests {
         let event = RaindexTradeEvent::ClearV3(Box::new(clear_event));
         let job = AccountForDexTrade {
             trade: EmittedOnChain::from_log(event, &clear_log).unwrap(),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // AfterClearV2 crediting alice 9 shares (aliceOutput) for 0 USDC
@@ -889,6 +994,7 @@ mod tests {
         let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
         let job = AccountForDexTrade {
             trade: EmittedOnChain::from_log(event, &log).unwrap(),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Reconstructed log's tx_hash is get_test_log's; the parser fetches the
@@ -980,6 +1086,7 @@ mod tests {
         let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
         let job = AccountForDexTrade {
             trade: EmittedOnChain::from_log(event, &log).unwrap(),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let tx_hash = alloy::primitives::fixed_bytes!(
@@ -1067,6 +1174,7 @@ mod tests {
         let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
         let job = AccountForDexTrade {
             trade: EmittedOnChain::from_log(event, &log).unwrap(),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let tx_hash = alloy::primitives::fixed_bytes!(
@@ -1164,6 +1272,7 @@ mod tests {
         let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
         let job = AccountForDexTrade {
             trade: EmittedOnChain::from_log(event, &log).unwrap(),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let tx_hash = alloy::primitives::fixed_bytes!(
@@ -1274,6 +1383,7 @@ mod tests {
         let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
         let job = AccountForDexTrade {
             trade: EmittedOnChain::from_log(event, &log).unwrap(),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // The parser fetches the receipt, then the deposit- (USDC, 6dp)
@@ -1399,6 +1509,234 @@ mod tests {
         assert_eq!(order_count, 1, "the hedge order must be placed");
     }
 
+    /// Executor whose `preflight_counter_trade` always fails with a
+    /// classified broker rate-limit (429) -- `MockExecutor`'s errors are all
+    /// `ExecutionError`, which is never classifiable, so a real `Executor`
+    /// impl with `Error = AlpacaBrokerApiError` is needed to drive a
+    /// classified 429 through the REAL `process_queued_trade` call site
+    /// (RAI-1494 finding: the perform -> handler wiring itself was
+    /// previously unverified for this job).
+    #[derive(Clone)]
+    struct RateLimitedPreflightExecutor;
+
+    #[async_trait::async_trait]
+    impl Executor for RateLimitedPreflightExecutor {
+        type Error = AlpacaBrokerApiError;
+        type OrderId = String;
+        type Ctx = ();
+
+        async fn try_from_ctx(_ctx: Self::Ctx) -> Result<Self, Self::Error> {
+            Ok(Self)
+        }
+
+        async fn is_market_open(&self) -> Result<bool, Self::Error> {
+            Ok(true)
+        }
+
+        async fn place_market_order(
+            &self,
+            _order: st0x_execution::MarketOrder,
+        ) -> Result<st0x_execution::OrderPlacement<Self::OrderId>, Self::Error> {
+            unimplemented!("not exercised: the preflight check fails before any placement")
+        }
+
+        async fn get_order_status(
+            &self,
+            _order_id: &Self::OrderId,
+        ) -> Result<st0x_execution::OrderState, Self::Error> {
+            unimplemented!("not exercised: the preflight check fails before any status poll")
+        }
+
+        fn to_supported_executor(&self) -> SupportedExecutor {
+            SupportedExecutor::DryRun
+        }
+
+        fn parse_order_id(&self, order_id_str: &str) -> Result<Self::OrderId, Self::Error> {
+            Ok(order_id_str.to_string())
+        }
+
+        async fn get_inventory(&self) -> Result<InventoryResult, Self::Error> {
+            Ok(InventoryResult::Unimplemented)
+        }
+
+        async fn place_limit_order(
+            &self,
+            _order: st0x_execution::LimitOrder,
+        ) -> Result<st0x_execution::OrderPlacement<Self::OrderId>, Self::Error> {
+            unimplemented!("not exercised by this test")
+        }
+
+        async fn cancel_order(
+            &self,
+            _order_id: &Self::OrderId,
+        ) -> Result<CancellationOutcome, Self::Error> {
+            unimplemented!("not exercised by this test")
+        }
+
+        async fn preflight_counter_trade(
+            &self,
+            _order: st0x_execution::MarketOrder,
+        ) -> Result<st0x_execution::CounterTradePreflight, Self::Error> {
+            Err(AlpacaBrokerApiError::ApiError {
+                status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                alpaca_code: None,
+                message: "rate limited".to_string(),
+                retry_after: Some(Duration::from_millis(1)),
+            })
+        }
+
+        async fn preflight_counter_trade_at_price(
+            &self,
+            order: st0x_execution::MarketOrder,
+            _reference_price: st0x_execution::Positive<st0x_execution::Usd>,
+        ) -> Result<st0x_execution::CounterTradePreflight, Self::Error> {
+            self.preflight_counter_trade(order).await
+        }
+    }
+
+    /// Drives a classified 429 through the REAL `Job::perform` entry point
+    /// (not `handle_process_queued_trade_error` called directly), pinning
+    /// the perform -> handler wiring the sibling `handle_process_queued_trade_error`-only
+    /// tests above cannot prove. Reuses
+    /// `perform_hedges_inventory_trade_with_hedgeable_pair`'s fixture with
+    /// the executor swapped for one that fails the preflight check: the fill
+    /// is accounted (guard commits) before the 429 surfaces, matching this
+    /// job's "reschedule-then-backstop" shape -- no hedge order is placed.
+    #[tokio::test]
+    async fn perform_reschedules_with_incremented_streak_on_a_preflight_429_without_placing_a_hedge()
+     {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let asserter = Asserter::new();
+
+        let usdc_token = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+        let equity_token = address!("0x5CdA0E1cA4ce2Af96315F7F8963c85399c172204");
+        let operator = address!("0x8b8b6e0507c125934c6129563f48e48c66f86475");
+
+        let inventory_trade = InventoryTrade {
+            deposit: OperatorDeposit {
+                operator,
+                token: usdc_token,
+                vaultId: alloy::primitives::b256!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000004"
+                ),
+                amount: alloy::primitives::uint!(5_000_000_U256),
+            },
+            withdraw: OperatorWithdraw {
+                operator,
+                token: equity_token,
+                vaultId: alloy::primitives::b256!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000003"
+                ),
+                amount: alloy::primitives::uint!(34_172_366_621_067_031_U256),
+            },
+        };
+
+        let tx_hash = alloy::primitives::fixed_bytes!(
+            "0xe13a11de734768f08a9c1ef66e8de3bcb9072f8cdabce9f1d819e1ae9909d4b9"
+        );
+        let mut log = crate::test_utils::create_log(0x97);
+        log.transaction_hash = Some(tx_hash);
+        log.block_number = Some(48_030_415);
+        log.block_timestamp = Some(1_782_850_177);
+
+        let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
+        let job = AccountForDexTrade {
+            trade: EmittedOnChain::from_log(event, &log).unwrap(),
+            backpressure_streak: BackpressureStreak::default(),
+        };
+
+        asserter.push_success(&serde_json::json!({
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x3b",
+            "blockHash": "0x373307a0e2154c2de6b046e349fc27f9bb02b01fdddbb15eeba57f3ce3b24973",
+            "blockNumber": "0x2dce2cf",
+            "from": "0x679df30b30ac2947aa3143490add6717af81dcc3",
+            "to": "0xbeb0009aca35087ce7ccf11637e24dd1aad3bf2a",
+            "gasUsed": "0x7a62d",
+            "effectiveGasPrice": "0x57bcf0",
+            "cumulativeGasUsed": "0xa00b4e",
+            "status": "0x1",
+            "type": "0x2",
+            "logsBloom": format!("0x{}", "0".repeat(512)),
+            "logs": []
+        }));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&6u8));
+        asserter.push_success(&<decimalsCall as SolCall>::abi_encode_returns(&18u8));
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = RateLimitedPreflightExecutor;
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
+
+        let mut symbols = HashMap::new();
+        symbols.insert(
+            Symbol::new("COIN").unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: Address::ZERO,
+                tokenized_equity_derivative: equity_token,
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                extended_hours_counter_trading: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+        ctx.assets = AssetsConfig {
+            equities: EquitiesConfig {
+                operational_limit: None,
+                symbols,
+            },
+            cash: None,
+        };
+
+        let cache = SymbolCache::default();
+        cache.preload_symbol(usdc_token, "USDC");
+        cache.preload_symbol(equity_token, "wtCOIN");
+
+        let accountant_ctx = build_test_accountant_ctx(
+            pool.clone(),
+            &apalis_pool,
+            ctx,
+            cache,
+            provider,
+            executor,
+            ExecutionThreshold::shares(Positive::new(FractionalShares::new(float!(0.01))).unwrap()),
+        )
+        .await;
+
+        // The 429 must reschedule (Ok(())) through the REAL Job::perform
+        // entry point, not propagate as Err.
+        job.perform(&accountant_ctx).await.unwrap();
+
+        assert_eq!(successor_backpressure_streak(&apalis_pool).await, 1);
+
+        // The fill was still accounted (the guard commits before any Alpaca
+        // touch), but no hedge order was placed -- this job is
+        // "reschedule-then-backstop", not "true retry".
+        let (fill_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("OnChainTradeEvent::Filled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            fill_count, 1,
+            "the fill must still be accounted before the preflight 429 surfaces"
+        );
+
+        let (order_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM events WHERE event_type = 'OffchainOrderEvent::Placed'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            order_count, 0,
+            "a preflight 429 must not place a hedge order"
+        );
+    }
+
     /// The real univ4-routed prod settlement (`0x9ee8e401a6f12227df1a30a236b60ac83c72b2b1eb610d83cf292ae789eb0805`,
     /// also pinned at the parser level in `onchain::trade`'s
     /// `try_from_inventory_trade_real_univ4_fill_is_buy`) must flow all the
@@ -1451,6 +1789,7 @@ mod tests {
         let event = RaindexTradeEvent::InventoryTrade(Box::new(inventory_trade));
         let job = AccountForDexTrade {
             trade: EmittedOnChain::from_log(event, &log).unwrap(),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // The parser fetches the receipt, then the deposit- (wtCOIN, 18dp)
@@ -1620,5 +1959,164 @@ mod tests {
         assert_eq!(decoded.token, withdraw.token);
         assert_eq!(decoded.vaultId, withdraw.vaultId);
         assert_eq!(decoded.amount, withdraw.amount);
+    }
+
+    fn account_for_dex_trade_job_type() -> &'static str {
+        std::any::type_name::<AccountForDexTrade>()
+    }
+
+    async fn successor_backpressure_streak(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {
+        let streaks: Vec<i64> = sqlx_apalis::query_scalar(
+            "SELECT json_extract(CAST(job AS TEXT), '$.backpressure_streak') FROM Jobs \
+             WHERE job_type = ?",
+        )
+        .bind(account_for_dex_trade_job_type())
+        .fetch_all(apalis_pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            streaks.len(),
+            1,
+            "a 429 must enqueue exactly one AccountForDexTrade successor"
+        );
+        streaks.into_iter().next().unwrap()
+    }
+
+    #[test]
+    fn account_for_dex_trade_payload_without_backpressure_streak_deserializes_to_zero() {
+        let job = test_job();
+        let mut value = serde_json::to_value(&job).unwrap();
+        value.as_object_mut().unwrap().remove("backpressure_streak");
+
+        let decoded: AccountForDexTrade = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded.backpressure_streak, BackpressureStreak::default());
+    }
+
+    /// `handle_process_queued_trade_error` is the actual new RAI-1494
+    /// mechanism this job gained; `account_for_onchain_fill`'s
+    /// `(tx_hash, log_index)` guard (the reason this job is
+    /// "reschedule-then-backstop", not "true retry") is pre-existing,
+    /// untouched by this plan, and already idempotent under the existing
+    /// `retries(3)` path -- exercised directly at the unit level here rather
+    /// than re-proven end to end.
+    #[tokio::test]
+    async fn account_for_dex_trade_429_reschedules_with_incremented_streak_and_does_not_propagate_err()
+     {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+
+        let accountant_ctx = build_test_accountant_ctx(
+            pool,
+            &apalis_pool,
+            ctx,
+            SymbolCache::default(),
+            provider,
+            executor,
+            ExecutionThreshold::whole_share(),
+        )
+        .await;
+
+        let job = test_job();
+        let error = TradeAccountingError::AlpacaBrokerApi(AlpacaBrokerApiError::ApiError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            alpaca_code: None,
+            message: "rate limited".to_string(),
+            retry_after: Some(Duration::from_millis(1)),
+        });
+
+        job.handle_process_queued_trade_error(&accountant_ctx, error)
+            .await
+            .unwrap();
+
+        assert_eq!(successor_backpressure_streak(&apalis_pool).await, 1);
+    }
+
+    #[tokio::test]
+    async fn account_for_dex_trade_429_past_reschedule_limit_dead_letters_without_propagating_err()
+    {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+
+        let accountant_ctx = build_test_accountant_ctx(
+            pool,
+            &apalis_pool,
+            ctx,
+            SymbolCache::default(),
+            provider,
+            executor,
+            ExecutionThreshold::whole_share(),
+        )
+        .await;
+
+        let mut job = test_job();
+        job.backpressure_streak = BackpressureStreak(BACKPRESSURE_RESCHEDULE_LIMIT);
+        let error = TradeAccountingError::AlpacaBrokerApi(AlpacaBrokerApiError::ApiError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            alpaca_code: None,
+            message: "rate limited".to_string(),
+            retry_after: Some(Duration::from_millis(1)),
+        });
+
+        job.handle_process_queued_trade_error(&accountant_ctx, error)
+            .await
+            .unwrap();
+
+        let job_count: i64 =
+            sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                .bind(account_for_dex_trade_job_type())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            job_count, 0,
+            "an exhausted backpressure streak must dead-letter, not reschedule"
+        );
+    }
+
+    #[tokio::test]
+    async fn account_for_dex_trade_non_backpressure_error_propagates_unchanged() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+
+        let accountant_ctx = build_test_accountant_ctx(
+            pool,
+            &apalis_pool,
+            ctx,
+            SymbolCache::default(),
+            provider,
+            executor,
+            ExecutionThreshold::whole_share(),
+        )
+        .await;
+
+        let job = test_job();
+        let error = TradeAccountingError::AlpacaBrokerApi(AlpacaBrokerApiError::ApiError {
+            status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            alpaca_code: None,
+            message: "boom".to_string(),
+            retry_after: None,
+        });
+
+        let result = job
+            .handle_process_queued_trade_error(&accountant_ctx, error)
+            .await;
+        let Err(TradeAccountingError::AlpacaBrokerApi(AlpacaBrokerApiError::ApiError {
+            status,
+            ..
+        })) = result
+        else {
+            panic!("expected the non-backpressure error to propagate unchanged");
+        };
+        assert_eq!(status, reqwest::StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -50,7 +50,7 @@ use super::aggregate::{
 #[cfg(test)]
 use crate::bot_gas::BotGasReceiptCostEnqueuer;
 use crate::bot_gas::redrive::{BotGasFailureClassifier, redrive_on_bot_gas_failure};
-use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
+use crate::conductor::job::{BackpressureStreak, Job, JobQueue, Label, QueuePushError};
 use crate::equity_redemption::{EquityRedemption, RedemptionAggregateId};
 use crate::inventory::BroadcastingInventory;
 use crate::inventory::view::{InFlightEquityLocation, InventoryView};
@@ -156,6 +156,22 @@ pub(crate) enum UnwrappedEquityRecoveryJobError {
 pub(crate) struct UnwrappedEquityRecoveryJob {
     pub(crate) symbol: Symbol,
     pub(crate) recovery_id: UnwrappedEquityRecoveryId,
+    /// Count of consecutive broker rate-limit (429) reschedules leading up to
+    /// this attempt (RAI-1494). `#[serde(default)]` so a row enqueued under
+    /// the pre-this-change payload shape still deserializes to `0` instead of
+    /// crashing the poll stream's `sqlx::Decode`.
+    ///
+    /// NOT YET wired to a reschedule: mirrors `WrappedEquityRecoveryJob`'s
+    /// identical gap -- `resume_mint`/`resume_redemption` failures are caught
+    /// inside the aggregate's command handler and recorded as a terminal
+    /// `RecoveryFailed` event with only a Display-formatted `String` reason,
+    /// so `ctx.store.send()` returns `Ok(())` regardless and `perform()`
+    /// never observes an `Err` to classify. See `WrappedEquityRecoveryJob`'s
+    /// field doc and the RAI-1494 decision log for the follow-up needed to
+    /// close this gap. Field added now so the payload schema is ready when
+    /// that follow-up lands.
+    #[serde(default)]
+    pub(crate) backpressure_streak: BackpressureStreak,
 }
 
 impl Job<UnwrappedEquityRecoveryCtx> for UnwrappedEquityRecoveryJob {
@@ -757,6 +773,17 @@ mod tests {
     use super::super::aggregate::UnwrappedEquityRecoveryServices;
     use super::*;
 
+    #[test]
+    fn unwrapped_equity_recovery_job_payload_without_backpressure_streak_deserializes_to_zero() {
+        let payload = serde_json::json!({
+            "symbol": Symbol::new("AAPL").unwrap(),
+            "recovery_id": UnwrappedEquityRecoveryId(Uuid::new_v4()),
+        });
+
+        let job: UnwrappedEquityRecoveryJob = serde_json::from_value(payload).unwrap();
+        assert_eq!(job.backpressure_streak, BackpressureStreak::default());
+    }
+
     fn mock_vault_lookup() -> MockVaultLookup {
         MockVaultLookup::new()
             .with_vault(Address::ZERO, RaindexVaultId(B256::ZERO))
@@ -905,6 +932,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Guard contention must NOT yield a retryable error (exhausting the retry
@@ -1050,6 +1078,7 @@ mod tests {
             .push(UnwrappedEquityRecoveryJob {
                 symbol: Symbol::new("GOOGL").unwrap(),
                 recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -1356,6 +1385,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)
@@ -1379,6 +1409,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         let error = job
@@ -1407,6 +1438,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)
@@ -1453,6 +1485,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         // Must return Ok(()) -- no apalis retry.
@@ -1515,6 +1548,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: recovery_id.clone(),
+            backpressure_streak: BackpressureStreak::default(),
         };
         job.perform(&ctx)
             .await
@@ -1546,6 +1580,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)
@@ -1586,6 +1621,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: recovery_id.clone(),
+            backpressure_streak: BackpressureStreak::default(),
         };
         job.perform(&ctx)
             .await
@@ -1625,6 +1661,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: recovery_id.clone(),
+            backpressure_streak: BackpressureStreak::default(),
         };
         job.perform(&ctx)
             .await
@@ -1664,6 +1701,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: recovery_id.clone(),
+            backpressure_streak: BackpressureStreak::default(),
         };
         job.perform(&ctx)
             .await
@@ -1734,6 +1772,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
+            backpressure_streak: BackpressureStreak::default(),
         };
         job.perform(&ctx)
             .await
@@ -1796,6 +1835,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: UnwrappedEquityRecoveryId(Uuid::new_v4()),
+            backpressure_streak: BackpressureStreak::default(),
         };
         job.perform(&ctx)
             .await
@@ -1864,6 +1904,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: recovery_id.clone(),
+            backpressure_streak: BackpressureStreak::default(),
         };
         job.perform(&ctx)
             .await
@@ -1929,6 +1970,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: recovery_id.clone(),
+            backpressure_streak: BackpressureStreak::default(),
         };
         job.perform(&ctx)
             .await
@@ -2001,6 +2043,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: recovery_id.clone(),
+            backpressure_streak: BackpressureStreak::default(),
         };
         job.perform(&ctx)
             .await
@@ -2118,6 +2161,7 @@ mod tests {
         let job = UnwrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: recovery_id.clone(),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -43,7 +43,7 @@ use super::aggregate::{
 #[cfg(test)]
 use crate::bot_gas::BotGasReceiptCostEnqueuer;
 use crate::bot_gas::redrive::{BotGasFailureClassifier, redrive_on_bot_gas_failure};
-use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
+use crate::conductor::job::{BackpressureStreak, Job, JobQueue, Label, QueuePushError};
 use crate::equity_redemption::{EquityRedemption, RedemptionAggregateId};
 use crate::inventory::BroadcastingInventory;
 use crate::inventory::view::{InFlightEquityLocation, InventoryView};
@@ -151,6 +151,31 @@ pub(crate) enum WrappedEquityRecoveryJobError {
 pub(crate) struct WrappedEquityRecoveryJob {
     pub(crate) symbol: Symbol,
     pub(crate) recovery_id: WrappedEquityRecoveryId,
+    /// Count of consecutive broker rate-limit (429) reschedules leading up to
+    /// this attempt (RAI-1494). `#[serde(default)]` so a row enqueued under
+    /// the pre-this-change payload shape still deserializes to `0` instead of
+    /// crashing the poll stream's `sqlx::Decode`.
+    ///
+    /// NOT YET wired to a reschedule: `resume_mint`/`resume_redemption`
+    /// failures are caught inside the aggregate's command handler and
+    /// recorded as a terminal `RecoveryFailed` event with only a
+    /// Display-formatted `String` reason (see `resume_mint_or_fail` /
+    /// `resume_redemption_or_fail` in `aggregate.rs`) -- `ctx.store.send()`
+    /// therefore returns `Ok(())` regardless, so `perform()` never observes
+    /// an `Err` to classify for this failure class, and `find_backpressure`
+    /// cannot walk to a real Alpaca error type from any constructible
+    /// `WrappedEquityRecoveryJobError` today. This is pre-existing behavior,
+    /// not a regression: a 429 here has always immediately terminalized the
+    /// recovery with zero retries. Closing this gap needs the aggregate's
+    /// error type to preserve the classified error (not just its Display
+    /// string) and `transition()` to return `Err` instead of
+    /// `Ok(RecoveryFailed)` on a classified 429, plus threading this streak
+    /// into the `Command` (the aggregate has no visibility into the job's own
+    /// payload) -- a redesign of the aggregate's error contract, out of scope
+    /// for this task's per-job wiring. Field added now so the payload schema
+    /// is ready when that follow-up lands.
+    #[serde(default)]
+    pub(crate) backpressure_streak: BackpressureStreak,
 }
 
 impl Job<WrappedEquityRecoveryCtx> for WrappedEquityRecoveryJob {
@@ -571,6 +596,17 @@ mod tests {
     use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
     use crate::vault_lookup::{MockVaultLookup, VaultLookup};
 
+    #[test]
+    fn wrapped_equity_recovery_job_payload_without_backpressure_streak_deserializes_to_zero() {
+        let payload = serde_json::json!({
+            "symbol": Symbol::new("AAPL").unwrap(),
+            "recovery_id": WrappedEquityRecoveryId(Uuid::new_v4()),
+        });
+
+        let job: WrappedEquityRecoveryJob = serde_json::from_value(payload).unwrap();
+        assert_eq!(job.backpressure_streak, BackpressureStreak::default());
+    }
+
     #[tokio::test]
     async fn guard_contention_reschedules_without_dropping_the_recovery() {
         let symbol = Symbol::new("AAPL").unwrap();
@@ -627,6 +663,7 @@ mod tests {
         let job = WrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: WrappedEquityRecoveryId(Uuid::new_v4()),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx).await.unwrap();
@@ -658,6 +695,7 @@ mod tests {
             .push(WrappedEquityRecoveryJob {
                 symbol: Symbol::new("GOOGL").unwrap(),
                 recovery_id: WrappedEquityRecoveryId(Uuid::new_v4()),
+                backpressure_streak: BackpressureStreak::default(),
             })
             .await
             .unwrap();
@@ -801,6 +839,7 @@ mod tests {
         let job = WrappedEquityRecoveryJob {
             symbol: symbol.clone(),
             recovery_id: recovery_id.clone(),
+            backpressure_streak: BackpressureStreak::default(),
         };
 
         job.perform(&ctx)


### PR DESCRIPTION
## What

- Make an Alpaca HTTP 429 (rate limit) back off instead of failing the job. This is one of three sub-issues of the [RAI-1492](https://linear.app/makeitrain/issue/RAI-1492) production incident. See [RAI-1494](https://linear.app/makeitrain/issue/RAI-1494).
- On a 429 inside an apalis job, the job reschedules itself with a delay and returns `Ok`, so the 429 never burns the retry budget and never reaches the circuit breaker.
- Honour `Retry-After` when Alpaca sends it (integer-seconds and HTTP-date forms), else use an escalating capped backoff, floored so it cannot hot-loop.
- Cover every reachable Alpaca call site: `PollOrderStatus`, `PlaceHedge`, `AccountForDexTrade`, the USDC deposit and withdrawal legs, and the synchronous CLI commands.

## Why

- On 2026-07-22 a runaway made about 15 `PollOrderStatus` jobs per second. Alpaca returned 429. The 429 was classed as a transient job failure, so it burned `RetryPolicy::retries(3)` in seconds, went terminal, opened the circuit breaker, and latched the single worker idle. All hedging stopped, silently, for 3 hours and 25 minutes.
- A 429 means "wait, then try again". It is back-pressure, not a bad work item. Treating it as a normal failure turns a recoverable signal into a worker-level fault.

## How

- On a 429 the job computes a delay (`Retry-After` or escalating fallback, floored at a minimum), carries an incremented `BackpressureStreak` in its own payload (`#[serde(default)]`, so old in-flight payloads still deserialize), pushes a fresh copy of itself with that delay, and returns `Ok`. This frees the single worker at once.
- `PollOrderStatus` is the only true-retry job (a 429 on a pure read genuinely re-hits Alpaca). Its reschedule goes through the RAI-1493 dedup, so it never forks a second poll chain.
- `AccountForDexTrade` and `PlaceHedge` short-circuit behind their committed idempotency guards on re-run, so the reschedule does not re-place an order or re-account a trade. It only avoids burning the budget and latching the worker; the recovery backstop completes the work.
- At `BACKPRESSURE_RESCHEDULE_LIMIT` (500) a supervised job dead-letters cleanly (loud `error!` plus terminal, via the RAI-1110 dead-letter path). It never returns a transient `Err`, so it stays decoupled from the RAI-1495 circuit-breaker fix. Operators still get paged: on dead-letter, and once when a streak crosses a roughly four-hour alert deadline.
- Synchronous CLI Alpaca calls have no worker to free, so they do a small bounded in-call retry instead.
- Shared building blocks: `parse_retry_after`, a `Backpressure` type with a `.backpressure()` method on each Alpaca error, `find_backpressure` (walks the error source chain), `decide_backpressure`, and `apply_backpressure_step` (the shared reschedule-or-dead-letter execution).

## Testing

- httpmock drives real Alpaca 429 responses (no live calls). Some tests drive the real apalis fetch and ack paths, so they pin apalis's actual retry contract, not a guess. That caught a wrong assumption that a retryable `Failed` row is inert.
- Old-payload deserialization tests confirm a job row saved before this change still decodes (streak 0), so a mid-flight row cannot crash the worker on deploy.
- Coverage for every wired call site, the dead-letter-at-limit path, the operator-paging deadline, the `Retry-After` floor and HTTP-date forms, and the conversion fail-fast behavior below.
- Ran the scoped suites, `cargo clippy --all-targets --all-features`, and `nix run .#ci` locally. All green.

## Anything else

- Scope note: two error types feeding five jobs (the equity-transfer and equity-recovery jobs) stringify the Alpaca error (`error.to_string()`) or swallow it into a terminal event before it reaches the job, so there is nothing to classify. Wiring them would be dead code. They got the schema field for future-proofing only. Closing this needs an aggregate error-type redesign, tracked as a follow-up.
- The USDC currency-conversion 429 path is deliberately NOT covered here and fails fast, the same as before this work. The conversion aggregate commits its `Converting` state before it places the order, so a rejected 429 leaves a committed state with no order that the resume paths cannot recover safely (the naive fix risks double-placing a conversion). Making it reschedule-safe needs a place-then-commit reorder of the aggregate. Tracked as a follow-up. `SPEC.md` and `docs/conductor.md` state this plainly.
- A global rate limiter for aggregate multi-worker request storms is a separate follow-up.
- No migration. The payload field is a transparent newtype over `u32` with a serde default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic backpressure handling for broker rate-limit (HTTP 429) responses. Operations triggering rate limits now reschedule with exponential backoff instead of failing, respecting broker `Retry-After` hints. Exceeded reschedule budgets are dead-lettered with operator alerts.
  * CLI commands for trading, deposits, and tokenization now retry rate-limit errors in-place with bounded attempt budgets.

* **Documentation**
  * Added comprehensive guide on broker rate-limit backpressure handling and rescheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->