### PR TITLE
chore(config): add GOOGL, INTC, AAPL, MSFT, LLY, and PTY equities

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -410,3 +410,57 @@ extended_hours_counter_trading = "enabled"
 vault_id = "0xfab"
 tokenized_equity = "0x1a29eD11DF8295D5F3B5F59849FD94caD615E024"
 tokenized_equity_derivative = "0x045Fb493D970f94a54FeaF931033622fC82192e6"
+
+[assets.equities.GOOGL]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x15De944Cd020A18C8E5626fB0F81b36e73956199"
+tokenized_equity_derivative = "0x6a2357Df4975C667B171bE53dA6FFe6deBf7030c"
+
+[assets.equities.INTC]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xBDC237Aa3B67cC3088adAf117913F30Bf08157a3"
+tokenized_equity_derivative = "0xf567652fC2d7Db8D5469fD06AEbe8C9c4372d722"
+
+[assets.equities.AAPL]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xD36056a4a03707D3743fCE4e9C08852820ADcfdC"
+tokenized_equity_derivative = "0x1020EC8Aa3f709a1f3D8705cdBa89b950451bd88"
+
+[assets.equities.MSFT]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x6a071E25fa25653cF15d1ee320eA3df771926Aa0"
+tokenized_equity_derivative = "0x515A3Ac2a6aB590bDFa970caFFFd7fAdC680886E"
+
+[assets.equities.LLY]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xA41Ce7B8255A01062ED1AF23ea5E8137B9300554"
+tokenized_equity_derivative = "0x892CcF5E75f4a7Ee6402971a1587F65BEE4d52bd"
+
+[assets.equities.PTY]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xb6021810971714cD48572af527307Acc324ecF61"
+tokenized_equity_derivative = "0xb6D779A79E7493ed821a65D52bA419F0F6D5dD0a"

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -395,3 +395,57 @@ extended_hours_counter_trading = "disabled"
 vault_id = "0xfab"
 tokenized_equity = "0x1a29eD11DF8295D5F3B5F59849FD94caD615E024"
 tokenized_equity_derivative = "0x045Fb493D970f94a54FeaF931033622fC82192e6"
+
+[assets.equities.GOOGL]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x15De944Cd020A18C8E5626fB0F81b36e73956199"
+tokenized_equity_derivative = "0x6a2357Df4975C667B171bE53dA6FFe6deBf7030c"
+
+[assets.equities.INTC]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0xBDC237Aa3B67cC3088adAf117913F30Bf08157a3"
+tokenized_equity_derivative = "0xf567652fC2d7Db8D5469fD06AEbe8C9c4372d722"
+
+[assets.equities.AAPL]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0xD36056a4a03707D3743fCE4e9C08852820ADcfdC"
+tokenized_equity_derivative = "0x1020EC8Aa3f709a1f3D8705cdBa89b950451bd88"
+
+[assets.equities.MSFT]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x6a071E25fa25653cF15d1ee320eA3df771926Aa0"
+tokenized_equity_derivative = "0x515A3Ac2a6aB590bDFa970caFFFd7fAdC680886E"
+
+[assets.equities.LLY]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0xA41Ce7B8255A01062ED1AF23ea5E8137B9300554"
+tokenized_equity_derivative = "0x892CcF5E75f4a7Ee6402971a1587F65BEE4d52bd"
+
+[assets.equities.PTY]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0xb6021810971714cD48572af527307Acc324ecF61"
+tokenized_equity_derivative = "0xb6D779A79E7493ed821a65D52bA419F0F6D5dD0a"


### PR DESCRIPTION
## What

- Adds `GOOGL`, `INTC`, `AAPL`, `MSFT`, `LLY`, and `PTY` to `config/prod/st0x-hedge.toml`, all four flags `enabled`, per [RAI-1608](https://linear.app/makeitrain/issue/RAI-1608).
- Adds the same six to `config/staging/st0x-hedge.toml`, all four flags `disabled`.
- The tokens come from [st0x.registry#46](https://github.com/ST0x-Technology/st0x.registry/pull/46).

## Why

- The tokens are live on Base, but the bot does not know their addresses. So it cannot recognise a fill, account for it, or hedge it.

## How

- Config only, no Rust changes. Same shape as #1067.
- `tokenized_equity` is the `t<SYM>` share token. `tokenized_equity_derivative` is the `wt<SYM>` wrapper.
- I checked every pair on Base with `cast`. Each wrapper reports `symbol()` `wt<SYM>`, `decimals()` 18, and `asset()` equal to the `tokenized_equity` address in this diff. So the two fields are not flipped.
- `vault_id = "0xfab"` like every other equity.
- `pyth_feed_id` is unset on all six. We only pin a feed after we confirm it on-chain. A missing feed skips trade enrichment for analytics. Hedging is unaffected.
- staging registers the six but keeps every flag `disabled`. staging only trades RKLB.

## Testing

- `cargo nextest run -p st0x-config --all-features` -> 176/176 pass.
- `server_config_toml_is_valid` and `all_repo_config_tomls_are_valid` read the real prod and staging TOML files. So the twelve new blocks are parsed and validated.
- Not hotfixed on the live prod config. Prod picks these up on the next deploy.

## Anything else

- This turns on live prod trading for all six. To hold one back, flip its prod `trading` to `disabled` before the deploy.
- `PTY` is a closed-end fund, not a common stock. Worth a check that the broker fills it the same way.
- Out of scope: the Raindex orders in `st0x.raindex-deploy`, and the issuance registration. The bot sees no fills until those orders are deployed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GOOGL, INTC, AAPL, MSFT, LLY, and PTY equity assets.
  * Configured tokenized equity and derivative contract addresses for each asset.
  * Enabled relevant trading and recovery capabilities in production.
  * Added the assets in staging with functionality disabled pending activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
