### PR TITLE
feat: add network selection to alpaca tokenize/redeem CLI commands

### DIFF
--- a/crates/tokenization/src/alpaca.rs
+++ b/crates/tokenization/src/alpaca.rs
@@ -66,6 +66,7 @@ impl<W: Wallet> AlpacaTokenizationService<W> {
         api_key: String,
         api_secret: String,
         wallet: W,
+        network: Network,
         redemption_wallet: Option<Address>,
     ) -> Self {
         let client = AlpacaTokenizationClient::new(
@@ -74,6 +75,7 @@ impl<W: Wallet> AlpacaTokenizationService<W> {
             api_key,
             api_secret,
             wallet,
+            network,
             redemption_wallet,
         );
 
@@ -102,7 +104,7 @@ impl<W: Wallet> AlpacaTokenizationService<W> {
             underlying_symbol,
             quantity,
             issuer: Issuer::new("st0x"),
-            network: Network::new("base"),
+            network: self.client.network.clone(),
             wallet,
             issuer_request_id,
         };
@@ -585,6 +587,7 @@ struct AlpacaTokenizationClient<W: Wallet> {
     api_key: String,
     api_secret: String,
     wallet: W,
+    network: Network,
     redemption_wallet: Option<Address>,
 }
 
@@ -595,6 +598,7 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
         api_key: String,
         api_secret: String,
         wallet: W,
+        network: Network,
         redemption_wallet: Option<Address>,
     ) -> Self {
         Self {
@@ -604,6 +608,7 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
             api_key,
             api_secret,
             wallet,
+            network,
             redemption_wallet,
         }
     }
@@ -1195,6 +1200,7 @@ pub(crate) mod tests {
             "test_api_key".to_string(),
             "test_api_secret".to_string(),
             wallet,
+            Network::new("base"),
             Some(redemption_wallet),
         )
     }
@@ -1293,6 +1299,63 @@ pub(crate) mod tests {
         assert!(logs_contain("tok_req_123"));
         assert!(logs_contain("pending"));
 
+        mint_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn service_mint_request_carries_configured_network() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, key) = setup_anvil();
+        let provider = ProviderBuilder::new().connect(&endpoint).await.unwrap();
+        let wallet = RawPrivateKeyWallet::new(&key, provider, 1).unwrap();
+
+        let client = AlpacaTokenizationClient::new(
+            server.base_url(),
+            TEST_ACCOUNT_ID,
+            "test_api_key".to_string(),
+            "test_api_secret".to_string(),
+            wallet,
+            Network::new("ethereum"),
+            Some(TEST_REDEMPTION_WALLET),
+        );
+        let service = create_test_service(client);
+
+        let recipient = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let issuer_id = issuer_request_id("test-ethereum-mint");
+        let issuer_id_str = issuer_id.to_string();
+
+        let mint_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(tokenization_mint_path())
+                .json_body_includes(r#"{"network":"ethereum"}"#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "tokenization_request_id": "tok_req_eth_1",
+                    "type": "mint",
+                    "status": "pending",
+                    "underlying_symbol": "RKLB",
+                    "token_symbol": "tRKLB",
+                    "qty": "1",
+                    "issuer": "st0x",
+                    "network": "ethereum",
+                    "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+                    "issuer_request_id": issuer_id_str,
+                    "created_at": "2026-08-02T10:30:00Z"
+                }));
+        });
+
+        let result = service
+            .request_mint(
+                Symbol::new("RKLB").unwrap(),
+                FractionalShares::new(float!(1.0)),
+                recipient,
+                issuer_id,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.id, tokenization_request_id("tok_req_eth_1"));
         mint_mock.assert();
     }
 
@@ -1721,6 +1784,7 @@ pub(crate) mod tests {
             "test_api_key".to_string(),
             "test_api_secret".to_string(),
             wallet,
+            Network::new("base"),
             Some(TEST_REDEMPTION_WALLET),
         );
 
