### PR TITLE
fix: prevent skipped CI from satisfying required checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, edited]
 
-# Metadata-only pull request edits (title/body, see `optimize_ci`) get their
-# own group. They skip the real checks, so sharing the group would let a title
-# edit cancel a live run and then report every required check as skipped --
-# which branch protection reads as a pass on code that was never tested.
+# Pull request events for the same merge ref share a group. A later head, base,
+# title, or body update may replace an older run, but every replacement performs
+# the same validation, so cancellation cannot leave behind a green no-op run.
+# Master keeps one group per SHA so independent post-merge runs do not cancel.
 concurrency:
-  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}-${{ github.event.action == 'edited' && !github.event.changes.base && 'metadata-edit' || '' }}-${{ github.ref == 'refs/heads/master' && github.sha || ''}}
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/master' && github.sha || ''}}
   cancel-in-progress: true
 
 # CI validates untrusted pull request code, so its repository access stays
@@ -25,8 +25,8 @@ env:
   # GitHub holds fork pull_request runs for maintainer approval, removes every
   # repository secret, and limits GITHUB_TOKEN to read access. Dependabot runs
   # have the same restrictions despite using a branch in this repository. Keep
-  # an explicit flag as well, so no authenticated optimizer or cache publisher
-  # is even invoked for untrusted code.
+  # an explicit flag as well, so no authenticated cache publisher is invoked
+  # for untrusted code.
   UNTRUSTED_PR: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || github.event.pull_request.user.login == 'dependabot[bot]') }}
 
 # Nix is installed via nix-quick-install-action and both the shared
@@ -36,52 +36,6 @@ env:
 # which did not share the `rainlanguage` cache that raindex CI populates.
 
 jobs:
-  optimize_ci:
-    runs-on: "blacksmith-2vcpu-ubuntu-2404"
-    timeout-minutes: 5
-    outputs:
-      skip: ${{ steps.metadata_edit.outputs.skip == 'true' && 'true' || steps.check_skip.outputs.skip }}
-    steps:
-      # `edited` is in the trigger list for base retargets: a stacked pull
-      # request keeps its head commit when its parent merges, so only the
-      # retarget event tells CI the diff under test changed. GitHub fires the
-      # same event for title and body edits, which change no code at all, and
-      # `/pr-description` edits both right after submit. `github.event.changes`
-      # carries `base` only on a retarget, so its absence marks the edit as
-      # metadata-only and reuses the optimizer's `skip` contract to stand every
-      # real job down.
-      - name: Detect metadata-only pull request edit
-        id: metadata_edit
-        if: ${{ github.event.action == 'edited' && !github.event.changes.base }}
-        run: echo "skip=true" >> "$GITHUB_OUTPUT"
-
-      # Pinned to the v0.0.9 release commit, not a mutable ref: this action
-      # gates all CI and holds the Graphite token, so the SHA freezes both the
-      # supply chain and the `skip` output contract (set in dist/index.js but
-      # undeclared in the action's action.yml).
-      #
-      # Fork pull requests are not Graphite stacks. The optimizer's `skip`
-      # contract is not defined for them, and a `true` would skip the real
-      # jobs, which branch protection then reads as a pass. Do not invoke the
-      # optimizer or expose its token for untrusted code.
-      #
-      # The STEP carries this condition, not the job, on purpose. The job still
-      # runs and still succeeds, so no dependent job can be cascade-skipped by
-      # a skipped dependency. `skip` is then simply empty, and every gate below
-      # tests `!= 'true'`, so all of them fall into the run-the-real-checks
-      # bucket.
-      - name: Optimize CI
-        id: check_skip
-        if: ${{ env.UNTRUSTED_PR != 'true' && steps.metadata_edit.outputs.skip != 'true' }}
-        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689  # v0.0.9
-        with:
-          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZATION_TOKEN }}
-          # Declared required by the action but unused at the pinned version
-          # (it reads only graphite_token/endpoint/timeout; there is no
-          # run-cancel path). Skipping is enforced solely by the `skip` output
-          # and the job-level if-gates.
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
   # Classifies the push: `code == 'true'` when at least one changed file is
   # NOT a docs file. With `predicate-quantifier: every`, a file matches the
   # `code` filter only if it matches `**` AND every negated docs glob -- i.e.
