### PR TITLE
chore: pause AMAT rebalancing for the receipt-custody migration

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -386,7 +386,10 @@ tokenized_equity_derivative = "0x70A182f481AEF05836666B6CfDbe84dCBCE8AC19"
 
 [assets.equities.AMAT]
 trading = "enabled"
-rebalancing = "enabled"
+# Paused for the receipt-custody migration (Fireblocks -> Turnkey): rebalancing
+# drives issuance mint/redeem traffic, which must be quiescent while AMAT's
+# receipts move. Re-enable only after the custody cutover completes.
+rebalancing = "disabled"
 wrapped_equity_recovery = "enabled"
 extended_hours_counter_trading = "enabled"
 vault_id = "0xfab"


### PR DESCRIPTION
## What

Disables `rebalancing` for AMAT in the prod config. Part of the receipt-custody
migration (Fireblocks -> Turnkey) coordinated in RAI-1509; AMAT is the
single-asset rehearsal.

## Why

Equity rebalancing drives issuance mint/redeem traffic. The custody migration
refuses to move receipts unless the vault is quiescent (no reserved burns, no
in-flight mints or redemptions), so AMAT's rebalancing must be off for the
rehearsal window — and it stays off between the rehearsal rollback and the full
cutover, since the rehearsal leaves custody events in AMAT's stream that the
running Fireblocks-era issuance binary cannot read.

## How

`rebalancing = "enabled"` -> `"disabled"` in AMAT's block of
`config/prod/st0x-hedge.toml`, with a comment stating when it may be
re-enabled. Trading and hedging are untouched — onchain fills and broker
hedges do not create issuance traffic.

## Testing

Config-only change; `is_rebalancing_enabled` behavior for disabled/unknown
symbols is covered by existing loader tests.

## Anything else

Stacked: this PR (merge before the AMAT rehearsal) -> pause-all (merge before
the full cutover) -> resume (merge after cutover completes).
