### PR TITLE
fix: attribute Bebop fills to the Bebop venue

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,13 @@ The `[raindex]` section requires an explicit `inventory_mode` (`"legacy"` or
 `"managed"`) and a `vault_owner` address (the on-chain owner the vaults are
 keyed by; no fallback). `"managed"` additionally requires an `inventory` address
 (the shared `RaindexInventory` the bot operates via `OPERATOR_ROLE`) and is
-forbidden from being set under `"legacy"`. See the `[raindex]` block in
-`example.config.toml` for the full field documentation.
+forbidden from being set under `"legacy"`. Its required `inventory_adapters`
+table maps public operator addresses to venues such as Bebop and Uniswap v4;
+unknown operators remain visibly unattributed. This deployment metadata belongs
+in plaintext config, not secrets or environment variables. Trade protocol v3
+preserves configured and unknown onchain venues; older protocol versions
+collapse adapter and Unknown Onchain venues to Raindex for compatibility. See
+the `[raindex]` block in `example.config.toml` for the full field documentation.
 
 Current broker support is limited to `alpaca-broker-api` and `dry-run`.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -120,6 +120,13 @@ explicitly per deployment via `inventory_mode` under `[raindex]`:
   clear error rather than reverting on the first rebalance; it also revokes any
   stale pre-migration allowance the bot granted the OrderBook directly.
 
+Each deployment explicitly configures its inventory adapters under `[raindex]`
+as venue/operator pairs. These public onchain addresses are deployment settings,
+not secrets or environment variables. The same venue may list more than one
+operator during a rotation, but one operator cannot name multiple venues. Legacy
+mode forbids adapter entries because it has no shared inventory through which
+they could settle.
+
 Distinct from the settlement target is `vault_owner`: the on-chain owner every
 `vaultBalance2` read, vault-registry entry, and ClearV3/TakeOrderV3 order-owner
 fill match is scoped by. It is required and explicit (no fallback). While the
@@ -4507,24 +4514,43 @@ multiple broker-specific contexts.
    reference, spread bps) and per-symbol price charts over time.
 
 4. **Trade History**: Recent trades filterable by venue (onchain/offchain/both).
-   Onchain entries are completed fills. Offchain counter-trade entries include
-   successful fills, terminal failures, and terminal cancellations; each entry
-   carries its terminal outcome timestamp. Failed entries expose the broker or
-   placement error. Failed and cancelled entries keep the requested quantity
-   distinct from the broker-accepted quantity. The accepted and actually-filled
-   quantities are nullable provenance: `null` means the persisted history does
-   not prove that fact, including legacy outcomes that predate explicit fill
-   evidence. An explicit broker-reported zero therefore distinguishes a wholly
-   unfilled cancellation from an outcome whose fill remains unknown. Remaining
-   and excess quantities are derived only when both accepted and filled
-   quantities are known. An overfill reports the complete actual fill plus its
-   excess rather than clamping the fill to the accepted quantity. Non-terminal
-   submitted, partially-filled, and cancelling orders remain excluded. Terminal
-   outcomes use the same provenance in initial history and live dashboard
-   updates. A broker-terminal failure or cancellation with a positive fill but
-   no execution price is still persisted and surfaced; the owning position
-   remains pending for manual reconciliation so the unpriced fill cannot be
-   silently applied or discarded.
+   Onchain entries are completed fills and carry their execution source:
+   `ClearV3`/`TakeOrderV3` fills are Raindex, while an `InventoryTrade` persists
+   the raw inventory `operator` and resolves it through the deployment's
+   configured adapter table. Recognized operators are reported as their venue
+   (currently Bebop or Uniswap v4). An operator absent from the table is
+   persisted and logged as unrecognized, and its trade is reported as the
+   distinct Unknown Onchain venue rather than being asserted to be Raindex.
+   Initial history and live WebSocket updates derive the venue from the same
+   persisted source, and venue filtering includes every exposed adapter venue.
+   Legacy `OnChainTradeEvent::Filled` events that predate source persistence
+   retain a legacy source marker and display as Raindex for compatibility. The
+   event store alone cannot reconstruct their discarded operator. Reprocessing
+   the transaction through the existing `process-tx` recovery path reads the
+   operator from chain and appends a source-attribution event through CQRS,
+   repairing history without repeating an already-acknowledged hedge. The same
+   repair upgrades an Unknown Onchain fill when its persisted operator is later
+   configured, but cannot replace it with an adapter carrying a different
+   operator.
+
+   Offchain counter-trade entries include successful fills, terminal failures,
+   and terminal cancellations; each entry carries its terminal outcome
+   timestamp. Failed entries expose the broker or placement error. Failed and
+   cancelled entries keep the requested quantity distinct from the
+   broker-accepted quantity. The accepted and actually-filled quantities are
+   nullable provenance: `null` means the persisted history does not prove that
+   fact, including legacy outcomes that predate explicit fill evidence. An
+   explicit broker-reported zero therefore distinguishes a wholly unfilled
+   cancellation from an outcome whose fill remains unknown. Remaining and excess
+   quantities are derived only when both accepted and filled quantities are
+   known. An overfill reports the complete actual fill plus its excess rather
+   than clamping the fill to the accepted quantity. Non-terminal submitted,
+   partially-filled, and cancelling orders remain excluded. Terminal outcomes
+   use the same provenance in initial history and live dashboard updates. A
+   broker-terminal failure or cancellation with a positive fill but no execution
+   price is still persisted and surfaced; the owning position remains pending
+   for manual reconciliation so the unpriced fill cannot be silently applied or
+   discarded.
 
    Dashboard trade messages remain compatible during rolling deploys. The
    canonical protocol sends every terminal outcome as `trade_update`. Filled
@@ -4544,13 +4570,18 @@ multiple broker-specific contexts.
    `trade_protocol=terminal_outcomes_v2`. Cancelled outcomes are also v2-only,
    because adding a new tagged outcome to v1 would break older exhaustive
    consumers; a v1 fallback therefore omits cancelled entries from history
-   rather than losing them. A newer dashboard requests v2 and retries both
-   WebSocket and HTTP history with v1 when an older backend rejects the unknown
-   protocol value, while continuing to accept v1 responses and reconstructing
-   the complete fill as the legacy filled plus excess quantity. A legacy zero
-   fill remains unknown because v1 synthesized zero when no fill evidence
-   existed. A successful v1 WebSocket fallback probes v2 again after its next
-   disconnect so a transient restart cannot pin the client to v1. Failed
+   rather than losing them. Adapter-specific venue values use
+   `trade_protocol=terminal_outcomes_v3`; legacy, v1, and v2 responses downgrade
+   every adapter or unknown-onchain venue to Raindex so an older exhaustive
+   dashboard cannot enter a parse/reconnect loop. A newer dashboard requests v3
+   and retries v2, then v1, when an older backend rejects an unknown protocol.
+   Legacy-protocol filter requests likewise collapse selected adapter venues to
+   Raindex so an old backend does not reject the venue query. The dashboard
+   continues to accept v1 responses and reconstructs the complete fill as the
+   legacy filled plus excess quantity. A legacy zero fill remains unknown
+   because v1 synthesized zero when no fill evidence existed. A successful
+   lower-version WebSocket fallback probes v3 again after its next disconnect so
+   a transient restart cannot pin the client to an older protocol. Failed
    outcomes are sent only through a terminal-outcome protocol. Trade ordering
    compares the complete RFC 3339 timestamp, including sub-millisecond
    precision, then uses the same stable trade-ID tie-breaker for initial history
@@ -4561,13 +4592,15 @@ multiple broker-specific contexts.
    the same validation rules for the canonical and legacy wire shapes:
    timestamps must be valid UTC RFC 3339 values, venues/directions/outcomes must
    be known variants, the total share quantity must be positive, and outcome
-   quantities must be non-negative decimal strings. An invalid payload is
-   reported visibly and leaves the last known-good trade state unchanged. The
-   remaining domains from an otherwise valid snapshot still refresh. An invalid
-   WebSocket payload closes the connection, shows the reconnect banner, and
-   retries with bounded exponential backoff. The Rust trade DTO encodes the
-   positive total-quantity invariant so an invalid trade cannot be constructed
-   or deserialized at the server boundary.
+   quantities must be non-negative decimal strings. A trade carrying a future,
+   unknown venue is skipped with a warning so a rolling dashboard deployment can
+   continue showing compatible trades without reconnecting. Any other invalid
+   payload is reported visibly and leaves the last known-good trade state
+   unchanged. The remaining domains from an otherwise valid snapshot still
+   refresh. Any other invalid WebSocket payload closes the connection, shows the
+   reconnect banner, and retries with bounded exponential backoff. The Rust
+   trade DTO encodes the positive total-quantity invariant so an invalid trade
+   cannot be constructed or deserialized at the server boundary.
 
    Terminal trade live updates are delivered through a persistent delivery
    ledger and job queue, not directly from the CQRS reactor. The ledger is keyed
@@ -4584,7 +4617,13 @@ multiple broker-specific contexts.
    permitted: the dashboard merges trade updates by trade ID, making a retry or
    crash replay idempotent from the operator's point of view. Publishing with no
    connected WebSocket receivers is successful because the next connection
-   obtains the same terminal outcome from its initial-state snapshot.
+   obtains the same terminal outcome from its initial-state snapshot. A later
+   source-attribution correction reloads the authoritative onchain-trade history
+   and broadcasts a replacement update. Transient reload failures receive
+   bounded retries; exhaustion restarts the handoff monitor, whose startup
+   reconciliation reloads every pending source correction retained by that
+   monitor. After a process restart, clients reconnect from the
+   already-corrected snapshot.
 
 5. **Live Events**: Real-time domain event stream (aggregate type, ID, sequence,
    event type, timestamp). Starts empty, populates via WebSocket.

--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -51,6 +51,8 @@ orderbook = "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D"
 # `vault_owner` below to that same address in the change that grants the bot
 # OPERATOR_ROLE and migrates the vaults.
 inventory_mode = "legacy"
+# Legacy mode has no shared inventory, so adapter settlements are impossible.
+inventory_adapters = []
 # REQUIRED. Owner of the Raindex orders/vaults on-chain -- the key every
 # vaultBalance2 read, vault-registry entry, and order-owner fill match is
 # scoped by. Currently the bot's Turnkey wallet (= [wallet].address below),

--- a/config/s01-issuer.toml
+++ b/config/s01-issuer.toml
@@ -30,6 +30,7 @@ orderbook = "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D"
 # The issuer/dividend-ops bot does not rebalance, so it settles nothing through a
 # shared inventory: "legacy" keeps the OPERATOR_ROLE preflight off.
 inventory_mode = "legacy"
+inventory_adapters = []
 # Owner of the Raindex orders/vaults this bot reads -- its own dividend-ops
 # wallet (= [wallet].address below).
 vault_owner = "0x975789F46b5De4624d6a4c3B3679901edF1a5bdA"

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -46,6 +46,12 @@ orderbook = "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D"
 # Staging settles through its dedicated shared inventory. The Turnkey wallet
 # holds OPERATOR_ROLE on this contract; startup fails closed if that changes.
 inventory_mode = "managed"
+# Public OPERATOR_ROLE holders for venue attribution. Captured Base settlement
+# fixtures pin both addresses in src/onchain/trade.rs.
+inventory_adapters = [
+  { venue = "bebop", operator = "0x8b8b6e0507c125934c6129563f48e48c66f86475" },
+  { venue = "uniswap_v4", operator = "0x36ebb1e5149c60111dd035f0417a4b00d39caa88" },
+]
 inventory = "0x5FE36e6b6c320f8FD0B6109B2315253387DbdeF2"
 # REQUIRED. Owner of the Raindex orders/vaults on-chain (vaultBalance2 /
 # registry / fill match key). Managed mode scopes all three to the inventory

--- a/crates/config/src/evm.rs
+++ b/crates/config/src/evm.rs
@@ -1,5 +1,7 @@
 //! EVM configuration types: chain config, RPC secrets, and runtime context.
 
+use std::collections::HashSet;
+
 use alloy::primitives::Address;
 use serde::Deserialize;
 use thiserror::Error;
@@ -71,6 +73,69 @@ pub enum InventoryModeTag {
     Managed,
 }
 
+/// Venue identified by an inventory adapter's `operator` address.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InventoryAdapterVenue {
+    Bebop,
+    UniswapV4,
+}
+
+/// One deployment-specific shared-inventory adapter.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct InventoryAdapter {
+    pub venue: InventoryAdapterVenue,
+    pub operator: Address,
+}
+
+/// Explicit inventory-adapter table configured for one deployment.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(try_from = "Vec<InventoryAdapter>")]
+pub struct InventoryAdapters(Vec<InventoryAdapter>);
+
+impl TryFrom<Vec<InventoryAdapter>> for InventoryAdapters {
+    type Error = EvmConfigError;
+
+    fn try_from(adapters: Vec<InventoryAdapter>) -> Result<Self, Self::Error> {
+        Self::try_new(adapters)
+    }
+}
+
+impl InventoryAdapters {
+    /// Builds and validates an explicit adapter table.
+    pub fn try_new(adapters: Vec<InventoryAdapter>) -> Result<Self, EvmConfigError> {
+        let adapters = Self(adapters);
+        adapters.validate()?;
+        Ok(adapters)
+    }
+
+    /// Returns the venue configured for `operator`, if any.
+    pub fn venue_for(&self, operator: Address) -> Option<InventoryAdapterVenue> {
+        self.0
+            .iter()
+            .find(|adapter| adapter.operator == operator)
+            .map(|adapter| adapter.venue)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn validate(&self) -> Result<(), EvmConfigError> {
+        let mut operators = HashSet::new();
+        for adapter in &self.0 {
+            if !operators.insert(adapter.operator) {
+                return Err(EvmConfigError::DuplicateInventoryAdapterOperator {
+                    operator: adapter.operator,
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// Errors resolving an [`EvmConfig`] into a runtime [`EvmCtx`].
 #[derive(Debug, Error)]
 pub enum EvmConfigError {
@@ -85,6 +150,16 @@ pub enum EvmConfigError {
          enable a shared inventory"
     )]
     LegacyWithInventory { inventory: Address },
+    #[error(
+        "[raindex] inventory_mode = \"legacy\" forbids inventory adapters because \
+         no shared inventory exists"
+    )]
+    LegacyWithInventoryAdapters,
+    #[error(
+        "[raindex].inventory_adapters configures operator {operator} more than once; \
+         one operator cannot identify multiple venues"
+    )]
+    DuplicateInventoryAdapterOperator { operator: Address },
 }
 
 #[derive(Debug, Deserialize)]
@@ -104,6 +179,9 @@ pub struct EvmConfig {
     /// events on the pooled vaults are also surfaced here as
     /// `OperatorDeposit`/`OperatorWithdraw`.
     pub inventory: Option<Address>,
+    /// Public, deployment-specific adapter operator addresses used to attribute
+    /// shared-inventory settlements to their execution venue.
+    pub inventory_adapters: InventoryAdapters,
     /// Address that owns the Raindex orders and vaults on-chain -- the key every
     /// `vaultBalance2` read, vault-registry entry, and order-owner fill match is
     /// scoped by. Required and explicit (no fallback): this parameter determines
@@ -135,6 +213,14 @@ impl EvmConfig {
             }
             (InventoryModeTag::Managed, None) => Err(EvmConfigError::ManagedWithoutInventory),
         }
+    }
+
+    fn validate_inventory_adapters(&self) -> Result<(), EvmConfigError> {
+        if self.inventory_mode == InventoryModeTag::Legacy && !self.inventory_adapters.is_empty() {
+            return Err(EvmConfigError::LegacyWithInventoryAdapters);
+        }
+
+        self.inventory_adapters.validate()
     }
 }
 