@@ -1762,6 +1826,7 @@ pub(crate) mod tests {
             "test_api_key".to_string(),
             "test_api_secret".to_string(),
             wallet,
+            Network::new("base"),
             Some(TEST_REDEMPTION_WALLET),
         );
 
@@ -1791,6 +1856,7 @@ pub(crate) mod tests {
             "test_api_key".to_string(),
             "test_api_secret".to_string(),
             wallet,
+            Network::new("base"),
             Some(TEST_REDEMPTION_WALLET),
         );
 

--- a/src/cli/dividend.rs
+++ b/src/cli/dividend.rs
@@ -10,19 +10,16 @@
 
 use std::io::Write;
 
-use alloy::providers::Provider;
-
 use st0x_config::Ctx;
 use st0x_execution::{FractionalShares, Positive, Symbol};
 
-use super::{rebalancing, trading, wrapper};
+use super::{TokenizationNetwork, rebalancing, trading, wrapper};
 
-pub(super) async fn dividend_bump_command<Writer: Write, Prov: Provider + Clone + 'static>(
+pub(super) async fn dividend_bump_command<Writer: Write>(
     stdout: &mut Writer,
     symbol: Symbol,
     quantity: Positive<FractionalShares>,
     ctx: &Ctx,
-    provider: Prov,
 ) -> anyhow::Result<()> {
     writeln!(stdout, "Dividend NAV bump: {quantity} {symbol}")?;
 
@@ -38,8 +35,9 @@ pub(super) async fn dividend_bump_command<Writer: Write, Prov: Provider + Clone 
         symbol.clone(),
         quantity.inner(),
         None,
+        TokenizationNetwork::Base,
+        None,
         ctx,
-        provider,
     )
     .await?;
 
@@ -56,7 +54,6 @@ pub(super) async fn dividend_bump_command<Writer: Write, Prov: Provider + Clone 
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, address};
-    use alloy::providers::ProviderBuilder;
     use url::Url;
 
     use st0x_config::create_test_issuance_ctx;
