### PR TITLE
Fix boot-ordering regression bug

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -20,7 +20,7 @@ use apalis_core::error::BoxDynError;
 use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
 use sqlx_apalis::sqlite::{SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::num::TryFromIntError;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -1467,12 +1467,26 @@ async fn compact_inventory_snapshot_events(pool: &SqlitePool) -> Result<u64, sql
 /// still empty. Seeding the gate first would skip hydration for every symbol
 /// with an open hedge order, booting it with an uninitialized offchain
 /// balance that imbalance detection could then misread.
+///
+/// The gate is cleared on entry rather than assumed empty: any gate write
+/// that lands before this seam (an earlier startup step seeding it "for
+/// safety") would otherwise silently starve hydration for its symbols, and
+/// nothing at the call sites can enforce that no such write exists. Clearing
+/// here makes the hydrate-before-seed order structural instead of an
+/// ordering convention every caller must know about. Safe because the gate's
+/// only authoritative source at boot is the `Position` projection seeded
+/// below, and no reactors or workers run concurrently with this seam.
 pub(crate) async fn restore_inventory_at_boot(
     pool: &SqlitePool,
     inventory: &Arc<BroadcastingInventory>,
     rebalancing_service: Option<&Arc<RebalancingService>>,
     position_projection: &Projection<Position>,
 ) -> Result<(), ProjectionError<Position>> {
+    inventory
+        .write_without_broadcast()
+        .await
+        .set_pending_offchain_order_symbols(HashSet::new());
+
     hydrate_inventory_from_snapshot(pool, inventory).await;
 
     if let Some(service) = rebalancing_service {
@@ -2080,10 +2094,6 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             equity_transfer_services,
         )
         .await?;
-
-        rebalancing_service
-            .recover_pending_offchain_order_symbols(&built.position_projection)
-            .await?;
 
         rebalancing_service
             .set_stores(

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -23918,4 +23918,101 @@ mod tests {
             "an absent slot must report a successful (no-op) clear",
         );
     }
+
+    /// The regression the direct-seam test above cannot catch: a gate write
+    /// that lands BEFORE `restore_inventory_at_boot` (production used to seed
+    /// the gate during rebalancing-infrastructure setup). Guard 1 is then
+    /// live during hydration and the gated symbol boots with an
+    /// uninitialized offchain balance, silently disabling imbalance
+    /// detection for it. The boot seam must clear the gate before hydrating
+    /// so hydrate-before-seed holds structurally, regardless of what ran
+    /// earlier in startup.
+    #[tokio::test]
+    async fn boot_hydration_survives_gate_seeded_before_restore() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let trigger = make_trigger_with_inventory(InventoryView::default()).await;
+        let pool = crate::test_utils::setup_test_db().await;
+
+        let snapshot_store = test_store::<InventorySnapshot>(pool.clone(), ());
+        snapshot_store
+            .send(
+                &InventorySnapshotId {
+                    orderbook: TEST_ORDERBOOK,
+                    owner: TEST_ORDER_OWNER,
+                },
+                InventorySnapshotCommand::OffchainEquity {
+                    positions: BTreeMap::from([(symbol.clone(), shares(90))]),
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let position_store = test_store::<Position>(pool.clone(), ());
+        position_store
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 1,
+                    },
+                    amount: shares(10),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        position_store
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id: OffchainOrderId::new(),
+                    shares: Positive::new(shares(10)).unwrap(),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+        let projection = Projection::<Position>::sqlite(pool.clone());
+        projection.catch_up().await.unwrap();
+
+        // The regression shape: something seeds the gate before the boot
+        // seam runs.
+        trigger
+            .inventory
+            .write_without_broadcast()
+            .await
+            .mark_offchain_order_pending(symbol.clone());
+
+        crate::conductor::restore_inventory_at_boot(
+            &pool,
+            &trigger.inventory,
+            Some(&trigger),
+            &projection,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            trigger.has_pending_offchain_order(&symbol).await,
+            "the open hedge order must still be gated after boot"
+        );
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .equity_available(&symbol, Venue::Hedging),
+            Some(shares(90)),
+            "a gate seeded before the boot seam must not starve hydration; \
+             None means guard 1 was live while the snapshot replayed"
+        );
+    }
 }


### PR DESCRIPTION
## What

The setup-time seed is deleted — `restore_inventory_at_boot` is again the single seeding site, and nothing between the deleted call and `finish_startup_recovery` reads the gate (verified: only `set_stores`, `recover_usdc_guard`, and wallet-polling construction run in that window, before any workers or reactors start). Beyond the deletion, `restore_inventory_at_boot` now clears the gate on entry before hydrating: deleting the call alone restores the ordering but leaves it a convention any future startup change can silently break — which is precisely how this regressed. Clearing at the seam makes hydrate-before-seed structural. It's safe because the gate's only authoritative source at boot is the `Position` projection seeded immediately afterwards, and the seam runs before anything concurrent. The regression test (`boot_hydration_survives_gate_seeded_before_restore`) reproduces the production shape — gate seeded before the boot seam — and was verified red without the fix. Downside accepted: a hypothetical future startup step that legitimately wanted to pre-populate the gate before hydration would be silently overridden; no such step exists, and the projection re-derives the full set anyway.

Clears the pending offchain order gate at the start of `restore_inventory_at_boot` before hydration runs, and removes the earlier `recover_pending_offchain_order_symbols` call from rebalancing infrastructure setup.

## Why

A gate write landing before `restore_inventory_at_boot` (e.g. during rebalancing infrastructure setup) would leave guard 1 live while the inventory snapshot replayed. Any symbol already in the gate would be skipped by hydration, booting with an uninitialized offchain balance. Imbalance detection would then silently misread that symbol's state for the entire session.

The previous code relied on an ordering convention — callers had to ensure nothing wrote to the gate before the boot seam — but nothing enforced this structurally.

## How

The gate is now explicitly cleared at the top of `restore_inventory_at_boot` before hydration begins. This makes the hydrate-before-seed ordering structural rather than a convention callers must know about. This is safe because the gate's only authoritative source at boot is the `Position` projection seeded immediately after, and no reactors or workers run concurrently with this seam.

The `recover_pending_offchain_order_symbols` call that previously ran during rebalancing infrastructure setup is removed, as that was the source of the premature gate write.

## Testing

A regression test `boot_hydration_survives_gate_seeded_before_restore` was added that reproduces the exact failure shape: it seeds the gate before calling `restore_inventory_at_boot`, then asserts that hydration still completes correctly and the symbol's offchain equity is populated. A `None` equity result indicates guard 1 was live during snapshot replay, which is the bug this change fixes.

Closes [RAI-1628](https://linear.app/makeitrain/issue/RAI-1628/boot-seeds-the-open-hedge-gate-before-inventory-hydration-booting)

Closes [RAI-1629](https://linear.app/makeitrain/issue/RAI-1629/boot-ordering-bug)

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup recovery so persisted inventory and off-chain equity are restored reliably.
  - Prevented stale pending-order state from interfering with inventory hydration during launch.
  - Preserved safety gates for pending hedges after recovery, helping prevent unintended trading activity.

- **Tests**
  - Added coverage for recovery scenarios involving pre-existing off-chain order gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->