### PR TITLE
fix: stop supervised workers latching idle on exhausted retries

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4120,7 +4120,7 @@ chain.
 ##### Broker rate-limit (429) backpressure
 
 A `429 Too Many Requests` from Alpaca is not a bug and must not consume a job's
-terminal retry budget or open its circuit breaker. Three call-site shapes, each
+terminal retry budget or fail-stop its worker. Three call-site shapes, each
 handled differently:
 
 - **Apalis jobs**: on a classified 429, the job's `perform()` catches the error
@@ -4135,17 +4135,17 @@ handled differently:
   dispatches) and bounds this to a large but finite reschedule budget; once
   exhausted, a supervised job (e.g. `Order status
   poll`) logs loudly and
-  dead-letters cleanly (`Ok(())`, not `Err`) rather than opening its circuit
-  breaker, since a persistent 429 there signals a structurally-dead integration
-  (suspended account, revoked key), not a process fault. An exhausted
-  `Order status poll` retains its completed queue row as a durable dead-letter
-  marker so periodic submitted-order recovery cannot reset the budget and
-  immediately re-arm it. `Order status poll` reads and idempotent hedge-order
-  placement are the jobs whose successors genuinely re-drive the broker call;
-  other jobs' 429s can land after their own idempotency guard already committed,
-  in which case the reschedule still frees the worker and preserves the retry
-  budget but the guard itself (not the reschedule) is what makes the eventual
-  retry safe.
+  dead-letters cleanly (`Ok(())`, not `Err`) rather than emitting a
+  terminal-failure signal, since a persistent 429 there signals a
+  structurally-dead integration (suspended account, revoked key), not a process
+  fault. An exhausted `Order status poll` retains its completed queue row as a
+  durable dead-letter marker so periodic submitted-order recovery cannot reset
+  the budget and immediately re-arm it. `Order status poll` reads and idempotent
+  hedge-order placement are the jobs whose successors genuinely re-drive the
+  broker call; other jobs' 429s can land after their own idempotency guard
+  already committed, in which case the reschedule still frees the worker and
+  preserves the retry budget but the guard itself (not the reschedule) is what
+  makes the eventual retry safe.
   - **Exception -- equity recovery jobs**: wrapped/unwrapped equity recovery
     currently records provider failures as terminal aggregate events carrying
     display text, so the job never receives a typed 429 to classify or

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -226,13 +226,26 @@ lifecycle above, such a row is a live, immediately re-dispatchable chain head --
 `ack.sql` never reschedules `run_at` on a `Failed` ack, so `fetch_next.sql`
 picks it straight back up the moment a worker is free -- so counting it as live
 is what actually prevents recovery from forking a second chain alongside the one