@@ -122,8 +119,6 @@ mod tests {
     #[tokio::test]
     async fn dividend_bump_stops_after_buy_when_tokenize_fails() {
         let ctx = dry_run_ctx();
-        let provider =
-            ProviderBuilder::new().connect_http(Url::parse("http://localhost:8545").unwrap());
         let mut stdout = Vec::new();
 
         let error = dividend_bump_command(
@@ -131,7 +126,6 @@ mod tests {
             Symbol::new("COIN").unwrap(),
             positive_shares("10"),
             &ctx,
-            provider,
         )
         .await
         .unwrap_err();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -144,6 +144,20 @@ pub enum CctpChain {
     Base,
 }
 
+/// Target network for Alpaca tokenization mint/redeem commands.
+///
+/// Selects both the Alpaca ITN `network` wire value and the bot wallet
+/// (and therefore the chain) used for onchain legs of the flow; the pairing
+/// is produced by a single match in `rebalancing::tokenization_network_context`
+/// so the two cannot diverge.
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum TokenizationNetwork {
+    /// Base mainnet
+    Base,
+    /// Ethereum mainnet
+    Ethereum,
+}
+
 /// Manual position-recovery operations for stuck local CQRS state.
 #[derive(Debug, Subcommand)]
 pub enum PositionRecoveryCommand {
@@ -631,6 +645,14 @@ pub enum Commands {
         /// Recipient wallet address (defaults to configured wallet address)
         #[arg(short = 'r', long = "recipient")]
         recipient: Option<Address>,
+        /// Target network for the mint (selects the Alpaca `network` wire
+        /// value and the wallet used to observe token arrival)
+        #[arg(long = "network", value_enum, default_value_t = TokenizationNetwork::Base)]
+        network: TokenizationNetwork,
+        /// Tokenized equity (tStock) address override. Required for
+        /// non-base networks -- `[assets.equities]` holds Base addresses
+        #[arg(long = "token")]
+        token: Option<Address>,
     },
 
     /// Request redemption of tokenized shares via Alpaca (isolated test command)
@@ -649,6 +671,14 @@ pub enum Commands {
         /// Alpaca redemption wallet (overrides [tokenization] config)
         #[arg(long = "redemption-wallet")]
         redemption_wallet: Option<Address>,
+        /// Target network for the redemption (selects the wallet that sends
+        /// the tokens and therefore the chain the transfer lands on)
+        #[arg(long = "network", value_enum, default_value_t = TokenizationNetwork::Base)]
+        network: TokenizationNetwork,
+        /// Tokenized equity (tStock) address override. Required for
+        /// non-base networks -- `[assets.equities]` holds Base addresses
+        #[arg(long = "token")]
+        token: Option<Address>,
     },
 
     /// Convert USDC to/from USD on Alpaca
@@ -1182,11 +1212,15 @@ enum ProviderCommand {
         symbol: Symbol,
         quantity: FractionalShares,
         recipient: Option<Address>,
+        network: TokenizationNetwork,
+        token: Option<Address>,
     },
     AlpacaRedeem {
         symbol: Symbol,
         quantity: FractionalShares,
         redemption_wallet: Option<Address>,
+        network: TokenizationNetwork,
+        token: Option<Address>,
     },
     DividendBump {
         symbol: Symbol,
@@ -1358,19 +1392,27 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
             symbol,
             quantity,
             recipient,
+            network,
+            token,
         } => Err(ProviderCommand::AlpacaTokenize {
             symbol,
             quantity,
             recipient,
+            network,
+            token,
         }),
         Commands::AlpacaRedeem {
             symbol,
             quantity,
             redemption_wallet,
+            network,
+            token,
         } => Err(ProviderCommand::AlpacaRedeem {
             symbol,
             quantity,
             redemption_wallet,
+            network,
+            token,
         }),
         Commands::DividendBump { symbol, quantity } => {
             Err(ProviderCommand::DividendBump { symbol, quantity })
@@ -1882,20 +1924,34 @@ async fn run_provider_command<W: Write>(
             symbol,
             quantity,
             recipient,
+            network,
+            token,
         } => {
-            rebalancing::alpaca_tokenize_command(stdout, symbol, quantity, recipient, ctx, provider)
-                .await
+            rebalancing::alpaca_tokenize_command(
+                stdout, symbol, quantity, recipient, network, token, ctx,
+            )
+            .await
         }
         ProviderCommand::AlpacaRedeem {
             symbol,
             quantity,
             redemption_wallet,
+            network,
+            token,
         } => {
-            rebalancing::alpaca_redeem_command(stdout, symbol, quantity, redemption_wallet, ctx)
-                .await
+            rebalancing::alpaca_redeem_command(
+                stdout,
+                symbol,
+                quantity,
+                redemption_wallet,
+                network,
+                token,
+                ctx,
+            )
+            .await
         }
         ProviderCommand::DividendBump { symbol, quantity } => {
-            dividend::dividend_bump_command(stdout, symbol, quantity, ctx, provider).await
+            dividend::dividend_bump_command(stdout, symbol, quantity, ctx).await
         }
         ProviderCommand::AlpacaTokenizationRequests => {
             rebalancing::alpaca_tokenization_requests_command(stdout, ctx).await

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -1,7 +1,7 @@
 //! Transfer equity and USDC rebalancing CLI commands.
 
 use alloy::primitives::{Address, U256};
-use alloy::providers::Provider;
+use alloy::providers::RootProvider;
 use anyhow::Context;
 use sqlx::SqlitePool;
 use std::future::Future;
@@ -12,11 +12,14 @@ use tracing::warn;
 use uuid::Uuid;
 
 use st0x_bridge::cctp::{CctpBridge, CctpCtx};
+use st0x_config::{BrokerCtx, Ctx, OnchainWalletCtx};
 use st0x_event_sorcery::{AggregateError, StoreBuilder};
-use st0x_evm::{Evm, IERC20, OpenChainErrorRegistry, ReadOnlyEvm, USDC_BASE, USDC_ETHEREUM};
+use st0x_evm::{
+    Evm, IERC20, OpenChainErrorRegistry, ReadOnlyEvm, USDC_BASE, USDC_ETHEREUM, Wallet,
+};
 use st0x_execution::{
     AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, AlpacaWalletService, Executor,
-    FractionalShares, Symbol, TimeInForce,
+    FractionalShares, Network, Symbol, TimeInForce,
 };
 use st0x_finance::Usdc;
 use st0x_raindex::{RaindexService, RaindexVaultId};
@@ -27,7 +30,7 @@ use st0x_tokenization::{
 use st0x_wrapper::{Wrapper, WrapperService};
 
 use super::backpressure_retry::{BACKPRESSURE_RETRY_MAX_ATTEMPTS, retry_on_backpressure};
-use super::{TransferDirection, TransferType};
+use super::{TokenizationNetwork, TransferDirection, TransferType};
 use crate::api::ResumeResponse;
 use crate::bot_gas::BotGasReceiptCostEnqueuer;
 use crate::equity_redemption::{
@@ -44,7 +47,6 @@ use crate::usdc_rebalance::{
 };
 use crate::vault_lookup::{VaultLookup, VaultRegistryLookup};
 use crate::vault_registry::{VaultRegistry, VaultRegistryId};
-use st0x_config::{BrokerCtx, Ctx};
 
 struct EquityTransferCliServices {
     transfer: CrossVenueEquityTransfer,
@@ -53,9 +55,31 @@ struct EquityTransferCliServices {
 
 /// Resolves the redemption wallet address from CLI flag or config.
 ///
-/// CLI flag takes precedence. Falls back to `[tokenization]` config.
+/// CLI flag takes precedence; otherwise `[tokenization]` config is used for
+/// every network. Alpaca's redemption address is the same on all EVM chains
+/// (same key → same address), so ethereum does not need a separate override.
 fn resolve_redemption_wallet(flag: Option<Address>, ctx: &Ctx) -> anyhow::Result<Address> {
-    flag.map_or_else(|| ctx.redemption_wallet().map_err(Into::into), Ok)
+    if let Some(address) = flag {
+        return Ok(address);
+    }
+
+    ctx.redemption_wallet().map_err(Into::into)
+}
+
+/// The bot wallet whose chain matches the selected tokenization network,
+/// paired with that network's Alpaca `network` wire value. One match produces
+/// both so a wallet/wire mismatch cannot be constructed at the call site.
+fn tokenization_network_context(
+    wallet_ctx: &OnchainWalletCtx,
+    network: TokenizationNetwork,
+) -> (Arc<dyn Wallet<Provider = RootProvider>>, Network) {
+    match network {
+        TokenizationNetwork::Base => (wallet_ctx.base_wallet().clone(), Network::new("base")),
+        TokenizationNetwork::Ethereum => (
+            wallet_ctx.ethereum_wallet().clone(),
+            Network::new("ethereum"),
+        ),
+    }
 }
 
 async fn build_equity_transfer_services(
@@ -78,6 +102,7 @@ async fn build_equity_transfer_services(
         alpaca_auth.api_key.clone(),
         alpaca_auth.api_secret.clone(),
         base_caller.clone(),
+        Network::new("base"),
         Some(redemption_wallet),
     ));
 
@@ -1027,23 +1052,47 @@ pub(super) async fn reconcile_usdc_transfer_command<Writer: Write>(
     Ok(())
 }
 
+/// Resolves the tokenized-equity (tStock) address for a tokenization
+/// command: an explicit `--token` override wins; otherwise the Base address
+/// comes from `[assets.equities]`. Non-base networks have no config source,
+/// so they require the override.
+fn resolve_tokenization_token(
+    token_override: Option<Address>,
+    network: TokenizationNetwork,
+    symbol: &Symbol,
+    ctx: &Ctx,
+) -> anyhow::Result<Address> {
+    if let Some(address) = token_override {
+        return Ok(address);
+    }
+
+    match network {
+        TokenizationNetwork::Base => ctx.assets.tokenized_equity(symbol).ok_or_else(|| {
+            anyhow::anyhow!("equity {symbol} is not configured in [assets.equities]")
+        }),
+        TokenizationNetwork::Ethereum => Err(anyhow::anyhow!(
+            "pass --token with the Ethereum tStock address for {symbol}: \
+             [assets.equities] holds Base addresses only"
+        )),
+    }
+}
+
 /// Isolated tokenization command - calls Alpaca tokenization API directly.
-pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clone + 'static>(
+pub(super) async fn alpaca_tokenize_command<Writer: Write>(
     stdout: &mut Writer,
     symbol: Symbol,
     quantity: FractionalShares,
     recipient: Option<Address>,
+    network: TokenizationNetwork,
+    token_override: Option<Address>,
     ctx: &Ctx,
-    provider: Prov,
 ) -> anyhow::Result<()> {
     writeln!(stdout, "🔄 Requesting tokenization via Alpaca API")?;
     writeln!(stdout, "   Symbol: {symbol}")?;
     writeln!(stdout, "   Quantity: {quantity}")?;
+    writeln!(stdout, "   Network: {network:?}")?;
 
-    let token = ctx
-        .assets
-        .tokenized_equity(&symbol)
-        .ok_or_else(|| anyhow::anyhow!("equity {symbol} is not configured in [assets.equities]"))?;
+    let token = resolve_tokenization_token(token_override, network, &symbol, ctx)?;
     writeln!(stdout, "   Token: {token}")?;
 
     let BrokerCtx::AlpacaBrokerApi(alpaca_auth) = &ctx.broker else {
@@ -1051,11 +1100,12 @@ pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clon
     };
 
     let wallet_ctx = ctx.wallet()?;
+    let (wallet, wire_network) = tokenization_network_context(wallet_ctx, network);
 
-    let receiving_wallet = recipient.unwrap_or_else(|| wallet_ctx.base_wallet().address());
+    let receiving_wallet = recipient.unwrap_or_else(|| wallet.address());
     writeln!(stdout, "   Receiving wallet: {receiving_wallet}")?;
 
-    let read_evm = ReadOnlyEvm::new(provider.clone());
+    let read_evm = ReadOnlyEvm::new(wallet.provider().clone());
     let initial_balance: U256 = read_evm
         .call::<OpenChainErrorRegistry, _>(
             token,
@@ -1079,7 +1129,8 @@ pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clon
         alpaca_auth.account_id,
         alpaca_auth.api_key.clone(),
         alpaca_auth.api_secret.clone(),
-        wallet_ctx.base_wallet().clone(),
+        wallet,
+        wire_network,
         None,
     );
 
@@ -1128,7 +1179,7 @@ pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clon
         }
     }
 
-    writeln!(stdout, "   Polling for tokens to arrive on Base...")?;
+    writeln!(stdout, "   Polling for tokens to arrive on {network:?}...")?;
 
     let poll_interval = std::time::Duration::from_secs(5);
     let max_attempts = 60; // 5 minutes max
@@ -1180,16 +1231,16 @@ pub(super) async fn alpaca_redeem_command<Writer: Write>(
     symbol: Symbol,
     quantity: FractionalShares,
     redemption_wallet_flag: Option<Address>,
+    network: TokenizationNetwork,
+    token_override: Option<Address>,
     ctx: &Ctx,
 ) -> anyhow::Result<()> {
     writeln!(stdout, "🔄 Requesting redemption via Alpaca API")?;
     writeln!(stdout, "   Symbol: {symbol}")?;
     writeln!(stdout, "   Quantity: {quantity}")?;
+    writeln!(stdout, "   Network: {network:?}")?;
 
-    let token = ctx
-        .assets
-        .tokenized_equity(&symbol)
-        .ok_or_else(|| anyhow::anyhow!("equity {symbol} is not configured in [assets.equities]"))?;
+    let token = resolve_tokenization_token(token_override, network, &symbol, ctx)?;
     writeln!(stdout, "   Token: {token}")?;
 
     let BrokerCtx::AlpacaBrokerApi(alpaca_auth) = &ctx.broker else {
@@ -1198,6 +1249,7 @@ pub(super) async fn alpaca_redeem_command<Writer: Write>(
 
     let redemption_wallet = resolve_redemption_wallet(redemption_wallet_flag, ctx)?;
     let wallet_ctx = ctx.wallet()?;
+    let (wallet, wire_network) = tokenization_network_context(wallet_ctx, network);
     writeln!(stdout, "   Redemption wallet: {redemption_wallet}")?;
 
     let tokenization_service = AlpacaTokenizationService::new(
@@ -1205,7 +1257,8 @@ pub(super) async fn alpaca_redeem_command<Writer: Write>(
         alpaca_auth.account_id,
         alpaca_auth.api_key.clone(),
         alpaca_auth.api_secret.clone(),
-        wallet_ctx.base_wallet().clone(),
+        wallet,
+        wire_network,
         Some(redemption_wallet),
     );
 
@@ -1281,6 +1334,7 @@ pub(super) async fn alpaca_tokenization_requests_command<Writer: Write>(
         alpaca_auth.api_key.clone(),
         alpaca_auth.api_secret.clone(),
         wallet_ctx.base_wallet().clone(),
+        Network::new("base"),
         None,
     );
 
@@ -1700,7 +1754,6 @@ pub(crate) async fn resume_interrupted_transfers_command<W: Write>(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, B256, address, b256};
-    use alloy::providers::ProviderBuilder;
     use chrono::Utc;
     use rain_math_float::Float;
     use url::Url;
@@ -1716,6 +1769,8 @@ mod tests {
     };
     use st0x_config::{EvmCtx, IngestionCutoff, InventoryMode};
     use st0x_event_sorcery::LifecycleError;
+    #[cfg(feature = "test-support")]
+    use st0x_evm::StubWallet;
     use st0x_execution::{
         AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, AlpacaTransferId,
         AlpacaWalletError, ClientOrderId, TimeInForce,
@@ -2727,6 +2782,42 @@ mod tests {
             err_msg.contains("requires [tokenization]"),
             "Expected tokenization config error, got: {err_msg}"
         );
+    }
+
+    /// Same key → same address on every EVM chain; ethereum uses the
+    /// `[tokenization]` config wallet without requiring `--redemption-wallet`.
+    #[test]
+    fn resolve_redemption_wallet_ethereum_uses_config() {
+        let mut ctx = create_alpaca_ctx_without_rebalancing();
+        let config_wallet = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        ctx.redemption_wallet = Some(config_wallet);
+
+        let result = resolve_redemption_wallet(None, &ctx).unwrap();
+        assert_eq!(result, config_wallet);
+    }
+
+    /// One match yields both the wallet and the wire value, so the pairing is
+    /// pinned here for both networks: ethereum selects the ethereum wallet and
+    /// the "ethereum" wire value, base the base pair.
+    #[cfg(feature = "test-support")]
+    #[test]
+    fn tokenization_network_context_pairs_wallet_and_wire() {
+        let base_address = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let ethereum_address = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let wallet_ctx = OnchainWalletCtx::from_wallets(
+            StubWallet::stub(base_address),
+            StubWallet::stub(ethereum_address),
+        );
+
+        let (base_wallet, base_wire) =
+            tokenization_network_context(&wallet_ctx, TokenizationNetwork::Base);
+        assert_eq!(base_wallet.address(), base_address);
+        assert_eq!(base_wire, Network::new("base"));
+
+        let (ethereum_wallet, ethereum_wire) =
+            tokenization_network_context(&wallet_ctx, TokenizationNetwork::Ethereum);
+        assert_eq!(ethereum_wallet.address(), ethereum_address);
+        assert_eq!(ethereum_wire, Network::new("ethereum"));
     }
 
     async fn seed_to_withdrawal_complete(
@@ -3770,8 +3861,6 @@ mod tests {
     #[tokio::test]
     async fn alpaca_tokenize_fails_when_symbol_not_configured() {
         let ctx = create_alpaca_ctx_without_rebalancing();
-        let provider =
-            ProviderBuilder::new().connect_http(Url::parse("http://localhost:8545").unwrap());
         let mut stdout = Vec::new();
 
         let error = alpaca_tokenize_command(
@@ -3779,8 +3868,9 @@ mod tests {
             Symbol::new("COIN").unwrap(),
             FractionalShares::new(float!(10)),
             None,
+            TokenizationNetwork::Base,
+            None,
             &ctx,
-            provider,
         )
         .await
         .unwrap_err();
@@ -3802,6 +3892,8 @@ mod tests {
             &mut stdout,
             Symbol::new("COIN").unwrap(),
             FractionalShares::new(float!(10)),
+            None,
+            TokenizationNetwork::Base,
             None,
             &ctx,
         )
@@ -3845,6 +3937,7 @@ mod tests {
             "test_key".to_string(),
             "test_secret".to_string(),
             st0x_evm::StubWallet::stub(Address::ZERO),
+            Network::new("base"),
             None,
         );
         let issuer_request_id = IssuerRequestId::generate();
@@ -3897,6 +3990,7 @@ mod tests {
             "test_key".to_string(),
             "test_secret".to_string(),
             st0x_evm::StubWallet::stub(Address::ZERO),
+            Network::new("base"),
             None,
         );
         let tx_hash = alloy::primitives::TxHash::ZERO;
@@ -3916,6 +4010,45 @@ mod tests {
         list_mock
             .assert_calls_async(BACKPRESSURE_RETRY_MAX_ATTEMPTS as usize)
             .await;
+    }
+
+    #[tokio::test]
+    async fn ethereum_network_requires_explicit_token_address() {
+        let ctx = create_alpaca_ctx_without_rebalancing();
+        let mut stdout = Vec::new();
+
+        let error = alpaca_redeem_command(
+            &mut stdout,
+            Symbol::new("RKLB").unwrap(),
+            FractionalShares::new(float!(1)),
+            None,
+            TokenizationNetwork::Ethereum,
+            None,
+            &ctx,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("pass --token"),
+            "ethereum without --token must fail closed, got: {error}"
+        );
+    }
+
+    #[test]
+    fn token_override_bypasses_assets_config() {
+        let ctx = create_alpaca_ctx_without_rebalancing();
+        let token = address!("0xED0c085d92C262FB46937CB0B3C9763Af7fCCf30");
+
+        let resolved = resolve_tokenization_token(
+            Some(token),
+            TokenizationNetwork::Ethereum,
+            &Symbol::new("RKLB").unwrap(),
+            &ctx,
+        )
+        .unwrap();
+
+        assert_eq!(resolved, token);
     }
 
     fn redemption_services() -> EquityTransferServices {

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -44,7 +44,7 @@ use st0x_evm::{OpenChainErrorRegistry, USDC_BASE, Wallet};
 use st0x_execution::{
     AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaWalletService, ClientOrderId, CounterTradePreflight,
     CounterTradeReservation, CounterTradeSkipReason, ExecutionError, Executor, FractionalShares,
-    MarketOrder, MarketSession, Symbol, TryIntoExecutor,
+    MarketOrder, MarketSession, Network, Symbol, TryIntoExecutor,
 };
 use st0x_issuance_client::IssuanceClient;
 use st0x_raindex::{RaindexService, RaindexVaultId, RevokeOutcome};
@@ -2027,6 +2027,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             alpaca_auth.api_key.clone(),
             alpaca_auth.api_secret.clone(),
             base_wallet.clone(),
+            Network::new("base"),
             Some(redemption_wallet),
         ));
 

--- a/src/integration_tests/tokenization.rs
+++ b/src/integration_tests/tokenization.rs
@@ -11,7 +11,7 @@ use uuid::uuid;
 
 use st0x_evm::Wallet;
 use st0x_evm::local::RawPrivateKeyWallet;
-use st0x_execution::{AlpacaAccountId, PollingConfig};
+use st0x_execution::{AlpacaAccountId, Network, PollingConfig};
 use st0x_tokenization::{AlpacaTokenizationService, IssuerRequestId};
 
 pub(crate) const TEST_ACCOUNT_ID: AlpacaAccountId =
@@ -46,6 +46,7 @@ pub(crate) async fn create_test_service_from_mock(
         "test_api_key".to_string(),
         "test_api_secret".to_string(),
         wallet,
+        Network::new("base"),
         Some(redemption_wallet),
     )
     .with_polling_config(PollingConfig {


### PR DESCRIPTION
## What

Adds a `--network` flag (base | ethereum, default base) and a `--token` address override to the `alpaca-tokenize` and `alpaca-redeem` CLI commands, and threads an explicit `Network` through `AlpacaTokenizationService`. On ethereum, both commands require `--token` (the config holds Base token addresses only). Redemption wallet resolution is network-agnostic: CLI flag wins, else `[tokenization]` config — Alpaca's redemption address is the same on all EVM chains (same key → same address).

## Why

The first multichain mint/redeem on Ethereum (RAI-1508 activation on the issuance side) needs the AP-side tokenization requests to carry `"network": "ethereum"`. Until now the service hardcoded `base` in the mint payload and always signed/observed through the Base wallet, so there was no way to drive an Ethereum tokenization from the CLI.

## How

- `AlpacaTokenizationService::new` takes the `Network` wire value explicitly; the mint payload uses it instead of a hardcoded `base`. All production construction sites pass `base` explicitly — server behavior is unchanged.
- `tokenization_network_context(wallet_ctx, network)` produces the (wallet, wire value) pair from a single match, so a chain/wire mismatch cannot be constructed: `ethereum` routes `send_for_redemption` and balance polling through `wallet_ctx.ethereum_wallet()` (already present for CCTP).
- `--token` overrides the `[assets.equities]` lookup; ethereum requires it (the config holds Base addresses only). `resolve_redemption_wallet` uses the flag or `[tokenization]` for every network — no ethereum fail-closed path.
- The tokenize command reads balances via the selected wallet's provider, so the arrival check watches the right chain. As a result the tokenize and dividend-bump handlers no longer take a dispatcher-supplied provider — `dividend_bump_command` drops its `Prov` generic and pins `base` explicitly.

## Testing

- `service_mint_request_carries_configured_network`: mock Alpaca asserts the mint body carries `"network": "ethereum"`.
- `ethereum_network_requires_explicit_token_address`: ethereum redeem fails closed without `--token`; the tokenize path's `--token` requirement is covered via `resolve_tokenization_token` unit tests (`token_override_bypasses_assets_config` and the base fallback cases).
- `resolve_redemption_wallet_*`: flag precedence, config fallback (including ethereum), missing-config error.
- `tokenization_network_context_pairs_wallet_and_wire`: two distinct stub wallets pin the wallet/wire pairing for both networks.
- Full workspace check, affected nextest targets, and clippy green.

## Anything else

Secrets schema is untouched: `[evm].ethereum_rpc_url` is already required when `[wallet]` is configured, so no `.age` update is forced by this PR — but the deployed secret's Ethereum RPC should be pointed at the team Alchemy endpoint before the first real run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Base and Ethereum network selection for Alpaca tokenization and redemption.
  * Added optional token address overrides for command-line operations.
  * Network-specific wallets and token addresses are selected automatically.
  * Tokenization status and output now identify the selected network.

* **Bug Fixes**
  * Prevented Base-only settings from being used for Ethereum operations.
  * Ensured mint requests use the configured network instead of defaulting to Base.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->