@@ -90,17 +44,11 @@ jobs:
   # all-docs push yields `code == 'false'`. If this job errors or is
   # skipped, `code` is empty/unknown and the gates require the real checks.
   #
-  # Runs whenever the optimizer did NOT confirm a skip (`skip != 'true'`),
-  # including when `optimize_ci` itself failed (empty skip) -- so a broken
-  # optimizer falls into the run-CI bucket, never the skip bucket.
-  #
   # NOTE: paths-filter uses the Pull Requests API for pull_request runs and git
   # change detection for push/workflow_dispatch, so the checkout is needed for
   # the latter two events.
   changes:
     name: changes
-    needs: optimize_ci
-    if: ${{ always() && needs.optimize_ci.outputs.skip != 'true' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     outputs:
@@ -110,6 +58,7 @@ jobs:
       code: ${{ github.event_name == 'pull_request' && github.event.pull_request.changed_files >= 3000 && 'true' || steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           persist-credentials: false
 
@@ -127,8 +76,8 @@ jobs:
 
   backend-build:
     name: backend build
-    needs: [optimize_ci, changes]
-    if: ${{ needs.optimize_ci.outputs.skip != 'true' && needs.changes.outputs.code == 'true' }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     env:
@@ -206,8 +155,8 @@ jobs:
 
   backend-test:
     name: backend test ${{ matrix.partition }} of 4
-    needs: [optimize_ci, changes, backend-build]
-    if: ${{ needs.optimize_ci.outputs.skip != 'true' && needs.changes.outputs.code == 'true' }}
+    needs: [changes, backend-build]
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     strategy:
@@ -274,11 +223,10 @@ jobs:
 
   backend:
     name: backend
-    needs: [optimize_ci, changes, backend-build, backend-test]
-    # Runs unless the optimizer CONFIRMED a skip (skip == 'true'). A failed or
-    # empty optimizer (skip == '') falls through here and runs the gate, so a
-    # broken optimizer can never silently satisfy this required check.
-    if: ${{ always() && needs.optimize_ci.outputs.skip != 'true' }}
+    needs: [changes, backend-build, backend-test]
+    # Inspect every dependency state, including failures, skips, and
+    # cancellations, so this required check cannot pass without validation.
+    if: ${{ always() }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -299,33 +247,26 @@ jobs:
             exit 1
           fi
 
-  # Required check. Always runs when not graphite-skipped; the real build
-  # steps are skipped only on a confirmed docs-only push (changes succeeded
-  # AND code == 'false'), so a docs-only push reports this check green
-  # without spinning up the dashboard toolchain.
-  dashboard:
-    needs: [optimize_ci, changes]
-    if: ${{ always() && needs.optimize_ci.outputs.skip != 'true' }}
+  # Cancellable dashboard work. The separate required gate below inspects this
+  # result, so cancellation cannot turn the required check green while an
+  # obsolete build still consumes a runner.
+  dashboard-build:
+    name: dashboard build
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
-      - name: Docs-only change - dashboard build not required
-        if: ${{ needs.changes.result == 'success' && needs.changes.outputs.code == 'false' }}
-        run: echo "Docs-only change; skipping dashboard build."
-
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
-        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         with:
           persist-credentials: false
 
       - name: Configure Git fetch fail-fast
-        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         run: |
           git config --global http.lowSpeedLimit 524288
           git config --global http.lowSpeedTime 60
 
       - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035  # v34
-        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         with:
           # Nix 2.24-2.28 fail to resolve rainix's overridden `foundry` input
           # (`cannot find flake 'flake:foundry'`); the fix landed in 2.30. v30
@@ -340,7 +281,6 @@ jobs:
             keep-outputs = true
 
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
-        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         continue-on-error: true
         with:
           name: rainlanguage
@@ -349,7 +289,6 @@ jobs:
           useDaemon: false
 
       - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569  # v7
-        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
@@ -357,35 +296,47 @@ jobs:
           save: ${{ env.UNTRUSTED_PR != 'true' }}
 
       - name: Check bun.nix is up to date
-        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         run: |
           nix run .#genBunNix
           nix fmt -- dashboard/bun.nix
           git diff --exit-code dashboard/bun.nix
 
       - name: Generate dashboard API bindings
-        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         run: nix run .#st0x-dto -- dashboard/src/lib/api
 
       - name: Dashboard lint
-        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         working-directory: dashboard
         run: |
           nix develop "$GITHUB_WORKSPACE#ci-dashboard" -c bun install --frozen-lockfile
           nix develop "$GITHUB_WORKSPACE#ci-dashboard" -c bun run lint
 
       - name: Dashboard
-        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         run: nix build .#st0x-dashboard
 
-  # Required check. Runs fully whenever not graphite-skipped -- including on
-  # docs-only pushes -- because pre-commit is the only check that validates
-  # docs files (deno fmt covers markdown). Short-circuiting it on docs-only
-  # pushes would let unformatted docs merge green and then break
-  # `pre-commit run --all-files` for every subsequent push on any branch.
-  hooks:
-    needs: optimize_ci
-    if: ${{ always() && needs.optimize_ci.outputs.skip != 'true' }}
+  # Required dashboard check. A confirmed docs-only change may skip the real
+  # build. Every other dependency state, including cancellation, fails closed.
+  dashboard:
+    name: dashboard
+    needs: [changes, dashboard-build]
+    if: ${{ always() }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - name: Check dashboard validation
+        run: |
+          if [ "${{ needs.changes.result }}" = "success" ] && [ "${{ needs.changes.outputs.code }}" = "false" ]; then
+            echo "Docs-only change - dashboard validation not required."
+            exit 0
+          fi
+          if [ "${{ needs.dashboard-build.result }}" != "success" ]; then
+            echo "dashboard validation failed (build=${{ needs.dashboard-build.result }})"
+            exit 1
+          fi
+
+  # Cancellable hooks work. It runs on docs-only changes because pre-commit is
+  # the only check that validates docs files (deno fmt covers markdown).
+  hooks-run:
+    name: hooks validation
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -435,3 +386,19 @@ jobs:
 
       - name: pre-commit hooks
         run: nix develop .#ci-hooks -c pre-commit run --all-files
+
+  # Required hooks check. Inspect the work result even when it was skipped or
+  # canceled, so branch protection never accepts an unvalidated commit.
+  hooks:
+    name: hooks
+    needs: hooks-run
+    if: ${{ always() }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - name: Check hooks validation
+        run: |
+          if [ "${{ needs.hooks-run.result }}" != "success" ]; then
+            echo "hooks validation failed (result=${{ needs.hooks-run.result }})"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ nix run .#deployAll   # first deployment
 ### CI/CD
 
 - **CI** (`.github/workflows/ci.yaml`): Builds all packages, runs tests and
-  clippy inside nix derivations, builds dashboard. Runs on every push.
+  clippy inside nix derivations, and builds the dashboard. Runs for pull request
+  activity and pushes to `master`.
 - **CD** (`.github/workflows/cd.yaml`): Deploys to the NixOS host via
   `nix run .#deployAll`. Runs on push to master.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -13,10 +13,24 @@ commit. A skipped or stale duplicate could then hide the result that branch
 protection was meant to require.
 
 Retargeting a PR emits an `edited` event and reruns CI against the new base.
-GitHub emits the same event for title and body edits, which change no code.
-Those runs stand the real jobs down through the optimizer `skip` output, and
-they use a separate concurrency group so they cannot cancel a live run and
-report its required checks as skipped.
+GitHub emits the same event for title and body edits, which change no code. All
+subscribed events for a pull request share one concurrency group, so a later
+event cancels and replaces an older run. The replacement performs the same
+validation even when only PR metadata changed. This avoids a race where a head
+or base update is cancelled and the surviving run reports the required jobs as
+skipped, which GitHub treats as successful.
+
+The required checks are never gated by the Graphite CI optimizer. In particular,
+middle-of-stack PRs run their own backend validation rather than relying on a
+different stack branch. Only a confirmed docs-only diff short-circuits the
+backend and dashboard toolchains; their required gate jobs still execute, and
+pre-commit hooks continue to validate the documentation.
+
+The backend build and test matrix, dashboard build, and pre-commit hooks run in
+cancellable work jobs. Separate `backend`, `dashboard`, and `hooks` gate jobs
+use `always()` to inspect their results and fail on skipped, failed, or
+cancelled work. This keeps replacement runs responsive without allowing an
+obsolete run to publish a successful required check.
 
 Pull requests with at least 3,000 changed files always run full CI because
 GitHub's pull request files API truncates responses at that boundary.
@@ -33,7 +47,6 @@ read access. Dependabot runs receive the same restrictions despite using an
 in-repository branch. The workflow treats either case as an explicit trust
 boundary:
 
-- the Graphite optimizer does not run;
 - Cachix gets no auth token and cannot push;
 - Nix and Rust caches restore but do not save.
 

--- a/scripts/test-fork-pr-ci.sh
+++ b/scripts/test-fork-pr-ci.sh
@@ -28,6 +28,15 @@ assert_count() {
   fi
 }
 
+assert_absent() {
+  local unexpected=$1
+
+  if grep -Fq -- "$unexpected" "$workflow_file"; then
+    echo "unsafe CI configuration remains: $unexpected" >&2
+    exit 1
+  fi
+}
+
 # Native pull_request runs attach the required jobs to both internal and fork
 # pull requests, including Graphite PRs targeting a parent feature branch. Push
 # CI is limited to master so one commit cannot get a second set of identically
@@ -36,25 +45,210 @@ assert_count 1 '    branches: [master]'
 assert_line '  pull_request:'
 assert_line '    types: [opened, synchronize, reopened, ready_for_review, edited]'
 
-# paths-filter needs this permission on pull_request events. It remains
-# read-only for fork runs.
-assert_line '  contents: read'
-assert_line '  pull-requests: read'
-if grep -Eq '^[[:space:]]*permissions:[[:space:]]*write-all|^[[:space:]]*[[:alnum:]_-]+:[[:space:]]*write$' "$workflow_file"; then
-  echo "CI permissions must remain read-only" >&2
-  exit 1
-fi
+# Every subscribed pull request event must leave behind a run that executes the
+# required checks. An optimizer-controlled job-level skip is unsafe because
+# GitHub reports a skipped required job as successful. A replacement event may
+# cancel an older run, but the replacement must use the same concurrency group
+# and perform validation itself.
+assert_absent 'withgraphite/graphite-ci-action@'
+assert_absent 'GRAPHITE_CI_OPTIMIZATION_TOKEN'
 
-# Every third-party action is immutable. Reject alternate YAML spellings so a
-# valid inline map or spaced key cannot bypass the scanner. Version comments
-# keep update intent readable without trusting a mutable tag at execution time.
+# Parse the workflow once for structural, gate, and immutable-action checks.
 parsed_action_count=$(
   ruby - "$workflow_file" <<'RUBY'
 require "yaml"
+require "open3"
 
 workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
-actions = []
+jobs = workflow.fetch("jobs")
+concurrency = workflow.fetch("concurrency")
 
+expected_group = "${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/master' && github.sha || ''}}"
+unless concurrency["group"] == expected_group && concurrency["cancel-in-progress"] == true
+  warn "pull request replacement runs must share a cancel-in-progress concurrency group"
+  exit 1
+end
+
+if jobs.key?("optimize_ci")
+  warn "the Graphite optimizer must not control required CI checks"
+  exit 1
+end
+
+expected_wiring = {
+  "changes" => { "needs" => nil, "if" => nil },
+  "backend-build" => {
+    "needs" => "changes",
+    "if" => "${{ needs.changes.outputs.code == 'true' }}"
+  },
+  "backend-test" => {
+    "needs" => %w[changes backend-build],
+    "if" => "${{ needs.changes.outputs.code == 'true' }}"
+  },
+  "backend" => {
+    "needs" => %w[changes backend-build backend-test],
+    "if" => "${{ always() }}"
+  },
+  "dashboard-build" => {
+    "needs" => "changes",
+    "if" => "${{ needs.changes.outputs.code == 'true' }}"
+  },
+  "dashboard" => {
+    "needs" => %w[changes dashboard-build],
+    "if" => "${{ always() }}"
+  },
+  "hooks-run" => { "needs" => nil, "if" => nil },
+  "hooks" => {
+    "needs" => "hooks-run",
+    "if" => "${{ always() }}"
+  }
+}
+
+expected_wiring.each do |job_name, expected|
+  job = jobs.fetch(job_name)
+  expected.each do |key, value|
+    next if job[key] == value
+
+    warn "#{job_name}.#{key} must be #{value.inspect}, got #{job[key].inspect}"
+    exit 1
+  end
+end
+
+%w[backend dashboard hooks].each do |job_name|
+  effective_name = jobs.fetch(job_name).fetch("name", job_name)
+  next if effective_name == job_name
+
+  warn "required job #{job_name} must publish the #{job_name.inspect} check, got #{effective_name.inspect}"
+  exit 1
+end
+
+filter_step = jobs.fetch("changes").fetch("steps").find { |step| step["id"] == "filter" }
+filter_config = filter_step.fetch("with")
+filters = YAML.safe_load(filter_config.fetch("filters")).fetch("code")
+expected_filters = %w[** !**/*.md !docs/** !AGENTS.md !README*]
+unless filter_config["predicate-quantifier"] == "every" && filters == expected_filters
+  warn "the code classifier must exclude only documentation paths"
+  exit 1
+end
+
+checkout_step = jobs.fetch("changes").fetch("steps").find do |step|
+  step.fetch("uses", "").start_with?("actions/checkout@")
+end
+unless checkout_step&.fetch("if", nil) == "${{ github.event_name != 'pull_request' }}"
+  warn "changes checkout must run for push detection and stay off pull_request API detection"
+  exit 1
+end
+
+workflow_permissions = workflow.fetch("permissions")
+unless workflow_permissions["contents"] == "read" &&
+    workflow_permissions["pull-requests"] == "read"
+  warn "paths-filter permissions must remain explicitly read-only"
+  exit 1
+end
+
+permission_sets = [workflow_permissions] + jobs.values.map { |job| job["permissions"] }.compact
+permission_sets.each do |permissions|
+  grants_write = permissions == "write-all" ||
+    (permissions.is_a?(Hash) && permissions.values.any? { |value| value.to_s == "write" })
+  next unless grants_write
+
+  warn "CI permissions must remain read-only, got #{permissions.inspect}"
+  exit 1
+end
+
+check_gate = lambda do |job_name, step_name, expressions, cases|
+  gate_job = jobs.fetch(job_name)
+  gate_step = gate_job.fetch("steps").find do |step|
+    step["name"] == step_name
+  end
+  unless gate_job.fetch("continue-on-error", false) == false &&
+      gate_step&.fetch("if", nil).nil? &&
+      gate_step&.fetch("continue-on-error", false) == false
+    warn "#{job_name} gate enforcement must run and propagate failures"
+    exit 1
+  end
+
+  gate_script = gate_step.fetch("run")
+  expressions.each do |expression|
+    next if gate_script.include?("${{ #{expression} }}")
+
+    warn "#{job_name} gate no longer references #{expression}"
+    exit 1
+  end
+
+  cases.each do |values, expected_success|
+    rendered = expressions.zip(values).reduce(gate_script) do |script, (expression, value)|
+      script.gsub("${{ #{expression} }}", value)
+    end
+    if rendered.include?("$" + "{{")
+      warn "#{job_name} gate has unrendered expressions"
+      exit 1
+    end
+
+    _stdout, _stderr, status = Open3.capture3("bash", "-c", rendered)
+    next if status.success? == expected_success
+
+    warn "#{job_name} gate returned #{status.exitstatus} for #{values.inspect}"
+    exit 1
+  end
+end
+
+check_gate.call(
+  "backend",
+  "Check backend validation",
+  %w[
+    needs.changes.result
+    needs.changes.outputs.code
+    needs.backend-build.result
+    needs.backend-test.result
+  ],
+  [
+    [%w[success false skipped skipped], true],
+    [%w[success true success success], true],
+    [%w[success true failure success], false],
+    [%w[success true skipped success], false],
+    [%w[success true cancelled success], false],
+    [%w[success true success failure], false],
+    [%w[success true success skipped], false],
+    [%w[success true success cancelled], false],
+    [%w[failure unknown skipped skipped], false],
+    [%w[skipped unknown skipped skipped], false],
+    [%w[cancelled unknown skipped skipped], false]
+  ]
+)
+
+check_gate.call(
+  "dashboard",
+  "Check dashboard validation",
+  %w[
+    needs.changes.result
+    needs.changes.outputs.code
+    needs.dashboard-build.result
+  ],
+  [
+    [%w[success false skipped], true],
+    [%w[success true success], true],
+    [%w[success true failure], false],
+    [%w[success true skipped], false],
+    [%w[success true cancelled], false],
+    [%w[failure unknown skipped], false],
+    [%w[skipped unknown skipped], false],
+    [%w[cancelled unknown skipped], false]
+  ]
+)
+
+check_gate.call(
+  "hooks",
+  "Check hooks validation",
+  %w[needs.hooks-run.result],
+  [
+    [%w[success], true],
+    [%w[failure], false],
+    [%w[skipped], false],
+    [%w[cancelled], false]
+  ]
+)
+
+actions = []
 visit = lambda do |value|
   case value
   when Hash
@@ -77,7 +271,6 @@ visit = lambda do |value|
 end
 
 visit.call(workflow)
-
 actions.each do |action|
   unless action.is_a?(String) && action.match?(/\A[^@\s]+@[0-9a-f]{40}\z/)
     warn "CI action is not pinned to a commit SHA: #{action.inspect}"
@@ -89,6 +282,9 @@ puts actions.length
 RUBY
 )
 
+# Every third-party action is immutable. Reject alternate YAML spellings so a
+# valid inline map or spaced key cannot bypass the scanner. Version comments
+# keep update intent readable without trusting a mutable tag at execution time.
 action_line_pattern='^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]+[^[:space:]@]+@[0-9a-f]{40}[[:space:]]+# v[0-9][^[:space:]]*$'
 action_line_count=0
 while IFS= read -r action_line; do
@@ -104,7 +300,6 @@ if [ "$parsed_action_count" -ne "$action_line_count" ]; then
   exit 1
 fi
 
-assert_count 1 '        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689  # v0.0.9'
 assert_count 5 '      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6'
 assert_count 1 '      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3'
 assert_count 4 '      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035  # v34'
@@ -136,28 +331,14 @@ RUBY
 # from a branch naming convention. Dependabot uses an in-repository branch but
 # receives the same restricted token and secret treatment as a fork.
 assert_line "  UNTRUSTED_PR: \${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || github.event.pull_request.user.login == 'dependabot[bot]') }}"
-assert_line "        if: \${{ env.UNTRUSTED_PR != 'true' && steps.metadata_edit.outputs.skip != 'true' }}"
 assert_count 4 "          authToken: \${{ env.UNTRUSTED_PR != 'true' && secrets.CACHIX_AUTH_TOKEN || '' }}"
 assert_count 4 "          skipPush: \${{ env.UNTRUSTED_PR == 'true' }}"
 assert_count 4 "          save: \${{ env.UNTRUSTED_PR != 'true' }}"
 assert_count 1 "          save-if: \${{ env.UNTRUSTED_PR != 'true' }}"
 
-# A metadata-only `edited` event must stand the real jobs down and must not
-# share the concurrency group with a real run. Without the separate group a
-# title edit would cancel a live run and then report every required check as
-# skipped, which branch protection reads as a pass on untested code.
-assert_line "        if: \${{ github.event.action == 'edited' && !github.event.changes.base }}"
-assert_line "      skip: \${{ steps.metadata_edit.outputs.skip == 'true' && 'true' || steps.check_skip.outputs.skip }}"
-assert_line "  group: \${{ github.repository }}-\${{ github.workflow }}-\${{ github.ref }}-\${{ github.event.action == 'edited' && !github.event.changes.base && 'metadata-edit' || '' }}-\${{ github.ref == 'refs/heads/master' && github.sha || ''}}"
-
 # The pull request files API truncates after 3,000 files. The workflow must run
 # full CI at that boundary rather than accepting a docs-only false negative.
 assert_line "      code: \${{ github.event_name == 'pull_request' && github.event.pull_request.changed_files >= 3000 && 'true' || steps.filter.outputs.code }}"
-
-# Branch protection requires these exact GitHub Actions job names.
-assert_line '  backend:'
-assert_line '  dashboard:'
-assert_line '  hooks:'
 
 if grep -R -n -F 'external-pr/' \
   --exclude='test-fork-pr-ci.sh' \


### PR DESCRIPTION
## What

Closes RAI-1602.

Prevents a pull request head SHA from satisfying the required CI checks when validation work is skipped or a replacement pull request event cancels an older run.

## Why

The Graphite CI optimizer can intentionally skip a middle-of-stack pull request, and GitHub treats skipped required jobs as successful. A concurrent head/base update and metadata edit could therefore cancel the validating run while the surviving run reported `backend`, `dashboard`, and `hooks` green without executing the required validation.

## How

- Remove the Graphite optimizer from the required workflow so every subscribed pull request event performs validation.
- Put all events for the same pull request merge ref in one cancel-in-progress group; a later event replaces the earlier run with equivalent validation.
- Keep expensive backend, dashboard, and hooks work cancellable while routing branch protection through small `always()` gate jobs that fail closed on failed, skipped, cancelled, or unknown dependency states.
- Preserve the docs-only backend/dashboard shortcut only when change classification succeeds and explicitly confirms there are no code changes.
- Avoid an unnecessary checkout when the pull request files API supplies the classifier input.
- Expand the CI invariant harness to verify concurrency, exact required check names, job wiring, classifier configuration, gate enforcement, and dependency-result matrices.
- Document the required-check and replacement-run invariants.

## Testing

- [x] `./scripts/test-fork-pr-ci.sh`
- [x] Full repository pre-commit suite
- [x] `nix run .#ci` — 4,184 tests passed with 6 configured skips; workspace checks, Clippy, rustfmt, DTO regeneration, and dashboard checks passed
- [x] Three-angle simplification review plus two independent round-one reviews and one clean round-two review
- Live GitHub verification: this description update intentionally replaces the synchronize run; the surviving run must execute every backend job and publish `backend`, `dashboard`, and `hooks`

## Screenshots

N/A

## Anything else

Middle-of-stack pull requests now spend the full CI cost instead of relying on another stack branch. The required gate jobs add small runner hops so branch protection receives deterministic, fail-closed check contexts even when validation work is cancelled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Improved pull-request validation reliability with clearer cancellation and rerun behavior.
  * Required checks now run independently and fail safely when validation cannot confirm documentation-only changes.
  * Dashboard, hooks, and backend checks provide more consistent build and test coverage.
  * Enhanced safeguards for forked pull requests, caching, permissions, and large changes.

* **Documentation**
  * Clarified when CI runs, what it validates, and how pull-request updates are handled.
  * Updated contributor guidance to reflect current build and test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->