-apalis is about to re-run. But a row stuck behind a latched worker (e.g. a
-circuit-breaker fault, RAI-1495) would otherwise sit `Failed` forever without a
-fresh `ack.sql` write, and `done_at` IS refreshed on every ack -- so bounding by
-`done_at > now - stale_after` (the same staleness bound as the
+apalis is about to re-run. But a row stuck behind a stalled worker process (e.g.
+the crashed-mid-restart window between a supervised fail-stop exit and systemd
+bringing the process back up -- the circuit-breaker latch that used to strand a
+worker indefinitely here, RAI-1495, no longer exists: supervised workers install
+no circuit breaker at all, so `on_terminal_failure` reliably fires and the
+process exits instead of latching) would otherwise sit `Failed` forever without
+a fresh `ack.sql` write, and `done_at` IS refreshed on every ack -- so bounding
+by `done_at > now - stale_after` (the same staleness bound as the
 `Queued`/`Running` arm below) gives both properties: a just-failed row counts as
 live, but one that has sat `Failed` past `stale_after` without a fresh ack stops
 suppressing recovery.
+
+The two predicates are separate and must not be collapsed. Apalis's own retry
+eligibility is `attempts < max_attempts` alone -- `fetch_next.sql` ignores
+`done_at` entirely, so a stale `Failed` row stays re-dispatchable as far as
+apalis is concerned. The `done_at` freshness bound is an app-level recovery
+guard layered on top, applied only to `Failed` rows, and it decides one thing
+only: whether this recovery pass treats the row as already-armed polling. A row
+excluded by staleness is not thereby dead to apalis; recovery just stops
+assuming apalis will get to it.
 
 The predicate also bounds the `Queued`/`Running` arm by staleness
 (`lock_at > now - stale_after`, `stale_after` a small multiple of the poll
@@ -305,11 +318,14 @@ order sharing this job type, not just the corrupt row's own.
 an Alpaca call inside `Job::perform()` -- including an HTTP 429 -- went through
 the unmodified `RetryPolicy::retries(3)` path. Three quick in-place retries
 exhaust in seconds against a sustained rate-limit condition, tripping the
-supervised circuit breaker and reproducing RAI-1492's "hedging silently stops"
-incident. Retrying _in place_ for longer (a naive fix) is worse: it would hold
-the job's `concurrency(1)` worker slot for the whole backoff window, blocking
-every other pending item behind it -- the same "one item monopolizes the worker"
-failure shape, just invisible instead of a visible circuit-breaker trip.
+then-installed supervised circuit breaker and reproducing RAI-1492's "hedging
+silently stops" incident (the breaker itself was removed by RAI-1495; see below
+-- this section describes RAI-1494's own reasoning at the time, which remains
+valid independent of that later change). Retrying _in place_ for longer (a naive
+fix) is worse: it would hold the job's `concurrency(1)` worker slot for the
+whole backoff window, blocking every other pending item behind it -- the same
+"one item monopolizes the worker" failure shape, just invisible instead of a
+loud fail-stop.
 
 **Mechanism**: a 429 is intercepted _before_ `perform()` returns `Err` at all.
 The job classifies the error, computes a delay, pushes a fresh copy of itself
@@ -317,11 +333,11 @@ onto its own queue after that delay via `push_with_delay`, and returns `Ok(())`.
 The row acks `Done` immediately and the worker is free on the very next poll
 tick to pick up any other pending item. The pushed successor is a brand-new
 `Pending` row apalis dispatches when its `run_at` arrives. Because the error
-never reaches `RetryPolicy`/`calculate_status`/the circuit breaker, a pure-429
-sequence can never produce apalis's `Event::Error` and can never open the
-circuit breaker -- RAI-1494 is fully decoupled from RAI-1495 (the
-circuit-breaker latch-with-no-wakeup bug) by construction, not by scoping
-discipline.
+never reaches `RetryPolicy`/`calculate_status`, a pure-429 sequence can never
+produce apalis's `Event::Error` and can never fail-stop the worker -- RAI-1494
+is fully decoupled from RAI-1495 (the circuit-breaker latch-with-no-wakeup bug,
+fixed by removing the breaker entirely -- see below) by construction, not by
+scoping discipline.
 
 **Shared building blocks** (`src/conductor/job.rs`, `crates/execution/src/`):
 
@@ -404,18 +420,18 @@ heartbeat timeout. Even the widest delay this mechanism produces
 
 **Terminal behavior at `BACKPRESSURE_RESCHEDULE_LIMIT` exhaustion depends on
 worker supervision.** For a job registered on a _supervised_ worker
-(`build_supervised_worker!`), propagating a bare `Err` at exhaustion would open
-the circuit breaker for a cause that is not a genuine bug -- reproducing the
-parent incident, just delayed by up to 500 reschedules instead of happening
-immediately. So a supervised job instead dead-letters at exhaustion: log a loud,
-distinct `error!` naming the item and the exhausted streak, then return
-`Ok(())`, so the row acks `Done` and the worker's shared circuit breaker never
-observes an `Event::Error` for this cause. A genuine _non-backpressure_ `Err` on
-these jobs is completely untouched by this decision and still fail-stops exactly
-as before. A best-effort-worker job (`build_best_effort_worker!`) is already
-log-only-and-continue on any terminal failure (RAI-1110), so exhaustion there
-needs no special case: the existing best-effort terminal handling already covers
-it.
+(`build_supervised_worker!`), propagating a bare `Err` at exhaustion would
+fail-stop the whole conductor for a cause that is not a genuine bug -- sustained
+rate-limiting is an expected, self-clearing condition, not the kind of fault the
+supervised fail-stop exists to catch. So a supervised job instead dead-letters
+at exhaustion: log a loud, distinct `error!` naming the item and the exhausted
+streak, then return `Ok(())`, so the row acks `Done` and
+`Event::Error`/`on_terminal_failure` never observe this cause at all. A genuine
+_non-backpressure_ `Err` on these jobs is completely untouched by this decision
+and still fail-stops exactly as before. A best-effort-worker job
+(`build_best_effort_worker!`) is already log-only-and-continue on any terminal
+failure (RAI-1110), so exhaustion there needs no special case: the existing
+best-effort terminal handling already covers it.
 
 **True retry vs. reschedule-then-backstop -- not every job's reschedule
 re-drives the Alpaca call.** Whether a reschedule's successor attempt actually
@@ -591,7 +607,6 @@ WorkerBuilder::new(name)
     .data(ctx)
     .concurrency(1)                                          // sequential processing
     .retry(RetryPolicy::retries(3).with_backoff(backoff))    // 1 + 3 = 4 attempts, with backoff
-    .break_circuit_with(fail_stop_config)                    // halt on terminal failure
     .on_event(|ctx, event| { ... })                          // observability + lifecycle
     .build(work::<MyCtx, MyJob>)
 ```
@@ -604,41 +619,132 @@ WorkerBuilder::new(name)
 - **`.retry(RetryPolicy::retries(3).with_backoff(RETRY_BACKOFF))`** — retries
   failed jobs (replaces backon in the handler). `retries(3)` = 4 total attempts.
   `RETRY_BACKOFF` is a deterministic exponential backoff (1s base, doubles each
-  attempt, capped at 30s) so transient failures (RPC blips, broker rate limits)
-  don't fast-fail into the circuit breaker. No jitter -- single-worker queues
-  don't thunder.
-- **`.break_circuit_with(config)`** — opens the circuit after
-  `failure_threshold` errors, returning `Poll::Pending` from `poll_ready` to
-  block new job pickup. Use `failure_threshold(1)` + very long
-  `recovery_timeout` for fail-stop. Do not install this layer on best-effort
-  workers: in apalis-core 1.0.0-rc.9, an open circuit can return `Poll::Pending`
-  without scheduling a wakeup, so a short `recovery_timeout` does not guarantee
-  the worker will resume.
+  attempt, capped at 30s) so transient failures (RPC blips, broker 5xx) get a
+  few spaced-out attempts before the job is treated as terminal. Classified
+  broker 429s never reach this layer at all -- they are intercepted before
+  `perform()` returns `Err` and rescheduled onto their own queue (see the
+  backpressure section above), so they neither consume the retry budget nor
+  reach `calculate_status`.
+- **No circuit breaker (RAI-1495).** Supervised workers do NOT install Apalis'
+  `CircuitBreakerService` layer -- neither does `build_best_effort_worker!`,
+  which never had one. Previously `build_supervised_worker!` did
+  (`.break_circuit_with(fail_stop_config)` between `.retry()` and
+  `.on_event()`), configured `failure_threshold(1)` + a ~1yr `recovery_timeout`
+  for fail-stop. This was removed: in apalis-core 1.0.0-rc.9,
+  `tower::retry::Retry` sits OUTER of the circuit breaker (the first
+  `.layer()`-style call added ends up outermost), so its `ResponseFuture` calls
+  the circuit's `poll_ready` between retry attempts. Once open, `poll_ready`
+  returns a bare `Poll::Pending` with **no waker registered at all** -- not
+  merely a long wait, but a future that is never polled again, ever. Because
+  that `Poll::Pending` sits inside the retry future, `work()`'s call never
+  resolves to `Err`, `Event::Error` is never emitted, and `on_terminal_failure`
+  (wired via `.on_event()`, listening for exactly that event) can never fire. A
+  single-concurrency worker latches idle forever with no log, no stop, no crash
+  -- `systemctl` still reports `active`. This is what happened to
+  `PollOrderStatus` on 2026-07-22 (RAI-1492): 3h25m of fully silent hedging
+  outage. Removing the breaker closes its own indefinite-Pending gate, the one
+  reachable at any point during ordinary retry exhaustion. `RetryPolicy`'s own
+  give-up decision depends only on attempt count, never on error content, so
+  once it exhausts there is no remaining layer that can defer or swallow the
+  resulting `Err` -- it reaches `on_terminal_failure` for every retry-
+  exhaustion cause, every time.
+
+  A second, narrower bare-`Poll::Pending`-with-no-waker gate remains outside
+  this fix's scope: `ReadinessService::poll_ready` (apalis-core, same shape of
+  bug) returns `Poll::Pending` -- again without registering a waker -- when
+  `ctx.is_shutting_down()` or `ctx.is_paused()` is true. This is
+  retry-reachable, not outside the retry loop -- `RetryPolicy` sits OUTER of
+  `ReadinessService` in this stack, so `tower::retry`'s
+  `ResponseFuture::Retrying` polls `ReadinessService::poll_ready` directly
+  between attempts, the identical delegation path described above for the
+  removed breaker. What differs from the breaker bug is _when_ it can trip: this
+  codebase never calls `.pause()` (grep confirms), so the only live trigger is
+  `is_shutting_down()`, true only during the conductor's own graceful-shutdown
+  sequence. A supervised job that is between retry attempts right as shutdown
+  fires can therefore still hang past that window with no waker -- a
+  shutdown-time hang, not a silent steady-state latch. Not closed by this
+  change; tracked as a follow-up in RAI-1524. The existing
+  `best_effort_worker_does_not_latch_on_single_terminal_failure` regression test
+  does not prove this window is safe -- it only proves a sibling job survives a
+  different job's terminal failure, never exercising shutdown or an in-flight
+  retry backoff.
 - **`.on_event()`** — fires on `Event::Error` (after retries exhaust),
-  `Event::Success`, `Event::Start`, `Event::Stop`. Use for logging AND for
-  calling `ctx.stop()` on terminal failure. The circuit breaker alone only
-  pauses the worker (`Poll::Pending`); `ctx.stop()` is needed to actually make
-  the worker exit.
+  `Event::Success`, `Event::Start`, `Event::Stop`. Use for logging, recording
+  the failure info for the alert path (see below), and calling `ctx.stop()` on
+  terminal failure -- now the SOLE halt mechanism for a supervised worker.
 
 ### Error propagation: handler failure -> bot shutdown
 
-1. `work()` returns `Err` -> retry layer retries
-2. Retries exhaust -> error reaches circuit breaker -> circuit opens
-3. Error becomes `Ok(Event::Error)` in apalis `poll_tasks`
-4. `on_event` catches `Event::Error`, fires the shared `failure_notify`
-   (`tokio::sync::Notify`), and calls `ctx.stop()`
-5. Worker exits cleanly (`Ok(())`)
-6. The spawned monitor task's biased `tokio::select!` observes the Notify and
-   returns `Err(MonitorTaskError::TerminalJobFailure)` immediately -- it does
-   not wait for `apalis_monitor.run()` to wind down. The conductor's
-   `wait_for_completion` sees the monitor task exit with that error and shuts
-   the bot down.
+1. `work()` returns `Err` -> retry layer retries (1s/2s/4s backoff)
+2. Retries exhaust -> `RetryPolicy` resolves to `Err` unconditionally -> this
+   becomes `Event::Error` in apalis `poll_tasks`
+3. `on_event` (`on_terminal_failure`) catches `Event::Error`, logs `error!()`,
+   records a `TerminalFailureInfo { worker, context, source }` -- `source` is
+   the same `Arc<BoxDynError>` apalis handed to the callback, not a flattened
+   string, so the original error's chain survives -- into the shared
+   `TerminalFailureSignal` (an `Arc`-wrapped `Notify` + `OnceLock<_>` threaded
+   through every `build_supervised_worker!` call site exactly like the plain
+   `Notify` it replaces), then calls `ctx.stop()`. The info is always recorded
+   before the `Notify` fires, so a waiter that wakes is guaranteed to see it.
+   `OnceLock::set` makes concurrent terminal failures from different workers
+   first-writer-wins: whichever lands first is the only info any reader ever
+   observes, atomically -- never a torn or mixed pair. Every worker still
+   notifies and stops regardless of which one wins.
+4. Worker exits cleanly (`Ok(())`)
+5. The spawned monitor task's biased `tokio::select!` observes the signal and
+   returns
+   `Err(MonitorTaskError::TerminalJobFailure { worker, context,
+   source })`
+   immediately -- it does not wait for `apalis_monitor.run()` to wind down.
+   `source` is `#[source]` on the error variant, so it is not rendered by
+   `Display`/`{}` but IS walked by anyhow's `{:?}` "Caused by:" chain.
+6. `Conductor::wait_for_completion` (the async exit path) sees this variant and
+   awaits sending an operator alert through `worker_failure_notifier`
+   (`Arc<dyn Notifier>`, `NoopNotifier` when `[alerts]` is unconfigured),
+   bounded by a short timeout so a slow/unreachable Telegram endpoint cannot
+   delay process exit -- then propagates the error, so the bot process exits
+   non-zero.
 
-**Critical:** the spawned monitor task must select on the shared Notify
-alongside `apalis_monitor.run()` and return the terminal error. Without the
-Notify branch, the conductor would only learn of the failure once apalis
-finished tearing down all workers; without returning the error, the conductor
-would never see the failure at all.
+**Critical:** the spawned monitor task must select on the shared signal
+alongside `apalis_monitor.run()` and return the terminal error. Without that
+branch, the conductor would only learn of the failure once apalis finished
+tearing down all workers; without returning the error, the conductor would never
+see the failure at all.
+
+**Why the alert is sent from the exit path, not from `on_event`.** `on_event` is
+a synchronous `Fn(&WorkerContext, &Event)` -- it cannot `.await` a Telegram HTTP
+call. Firing the alert as a detached `tokio::spawn` from inside that callback
+would race process teardown: `ctx.stop()` and the resulting process exit can
+complete before the spawned send does, silently dropping it in the common case.
+`wait_for_completion` is async and runs strictly before the process returns, so
+awaiting the alert there (with a bounded timeout) is what actually guarantees
+delivery-or-timeout instead of delivery-or-silently-lost.
+
+**Blast radius: this restores the existing fail-stop design; it does not invent
+universal self-recovery.** `on_terminal_failure`'s `ctx.stop()` + non-zero
+exit + systemd `Restart = "always"` / `RestartSec = 30` is not new behavior --
+it is the pre-existing fail-stop path the circuit breaker bug was silently
+suppressing. What changes is that it now actually fires. Two distinct outcomes
+follow, and only one of them is "self-heals":
+
+- **Transient cause** (an RPC blip, a momentary broker 5xx): the process exits,
+  systemd restarts it within 30s, and the worker resumes cleanly -- no operator
+  action needed. This is the "resumes by itself" case.
+- **Persistent cause** (poison job, sustained downstream outage): the single
+  poison row itself does not re-drive (`ack.sql` leaves an exhausted `Failed`
+  row alone; `requeue_orphaned` only touches `Running`/`Queued`), so one crash
+  is usually a clean restart. But several supervised jobs are re-seeded on every
+  boot (e.g. `PollOrderStatus` via `recover_submitted_offchain_orders`,
+  `CheckPositions`'s self-reschedule) -- against a genuinely persistent, non-429
+  failure (RAI-1494's reschedule only intercepts classified 429s), each boot
+  re-pushes a fresh row that fails again, producing a real crash-loop. systemd's
+  `StartLimitBurst`/`StartLimitIntervalSec` (see `nix/upgradeable-services.nix`)
+  eventually trips and leaves the unit fully dead -- loud and visible in
+  `systemctl status`/telemetry, but operator- required, and it takes every
+  supervised subsystem down together (hedging, fill detection, rebalancing), not
+  just the one worker that first failed. This is strictly better than the silent
+  single-subsystem latch it replaces, but it is not "always self-recovers" -- a
+  persistent fault ends in a visible dead unit, not a quiet resume.
 
 ### Monitor configuration
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -16,6 +16,7 @@ use alloy::providers::{Identity, Provider, ProviderBuilder, RootProvider};
 use alloy::rpc::client::ClientBuilder;
 use anyhow::Context;
 use apalis::prelude::Status;
+use apalis_core::error::BoxDynError;
 use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
 use sqlx_apalis::sqlite::{SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode};
@@ -52,12 +53,12 @@ use st0x_tokenization::AlpacaTokenizationService;
 use st0x_tokenization::Tokenizer;
 use st0x_wrapper::{Wrapper, WrapperService};
 
-use crate::alerts::{NoopNotifier, NotifierError, TelegramNotifier};
+use crate::alerts::{NoopNotifier, Notifier, NotifierError, TelegramNotifier};
 use crate::bot_gas::{
     BotGasCostLedger, BotGasReceiptCost, BotGasReceiptCostEnqueuer, RecordBotGasReceiptCostCtx,
     RecordBotGasReceiptCostJobQueue,
 };
-use crate::conductor::exit::{ConductorExit, MonitorTaskError};
+use crate::conductor::exit::{ConductorExit, ConductorExitError, MonitorTaskError};
 use crate::conductor::job::{BACKPRESSURE_RESCHEDULE_LIMIT, BackpressureStreak};
 use crate::conductor::monitor::order_fills::{CutoffProbe, probe_cutoff_block_support};
 use crate::dashboard::{Broadcaster, DashboardTradeDelivery};
@@ -353,7 +354,19 @@ pub(crate) struct Conductor {
     /// Independent token for apalis — cancelled explicitly in Phase 2 after
     /// producers are stopped.
     apalis_shutdown_token: CancellationToken,
+    /// Alerts an operator when a supervised worker fails terminally, awaited
+    /// (bounded by [`TERMINAL_FAILURE_ALERT_TIMEOUT`]) from
+    /// `wait_for_completion` before the process returns a non-zero exit --
+    /// `NoopNotifier` when `[alerts]` is unconfigured.
+    worker_failure_notifier: Arc<dyn Notifier>,
 }
+
+/// Bounds how long `wait_for_completion` waits for the terminal-failure alert
+/// to send before proceeding with process exit. The fail-stop itself
+/// (non-zero exit, systemd restart) is the load-bearing recovery signal; this
+/// alert is a best-effort convenience on top and must never delay it by more
+/// than a few seconds.
+const TERMINAL_FAILURE_ALERT_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Resets a transfer queue's orphaned `Running`/`Queued` rows back to `Pending`
 /// at startup -- run before workers spawn, so any such row is orphaned by a dead
@@ -791,7 +804,7 @@ impl Conductor {
         catch_up_lifecycle_failures(&pool).await?;
 
         let rebalancing = optional_rebalancing_ctx(&ctx)?;
-        let notifier = build_notifier(ctx.alerts.as_ref())?;
+        let notifier = build_alert_notifier(ctx.alerts.as_ref(), "Operational alerting")?;
 
         let PositionAndRebalancing {
             position,
@@ -944,7 +957,7 @@ impl Conductor {
             .rejection_queue(rejection_queue)
             .check_positions_queue(check_positions_queue)
             .portfolio_snapshot_queue(portfolio_snapshot_queue)
-            .notifier(notifier)
+            .notifier(notifier.clone())
             .wrapped_equity_recovery_queue(wrapped_equity_recovery_queue)
             .maybe_wrapped_equity_recovery_ctx(wrapped_equity_recovery_ctx)
             .unwrapped_equity_recovery_queue(unwrapped_equity_recovery_queue)
@@ -968,6 +981,9 @@ impl Conductor {
             .maybe_record_bot_gas_receipt_cost_ctx(record_bot_gas_receipt_cost_ctx)
             .job_cleanup(job_cleanup)
             .telemetry_writer(telemetry_writer)
+            // Worker-failure pages share the operational `[alerts]` channel
+            // rather than building a second notifier against the same config.
+            .worker_failure_notifier(notifier)
             .call()?;
 
         publish_recovery_handle(&recovery_cell, recovery_transfer, recovery_service);
@@ -989,8 +1005,32 @@ impl Conductor {
             result = &mut self.job_cleanup => ConductorExit::JobCleanup(result),
         };
 
+        // Alert here (the async exit path), not from the sync `on_event`
+        // callback that recorded this failure: awaiting the alert send is
+        // only possible once we are back in an async context, and doing it
+        // here -- before `handle()` propagates the error and the process
+        // exits -- is what guarantees the send actually completes (or times
+        // out) rather than racing runtime teardown.
+        if let ConductorExit::Monitor(Ok(Err(error))) = &exit {
+            self.maybe_alert_terminal_job_failure(error).await;
+        }
+
         match exit {
-            ConductorExit::GracefulShutdown => self.drain_gracefully().await,
+            ConductorExit::GracefulShutdown => {
+                let drain_result = self.drain_gracefully().await;
+
+                // Mirror the direct-Monitor-branch check above: apalis's
+                // RetryPolicy gives up the instant `worker.is_shutting_down()`
+                // is true, so a supervised job mid-retry when a graceful
+                // shutdown begins can still terminalize during the drain
+                // window (Phase 2 of `drain_gracefully`), not just via the
+                // top-level select. The same alert guarantee must apply here.
+                if let Err(ConductorExitError::Monitor(error)) = &drain_result {
+                    self.maybe_alert_terminal_job_failure(error).await;
+                }
+
+                drain_result.map_err(anyhow::Error::from)
+            }
             other => {
                 other.handle()?;
                 Ok(())
@@ -998,8 +1038,66 @@ impl Conductor {
         }
     }
 
+    /// Shared guard for the two `wait_for_completion` exit paths (the direct
+    /// Monitor branch and the graceful-drain branch): both need to alert on
+    /// a `MonitorTaskError::TerminalJobFailure` and ignore every other
+    /// `MonitorTaskError` variant, so the destructuring lives here once.
+    async fn maybe_alert_terminal_job_failure(&self, error: &MonitorTaskError) {
+        match error {
+            MonitorTaskError::TerminalJobFailure {
+                worker,
+                context,
+                source,
+            } => {
+                self.alert_terminal_job_failure(worker, context, source)
+                    .await;
+            }
+            // Not a per-worker failure: the propagated error is the operator
+            // signal, so no separate alert.
+            MonitorTaskError::UnexpectedExit { .. } => {}
+        }
+    }
+
+    /// Sends an operator alert for a supervised worker's terminal failure,
+    /// bounded by [`TERMINAL_FAILURE_ALERT_TIMEOUT`] so a slow or
+    /// unreachable Telegram endpoint cannot delay process exit. The alert
+    /// text is assembled here, at the point it is actually needed, rather
+    /// than flattened into a string when the failure was first recorded --
+    /// so `source`'s full `Display` (and, separately, its `#[source]` chain
+    /// on `MonitorTaskError::TerminalJobFailure`) both stay intact.
+    async fn alert_terminal_job_failure(
+        &self,
+        worker: &str,
+        context: &'static str,
+        source: &BoxDynError,
+    ) {
+        // Deliberately states only what this process controls. The restart
+        // interval is owned by the systemd unit's `RestartSec`, so naming a
+        // value here would drift silently the moment the unit changes and
+        // page an operator with a stale SLA.
+        let alert =
+            format!("st0x-hedge: {worker}: {context}: {source}; process will exit for restart");
+
+        match tokio::time::timeout(
+            TERMINAL_FAILURE_ALERT_TIMEOUT,
+            self.worker_failure_notifier.notify(&alert),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => error!(%error, "Failed to send terminal-failure alert"),
+            Err(_) => error!("Timed out sending terminal-failure alert"),
+        }
+    }
+
     /// Two-phase graceful drain: stop producers, then wait for consumers.
-    async fn drain_gracefully(&mut self) -> anyhow::Result<()> {
+    ///
+    /// Returns the raw [`ConductorExitError`] (not flattened to `anyhow`) so
+    /// `wait_for_completion` can still pattern-match a
+    /// `MonitorTaskError::TerminalJobFailure` surfaced during Phase 2 and
+    /// send the same operator alert it sends for the direct-Monitor-exit
+    /// path.
+    async fn drain_gracefully(&mut self) -> Result<(), ConductorExitError> {
         // Phase 1: stop supervised tasks (OrderFillMonitor, PositionMonitor)
         // so they stop enqueuing new jobs.
         info!(target: "shutdown", "Phase 1: stopping producers (supervisor)");
@@ -1254,14 +1352,15 @@ pub(crate) struct AccumulatedPositionExecutionCtx<'a> {
 
 fn check_monitor_drain_result(
     join_result: Result<Result<(), MonitorTaskError>, JoinError>,
-) -> anyhow::Result<()> {
+) -> Result<(), ConductorExitError> {
     let monitor_result = match join_result {
         Ok(inner) => inner,
         Err(join_error) => {
             error!(%join_error, "Monitor task panicked during drain");
-            return Err(
-                anyhow::Error::from(join_error).context("Monitor task panicked during drain")
-            );
+            return Err(ConductorExitError::TaskFailed {
+                task: "Apalis monitor",
+                source: join_error,
+            });
         }
     };
 
@@ -1621,7 +1720,10 @@ impl PositionAndRebalancing {
     }
 }
 
-/// Builds the shared operational-alerting notifier.
+/// Builds an alert notifier for one `[alerts]`-gated channel. Shared by every
+/// alerting call site (USDC rebalancing, supervised-worker terminal failure)
+/// -- `channel` only labels the log lines so each call site's startup
+/// behaviour stays distinguishable.
 ///
 /// Returns `Ok(Arc<NoopNotifier>)` when `[alerts]` is absent — silence is
 /// the correct behaviour for an unconfigured optional channel.
@@ -1629,18 +1731,19 @@ impl PositionAndRebalancing {
 /// Returns `Err` when `[alerts]` IS present but `TelegramNotifier` fails to
 /// initialise. The caller must propagate this so the server fails to start:
 /// an operator who configured `[alerts]` believes alerts are active; silently
-/// falling back to Noop would suppress all redrive-limit and terminal-error
-/// pages with no runtime indication.
-fn build_notifier(
+/// falling back to Noop would suppress that channel's alerts with no runtime
+/// indication.
+fn build_alert_notifier(
     alerts: Option<&st0x_config::AlertsCtx>,
+    channel: &'static str,
 ) -> Result<Arc<dyn crate::alerts::Notifier>, NotifierError> {
     let Some(alerts) = alerts else {
-        debug!("Alerting: [alerts] section absent, using NoopNotifier");
+        debug!("{channel}: [alerts] section absent, using NoopNotifier");
         return Ok(Arc::new(NoopNotifier));
     };
     let notifier =
         TelegramNotifier::new(&alerts.bot_token, alerts.chat_id, alerts.message_thread_id)?;
-    info!("Telegram notifier configured");
+    info!("{channel}: Telegram notifier configured");
     Ok(Arc::new(notifier))
 }
 
@@ -4046,6 +4149,7 @@ mod tests {
     use st0x_wrapper::{MockWrapper, RATIO_ONE, UnderlyingPerWrapped, Wrapper};
 
     use super::*;
+    use crate::alerts::CapturingNotifier;
     use crate::bindings::IRaindexInventory::{OperatorDeposit, OperatorWithdraw};
     use crate::bindings::IRaindexV6::{
         ClearConfigV2, ClearV3, EvaluableV4, IOV2, OrderV4, TakeOrderConfigV4, TakeOrderV3,
@@ -4212,6 +4316,7 @@ mod tests {
             telemetry_writer: tokio::spawn(pending::<()>()),
             shutdown_token: CancellationToken::new(),
             apalis_shutdown_token: CancellationToken::new(),
+            worker_failure_notifier: Arc::new(NoopNotifier),
         }
     }
 
@@ -11246,6 +11351,7 @@ mod tests {
             telemetry_writer: tokio::spawn(pending::<()>()),
             shutdown_token: shutdown_token.clone(),
             apalis_shutdown_token,
+            worker_failure_notifier: Arc::new(NoopNotifier),
         };
 
         shutdown_token.cancel();
@@ -11262,7 +11368,12 @@ mod tests {
         // Monitor returns an error after shutdown signal.
         let monitor = tokio::spawn(async move {
             apalis_token_clone.cancelled().await;
-            Err(MonitorTaskError::TerminalJobFailure)
+            let source: Arc<BoxDynError> = Arc::new("boom".into());
+            Err(MonitorTaskError::TerminalJobFailure {
+                worker: "test-worker-0".to_string(),
+                context: "terminal failure",
+                source,
+            })
         });
 
         let job_cleanup = tokio::spawn(pending::<()>());
@@ -11274,6 +11385,7 @@ mod tests {
             telemetry_writer: tokio::spawn(pending::<()>()),
             shutdown_token: shutdown_token.clone(),
             apalis_shutdown_token,
+            worker_failure_notifier: Arc::new(NoopNotifier),
         };
 
         shutdown_token.cancel();
@@ -11284,6 +11396,277 @@ mod tests {
         );
     }
 
+    /// M1 regression test: a supervised worker's terminal failure must
+    /// actually deliver an operator alert, not merely fire the fail-stop
+    /// signal. Asserts the `CapturingNotifier` received the message --
+    /// containing the worker name and failure text -- via
+    /// `wait_for_completion`'s async exit path, proving the alert send
+    /// completes rather than racing (and losing to) process teardown the way
+    /// a fire-and-forget `tokio::spawn` from the sync `on_event` callback
+    /// would.
+    #[tokio::test]
+    async fn wait_for_completion_sends_terminal_failure_alert_before_propagating() {
+        let supervisor = SupervisorBuilder::default().build().run();
+        let shutdown_token = CancellationToken::new();
+        let apalis_shutdown_token = CancellationToken::new();
+
+        // Monitor fails immediately -- no shutdown signal involved, so this
+        // exercises the direct Monitor branch of `wait_for_completion`'s
+        // select, not the graceful-drain path.
+        let monitor = tokio::spawn(async {
+            let source: Arc<BoxDynError> = Arc::new("boom".into());
+            Err(MonitorTaskError::TerminalJobFailure {
+                worker: "test-worker-0".to_string(),
+                context: "terminal failure",
+                source,
+            })
+        });
+
+        let job_cleanup = tokio::spawn(pending::<()>());
+        let notifier = Arc::new(CapturingNotifier::default());
+
+        let mut conductor = Conductor {
+            supervisor,
+            monitor,
+            job_cleanup,
+            telemetry_writer: tokio::spawn(pending::<()>()),
+            shutdown_token,
+            apalis_shutdown_token,
+            worker_failure_notifier: notifier.clone(),
+        };
+
+        let error = conductor.wait_for_completion().await.unwrap_err();
+        assert!(
+            error.to_string().contains("terminal failure"),
+            "the terminal job failure must still propagate after alerting; got: {error}"
+        );
+        assert!(
+            format!("{error:?}").contains("boom"),
+            "the original error must survive as a #[source] on MonitorTaskError so anyhow's \
+             'Caused by:' chain still surfaces it (not flattened into a string); got: {error:?}"
+        );
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "exactly one alert must be sent for the terminal failure; got: {messages:?}"
+        );
+        assert!(
+            messages[0].contains("test-worker-0") && messages[0].contains("boom"),
+            "the alert must name the worker and the failure text; got: {}",
+            messages[0]
+        );
+    }
+
+    /// The `UnexpectedExit` arm of `maybe_alert_terminal_job_failure` is a
+    /// deliberate no-alert decision: that error is not a per-worker failure,
+    /// so propagating it IS the operator signal. Pinned here because nothing
+    /// else does -- a future variant that started paging (or double-paging)
+    /// on a non-per-worker exit would otherwise pass the whole suite.
+    #[tokio::test]
+    async fn wait_for_completion_does_not_alert_on_unexpected_monitor_exit() {
+        let supervisor = SupervisorBuilder::default().build().run();
+        let monitor =
+            tokio::spawn(async { Err(MonitorTaskError::UnexpectedExit { source: None }) });
+        let notifier = Arc::new(CapturingNotifier::default());
+
+        let mut conductor = Conductor {
+            supervisor,
+            monitor,
+            job_cleanup: tokio::spawn(pending::<()>()),
+            telemetry_writer: tokio::spawn(pending::<()>()),
+            shutdown_token: CancellationToken::new(),
+            apalis_shutdown_token: CancellationToken::new(),
+            worker_failure_notifier: notifier.clone(),
+        };
+
+        let error = conductor.wait_for_completion().await.unwrap_err();
+        assert!(
+            error.to_string().contains("exited unexpectedly"),
+            "the unexpected exit must still propagate; got: {error}"
+        );
+
+        let messages = notifier.messages();
+        assert!(
+            messages.is_empty(),
+            "an UnexpectedExit must propagate without paging an operator; got: {messages:?}"
+        );
+    }
+
+    /// Same M1 guarantee as
+    /// `wait_for_completion_sends_terminal_failure_alert_before_propagating`,
+    /// but for the graceful-shutdown drain path: `shutdown_token` cancels
+    /// first, so the outer biased `select!` takes `GracefulShutdown` rather
+    /// than the direct `Monitor` branch, and the monitor only resolves with
+    /// `TerminalJobFailure` once `drain_gracefully`'s Phase 2 cancels
+    /// `apalis_shutdown_token` -- mirroring apalis's own `RetryPolicy` giving
+    /// up mid-retry the instant `worker.is_shutting_down()` becomes true.
+    /// The alert must still fire, and exactly once.
+    #[tokio::test]
+    async fn wait_for_completion_sends_terminal_failure_alert_during_graceful_drain() {
+        let supervisor = SupervisorBuilder::default().build().run();
+        let shutdown_token = CancellationToken::new();
+        let apalis_shutdown_token = CancellationToken::new();
+        let apalis_token_clone = apalis_shutdown_token.clone();
+
+        // Only resolves with a terminal failure after Phase 2 of
+        // `drain_gracefully` cancels the apalis shutdown token -- proving
+        // this exercises the drain window, not the top-level select branch.
+        let monitor = tokio::spawn(async move {
+            apalis_token_clone.cancelled().await;
+            let source: Arc<BoxDynError> = Arc::new("boom".into());
+            Err(MonitorTaskError::TerminalJobFailure {
+                worker: "test-worker-0".to_string(),
+                context: "terminal failure",
+                source,
+            })
+        });
+
+        let job_cleanup = tokio::spawn(pending::<()>());
+        let notifier = Arc::new(CapturingNotifier::default());
+
+        let mut conductor = Conductor {
+            supervisor,
+            monitor,
+            job_cleanup,
+            telemetry_writer: tokio::spawn(pending::<()>()),
+            shutdown_token: shutdown_token.clone(),
+            apalis_shutdown_token,
+            worker_failure_notifier: notifier.clone(),
+        };
+
+        shutdown_token.cancel();
+        let error = conductor.wait_for_completion().await.unwrap_err();
+        assert!(
+            error.to_string().contains("terminal failure"),
+            "the terminal job failure surfaced during drain must still propagate; got: {error}"
+        );
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "exactly one alert must be sent for a terminal failure discovered during the \
+             graceful-shutdown drain window; got: {messages:?}"
+        );
+        assert!(
+            messages[0].contains("test-worker-0") && messages[0].contains("boom"),
+            "the alert must name the worker and the failure text; got: {}",
+            messages[0]
+        );
+    }
+
+    /// A [`Notifier`] whose `notify()` never resolves, for asserting
+    /// [`TERMINAL_FAILURE_ALERT_TIMEOUT`] actually bounds
+    /// `alert_terminal_job_failure`'s wait instead of blocking process exit
+    /// indefinitely on a stalled alert channel.
+    struct HangingNotifier;
+
+    #[async_trait::async_trait]
+    impl Notifier for HangingNotifier {
+        async fn notify(&self, _message: &str) -> Result<(), NotifierError> {
+            std::future::pending().await
+        }
+    }
+
+    /// A [`Notifier`] whose `notify()` always errors, for asserting the
+    /// fail-stop still propagates even when the alert channel itself fails
+    /// to deliver.
+    struct ErroringNotifier;
+
+    #[async_trait::async_trait]
+    impl Notifier for ErroringNotifier {
+        async fn notify(&self, _message: &str) -> Result<(), NotifierError> {
+            Err(NotifierError::ApiError {
+                status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                body: "simulated Telegram outage".to_string(),
+            })
+        }
+    }
+
+    /// The alert must never block the fail-stop: a hung notifier still lets
+    /// `wait_for_completion` return the propagated `TerminalJobFailure`
+    /// within [`TERMINAL_FAILURE_ALERT_TIMEOUT`]. Uses paused virtual time so
+    /// the 3s bound is exercised without the test actually waiting 3s.
+    #[tokio::test(start_paused = true)]
+    async fn wait_for_completion_propagates_past_a_hung_notifier_within_the_timeout() {
+        let supervisor = SupervisorBuilder::default().build().run();
+        let shutdown_token = CancellationToken::new();
+        let apalis_shutdown_token = CancellationToken::new();
+
+        let monitor = tokio::spawn(async {
+            let source: Arc<BoxDynError> = Arc::new("boom".into());
+            Err(MonitorTaskError::TerminalJobFailure {
+                worker: "test-worker-0".to_string(),
+                context: "terminal failure",
+                source,
+            })
+        });
+
+        let job_cleanup = tokio::spawn(pending::<()>());
+
+        let mut conductor = Conductor {
+            supervisor,
+            monitor,
+            job_cleanup,
+            telemetry_writer: tokio::spawn(pending::<()>()),
+            shutdown_token,
+            apalis_shutdown_token,
+            worker_failure_notifier: Arc::new(HangingNotifier),
+        };
+
+        let error = tokio::time::timeout(Duration::from_secs(10), conductor.wait_for_completion())
+            .await
+            .expect(
+                "wait_for_completion must not hang past TERMINAL_FAILURE_ALERT_TIMEOUT even \
+                 with a hung notifier",
+            )
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("terminal failure"),
+            "the terminal job failure must still propagate despite a hung notifier; got: {error}"
+        );
+    }
+
+    /// The alert must never swallow the fail-stop: a notifier that errors
+    /// still lets `wait_for_completion` return the propagated
+    /// `TerminalJobFailure`.
+    #[tokio::test]
+    async fn wait_for_completion_propagates_when_the_notifier_itself_errors() {
+        let supervisor = SupervisorBuilder::default().build().run();
+        let shutdown_token = CancellationToken::new();
+        let apalis_shutdown_token = CancellationToken::new();
+
+        let monitor = tokio::spawn(async {
+            let source: Arc<BoxDynError> = Arc::new("boom".into());
+            Err(MonitorTaskError::TerminalJobFailure {
+                worker: "test-worker-0".to_string(),
+                context: "terminal failure",
+                source,
+            })
+        });
+
+        let job_cleanup = tokio::spawn(pending::<()>());
+
+        let mut conductor = Conductor {
+            supervisor,
+            monitor,
+            job_cleanup,
+            telemetry_writer: tokio::spawn(pending::<()>()),
+            shutdown_token,
+            apalis_shutdown_token,
+            worker_failure_notifier: Arc::new(ErroringNotifier),
+        };
+
+        let error = conductor.wait_for_completion().await.unwrap_err();
+        assert!(
+            error.to_string().contains("terminal failure"),
+            "the terminal job failure must still propagate even when the notifier itself \
+             errors; got: {error}"
+        );
+    }
+
     #[test]
     fn check_monitor_drain_result_ok() {
         check_monitor_drain_result(Ok(Ok(()))).unwrap();
@@ -11291,8 +11674,13 @@ mod tests {
 
     #[test]
     fn check_monitor_drain_result_propagates_monitor_error() {
-        let error =
-            check_monitor_drain_result(Ok(Err(MonitorTaskError::TerminalJobFailure))).unwrap_err();
+        let source: Arc<BoxDynError> = Arc::new("boom".into());
+        let error = check_monitor_drain_result(Ok(Err(MonitorTaskError::TerminalJobFailure {
+            worker: "test-worker-0".to_string(),
+            context: "terminal failure",
+            source,
+        })))
+        .unwrap_err();
 
         assert!(
             error.to_string().contains("Apalis worker failed"),
@@ -11984,21 +12372,26 @@ mod tests {
         );
     }
 
-    /// When `[alerts]` is absent, `build_notifier` returns a `NoopNotifier`
-    /// that silently discards notifications without error.
+    /// When `[alerts]` is absent, `build_alert_notifier` returns a
+    /// `NoopNotifier` that silently discards notifications without error --
+    /// exercised here through the USDC alerting call site's exact arguments.
+    /// `channel` only labels log lines (see `build_alert_notifier`'s doc), so
+    /// this also covers the supervised-worker terminal-failure call site,
+    /// which shares this exact code path with a different `channel` string.
     #[tokio::test]
-    async fn build_notifier_returns_ok_noop_when_alerts_absent() {
-        let notifier = build_notifier(None).unwrap();
+    async fn build_usdc_notifier_returns_ok_noop_when_alerts_absent() {
+        let notifier = build_alert_notifier(None, "USDC alerting").unwrap();
         notifier
             .notify("test message")
             .await
             .expect("NoopNotifier must not error on notify");
     }
 
-    /// When `[alerts]` IS present, `build_notifier` constructs a real
+    /// When `[alerts]` IS present, `build_alert_notifier` constructs a real
     /// Telegram notifier and returns `Ok` -- it must NOT fail startup for a
     /// well-formed config, and it must NOT silently fall back to `NoopNotifier`
     /// (which would suppress every redrive-limit and terminal-error page).
+    /// Exercised here through the USDC alerting call site's exact arguments.
     ///
     /// The error branch (`Err(NotifierError::ClientBuild)`) is only reachable on
     /// a reqwest/TLS backend init failure; it cannot be triggered deterministically
@@ -12006,8 +12399,11 @@ mod tests {
     /// site the `?` propagation fails startup, which is the behaviour that matters.
     /// `notify()` is deliberately not exercised: the present-branch notifier posts
     /// to the live Telegram API, which a unit test must never reach.
+    /// `channel` only labels log lines (see `build_alert_notifier`'s doc), so
+    /// this also covers the supervised-worker terminal-failure call site,
+    /// which shares this exact code path with a different `channel` string.
     #[tokio::test]
-    async fn build_notifier_returns_ok_telegram_when_alerts_present() {
+    async fn build_usdc_notifier_returns_ok_telegram_when_alerts_present() {
         let alerts = st0x_config::AlertsCtx {
             chat_id: 123,
             bot_token: "test-bot-token".to_string(),
@@ -12017,7 +12413,7 @@ mod tests {
             message_thread_id: Some(42),
         };
 
-        build_notifier(Some(&alerts))
+        build_alert_notifier(Some(&alerts), "USDC alerting")
             .expect("a well-formed [alerts] config must yield a notifier, not a startup error");
     }
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -3,7 +3,6 @@
 use alloy::primitives::{Address, B256};
 use alloy::providers::Provider;
 use apalis::prelude::Monitor;
-use apalis_core::worker::ext::circuit_breaker::config::CircuitBreakerConfig;
 use sqlx::SqlitePool;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
@@ -27,7 +26,7 @@ use super::exit::MonitorTaskError;
 #[cfg(any(test, feature = "test-support"))]
 use super::job::FailureInjector;
 use super::job::{
-    FAIL_STOP_RECOVERY_TIMEOUT, build_best_effort_worker, build_supervised_worker,
+    TerminalFailureInfo, TerminalFailureSignal, build_best_effort_worker, build_supervised_worker,
     build_worker_inner,
 };
 use super::monitor::executor_maintenance::ExecutorMaintenance;
@@ -214,6 +213,7 @@ pub(crate) fn spawn<Prov, Exec>(
     record_bot_gas_receipt_cost_ctx: Option<Arc<RecordBotGasReceiptCostCtx>>,
     job_cleanup: JoinHandle<()>,
     telemetry_writer: JoinHandle<()>,
+    worker_failure_notifier: Arc<dyn Notifier>,
 ) -> Result<Conductor, chrono::OutOfRangeError>
 where
     Prov: Provider + Clone + Send + Sync + 'static,
@@ -518,6 +518,7 @@ where
         telemetry_writer,
         shutdown_token: context.shutdown_token,
         apalis_shutdown_token: apalis_shutdown_token_for_struct,
+        worker_failure_notifier,
     })
 }
 
@@ -666,7 +667,7 @@ where
         let failure_injector_for_resume_tokenization = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_record_bot_gas_receipt_cost = failure_injector.clone();
-        let failure_notify = Arc::new(tokio::sync::Notify::new());
+        let failure_notify = Arc::new(TerminalFailureSignal::default());
         let failure_notify_for_hedge = failure_notify.clone();
         let failure_notify_for_backfill = failure_notify.clone();
         let failure_notify_for_dashboard_trade_delivery = failure_notify.clone();
@@ -683,23 +684,6 @@ where
         let failure_notify_for_transfer_usdc_to_market_making = failure_notify.clone();
         let failure_notify_for_select = failure_notify.clone();
 
-        let fail_stop = CircuitBreakerConfig::default()
-            .with_failure_threshold(1)
-            .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
-        let fail_stop_for_hedge = fail_stop.clone();
-        let fail_stop_for_backfill = fail_stop.clone();
-        let fail_stop_for_dashboard_trade_delivery = fail_stop.clone();
-        let fail_stop_for_poll = fail_stop.clone();
-        let fail_stop_for_reconcile = fail_stop.clone();
-        let fail_stop_for_rejection = fail_stop.clone();
-        let fail_stop_for_equity_rebalancing_check = fail_stop.clone();
-        let fail_stop_for_usdc_rebalancing_check = fail_stop.clone();
-        let fail_stop_for_seed_vault_registry = fail_stop.clone();
-        let fail_stop_for_wrapped_equity_recovery = fail_stop.clone();
-        let fail_stop_for_unwrapped_equity_recovery = fail_stop.clone();
-        let fail_stop_for_check_positions = fail_stop.clone();
-        let fail_stop_for_transfer_usdc_to_hedging = fail_stop.clone();
-        let fail_stop_for_transfer_usdc_to_market_making = fail_stop.clone();
         let accountant_ctx_for_backfill = accountant_ctx.clone();
 
         tokio::spawn(async move {
@@ -711,7 +695,6 @@ where
                         index,
                         job_queue.clone(),
                         accountant_ctx.clone(),
-                        fail_stop.clone(),
                         failure_notify.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector.clone(),
@@ -723,7 +706,6 @@ where
                         index,
                         dashboard_trade_delivery_queue.clone(),
                         dashboard_trade_delivery_ctx.clone(),
-                        fail_stop_for_dashboard_trade_delivery.clone(),
                         failure_notify_for_dashboard_trade_delivery.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_dashboard_trade_delivery.clone(),
@@ -735,7 +717,6 @@ where
                         index,
                         hedge_queue.clone(),
                         hedge_ctx.clone(),
-                        fail_stop_for_hedge.clone(),
                         failure_notify_for_hedge.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_hedge.clone(),
@@ -747,7 +728,6 @@ where
                         index,
                         backfill_queue.clone(),
                         accountant_ctx_for_backfill.clone(),
-                        fail_stop_for_backfill.clone(),
                         failure_notify_for_backfill.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_backfill.clone(),
@@ -759,7 +739,6 @@ where
                         index,
                         poll_status_queue.clone(),
                         poll_status_ctx.clone(),
-                        fail_stop_for_poll.clone(),
                         failure_notify_for_poll.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_poll.clone(),
@@ -771,7 +750,6 @@ where
                         index,
                         reconcile_queue.clone(),
                         reconcile_ctx.clone(),
-                        fail_stop_for_reconcile.clone(),
                         failure_notify_for_reconcile.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_reconcile.clone(),
@@ -783,7 +761,6 @@ where
                         index,
                         rejection_queue.clone(),
                         rejection_ctx.clone(),
-                        fail_stop_for_rejection.clone(),
                         failure_notify_for_rejection.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_rejection.clone(),
@@ -795,7 +772,6 @@ where
                         index,
                         seed_vault_registry_queue.clone(),
                         seed_vault_registry_ctx.clone(),
-                        fail_stop_for_seed_vault_registry.clone(),
                         failure_notify_for_seed_vault_registry.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_seed_vault_registry.clone(),
@@ -807,7 +783,6 @@ where
                         index,
                         check_positions_queue.clone(),
                         check_positions_ctx.clone(),
-                        fail_stop_for_check_positions.clone(),
                         failure_notify_for_check_positions.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_check_positions.clone(),
@@ -841,7 +816,6 @@ where
                             index,
                             equity_queue.clone(),
                             equity_service.clone(),
-                            fail_stop_for_equity_rebalancing_check.clone(),
                             failure_notify_for_equity_rebalancing_check.clone(),
                             #[cfg(any(test, feature = "test-support"))]
                             failure_injector_for_equity_rebalancing_check.clone(),
@@ -853,7 +827,6 @@ where
                             index,
                             usdc_queue.clone(),
                             usdc_service.clone(),
-                            fail_stop_for_usdc_rebalancing_check.clone(),
                             failure_notify_for_usdc_rebalancing_check.clone(),
                             #[cfg(any(test, feature = "test-support"))]
                             failure_injector_for_usdc_rebalancing_check.clone(),
@@ -867,7 +840,6 @@ where
                 apalis_monitor,
                 wrapped_equity_recovery_ctx,
                 wrapped_equity_recovery_queue,
-                FailStopCircuit(fail_stop_for_wrapped_equity_recovery),
                 failure_notify_for_wrapped_equity_recovery,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_wrapped_equity_recovery,
@@ -877,7 +849,6 @@ where
                 apalis_monitor,
                 unwrapped_equity_recovery_ctx,
                 unwrapped_equity_recovery_queue,
-                FailStopCircuit(fail_stop_for_unwrapped_equity_recovery),
                 failure_notify_for_unwrapped_equity_recovery,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_unwrapped_equity_recovery,
@@ -887,7 +858,6 @@ where
                 apalis_monitor,
                 transfer_usdc_to_hedging_ctx,
                 transfer_usdc_to_hedging_queue,
-                FailStopCircuit(fail_stop_for_transfer_usdc_to_hedging),
                 failure_notify_for_transfer_usdc_to_hedging,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_transfer_usdc_to_hedging,
@@ -897,7 +867,6 @@ where
                 apalis_monitor,
                 transfer_usdc_to_market_making_ctx,
                 transfer_usdc_to_market_making_queue,
-                FailStopCircuit(fail_stop_for_transfer_usdc_to_market_making),
                 failure_notify_for_transfer_usdc_to_market_making,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_transfer_usdc_to_market_making,
@@ -949,12 +918,27 @@ where
 
             tokio::select! {
                 biased;
-                // During drain, suppress terminal job failures — let remaining
-                // workers finish instead of short-circuiting the drain.
-                () = failure_notify_for_select.notified(),
+                // `select!` evaluates this precondition ONCE, when the select
+                // is entered at monitor-task startup -- it is not re-checked
+                // on each wakeup. It therefore only disarms this branch in
+                // the edge case where shutdown was already requested before
+                // the monitor task's first poll. A terminal failure landing
+                // during a later drain window still fires this branch,
+                // aborting the drain; `wait_for_completion`'s drain branch
+                // alerts on exactly that path, so the failure surfaces
+                // rather than being suppressed.
+                TerminalFailureInfo {
+                    worker,
+                    context,
+                    source,
+                } = failure_notify_for_select.notified(),
                     if !is_draining.is_cancelled() =>
                 {
-                    Err(MonitorTaskError::TerminalJobFailure)
+                    Err(MonitorTaskError::TerminalJobFailure {
+                        worker,
+                        context,
+                        source,
+                    })
                 }
                 result = apalis_monitor.run_with_signal(shutdown_signal) => match result {
                     Ok(()) => Ok(()),
@@ -998,14 +982,6 @@ fn log_optional_task_status(task_name: &str, is_configured: bool) {
     }
 }
 
-/// A circuit-breaker config for a FAIL-STOP worker (threshold 1, ~1yr timeout):
-/// a single terminal failure opens the circuit and latches the worker idle,
-/// tripping the conductor-wide fail-stop. A distinct type from
-/// [`BestEffortCircuit`] so the two policies cannot be cross-assigned at a
-/// worker-registration site -- passing the wrong one would be a compile error
-/// rather than a silent freeze.
-struct FailStopCircuit(CircuitBreakerConfig);
-
 /// Conditionally registers the wrapped-equity recovery worker against the
 /// apalis monitor. Extracted because this is the only `Option`-gated worker
 /// registration and inlining the let-else + debug log keeps
@@ -1014,8 +990,7 @@ fn register_wrapped_equity_recovery_worker(
     monitor: Monitor,
     recovery_ctx: Option<Arc<WrappedEquityRecoveryCtx>>,
     recovery_queue: WrappedEquityRecoveryJobQueue,
-    FailStopCircuit(fail_stop): FailStopCircuit,
-    failure_notify: Arc<tokio::sync::Notify>,
+    failure_notify: Arc<TerminalFailureSignal>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
     let Some(recovery_ctx) = recovery_ctx else {
@@ -1032,7 +1007,6 @@ fn register_wrapped_equity_recovery_worker(
             index,
             recovery_queue.clone(),
             recovery_ctx.clone(),
-            fail_stop.clone(),
             failure_notify.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector.clone(),
@@ -1046,8 +1020,7 @@ fn register_unwrapped_equity_recovery_worker(
     monitor: Monitor,
     recovery_ctx: Option<Arc<UnwrappedEquityRecoveryCtx>>,
     recovery_queue: UnwrappedEquityRecoveryJobQueue,
-    FailStopCircuit(fail_stop): FailStopCircuit,
-    failure_notify: Arc<tokio::sync::Notify>,
+    failure_notify: Arc<TerminalFailureSignal>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
     let Some(recovery_ctx) = recovery_ctx else {
@@ -1064,7 +1037,6 @@ fn register_unwrapped_equity_recovery_worker(
             index,
             recovery_queue.clone(),
             recovery_ctx.clone(),
-            fail_stop.clone(),
             failure_notify.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector.clone(),
@@ -1080,8 +1052,7 @@ fn register_transfer_usdc_to_hedging_worker(
     monitor: Monitor,
     transfer_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
     transfer_queue: TransferUsdcToHedgingJobQueue,
-    FailStopCircuit(fail_stop): FailStopCircuit,
-    failure_notify: Arc<tokio::sync::Notify>,
+    failure_notify: Arc<TerminalFailureSignal>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
     let Some(transfer_ctx) = transfer_ctx else {
@@ -1098,7 +1069,6 @@ fn register_transfer_usdc_to_hedging_worker(
             index,
             transfer_queue.clone(),
             transfer_ctx.clone(),
-            fail_stop.clone(),
             failure_notify.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector.clone(),
@@ -1112,8 +1082,7 @@ fn register_transfer_usdc_to_market_making_worker(
     monitor: Monitor,
     transfer_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
     transfer_queue: TransferUsdcToMarketMakingJobQueue,
-    FailStopCircuit(fail_stop): FailStopCircuit,
-    failure_notify: Arc<tokio::sync::Notify>,
+    failure_notify: Arc<TerminalFailureSignal>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> Monitor {
     let Some(transfer_ctx) = transfer_ctx else {
@@ -1130,7 +1099,6 @@ fn register_transfer_usdc_to_market_making_worker(
             index,
             transfer_queue.clone(),
             transfer_ctx.clone(),
-            fail_stop.clone(),
             failure_notify.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector.clone(),

--- a/src/conductor/exit.rs
+++ b/src/conductor/exit.rs
@@ -4,14 +4,21 @@
 //! [`ConductorExit::handle`] turns that into either `Ok(())` for clean shutdown
 //! or an error explaining what went wrong.
 
+use apalis_core::error::BoxDynError;
+use std::sync::Arc;
 use task_supervisor::SupervisorError;
 use tokio::task::JoinError;
 use tracing::{error, info};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum MonitorTaskError {
-    #[error("Apalis worker failed after retries")]
-    TerminalJobFailure,
+    #[error("Apalis worker failed after retries: {worker}: {context}")]
+    TerminalJobFailure {
+        worker: String,
+        context: &'static str,
+        #[source]
+        source: Arc<BoxDynError>,
+    },
     #[error("Apalis monitor exited unexpectedly")]
     UnexpectedExit {
         #[source]
@@ -131,11 +138,16 @@ mod tests {
 
     #[tokio::test]
     async fn monitor_inner_terminal_job_failure_returns_monitor_variant() {
+        let source: BoxDynError = "boom".into();
         assert!(matches!(
-            ConductorExit::Monitor(Ok(Err(MonitorTaskError::TerminalJobFailure)))
-                .handle()
-                .unwrap_err(),
-            ConductorExitError::Monitor(MonitorTaskError::TerminalJobFailure)
+            ConductorExit::Monitor(Ok(Err(MonitorTaskError::TerminalJobFailure {
+                worker: "test-worker-0".to_string(),
+                context: "terminal failure",
+                source: Arc::new(source),
+            })))
+            .handle()
+            .unwrap_err(),
+            ConductorExitError::Monitor(MonitorTaskError::TerminalJobFailure { .. })
         ));
     }
 

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -9,6 +9,7 @@ use apalis::layers::retry::backoff::Backoff;
 use apalis::prelude::{Attempt, Data, TaskBuilder, TaskSink};
 use apalis_core::backend::TaskSinkError;
 use apalis_core::backend::poll_strategy::{BackoffConfig, IntervalStrategy, StrategyBuilder};
+use apalis_core::error::BoxDynError;
 use apalis_core::worker::context::WorkerContext;
 use apalis_core::worker::event::Event;
 use apalis_sqlite::{Config, SqliteContext, SqlitePool, SqliteStorage, SqlxError};
@@ -23,12 +24,6 @@ use tracing::{debug, error, warn};
 
 use st0x_execution::{AlpacaBrokerApiError, AlpacaWalletError, Backpressure};
 use st0x_tokenization::{AlpacaTokenizationError, TokenizerError};
-
-/// Recovery timeout for the fail-stop circuit breaker. Effectively
-/// infinite for any plausible bot uptime; chosen to be finite so
-/// `last_failure + recovery_timeout` cannot overflow if apalis
-/// changes its check from `elapsed() >=` to addition.
-pub(crate) const FAIL_STOP_RECOVERY_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24 * 365);
 
 /// Deterministic exponential backoff for the apalis retry layer.
 /// Doubles the delay each attempt up to `max`, with no jitter (unnecessary
@@ -134,7 +129,7 @@ pub(crate) struct BackpressureDecision {
     /// self-contained terminal event (a loud `error!` log, then `Ok(())`)
     /// rather than propagating the original `Err` into the shared
     /// supervised on-event path, so a persistently-429ing item cannot
-    /// re-open the circuit breaker RAI-1495 already knows how to latch.
+    /// reach `on_terminal_failure`'s `ctx.stop()` and halt the worker.
     pub(crate) exhausted: bool,
 }
 
@@ -545,14 +540,12 @@ macro_rules! build_worker_inner {
         $index:expr,
         $queue:expr,
         $ctx:expr,
-        $circuit:expr,
         $on_event:expr
         $(, $failure_injector:expr)? $(,)?
     ) => {{
         use ::apalis::layers::WorkerBuilderExt;
         use ::apalis::layers::retry::RetryPolicy;
         use ::apalis::prelude::WorkerBuilder;
-        use ::apalis_core::worker::ext::circuit_breaker::CircuitBreaker;
         use ::apalis_core::worker::ext::event_listener::EventListenerExt;
 
         let builder = WorkerBuilder::new(format!(
@@ -576,7 +569,6 @@ macro_rules! build_worker_inner {
                 RetryPolicy::retries(3)
                     .with_backoff($crate::conductor::job::RETRY_BACKOFF.clone()),
             )
-            .break_circuit_with($circuit)
             .on_event($on_event)
             .build($crate::conductor::job::work::<$ctx_type, $job>)
     }};
@@ -588,8 +580,14 @@ pub(crate) use build_worker_inner;
 ///
 /// Mirrors the `work::<Ctx, Job>` turbofish style: pass the same two
 /// types and the macro expands to a fully-wired worker (queue backend,
-/// retry policy, fail-stop circuit breaker, terminal-failure notifier,
-/// `.build(work::<Ctx, Job>)`).
+/// retry policy, terminal-failure notifier, `.build(work::<Ctx, Job>)`).
+///
+/// Deliberately installs no Apalis circuit-breaker layer -- see
+/// [`build_best_effort_worker!`]'s doc comment for why: an open circuit can
+/// return `Poll::Pending` from `poll_ready` without scheduling a wakeup,
+/// permanently latching a single-concurrency worker idle with no log and no
+/// stop (RAI-1495). `on_terminal_failure`'s `ctx.stop()`, fired the instant
+/// `RetryPolicy` exhausts, is the sole halt mechanism.
 ///
 /// A macro because `.build()` returns a deeply-nested
 /// `Worker<Args, Ctx, Backend, Svc, Middleware>` whose `Svc` and
@@ -602,7 +600,6 @@ macro_rules! build_supervised_worker {
         $index:expr,
         $queue:expr,
         $ctx:expr,
-        $fail_stop:expr,
         $failure_notify:expr
         $(, $failure_injector:expr)? $(,)?
     ) => {{
@@ -611,7 +608,6 @@ macro_rules! build_supervised_worker {
             $index,
             $queue,
             $ctx,
-            $fail_stop,
             $crate::conductor::job::on_terminal_failure(
                 $failure_notify,
                 <$job as $crate::conductor::job::Job<$ctx_type>>::TERMINAL_FAILURE_MSG,
@@ -938,17 +934,105 @@ where
     })
 }
 
+/// Worker name, static failure context, and the original apalis error for a
+/// supervised worker's terminal failure (retries exhausted), captured for the
+/// async exit path (`Conductor::wait_for_completion`) to alert an operator on
+/// before the process returns a non-zero exit code. `source` is the same
+/// `Arc` apalis handed to `on_terminal_failure` (cheap to clone), not a
+/// flattened string, so `MonitorTaskError::TerminalJobFailure`'s `#[source]`
+/// chain -- and therefore anyhow's "Caused by:" rendering -- still reaches the
+/// underlying error. The error is also logged in full via `error!()` at the
+/// point of failure; this is the same error carried forward, not a
+/// replacement for the structured log.
+#[derive(Debug, Clone)]
+pub(crate) struct TerminalFailureInfo {
+    pub(crate) worker: String,
+    pub(crate) context: &'static str,
+    pub(crate) source: Arc<BoxDynError>,
+}
+
+/// Wakes the apalis monitor's `tokio::select!` on a supervised worker's
+/// terminal failure and carries the [`TerminalFailureInfo`] the async exit
+/// path needs to alert on. Threaded through every `build_supervised_worker!`
+/// call site as a single `Arc` clone -- the same shape as the plain
+/// `tokio::sync::Notify` it replaces, so no call site needs an extra clone.
+///
+/// All supervised workers share one signal, so two different workers can
+/// fail terminally close together. `info` resolves that race first-writer-
+/// wins via `OnceLock::set`: whichever `record_and_notify` call lands first
+/// is the info every reader ever observes, atomically -- never a torn or
+/// mixed combination of two failures. The later failure's own `ctx.stop()`
+/// and `error!()` log still happen regardless; only its entry in the alert
+/// is superseded.
+///
+/// `info` is always recorded before `notify_waiters()` fires, so a waiter that
+/// wakes always has the info available. [`notified`](Self::notified) returns it
+/// directly rather than leaving the caller to re-read an `Option` it cannot
+/// meaningfully handle as `None`.
+#[derive(Default)]
+pub(crate) struct TerminalFailureSignal {
+    notify: tokio::sync::Notify,
+    info: std::sync::OnceLock<TerminalFailureInfo>,
+}
+
+impl TerminalFailureSignal {
+    /// Resolves with the recorded failure once any supervised worker sharing
+    /// this signal fails terminally, whether that failure happened before or
+    /// after this call.
+    ///
+    /// `Notify::notify_waiters` wakes only the waiters registered at that
+    /// instant and stores no permit, so a failure recorded before the monitor
+    /// reaches its `select!` would otherwise be lost -- the same missed-wakeup
+    /// shape RAI-1495 is about. Registering the `Notified` future via
+    /// `enable()` *before* reading `info` closes that window in both
+    /// directions: a failure landing before `enable()` is caught by the
+    /// `Some` check below, and one landing after is caught by the registered
+    /// waiter.
+    ///
+    /// The loop re-registers rather than unwrapping after the await:
+    /// `record_and_notify` writes `info` before waking, so the first wakeup
+    /// carries it, but expressing that as a loop keeps the "signalled with no
+    /// info" state unrepresentable without a panicking `expect`.
+    pub(crate) async fn notified(&self) -> TerminalFailureInfo {
+        loop {
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            if let Some(info) = self.info.get() {
+                return info.clone();
+            }
+
+            notified.await;
+        }
+    }
+
+    fn record_and_notify(&self, info: TerminalFailureInfo) {
+        // `OnceLock::set` is a first-writer-wins compare-and-set: on a race
+        // between two workers, the losing `Err(_)` is intentionally dropped
+        // (see the doc comment above), but every worker still notifies so no
+        // failure's fail-stop is ever lost.
+        let _ = self.info.set(info);
+        self.notify.notify_waiters();
+    }
+}
+
 /// On-event handler shared by every supervised worker: when apalis
-/// reports a terminal job failure (retries exhausted), notify the
-/// monitor task and stop the worker.
+/// reports a terminal job failure (retries exhausted), record the failure
+/// info, notify the monitor task, and stop the worker.
 pub(crate) fn on_terminal_failure(
-    failure_notify: Arc<tokio::sync::Notify>,
+    failure_signal: Arc<TerminalFailureSignal>,
     error_msg: &'static str,
 ) -> impl Fn(&WorkerContext, &Event) + Send + Sync + 'static {
     move |ctx, event| {
         if let Event::Error(err) = event {
-            error!(%err, worker = %ctx.name(), "{error_msg}");
-            failure_notify.notify_waiters();
+            let worker = ctx.name().clone();
+            error!(%err, worker = %worker, "{error_msg}");
+            failure_signal.record_and_notify(TerminalFailureInfo {
+                worker,
+                context: error_msg,
+                source: Arc::clone(err),
+            });
             let _ = ctx.stop();
         }
     }
@@ -978,7 +1062,6 @@ pub(crate) fn on_terminal_failure_log_only(
 #[cfg(test)]
 mod tests {
     use apalis::prelude::{Monitor, Status};
-    use apalis_core::worker::ext::circuit_breaker::config::CircuitBreakerConfig;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
@@ -1521,6 +1604,14 @@ mod tests {
 
     /// A job that fails after all retries must halt further processing --
     /// the worker must not pick up the next job with stale state.
+    ///
+    /// Note: this test's single failing job halts via `on_terminal_failure`
+    /// at `RetryPolicy`'s own exhaustion (attempt 4 of `retries(3)`), well
+    /// below the vendored circuit breaker's hardcoded `failure_count >= 5`
+    /// open threshold that used to sit in this path -- so this test passed
+    /// even before RAI-1495's fix and never exercised the removed layer. See
+    /// [`supervised_worker_fail_stops_past_the_vendored_circuit_breakers_hardcoded_threshold`]
+    /// for the regression test that does.
     #[tokio::test]
     async fn job_failure_after_retries_halts_processing() {
         let apalis_pool = setup_test_apalis_pool().await;
@@ -1529,7 +1620,7 @@ mod tests {
         queue.push(TestJob { should_fail: true }).await.unwrap();
         let mut push_queue = queue.clone();
 
-        let failure_notify = Arc::new(tokio::sync::Notify::new());
+        let failure_notify = Arc::new(TerminalFailureSignal::default());
         let failing_job_started = Arc::new(tokio::sync::Notify::new());
         let ctx = Arc::new(TestCtx {
             success_count: AtomicUsize::new(0),
@@ -1537,10 +1628,6 @@ mod tests {
             failing_job_started: failing_job_started.clone(),
         });
         let ctx_for_assert = ctx.clone();
-
-        let fail_stop = CircuitBreakerConfig::default()
-            .with_failure_threshold(1)
-            .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
 
         let failing_job_started_wait = failing_job_started.notified();
 
@@ -1554,7 +1641,6 @@ mod tests {
                         index,
                         queue.clone(),
                         ctx.clone(),
-                        fail_stop.clone(),
                         failure_notify.clone(),
                         FailureInjector::new(),
                     )
@@ -1598,7 +1684,7 @@ mod tests {
 
     async fn wait_for_fail_stop_without_processing_sibling(
         apalis_pool: &apalis_sqlite::SqlitePool,
-        failure_notify: &Arc<tokio::sync::Notify>,
+        failure_notify: &Arc<TerminalFailureSignal>,
         monitor_handle: tokio::task::JoinHandle<()>,
     ) {
         let terminal = tokio::time::timeout(Duration::from_secs(30), async {
@@ -1619,7 +1705,7 @@ mod tests {
                 }
 
                 tokio::select! {
-                    () = failure_notify.notified() => {
+                    _ = failure_notify.notified() => {
                         // Terminal failure fired stop; give the monitor a moment to exit.
                         for _ in 0..100 {
                             if monitor_handle.is_finished() {
@@ -1645,6 +1731,134 @@ mod tests {
             .await
             .expect("Monitor should exit within 5s after terminal job failure");
         join_result.expect("Monitor task should not panic");
+    }
+
+    /// Regression test for RAI-1495: a supervised worker driven through many
+    /// more consecutive failures than the vendored circuit breaker's
+    /// hardcoded `failure_count >= 5` open threshold
+    /// (`CircuitBreakerService::call`, apalis-core 1.0.0-rc.9) must still
+    /// reach a terminal, observable fail-stop -- not latch silently idle.
+    /// `retries(12)` (13 attempts total) with a fast fixed backoff (not
+    /// `RETRY_BACKOFF`, to keep the test fast) comfortably crosses that
+    /// threshold. Uses a raw `WorkerBuilder` (not `build_supervised_worker!`,
+    /// which hardcodes `retries(3)`) so the retry budget can be pushed past
+    /// the vendored threshold; `job_failure_after_retries_halts_processing`
+    /// above remains the macro-path guard for the real production wiring.
+    ///
+    /// What this proves: after RAI-1495's fix (no circuit-breaker layer at
+    /// all on supervised workers), no in-process circuit-breaker-shaped
+    /// mechanism can latch a worker regardless of accumulated failure count
+    /// -- the terminal failure signal fires deterministically, asserted via
+    /// `failure_notify.notified()` resolving and the captured
+    /// [`TerminalFailureInfo`], not merely "no latch observed within a
+    /// timeout" (a weaker, non-deterministic check that would also pass if
+    /// the worker were simply slow).
+    ///
+    /// What this does NOT prove: it does not exercise the full
+    /// systemd-restart loop (out of process, untestable at this layer), and
+    /// it does not cover a `Job::perform()` future that itself never
+    /// resolves -- a distinct, pre-existing failure class this issue does
+    /// not claim to fix.
+    #[tokio::test]
+    async fn supervised_worker_fail_stops_past_the_vendored_circuit_breakers_hardcoded_threshold() {
+        use apalis::layers::WorkerBuilderExt;
+        use apalis::layers::retry::RetryPolicy;
+        use apalis::prelude::WorkerBuilder;
+        use apalis_core::worker::ext::event_listener::EventListenerExt;
+        use apalis_sqlite::TaskBuilderExt;
+
+        const FAST_BACKOFF: ExponentialBackoff =
+            ExponentialBackoff::new(Duration::from_millis(1), Duration::from_millis(5));
+        const RETRIES_PAST_HARDCODED_CIRCUIT_THRESHOLD: usize = 12;
+
+        let apalis_pool = setup_test_apalis_pool().await;
+        let queue: JobQueue<TestJob> = JobQueue::new(&apalis_pool);
+
+        // A plain `queue.push(...)` defaults to apalis's own `SqlContext`
+        // max_attempts of 5 -- coincidentally the same number as the
+        // vendored circuit breaker's hardcoded open threshold, and well
+        // below the 13 attempts this test needs to exercise. Push with an
+        // explicit higher `max_attempts` so the storage layer's own cap
+        // cannot truncate the retry budget before `RetryPolicy` does.
+        let scheduled = TaskBuilder::<TestJob, apalis_sqlite::SqliteContext, _>::new(TestJob {
+            should_fail: true,
+        })
+        .max_attempts(
+            u32::try_from(RETRIES_PAST_HARDCODED_CIRCUIT_THRESHOLD).expect("fits u32") + 1,
+        )
+        .build();
+        TaskSink::push_task(&mut queue.clone().into_storage(), scheduled)
+            .await
+            .unwrap();
+
+        let failure_notify = Arc::new(TerminalFailureSignal::default());
+        let ctx = Arc::new(TestCtx {
+            success_count: AtomicUsize::new(0),
+            success_notify: Arc::new(tokio::sync::Notify::new()),
+            failing_job_started: Arc::new(tokio::sync::Notify::new()),
+        });
+
+        let monitor_handle = tokio::spawn({
+            let failure_notify = failure_notify.clone();
+            let monitor = Monitor::new()
+                .should_restart(|_ctx, _error, _attempt| false)
+                .register(move |index| {
+                    WorkerBuilder::new(format!("stress-test-worker-{index}"))
+                        .backend(queue.clone().into_storage())
+                        .data(ctx.clone())
+                        .data(FailureInjector::new())
+                        .data(JobKind::OrderFill)
+                        .concurrency(1)
+                        .retry(
+                            RetryPolicy::retries(RETRIES_PAST_HARDCODED_CIRCUIT_THRESHOLD)
+                                .with_backoff(FAST_BACKOFF),
+                        )
+                        .on_event(on_terminal_failure(
+                            failure_notify.clone(),
+                            "stress test terminal failure",
+                        ))
+                        .build(work::<TestCtx, TestJob>)
+                });
+
+            async move {
+                let _ = monitor.run().await;
+            }
+        });
+
+        let info = tokio::time::timeout(Duration::from_secs(10), failure_notify.notified())
+            .await
+            .expect(
+                "terminal failure must fire deterministically past 13 attempts, \
+                 not latch silently",
+            );
+
+        let attempts =
+            sqlx_apalis::query_scalar::<_, i64>("SELECT attempts FROM Jobs WHERE job_type = ?")
+                .bind(std::any::type_name::<TestJob>())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        assert!(
+            attempts > i64::try_from(RETRIES_PAST_HARDCODED_CIRCUIT_THRESHOLD).expect("fits i64"),
+            "job should have exhausted all {} attempts before fail-stop fired; attempts={attempts}",
+            RETRIES_PAST_HARDCODED_CIRCUIT_THRESHOLD + 1,
+        );
+
+        assert_eq!(
+            info.context, "stress test terminal failure",
+            "the recorded failure info must carry the exact static context",
+        );
+        assert_eq!(
+            info.source.to_string(),
+            "test-job(should_fail=true): test job deliberately failed",
+            "the recorded failure info must carry the original apalis error, not a flattened \
+             string",
+        );
+
+        tokio::time::timeout(Duration::from_secs(5), monitor_handle)
+            .await
+            .expect("Monitor should exit within 5s after terminal job failure")
+            .expect("Monitor task should not panic");
     }
 
     async fn insert_job(
@@ -1938,6 +2152,134 @@ mod tests {
             status_of(&apalis_pool, "other").await,
             "Running",
             "another queue's in-flight row is untouched",
+        );
+    }
+
+    /// Regression test for the concurrent-terminal-failure race: two
+    /// different supervised workers sharing one `TerminalFailureSignal` both
+    /// fail terminally at the same time. The recorded info must be a
+    /// consistent `(worker, context, source)` triple from exactly ONE of the
+    /// two failures -- never a torn/mixed combination -- and the fail-stop
+    /// signal must still fire regardless of which one wins.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_terminal_failures_record_a_consistent_pair_from_one_of_them() {
+        let signal = Arc::new(TerminalFailureSignal::default());
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let source_a: Arc<BoxDynError> = Arc::new("failure-a".into());
+        let source_b: Arc<BoxDynError> = Arc::new("failure-b".into());
+
+        let task_a = tokio::spawn({
+            let signal = signal.clone();
+            let barrier = barrier.clone();
+            async move {
+                barrier.wait().await;
+                signal.record_and_notify(TerminalFailureInfo {
+                    worker: "worker-a".to_string(),
+                    context: "context-a",
+                    source: source_a,
+                });
+            }
+        });
+        let task_b = tokio::spawn({
+            let signal = signal.clone();
+            let barrier = barrier.clone();
+            async move {
+                barrier.wait().await;
+                signal.record_and_notify(TerminalFailureInfo {
+                    worker: "worker-b".to_string(),
+                    context: "context-b",
+                    source: source_b,
+                });
+            }
+        });
+
+        let info = tokio::time::timeout(Duration::from_secs(5), signal.notified())
+            .await
+            .expect("fail-stop must fire even when two workers fail terminally at once");
+        task_a.await.unwrap();
+        task_b.await.unwrap();
+
+        // Either winner is an acceptable, genuinely equivalent outcome here
+        // (first-writer-wins is explicitly non-deterministic by design) --
+        // what must never happen is a mix of the two, e.g. worker-a paired
+        // with context-b.
+        let consistent_with_a = info.worker == "worker-a"
+            && info.context == "context-a"
+            && info.source.to_string() == "failure-a";
+        let consistent_with_b = info.worker == "worker-b"
+            && info.context == "context-b"
+            && info.source.to_string() == "failure-b";
+        assert!(
+            consistent_with_a || consistent_with_b,
+            "recorded info must be a consistent (worker, context, source) triple from exactly \
+             one failure, got worker={} context={} source={}",
+            info.worker,
+            info.context,
+            info.source,
+        );
+    }
+
+    /// Regression guard for RAI-1495: no test can drive a macro-path worker
+    /// past the vendored circuit breaker's hardcoded `failure_count >= 5`
+    /// threshold without an explicit `max_attempts` override the production
+    /// macro never applies (see
+    /// `supervised_worker_fail_stops_past_the_vendored_circuit_breakers_hardcoded_threshold`'s
+    /// doc comment), so no runtime test would go red if a future change
+    /// reinstalled the breaker inside `build_worker_inner!`. That behavioral
+    /// test remains the real guarantee that the breaker cannot latch a
+    /// worker idle; this test is a cheap, deliberately non-behavioral
+    /// structural backstop layered on top of it, catching a reinstalled
+    /// breaker even before a behavioral test would need to exercise it.
+    ///
+    /// Scoped to only the `build_worker_inner!` definition (extracted from
+    /// this file's own source between its `macro_rules!` header and its
+    /// `pub(crate) use` re-export) -- the actual worker-builder path this
+    /// guard claims to cover -- rather than the whole `src/` tree, so an
+    /// unrelated file mentioning either identifier (e.g. in a string
+    /// literal or doc comment about this very regression) cannot fail the
+    /// build, and so this guard cannot miss a reinstalled breaker that
+    /// lands anywhere inside the macro body.
+    ///
+    /// The forbidden identifiers below are built via `.concat()` rather than
+    /// written as string literals so this test's own source does not contain
+    /// a literal match for what it searches for.
+    ///
+    /// Matches the macro's raw source text, comments included. The macro body
+    /// is a 40-line declarative expansion that carries no comments of its own,
+    /// so there is nothing for a comment-aware pass to disambiguate. If a
+    /// future comment inside the body needs to name either identifier while
+    /// explaining why not to reinstall it, refer to it indirectly (or split it
+    /// the way this test's own patterns are split) rather than reintroducing a
+    /// comment stripper here.
+    #[test]
+    fn build_worker_inner_never_reinstalls_the_vendored_circuit_breaker() {
+        let forbidden_identifiers = [
+            ["break_circuit", "_with("].concat(),
+            ["CircuitBreaker", "Config"].concat(),
+        ];
+
+        let file_source = include_str!("job.rs");
+        let macro_start = file_source
+            .find("macro_rules! build_worker_inner {")
+            .expect("build_worker_inner! macro definition must exist in this file");
+        let macro_and_after = &file_source[macro_start..];
+        let macro_end = macro_and_after
+            .find("pub(crate) use build_worker_inner;")
+            .expect("build_worker_inner! definition must be followed by its pub(crate) use");
+        let macro_text = &macro_and_after[..macro_end];
+
+        let offending_identifiers: Vec<&str> = forbidden_identifiers
+            .iter()
+            .filter(|identifier| macro_text.contains(identifier.as_str()))
+            .map(String::as_str)
+            .collect();
+
+        assert!(
+            offending_identifiers.is_empty(),
+            "production code must never reinstall apalis's circuit-breaker layer inside \
+             `build_worker_inner!` (RAI-1495 regression): found forbidden identifiers \
+             {offending_identifiers:?}",
         );
     }
 }

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -868,7 +868,6 @@ impl Reactor for Broadcaster {
 #[cfg(test)]
 mod tests {
     use apalis::prelude::Monitor;
-    use apalis_core::worker::ext::circuit_breaker::config::CircuitBreakerConfig;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -877,7 +876,7 @@ mod tests {
 
     use super::*;
     use crate::conductor::job::{
-        FAIL_STOP_RECOVERY_TIMEOUT, FailureInjector, build_supervised_worker, build_worker_inner,
+        FailureInjector, TerminalFailureSignal, build_supervised_worker, build_worker_inner,
     };
     use crate::dashboard::trade_loader::load_trades;
     use crate::offchain::order::{OffchainOrderCommand, OffchainOrderEvent};
@@ -1044,12 +1043,8 @@ mod tests {
     fn spawn_delivery_worker(
         queue: DashboardTradeDeliveryJobQueue,
         ctx: Arc<DashboardTradeDeliveryCtx>,
-        failure_notify: Arc<tokio::sync::Notify>,
+        failure_notify: Arc<TerminalFailureSignal>,
     ) -> tokio::task::JoinHandle<()> {
-        let fail_stop = CircuitBreakerConfig::default()
-            .with_failure_threshold(1)
-            .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
-
         tokio::spawn(async move {
             let monitor = Monitor::new()
                 .should_restart(|_ctx, _error, _attempt| false)
@@ -1059,7 +1054,6 @@ mod tests {
                         index,
                         queue.clone(),
                         ctx.clone(),
-                        fail_stop.clone(),
                         failure_notify.clone(),
                         FailureInjector::new(),
                     )
@@ -1622,8 +1616,11 @@ mod tests {
         let ctx = Arc::new(DashboardTradeDeliveryCtx::new(sender, pool));
         enqueue_test_delivery(&mut queue, &ctx, test_trade()).await;
         ctx.fail_next(1);
-        let monitor =
-            spawn_delivery_worker(queue, ctx.clone(), Arc::new(tokio::sync::Notify::new()));
+        let monitor = spawn_delivery_worker(
+            queue,
+            ctx.clone(),
+            Arc::new(TerminalFailureSignal::default()),
+        );
 
         tokio::time::timeout(Duration::from_secs(10), async {
             while !ctx.store.is_delivered("terminal-trade-1").await.unwrap() {
@@ -1663,7 +1660,7 @@ mod tests {
         let monitor = spawn_delivery_worker(
             delivery.queue,
             delivery.ctx,
-            Arc::new(tokio::sync::Notify::new()),
+            Arc::new(TerminalFailureSignal::default()),
         );
         let statement = tokio::time::timeout(Duration::from_secs(10), receiver.recv())
             .await
@@ -1737,7 +1734,7 @@ mod tests {
         let ctx = Arc::new(DashboardTradeDeliveryCtx::new(sender, pool));
         enqueue_test_delivery(&mut queue, &ctx, test_trade()).await;
         ctx.fail_next(usize::MAX);
-        let failure_notify = Arc::new(tokio::sync::Notify::new());
+        let failure_notify = Arc::new(TerminalFailureSignal::default());
         let terminal_failure = failure_notify.notified();
         let monitor = spawn_delivery_worker(queue, ctx, failure_notify.clone());
 

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -1530,7 +1530,6 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use apalis::prelude::Monitor;
-    use apalis_core::worker::ext::circuit_breaker::config::CircuitBreakerConfig;
     use chrono::Utc;
     use futures_util::future::join_all;
     use httpmock::prelude::*;
@@ -1549,7 +1548,7 @@ mod tests {
 
     use super::*;
     use crate::conductor::job::{
-        FAIL_STOP_RECOVERY_TIMEOUT, FailureInjector, build_supervised_worker, build_worker_inner,
+        FailureInjector, TerminalFailureSignal, build_supervised_worker, build_worker_inner,
     };
     use crate::offchain::order::{
         NoFillOutcome, OffchainOrderCommand, TerminalPositionFinalization, noop_order_placer,
@@ -5218,10 +5217,7 @@ mod tests {
             .unwrap();
 
         let ctx = Arc::new(ctx);
-        let failure_notify = Arc::new(tokio::sync::Notify::new());
-        let fail_stop = CircuitBreakerConfig::default()
-            .with_failure_threshold(1)
-            .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
+        let failure_notify = Arc::new(TerminalFailureSignal::default());
 
         let monitor_handle = tokio::spawn({
             let failure_notify = failure_notify.clone();
@@ -5235,7 +5231,6 @@ mod tests {
                         index,
                         queue.clone(),
                         ctx.clone(),
-                        fail_stop.clone(),
                         failure_notify.clone(),
                         FailureInjector::new(),
                     )
@@ -5295,13 +5290,14 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
 
-        assert!(
-            !matches!(
-                tokio::time::timeout(Duration::from_millis(50), failure_notify.notified()).await,
-                Ok(())
-            ),
-            "repeated 429s must never open the circuit breaker or signal a terminal job failure"
-        );
+        if let Ok(info) =
+            tokio::time::timeout(Duration::from_millis(50), failure_notify.notified()).await
+        {
+            panic!(
+                "repeated 429s must never open the circuit breaker or signal a terminal job \
+                 failure; got: {info:?}"
+            );
+        }
 
         let terminally_failed: i64 = sqlx_apalis::query_scalar(
             "SELECT COUNT(*) FROM Jobs WHERE job_type = ? AND status IN ('Failed', 'Killed')",

--- a/src/vault_registry.rs
+++ b/src/vault_registry.rs
@@ -733,13 +733,20 @@ impl Job<SeedVaultRegistryCtx> for SeedVaultRegistry {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{address, b256};
+    use apalis::layers::WorkerBuilderExt;
+    use apalis::layers::retry::RetryPolicy;
+    use apalis::prelude::{Monitor, WorkerBuilder};
+    use apalis_core::worker::event::Event;
+    use apalis_core::worker::ext::event_listener::EventListenerExt;
     use async_trait::async_trait;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     use st0x_event_sorcery::{EntityList, Reactor, StoreBuilder, TestHarness, deps, replay};
 
     use super::*;
+    use crate::conductor::job::{FailureInjector, JobQueue, work};
     use crate::test_utils::{setup_test_db, setup_test_pools};
 
     const TEST_ORDERBOOK: Address = address!("0x1234567890123456789012345678901234567890");
@@ -1744,18 +1751,6 @@ mod tests {
     // happened.
     #[tokio::test]
     async fn enqueued_job_retries_on_aggregate_command_failure() {
-        use apalis::layers::WorkerBuilderExt;
-        use apalis::layers::retry::RetryPolicy;
-        use apalis::prelude::{Monitor, WorkerBuilder};
-        use apalis_core::worker::event::Event;
-        use apalis_core::worker::ext::circuit_breaker::{
-            CircuitBreaker, config::CircuitBreakerConfig,
-        };
-        use apalis_core::worker::ext::event_listener::EventListenerExt;
-        use std::time::Duration;
-
-        use crate::conductor::job::{FAIL_STOP_RECOVERY_TIMEOUT, FailureInjector, JobQueue, work};
-
         let (pool, apalis_pool) = setup_test_pools().await;
 
         let ctx = ctx_with_seeded_assets();
@@ -1775,17 +1770,17 @@ mod tests {
             let monitor = Monitor::new()
                 .should_restart(|_ctx, _error, _attempt| false)
                 .register(move |index| {
-                    let fail_stop = CircuitBreakerConfig::default()
-                        .with_failure_threshold(1)
-                        .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
-
                     WorkerBuilder::new(format!("seed-vault-registry-test-{index}"))
                         .backend(queue_for_worker.clone().into_storage())
                         .data(ctx_for_worker.clone())
                         .data(injector_for_worker.clone())
+                        // Without this the test-support `work` handler fails
+                        // every attempt on missing `Data<JobKind>` extraction,
+                        // so the armed injector never runs and the retries
+                        // asserted below would come from the wrong failure.
+                        .data(crate::conductor::job::JobKind::SeedVaultRegistry)
                         .concurrency(1)
                         .retry(RetryPolicy::retries(3))
-                        .break_circuit_with(fail_stop)
                         .on_event(|ctx, event| {
                             if let Event::Error(_) = event {
                                 let _ = ctx.stop();


### PR DESCRIPTION
## What

- Stop a supervised apalis worker from latching silently idle after its retries are exhausted. This is the last of three sub-issues of the [RAI-1492](https://linear.app/makeitrain/issue/RAI-1492) production incident. See [RAI-1495](https://linear.app/makeitrain/issue/RAI-1495).
- Delete the apalis/tower `CircuitBreaker` from `build_supervised_worker!` so an exhausted retry becomes loud and recoverable instead of a permanent silent stall.
- Page an operator (bounded) when a supervised worker fail-stops, on both the direct and the graceful-shutdown exit paths.

## Why

- On 2026-07-22 an exhausted `PollOrderStatus` retry opened the circuit breaker and latched the worker idle for 3 hours 25 minutes. No crash, no log, no stop. `systemctl` said `active`, sibling workers kept running, the dashboard showed nothing. Only a restart recovered it, and only an operator could notice it was needed.
- Root cause (verified against the vendored `apalis-core` 1.0.0-rc.9 and `tower` 0.5.3 source): the tower layer order is `RetryPolicy` (outer) then `CircuitBreakerService` then the event listener. `tower::retry` calls the inner circuit service's `poll_ready` between attempts. When the circuit is open, `CircuitBreakerService::poll_ready` returns a bare `Poll::Pending` with NO waker (`circuit_breaker/service.rs:204`), and this repo set the recovery timeout to 365 days. So the retry future stalls forever, the call never resolves to `Err`, `Event::Error` never fires, and `on_terminal_failure` never runs. The circuit's own gate sits inside the retry loop that would otherwise have produced the terminal error.

## How

- Remove `.break_circuit_with(...)` from `build_worker_inner!` (mirroring `build_best_effort_worker!`, which already omits it). Now `on_terminal_failure` is the sole gate: an exhausted retry propagates `Err` to `Event::Error`, which logs, records the failure, and calls `ctx.stop()`. That errs the per-queue task, becomes `MonitorTaskError::TerminalJobFailure`, and the process exits. systemd (`Restart=always`, `RestartSec=30`) restarts it.
- This restores the conductor's EXISTING designed fail-stop behavior that the circuit breaker was silently suppressing. It does not invent a new blast radius. A transient failure self-heals via restart. A persistent non-429 failure crash-loops until systemd's start-limit leaves the unit dead: loud and monitorable, which is the desired end state, and strictly better than a silent idle worker.
- Preserve the error source chain: `TerminalFailureInfo` carries the original `Arc<BoxDynError>` as a `#[source]`, so the crash log's "Caused by:" chain walks the real underlying error. No stringified error variant.
- Operator alert: `wait_for_completion` sends a bounded (3 second) alert via `worker_failure_notifier` before propagating the fail-stop, on BOTH the direct-Monitor path and the graceful-shutdown drain path, so a terminal failure during a deploy still pages. The alert never blocks or swallows the fail-stop.
- Concurrent terminal failures across workers record a consistent first-writer-wins pair via `OnceLock`, so the alert never carries a torn worker/error pair.

## Testing

- `supervised_worker_fail_stops_past_the_vendored_circuit_breakers_hardcoded_threshold` drives a real worker through 13 failures (past the vendored breaker's hardcoded threshold) and asserts the fail-stop fires: the regression test that would have caught the incident. Needs an explicit `max_attempts` override because apalis's `SqlContext` caps attempts at 5 by default.
- Alert coverage: the alert fires on the direct path, on the graceful-shutdown drain path, and still propagates the fail-stop when the notifier hangs (bounded by the 3s timeout) or errors.
- A structural backstop test asserts `build_worker_inner!`'s own macro body never re-adds the circuit breaker (scoped to the macro, not the whole tree).
- Ran the scoped conductor suite, `cargo clippy --all-targets --all-features`, and `nix run .#ci` locally. All green.

## Anything else

- Blast radius is documented in `docs/conductor.md`: a supervised terminal failure fail-stops the whole conductor. If a job should degrade in isolation instead of taking the process down, it should be a best-effort worker.
- Follow-up [RAI-1524](https://linear.app/makeitrain/issue/RAI-1524): `ReadinessService::poll_ready` has the SAME bare-Pending-without-waker shape on the shutdown/pause path (not closed here). It can hang a graceful shutdown if a job is mid-retry when shutdown begins. Distinct from the steady-state circuit-breaker gate this PR fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved worker failure handling and shutdown reliability.
  - Preserved worker names, failure context, and underlying error details in terminal failure reports.
  - Added bounded alert delivery to prevent shutdown delays while safely handling notifier errors.
  - Improved failure propagation so conductor shutdown results accurately reflect terminal failures.

- **Documentation**
  - Clarified broker backpressure, retry and rescheduling behavior, terminal failure handling, and shutdown procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->