@@ -192,6 +278,8 @@ impl std::fmt::Debug for EvmCtx {
 
 impl EvmCtx {
     pub fn new(config: &EvmConfig, secrets: EvmSecrets) -> Result<Self, EvmConfigError> {
+        config.validate_inventory_adapters()?;
+
         Ok(Self {
             rpc_url: secrets.rpc,
             orderbook: config.orderbook,
@@ -248,6 +336,7 @@ mod tests {
         let result: Result<EvmConfig, _> = toml::from_str(
             "orderbook = \"0x1111111111111111111111111111111111111111\"\n\
              inventory_mode = \"managed\"\n\
+             inventory_adapters = []\n\
              inventory = \"0x2222222222222222222222222222222222222222\"\n\
              deployment_block = 1\n\
              required_confirmations = 3\n\
@@ -262,6 +351,142 @@ mod tests {
     }
 
     #[test]
+    fn inventory_adapters_are_required() {
+        let result: Result<EvmConfig, _> = toml::from_str(
+            "orderbook = \"0x1111111111111111111111111111111111111111\"\n\
+             inventory_mode = \"managed\"\n\
+             inventory = \"0x2222222222222222222222222222222222222222\"\n\
+             vault_owner = \"0x3333333333333333333333333333333333333333\"\n\
+             deployment_block = 1\n\
+             required_confirmations = 3\n\
+             ingestion_cutoff = \"safe\"",
+        );
+
+        let error = result.unwrap_err();
+        assert!(
+            error.to_string().contains("inventory_adapters"),
+            "expected missing-field error for inventory_adapters, got: {error}"
+        );
+    }
+
+    #[test]
+    fn inventory_adapters_resolve_configured_operator_venues() {
+        let config: EvmConfig = toml::from_str(
+            "orderbook = \"0x1111111111111111111111111111111111111111\"\n\
+             inventory_mode = \"managed\"\n\
+             inventory_adapters = [\n\
+               { venue = \"bebop\", operator = \"0x4444444444444444444444444444444444444444\" },\n\
+               { venue = \"uniswap_v4\", operator = \"0x5555555555555555555555555555555555555555\" },\n\
+             ]\n\
+             inventory = \"0x2222222222222222222222222222222222222222\"\n\
+             vault_owner = \"0x3333333333333333333333333333333333333333\"\n\
+             deployment_block = 1\n\
+             required_confirmations = 3\n\
+             ingestion_cutoff = \"safe\"",
+        )
+        .unwrap();
+
+        EvmCtx::new(&config, dummy_secrets()).unwrap();
+
+        assert_eq!(
+            config
+                .inventory_adapters
+                .venue_for(alloy::primitives::address!(
+                    "0x4444444444444444444444444444444444444444"
+                )),
+            Some(InventoryAdapterVenue::Bebop),
+        );
+        assert_eq!(
+            config
+                .inventory_adapters
+                .venue_for(alloy::primitives::address!(
+                    "0x5555555555555555555555555555555555555555"
+                )),
+            Some(InventoryAdapterVenue::UniswapV4),
+        );
+        assert_eq!(
+            config
+                .inventory_adapters
+                .venue_for(Address::repeat_byte(0x66)),
+            None,
+        );
+    }
+
+    #[test]
+    fn duplicate_inventory_adapter_operator_fails_during_deserialization() {
+        let error = toml::from_str::<EvmConfig>(
+            "orderbook = \"0x1111111111111111111111111111111111111111\"\n\
+             inventory_mode = \"managed\"\n\
+             inventory_adapters = [\n\
+               { venue = \"bebop\", operator = \"0x4444444444444444444444444444444444444444\" },\n\
+               { venue = \"uniswap_v4\", operator = \"0x4444444444444444444444444444444444444444\" },\n\
+             ]\n\
+             inventory = \"0x2222222222222222222222222222222222222222\"\n\
+             vault_owner = \"0x3333333333333333333333333333333333333333\"\n\
+             deployment_block = 1\n\
+             required_confirmations = 3\n\
+             ingestion_cutoff = \"safe\"",
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains(
+                "configures operator 0x4444444444444444444444444444444444444444 more than once"
+            ),
+            "duplicate operators must fail before an EvmConfig can be constructed: {error}"
+        );
+    }
+
+    #[test]
+    fn inventory_adapters_allow_operator_rotation_for_one_venue() {
+        let config: EvmConfig = toml::from_str(
+            "orderbook = \"0x1111111111111111111111111111111111111111\"\n\
+             inventory_mode = \"managed\"\n\
+             inventory_adapters = [\n\
+               { venue = \"bebop\", operator = \"0x4444444444444444444444444444444444444444\" },\n\
+               { venue = \"bebop\", operator = \"0x5555555555555555555555555555555555555555\" },\n\
+             ]\n\
+             inventory = \"0x2222222222222222222222222222222222222222\"\n\
+             vault_owner = \"0x3333333333333333333333333333333333333333\"\n\
+             deployment_block = 1\n\
+             required_confirmations = 3\n\
+             ingestion_cutoff = \"safe\"",
+        )
+        .unwrap();
+
+        EvmCtx::new(&config, dummy_secrets()).unwrap();
+
+        assert_eq!(
+            config
+                .inventory_adapters
+                .venue_for(alloy::primitives::address!(
+                    "0x5555555555555555555555555555555555555555"
+                )),
+            Some(InventoryAdapterVenue::Bebop),
+        );
+    }
+
+    #[test]
+    fn legacy_mode_with_inventory_adapters_fails() {
+        let config: EvmConfig = toml::from_str(
+            "orderbook = \"0x1111111111111111111111111111111111111111\"\n\
+             inventory_mode = \"legacy\"\n\
+             inventory_adapters = [\n\
+               { venue = \"bebop\", operator = \"0x4444444444444444444444444444444444444444\" },\n\
+             ]\n\
+             vault_owner = \"0x3333333333333333333333333333333333333333\"\n\
+             deployment_block = 1\n\
+             required_confirmations = 3\n\
+             ingestion_cutoff = \"safe\"",
+        )
+        .unwrap();
+
+        let error = EvmCtx::new(&config, dummy_secrets()).unwrap_err();
+
+        assert!(matches!(error, EvmConfigError::LegacyWithInventoryAdapters));
+    }
+
+    #[test]
     fn evm_ctx_new_maps_config_fields_to_their_own_slots() {
         // Three same-typed Address fields flow through EvmCtx::new. A swap in the
         // mapping would compile silently, so assert each distinct address lands
@@ -269,6 +494,7 @@ mod tests {
         let config: EvmConfig = toml::from_str(
             "orderbook = \"0x1111111111111111111111111111111111111111\"\n\
              inventory_mode = \"managed\"\n\
+             inventory_adapters = []\n\
              inventory = \"0x2222222222222222222222222222222222222222\"\n\
              vault_owner = \"0x3333333333333333333333333333333333333333\"\n\
              deployment_block = 1\n\
@@ -306,6 +532,7 @@ mod tests {
         let config: EvmConfig = toml::from_str(
             "orderbook = \"0x1111111111111111111111111111111111111111\"\n\
              inventory_mode = \"managed\"\n\
+             inventory_adapters = []\n\
              vault_owner = \"0x3333333333333333333333333333333333333333\"\n\
              deployment_block = 1\n\
              required_confirmations = 3\n\
@@ -326,6 +553,7 @@ mod tests {
         let config: EvmConfig = toml::from_str(
             "orderbook = \"0x1111111111111111111111111111111111111111\"\n\
              inventory_mode = \"legacy\"\n\
+             inventory_adapters = []\n\
              inventory = \"0x2222222222222222222222222222222222222222\"\n\
              vault_owner = \"0x3333333333333333333333333333333333333333\"\n\
              deployment_block = 1\n\
@@ -349,6 +577,7 @@ mod tests {
         let config: EvmConfig = toml::from_str(
             "orderbook = \"0x1111111111111111111111111111111111111111\"\n\
              inventory_mode = \"legacy\"\n\
+             inventory_adapters = []\n\
              vault_owner = \"0x3333333333333333333333333333333333333333\"\n\
              deployment_block = 1\n\
              required_confirmations = 3\n\
@@ -392,6 +621,7 @@ mod tests {
         let result: Result<EvmConfig, _> = toml::from_str(
             "orderbook = \"0x1111111111111111111111111111111111111111\"\n\
              inventory_mode = \"managed\"\n\
+             inventory_adapters = []\n\
              inventory = \"0x2222222222222222222222222222222222222222\"\n\
              vault_owner = \"0x3333333333333333333333333333333333333333\"\n\
              deployment_block = 1\n\

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -18,7 +18,8 @@ mod wallet;
 pub use alerts::{AlertsAssemblyError, AlertsConfig, AlertsCtx, AlertsSecrets};
 pub use bot_gas_valuation::BotGasValuationConfig;
 pub use evm::{
-    EvmConfig, EvmConfigError, EvmCtx, EvmSecrets, IngestionCutoff, InventoryMode, InventoryModeTag,
+    EvmConfig, EvmConfigError, EvmCtx, EvmSecrets, IngestionCutoff, InventoryAdapter,
+    InventoryAdapterVenue, InventoryAdapters, InventoryMode, InventoryModeTag,
 };
 pub use imbalance_threshold::{ImbalanceThreshold, InvalidImbalanceThreshold};
 pub use loader::*;

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -24,8 +24,8 @@ use url::Url;
 
 use crate::{
     AlertsConfig, AlertsCtx, AlertsSecrets, BotGasValuationConfig, EvmConfig, EvmCtx, EvmSecrets,
-    ExecutionThreshold, InvalidThresholdError, RebalancingConfig, RebalancingCtx,
-    RebalancingCtxError, TelemetryConfig, TelemetryCtx,
+    ExecutionThreshold, InvalidThresholdError, InventoryAdapters, RebalancingConfig,
+    RebalancingCtx, RebalancingCtxError, TelemetryConfig, TelemetryCtx,
 };
 use st0x_float_macro::float;
 
@@ -558,6 +558,8 @@ pub struct Ctx {
     pub server_port: u16,
     pub board_port: u16,
     pub evm: EvmCtx,
+    /// Deployment-specific shared-inventory operator-to-venue attribution.
+    pub inventory_adapters: InventoryAdapters,
     pub order_polling_interval: u64,
     pub order_polling_max_jitter: u64,
     pub position_check_interval: u64,
@@ -679,6 +681,7 @@ impl std::fmt::Debug for Ctx {
             .field("server_port", &self.server_port)
             .field("board_port", &self.board_port)
             .field("evm", &self.evm)
+            .field("inventory_adapters", &self.inventory_adapters)
             .field("order_polling_interval", &self.order_polling_interval)
             .field("order_polling_max_jitter", &self.order_polling_max_jitter)
             .field("position_check_interval", &self.position_check_interval)
@@ -762,6 +765,7 @@ struct ValidatedParts {
     server_port: u16,
     board_port: u16,
     evm: EvmCtx,
+    inventory_adapters: InventoryAdapters,
     order_polling_interval: u64,
     order_polling_max_jitter: u64,
     position_check_interval: u64,
@@ -807,6 +811,24 @@ pub struct WalletMeta {
     pub organization_id: Option<String>,
 }
 
+/// Rejects extended-hours trading that its prerequisite can never reach.
+fn validate_extended_hours_counter_trading(assets: &AssetsConfig) -> Result<(), CtxError> {
+    // The hedge path gates on `trading` before it consults the extended-hours
+    // session, so enabling extended-hours counter-trading while disabling
+    // counter-trading creates a dead configuration that can never execute.
+    for (symbol, equity) in &assets.equities.symbols {
+        if equity.extended_hours_counter_trading == OperationMode::Enabled
+            && equity.trading == OperationMode::Disabled
+        {
+            return Err(CtxError::ExtendedHoursWithoutCounterTrading {
+                symbol: symbol.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
 /// Single validation path shared by [`Ctx::load_files`] and
 /// [`Ctx::validate_files`]. All config/secrets business-rule checks live
 /// here — neither caller duplicates validation logic.
@@ -832,21 +854,7 @@ fn parse_and_validate(
         });
     }
 
-    // Extended-hours counter-trading depends on counter-trading itself: the
-    // hedge path gates on `trading` before it ever consults the extended-hours
-    // session (see `check_execution_readiness`), so
-    // `extended_hours_counter_trading = enabled` with `trading = disabled` is a
-    // dead configuration that can never execute. Reject it so the invalid
-    // combination never loads and never reaches the dashboard.
-    for (symbol, equity) in &config.assets.equities.symbols {
-        if equity.extended_hours_counter_trading == OperationMode::Enabled
-            && equity.trading == OperationMode::Disabled
-        {
-            return Err(CtxError::ExtendedHoursWithoutCounterTrading {
-                symbol: symbol.clone(),
-            });
-        }
-    }
+    validate_extended_hours_counter_trading(&config.assets)?;
 
     let broker = BrokerCtx::from_parts(secrets.broker, config.broker.as_ref())?;
     let telemetry = config.telemetry.map(TelemetryCtx::from);
@@ -861,9 +869,7 @@ fn parse_and_validate(
     // Extract RPC URLs before EvmCtx consumes secrets.evm.
     let base_rpc_url = secrets.evm.base.take();
     let ethereum_rpc_url = secrets.evm.ethereum.take();
-
     let evm = EvmCtx::new(&config.raindex, secrets.evm)?;
-
     // Validate wallet config/secrets pairing and required RPC URLs.
     // Actual wallet construction (async, connects to RPC) is deferred.
     let (wallet_inputs, wallet_meta) = match (config.wallet, secrets.wallet) {
@@ -1021,6 +1027,7 @@ fn parse_and_validate(
         server_port: config.server_port,
         board_port: config.board_port,
         evm,
+        inventory_adapters: config.raindex.inventory_adapters,
         order_polling_interval,
         order_polling_max_jitter: config.order_polling_max_jitter.unwrap_or(5),
         position_check_interval,
@@ -1160,6 +1167,7 @@ impl Ctx {
             server_port: parts.server_port,
             board_port: parts.board_port,
             evm: parts.evm,
+            inventory_adapters: parts.inventory_adapters,
             order_polling_interval: parts.order_polling_interval,
             order_polling_max_jitter: parts.order_polling_max_jitter,
             position_check_interval: parts.position_check_interval,
@@ -1382,6 +1390,7 @@ impl Ctx {
         /// of `order_owner`.
         #[builder(default = InventoryMode::Legacy)]
         inventory_mode: InventoryMode,
+        #[builder(default = InventoryAdapters::default())] inventory_adapters: InventoryAdapters,
         assets: AssetsConfig,
         #[builder(default = 2)] inventory_poll_interval: u64,
         #[builder(default = const { NonZeroU32::new(10).unwrap() })]
@@ -1440,6 +1449,7 @@ impl Ctx {
                 required_confirmations,
                 ingestion_cutoff: IngestionCutoff::Safe,
             },
+            inventory_adapters,
             order_polling_interval: 1,
             order_polling_max_jitter: 0,
             position_check_interval: 2,
@@ -1756,6 +1766,7 @@ pub fn create_test_ctx_with_order_owner(order_owner: Address) -> Ctx {
             required_confirmations: 1,
             ingestion_cutoff: IngestionCutoff::Safe,
         },
+        inventory_adapters: InventoryAdapters::default(),
         order_polling_interval: 15,
         order_polling_max_jitter: 5,
         position_check_interval: 60,
@@ -1893,6 +1904,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -1925,6 +1937,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -1961,6 +1974,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -2144,6 +2158,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -2194,6 +2209,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -2241,6 +2257,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -2288,6 +2305,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -2371,6 +2389,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -2462,6 +2481,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -2502,6 +2522,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "managed"
+            inventory_adapters = []
             inventory = "0x2222222222222222222222222222222222222222"
             vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -2542,6 +2563,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "managed"
+            inventory_adapters = []
             inventory = "0x2222222222222222222222222222222222222222"
             vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -2581,6 +2603,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -2621,6 +2644,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -2667,6 +2691,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "managed"
+            inventory_adapters = []
             inventory = "0x2222222222222222222222222222222222222222"
             vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -2708,6 +2733,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -2752,6 +2778,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -2795,6 +2822,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -2856,6 +2884,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -2925,6 +2954,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -2983,6 +3013,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -3080,6 +3111,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -3142,6 +3174,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -3209,6 +3242,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -3280,6 +3314,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -3360,6 +3395,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "managed"
+            inventory_adapters = []
             inventory = "0x2222222222222222222222222222222222222222"
             vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -3491,6 +3527,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "managed"
+            inventory_adapters = []
             inventory = "0x2222222222222222222222222222222222222222"
             vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -3547,6 +3584,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -3604,6 +3642,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -3706,6 +3745,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "managed"
+            inventory_adapters = []
             inventory = "0x2222222222222222222222222222222222222222"
             vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -3861,6 +3901,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "managed"
+            inventory_adapters = []
             inventory = "0x2222222222222222222222222222222222222222"
             vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -3917,6 +3958,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "managed"
+            inventory_adapters = []
             inventory = "0x2222222222222222222222222222222222222222"
             vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -3977,6 +4019,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -4035,6 +4078,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "managed"
+            inventory_adapters = []
             inventory = "0x2222222222222222222222222222222222222222"
             vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -4094,6 +4138,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "managed"
+            inventory_adapters = []
             inventory = "0x2222222222222222222222222222222222222222"
             vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -4479,6 +4524,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -4650,6 +4696,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -4717,6 +4764,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -4995,6 +5043,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -5032,6 +5081,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -5073,6 +5123,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -5109,6 +5160,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -5198,6 +5250,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -6113,6 +6166,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "legacy"
+            inventory_adapters = []
             vault_owner = "0x0000000000000000000000000000000000000001"
             deployment_block = 1
             required_confirmations = 3
@@ -6157,6 +6211,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "legacy"
+            inventory_adapters = []
             vault_owner = "0x0000000000000000000000000000000000000001"
             deployment_block = 1
             required_confirmations = 3
@@ -6197,6 +6252,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "legacy"
+            inventory_adapters = []
             vault_owner = "0x0000000000000000000000000000000000000001"
             deployment_block = 1
             required_confirmations = 3
@@ -6239,6 +6295,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "legacy"
+            inventory_adapters = []
             vault_owner = "0x0000000000000000000000000000000000000001"
             deployment_block = 1
             required_confirmations = 3
@@ -6284,6 +6341,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             inventory_mode = "legacy"
+            inventory_adapters = []
             vault_owner = "0x0000000000000000000000000000000000000001"
             deployment_block = 1
             required_confirmations = 3
@@ -6320,6 +6378,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -6373,6 +6432,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -6412,6 +6472,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -6468,6 +6529,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
             deployment_block = 1
@@ -6560,6 +6622,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 
@@ -6606,6 +6669,7 @@ mod tests {
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
            inventory_mode = "managed"
+           inventory_adapters = []
            inventory = "0x2222222222222222222222222222222222222222"
            vault_owner = "0x3333333333333333333333333333333333333333"
 

--- a/crates/dto/src/trade.rs
+++ b/crates/dto/src/trade.rs
@@ -13,6 +13,9 @@ use st0x_finance::{FractionalShares, NonNegative, Positive, Symbol};
 #[serde(rename_all = "snake_case")]
 pub enum TradingVenue {
     Raindex,
+    Bebop,
+    UniswapV4,
+    UnknownOnchain,
     Alpaca,
     DryRun,
 }
@@ -21,8 +24,30 @@ impl TradingVenue {
     fn as_str(self) -> &'static str {
         match self {
             Self::Raindex => "raindex",
+            Self::Bebop => "bebop",
+            Self::UniswapV4 => "uniswap_v4",
+            Self::UnknownOnchain => "unknown_onchain",
             Self::Alpaca => "alpaca",
             Self::DryRun => "dry_run",
+        }
+    }
+
+    /// Whether trades from this venue settle onchain.
+    #[must_use]
+    pub const fn is_onchain(self) -> bool {
+        match self {
+            Self::Raindex | Self::Bebop | Self::UniswapV4 | Self::UnknownOnchain => true,
+            Self::Alpaca | Self::DryRun => false,
+        }
+    }
+
+    /// Venue value understood by dashboard protocols that predate adapter
+    /// attribution.
+    #[must_use]
+    pub const fn legacy_compatible(self) -> Self {
+        match self {
+            Self::Raindex | Self::Alpaca | Self::DryRun => self,
+            Self::Bebop | Self::UniswapV4 | Self::UnknownOnchain => Self::Raindex,
         }
     }
 }
@@ -39,6 +64,9 @@ impl std::str::FromStr for TradingVenue {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "raindex" => Ok(Self::Raindex),
+            "bebop" => Ok(Self::Bebop),
+            "uniswap_v4" => Ok(Self::UniswapV4),
+            "unknown_onchain" => Ok(Self::UnknownOnchain),
             "alpaca" => Ok(Self::Alpaca),
             "dry_run" => Ok(Self::DryRun),
             other => Err(InvalidTradingVenue {
@@ -538,8 +566,8 @@ pub fn sort_trades_newest_first(trades: &mut [Trade]) {
 }
 
 fn compare_trade_ids(left: &Trade, right: &Trade) -> std::cmp::Ordering {
-    if left.venue == TradingVenue::Raindex
-        && right.venue == TradingVenue::Raindex
+    if left.venue.is_onchain()
+        && right.venue.is_onchain()
         && let (Some((left_hash, left_index)), Some((right_hash, right_index))) = (
             parse_onchain_trade_id(&left.id),
             parse_onchain_trade_id(&right.id),
@@ -582,6 +610,36 @@ mod tests {
     fn direction_from_str_rejects_unknown_input() {
         let error = Direction::from_str("hold").unwrap_err();
         assert_eq!(error.direction_provided, "hold");
+    }
+
+    #[test]
+    fn venue_classifies_onchain_execution() {
+        assert!(TradingVenue::Raindex.is_onchain());
+        assert!(TradingVenue::Bebop.is_onchain());
+        assert!(TradingVenue::UniswapV4.is_onchain());
+        assert!(TradingVenue::UnknownOnchain.is_onchain());
+        assert!(!TradingVenue::Alpaca.is_onchain());
+        assert!(!TradingVenue::DryRun.is_onchain());
+    }
+
+    #[test]
+    fn legacy_venue_protocols_collapse_adapter_attribution_to_raindex() {
+        assert_eq!(
+            TradingVenue::Bebop.legacy_compatible(),
+            TradingVenue::Raindex
+        );
+        assert_eq!(
+            TradingVenue::UniswapV4.legacy_compatible(),
+            TradingVenue::Raindex
+        );
+        assert_eq!(
+            TradingVenue::UnknownOnchain.legacy_compatible(),
+            TradingVenue::Raindex
+        );
+        assert_eq!(
+            TradingVenue::Alpaca.legacy_compatible(),
+            TradingVenue::Alpaca
+        );
     }
 
     #[test]
@@ -1054,10 +1112,10 @@ mod tests {
     fn newest_first_sort_uses_numeric_log_index_for_tied_onchain_trades() {
         let timestamp = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
         let older = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
-        let trade = |id: &str, occurred_at| Trade {
+        let trade = |id: &str, occurred_at, venue| Trade {
             id: id.to_string(),
             occurred_at,
-            venue: TradingVenue::Raindex,
+            venue,
             direction: Direction::Buy,
             symbol: Symbol::new("AAPL").unwrap(),
             shares: positive_shares("1"),
@@ -1065,9 +1123,9 @@ mod tests {
         };
         let tx_hash = "0x0000000000000000000000000000000000000000000000000000000000000000";
         let mut trades = vec![
-            trade(&format!("{tx_hash}:2"), timestamp),
-            trade("older", older),
-            trade(&format!("{tx_hash}:10"), timestamp),
+            trade(&format!("{tx_hash}:11"), timestamp, TradingVenue::Raindex),
+            trade("older", older, TradingVenue::Raindex),
+            trade(&format!("{tx_hash}:20"), timestamp, TradingVenue::Bebop),
         ];
 
         sort_trades_newest_first(&mut trades);
@@ -1075,8 +1133,8 @@ mod tests {
         assert_eq!(
             trades.into_iter().map(|trade| trade.id).collect::<Vec<_>>(),
             [
-                format!("{tx_hash}:10"),
-                format!("{tx_hash}:2"),
+                format!("{tx_hash}:20"),
+                format!("{tx_hash}:11"),
                 "older".to_string()
             ]
         );

--- a/dashboard/src/lib/components/trade-history-panel.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.svelte
@@ -21,7 +21,16 @@
   import { formatDecimal } from '$lib/decimal'
   import { equityUsdTooltip } from '$lib/inventory-value'
   import { tradeRecoveryCommands } from '$lib/transfer'
-  import { mergeTradeHistory, normalizeTrade, type TradeHistoryFilter } from '$lib/trade'
+  import {
+    TRADING_VENUES,
+    fallbackTradeProtocol,
+    isOnchainVenue,
+    legacyCompatibleVenues,
+    mergeTradeHistory,
+    normalizeTrade,
+    type TradeProtocol,
+    type TradeHistoryFilter
+  } from '$lib/trade'
   import { parseTradeResponse } from '$lib/trade-payload'
 
   type TradeEvent = {
@@ -34,7 +43,7 @@
 
   const PAGE_SIZE = 100
   const POLL_INTERVAL_MS = 10_000
-  const ALL_VENUES = ['raindex', 'alpaca', 'dry_run'] as const
+  const V3_REPROBE_INTERVAL_MS = 60_000
 
   const entries = reactive<TradeEntry[]>([])
   const loading = reactive(false)
@@ -43,7 +52,7 @@
   const offset = reactive(0)
   const total = reactive(0)
   const hasMore = reactive(false)
-  const selectedVenues = reactive<Set<TradingVenue>>(new Set(ALL_VENUES))
+  const selectedVenues = reactive<Set<TradingVenue>>(new Set(TRADING_VENUES))
   const selectedSymbols = reactive<Set<string>>(new Set())
   const allSymbols = reactive<string[]>([])
   const since = reactive('')
@@ -52,6 +61,9 @@
   let sinceInput: HTMLInputElement | undefined
   let untilInput: HTMLInputElement | undefined
   let historyRequestVersion = 0
+  let preferredTradeProtocol: TradeProtocol = 'terminal_outcomes_v3'
+  let nextV3ProbeAt = 0
+  let historyTradeProtocol: TradeProtocol = 'terminal_outcomes_v3'
 
   const positionsQuery = createQuery<Position[]>(() => ({
     queryKey: ['positions'],
@@ -68,39 +80,34 @@
     )
   )
 
-  const venueLabel = (venue: string): string => {
-    switch (venue) {
-      case 'raindex':
-        return 'Raindex'
-      case 'alpaca':
-        return 'Alpaca'
-      case 'dry_run':
-        return 'DryRun'
-      default:
-        return venue
-    }
-  }
+  const venueLabels = {
+    raindex: 'Raindex',
+    bebop: 'Bebop',
+    uniswap_v4: 'Uniswap v4',
+    unknown_onchain: 'Unknown Onchain',
+    alpaca: 'Alpaca',
+    dry_run: 'DryRun'
+  } as const satisfies Record<TradingVenue, string>
 
-  const venueColor = (venue: string): string => {
-    switch (venue) {
-      case 'raindex':
-        return 'text-blue-400'
-      case 'alpaca':
-        return 'text-amber-400'
-      case 'dry_run':
-        return 'text-muted-foreground'
-      default:
-        return ''
-    }
-  }
+  const venueColors = {
+    raindex: 'text-blue-400',
+    bebop: 'text-violet-400',
+    uniswap_v4: 'text-pink-400',
+    unknown_onchain: 'text-slate-400',
+    alpaca: 'text-amber-400',
+    dry_run: 'text-muted-foreground'
+  } as const satisfies Record<TradingVenue, string>
 
-  const venueOptions = ALL_VENUES.map((venue) => ({ value: venue, label: venueLabel(venue) }))
+  const venueLabel = (venue: TradingVenue): string => venueLabels[venue]
+  const venueColor = (venue: TradingVenue): string => venueColors[venue]
+
+  const venueOptions = TRADING_VENUES.map((venue) => ({ value: venue, label: venueLabel(venue) }))
   const symbolOptions = $derived(allSymbols.current.map((sym) => ({ value: sym, label: sym })))
 
   const buildParams = (
     limit = PAGE_SIZE,
     requestOffset = offset.current,
-    protocol: 'terminal_outcomes_v2' | 'terminal_outcomes_v1' = 'terminal_outcomes_v2'
+    protocol: TradeProtocol = 'terminal_outcomes_v3'
   ): URLSearchParams => {
     const params = new URLSearchParams({
       limit: String(limit),
@@ -108,8 +115,12 @@
       trade_protocol: protocol
     })
 
-    if (selectedVenues.current.size > 0 && selectedVenues.current.size < ALL_VENUES.length) {
-      params.set('venue', [...selectedVenues.current].join(','))
+    if (selectedVenues.current.size > 0 && selectedVenues.current.size < TRADING_VENUES.length) {
+      const protocolVenues =
+        protocol === 'terminal_outcomes_v3'
+          ? selectedVenues.current
+          : legacyCompatibleVenues(selectedVenues.current)
+      params.set('venue', [...protocolVenues].join(','))
     }
 
     if (selectedSymbols.current.size > 0) {
@@ -122,15 +133,20 @@
     return params
   }
 
-  const historyFilter = (): TradeHistoryFilter => ({
-    venues: selectedVenues.current,
+  const historyFilter = (protocol: TradeProtocol = historyTradeProtocol): TradeHistoryFilter => ({
+    venues:
+      protocol === 'terminal_outcomes_v3'
+        ? selectedVenues.current
+        : legacyCompatibleVenues(selectedVenues.current),
     symbols: selectedSymbols.current,
     since: since.current ? toRfc3339(since.current) : null,
     until: until.current ? toRfc3339(until.current) : null
   })
 
-  const mergeLiveTrades = (current: TradeEntry[]): TradeEntry[] =>
-    mergeTradeHistory(current, tradesQuery.data ?? [], historyFilter())
+  const mergeLiveTrades = (
+    current: TradeEntry[],
+    protocol: TradeProtocol = historyTradeProtocol
+  ): TradeEntry[] => mergeTradeHistory(current, tradesQuery.data ?? [], historyFilter(protocol))
 
   const resetHistoryForFilter = () => {
     entries.update(() => [])
@@ -180,13 +196,18 @@
 
     try {
       const baseUrl = getApiBaseUrl()
-      const fetchWithProtocol = (protocol: 'terminal_outcomes_v2' | 'terminal_outcomes_v1') =>
+      const fetchWithProtocol = (protocol: TradeProtocol) =>
         fetch(`${baseUrl}/trades?${buildParams(PAGE_SIZE, requestOffset, protocol).toString()}`, {
           signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
         })
-      let response = await fetchWithProtocol('terminal_outcomes_v2')
-      if (response.status === 400) {
-        response = await fetchWithProtocol('terminal_outcomes_v1')
+      let protocol: TradeProtocol =
+        preferredTradeProtocol === 'terminal_outcomes_v3' || Date.now() >= nextV3ProbeAt
+          ? 'terminal_outcomes_v3'
+          : preferredTradeProtocol
+      let response = await fetchWithProtocol(protocol)
+      while (response.status === 400 && protocol !== 'terminal_outcomes_v1') {
+        protocol = fallbackTradeProtocol(protocol)
+        response = await fetchWithProtocol(protocol)
       }
 
       if (!response.ok) {
@@ -200,8 +221,12 @@
       const data = { ...wireData, entries: wireData.entries.map(normalizeTrade) }
       if (requestVersion !== historyRequestVersion) return
 
+      preferredTradeProtocol = protocol
+      nextV3ProbeAt = protocol === 'terminal_outcomes_v3' ? 0 : Date.now() + V3_REPROBE_INTERVAL_MS
+      historyTradeProtocol = protocol
+
       const merged = isLoadMore ? [...entries.current, ...data.entries] : data.entries
-      const nextEntries = mergeLiveTrades(merged)
+      const nextEntries = mergeLiveTrades(merged, protocol)
       // A replace is an authoritative snapshot: trust the server total and add
       // back only the live trades the snapshot has not caught up with yet.
       const liveExtras = Math.max(0, nextEntries.length - merged.length)
@@ -258,7 +283,7 @@
   const jumpToLatest = () => {
     since.update(() => '')
     until.update(() => '')
-    selectedVenues.update(() => new Set(ALL_VENUES))
+    selectedVenues.update(() => new Set(TRADING_VENUES))
     selectedSymbols.update(() => new Set())
     if (sinceInput) sinceInput.value = ''
     if (untilInput) untilInput.value = ''
@@ -268,7 +293,7 @@
   const hasFilters = $derived(
     since.current !== '' ||
       until.current !== '' ||
-      selectedVenues.current.size < ALL_VENUES.length ||
+      selectedVenues.current.size < TRADING_VENUES.length ||
       selectedSymbols.current.size > 0
   )
   onMount(() => {
@@ -420,7 +445,7 @@
       <span class="flex items-center gap-1.5">
         Trade History
         <HoverTooltip
-          tooltip="Onchain fills from Raindex orders and the corresponding Alpaca hedge trades placed to offset exposure."
+          tooltip="Direct Raindex fills, fills routed through supported adapters such as Bebop, and the corresponding Alpaca hedge trades placed to offset exposure."
           class="cursor-help text-muted-foreground"
         >
           <svg
@@ -642,7 +667,7 @@
         <div class="mb-4 space-y-1.5 text-xs">
           <div class="flex items-center gap-2 font-mono">
             <span class="shrink-0 text-muted-foreground">ID</span>
-            {#if trade.venue === 'raindex'}
+            {#if isOnchainVenue(trade.venue)}
               {@const txHash = trade.id.slice(0, trade.id.lastIndexOf(':'))}
               {@const logIndex = trade.id.slice(trade.id.lastIndexOf(':') + 1)}
               <a

--- a/dashboard/src/lib/components/trade-history-panel.test.ts
+++ b/dashboard/src/lib/components/trade-history-panel.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { LegacyTrade } from '$lib/api/LegacyTrade'
 import type { Statement } from '$lib/api/Statement'
 import type { Trade } from '$lib/api/Trade'
+import { getExplorerTxUrl } from '$lib/env'
 import { createWebSocket } from '$lib/websocket'
 import TradeHistoryPanelHarness from './trade-history-panel.test-harness.svelte'
 
@@ -85,6 +86,12 @@ const tradeResponse = (
     headers: { 'content-type': 'application/json' }
   })
 
+const requestUrl = (input: RequestInfo | URL): string => {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.href
+  return input.url
+}
+
 const mountedPanels: ReturnType<typeof mount>[] = []
 
 const mountPanel = () => {
@@ -141,7 +148,107 @@ describe('TradeHistoryPanel', () => {
     target.remove()
   })
 
-  it('retries trade history with v1 when the previous backend rejects v2', async () => {
+  it('renders Bebop fills and removes Bebop from the v3 venue filter', async () => {
+    const bebopTrade: Trade = {
+      id: '0x28a364eaa0fc6d505ddd0702cd9949853193bb28c92cdfef68bcd5a803f1806b:194',
+      occurredAt: '2026-07-31T12:00:00Z',
+      venue: 'bebop',
+      direction: 'buy',
+      symbol: 'COIN',
+      shares: '1',
+      outcome: { status: 'filled' }
+    }
+    const fetchMock = vi.fn((_input: RequestInfo | URL) =>
+      Promise.resolve(tradeResponse([bebopTrade], 1))
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { target } = mountPanel()
+
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('COIN')
+      expect(target.textContent).toContain('Bebop')
+      expect(target.textContent).toContain('1 of 1')
+    })
+
+    const venues = [...target.querySelectorAll('button')].find((button) =>
+      button.textContent.includes('Venues')
+    )
+    venues?.click()
+    await tick()
+    const bebopOption = [...target.querySelectorAll('button')].find((button) =>
+      button.textContent.trim().endsWith('Bebop')
+    )
+    bebopOption?.click()
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    const filteredInput = fetchMock.mock.calls[1]?.[0]
+    if (filteredInput === undefined) throw new Error('filtered trade request was not captured')
+    const filteredUrl = new URL(requestUrl(filteredInput))
+    expect(filteredUrl.searchParams.get('trade_protocol')).toBe('terminal_outcomes_v3')
+    const venueParam = filteredUrl.searchParams.get('venue')
+    expect(venueParam).not.toBeNull()
+    expect(venueParam?.split(',')).not.toContain('bebop')
+
+    target.remove()
+  })
+
+  it('keeps downgraded Raindex rows visible for a Bebop-only fallback filter', async () => {
+    const downgradedBebop: Trade = {
+      id: `0x${'b'.repeat(64)}:194`,
+      occurredAt: '2026-07-31T12:00:00Z',
+      venue: 'raindex',
+      direction: 'buy',
+      symbol: 'DOWNGRADED',
+      shares: '1',
+      outcome: { status: 'filled' }
+    }
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(requestUrl(input))
+      const protocol = url.searchParams.get('trade_protocol')
+      const venue = url.searchParams.get('venue')
+      if (protocol === 'terminal_outcomes_v3' && venue === 'bebop') {
+        return Promise.resolve(new Response(null, { status: 400 }))
+      }
+      if (protocol === 'terminal_outcomes_v2' && venue === 'raindex') {
+        return Promise.resolve(tradeResponse([downgradedBebop], 1))
+      }
+      return Promise.resolve(tradeResponse([], 0))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { target } = mountPanel()
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled())
+
+    const venues = [...target.querySelectorAll('button')].find((button) =>
+      button.textContent.includes('Venues')
+    )
+    venues?.click()
+    await tick()
+
+    for (const label of ['Raindex', 'Uniswap v4', 'Unknown Onchain', 'Alpaca', 'DryRun']) {
+      const option = [...target.querySelectorAll('button')].find((button) =>
+        button.textContent.trim().endsWith(label)
+      )
+      option?.click()
+      await tick()
+    }
+
+    await vi.waitFor(() => expect(target.textContent).toContain('DOWNGRADED'))
+    expect(
+      fetchMock.mock.calls.some(([input]) => {
+        const url = new URL(requestUrl(input))
+        return (
+          url.searchParams.get('trade_protocol') === 'terminal_outcomes_v2' &&
+          url.searchParams.get('venue') === 'raindex'
+        )
+      })
+    ).toBe(true)
+
+    target.remove()
+  })
+
+  it('retries trade history with v2 when the previous backend rejects v3', async () => {
     const fetchMock = vi
       .fn<() => Promise<Response>>()
       .mockResolvedValueOnce(new Response(null, { status: 400 }))
@@ -153,14 +260,76 @@ describe('TradeHistoryPanel', () => {
     await vi.waitFor(() => expect(target.textContent).toContain('1 of 1'))
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining('trade_protocol=terminal_outcomes_v2'),
+      expect.stringContaining('trade_protocol=terminal_outcomes_v3'),
       expect.any(Object)
     )
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining('trade_protocol=terminal_outcomes_v1'),
+      expect.stringContaining('trade_protocol=terminal_outcomes_v2'),
       expect.any(Object)
     )
+
+    target.remove()
+  })
+
+  it('links a Bebop trade detail ID to its transaction explorer', async () => {
+    const txHash = `0x${'a'.repeat(64)}`
+    const bebopTrade: Trade = {
+      id: `${txHash}:194`,
+      occurredAt: '2026-07-31T12:00:00Z',
+      venue: 'bebop',
+      direction: 'buy',
+      symbol: 'COIN',
+      shares: '1',
+      outcome: { status: 'filled' }
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL | Request) =>
+        Promise.resolve(
+          requestUrl(input).includes('/events')
+            ? new Response(JSON.stringify({ events: [] }), { status: 200 })
+            : tradeResponse([bebopTrade], 1)
+        )
+      )
+    )
+
+    const { target } = mountPanel()
+    await vi.waitFor(() => expect(target.textContent).toContain('COIN'))
+    const details = target.querySelector<HTMLButtonElement>('button[title="View trade details"]')
+    details?.click()
+
+    await vi.waitFor(() => {
+      const explorer = target.querySelector<HTMLAnchorElement>(
+        `a[href="${getExplorerTxUrl(txHash)}"]`
+      )
+      expect(explorer).not.toBeNull()
+    })
+
+    target.remove()
+  })
+
+  it('renders an offchain trade detail ID without an explorer link', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL | Request) =>
+        Promise.resolve(
+          requestUrl(input).includes('/events')
+            ? new Response(JSON.stringify({ events: [] }), { status: 200 })
+            : tradeResponse([staleTrade], 1)
+        )
+      )
+    )
+
+    const { target } = mountPanel()
+    await vi.waitFor(() => expect(target.textContent).toContain('SPCX'))
+    const details = target.querySelector<HTMLButtonElement>('button[title="View trade details"]')
+    details?.click()
+
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain(staleTrade.id)
+      expect(target.querySelector('dialog a')).toBeNull()
+    })
 
     target.remove()
   })
@@ -169,14 +338,15 @@ describe('TradeHistoryPanel', () => {
     const fetchMock = vi
       .fn<() => Promise<Response>>()
       .mockResolvedValueOnce(new Response(null, { status: 400 }))
+      .mockResolvedValueOnce(new Response(null, { status: 400 }))
       .mockResolvedValueOnce(tradeResponse([failedTrade('v1-failure')], 1))
     vi.stubGlobal('fetch', fetchMock)
 
     const { target } = mountPanel()
 
     await vi.waitFor(() => expect(target.textContent).toContain('1 of 1'))
-    const quantityTooltip = Array.from(target.querySelectorAll('button')).find((button) =>
-      button.getAttribute('aria-label')?.startsWith('Order quantity.') === true
+    const quantityTooltip = Array.from(target.querySelectorAll('button')).find(
+      (button) => button.getAttribute('aria-label')?.startsWith('Order quantity.') === true
     )
     expect(quantityTooltip).toBeDefined()
     expect(quantityTooltip?.getAttribute('aria-label')).not.toContain('Requested quantity')
@@ -184,8 +354,10 @@ describe('TradeHistoryPanel', () => {
     target.remove()
   })
 
-  it('re-probes v2 on the next refresh after a v1 fallback', async () => {
+  it('caches a fallback protocol and periodically re-probes v3', async () => {
     let poll: (() => void) | undefined
+    let now = Date.now()
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
     vi.spyOn(globalThis, 'setInterval').mockImplementation((handler) => {
       poll = handler as () => void
       return {} as ReturnType<typeof setInterval>
@@ -193,11 +365,13 @@ describe('TradeHistoryPanel', () => {
     const fetchMock = vi
       .fn<() => Promise<Response>>()
       .mockResolvedValueOnce(new Response(null, { status: 400 }))
+      .mockResolvedValueOnce(new Response(null, { status: 400 }))
       .mockResolvedValueOnce(tradeResponse([failedTrade('v1-failure')], 1))
+      .mockResolvedValueOnce(tradeResponse([failedTrade('cached-v1')], 1))
       .mockResolvedValueOnce(
         tradeResponse(
           [
-            failedTrade('v2-failure', {
+            failedTrade('v3-failure', {
               symbol: 'UPGRADED',
               outcome: {
                 status: 'failed',
@@ -215,14 +389,24 @@ describe('TradeHistoryPanel', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { target } = mountPanel()
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
 
     poll?.()
 
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4))
     expect(fetchMock).toHaveBeenNthCalledWith(
-      3,
-      expect.stringContaining('trade_protocol=terminal_outcomes_v2'),
+      4,
+      expect.stringContaining('trade_protocol=terminal_outcomes_v1'),
+      expect.any(Object)
+    )
+
+    now += 60_000
+    poll?.()
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5))
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
+      expect.stringContaining('trade_protocol=terminal_outcomes_v3'),
       expect.any(Object)
     )
     await vi.waitFor(() => expect(target.textContent).toContain('UPGRADED'))
@@ -230,7 +414,7 @@ describe('TradeHistoryPanel', () => {
     target.remove()
   })
 
-  it('retries each concurrent v2 history request independently', async () => {
+  it('retries each concurrent v3 history request independently', async () => {
     let poll: (() => void) | undefined
     vi.spyOn(globalThis, 'setInterval').mockImplementation((handler) => {
       poll = handler as () => void
@@ -254,17 +438,17 @@ describe('TradeHistoryPanel', () => {
     poll?.()
     await vi.waitFor(() => expect(pendingRequests).toHaveLength(2))
 
-    expect(pendingRequests[0]?.url).toContain('trade_protocol=terminal_outcomes_v2')
-    expect(pendingRequests[1]?.url).toContain('trade_protocol=terminal_outcomes_v2')
+    expect(pendingRequests[0]?.url).toContain('trade_protocol=terminal_outcomes_v3')
+    expect(pendingRequests[1]?.url).toContain('trade_protocol=terminal_outcomes_v3')
 
     pendingRequests[0]?.resolve(new Response(null, { status: 400 }))
     await vi.waitFor(() => expect(pendingRequests).toHaveLength(3))
-    expect(pendingRequests[2]?.url).toContain('trade_protocol=terminal_outcomes_v1')
+    expect(pendingRequests[2]?.url).toContain('trade_protocol=terminal_outcomes_v2')
     pendingRequests[2]?.resolve(tradeResponse([staleTrade], 1))
 
     pendingRequests[1]?.resolve(new Response(null, { status: 400 }))
     await vi.waitFor(() => expect(pendingRequests).toHaveLength(4))
-    expect(pendingRequests[3]?.url).toContain('trade_protocol=terminal_outcomes_v1')
+    expect(pendingRequests[3]?.url).toContain('trade_protocol=terminal_outcomes_v2')
     pendingRequests[3]?.resolve(
       tradeResponse([failedTrade('current-request', { symbol: 'CURR' })], 1)
     )
@@ -348,7 +532,7 @@ describe('TradeHistoryPanel', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('limit=100'), expect.any(Object))
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('trade_protocol=terminal_outcomes_v2'),
+      expect.stringContaining('trade_protocol=terminal_outcomes_v3'),
       expect.any(Object)
     )
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -581,7 +765,7 @@ describe('TradeHistoryPanel', () => {
     venues?.click()
     await tick()
 
-    for (const label of ['Raindex', 'Alpaca', 'DryRun']) {
+    for (const label of ['Raindex', 'Bebop', 'Uniswap v4', 'Unknown Onchain', 'Alpaca', 'DryRun']) {
       const option = [...target.querySelectorAll('button')].find((button) =>
         button.textContent.trim().endsWith(label)
       )
@@ -595,7 +779,7 @@ describe('TradeHistoryPanel', () => {
       expect(target.textContent).toContain('No trades yet')
       expect(target.textContent).toContain('0 of 0')
       expect(target.textContent).not.toContain('Loading...')
-      expect(fetchMock).toHaveBeenCalledTimes(4)
+      expect(fetchMock).toHaveBeenCalledTimes(7)
     })
 
     for (const resolve of pendingResponses) {

--- a/dashboard/src/lib/trade-payload.test.ts
+++ b/dashboard/src/lib/trade-payload.test.ts
@@ -3,7 +3,8 @@ import {
   parseCanonicalTrade,
   parseTrade,
   parseTradeEntries,
-  parseTradeResponse
+  parseTradeResponse,
+  TradePayloadError
 } from './trade-payload'
 
 const validTrade = (overrides: Record<string, unknown> = {}): unknown => ({
@@ -37,6 +38,31 @@ describe('trade payload validation', () => {
       symbol: 'TSLA',
       shares: '2'
     })
+  })
+
+  it.each(['bebop', 'uniswap_v4', 'unknown_onchain'])(
+    'accepts %s as an onchain trading venue',
+    (venue) => {
+      const onchain = validTrade({
+      id: '0x28a364eaa0fc6d505ddd0702cd9949853193bb28c92cdfef68bcd5a803f1806b:194',
+        venue
+      })
+
+      expect(parseTrade(onchain)).toEqual(onchain)
+    }
+  )
+
+  it('skips only an entry whose venue is newer than this dashboard', () => {
+    const supported = validTrade({ id: 'supported' })
+    const unsupported = validTrade({ id: 'unsupported', venue: 'future_venue' })
+
+    expect(parseTradeEntries([unsupported, supported])).toEqual([supported])
+  })
+
+  it('rejects the payload when an entry has a non-venue validation error', () => {
+    const malformed = validTrade({ id: 'malformed', shares: 'not-a-number' })
+
+    expect(() => parseTradeEntries([malformed, validTrade()])).toThrow(TradePayloadError)
   })
 
   it.each([

--- a/dashboard/src/lib/trade-payload.ts
+++ b/dashboard/src/lib/trade-payload.ts
@@ -5,6 +5,7 @@ import type { Trade } from '$lib/api/Trade'
 import type { TradeOutcome } from '$lib/api/TradeOutcome'
 import type { TradingVenue } from '$lib/api/TradingVenue'
 import { tryCatch } from '$lib/fp'
+import { isTradingVenue } from '$lib/trade'
 
 type JsonRecord = Record<string, unknown>
 type CommonTradeFields = Pick<Trade, 'id' | 'venue' | 'direction' | 'symbol' | 'shares'>
@@ -17,12 +18,21 @@ export type TradeResponse = {
   hasMore: boolean
 }
 
+type TradePayloadErrorCode = 'invalid_payload' | 'unsupported_trade_venue'
+
 export class TradePayloadError extends Error {
-  constructor(path: string, expected: string) {
+  constructor(
+    readonly path: string,
+    readonly expected: string,
+    readonly code: TradePayloadErrorCode = 'invalid_payload'
+  ) {
     super(`Invalid trade payload at ${path}: expected ${expected}`)
     this.name = 'TradePayloadError'
   }
 }
+
+export const isUnsupportedTradeVenue = (error: unknown): error is TradePayloadError =>
+  error instanceof TradePayloadError && error.code === 'unsupported_trade_venue'
 
 const fieldPath = (path: string, field: string): string =>
   path === '' ? field : `${path}.${field}`
@@ -115,8 +125,9 @@ const parseTimestamp = (value: unknown, path: string): string => {
 }
 
 const parseVenue = (value: unknown, path: string): TradingVenue => {
-  if (value === 'raindex' || value === 'alpaca' || value === 'dry_run') return value
-  return invalid(path, 'a known trading venue')
+  if (isTradingVenue(value)) return value
+
+  throw new TradePayloadError(path, 'a known trading venue', 'unsupported_trade_venue')
 }
 
 const parseDirection = (value: unknown, path: string): Direction => {
@@ -288,7 +299,18 @@ export const parseTrade = (value: unknown, path = ''): Trade | LegacyTrade => {
 
 export const parseTradeEntries = (value: unknown, path = 'trades'): Array<Trade | LegacyTrade> => {
   if (!Array.isArray(value)) return invalid(path, 'an array')
-  return value.map((trade, index) => parseTrade(trade, `${path}[${String(index)}]`))
+
+  return value.flatMap((trade, index) => {
+    const parsed = tryCatch(() => parseTrade(trade, `${path}[${String(index)}]`))
+    if (parsed.tag === 'ok') return [parsed.value]
+
+    if (isUnsupportedTradeVenue(parsed.error)) {
+      console.warn(`Skipping trade with an unsupported venue at ${parsed.error.path}`)
+      return []
+    }
+
+    throw parsed.error
+  })
 }
 
 export const parseTradeResponse = (value: unknown): TradeResponse => {

--- a/dashboard/src/lib/trade.test.ts
+++ b/dashboard/src/lib/trade.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest'
 import type { LegacyTrade } from '$lib/api/LegacyTrade'
 import type { Trade } from '$lib/api/Trade'
 import {
+  fallbackTradeProtocol,
+  isOnchainVenue,
+  legacyCompatibleVenues,
   mergeTradeHistory,
   normalizeTrade,
   tradeFailureReason,
@@ -9,6 +12,14 @@ import {
   tradeOutcomeClass,
   tradeOutcomeLabel
 } from './trade'
+
+describe('trade protocol fallback', () => {
+  it('steps through each supported protocol and remains at v1', () => {
+    expect(fallbackTradeProtocol('terminal_outcomes_v3')).toBe('terminal_outcomes_v2')
+    expect(fallbackTradeProtocol('terminal_outcomes_v2')).toBe('terminal_outcomes_v1')
+    expect(fallbackTradeProtocol('terminal_outcomes_v1')).toBe('terminal_outcomes_v1')
+  })
+})
 
 describe('trade outcome presentation', () => {
   it('renders filled outcomes as successful', () => {
@@ -209,6 +220,36 @@ describe('live trade history', () => {
         until: null
       })
     ).toEqual([log10, log2])
+  })
+
+  it('sorts tied Raindex and Bebop trades by numeric log index', () => {
+    const txHash = `0x${'0'.repeat(64)}`
+    const raindexLog11 = trade({ id: `${txHash}:11`, venue: 'raindex' })
+    const bebopLog20 = trade({ id: `${txHash}:20`, venue: 'bebop' })
+
+    expect(
+      mergeTradeHistory([raindexLog11], [bebopLog20], {
+        venues: new Set(['raindex', 'bebop']),
+        symbols: new Set(),
+        since: null,
+        until: null
+      })
+    ).toEqual([bebopLog20, raindexLog11])
+  })
+
+  it('classifies every adapter and unknown inventory venue as onchain', () => {
+    expect(isOnchainVenue('raindex')).toBe(true)
+    expect(isOnchainVenue('bebop')).toBe(true)
+    expect(isOnchainVenue('uniswap_v4')).toBe(true)
+    expect(isOnchainVenue('unknown_onchain')).toBe(true)
+    expect(isOnchainVenue('alpaca')).toBe(false)
+    expect(isOnchainVenue('dry_run')).toBe(false)
+  })
+
+  it('collapses adapter venue filters for pre-v3 backends', () => {
+    expect(legacyCompatibleVenues(new Set(['bebop', 'uniswap_v4', 'alpaca']))).toEqual(
+      new Set(['raindex', 'alpaca'])
+    )
   })
 
   it('preserves sub-millisecond RFC 3339 ordering', () => {

--- a/dashboard/src/lib/trade.ts
+++ b/dashboard/src/lib/trade.ts
@@ -72,6 +72,38 @@ export type TradeHistoryFilter = {
   until: string | null
 }
 
+const VENUE_IS_ONCHAIN = {
+  raindex: true,
+  bebop: true,
+  uniswap_v4: true,
+  unknown_onchain: true,
+  alpaca: false,
+  dry_run: false
+} as const satisfies Record<TradingVenue, boolean>
+
+export const TRADING_VENUES = Object.keys(VENUE_IS_ONCHAIN) as TradingVenue[]
+
+export const isTradingVenue = (value: unknown): value is TradingVenue =>
+  typeof value === 'string' && Object.hasOwn(VENUE_IS_ONCHAIN, value)
+
+export const isOnchainVenue = (venue: TradingVenue): boolean => VENUE_IS_ONCHAIN[venue]
+
+export type TradeProtocol = 'terminal_outcomes_v3' | 'terminal_outcomes_v2' | 'terminal_outcomes_v1'
+
+const TRADE_PROTOCOL_FALLBACK = {
+  terminal_outcomes_v3: 'terminal_outcomes_v2',
+  terminal_outcomes_v2: 'terminal_outcomes_v1',
+  terminal_outcomes_v1: 'terminal_outcomes_v1'
+} as const satisfies Record<TradeProtocol, TradeProtocol>
+
+export const fallbackTradeProtocol = (protocol: TradeProtocol): TradeProtocol =>
+  TRADE_PROTOCOL_FALLBACK[protocol]
+
+export const legacyCompatibleVenues = (
+  venues: ReadonlySet<TradingVenue>
+): ReadonlySet<TradingVenue> =>
+  new Set([...venues].map((venue) => (isOnchainVenue(venue) ? ('raindex' as const) : venue)))
+
 const matchesHistoryFilter = (trade: Trade, filter: TradeHistoryFilter): boolean => {
   if (!filter.venues.has(trade.venue)) return false
   if (filter.symbols.size > 0 && !filter.symbols.has(trade.symbol)) return false
@@ -137,7 +169,7 @@ const compareRfc3339Timestamps = (left: string, right: string): number => {
 }
 
 const compareTradeIds = (left: Trade, right: Trade): number => {
-  if (left.venue === 'raindex' && right.venue === 'raindex') {
+  if (isOnchainVenue(left.venue) && isOnchainVenue(right.venue)) {
     const leftId = parseOnchainTradeId(left.id)
     const rightId = parseOnchainTradeId(right.id)
     if (leftId !== null && rightId !== null && leftId.txHash === rightId.txHash) {

--- a/dashboard/src/lib/websocket/connection.svelte.test.ts
+++ b/dashboard/src/lib/websocket/connection.svelte.test.ts
@@ -195,24 +195,29 @@ describe('createWebSocket', () => {
       expect(ws.state).toBe('connected')
     })
 
-    it('retries with v1 when the previous backend rejects v2', () => {
+    it('falls back from v3 through v2 and re-probes v3 after a connection', () => {
       const { getInstance } = setupWebSocketTest()
       const queryClient = createMockQueryClient()
       const ws = createWebSocket(WS_URL, queryClient)
 
       ws.connect()
-      expect(getInstance(0).url).toContain('trade_protocol=terminal_outcomes_v2')
+      expect(getInstance(0).url).toContain('trade_protocol=terminal_outcomes_v3')
 
       getInstance(0).simulateError()
       vi.advanceTimersByTime(1000)
 
-      expect(getInstance(1).url).toContain('trade_protocol=terminal_outcomes_v1')
+      expect(getInstance(1).url).toContain('trade_protocol=terminal_outcomes_v2')
 
-      getInstance(1).simulateOpen()
-      getInstance(1).simulateClose()
+      getInstance(1).simulateError()
       vi.advanceTimersByTime(2000)
 
-      expect(getInstance(2).url).toContain('trade_protocol=terminal_outcomes_v2')
+      expect(getInstance(2).url).toContain('trade_protocol=terminal_outcomes_v1')
+
+      getInstance(2).simulateOpen()
+      getInstance(2).simulateClose()
+      vi.advanceTimersByTime(4000)
+
+      expect(getInstance(3).url).toContain('trade_protocol=terminal_outcomes_v3')
     })
 
     it('transitions to error on close from connected', () => {
@@ -302,6 +307,31 @@ describe('createWebSocket', () => {
       expect(trades).toHaveLength(2)
       expect(trades[0]?.symbol).toBe('AAPL')
       expect(trades[1]?.symbol).toBe('TSLA')
+    })
+
+    it('skips a future trade venue without reconnecting', () => {
+      const { getInstance } = setupWebSocketTest()
+      const queryClient = createMockQueryClient()
+      const knownGood = makeTrade({ id: 'known-good' })
+      queryClient.cache.set('["trades"]', [knownGood])
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+      const ws = createWebSocket(WS_URL, queryClient)
+
+      ws.connect()
+      getInstance(0).simulateOpen()
+      getInstance(0).simulateRawMessage(
+        JSON.stringify({
+          type: 'trade_update',
+          data: makeTrade({ id: 'future-venue', venue: 'future_dex' as Trade['venue'] })
+        })
+      )
+
+      expect(queryClient.cache.get('["trades"]')).toEqual([knownGood])
+      expect(ws.state).toBe('connected')
+      expect(getInstance(0).closeCalls).toBe(0)
+      expect(consoleWarn).toHaveBeenCalledWith(
+        'Skipping WebSocket trade with an unsupported venue at venue'
+      )
     })
 
     it('normalizes legacy fills from an old server snapshot', () => {

--- a/dashboard/src/lib/websocket/connection.svelte.ts
+++ b/dashboard/src/lib/websocket/connection.svelte.ts
@@ -4,7 +4,13 @@ import type { Statement } from '$lib/api/Statement'
 import { isStatement } from '$lib/api/StatementGuard'
 import { matcher, tryCatch } from '$lib/fp'
 import { reactive } from '$lib/frp.svelte'
-import { parseCanonicalTrade, parseLegacyTrade, parseTradeEntries } from '$lib/trade-payload'
+import { fallbackTradeProtocol, type TradeProtocol } from '$lib/trade'
+import {
+  isUnsupportedTradeVenue,
+  parseCanonicalTrade,
+  parseLegacyTrade,
+  parseTradeEntries
+} from '$lib/trade-payload'
 import { seedTrades, appendTrade } from './trades'
 import { seedInventory, updateSnapshot, upsertPosition } from './inventory'
 import { seedTransfers, upsertTransfer } from './transfers'
@@ -16,7 +22,6 @@ type ConnectionEvent = 'connect' | 'open' | 'close' | 'error' | 'disconnect'
 
 const RECONNECT_DELAY_MS = 1000
 const MAX_RECONNECT_DELAY_MS = 10000
-type TradeProtocol = 'terminal_outcomes_v2' | 'terminal_outcomes_v1'
 
 const withTradeProtocol = (url: string, tradeProtocol: TradeProtocol): string => {
   const protocolUrl = new URL(url)
@@ -35,7 +40,7 @@ export type ErrorContext = {
 
 export const createWebSocket = (url: string, queryClient: QueryClient) => {
   let socket: WebSocket | null = null
-  let tradeProtocol: TradeProtocol = 'terminal_outcomes_v2'
+  let tradeProtocol: TradeProtocol = 'terminal_outcomes_v3'
   let reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null
   let failureMessage = 'WebSocket connection error'
   const reconnectAttempts = reactive(0)
@@ -84,11 +89,12 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
 
     socket.onopen = () => {
       opened = true
-      // A v1 connection proves the fallback works, not that v2 is permanently
-      // unavailable. Probe v2 again after the next disconnect so a transient
-      // restart cannot pin this dashboard to the lower-fidelity protocol.
-      if (attemptedProtocol === 'terminal_outcomes_v1') {
-        tradeProtocol = 'terminal_outcomes_v2'
+      // A lower-version connection proves the fallback works, not that v3 is
+      // permanently unavailable. Probe v3 after the next disconnect so a
+      // transient rolling restart cannot pin this dashboard to a protocol that
+      // collapses adapter venues to Raindex.
+      if (attemptedProtocol !== 'terminal_outcomes_v3') {
+        tradeProtocol = 'terminal_outcomes_v3'
       }
       if (import.meta.env.DEV) console.log(`[ws] connected to ${protocolUrl}`)
       fsm.send('open')
@@ -119,6 +125,11 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
         markHealthy()
         return
       }
+      if (isUnsupportedTradeVenue(handled.error)) {
+        console.warn(`Skipping WebSocket trade with an unsupported venue at ${handled.error.path}`)
+        markHealthy()
+        return
+      }
 
       failureMessage =
         handled.error instanceof Error
@@ -129,8 +140,8 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
     }
 
     socket.onclose = (event) => {
-      if (!opened && attemptedProtocol === 'terminal_outcomes_v2') {
-        tradeProtocol = 'terminal_outcomes_v1'
+      if (!opened) {
+        tradeProtocol = fallbackTradeProtocol(attemptedProtocol)
       }
       if (import.meta.env.DEV)
         console.log(`[ws] closed (code=${String(event.code)}, reason="${event.reason}")`)
@@ -140,8 +151,8 @@ export const createWebSocket = (url: string, queryClient: QueryClient) => {
     }
 
     socket.onerror = () => {
-      if (!opened && attemptedProtocol === 'terminal_outcomes_v2') {
-        tradeProtocol = 'terminal_outcomes_v1'
+      if (!opened) {
+        tradeProtocol = fallbackTradeProtocol(attemptedProtocol)
       }
       failureMessage = 'WebSocket connection error'
       fsm.send('error')

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -94,11 +94,15 @@ and confusing.
 A location where trades are executed. The system operates across two types of
 venue:
 
-- **Onchain venue (Raindex)**: A decentralized exchange on Base where tokenized
-  equities and USDC are traded via limit orders placed and priced externally.
-  The bot monitors fills on those orders and manages vault balances
-  (deposits/withdrawals) for rebalancing; it does not add, remove, or reprice
-  the orders themselves.
+- **Onchain venue**: A protocol or liquidity source that executes
+  tokenized-equity trades on Base. Raindex is the onchain orderbook that holds
+  the bot's tokenized-equity orders and their backing vaults; direct fills
+  execute there. A shared-inventory adapter may execute the trade on another
+  venue, such as Bebop or Uniswap v4, before settling it through the bot's
+  pooled inventory. The adapter's onchain operator address identifies that
+  venue. An operator that is absent from the deployment's explicit adapter
+  configuration is reported as Unknown Onchain rather than being misattributed
+  to Raindex.
 - **Offchain venue (brokerage)**: A traditional equity market accessed through
   the Alpaca Broker API. The bot executes offsetting trades here to hedge
   onchain exposure.

--- a/e2e/config.toml
+++ b/e2e/config.toml
@@ -21,6 +21,7 @@ tokenized_equity_derivative = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 [raindex]
 orderbook = "0x1111111111111111111111111111111111111111"
 inventory_mode = "legacy"
+inventory_adapters = []
 vault_owner = "0x3333333333333333333333333333333333333333"
 deployment_block = 1
 required_confirmations = 0

--- a/example.config.toml
+++ b/example.config.toml
@@ -41,6 +41,13 @@ orderbook = "0x1111111111111111111111111111111111111111"
 # default): "managed" without an `inventory`, or "legacy" with one, fails at
 # startup.
 inventory_mode = "managed"
+# Public OPERATOR_ROLE holders whose inventory settlements should be attributed
+# to a named venue. These are deployment-specific and must be updated when an
+# adapter rotates or is redeployed.
+inventory_adapters = [
+  { venue = "bebop", operator = "0x4444444444444444444444444444444444444444" },
+  { venue = "uniswap_v4", operator = "0x5555555555555555555555555555555555555555" },
+]
 # Shared RaindexInventory (rainlanguage/raindex.governance) that owns the
 # Raindex orders/vaults. REQUIRED when inventory_mode = "managed" (and forbidden
 # for "legacy"). Rebalance deposits/withdrawals settle through this contract;

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,23 +19,22 @@ use tracing::{error, info, warn};
 use st0x_config::BrokerCtx;
 use st0x_dto::{
     EquityTimings, HedgeLatencies, InfraReport, RebalanceTimings, ReliabilityReport, Trade,
-    TradeOutcome, TradingVenue, sort_trades_newest_first,
+    TradingVenue, sort_trades_newest_first,
 };
 use st0x_execution::Symbol;
 use st0x_execution::alpaca_broker_api::AccountActivitiesQuery;
-use st0x_finance::{FractionalShares, NotPositive, Positive};
+use st0x_finance::FractionalShares;
 use st0x_tokenization::IssuerRequestId;
 
 use crate::AppState;
-use crate::dashboard::TradeProtocol;
 use crate::dashboard::pnl::{
     PnlError, PnlQuery, PnlResponse, acquire_pnl_report_permit, build_pnl_report_with_permit,
     validate_pnl_snapshot_rowid,
 };
 use crate::dashboard::transfer_loader::{InvalidTransferKind, TransferKind};
+use crate::dashboard::{DashboardTradeHistoryError, TradeProtocol, load_onchain_trades};
 use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
 use crate::offchain::order::{OffchainOrder, OffchainOrderId, TradeConversionError};
-use crate::onchain_trade::{OnChainTradeEvent, OnChainTradeId, ParseOnChainTradeIdError};
 use crate::performance::equity_timing::load_equity_timings;
 use crate::performance::infra::{load_dependency_stats, load_monitor_telemetry};
 use crate::performance::rebalance::load_rebalance_timings;
@@ -603,6 +602,7 @@ async fn trades(
         venues,
         since: since_dt,
         until: until_dt,
+        trade_protocol: query.trade_protocol,
     };
 
     let mut all_trades = load_trade_rows(&state.pool, &trade_filter)
@@ -616,13 +616,7 @@ async fn trades(
     let end = total.min(offset.saturating_add(limit));
     let entries = all_trades[offset.min(total)..end]
         .iter()
-        .map(|trade| {
-            if query.trade_protocol == TradeProtocol::TerminalOutcomesV1 {
-                serde_json::to_value(trade.terminal_outcomes_v1())
-            } else {
-                serde_json::to_value(trade)
-            }
-        })
+        .map(|trade| query.trade_protocol.serialize_trade(trade))
         .collect::<Result<Vec<_>, _>>()
         .inspect_err(
             |error| warn!(target: "dashboard", ?error, "Failed to serialize trade history"),
@@ -642,6 +636,7 @@ struct TradeFilter {
     venues: Option<Vec<TradingVenue>>,
     since: Option<DateTime<Utc>>,
     until: Option<DateTime<Utc>>,
+    trade_protocol: TradeProtocol,
 }
 
 impl TradeFilter {
@@ -666,9 +661,28 @@ impl TradeFilter {
     }
 
     fn matches_venue(&self, venue: TradingVenue) -> bool {
+        self.venues.as_ref().is_none_or(|venues| {
+            venues.iter().any(|filter| match self.trade_protocol {
+                TradeProtocol::TerminalOutcomesV3 => *filter == venue,
+                TradeProtocol::LegacyFills
+                | TradeProtocol::TerminalOutcomesV1
+                | TradeProtocol::TerminalOutcomesV2 => {
+                    filter.legacy_compatible() == venue.legacy_compatible()
+                }
+            })
+        })
+    }
+
+    fn includes_onchain(&self) -> bool {
         self.venues
             .as_ref()
-            .is_none_or(|venues| venues.contains(&venue))
+            .is_none_or(|venues| venues.iter().any(|venue| venue.is_onchain()))
+    }
+
+    fn includes_offchain(&self) -> bool {
+        self.venues
+            .as_ref()
+            .is_none_or(|venues| venues.iter().any(|venue| !venue.is_onchain()))
     }
 }
 
@@ -727,9 +741,8 @@ async fn load_trade_rows(
     pool: &SqlitePool,
     filter: &TradeFilter,
 ) -> Result<Vec<Trade>, TradeHistoryError> {
-    let include_onchain = filter.matches_venue(TradingVenue::Raindex);
-    let include_offchain =
-        filter.matches_venue(TradingVenue::Alpaca) || filter.matches_venue(TradingVenue::DryRun);
+    let include_onchain = filter.includes_onchain();
+    let include_offchain = filter.includes_offchain();
 
     let mut trades = Vec::new();
 
@@ -748,70 +761,16 @@ async fn load_onchain_trade_rows(
     pool: &SqlitePool,
     filter: &TradeFilter,
 ) -> Result<Vec<Trade>, TradeHistoryError> {
-    let rows: Vec<(String, String)> = sqlx::query_as(
-        "SELECT aggregate_id, payload FROM events \
-         WHERE event_type = 'OnChainTradeEvent::Filled' \
-         ORDER BY rowid DESC",
-    )
-    .fetch_all(pool)
-    .await?;
-
-    Ok(rows
+    Ok(load_onchain_trades(pool)
+        .await
+        .map_err(|source| TradeHistoryError::Onchain(Box::new(source)))?
         .into_iter()
-        .filter_map(|(aggregate_id, payload)| {
-            parse_onchain_trade_row(aggregate_id, &payload, filter)
-                .inspect_err(|error| {
-                    warn!(
-                        target: "dashboard",
-                        %error,
-                        "Skipping unparseable onchain trade history row"
-                    );
-                })
-                .ok()
-                .flatten()
+        .filter(|trade| {
+            filter.matches_venue(trade.venue)
+                && filter.matches_symbol(&trade.symbol)
+                && filter.matches_time(trade.occurred_at)
         })
         .collect())
-}
-
-fn parse_onchain_trade_row(
-    aggregate_id: String,
-    payload: &str,
-    filter: &TradeFilter,
-) -> Result<Option<Trade>, TradeHistoryError> {
-    let result = (|| -> Result<Trade, OnchainTradeRowError> {
-        let id = OnChainTradeId::from_str(&aggregate_id)?;
-        let event: OnChainTradeEvent = serde_json::from_str(payload)?;
-        let OnChainTradeEvent::Filled {
-            symbol,
-            amount,
-            direction,
-            block_timestamp,
-            ..
-        } = event
-        else {
-            return Err(OnchainTradeRowError::UnexpectedEvent);
-        };
-
-        Ok(Trade {
-            id: id.to_string(),
-            occurred_at: block_timestamp,
-            venue: TradingVenue::Raindex,
-            direction,
-            symbol,
-            shares: Positive::new(FractionalShares::new(amount))?,
-            outcome: TradeOutcome::Filled,
-        })
-    })()
-    .map_err(|source| TradeHistoryError::InvalidOnchainRow {
-        aggregate_id,
-        source,
-    })?;
-
-    if !filter.matches_symbol(&result.symbol) || !filter.matches_time(result.occurred_at) {
-        return Ok(None);
-    }
-
-    Ok(Some(result))
 }
 
 async fn load_offchain_trade_rows(
@@ -858,27 +817,11 @@ enum OffchainTradeRowError {
 }
 
 #[derive(Debug, thiserror::Error)]
-enum OnchainTradeRowError {
-    #[error("invalid onchain trade id: {0}")]
-    Id(#[from] ParseOnChainTradeIdError),
-    #[error("invalid onchain trade event payload: {0}")]
-    Payload(#[from] serde_json::Error),
-    #[error("query returned a non-fill onchain event")]
-    UnexpectedEvent,
-    #[error("onchain trade quantity is not positive: {0}")]
-    Quantity(#[from] NotPositive<FractionalShares>),
-}
-
-#[derive(Debug, thiserror::Error)]
 enum TradeHistoryError {
     #[error("failed to query trade history: {0}")]
     Database(#[from] sqlx::Error),
-    #[error("failed to parse onchain trade history row {aggregate_id}: {source}")]
-    InvalidOnchainRow {
-        aggregate_id: String,
-        #[source]
-        source: OnchainTradeRowError,
-    },
+    #[error("failed to replay onchain trade history: {0}")]
+    Onchain(#[source] Box<DashboardTradeHistoryError>),
     #[error("failed to parse offchain trade history row {view_id}: {source}")]
     InvalidOffchainRow {
         view_id: String,
@@ -1303,7 +1246,8 @@ fn shares_from_u256_18_decimal(amount: U256) -> Option<String> {
 
 /// Returns the full event history for a single trade aggregate.
 ///
-/// For onchain trades (Raindex), returns Filled + optional Enriched events.
+/// For onchain trades (direct Raindex or adapter-routed), returns Filled +
+/// optional Enriched events.
 /// For offchain trades (Alpaca), returns the full order lifecycle
 /// (Placed -> Submitted -> PartiallyFilled -> Filled/Failed).
 async fn trade_events(
@@ -1311,9 +1255,10 @@ async fn trade_events(
     Path((venue_str, aggregate_id)): Path<(String, String)>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let venue = TradingVenue::from_str(&venue_str).map_err(|_| StatusCode::NOT_FOUND)?;
-    let aggregate_type = match venue {
-        TradingVenue::Raindex => "OnChainTrade",
-        TradingVenue::Alpaca | TradingVenue::DryRun => "OffchainOrder",
+    let aggregate_type = if venue.is_onchain() {
+        "OnChainTrade"
+    } else {
+        "OffchainOrder"
     };
 
     let rows: Vec<(String, String, i64)> = sqlx::query_as(
@@ -1909,6 +1854,7 @@ mod tests {
     use st0x_config::{
         BrokerCtx, Ctx, ExecutionThreshold, RestApiCtx, create_test_ctx_with_order_owner,
     };
+    use st0x_dto::TradeOutcome;
     use st0x_event_sorcery::{ReactorHarness, StoreBuilder};
     use st0x_execution::{
         AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode,
@@ -1927,6 +1873,9 @@ mod tests {
         self, BroadcastingInventory, PortfolioAsset, PortfolioBalanceRow, PortfolioLocation,
     };
     use crate::offchain::order::{OffchainOrder, OffchainOrderEvent, OffchainOrderId};
+    use crate::onchain_trade::{
+        InventoryVenue, OnChainTrade, OnChainTradeCommand, OnChainTradeId, OnChainTradeSource,
+    };
     use crate::performance::equity_timing::EquityTimingProjection;
     use crate::performance::reliability::LifecycleFailureProjection;
     use crate::portfolio_snapshot::{
@@ -2117,6 +2066,7 @@ mod tests {
                 venues: None,
                 since: None,
                 until: None,
+                trade_protocol: TradeProtocol::TerminalOutcomesV3,
             },
         )
         .await
@@ -2310,6 +2260,7 @@ mod tests {
                 venues: None,
                 since: None,
                 until: None,
+                trade_protocol: TradeProtocol::TerminalOutcomesV3,
             },
         )
         .await
@@ -2334,28 +2285,92 @@ mod tests {
         assert_eq!(body["entries"][0]["id"], valid_view_id);
     }
 
-    #[test]
-    fn onchain_trade_history_rejects_malformed_aggregate_ids() {
-        let error = parse_onchain_trade_row(
-            "not-an-onchain-trade-id".to_string(),
-            "{}",
+    #[tokio::test]
+    async fn trade_row_loading_replays_repaired_bebop_source() {
+        let state = empty_app_state(create_test_ctx_with_order_owner(Address::ZERO)).await;
+        let pool = state.pool.clone();
+        let now = Utc::now();
+        let id = OnChainTradeId {
+            tx_hash: TxHash::ZERO,
+            log_index: 194,
+        };
+        let store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Legacy,
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: float!(10),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::AttributeSource {
+                    source: OnChainTradeSource::Inventory {
+                        operator: Address::repeat_byte(0x8b),
+                        venue: InventoryVenue::Bebop,
+                    },
+                },
+            )
+            .await
+            .unwrap();
+
+        let bebop = load_trade_rows(
+            &pool,
             &TradeFilter {
                 symbols: None,
-                venues: None,
+                venues: Some(vec![TradingVenue::Bebop]),
                 since: None,
                 until: None,
+                trade_protocol: TradeProtocol::TerminalOutcomesV3,
             },
         )
-        .unwrap_err();
+        .await
+        .unwrap();
+        let alpaca = load_trade_rows(
+            &pool,
+            &TradeFilter {
+                symbols: None,
+                venues: Some(vec![TradingVenue::Alpaca]),
+                since: None,
+                until: None,
+                trade_protocol: TradeProtocol::TerminalOutcomesV3,
+            },
+        )
+        .await
+        .unwrap();
 
-        assert!(error.to_string().contains("not-an-onchain-trade-id"));
-        assert!(matches!(
-            error,
-            TradeHistoryError::InvalidOnchainRow {
-                source: OnchainTradeRowError::Id(_),
-                ..
-            }
-        ));
+        assert_eq!(bebop.len(), 1);
+        assert_eq!(bebop[0].venue, TradingVenue::Bebop);
+        assert!(alpaca.is_empty());
+
+        let response = build_app(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/trades?trade_protocol=terminal_outcomes_v2&venue=raindex")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value =
+            serde_json::from_str(&body_to_string(response).await).unwrap();
+        assert_eq!(body["total"], 1);
+        assert_eq!(body["entries"][0]["id"], id.to_string());
+        assert_eq!(body["entries"][0]["venue"], "raindex");
     }
 
     #[test]
@@ -2373,6 +2388,7 @@ mod tests {
                 venues: Some(vec![TradingVenue::Alpaca]),
                 since: Some("2026-01-01T00:00:01Z".parse().unwrap()),
                 until: Some("2026-01-01T00:00:01Z".parse().unwrap()),
+                trade_protocol: TradeProtocol::TerminalOutcomesV3,
             })
             .is_some()
         );
@@ -2383,24 +2399,28 @@ mod tests {
                 venues: None,
                 since: None,
                 until: None,
+                trade_protocol: TradeProtocol::TerminalOutcomesV3,
             },
             TradeFilter {
                 symbols: None,
                 venues: Some(vec![TradingVenue::DryRun]),
                 since: None,
                 until: None,
+                trade_protocol: TradeProtocol::TerminalOutcomesV3,
             },
             TradeFilter {
                 symbols: None,
                 venues: None,
                 since: Some("2026-01-01T00:00:02Z".parse().unwrap()),
                 until: None,
+                trade_protocol: TradeProtocol::TerminalOutcomesV3,
             },
             TradeFilter {
                 symbols: None,
                 venues: None,
                 since: None,
                 until: Some("2026-01-01T00:00:00Z".parse().unwrap()),
+                trade_protocol: TradeProtocol::TerminalOutcomesV3,
             },
         ] {
             assert!(parse(filter).is_none());

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -717,18 +717,18 @@ mod tests {
     use url::Url;
     use uuid::uuid;
 
-    use st0x_evm::NoOpErrorRegistry;
-    use st0x_execution::{AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, TimeInForce};
-
-    use super::*;
-    use crate::cli::ConvertDirection;
-    use crate::inventory::ImbalanceThreshold;
     use st0x_config::ExecutionThreshold;
     use st0x_config::RebalancingCtx;
     use st0x_config::create_test_issuance_ctx;
     use st0x_config::{AssetsConfig, EquitiesConfig, LogLevel, TradingMode};
-    use st0x_config::{EvmCtx, IngestionCutoff, InventoryMode};
+    use st0x_config::{EvmCtx, IngestionCutoff, InventoryAdapters, InventoryMode};
+    use st0x_evm::NoOpErrorRegistry;
+    use st0x_execution::{AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, TimeInForce};
     use st0x_float_macro::float;
+
+    use super::*;
+    use crate::cli::ConvertDirection;
+    use crate::inventory::ImbalanceThreshold;
 
     fn create_ctx_without_alpaca() -> Ctx {
         Ctx {
@@ -748,6 +748,7 @@ mod tests {
                 required_confirmations: 0,
                 ingestion_cutoff: IngestionCutoff::Safe,
             },
+            inventory_adapters: InventoryAdapters::default(),
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
             position_check_interval: 60,
@@ -830,6 +831,7 @@ mod tests {
                 required_confirmations: 0,
                 ingestion_cutoff: IngestionCutoff::Safe,
             },
+            inventory_adapters: InventoryAdapters::default(),
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
             position_check_interval: 60,

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -247,7 +247,7 @@ mod tests {
     use st0x_config::ExecutionThreshold;
     use st0x_config::create_test_issuance_ctx;
     use st0x_config::{AssetsConfig, BrokerCtx, CtxError, EquitiesConfig, LogLevel, TradingMode};
-    use st0x_config::{EvmCtx, IngestionCutoff, InventoryMode};
+    use st0x_config::{EvmCtx, IngestionCutoff, InventoryAdapters, InventoryMode};
     use st0x_evm::OpenChainErrorRegistry;
     use st0x_finance::Usdc;
 
@@ -271,6 +271,7 @@ mod tests {
                 required_confirmations: 0,
                 ingestion_cutoff: IngestionCutoff::Safe,
             },
+            inventory_adapters: InventoryAdapters::default(),
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
             position_check_interval: 60,

--- a/src/cli/dividend.rs
+++ b/src/cli/dividend.rs
@@ -62,7 +62,7 @@ mod tests {
     use st0x_config::create_test_issuance_ctx;
     use st0x_config::{
         AssetsConfig, BrokerCtx, EquitiesConfig, EvmCtx, ExecutionThreshold, IngestionCutoff,
-        InventoryMode, LogLevel, TradingMode,
+        InventoryAdapters, InventoryMode, LogLevel, TradingMode,
     };
 
     use super::*;
@@ -86,6 +86,7 @@ mod tests {
                 required_confirmations: 0,
                 ingestion_cutoff: IngestionCutoff::Safe,
             },
+            inventory_adapters: InventoryAdapters::default(),
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
             position_check_interval: 60,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1913,7 +1913,7 @@ mod tests {
     use st0x_config::ExecutionThreshold;
     use st0x_config::create_test_issuance_ctx;
     use st0x_config::{AssetsConfig, BrokerCtx, EquitiesConfig, LogLevel, TradingMode};
-    use st0x_config::{EvmCtx, IngestionCutoff, InventoryMode};
+    use st0x_config::{EvmCtx, IngestionCutoff, InventoryAdapters, InventoryMode};
     use st0x_event_sorcery::StoreBuilder;
     use st0x_float_macro::float;
     use st0x_tokenization::IssuerRequestId;
@@ -1946,6 +1946,7 @@ mod tests {
                 required_confirmations: 0,
                 ingestion_cutoff: IngestionCutoff::Safe,
             },
+            inventory_adapters: InventoryAdapters::default(),
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
             position_check_interval: 60,
@@ -3593,6 +3594,7 @@ mod tests {
                 [raindex]
                 orderbook = "0x1111111111111111111111111111111111111111"
                 inventory_mode = "managed"
+                inventory_adapters = []
                 inventory = "0x2222222222222222222222222222222222222222"
                 vault_owner = "0x3333333333333333333333333333333333333333"
                 deployment_block = 1

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -1714,7 +1714,7 @@ mod tests {
         AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, LogLevel, OperationMode,
         TradingMode,
     };
-    use st0x_config::{EvmCtx, IngestionCutoff, InventoryMode};
+    use st0x_config::{EvmCtx, IngestionCutoff, InventoryAdapters, InventoryMode};
     use st0x_event_sorcery::LifecycleError;
     use st0x_execution::{
         AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, AlpacaTransferId,
@@ -2130,6 +2130,7 @@ mod tests {
                 required_confirmations: 0,
                 ingestion_cutoff: IngestionCutoff::Safe,
             },
+            inventory_adapters: InventoryAdapters::default(),
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
             position_check_interval: 60,
@@ -2201,6 +2202,7 @@ mod tests {
                 required_confirmations: 0,
                 ingestion_cutoff: IngestionCutoff::Safe,
             },
+            inventory_adapters: InventoryAdapters::default(),
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
             position_check_interval: 60,

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -32,7 +32,7 @@ use crate::offchain::order::{
 };
 use crate::onchain::accumulator::check_execution_readiness;
 use crate::onchain::pyth::PythFeedIds;
-use crate::onchain::trade::BotOperator;
+use crate::onchain::trade::{BotOperator, RecoveryActors};
 use crate::onchain::{OnChainError, OnchainTrade, TradeValidationError};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeId};
 use crate::position::{Position, PositionCommand};
@@ -442,10 +442,14 @@ pub(super) async fn process_tx_with_provider<W: Write, P: Provider + Clone + 'st
     let pyth_feed_ids = PythFeedIds::new(ctx.pyth_feed_ids());
     // Matches ClearV3/TakeOrderV3 fills to our Raindex orders -- owned by the
     // inventory contract post-migration, the bot EOA before it.
-    let order_owner = ctx.vault_owner();
-    // Filters the bot's own inventory rebalancing legs out of an
-    // InventoryTrade settlement recovery, same as the backfill path.
-    let bot_operator = BotOperator(ctx.order_owner());
+    let actors = RecoveryActors {
+        // Matches ClearV3/TakeOrderV3 fills to our Raindex orders -- owned by
+        // the inventory contract post-migration, the bot EOA before it.
+        order_owner: ctx.vault_owner(),
+        // Filters the bot's own inventory rebalancing legs out of an
+        // InventoryTrade settlement recovery, same as the backfill path.
+        bot_operator: BotOperator(ctx.order_owner()),
+    };
     let read_evm = ReadOnlyEvm::new(provider.clone());
 
     match OnchainTrade::try_from_tx_hash(
@@ -454,9 +458,9 @@ pub(super) async fn process_tx_with_provider<W: Write, P: Provider + Clone + 'st
         cache,
         evm_ctx,
         &ctx.assets,
+        &ctx.inventory_adapters,
         &pyth_feed_ids,
-        order_owner,
-        bot_operator,
+        actors,
     )
     .await
     {
@@ -1109,7 +1113,7 @@ mod tests {
     use st0x_config::create_test_issuance_ctx;
     use st0x_config::{
         AssetsConfig, BrokerCtx, EquitiesConfig, EquityAssetConfig, EvmCtx, ExecutionThreshold,
-        IngestionCutoff, InventoryMode, LogLevel, OperationMode, TradingMode,
+        IngestionCutoff, InventoryAdapters, InventoryMode, LogLevel, OperationMode, TradingMode,
     };
     use st0x_execution::{
         AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, CancellationOutcome,
@@ -1125,7 +1129,9 @@ mod tests {
     };
     use crate::offchain::order::{CancellationReason, PollOrderStatusJobQueue, noop_order_placer};
     use crate::onchain::trade::RaindexTradeEvent;
-    use crate::onchain_trade::{OnChainTrade as OnChainTradeCqrs, OnChainTradeCommand};
+    use crate::onchain_trade::{
+        InventoryVenue, OnChainTrade as OnChainTradeCqrs, OnChainTradeCommand, OnChainTradeSource,
+    };
     use crate::test_utils::{
         OnchainTradeBuilder, TEST_POLL_INTERVAL, get_test_order, positive_shares, setup_test_db,
         setup_test_pools,
@@ -1324,6 +1330,7 @@ mod tests {
                 required_confirmations: 0,
                 ingestion_cutoff: IngestionCutoff::Safe,
             },
+            inventory_adapters: InventoryAdapters::default(),
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
             position_check_interval: 60,
@@ -2155,7 +2162,11 @@ mod tests {
 
         let order_placer = create_order_placer(&ctx, &pool);
 
-        let onchain_trade = OnchainTradeBuilder::default().build();
+        let source = OnChainTradeSource::Inventory {
+            operator: Address::repeat_byte(0x8b),
+            venue: InventoryVenue::Bebop,
+        };
+        let onchain_trade = OnchainTradeBuilder::default().with_source(source).build();
         let block_timestamp = onchain_trade.block_timestamp.unwrap();
 
         let trade_id = OnChainTradeId {
@@ -2172,13 +2183,15 @@ mod tests {
         onchain_store
             .send(
                 &trade_id,
-                OnChainTradeCommand::Witness {
+                OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Legacy,
                     symbol: onchain_trade.symbol.base().clone(),
                     amount: onchain_trade.amount.inner(),
                     direction: onchain_trade.direction,
                     price_usdc: onchain_trade.price.value(),
                     block_number: 1,
                     block_timestamp,
+                    filled_at: block_timestamp,
                 },
             )
             .await
@@ -2241,6 +2254,26 @@ mod tests {
             order_count, 0,
             "re-running process-tx on an acknowledged fill must place no broker order"
         );
+
+        let repaired = onchain_store
+            .load(&trade_id)
+            .await
+            .unwrap()
+            .expect("the acknowledged legacy trade must still exist");
+        assert_eq!(
+            repaired.source, source,
+            "process-tx must append chain-backed venue attribution without re-accounting the fill"
+        );
+        let (attribution_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("OnChainTradeEvent::SourceAttributed")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            attribution_count, 1,
+            "source repair must append exactly one CQRS attribution event"
+        );
     }
 
     /// `process-tx` must resume the acknowledge step when the fill was witnessed
@@ -2272,6 +2305,7 @@ mod tests {
             .send(
                 &trade_id,
                 OnChainTradeCommand::Witness {
+                    source: onchain_trade.source,
                     symbol: onchain_trade.symbol.base().clone(),
                     amount: onchain_trade.amount.inner(),
                     direction: onchain_trade.direction,
@@ -2974,6 +3008,7 @@ mod tests {
             .send(
                 &trade_id,
                 OnChainTradeCommand::Witness {
+                    source: onchain_trade.source,
                     symbol: onchain_trade.symbol.base().clone(),
                     amount: onchain_trade.amount.inner(),
                     direction: onchain_trade.direction,
@@ -3070,6 +3105,7 @@ mod tests {
             .send(
                 &trade_id,
                 OnChainTradeCommand::Witness {
+                    source: onchain_trade.source,
                     symbol: onchain_trade.symbol.base().clone(),
                     amount: onchain_trade.amount.inner(),
                     direction: onchain_trade.direction,
@@ -3193,6 +3229,7 @@ mod tests {
             .send(
                 &trade_id_a,
                 OnChainTradeCommand::Witness {
+                    source: fill_a.source,
                     symbol: fill_a.symbol.base().clone(),
                     amount: fill_a.amount.inner(),
                     direction: fill_a.direction,
@@ -3222,6 +3259,7 @@ mod tests {
             .send(
                 &trade_id_b,
                 OnChainTradeCommand::Witness {
+                    source: fill_b.source,
                     symbol: fill_b.symbol.base().clone(),
                     amount: fill_b.amount.inner(),
                     direction: fill_b.direction,
@@ -3351,6 +3389,7 @@ mod tests {
             .send(
                 &trade_id_b,
                 OnChainTradeCommand::Witness {
+                    source: fill_b.source,
                     symbol: fill_b.symbol.base().clone(),
                     amount: fill_b.amount.inner(),
                     direction: fill_b.direction,

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -200,7 +200,7 @@ mod tests {
         AssetsConfig, BrokerCtx, CashAssetConfig, EquitiesConfig, LogLevel, OperationMode,
         TradingMode,
     };
-    use st0x_config::{EvmCtx, IngestionCutoff, InventoryMode};
+    use st0x_config::{EvmCtx, IngestionCutoff, InventoryAdapters, InventoryMode};
     use st0x_evm::IERC20::decimalsCall;
     use st0x_evm::ReadOnlyEvm;
     use st0x_finance::Usdc;
@@ -227,6 +227,7 @@ mod tests {
                 required_confirmations: 0,
                 ingestion_cutoff: IngestionCutoff::Safe,
             },
+            inventory_adapters: InventoryAdapters::default(),
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
             position_check_interval: 60,
@@ -274,6 +275,7 @@ mod tests {
                 required_confirmations: 0,
                 ingestion_cutoff: IngestionCutoff::Safe,
             },
+            inventory_adapters: InventoryAdapters::default(),
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
             position_check_interval: 60,

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -195,7 +195,7 @@ mod tests {
     use st0x_config::ExecutionThreshold;
     use st0x_config::create_test_issuance_ctx;
     use st0x_config::{AssetsConfig, BrokerCtx, Ctx, EquitiesConfig, LogLevel, TradingMode};
-    use st0x_config::{EvmCtx, IngestionCutoff, InventoryMode};
+    use st0x_config::{EvmCtx, IngestionCutoff, InventoryAdapters, InventoryMode};
     use st0x_execution::Symbol;
     use st0x_wrapper::MockWrapper;
 
@@ -223,6 +223,7 @@ mod tests {
                 required_confirmations: 0,
                 ingestion_cutoff: IngestionCutoff::Safe,
             },
+            inventory_adapters: InventoryAdapters::default(),
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
             position_check_interval: 60,

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -84,7 +84,10 @@ use crate::onchain::accumulator::{ExecutionCtx, check_execution_readiness};
 use crate::onchain::approvals::{build_approval_targets, grant_startup_approvals};
 use crate::onchain::backfill::BackfillJobQueue;
 use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vaults_from_clear};
-use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeError, OnChainTradeId};
+use crate::onchain_trade::{
+    OnChainTrade, OnChainTradeCommand, OnChainTradeError, OnChainTradeId, OnChainTradeSource,
+    SourceAttributionDecision,
+};
 use crate::performance::HedgeLatencyProjection;
 use crate::performance::equity_timing::EquityTimingProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
@@ -2880,6 +2883,7 @@ pub(crate) async fn execute_witness_trade(
     let price_usdc = trade.price.value();
 
     let command = OnChainTradeCommand::Witness {
+        source: trade.source,
         symbol: trade.symbol.base().clone(),
         amount,
         direction: trade.direction,
@@ -2909,6 +2913,39 @@ pub(crate) async fn execute_witness_trade(
                 "OnChainTrade::Witness rejected as duplicate: already filled"
             );
             Ok(false)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Appends source attribution reconstructed from chain. A concurrent repair is
+/// safe because both jobs derive the same source from the same transaction
+/// receipt.
+async fn execute_attribute_trade_source(
+    onchain_trade: &Store<OnChainTrade>,
+    trade_id: &OnChainTradeId,
+    source: OnChainTradeSource,
+) -> Result<(), SendError<OnChainTrade>> {
+    match onchain_trade
+        .send(trade_id, OnChainTradeCommand::AttributeSource { source })
+        .await
+    {
+        Ok(()) => {
+            info!(
+                ?trade_id,
+                ?source,
+                "Attributed onchain trade source from chain"
+            );
+            Ok(())
+        }
+        Err(AggregateError::UserError(LifecycleError::Apply(
+            OnChainTradeError::SourceAlreadyAttributed,
+        ))) => {
+            debug!(
+                ?trade_id,
+                "Onchain trade source was attributed concurrently"
+            );
+            Ok(())
         }
         Err(error) => Err(error),
     }
@@ -3150,20 +3187,29 @@ pub(crate) async fn account_for_onchain_fill(
     };
 
     match onchain_trade.load(&trade_id).await {
-        Ok(Some(state)) if state.is_acknowledged() => {
-            debug!(
-                ?trade_id,
-                symbol = %trade.symbol,
-                "Trade already processed (duplicate event), skipping"
-            );
-            // Self-heal a marker-without-settle leak (ADR 0010): a crash
-            // between MARK and SETTLE leaves the trade marked but still in
-            // the pending set. The marker is durable, so prune it now. A
-            // no-op when already pruned.
-            execute_settle_fill(position, trade).await?;
-            return Ok(FillAccountingOutcome::AlreadyAcknowledged);
-        }
         Ok(Some(state)) => {
+            match state.source.attribution_decision(trade.source) {
+                SourceAttributionDecision::Apply => {
+                    execute_attribute_trade_source(onchain_trade, &trade_id, trade.source).await?;
+                }
+                SourceAttributionDecision::AlreadyAttributed
+                | SourceAttributionDecision::InvalidLegacyMarker => {}
+            }
+
+            if state.is_acknowledged() {
+                debug!(
+                    ?trade_id,
+                    symbol = %trade.symbol,
+                    "Trade already processed (duplicate event), skipping"
+                );
+                // Self-heal a marker-without-settle leak (ADR 0010): a crash
+                // between MARK and SETTLE leaves the trade marked but still in
+                // the pending set. The marker is durable, so prune it now. A
+                // no-op when already pruned.
+                execute_settle_fill(position, trade).await?;
+                return Ok(FillAccountingOutcome::AlreadyAcknowledged);
+            }
+
             info!(
                 ?trade_id,
                 symbol = %trade.symbol,
@@ -4348,6 +4394,7 @@ mod tests {
             .send(
                 &id,
                 crate::onchain_trade::OnChainTradeCommand::Witness {
+                    source: OnChainTradeSource::Raindex,
                     symbol: Symbol::new("AAPL").unwrap(),
                     amount: float!(1),
                     direction: Direction::Buy,

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -5,10 +5,12 @@ use anyhow::Context;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
+use std::str::FromStr;
 use std::sync::Arc;
 #[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use task_supervisor::{SupervisedTask, TaskResult};
 #[cfg(test)]
@@ -17,8 +19,10 @@ use tokio::sync::{Mutex, broadcast, mpsc};
 use tokio::time::{Instant, interval, sleep_until};
 use tracing::{debug, info, warn};
 
-use st0x_dto::{Statement, Trade, TradeOutcome, TradingVenue};
-use st0x_event_sorcery::{EntityList, Reactor, SendError, deps, load_entity};
+use st0x_dto::{Statement, Trade, TradeOutcome};
+use st0x_event_sorcery::{
+    AggregateError, EntityList, Reactor, SendError, deps, is_retryable_sqlite_busy, load_entity,
+};
 use st0x_finance::{FractionalShares, NotPositive, Positive};
 
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
@@ -26,7 +30,9 @@ use crate::equity_redemption::EquityRedemption;
 use crate::offchain::order::{
     OffchainOrder, OffchainOrderEvent, OffchainOrderId, TradeConversionError,
 };
-use crate::onchain_trade::{OnChainTrade, OnChainTradeEvent};
+use crate::onchain_trade::{
+    OnChainTrade, OnChainTradeEvent, OnChainTradeId, ParseOnChainTradeIdError,
+};
 use crate::position::{Position, PositionEvent};
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::usdc_rebalance::UsdcRebalance;
@@ -51,6 +57,50 @@ const HANDOFF_RETRY_MAX_ATTEMPTS: usize = 3;
 const HANDOFF_RETRY_QUEUE_CAPACITY: usize = 64;
 const HANDOFF_RECONCILIATION_INTERVAL: Duration = Duration::from_secs(30);
 
+#[derive(Clone, Default)]
+struct OnchainRevisionReloadFault {
+    #[cfg(test)]
+    failures_remaining: Arc<AtomicUsize>,
+    #[cfg(not(test))]
+    never_fail: bool,
+}
+
+impl OnchainRevisionReloadFault {
+    #[cfg(test)]
+    fn should_fail(&self) -> bool {
+        consume_failure(&self.failures_remaining)
+    }
+
+    #[cfg(not(test))]
+    const fn should_fail(&self) -> bool {
+        self.never_fail
+    }
+
+    #[cfg(test)]
+    fn fail_next(&self, count: usize) {
+        self.failures_remaining.store(count, Ordering::SeqCst);
+    }
+}
+
+#[derive(Clone, Default)]
+struct OnchainRevisionTracker {
+    pending: Arc<Mutex<HashSet<OnChainTradeId>>>,
+}
+
+impl OnchainRevisionTracker {
+    async fn track(&self, id: OnChainTradeId) {
+        self.pending.lock().await.insert(id);
+    }
+
+    async fn resolve(&self, id: &OnChainTradeId) {
+        self.pending.lock().await.remove(id);
+    }
+
+    async fn pending(&self) -> Vec<OnChainTradeId> {
+        self.pending.lock().await.iter().cloned().collect()
+    }
+}
+
 /// Runtime dependencies shared by terminal-trade reactors and their worker.
 pub(crate) struct DashboardTradeDelivery {
     pub(crate) queue: DashboardTradeDeliveryJobQueue,
@@ -71,21 +121,36 @@ impl DashboardTradeDelivery {
         let queue = DashboardTradeDeliveryJobQueue::new(apalis_pool);
         let store = Arc::new(DashboardTradeDeliveryStore::new(pool.clone()));
         let enqueuer = Arc::new(DashboardTradeEnqueuer::new(queue.clone(), store.clone()));
+        let revision_reload_fault = OnchainRevisionReloadFault::default();
+        let revision_tracker = OnchainRevisionTracker::default();
+        let publish_lock = Arc::new(Mutex::new(()));
         #[cfg(test)]
         let test_store = store.clone();
         let (handoff_retry_sender, handoff_retry_receiver) =
             mpsc::channel(HANDOFF_RETRY_QUEUE_CAPACITY);
-        let ctx = Arc::new(DashboardTradeDeliveryCtx::with_store(sender.clone(), store));
+        let ctx = Arc::new(DashboardTradeDeliveryCtx::with_store(
+            sender.clone(),
+            store,
+            pool.clone(),
+            publish_lock.clone(),
+        ));
         let broadcaster = Arc::new(Broadcaster::new(
-            sender,
+            sender.clone(),
             pool.clone(),
             enqueuer.clone(),
             handoff_retry_sender,
+            revision_reload_fault.clone(),
+            revision_tracker.clone(),
+            publish_lock.clone(),
         ));
         let handoff_monitor = DashboardTradeHandoffMonitor::new(
             handoff_retry_receiver,
             enqueuer.clone(),
             pool.clone(),
+            sender,
+            revision_reload_fault,
+            revision_tracker,
+            publish_lock,
         );
 
         Self {
@@ -141,6 +206,10 @@ impl DashboardTradeDelivery {
                 "Reconciled durable dashboard trade deliveries",
             );
         }
+
+        self.handoff_monitor
+            .skip_first_terminal_reconciliation
+            .store(true, Ordering::SeqCst);
 
         Ok(undelivered)
     }
@@ -224,6 +293,7 @@ impl DashboardTradeEnqueuer {
 pub(crate) enum DashboardTradeHandoff {
     Trade(Box<Trade>),
     ReloadOffchainOrder(OffchainOrderId),
+    ReloadOnchainTradeRevision(OnChainTradeId),
 }
 
 struct ScheduledDashboardTradeHandoff {
@@ -254,14 +324,65 @@ impl ScheduledDashboardTradeHandoff {
     }
 }
 
+struct LoadedOnchainTrade {
+    trade: Trade,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum OnchainTradeReplayError {
+    #[error("failed to replay onchain trade {id}: {source}")]
+    Replay {
+        id: OnChainTradeId,
+        #[source]
+        source: Box<SendError<OnChainTrade>>,
+    },
+    #[error("onchain trade {id} cannot be represented: {source}")]
+    Conversion {
+        id: OnChainTradeId,
+        #[source]
+        source: NotPositive<FractionalShares>,
+    },
+}
+
+async fn load_authoritative_onchain_trade(
+    pool: &SqlitePool,
+    id: &OnChainTradeId,
+) -> Result<Option<LoadedOnchainTrade>, OnchainTradeReplayError> {
+    let Some(entity) = load_entity::<OnChainTrade>(pool, id)
+        .await
+        .map_err(|source| OnchainTradeReplayError::Replay {
+            id: id.clone(),
+            source: Box::new(source),
+        })?
+    else {
+        return Ok(None);
+    };
+    let trade =
+        entity
+            .try_into_trade(id)
+            .map_err(|source| OnchainTradeReplayError::Conversion {
+                id: id.clone(),
+                source,
+            })?;
+
+    Ok(Some(LoadedOnchainTrade { trade }))
+}
+
 #[derive(Clone)]
 pub(crate) struct DashboardTradeHandoffMonitor {
     receiver: Arc<Mutex<mpsc::Receiver<DashboardTradeHandoff>>>,
     enqueuer: Arc<DashboardTradeEnqueuer>,
     pool: SqlitePool,
+    sender: broadcast::Sender<Statement>,
+    revision_reload_fault: OnchainRevisionReloadFault,
+    revision_tracker: OnchainRevisionTracker,
+    publish_lock: Arc<Mutex<()>>,
+    skip_first_terminal_reconciliation: Arc<AtomicBool>,
     reconciliation_interval: Duration,
     #[cfg(test)]
     exhaustion_notify: Arc<Notify>,
+    #[cfg(test)]
+    startup_notify: Arc<Notify>,
 }
 
 impl DashboardTradeHandoffMonitor {
@@ -269,14 +390,25 @@ impl DashboardTradeHandoffMonitor {
         receiver: mpsc::Receiver<DashboardTradeHandoff>,
         enqueuer: Arc<DashboardTradeEnqueuer>,
         pool: SqlitePool,
+        sender: broadcast::Sender<Statement>,
+        revision_reload_fault: OnchainRevisionReloadFault,
+        revision_tracker: OnchainRevisionTracker,
+        publish_lock: Arc<Mutex<()>>,
     ) -> Self {
         Self {
             receiver: Arc::new(Mutex::new(receiver)),
             enqueuer,
             pool,
+            sender,
+            revision_reload_fault,
+            revision_tracker,
+            publish_lock,
+            skip_first_terminal_reconciliation: Arc::new(AtomicBool::new(false)),
             reconciliation_interval: HANDOFF_RECONCILIATION_INTERVAL,
             #[cfg(test)]
             exhaustion_notify: Arc::new(Notify::new()),
+            #[cfg(test)]
+            startup_notify: Arc::new(Notify::new()),
         }
     }
 
@@ -291,6 +423,11 @@ impl DashboardTradeHandoffMonitor {
         self.exhaustion_notify.clone()
     }
 
+    #[cfg(test)]
+    fn startup_notification(&self) -> Arc<Notify> {
+        self.startup_notify.clone()
+    }
+
     async fn receive(&self) -> Option<DashboardTradeHandoff> {
         self.receiver.lock().await.recv().await
     }
@@ -299,8 +436,10 @@ impl DashboardTradeHandoffMonitor {
         &self,
         handoff: &DashboardTradeHandoff,
     ) -> Result<(), DashboardTradeHandoffAttemptError> {
-        let trade = match handoff {
-            DashboardTradeHandoff::Trade(trade) => trade.as_ref().clone(),
+        match handoff {
+            DashboardTradeHandoff::Trade(trade) => {
+                self.enqueuer.enqueue(trade.as_ref().clone()).await?;
+            }
             DashboardTradeHandoff::ReloadOffchainOrder(id) => {
                 let order = load_entity::<OffchainOrder>(&self.pool, id)
                     .await
@@ -310,13 +449,54 @@ impl DashboardTradeHandoffMonitor {
                     })?
                     .ok_or(DashboardTradeHandoffAttemptError::Missing { id: *id })?;
 
-                order.try_into_trade(id).map_err(|source| {
+                let trade = order.try_into_trade(id).map_err(|source| {
                     DashboardTradeHandoffAttemptError::Conversion { id: *id, source }
-                })?
-            }
-        };
+                })?;
 
-        self.enqueuer.enqueue(trade).await?;
+                self.enqueuer.enqueue(trade).await?;
+            }
+            DashboardTradeHandoff::ReloadOnchainTradeRevision(id) => {
+                self.revision_tracker.track(id.clone()).await;
+                self.broadcast_onchain_trade_revision(id).await?;
+                self.revision_tracker.resolve(id).await;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn broadcast_onchain_trade_revision(
+        &self,
+        id: &OnChainTradeId,
+    ) -> Result<(), DashboardTradeHandoffAttemptError> {
+        if self.revision_reload_fault.should_fail() {
+            #[cfg(test)]
+            return Err(DashboardTradeHandoffAttemptError::InjectedOnchainReplay {
+                id: id.clone(),
+            });
+        }
+
+        let _publish_guard = self.publish_lock.lock().await;
+        let Some(loaded) = load_authoritative_onchain_trade(&self.pool, id)
+            .await
+            .map_err(|source| DashboardTradeHandoffAttemptError::Onchain(Box::new(source)))?
+        else {
+            warn!(
+                target: "dashboard",
+                %id,
+                "Source-attributed onchain trade replayed to empty state"
+            );
+            return Ok(());
+        };
+        if let Err(error) = self.sender.send(Statement::TradeUpdate(loaded.trade)) {
+            debug!(
+                target: "dashboard",
+                %id,
+                %error,
+                "No dashboard receivers for corrected onchain trade"
+            );
+        }
+
         Ok(())
     }
 
@@ -338,6 +518,12 @@ impl DashboardTradeHandoffMonitor {
             if error.is_retryable() {
                 if scheduled.attempt < HANDOFF_RETRY_MAX_ATTEMPTS {
                     pending.push_back(scheduled.reschedule());
+                } else if let DashboardTradeHandoff::ReloadOnchainTradeRevision(id) =
+                    &scheduled.handoff
+                {
+                    return Err(DashboardTradeHandoffMonitorError::RevisionRetryExhausted {
+                        id: id.clone(),
+                    });
                 } else {
                     exhausted = true;
                     #[cfg(test)]
@@ -351,7 +537,7 @@ impl DashboardTradeHandoffMonitor {
                 }
             } else {
                 return Err(DashboardTradeHandoffMonitorError::DeterministicConversion(
-                    error,
+                    Box::new(error),
                 ));
             }
         }
@@ -388,11 +574,38 @@ impl DashboardTradeHandoffMonitor {
             ),
         }
     }
+
+    async fn reconcile_pending_onchain_revisions(
+        &self,
+    ) -> Result<(), DashboardTradeHandoffMonitorError> {
+        for id in self.revision_tracker.pending().await {
+            self.broadcast_onchain_trade_revision(&id)
+                .await
+                .map_err(|source| {
+                    DashboardTradeHandoffMonitorError::RevisionReconciliation(Box::new(source))
+                })?;
+            self.revision_tracker.resolve(&id).await;
+        }
+
+        Ok(())
+    }
 }
 
 impl SupervisedTask for DashboardTradeHandoffMonitor {
     async fn run(&mut self) -> TaskResult {
         info!(target: "dashboard", "Dashboard trade handoff monitor started");
+        if !self
+            .skip_first_terminal_reconciliation
+            .swap(false, Ordering::SeqCst)
+        {
+            self.enqueuer
+                .reconcile_undelivered()
+                .await
+                .map_err(DashboardTradeHandoffMonitorError::TerminalReconciliation)?;
+        }
+        self.reconcile_pending_onchain_revisions().await?;
+        #[cfg(test)]
+        self.startup_notify.notify_one();
         let mut pending = VecDeque::with_capacity(HANDOFF_RETRY_QUEUE_CAPACITY);
         let mut reconciliation = interval(self.reconciliation_interval);
         reconciliation.tick().await;
@@ -432,7 +645,13 @@ enum DashboardTradeHandoffMonitorError {
     #[error("dashboard trade handoff retry queue closed unexpectedly")]
     QueueClosed,
     #[error("dashboard trade cannot be represented for durable delivery: {0}")]
-    DeterministicConversion(#[source] DashboardTradeHandoffAttemptError),
+    DeterministicConversion(#[source] Box<DashboardTradeHandoffAttemptError>),
+    #[error("source-attribution broadcast retries exhausted for onchain trade {id}")]
+    RevisionRetryExhausted { id: OnChainTradeId },
+    #[error("failed to reconcile terminal dashboard trade deliveries: {0}")]
+    TerminalReconciliation(#[source] anyhow::Error),
+    #[error("failed to reconcile a source-attributed onchain trade broadcast: {0}")]
+    RevisionReconciliation(#[source] Box<DashboardTradeHandoffAttemptError>),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -445,6 +664,11 @@ enum DashboardTradeHandoffAttemptError {
         #[source]
         source: SendError<OffchainOrder>,
     },
+    #[error("failed to load source-attributed onchain trade: {0}")]
+    Onchain(#[source] Box<OnchainTradeReplayError>),
+    #[cfg(test)]
+    #[error("injected source-attributed onchain trade replay failure for {id}")]
+    InjectedOnchainReplay { id: OnChainTradeId },
     #[error("terminal offchain order {id} replayed to empty state")]
     Missing { id: OffchainOrderId },
     #[error("terminal offchain order {id} cannot be represented for delivery: {source}")]
@@ -459,6 +683,20 @@ impl DashboardTradeHandoffAttemptError {
     fn is_retryable(&self) -> bool {
         match self {
             Self::Persistence(_) | Self::Replay { .. } | Self::Missing { .. } => true,
+            Self::Onchain(source) => match source.as_ref() {
+                OnchainTradeReplayError::Replay { source, .. } => match source.as_ref() {
+                    AggregateError::DatabaseConnectionError(inner) => {
+                        is_retryable_onchain_replay_database_error(inner.as_ref())
+                    }
+                    AggregateError::UserError(_)
+                    | AggregateError::AggregateConflict
+                    | AggregateError::DeserializationError(_)
+                    | AggregateError::UnexpectedError(_) => false,
+                },
+                OnchainTradeReplayError::Conversion { .. } => false,
+            },
+            #[cfg(test)]
+            Self::InjectedOnchainReplay { .. } => true,
             // Exhaustive: a new conversion failure must force a deliberate
             // retry-or-fail-stop decision here. A catch-all would silently
             // classify it as fail-stop, which terminates the monitor.
@@ -476,6 +714,27 @@ impl DashboardTradeHandoffAttemptError {
             },
         }
     }
+}
+
+fn is_retryable_onchain_replay_database_error(error: &(dyn std::error::Error + 'static)) -> bool {
+    if is_retryable_sqlite_busy(error) {
+        return true;
+    }
+
+    let mut current = Some(error);
+    while let Some(source) = current {
+        if let Some(sqlx_error) = source.downcast_ref::<sqlx::Error>()
+            && matches!(
+                sqlx_error,
+                sqlx::Error::Io(_) | sqlx::Error::PoolTimedOut | sqlx::Error::WorkerCrashed
+            )
+        {
+            return true;
+        }
+        current = source.source();
+    }
+
+    false
 }
 
 /// Persistent delivery job for one terminal dashboard trade outcome.
@@ -580,19 +839,33 @@ fn consume_failure(failures_remaining: &AtomicUsize) -> bool {
 pub(crate) struct DashboardTradeDeliveryCtx {
     sender: broadcast::Sender<Statement>,
     store: Arc<DashboardTradeDeliveryStore>,
+    pool: SqlitePool,
+    publish_lock: Arc<Mutex<()>>,
 }
 
 impl DashboardTradeDeliveryCtx {
     #[cfg(test)]
     pub(crate) fn new(sender: broadcast::Sender<Statement>, pool: SqlitePool) -> Self {
-        Self::with_store(sender, Arc::new(DashboardTradeDeliveryStore::new(pool)))
+        Self::with_store(
+            sender,
+            Arc::new(DashboardTradeDeliveryStore::new(pool.clone())),
+            pool,
+            Arc::new(Mutex::new(())),
+        )
     }
 
     fn with_store(
         sender: broadcast::Sender<Statement>,
         store: Arc<DashboardTradeDeliveryStore>,
+        pool: SqlitePool,
+        publish_lock: Arc<Mutex<()>>,
     ) -> Self {
-        Self { sender, store }
+        Self {
+            sender,
+            store,
+            pool,
+            publish_lock,
+        }
     }
 
     #[cfg(test)]
@@ -612,6 +885,23 @@ impl DashboardTradeDeliveryCtx {
             debug!(target: "dashboard", %error, "No dashboard receivers for legacy trade fill");
         }
     }
+
+    async fn authoritative_trade(
+        &self,
+        trade: &Trade,
+    ) -> Result<Trade, DashboardTradeDeliveryError> {
+        if !trade.venue.is_onchain() {
+            return Ok(trade.clone());
+        }
+
+        let id = OnChainTradeId::from_str(&trade.id)?;
+        let loaded = load_authoritative_onchain_trade(&self.pool, &id)
+            .await
+            .map_err(|source| DashboardTradeDeliveryError::Onchain(Box::new(source)))?
+            .ok_or_else(|| DashboardTradeDeliveryError::OnchainMissing { id: id.clone() })?;
+
+        Ok(loaded.trade)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -620,6 +910,12 @@ pub(crate) enum DashboardTradeDeliveryError {
     Database(#[from] sqlx::Error),
     #[error("dashboard trade delivery record is missing for {trade_id}")]
     MissingRecord { trade_id: String },
+    #[error("invalid onchain dashboard trade ID: {0}")]
+    OnchainId(#[from] ParseOnChainTradeIdError),
+    #[error("failed to load authoritative onchain dashboard trade: {0}")]
+    Onchain(#[source] Box<OnchainTradeReplayError>),
+    #[error("onchain dashboard trade {id} replayed to empty state")]
+    OnchainMissing { id: OnChainTradeId },
     #[cfg(test)]
     #[error("injected dashboard trade delivery failure")]
     Injected,
@@ -642,6 +938,7 @@ impl Job<DashboardTradeDeliveryCtx> for DeliverDashboardTrade {
     }
 
     async fn perform(&self, ctx: &DashboardTradeDeliveryCtx) -> Result<Self::Output, Self::Error> {
+        let _publish_guard = ctx.publish_lock.lock().await;
         if ctx.store.is_delivered(&self.trade.id).await? {
             debug!(
                 target: "dashboard",
@@ -651,7 +948,7 @@ impl Job<DashboardTradeDeliveryCtx> for DeliverDashboardTrade {
             return Ok(());
         }
 
-        ctx.publish(self.trade.clone());
+        ctx.publish(ctx.authoritative_trade(&self.trade).await?);
         ctx.store.mark_delivered(&self.trade.id).await
     }
 }
@@ -663,6 +960,9 @@ pub(crate) struct Broadcaster {
     pool: SqlitePool,
     trade_enqueuer: Arc<DashboardTradeEnqueuer>,
     handoff_retry_sender: mpsc::Sender<DashboardTradeHandoff>,
+    revision_reload_fault: OnchainRevisionReloadFault,
+    revision_tracker: OnchainRevisionTracker,
+    publish_lock: Arc<Mutex<()>>,
 }
 
 impl Broadcaster {
@@ -671,13 +971,24 @@ impl Broadcaster {
         pool: SqlitePool,
         trade_enqueuer: Arc<DashboardTradeEnqueuer>,
         handoff_retry_sender: mpsc::Sender<DashboardTradeHandoff>,
+        revision_reload_fault: OnchainRevisionReloadFault,
+        revision_tracker: OnchainRevisionTracker,
+        publish_lock: Arc<Mutex<()>>,
     ) -> Self {
         Self {
             sender,
             pool,
             trade_enqueuer,
             handoff_retry_sender,
+            revision_reload_fault,
+            revision_tracker,
+            publish_lock,
         }
+    }
+
+    #[cfg(test)]
+    fn fail_next_onchain_revision_load(&self, count: usize) {
+        self.revision_reload_fault.fail_next(count);
     }
 
     async fn enqueue_trade(&self, trade: Trade) -> Result<(), DashboardTradeEnqueueError> {
@@ -727,6 +1038,77 @@ impl Broadcaster {
         Ok(())
     }
 
+    async fn broadcast_onchain_trade_revision(
+        &self,
+        id: OnChainTradeId,
+    ) -> Result<(), DashboardTradeEnqueueError> {
+        let replay = {
+            let _publish_guard = self.publish_lock.lock().await;
+            if self.revision_reload_fault.should_fail() {
+                None
+            } else {
+                Some(
+                    match load_authoritative_onchain_trade(&self.pool, &id).await {
+                        Ok(Some(loaded)) => {
+                            if let Err(error) =
+                                self.sender.send(Statement::TradeUpdate(loaded.trade))
+                            {
+                                debug!(
+                                    target: "dashboard",
+                                    %id,
+                                    %error,
+                                    "No dashboard receivers for corrected onchain trade"
+                                );
+                            }
+                            Ok(())
+                        }
+                        Ok(None) => {
+                            warn!(
+                                target: "dashboard",
+                                %id,
+                                "Source-attributed onchain trade replayed to empty state"
+                            );
+                            Ok(())
+                        }
+                        Err(error) => Err(error),
+                    },
+                )
+            }
+        };
+
+        match replay {
+            Some(Ok(())) => self.revision_tracker.resolve(&id).await,
+            Some(Err(OnchainTradeReplayError::Replay { source, .. })) => {
+                warn!(
+                    target: "dashboard",
+                    %id,
+                    ?source,
+                    "Failed to replay source-attributed onchain trade; queued for broadcast retry"
+                );
+                self.queue_onchain_trade_revision(id).await?;
+            }
+            Some(Err(OnchainTradeReplayError::Conversion { source, .. })) => {
+                return Err(DashboardTradeEnqueueError::Quantity(source));
+            }
+            None => {
+                self.queue_onchain_trade_revision(id).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn queue_onchain_trade_revision(
+        &self,
+        id: OnChainTradeId,
+    ) -> Result<(), DashboardTradeEnqueueError> {
+        self.revision_tracker.track(id.clone()).await;
+        self.handoff_retry_sender
+            .send(DashboardTradeHandoff::ReloadOnchainTradeRevision(id))
+            .await?;
+        Ok(())
+    }
+
     fn broadcast_position(&self, position: st0x_dto::Position) {
         if let Err(error) = self.sender.send(Statement::PositionUpdate(position)) {
             debug!(target: "dashboard", %error, "Failed to broadcast position update (no receivers)");
@@ -770,24 +1152,31 @@ impl Reactor for Broadcaster {
     ) -> Result<(), Self::Error> {
         event
             .on(|id, event| async move {
-                if let OnChainTradeEvent::Filled {
-                    symbol,
-                    amount,
-                    direction,
-                    block_timestamp,
-                    ..
-                } = event
-                {
-                    self.enqueue_trade(Trade {
-                        id: id.to_string(),
-                        occurred_at: block_timestamp,
-                        venue: TradingVenue::Raindex,
-                        direction,
+                match event {
+                    OnChainTradeEvent::Filled {
+                        source,
                         symbol,
-                        shares: Positive::new(FractionalShares::new(amount))?,
-                        outcome: TradeOutcome::Filled,
-                    })
-                    .await?;
+                        amount,
+                        direction,
+                        block_timestamp,
+                        ..
+                    } => {
+                        self.enqueue_trade(Trade {
+                            id: id.to_string(),
+                            occurred_at: block_timestamp,
+                            venue: source.trading_venue(),
+                            direction,
+                            symbol,
+                            shares: Positive::new(FractionalShares::new(amount))?,
+                            outcome: TradeOutcome::Filled,
+                        })
+                        .await?;
+                    }
+                    OnChainTradeEvent::SourceAttributed { .. } => {
+                        self.broadcast_onchain_trade_revision(id).await?;
+                    }
+                    OnChainTradeEvent::Enriched { .. }
+                    | OnChainTradeEvent::Acknowledged { .. } => {}
                 }
 
                 Ok(())
@@ -868,10 +1257,13 @@ impl Reactor for Broadcaster {
 #[cfg(test)]
 mod tests {
     use apalis::prelude::Monitor;
+    use std::borrow::Cow;
+    use std::fmt::{Display, Formatter};
     use std::sync::Arc;
     use std::time::Duration;
 
-    use st0x_event_sorcery::{ReactorHarness, StoreBuilder};
+    use st0x_dto::TradingVenue;
+    use st0x_event_sorcery::{LifecycleError, ReactorHarness, StoreBuilder};
     use st0x_execution::Symbol;
 
     use super::*;
@@ -880,8 +1272,60 @@ mod tests {
     };
     use crate::dashboard::trade_loader::load_trades;
     use crate::offchain::order::{OffchainOrderCommand, OffchainOrderEvent};
+    use crate::onchain_trade::{
+        InventoryVenue, OnChainTradeCommand, OnChainTradeError, OnChainTradeSource,
+    };
     use crate::position::{PositionCommand, PositionEvent, TradeId};
     use crate::test_utils::setup_test_pools;
+
+    #[derive(Debug)]
+    struct TestDatabaseError {
+        code: &'static str,
+    }
+
+    impl Display for TestDatabaseError {
+        fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("test database error")
+        }
+    }
+
+    impl std::error::Error for TestDatabaseError {}
+
+    impl sqlx::error::DatabaseError for TestDatabaseError {
+        fn message(&self) -> &'static str {
+            "test database error"
+        }
+
+        fn code(&self) -> Option<Cow<'_, str>> {
+            Some(Cow::Borrowed(self.code))
+        }
+
+        fn as_error(&self) -> &(dyn std::error::Error + Send + Sync + 'static) {
+            self
+        }
+
+        fn as_error_mut(&mut self) -> &mut (dyn std::error::Error + Send + Sync + 'static) {
+            self
+        }
+
+        fn into_error(self: Box<Self>) -> Box<dyn std::error::Error + Send + Sync + 'static> {
+            self
+        }
+
+        fn kind(&self) -> sqlx::error::ErrorKind {
+            sqlx::error::ErrorKind::Other
+        }
+    }
+
+    fn onchain_replay_error(source: SendError<OnChainTrade>) -> DashboardTradeHandoffAttemptError {
+        DashboardTradeHandoffAttemptError::Onchain(Box::new(OnchainTradeReplayError::Replay {
+            id: OnChainTradeId {
+                tx_hash: alloy::primitives::TxHash::ZERO,
+                log_index: 0,
+            },
+            source: Box::new(source),
+        }))
+    }
 
     fn test_broadcaster(
         pool: &SqlitePool,
@@ -1089,6 +1533,7 @@ mod tests {
                     log_index: 0,
                 },
                 OnChainTradeEvent::Filled {
+                    source: OnChainTradeSource::Raindex,
                     symbol: Symbol::new("AAPL").unwrap(),
                     amount: st0x_float_macro::float!(10),
                     direction: st0x_execution::Direction::Buy,
@@ -1130,6 +1575,7 @@ mod tests {
                     log_index: 9,
                 },
                 OnChainTradeEvent::Filled {
+                    source: OnChainTradeSource::Raindex,
                     symbol: Symbol::new("AAPL").unwrap(),
                     amount: st0x_float_macro::float!(1),
                     direction: st0x_execution::Direction::Buy,
@@ -1404,6 +1850,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn saturated_revision_retry_queue_does_not_hold_the_publish_lock() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        for _ in 0..HANDOFF_RETRY_QUEUE_CAPACITY {
+            delivery
+                .broadcaster
+                .handoff_retry_sender
+                .send(DashboardTradeHandoff::ReloadOffchainOrder(
+                    OffchainOrderId::new(),
+                ))
+                .await
+                .unwrap();
+        }
+
+        let revision_id = OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 198,
+        };
+        delivery.broadcaster.fail_next_onchain_revision_load(1);
+        let broadcaster = delivery.broadcaster.clone();
+        let revision_id_for_retry = revision_id.clone();
+        let blocked_retry = tokio::spawn(async move {
+            broadcaster
+                .broadcast_onchain_trade_revision(revision_id_for_retry)
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if delivery
+                    .broadcaster
+                    .revision_tracker
+                    .pending()
+                    .await
+                    .contains(&revision_id)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the source revision retry must reach the saturated queue");
+        assert!(
+            !blocked_retry.is_finished(),
+            "the revision retry must still be blocked on queue capacity"
+        );
+
+        let trade = test_trade();
+        delivery.store.register(&trade.id).await.unwrap();
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            DeliverDashboardTrade::new(trade).perform(&delivery.ctx),
+        )
+        .await
+        .expect("a saturated revision retry must not block durable publication")
+        .unwrap();
+
+        blocked_retry.abort();
+    }
+
+    #[tokio::test]
     async fn startup_reconciliation_recovers_terminal_trade_without_job() {
         let (pool, apalis_pool) = setup_test_pools().await;
         let store = StoreBuilder::<OnChainTrade>::new(pool.clone())
@@ -1419,6 +1927,7 @@ mod tests {
             .send(
                 &id,
                 crate::onchain_trade::OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Raindex,
                     symbol: Symbol::new("AAPL").unwrap(),
                     amount: st0x_float_macro::float!(1),
                     direction: st0x_execution::Direction::Buy,
@@ -1461,6 +1970,7 @@ mod tests {
             .send(
                 &id,
                 crate::onchain_trade::OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Raindex,
                     symbol: Symbol::new("AAPL").unwrap(),
                     amount: st0x_float_macro::float!(1),
                     direction: st0x_execution::Direction::Buy,
@@ -1519,6 +2029,7 @@ mod tests {
             .send(
                 &id,
                 crate::onchain_trade::OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Raindex,
                     symbol: Symbol::new("AAPL").unwrap(),
                     amount: st0x_float_macro::float!(1),
                     direction: st0x_execution::Direction::Buy,
@@ -1749,7 +2260,11 @@ mod tests {
         let (pool, apalis_pool) = setup_test_pools().await;
         let (broadcaster, mut receiver, queue, delivery_ctx) =
             test_broadcaster(&pool, &apalis_pool);
-        let harness = ReactorHarness::new(broadcaster);
+        let store = StoreBuilder::<OnChainTrade>::new(pool)
+            .with(broadcaster)
+            .build(())
+            .await
+            .unwrap();
 
         let now = chrono::Utc::now();
         let ingested_at = now + chrono::Duration::seconds(1);
@@ -1758,10 +2273,11 @@ mod tests {
             log_index: 0,
         };
 
-        harness
-            .receive::<OnChainTrade>(
-                id,
-                OnChainTradeEvent::Filled {
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Raindex,
                     symbol: Symbol::new("AAPL").unwrap(),
                     amount: st0x_float_macro::float!(10),
                     direction: st0x_execution::Direction::Buy,
@@ -1796,6 +2312,461 @@ mod tests {
             serde_json::to_value(now).expect("timestamp should serialize")
         );
         assert!(legacy["data"].get("outcome").is_none());
+    }
+
+    #[tokio::test]
+    async fn bebop_inventory_fill_broadcasts_bebop_venue() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (broadcaster, mut receiver, queue, delivery_ctx) =
+            test_broadcaster(&pool, &apalis_pool);
+        let store = StoreBuilder::<OnChainTrade>::new(pool)
+            .with(broadcaster)
+            .build(())
+            .await
+            .unwrap();
+        let now = chrono::Utc::now();
+        let id = OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 194,
+        };
+
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Inventory {
+                        operator: alloy::primitives::address!(
+                            "0x8b8b6e0507c125934c6129563f48e48c66f86475"
+                        ),
+                        venue: InventoryVenue::Bebop,
+                    },
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: st0x_float_macro::float!(10),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+
+        perform_pending_delivery(&queue, &delivery_ctx).await;
+
+        let msg = receiver.recv().await.expect("should receive fill");
+        let Statement::TradeUpdate(trade) = msg else {
+            panic!("expected TradeUpdate message");
+        };
+        assert_eq!(trade.venue, TradingVenue::Bebop);
+    }
+
+    #[tokio::test]
+    async fn pending_onchain_delivery_cannot_overwrite_a_source_correction() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (broadcaster, mut receiver, queue, delivery_ctx) =
+            test_broadcaster(&pool, &apalis_pool);
+        let store = StoreBuilder::<OnChainTrade>::new(pool)
+            .with(broadcaster)
+            .build(())
+            .await
+            .unwrap();
+        let id = OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 195,
+        };
+        let now = chrono::Utc::now();
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Legacy,
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: st0x_float_macro::float!(10),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::AttributeSource {
+                    source: OnChainTradeSource::Inventory {
+                        operator: alloy::primitives::Address::repeat_byte(0x8b),
+                        venue: InventoryVenue::Bebop,
+                    },
+                },
+            )
+            .await
+            .unwrap();
+
+        perform_pending_delivery(&queue, &delivery_ctx).await;
+
+        let updates = std::iter::from_fn(|| receiver.try_recv().ok())
+            .filter_map(|statement| match statement {
+                Statement::TradeUpdate(trade) => Some(trade),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(updates.len(), 2);
+        assert!(
+            updates
+                .iter()
+                .all(|trade| trade.venue == TradingVenue::Bebop),
+            "the direct correction and delayed durable delivery must both use the authoritative venue"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_attribution_broadcasts_corrected_venue() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (broadcaster, mut receiver, queue, delivery_ctx) =
+            test_broadcaster(&pool, &apalis_pool);
+        let store = StoreBuilder::<OnChainTrade>::new(pool)
+            .with(broadcaster)
+            .build(())
+            .await
+            .unwrap();
+        let id = OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 194,
+        };
+        let now = chrono::Utc::now();
+
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Legacy,
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: st0x_float_macro::float!(10),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+        perform_pending_delivery(&queue, &delivery_ctx).await;
+        let _legacy_update = receiver.recv().await.unwrap();
+        let _legacy_fill = receiver.recv().await.unwrap();
+
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::AttributeSource {
+                    source: OnChainTradeSource::Inventory {
+                        operator: alloy::primitives::Address::repeat_byte(0x8b),
+                        venue: InventoryVenue::Bebop,
+                    },
+                },
+            )
+            .await
+            .unwrap();
+
+        let corrected = receiver.recv().await.expect("corrected trade update");
+        let Statement::TradeUpdate(trade) = corrected else {
+            panic!("expected corrected TradeUpdate");
+        };
+        assert_eq!(trade.id, id.to_string());
+        assert_eq!(trade.venue, TradingVenue::Bebop);
+    }
+
+    #[tokio::test]
+    async fn source_attribution_reload_failure_retries_corrected_broadcast() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let id = OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 195,
+        };
+        let now = chrono::Utc::now();
+        let source = OnChainTradeSource::Inventory {
+            operator: alloy::primitives::Address::repeat_byte(0x8b),
+            venue: InventoryVenue::Bebop,
+        };
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Legacy,
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: st0x_float_macro::float!(10),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(&id, OnChainTradeCommand::AttributeSource { source })
+            .await
+            .unwrap();
+
+        let (sender, mut receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        let broadcaster = delivery.broadcaster;
+        let harness = ReactorHarness::new(broadcaster.clone());
+        let mut handoff_monitor = delivery.handoff_monitor;
+        let started = handoff_monitor.startup_notification();
+        let monitor = tokio::spawn(async move { handoff_monitor.run().await });
+        tokio::time::timeout(Duration::from_secs(1), started.notified())
+            .await
+            .expect("the handoff monitor must finish startup reconciliation");
+        broadcaster.fail_next_onchain_revision_load(1);
+        harness
+            .receive::<OnChainTrade>(
+                id.clone(),
+                OnChainTradeEvent::SourceAttributed {
+                    source,
+                    attributed_at: now,
+                },
+            )
+            .await
+            .expect("the failed reload should be queued for retry");
+
+        let corrected = tokio::time::timeout(Duration::from_secs(2), receiver.recv())
+            .await
+            .expect("the corrected venue should be retried")
+            .unwrap();
+        let Statement::TradeUpdate(trade) = corrected else {
+            panic!("expected corrected TradeUpdate");
+        };
+        assert_eq!(trade.id, id.to_string());
+        assert_eq!(trade.venue, TradingVenue::Bebop);
+        monitor.abort();
+    }
+
+    #[tokio::test]
+    async fn source_attribution_reconciliation_runs_after_monitor_restart() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let id = OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 196,
+        };
+        let now = chrono::Utc::now();
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Legacy,
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: st0x_float_macro::float!(10),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::AttributeSource {
+                    source: OnChainTradeSource::Inventory {
+                        operator: alloy::primitives::Address::repeat_byte(0x8b),
+                        venue: InventoryVenue::Bebop,
+                    },
+                },
+            )
+            .await
+            .unwrap();
+
+        let (sender, mut receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        let broadcaster = delivery.broadcaster.clone();
+        let harness = ReactorHarness::new(broadcaster.clone());
+        let mut first_monitor = delivery.handoff_monitor.clone();
+        let started = first_monitor.startup_notification();
+        let first = tokio::spawn(async move { first_monitor.run().await });
+        tokio::time::timeout(Duration::from_secs(1), started.notified())
+            .await
+            .expect("the first monitor must finish startup reconciliation");
+        broadcaster.fail_next_onchain_revision_load(usize::MAX);
+        harness
+            .receive::<OnChainTrade>(
+                id.clone(),
+                OnChainTradeEvent::SourceAttributed {
+                    source: OnChainTradeSource::Inventory {
+                        operator: alloy::primitives::Address::repeat_byte(0x8b),
+                        venue: InventoryVenue::Bebop,
+                    },
+                    attributed_at: now,
+                },
+            )
+            .await
+            .expect("the failed revision must be retained for monitor restart");
+        let error = tokio::time::timeout(Duration::from_secs(5), first)
+            .await
+            .expect("the revision must exhaust its bounded retry budget")
+            .unwrap()
+            .unwrap_err();
+        assert!(matches!(
+            error.downcast_ref::<DashboardTradeHandoffMonitorError>(),
+            Some(DashboardTradeHandoffMonitorError::RevisionRetryExhausted { .. })
+        ));
+
+        broadcaster.fail_next_onchain_revision_load(0);
+        let mut restarted_monitor = delivery.handoff_monitor.clone();
+        let restarted = tokio::spawn(async move { restarted_monitor.run().await });
+        let restarted_update = tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("monitor restart must reconcile the retained source attribution")
+            .unwrap();
+        assert!(matches!(
+            restarted_update,
+            Statement::TradeUpdate(Trade {
+                venue: TradingVenue::Bebop,
+                ..
+            })
+        ));
+        restarted.abort();
+    }
+
+    #[tokio::test]
+    async fn revision_retry_exhaustion_recovers_a_dropped_terminal_handoff_after_restart() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (sender, _receiver) = broadcast::channel(16);
+        let delivery = DashboardTradeDelivery::new(&apalis_pool, &pool, sender);
+        let mut first_monitor = delivery.handoff_monitor.clone();
+        let started = first_monitor.startup_notification();
+        let first = tokio::spawn(async move { first_monitor.run().await });
+        tokio::time::timeout(Duration::from_secs(1), started.notified())
+            .await
+            .expect("the first monitor must finish startup reconciliation");
+
+        let store = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let id = OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 197,
+        };
+        let now = chrono::Utc::now();
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Raindex,
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: st0x_float_macro::float!(10),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+            )
+            .await
+            .unwrap();
+        let trade = load_entity::<OnChainTrade>(&pool, &id)
+            .await
+            .unwrap()
+            .unwrap()
+            .try_into_trade(&id)
+            .unwrap();
+
+        delivery
+            .broadcaster
+            .fail_next_onchain_revision_load(usize::MAX);
+        delivery.store.fail_next_registration(usize::MAX);
+        delivery
+            .broadcaster
+            .handoff_retry_sender
+            .send(DashboardTradeHandoff::ReloadOnchainTradeRevision(
+                id.clone(),
+            ))
+            .await
+            .unwrap();
+        delivery
+            .broadcaster
+            .handoff_retry_sender
+            .send(DashboardTradeHandoff::Trade(Box::new(trade)))
+            .await
+            .unwrap();
+
+        let error = tokio::time::timeout(Duration::from_secs(5), first)
+            .await
+            .expect("a poison revision must exhaust instead of filling the intake forever")
+            .unwrap()
+            .unwrap_err();
+        assert!(matches!(
+            error.downcast_ref::<DashboardTradeHandoffMonitorError>(),
+            Some(DashboardTradeHandoffMonitorError::RevisionRetryExhausted { .. })
+        ));
+
+        delivery.broadcaster.fail_next_onchain_revision_load(0);
+        delivery.store.fail_next_registration(0);
+        let mut restarted_monitor = delivery.handoff_monitor.clone();
+        let restarted = tokio::spawn(async move { restarted_monitor.run().await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let pending: i64 = sqlx_apalis::query_scalar(
+                    "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+                )
+                .bind(std::any::type_name::<DeliverDashboardTrade>())
+                .fetch_one(delivery.queue.pool())
+                .await
+                .unwrap();
+                if pending == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("startup reconciliation must recover the dropped terminal handoff");
+        restarted.abort();
+    }
+
+    #[test]
+    fn onchain_replay_retry_classification_matches_aggregate_error_variants() {
+        let busy = sqlx::Error::Database(Box::new(TestDatabaseError { code: "5" }));
+        assert!(
+            onchain_replay_error(AggregateError::DatabaseConnectionError(Box::new(busy)))
+                .is_retryable()
+        );
+        assert!(
+            onchain_replay_error(AggregateError::DatabaseConnectionError(Box::new(
+                sqlx::Error::PoolTimedOut,
+            )))
+            .is_retryable()
+        );
+
+        let deterministic = [
+            onchain_replay_error(AggregateError::UserError(LifecycleError::Apply(
+                OnChainTradeError::NotFilled,
+            ))),
+            onchain_replay_error(AggregateError::AggregateConflict),
+            onchain_replay_error(AggregateError::DeserializationError(Box::new(
+                std::io::Error::other("invalid persisted event"),
+            ))),
+            onchain_replay_error(AggregateError::UnexpectedError(Box::new(
+                std::io::Error::other("unexpected replay failure"),
+            ))),
+        ];
+
+        assert!(deterministic.iter().all(|error| !error.is_retryable()));
     }
 
     #[tokio::test]

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -28,6 +28,9 @@ pub(crate) use event::{
     Broadcaster, DashboardTradeDelivery, DashboardTradeDeliveryCtx, DashboardTradeDeliveryJobQueue,
     DashboardTradeHandoffMonitor, DeliverDashboardTrade,
 };
+pub(crate) use trade_loader::{
+    TradeHistoryError as DashboardTradeHistoryError, load_onchain_trades,
+};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -36,6 +39,7 @@ pub(crate) enum TradeProtocol {
     LegacyFills,
     TerminalOutcomesV1,
     TerminalOutcomesV2,
+    TerminalOutcomesV3,
 }
 
 impl TradeProtocol {
@@ -49,7 +53,7 @@ impl TradeProtocol {
                 TradeOutcome::Filled | TradeOutcome::Failed { .. } => true,
                 TradeOutcome::Cancelled { .. } => false,
             },
-            Self::TerminalOutcomesV2 => match trade.outcome {
+            Self::TerminalOutcomesV2 | Self::TerminalOutcomesV3 => match trade.outcome {
                 TradeOutcome::Filled
                 | TradeOutcome::Failed { .. }
                 | TradeOutcome::Cancelled { .. } => true,
@@ -67,15 +71,34 @@ impl TradeProtocol {
                 | Statement::InventorySnapshot(_)
                 | Statement::TransferUpdate(_) => true,
             },
-            Self::TerminalOutcomesV1 | Self::TerminalOutcomesV2 => match statement {
-                Statement::TradeFill(_) => false,
-                Statement::TradeUpdate(trade) => self.includes_trade(trade),
-                Statement::CurrentState(_)
-                | Statement::PositionUpdate(_)
-                | Statement::InventorySnapshot(_)
-                | Statement::TransferUpdate(_) => true,
-            },
+            Self::TerminalOutcomesV1 | Self::TerminalOutcomesV2 | Self::TerminalOutcomesV3 => {
+                match statement {
+                    Statement::TradeFill(_) => false,
+                    Statement::TradeUpdate(trade) => self.includes_trade(trade),
+                    Statement::CurrentState(_)
+                    | Statement::PositionUpdate(_)
+                    | Statement::InventorySnapshot(_)
+                    | Statement::TransferUpdate(_) => true,
+                }
+            }
         }
+    }
+
+    pub(crate) fn serialize_trade(
+        self,
+        trade: &Trade,
+    ) -> Result<serde_json::Value, serde_json::Error> {
+        let (mut wire, legacy_venue) = match self {
+            Self::LegacyFills | Self::TerminalOutcomesV2 => (serde_json::to_value(trade)?, true),
+            Self::TerminalOutcomesV1 => (serde_json::to_value(trade.terminal_outcomes_v1())?, true),
+            Self::TerminalOutcomesV3 => (serde_json::to_value(trade)?, false),
+        };
+
+        if legacy_venue {
+            wire["venue"] = serde_json::to_value(trade.venue.legacy_compatible())?;
+        }
+
+        Ok(wire)
     }
 }
 
@@ -104,11 +127,15 @@ fn serialize_statement(
     statement: &Statement,
     trade_protocol: TradeProtocol,
 ) -> Result<String, serde_json::Error> {
-    match trade_protocol {
-        TradeProtocol::LegacyFills | TradeProtocol::TerminalOutcomesV2 => {
-            return serde_json::to_string(statement);
-        }
-        TradeProtocol::TerminalOutcomesV1 => {}
+    if trade_protocol == TradeProtocol::TerminalOutcomesV3
+        || matches!(
+            statement,
+            Statement::PositionUpdate(_)
+                | Statement::InventorySnapshot(_)
+                | Statement::TransferUpdate(_)
+        )
+    {
+        return serde_json::to_string(statement);
     }
 
     let mut wire = serde_json::to_value(statement)?;
@@ -118,12 +145,15 @@ fn serialize_statement(
                 state
                     .trades
                     .iter()
-                    .map(|trade| serde_json::to_value(trade.terminal_outcomes_v1()))
+                    .map(|trade| trade_protocol.serialize_trade(trade))
                     .collect::<Result<Vec<_>, _>>()?,
             );
         }
         Statement::TradeUpdate(trade) => {
-            wire["data"] = serde_json::to_value(trade.terminal_outcomes_v1())?;
+            wire["data"] = trade_protocol.serialize_trade(trade)?;
+        }
+        Statement::TradeFill(trade) if trade_protocol != TradeProtocol::TerminalOutcomesV3 => {
+            wire["data"]["venue"] = serde_json::to_value(trade.venue.legacy_compatible())?;
         }
         Statement::TradeFill(_)
         | Statement::PositionUpdate(_)
@@ -481,10 +511,12 @@ mod tests {
         assert!(!TradeProtocol::TerminalOutcomesV1.includes_statement(&legacy_fill));
         assert!(TradeProtocol::TerminalOutcomesV2.includes_statement(&trade_update));
         assert!(!TradeProtocol::TerminalOutcomesV2.includes_statement(&legacy_fill));
+        assert!(TradeProtocol::TerminalOutcomesV3.includes_statement(&trade_update));
+        assert!(!TradeProtocol::TerminalOutcomesV3.includes_statement(&legacy_fill));
     }
 
     #[test]
-    fn cancelled_outcomes_are_v2_only() {
+    fn cancelled_outcomes_require_v2_or_newer() {
         let trade = Trade {
             id: "cancelled-order".to_string(),
             occurred_at: chrono::Utc::now(),
@@ -510,9 +542,50 @@ mod tests {
         assert!(!TradeProtocol::LegacyFills.includes_trade(&trade));
         assert!(!TradeProtocol::TerminalOutcomesV1.includes_trade(&trade));
         assert!(TradeProtocol::TerminalOutcomesV2.includes_trade(&trade));
+        assert!(TradeProtocol::TerminalOutcomesV3.includes_trade(&trade));
         assert!(!TradeProtocol::LegacyFills.includes_statement(&update));
         assert!(!TradeProtocol::TerminalOutcomesV1.includes_statement(&update));
         assert!(TradeProtocol::TerminalOutcomesV2.includes_statement(&update));
+        assert!(TradeProtocol::TerminalOutcomesV3.includes_statement(&update));
+    }
+
+    #[test]
+    fn adapter_venues_are_exposed_only_by_v3() {
+        let trade = Trade {
+            id: "0xadapter:1".to_string(),
+            occurred_at: chrono::Utc::now(),
+            venue: TradingVenue::Bebop,
+            direction: Direction::Buy,
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            outcome: TradeOutcome::Filled,
+        };
+
+        for protocol in [
+            TradeProtocol::LegacyFills,
+            TradeProtocol::TerminalOutcomesV1,
+            TradeProtocol::TerminalOutcomesV2,
+        ] {
+            let rest = protocol.serialize_trade(&trade).unwrap();
+            assert_eq!(rest["venue"], "raindex");
+
+            let websocket =
+                serialize_statement(&Statement::TradeUpdate(trade.clone()), protocol).unwrap();
+            let websocket: serde_json::Value = serde_json::from_str(&websocket).unwrap();
+            assert_eq!(websocket["data"]["venue"], "raindex");
+        }
+
+        let rest = TradeProtocol::TerminalOutcomesV3
+            .serialize_trade(&trade)
+            .unwrap();
+        assert_eq!(rest["venue"], "bebop");
+        let websocket = serialize_statement(
+            &Statement::TradeUpdate(trade),
+            TradeProtocol::TerminalOutcomesV3,
+        )
+        .unwrap();
+        let websocket: serde_json::Value = serde_json::from_str(&websocket).unwrap();
+        assert_eq!(websocket["data"]["venue"], "bebop");
     }
 
     fn empty_settings() -> st0x_dto::Settings {

--- a/src/dashboard/trade_loader.rs
+++ b/src/dashboard/trade_loader.rs
@@ -13,6 +13,14 @@ use crate::offchain::order::{OffchainOrder, TradeConversionError};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeId};
 
 const MAX_TRADES: usize = 100;
+const MAX_TRADE_REPLAY_CONCURRENCY: u32 = 8;
+const RESERVED_POOL_CONNECTIONS: u32 = 1;
+
+fn trade_replay_concurrency(max_connections: u32) -> usize {
+    max_connections
+        .saturating_sub(RESERVED_POOL_CONNECTIONS)
+        .clamp(1, MAX_TRADE_REPLAY_CONCURRENCY) as usize
+}
 
 /// Load recent terminal trades from both onchain and offchain sources.
 ///
@@ -49,13 +57,15 @@ pub(crate) async fn load_all_trades(pool: &SqlitePool) -> Result<Vec<Trade>, Tra
     Ok(trades)
 }
 
-async fn load_onchain_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHistoryError> {
+pub(crate) async fn load_onchain_trades(
+    pool: &SqlitePool,
+) -> Result<Vec<Trade>, TradeHistoryError> {
     let ids = load_all_ids::<OnChainTrade>(pool)
         .await
         .map_err(TradeHistoryError::OnchainIds)?;
 
     Ok(stream::iter(ids)
-        .filter_map(|id| async move {
+        .map(|id| async move {
             let entity = match load_entity::<OnChainTrade>(pool, &id).await {
                 Ok(Some(entity)) => entity,
                 Ok(None) => {
@@ -82,6 +92,10 @@ async fn load_onchain_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHisto
                 }
             }
         })
+        .buffer_unordered(trade_replay_concurrency(
+            pool.options().get_max_connections(),
+        ))
+        .filter_map(|trade| async move { trade })
         .collect()
         .await)
 }
@@ -92,7 +106,7 @@ async fn load_offchain_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHist
         .map_err(TradeHistoryError::OffchainIds)?;
 
     Ok(stream::iter(ids)
-        .filter_map(|id| async move {
+        .map(|id| async move {
             let order = match load_entity::<OffchainOrder>(pool, &id).await {
                 Ok(Some(order)) => order,
                 Ok(None) => {
@@ -128,6 +142,10 @@ async fn load_offchain_trades(pool: &SqlitePool) -> Result<Vec<Trade>, TradeHist
                 }
             }
         })
+        .buffer_unordered(trade_replay_concurrency(
+            pool.options().get_max_connections(),
+        ))
+        .filter_map(|trade| async move { trade })
         .collect()
         .await)
 }
@@ -182,8 +200,19 @@ mod tests {
 
     use super::*;
     use crate::offchain::order::{CancellationReason, OffchainOrderCommand, OffchainOrderId};
-    use crate::onchain_trade::{OnChainTradeCommand, OnChainTradeId};
+    use crate::onchain_trade::{
+        InventoryVenue, OnChainTradeCommand, OnChainTradeId, OnChainTradeSource,
+    };
     use crate::test_utils::setup_test_db;
+
+    #[test]
+    fn replay_concurrency_preserves_shared_pool_capacity() {
+        assert_eq!(trade_replay_concurrency(1), 1);
+        assert_eq!(trade_replay_concurrency(2), 1);
+        assert_eq!(trade_replay_concurrency(3), 2);
+        assert_eq!(trade_replay_concurrency(10), 8);
+        assert_eq!(trade_replay_concurrency(100), 8);
+    }
 
     async fn seed_cancelled_order(
         store: &st0x_event_sorcery::Store<OffchainOrder>,
@@ -282,6 +311,7 @@ mod tests {
             .send(
                 &id,
                 OnChainTradeCommand::Witness {
+                    source: OnChainTradeSource::Raindex,
                     symbol: Symbol::new("AAPL").unwrap(),
                     amount: float!(10),
                     direction: Direction::Buy,
@@ -300,6 +330,47 @@ mod tests {
         assert_eq!(trades[0].symbol, Symbol::new("AAPL").unwrap());
         assert!(matches!(trades[0].venue, st0x_dto::TradingVenue::Raindex));
         assert!(matches!(trades[0].direction, st0x_dto::Direction::Buy));
+    }
+
+    #[tokio::test]
+    async fn load_trades_attributes_bebop_inventory_fills() {
+        let pool = setup_test_db().await;
+        let id = OnChainTradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 194,
+        };
+        let store = st0x_event_sorcery::StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &id,
+                OnChainTradeCommand::Witness {
+                    source: OnChainTradeSource::Inventory {
+                        operator: alloy::primitives::address!(
+                            "0x8b8b6e0507c125934c6129563f48e48c66f86475"
+                        ),
+                        venue: InventoryVenue::Bebop,
+                    },
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    amount: float!(10),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_number: 12345,
+                    block_timestamp: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let trades = load_trades(&pool, TradeProtocol::TerminalOutcomesV2)
+            .await
+            .unwrap();
+
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].venue, TradingVenue::Bebop);
     }
 
     #[tokio::test]
@@ -391,6 +462,7 @@ mod tests {
             .send(
                 &older_id,
                 OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Raindex,
                     symbol: Symbol::new("AAPL").unwrap(),
                     amount: float!(10),
                     direction: Direction::Buy,
@@ -407,6 +479,7 @@ mod tests {
             .send(
                 &newer_id,
                 OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Raindex,
                     symbol: Symbol::new("TSLA").unwrap(),
                     amount: float!(5),
                     direction: Direction::Sell,
@@ -423,6 +496,7 @@ mod tests {
             .send(
                 &tied_id,
                 OnChainTradeCommand::WitnessAt {
+                    source: OnChainTradeSource::Raindex,
                     symbol: Symbol::new("NVDA").unwrap(),
                     amount: float!(3),
                     direction: Direction::Buy,
@@ -469,6 +543,7 @@ mod tests {
                 .send(
                     id,
                     OnChainTradeCommand::WitnessAt {
+                        source: OnChainTradeSource::Raindex,
                         symbol: Symbol::new(symbol).unwrap(),
                         amount: float!(1),
                         direction: Direction::Buy,
@@ -523,6 +598,7 @@ mod tests {
                 .send(
                     &id,
                     OnChainTradeCommand::Witness {
+                        source: OnChainTradeSource::Raindex,
                         symbol: Symbol::new("AAPL").unwrap(),
                         amount: float!(1),
                         direction: Direction::Buy,

--- a/src/onchain/trade.rs
+++ b/src/onchain/trade.rs
@@ -15,7 +15,7 @@ use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
-use st0x_config::{AssetsConfig, EvmCtx};
+use st0x_config::{AssetsConfig, EvmCtx, InventoryAdapterVenue, InventoryAdapters};
 use st0x_evm::{Evm, EvmError, IERC20, OpenChainErrorRegistry, USDC_BASE};
 use st0x_execution::{Direction, FractionalShares, HasZero, Symbol};
 use st0x_float_serde::format_float_with_fallback;
@@ -30,7 +30,7 @@ use crate::onchain::io::{
     InputToken, OutputToken, TokenizedSymbol, TradeDetails, Usdc, WrappedTokenizedShares,
 };
 use crate::onchain::pyth::PythFeedIds;
-use crate::onchain_trade::PythPrice;
+use crate::onchain_trade::{InventoryVenue, OnChainTradeSource, PythPrice};
 
 /// Onchain trade event feeding the hedge pipeline.
 ///
@@ -82,6 +82,14 @@ impl RaindexTradeEvent {
 /// `OutputToken` guard against in `io.rs`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct BotOperator(pub(crate) Address);
+
+/// Addresses that distinguish the bot's two roles while recovering a trade
+/// from a transaction receipt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RecoveryActors {
+    pub(crate) order_owner: Address,
+    pub(crate) bot_operator: BotOperator,
+}
 
 /// Information about a vault extracted from an order's IO specification.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -190,6 +198,7 @@ pub(crate) fn extract_owned_vaults(
 
 #[derive(Debug, Clone)]
 pub struct OnchainTrade {
+    pub(crate) source: OnChainTradeSource,
     pub(crate) tx_hash: TxHash,
     pub(crate) log_index: u64,
     pub(crate) symbol: TokenizedSymbol<WrappedTokenizedShares>,
@@ -425,6 +434,7 @@ impl OnchainTrade {
             pyth_feed_ids,
             trade_details,
             TradeMetadata {
+                source: OnChainTradeSource::Raindex,
                 tx_hash,
                 log_index,
                 gas_used,
@@ -456,6 +466,7 @@ impl OnchainTrade {
         cache: &SymbolCache,
         evm: &EvmImpl,
         assets: &AssetsConfig,
+        inventory_adapters: &InventoryAdapters,
         trade: &InventoryTrade,
         log: Log,
         pyth_feed_ids: &PythFeedIds,
@@ -535,6 +546,9 @@ impl OnchainTrade {
             pyth_feed_ids,
             trade_details,
             TradeMetadata {
+                // Pairing quarantines settlements whose deposit and withdrawal
+                // operators differ, so either side identifies the adapter.
+                source: inventory_trade_source(trade.deposit.operator, inventory_adapters),
                 tx_hash,
                 log_index,
                 gas_used,
@@ -559,9 +573,9 @@ impl OnchainTrade {
         cache: &SymbolCache,
         ctx: &EvmCtx,
         assets: &AssetsConfig,
+        inventory_adapters: &InventoryAdapters,
         pyth_feed_ids: &PythFeedIds,
-        order_owner: Address,
-        bot_operator: BotOperator,
+        actors: RecoveryActors,
     ) -> Result<Option<Self>, OnChainError> {
         let receipt = evm
             .provider()
@@ -591,9 +605,15 @@ impl OnchainTrade {
         }
 
         for log in trades {
-            if let Some(trade) =
-                try_convert_log_to_onchain_trade(log, evm, cache, ctx, pyth_feed_ids, order_owner)
-                    .await?
+            if let Some(trade) = try_convert_log_to_onchain_trade(
+                log,
+                evm,
+                cache,
+                ctx,
+                pyth_feed_ids,
+                actors.order_owner,
+            )
+            .await?
             {
                 return Ok(Some(trade));
             }
@@ -611,6 +631,7 @@ impl OnchainTrade {
             cache,
             evm_ctx: ctx,
             assets,
+            inventory_adapters,
             pyth_feed_ids,
         };
 
@@ -618,7 +639,7 @@ impl OnchainTrade {
             tx_hash,
             evm,
             &recovery_config,
-            bot_operator,
+            actors.bot_operator,
             logs,
             receipt_metadata,
         )
@@ -677,6 +698,7 @@ impl OnchainTrade {
             config.cache,
             evm,
             config.assets,
+            config.inventory_adapters,
             &inv,
             withdraw_log,
             config.pyth_feed_ids,
@@ -692,7 +714,25 @@ struct InventoryRecoveryConfig<'config> {
     cache: &'config SymbolCache,
     evm_ctx: &'config EvmCtx,
     assets: &'config AssetsConfig,
+    inventory_adapters: &'config InventoryAdapters,
     pyth_feed_ids: &'config PythFeedIds,
+}
+
+fn inventory_trade_source(
+    operator: Address,
+    inventory_adapters: &InventoryAdapters,
+) -> OnChainTradeSource {
+    match inventory_adapters.venue_for(operator) {
+        Some(InventoryAdapterVenue::Bebop) => OnChainTradeSource::Inventory {
+            operator,
+            venue: InventoryVenue::Bebop,
+        },
+        Some(InventoryAdapterVenue::UniswapV4) => OnChainTradeSource::Inventory {
+            operator,
+            venue: InventoryVenue::UniswapV4,
+        },
+        None => OnChainTradeSource::UnrecognizedInventory { operator },
+    }
 }
 
 /// Reclassifies a Float-conversion failure surfaced by the shared
@@ -762,6 +802,7 @@ fn validate_inventory_token_addresses(
 /// needed by [`finalize_onchain_trade`] to finish constructing an
 /// [`OnchainTrade`] once `TradeDetails` has been resolved.
 struct TradeMetadata {
+    source: OnChainTradeSource,
     tx_hash: TxHash,
     log_index: u64,
     gas_used: Option<u64>,
@@ -780,6 +821,7 @@ async fn finalize_onchain_trade<P: Provider>(
     metadata: TradeMetadata,
 ) -> Result<Option<OnchainTrade>, OnChainError> {
     let TradeMetadata {
+        source,
         tx_hash,
         log_index,
         gas_used,
@@ -828,6 +870,7 @@ async fn finalize_onchain_trade<P: Provider>(
     let price = Usdc::new(price_per_share_usdc)?;
 
     Ok(Some(OnchainTrade {
+        source,
         tx_hash,
         log_index,
         symbol: equity_symbol,
@@ -1033,7 +1076,8 @@ mod tests {
     use rain_math_float::Float;
 
     use st0x_config::{
-        EquitiesConfig, EquityAssetConfig, EvmCtx, IngestionCutoff, InventoryMode, OperationMode,
+        EquitiesConfig, EquityAssetConfig, EvmCtx, IngestionCutoff, InventoryAdapter,
+        InventoryAdapterVenue, InventoryAdapters, InventoryMode, OperationMode,
     };
     use st0x_evm::IERC20::decimalsCall;
     use st0x_evm::IPyth::getPriceUnsafeCall;
@@ -1397,9 +1441,12 @@ mod tests {
             &cache,
             &ctx,
             &AssetsConfig::default(),
+            &InventoryAdapters::default(),
             &pyth_feed_ids,
-            Address::ZERO,
-            BotOperator(Address::ZERO),
+            RecoveryActors {
+                order_owner: Address::ZERO,
+                bot_operator: BotOperator(Address::ZERO),
+            },
         )
         .await;
 
@@ -1511,9 +1558,12 @@ mod tests {
             &cache,
             &ctx,
             &assets,
+            &InventoryAdapters::default(),
             &PythFeedIds::default(),
-            inventory,
-            BotOperator(bot_operator),
+            RecoveryActors {
+                order_owner: inventory,
+                bot_operator: BotOperator(bot_operator),
+            },
         )
         .await
         .unwrap()
@@ -1638,9 +1688,12 @@ mod tests {
             &cache,
             &ctx,
             &AssetsConfig::default(),
+            &InventoryAdapters::default(),
             &PythFeedIds::default(),
-            inventory,
-            BotOperator(bot_operator),
+            RecoveryActors {
+                order_owner: inventory,
+                bot_operator: BotOperator(bot_operator),
+            },
         )
         .await
         .unwrap();
@@ -1746,9 +1799,12 @@ mod tests {
             &cache,
             &ctx,
             &AssetsConfig::default(),
+            &InventoryAdapters::default(),
             &PythFeedIds::default(),
-            inventory,
-            BotOperator(bot_operator),
+            RecoveryActors {
+                order_owner: inventory,
+                bot_operator: BotOperator(bot_operator),
+            },
         )
         .await
         .unwrap();
@@ -2007,6 +2063,10 @@ mod tests {
         })
     }
 
+    fn inventory_adapters(venue: InventoryAdapterVenue, operator: Address) -> InventoryAdapters {
+        InventoryAdapters::try_new(vec![InventoryAdapter { venue, operator }]).unwrap()
+    }
+
     /// Drives `try_from_inventory_trade` with a pre-seeded symbol cache (so
     /// symbol resolution makes no RPC) and a deterministic mock queue:
     /// receipt, then the deposit-token then withdraw-token `decimals()` calls.
@@ -2040,6 +2100,7 @@ mod tests {
             &cache,
             &evm,
             &assets,
+            &InventoryAdapters::default(),
             &inv,
             log,
             &PythFeedIds::default(),
@@ -2064,6 +2125,12 @@ mod tests {
 
         assert_eq!(trade.symbol.to_string(), "wtAAPL");
         assert_eq!(trade.direction, Direction::Buy);
+        assert_eq!(
+            trade.source,
+            OnChainTradeSource::UnrecognizedInventory {
+                operator: Address::ZERO,
+            }
+        );
         assert_eq!(trade.equity_token, INVENTORY_EQUITY);
         assert_eq!(trade.amount, FractionalShares::new(float!(2)));
         assert!(trade.price.value().eq(float!(80)).unwrap());
@@ -2127,6 +2194,7 @@ mod tests {
             &cache,
             &evm,
             &assets,
+            &InventoryAdapters::default(),
             &inv,
             log,
             &PythFeedIds::default(),
@@ -2177,6 +2245,7 @@ mod tests {
             &cache,
             &evm,
             &assets,
+            &InventoryAdapters::default(),
             &inv,
             log,
             &PythFeedIds::default(),
@@ -2299,11 +2368,13 @@ mod tests {
 
         let inv = InventoryTrade { deposit, withdraw };
         let assets = assets_config_with_equity("COIN", REAL_WTCOIN_BASE);
+        let adapters = inventory_adapters(InventoryAdapterVenue::Bebop, operator);
 
         let trade = OnchainTrade::try_from_inventory_trade(
             &cache,
             &evm,
             &assets,
+            &adapters,
             &inv,
             log,
             &PythFeedIds::default(),
@@ -2315,6 +2386,13 @@ mod tests {
 
         assert_eq!(trade.symbol.to_string(), "wtCOIN");
         assert_eq!(trade.direction, Direction::Sell);
+        assert_eq!(
+            trade.source,
+            OnChainTradeSource::Inventory {
+                operator,
+                venue: InventoryVenue::Bebop,
+            }
+        );
         assert_eq!(trade.equity_token, REAL_WTCOIN_BASE);
         let expected_amount =
             Float::from_fixed_decimal(uint!(34_172_366_621_067_031_U256), 18).unwrap();
@@ -2384,11 +2462,13 @@ mod tests {
 
         let inv = InventoryTrade { deposit, withdraw };
         let assets = assets_config_with_equity("COIN", REAL_WTCOIN_BASE);
+        let adapters = inventory_adapters(InventoryAdapterVenue::UniswapV4, operator);
 
         let trade = OnchainTrade::try_from_inventory_trade(
             &cache,
             &evm,
             &assets,
+            &adapters,
             &inv,
             log,
             &PythFeedIds::default(),
@@ -2400,6 +2480,13 @@ mod tests {
 
         assert_eq!(trade.symbol.to_string(), "wtCOIN");
         assert_eq!(trade.direction, Direction::Buy);
+        assert_eq!(
+            trade.source,
+            OnChainTradeSource::Inventory {
+                operator,
+                venue: InventoryVenue::UniswapV4,
+            }
+        );
         assert_eq!(trade.equity_token, REAL_WTCOIN_BASE);
         assert!(trade.amount.inner().eq(float!(0.01)).unwrap());
         // 2 USDC / 0.01 wtCOIN = 200 USDC/share exactly.

--- a/src/onchain_trade.rs
+++ b/src/onchain_trade.rs
@@ -1,5 +1,5 @@
-//! OnChainTrade CQRS/ES aggregate for recording DEX fills
-//! from the Raindex orderbook.
+//! OnChainTrade CQRS/ES aggregate for recording direct Raindex orderbook fills
+//! and fills routed through shared-inventory adapters.
 //!
 //! Keyed by `(tx_hash, log_index)`. Can be enriched after
 //! the fact with gas costs and Pyth oracle price data.
@@ -8,19 +8,20 @@ use std::num::ParseIntError;
 use std::str::FromStr;
 
 use alloy::hex::FromHexError;
-use alloy::primitives::TxHash;
+use alloy::primitives::{Address, TxHash};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rain_math_float::Float;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tracing::warn;
 
 use st0x_dto::{Direction, Trade, TradeOutcome, TradingVenue};
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
 use st0x_execution::Symbol;
 use st0x_finance::{FractionalShares, NotPositive, Positive};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 
 pub(crate) struct OnChainTradeId {
     pub(crate) tx_hash: TxHash,
@@ -61,6 +62,8 @@ impl FromStr for OnChainTradeId {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct OnChainTrade {
+    #[serde(default = "legacy_source")]
+    pub(crate) source: OnChainTradeSource,
     pub(crate) symbol: Symbol,
     #[serde(
         serialize_with = "st0x_float_serde::serialize_float_as_string",
@@ -98,12 +101,13 @@ impl EventSourced for OnChainTrade {
 
     const AGGREGATE_TYPE: &'static str = "OnChainTrade";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 2;
+    const SCHEMA_VERSION: u64 = 3;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use OnChainTradeEvent::*;
         match event {
             Filled {
+                source,
                 symbol,
                 amount,
                 direction,
@@ -112,6 +116,7 @@ impl EventSourced for OnChainTrade {
                 block_timestamp,
                 filled_at,
             } => Some(Self {
+                source: *source,
                 symbol: symbol.clone(),
                 amount: *amount,
                 direction: *direction,
@@ -123,7 +128,7 @@ impl EventSourced for OnChainTrade {
                 acknowledged_at: None,
             }),
 
-            Enriched { .. } | Acknowledged { .. } => None,
+            SourceAttributed { .. } | Enriched { .. } | Acknowledged { .. } => None,
         }
     }
 
@@ -150,6 +155,11 @@ impl EventSourced for OnChainTrade {
                 ..entity.clone()
             })),
 
+            SourceAttributed { source, .. } => Ok(Some(Self {
+                source: *source,
+                ..entity.clone()
+            })),
+
             Filled { .. } => Ok(None),
         }
     }
@@ -162,24 +172,40 @@ impl EventSourced for OnChainTrade {
         use OnChainTradeEvent::*;
         match command {
             Witness {
+                source,
                 symbol,
                 amount,
                 direction,
                 price_usdc,
                 block_number,
                 block_timestamp,
-            } => Ok(vec![Filled {
-                symbol,
-                amount,
-                direction,
-                price_usdc,
-                block_number,
-                block_timestamp,
-                filled_at: Utc::now(),
-            }]),
+            } => {
+                match source {
+                    OnChainTradeSource::Legacy => {
+                        return Err(OnChainTradeError::LegacySourceWitness);
+                    }
+                    OnChainTradeSource::Raindex
+                    | OnChainTradeSource::Inventory { .. }
+                    | OnChainTradeSource::UnrecognizedInventory { .. } => {}
+                }
+
+                log_unrecognized_inventory_source(source);
+
+                Ok(vec![Filled {
+                    source,
+                    symbol,
+                    amount,
+                    direction,
+                    price_usdc,
+                    block_number,
+                    block_timestamp,
+                    filled_at: Utc::now(),
+                }])
+            }
 
             #[cfg(any(test, feature = "test-support"))]
             WitnessAt {
+                source,
                 symbol,
                 amount,
                 direction,
@@ -188,6 +214,7 @@ impl EventSourced for OnChainTrade {
                 block_timestamp,
                 filled_at,
             } => Ok(vec![Filled {
+                source,
                 symbol,
                 amount,
                 direction,
@@ -197,7 +224,9 @@ impl EventSourced for OnChainTrade {
                 filled_at,
             }]),
 
-            Enrich { .. } | Acknowledge => Err(OnChainTradeError::NotFilled),
+            AttributeSource { .. } | Enrich { .. } | Acknowledge => {
+                Err(OnChainTradeError::NotFilled)
+            }
         }
     }
 
@@ -213,6 +242,25 @@ impl EventSourced for OnChainTrade {
 
             #[cfg(any(test, feature = "test-support"))]
             WitnessAt { .. } => Err(OnChainTradeError::AlreadyFilled),
+
+            AttributeSource { source } => {
+                match self.source.attribution_decision(source) {
+                    SourceAttributionDecision::Apply => {}
+                    SourceAttributionDecision::AlreadyAttributed => {
+                        return Err(OnChainTradeError::SourceAlreadyAttributed);
+                    }
+                    SourceAttributionDecision::InvalidLegacyMarker => {
+                        return Err(OnChainTradeError::LegacySourceAttribution);
+                    }
+                }
+
+                log_unrecognized_inventory_source(source);
+
+                Ok(vec![SourceAttributed {
+                    source,
+                    attributed_at: Utc::now(),
+                }])
+            }
 
             Enrich {
                 gas_used,
@@ -271,12 +319,101 @@ impl OnChainTrade {
         Ok(Trade {
             id: id.to_string(),
             occurred_at: self.block_timestamp,
-            venue: TradingVenue::Raindex,
+            venue: self.source.trading_venue(),
             direction: self.direction,
             symbol: self.symbol,
             shares: Positive::new(FractionalShares::new(self.amount))?,
             outcome: TradeOutcome::Filled,
         })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) enum InventoryVenue {
+    Bebop,
+    UniswapV4,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) enum OnChainTradeSource {
+    /// Filled event persisted before source attribution existed. Displays as
+    /// Raindex until a chain-backed repair appends `SourceAttributed`.
+    Legacy,
+    Raindex,
+    Inventory {
+        operator: Address,
+        venue: InventoryVenue,
+    },
+    UnrecognizedInventory {
+        operator: Address,
+    },
+}
+
+const fn legacy_source() -> OnChainTradeSource {
+    OnChainTradeSource::Legacy
+}
+
+impl OnChainTradeSource {
+    pub(crate) fn trading_venue(self) -> TradingVenue {
+        match self {
+            Self::Legacy | Self::Raindex => TradingVenue::Raindex,
+            Self::Inventory {
+                venue: InventoryVenue::Bebop,
+                ..
+            } => TradingVenue::Bebop,
+            Self::Inventory {
+                venue: InventoryVenue::UniswapV4,
+                ..
+            } => TradingVenue::UniswapV4,
+            Self::UnrecognizedInventory { .. } => TradingVenue::UnknownOnchain,
+        }
+    }
+
+    fn unrecognized_inventory_operator(self) -> Option<Address> {
+        match self {
+            Self::Legacy | Self::Raindex | Self::Inventory { .. } => None,
+            Self::UnrecognizedInventory { operator } => Some(operator),
+        }
+    }
+
+    pub(crate) fn attribution_decision(self, replacement: Self) -> SourceAttributionDecision {
+        match self {
+            Self::Legacy => match replacement {
+                Self::Legacy => SourceAttributionDecision::InvalidLegacyMarker,
+                Self::Raindex | Self::Inventory { .. } | Self::UnrecognizedInventory { .. } => {
+                    SourceAttributionDecision::Apply
+                }
+            },
+            Self::UnrecognizedInventory { operator } => match replacement {
+                Self::Inventory {
+                    operator: attributed_operator,
+                    ..
+                } if attributed_operator == operator => SourceAttributionDecision::Apply,
+                Self::Legacy
+                | Self::Raindex
+                | Self::Inventory { .. }
+                | Self::UnrecognizedInventory { .. } => {
+                    SourceAttributionDecision::AlreadyAttributed
+                }
+            },
+            Self::Raindex | Self::Inventory { .. } => SourceAttributionDecision::AlreadyAttributed,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceAttributionDecision {
+    Apply,
+    AlreadyAttributed,
+    InvalidLegacyMarker,
+}
+
+fn log_unrecognized_inventory_source(source: OnChainTradeSource) {
+    if let Some(operator) = source.unrecognized_inventory_operator() {
+        warn!(
+            %operator,
+            "Inventory fill uses an unrecognized operator; attributing it to Unknown Onchain"
+        );
     }
 }
 
@@ -288,6 +425,12 @@ pub(crate) enum OnChainTradeError {
     AlreadyEnriched,
     #[error("Trade has already been filled")]
     AlreadyFilled,
+    #[error("Trade source has already been attributed")]
+    SourceAlreadyAttributed,
+    #[error("A legacy source marker cannot be used as a source attribution")]
+    LegacySourceAttribution,
+    #[error("A legacy source marker cannot be used when witnessing a live trade")]
+    LegacySourceWitness,
     #[error("Trade has already been acknowledged by the position")]
     AlreadyAcknowledged,
     #[error(
@@ -300,6 +443,7 @@ pub(crate) enum OnChainTradeError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum OnChainTradeCommand {
     Witness {
+        source: OnChainTradeSource,
         symbol: Symbol,
         #[serde(
             serialize_with = "st0x_float_serde::serialize_float_as_string",
@@ -315,11 +459,16 @@ pub(crate) enum OnChainTradeCommand {
         block_number: u64,
         block_timestamp: DateTime<Utc>,
     },
+    /// Repairs a source-less legacy fill after re-reading its operator from
+    /// chain, or upgrades an unrecognized inventory source after its same
+    /// operator is configured.
+    AttributeSource { source: OnChainTradeSource },
     /// Test/fixture-only: identical to `Witness` but takes `filled_at`
     /// explicitly instead of stamping `Utc::now()`, so fixture seeding can
     /// backdate synthetic history.
     #[cfg(any(test, feature = "test-support"))]
     WitnessAt {
+        source: OnChainTradeSource,
         symbol: Symbol,
         #[serde(
             serialize_with = "st0x_float_serde::serialize_float_as_string",
@@ -350,6 +499,8 @@ pub(crate) enum OnChainTradeCommand {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum OnChainTradeEvent {
     Filled {
+        #[serde(default = "legacy_source")]
+        source: OnChainTradeSource,
         symbol: Symbol,
         #[serde(
             serialize_with = "st0x_float_serde::serialize_float_as_string",
@@ -365,6 +516,10 @@ pub(crate) enum OnChainTradeEvent {
         block_number: u64,
         block_timestamp: DateTime<Utc>,
         filled_at: DateTime<Utc>,
+    },
+    SourceAttributed {
+        source: OnChainTradeSource,
+        attributed_at: DateTime<Utc>,
     },
     Enriched {
         gas_used: u64,
@@ -383,6 +538,7 @@ impl PartialEq for OnChainTradeEvent {
         match (self, other) {
             (
                 Self::Filled {
+                    source: source_a,
                     symbol: sym_a,
                     amount: amt_a,
                     direction: dir_a,
@@ -392,6 +548,7 @@ impl PartialEq for OnChainTradeEvent {
                     filled_at: fill_a,
                 },
                 Self::Filled {
+                    source: source_b,
                     symbol: sym_b,
                     amount: amt_b,
                     direction: dir_b,
@@ -401,7 +558,8 @@ impl PartialEq for OnChainTradeEvent {
                     filled_at: fill_b,
                 },
             ) => {
-                sym_a == sym_b
+                source_a == source_b
+                    && sym_a == sym_b
                     && amt_a.eq(*amt_b).unwrap_or(false)
                     && dir_a == dir_b
                     && price_a.eq(*price_b).unwrap_or(false)
@@ -431,6 +589,16 @@ impl PartialEq for OnChainTradeEvent {
                     acknowledged_at: a2,
                 },
             ) => a1 == a2,
+            (
+                Self::SourceAttributed {
+                    source: source_a,
+                    attributed_at: attributed_a,
+                },
+                Self::SourceAttributed {
+                    source: source_b,
+                    attributed_at: attributed_b,
+                },
+            ) => source_a == source_b && attributed_a == attributed_b,
             _ => false,
         }
     }
@@ -442,6 +610,7 @@ impl DomainEvent for OnChainTradeEvent {
     fn event_type(&self) -> String {
         match self {
             Self::Filled { .. } => "OnChainTradeEvent::Filled".to_string(),
+            Self::SourceAttributed { .. } => "OnChainTradeEvent::SourceAttributed".to_string(),
             Self::Enriched { .. } => "OnChainTradeEvent::Enriched".to_string(),
             Self::Acknowledged { .. } => "OnChainTradeEvent::Acknowledged".to_string(),
         }
@@ -471,9 +640,9 @@ pub(crate) struct PythPrice {
 #[cfg(test)]
 mod tests {
     use st0x_event_sorcery::{LifecycleError, TestHarness, replay};
+    use st0x_float_macro::float;
 
     use super::*;
-    use st0x_float_macro::float;
 
     #[tokio::test]
     async fn witness_command_creates_filled_event() {
@@ -483,6 +652,7 @@ mod tests {
         let events = TestHarness::<OnChainTrade>::with(())
             .given_no_previous_events()
             .when(OnChainTradeCommand::Witness {
+                source: OnChainTradeSource::Raindex,
                 symbol: symbol.clone(),
                 amount: float!(10.5),
                 direction: Direction::Buy,
@@ -497,6 +667,28 @@ mod tests {
         assert!(matches!(events[0], OnChainTradeEvent::Filled { .. }));
     }
 
+    #[tokio::test]
+    async fn witness_command_rejects_legacy_source_markers() {
+        let error = TestHarness::<OnChainTrade>::with(())
+            .given_no_previous_events()
+            .when(OnChainTradeCommand::Witness {
+                source: OnChainTradeSource::Legacy,
+                symbol: Symbol::new("AAPL").unwrap(),
+                amount: float!(10.5),
+                direction: Direction::Buy,
+                price_usdc: float!(150.25),
+                block_number: 12345,
+                block_timestamp: Utc::now(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(OnChainTradeError::LegacySourceWitness)
+        ));
+    }
+
     /// Covers the fixture-only `WitnessAt` sibling of `Witness`: it must
     /// thread the caller-supplied `filled_at` through to the emitted event's
     /// field rather than silently falling back to `Utc::now()`.
@@ -509,6 +701,7 @@ mod tests {
         let events = TestHarness::<OnChainTrade>::with(())
             .given_no_previous_events()
             .when(OnChainTradeCommand::WitnessAt {
+                source: OnChainTradeSource::Raindex,
                 symbol: symbol.clone(),
                 amount: float!(10.5),
                 direction: Direction::Buy,
@@ -545,6 +738,7 @@ mod tests {
 
         let events = TestHarness::<OnChainTrade>::with(())
             .given(vec![OnChainTradeEvent::Filled {
+                source: OnChainTradeSource::Raindex,
                 symbol: symbol.clone(),
                 amount: float!(10.5),
                 direction: Direction::Buy,
@@ -580,6 +774,7 @@ mod tests {
         let error = TestHarness::<OnChainTrade>::with(())
             .given(vec![
                 OnChainTradeEvent::Filled {
+                    source: OnChainTradeSource::Raindex,
                     symbol: symbol.clone(),
                     amount: float!(10.5),
                     direction: Direction::Buy,
@@ -650,6 +845,7 @@ mod tests {
 
         let error = TestHarness::<OnChainTrade>::with(())
             .given(vec![OnChainTradeEvent::Filled {
+                source: OnChainTradeSource::Raindex,
                 symbol,
                 amount: float!("10.5"),
                 direction: Direction::Buy,
@@ -679,6 +875,7 @@ mod tests {
 
         let events = TestHarness::<OnChainTrade>::with(())
             .given(vec![OnChainTradeEvent::Filled {
+                source: OnChainTradeSource::Raindex,
                 symbol,
                 amount: float!(10.5),
                 direction: Direction::Buy,
@@ -705,6 +902,7 @@ mod tests {
         let error = TestHarness::<OnChainTrade>::with(())
             .given(vec![
                 OnChainTradeEvent::Filled {
+                    source: OnChainTradeSource::Raindex,
                     symbol,
                     amount: float!(10.5),
                     direction: Direction::Buy,
@@ -752,6 +950,7 @@ mod tests {
 
         let trade = replay::<OnChainTrade>(vec![
             OnChainTradeEvent::Filled {
+                source: OnChainTradeSource::Raindex,
                 symbol,
                 amount: float!(10.5),
                 direction: Direction::Buy,
@@ -789,6 +988,7 @@ mod tests {
 
         let error = TestHarness::<OnChainTrade>::with(())
             .given(vec![OnChainTradeEvent::Filled {
+                source: OnChainTradeSource::Raindex,
                 symbol: symbol.clone(),
                 amount: float!(10.5),
                 direction: Direction::Buy,
@@ -798,6 +998,7 @@ mod tests {
                 filled_at: now,
             }])
             .when(OnChainTradeCommand::Witness {
+                source: OnChainTradeSource::Raindex,
                 symbol: symbol.clone(),
                 amount: float!(10.5),
                 direction: Direction::Buy,
@@ -829,6 +1030,7 @@ mod tests {
         let error = TestHarness::<OnChainTrade>::with(())
             .given(vec![
                 OnChainTradeEvent::Filled {
+                    source: OnChainTradeSource::Raindex,
                     symbol: symbol.clone(),
                     amount: float!(10.5),
                     direction: Direction::Buy,
@@ -845,6 +1047,7 @@ mod tests {
                 },
             ])
             .when(OnChainTradeCommand::Witness {
+                source: OnChainTradeSource::Raindex,
                 symbol: symbol.clone(),
                 amount: float!(10.5),
                 direction: Direction::Buy,
@@ -867,6 +1070,7 @@ mod tests {
         let now = Utc::now();
 
         let trade = replay::<OnChainTrade>(vec![OnChainTradeEvent::Filled {
+            source: OnChainTradeSource::Raindex,
             symbol,
             amount: float!(10.5),
             direction: Direction::Buy,
@@ -885,6 +1089,241 @@ mod tests {
     }
 
     #[test]
+    fn legacy_filled_event_without_source_retains_repairable_marker() {
+        let now = Utc::now();
+        let event = OnChainTradeEvent::Filled {
+            source: OnChainTradeSource::Inventory {
+                operator: Address::repeat_byte(0x8b),
+                venue: InventoryVenue::Bebop,
+            },
+            symbol: Symbol::new("AAPL").unwrap(),
+            amount: float!(10.5),
+            direction: Direction::Buy,
+            price_usdc: float!(150.25),
+            block_number: 12345,
+            block_timestamp: now,
+            filled_at: now,
+        };
+        let mut payload = serde_json::to_value(event).unwrap();
+        payload["Filled"].as_object_mut().unwrap().remove("source");
+
+        let legacy: OnChainTradeEvent = serde_json::from_value(payload).unwrap();
+        let OnChainTradeEvent::Filled { source, .. } = legacy else {
+            panic!("expected Filled event");
+        };
+
+        assert_eq!(source, OnChainTradeSource::Legacy);
+        assert_eq!(source.trading_venue(), TradingVenue::Raindex);
+    }
+
+    #[test]
+    fn inventory_source_maps_persisted_adapter_venue() {
+        assert_eq!(
+            OnChainTradeSource::Inventory {
+                operator: Address::repeat_byte(0x01),
+                venue: InventoryVenue::Bebop,
+            }
+            .trading_venue(),
+            TradingVenue::Bebop
+        );
+        assert_eq!(
+            OnChainTradeSource::Inventory {
+                operator: Address::repeat_byte(0x01),
+                venue: InventoryVenue::UniswapV4,
+            }
+            .trading_venue(),
+            TradingVenue::UniswapV4
+        );
+        assert_eq!(
+            OnChainTradeSource::UnrecognizedInventory {
+                operator: Address::repeat_byte(0x01),
+            }
+            .trading_venue(),
+            TradingVenue::UnknownOnchain
+        );
+    }
+
+    #[tokio::test]
+    async fn source_attribution_repairs_a_legacy_fill() {
+        let now = Utc::now();
+        let source = OnChainTradeSource::Inventory {
+            operator: Address::repeat_byte(0x8b),
+            venue: InventoryVenue::Bebop,
+        };
+        let filled = OnChainTradeEvent::Filled {
+            source: OnChainTradeSource::Legacy,
+            symbol: Symbol::new("AAPL").unwrap(),
+            amount: float!(1),
+            direction: Direction::Buy,
+            price_usdc: float!(150),
+            block_number: 12345,
+            block_timestamp: now,
+            filled_at: now,
+        };
+
+        let events = TestHarness::<OnChainTrade>::with(())
+            .given(vec![filled.clone()])
+            .when(OnChainTradeCommand::AttributeSource { source })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [OnChainTradeEvent::SourceAttributed {
+                source: attributed,
+                ..
+            }] if *attributed == source
+        ));
+        let repaired = replay::<OnChainTrade>(vec![filled, events[0].clone()])
+            .unwrap()
+            .unwrap();
+        assert_eq!(repaired.source, source);
+        assert_eq!(
+            repaired
+                .try_into_trade(&OnChainTradeId {
+                    tx_hash: TxHash::ZERO,
+                    log_index: 0,
+                })
+                .unwrap()
+                .venue,
+            TradingVenue::Bebop
+        );
+    }
+
+    #[tokio::test]
+    async fn source_attribution_upgrades_a_matching_unrecognized_operator() {
+        let now = Utc::now();
+        let operator = Address::repeat_byte(0x8b);
+        let source = OnChainTradeSource::Inventory {
+            operator,
+            venue: InventoryVenue::Bebop,
+        };
+        let filled = OnChainTradeEvent::Filled {
+            source: OnChainTradeSource::UnrecognizedInventory { operator },
+            symbol: Symbol::new("AAPL").unwrap(),
+            amount: float!(1),
+            direction: Direction::Buy,
+            price_usdc: float!(150),
+            block_number: 12345,
+            block_timestamp: now,
+            filled_at: now,
+        };
+
+        let events = TestHarness::<OnChainTrade>::with(())
+            .given(vec![filled.clone()])
+            .when(OnChainTradeCommand::AttributeSource { source })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [OnChainTradeEvent::SourceAttributed {
+                source: attributed,
+                ..
+            }] if *attributed == source
+        ));
+        let repaired = replay::<OnChainTrade>(vec![filled, events[0].clone()])
+            .unwrap()
+            .unwrap();
+        assert_eq!(repaired.source, source);
+        assert_eq!(
+            repaired
+                .try_into_trade(&OnChainTradeId {
+                    tx_hash: TxHash::ZERO,
+                    log_index: 0,
+                })
+                .unwrap()
+                .venue,
+            TradingVenue::Bebop
+        );
+    }
+
+    #[tokio::test]
+    async fn source_attribution_rejects_a_different_inventory_operator() {
+        let now = Utc::now();
+        let error = TestHarness::<OnChainTrade>::with(())
+            .given(vec![OnChainTradeEvent::Filled {
+                source: OnChainTradeSource::UnrecognizedInventory {
+                    operator: Address::repeat_byte(0x01),
+                },
+                symbol: Symbol::new("AAPL").unwrap(),
+                amount: float!(1),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_number: 12345,
+                block_timestamp: now,
+                filled_at: now,
+            }])
+            .when(OnChainTradeCommand::AttributeSource {
+                source: OnChainTradeSource::Inventory {
+                    operator: Address::repeat_byte(0x02),
+                    venue: InventoryVenue::Bebop,
+                },
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(OnChainTradeError::SourceAlreadyAttributed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn source_attribution_rejects_an_already_attributed_fill() {
+        let now = Utc::now();
+        let error = TestHarness::<OnChainTrade>::with(())
+            .given(vec![OnChainTradeEvent::Filled {
+                source: OnChainTradeSource::Raindex,
+                symbol: Symbol::new("AAPL").unwrap(),
+                amount: float!(1),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_number: 12345,
+                block_timestamp: now,
+                filled_at: now,
+            }])
+            .when(OnChainTradeCommand::AttributeSource {
+                source: OnChainTradeSource::UnrecognizedInventory {
+                    operator: Address::repeat_byte(0x01),
+                },
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(OnChainTradeError::SourceAlreadyAttributed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn source_attribution_rejects_legacy_source_markers() {
+        let now = Utc::now();
+        let error = TestHarness::<OnChainTrade>::with(())
+            .given(vec![OnChainTradeEvent::Filled {
+                source: OnChainTradeSource::Legacy,
+                symbol: Symbol::new("AAPL").unwrap(),
+                amount: float!(1),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_number: 12345,
+                block_timestamp: now,
+                filled_at: now,
+            }])
+            .when(OnChainTradeCommand::AttributeSource {
+                source: OnChainTradeSource::Legacy,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(OnChainTradeError::LegacySourceAttribution)
+        ));
+    }
+
+    #[test]
     fn dashboard_trade_rejects_non_positive_fill_quantity() {
         let now = Utc::now();
         let id = OnChainTradeId {
@@ -894,6 +1333,7 @@ mod tests {
 
         for amount in [float!(0), float!(-1)] {
             let trade = replay::<OnChainTrade>(vec![OnChainTradeEvent::Filled {
+                source: OnChainTradeSource::Raindex,
                 symbol: Symbol::new("AAPL").unwrap(),
                 amount,
                 direction: Direction::Buy,
@@ -922,6 +1362,7 @@ mod tests {
 
         let trade = replay::<OnChainTrade>(vec![
             OnChainTradeEvent::Filled {
+                source: OnChainTradeSource::Raindex,
                 symbol: Symbol::new("AAPL").unwrap(),
                 amount: float!(10.5),
                 direction: Direction::Buy,

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -65,7 +65,7 @@ use crate::offchain::order::{
     OrderPlacementResult, OrderPlacer,
 };
 #[cfg(any(test, feature = "test-support"))]
-use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
+use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId, OnChainTradeSource};
 #[cfg(any(test, feature = "test-support"))]
 use crate::position::{Position, PositionCommand, TradeId};
 
@@ -238,6 +238,7 @@ pub async fn seed_simulated_hedge_latency_history(
                 .send(
                     &OnChainTradeId { tx_hash, log_index },
                     OnChainTradeCommand::WitnessAt {
+                        source: OnChainTradeSource::Raindex,
                         symbol: symbol.clone(),
                         amount: amount.inner().inner(),
                         direction: Direction::Buy,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -21,6 +21,7 @@ use st0x_execution::{Direction, FractionalShares, Positive, Symbol};
 use crate::bindings::IRaindexV6::{EvaluableV4, IOV2, OrderV4};
 use crate::onchain::OnchainTrade;
 use crate::onchain::io::{TokenizedSymbol, Usdc, WrappedTokenizedShares};
+use crate::onchain_trade::OnChainTradeSource;
 
 const MAX_CONCURRENT_TEST_ANVILS: usize = 4;
 
@@ -397,6 +398,7 @@ impl OnchainTradeBuilder {
     pub(crate) fn new() -> Self {
         Self {
             trade: OnchainTrade {
+                source: OnChainTradeSource::Raindex,
                 tx_hash: fixed_bytes!(
                     "0x1111111111111111111111111111111111111111111111111111111111111111"
                 ),
@@ -428,6 +430,12 @@ impl OnchainTradeBuilder {
     #[must_use]
     pub(crate) fn with_equity_token(mut self, token: Address) -> Self {
         self.trade.equity_token = token;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_source(mut self, source: OnChainTradeSource) -> Self {
+        self.trade.source = source;
         self
     }
 

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -153,6 +153,7 @@ where
                     &ctx.cache,
                     &ctx.evm,
                     &ctx.ctx.assets,
+                    &ctx.ctx.inventory_adapters,
                     inv.as_ref(),
                     reconstructed_log,
                     &ctx.pyth_feed_ids,


### PR DESCRIPTION
## What

Closes RAI-1601.

Attributes shared-inventory fills to their configured onchain venue throughout the counter-trades window. The known Bebop and Uniswap v4 adapters now display as their actual venues, direct orderbook fills remain Raindex, and unconfigured operators display as Unknown Onchain instead of being misattributed.

## Why

Inventory settlements previously discarded their operator before the onchain trade was persisted. The dashboard therefore hardcoded every onchain fill as Raindex, including the Bebop fill from transaction `0x28a364eaa0fc6d505ddd0702cd9949853193bb28c92cdfef68bcd5a803f1806b` at log index `194`.

## How

- Configure public inventory-adapter operator addresses as explicit venue/operator pairs under `[raindex]`.
- Persist the execution source on each onchain trade and derive its venue consistently for REST history, live WebSocket updates, venue filtering, sorting, explorer links, and trade details.
- Preserve legacy source-less events, and let `process-tx` safely attribute already-accounted historical fills without placing another hedge, including upgrading an unknown inventory source when its matching adapter is later configured.
- Introduce `terminal_outcomes_v3` for the expanded venue model while retaining v2/v1 downgrade behavior for older clients and servers.
- Re-probe v3 after a temporary fallback, skip future unknown dashboard venues without reconnect loops, and keep legacy-compatible venue filters correct after downgrade.
- Retry transient source-correction reloads through a supervised handoff monitor, serialize authoritative publication, and retain pending corrections across monitor restarts.
- Update the specification, domain terminology, deployment configuration, Rust DTOs, and dashboard models.

## Testing

- [x] Full local CI: workspace checks with and without all features, 4,241 tests passed with 6 configured skips, workspace Clippy, and rustfmt
- [x] DTO generation and freshness check
- [x] Dashboard install, lint, and Svelte diagnostics
- [x] Focused regression coverage for attribution, historical repair, protocol downgrade/re-probe, venue filtering, future venues, explorer behavior, source-correction retries, publication ordering, retry-queue saturation, and shared SQLite pool capacity
- [x] Simplification pass plus three-round staged read-only review

## Screenshots

Validated in the deterministic market simulator with a Bebop-only filter showing the expected AAPL fill.

<img width="1280" height="720" alt="Bebop-only counter-trades filter" src="https://github.com/user-attachments/assets/a034b9e5-2ec7-47c3-a76b-79c3bc91c7cd" />

## Anything else

No environment variable or secret is needed. Adapter operator addresses are public onchain deployment configuration: staging declares the known Bebop and Uniswap v4 adapters, while legacy production configuration keeps the adapter list empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added support for Bebop, Uniswap V4, and unidentified on-chain venues in trade history.
- On-chain fills now display their attributed venue, including adapter-routed trades.
- Added venue-aware filtering, labels, colors, and transaction links.
- Added a newer trade-history protocol with automatic fallback for older clients.

## Bug Fixes
- Improved ordering for on-chain trades across supported venues.
- Preserved legacy fills and historical compatibility.
- Unsupported future venues are skipped without disrupting valid trade history.

## Documentation
- Updated guidance for venue attribution and adapter configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
