### PR TITLE
Block-watermark onchain fill absorption (ADR 0018)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3485,7 +3485,22 @@ know about cross-venue inventory.
 **InventoryView** listens to:
 
 - `PositionEvent::OnChainOrderFilled` - Updates available balances (trading
-  activity)
+  activity). Each delta leg (equity, USDC) is skipped when the fill's
+  `block_number` is at or below the leg's onchain snapshot block watermark: the
+  poller pins its `vaultBalance2` reads to a block and records it on the
+  `OnchainEquity`/`OnchainUsdc` snapshot events, so a snapshot at block N
+  provably already contains every fill at a block <= N and applying the delta on
+  top would double-count (ADR 0018). The equity watermark is per symbol (two
+  symbols advance independently); the USDC watermark is venue-level, because the
+  USDC balance is one number per venue. Two invariants, both enforced by
+  `InventoryView` with dedicated tests: a skipped snapshot (inflight, or stale
+  against the last rebalancing) never advances a watermark, since a fill it
+  never contained would otherwise read as absorbed; and block ordering is
+  authoritative for onchain reads, so a snapshot pinned below an established
+  watermark is rejected outright rather than lowering it -- only the recovery
+  force path may move a balance below the watermark, and it re-points the
+  watermark at the forced block. Legacy fills or snapshots without a block
+  number keep the unguarded behavior
 - `PositionEvent::OffChainOrderFilled` - Updates available balances (trading
   activity)
 - `TokenizedEquityMintEvent::MintAccepted` - Moves shares to inflight (leaving
@@ -3623,8 +3638,11 @@ balances and emitting them as events the system can react to:
   a positive balance, so stranded funds are visible without sending new
   rebalancing transfers to the retired vault.
 - **Polling runs on a 60-second interval** during market hours as a background
-  conductor task. Onchain polling uses the `vaultBalance2` contract call;
-  offchain polling uses the `Executor::get_inventory()` trait method.
+  conductor task. Onchain polling fetches the latest block number once per cycle
+  and pins every `vaultBalance2` contract call to it, so multi-vault sums cannot
+  straddle a block boundary and the emitted snapshot events carry the exact
+  block their balances were read at (ADR 0018); offchain polling uses the
+  `Executor::get_inventory()` trait method.
 
 ##### Broker Divergence Recovery
 

--- a/adrs/0018-block-watermarked-onchain-fill-absorption.md
+++ b/adrs/0018-block-watermarked-onchain-fill-absorption.md
@@ -1,0 +1,152 @@
+# ADR 0018: Block-watermarked absorption of onchain fill deltas
+
+- Status: Accepted
+- Date: 2026-08-03
+
+## Context
+
+RAI-1500 asked whether the MarketMaking venue has the snapshot-vs-fill
+double-count race that ADR 0015 closed for the Hedging venue. The answer is yes,
+and the window is wider:
+
+- **Delta writer.** `PositionEvent::OnChainOrderFilled` applies a MarketMaking
+  equity delta plus a mirrored USDC delta (`src/rebalancing/trigger/mod.rs`, the
+  onchain fill arm) — the structural twin of the offchain fill arm.
+- **Snapshot writer.** The inventory poller reads `vaultBalance2` at the latest
+  block (`crates/raindex/src/service.rs`, `get_vault_balance`) every ~60s and
+  emits `OnchainEquity` / `OnchainUsdc` snapshot events that set the
+  MarketMaking balances.
+- **The race.** A `vaultBalance2` read includes a `ClearV3`/`TakeOrderV3` fill
+  the moment its transaction lands. The fill delta arrives only after
+  `OrderFillMonitor` polls `eth_getLogs`, the apalis `AccountForDexTrade` job
+  runs, and the `Position` aggregate emits the event — a lag of seconds to
+  minutes, versus the broker's ~100ms window offchain. Any inventory poll in
+  that lag snapshots the post-fill vault balance; the delta then re-applies the
+  same fill on top. Loud variant: `InsufficientAvailable` underflow. Silent
+  variant: a wrong balance that drives needless rebalancing until the next poll.
+- Mint/redemption/bridge writers are already guarded: they set inflight, and
+  `has_inflight()` blocks snapshots for their whole window. Trade-fill deltas
+  are the unguarded second writer. `OnchainUsdc` lacks even the per-symbol
+  watermark that `OnchainEquity` has.
+
+The comment in `equity_snapshot_would_apply`'s empty `Venue::MarketMaking => {}`
+arm currently implies the onchain venue has no second writer. That claim is
+wrong and is corrected as part of this change.
+
+One asymmetry against the offchain problem decides the design: **both writers
+derive from the same chain**. A vault read is unambiguous _given its block
+number_ — a snapshot at block N provably contains every fill at block <= N and
+provably excludes every fill at block > N. The offchain fix had no such causal
+signal and had to fall back to gating snapshots on order state and host-clock
+readings. Here the exact signal exists; today it is simply discarded (nothing
+records the read's block, and the fill events do not carry the fill's block).
+
+## Decision
+
+**Guard the delta, not the snapshot.** Skip an `OnChainOrderFilled` delta leg
+iff a MarketMaking snapshot already provably contains it:
+
+> equity leg skipped iff
+> `fill.block_number <= onchain_snapshot_block_watermark[symbol]` USDC leg
+> skipped iff `fill.block_number <= onchain_usdc_snapshot_block_watermark`
+
+Concretely:
+
+1. **Pin and record the read block.** The Raindex service fetches the latest
+   block number first and pins every `vaultBalance2` `eth_call` of that poll to
+   it, returning the block alongside the balances. Pinning also fixes a latent
+   inconsistency: summing vaults across unpinned calls can straddle a block
+   boundary. Precedent: ADR 0017 pins Pyth reads the same way.
+2. **Carry the block through the snapshot commands.** `OnchainEquity` and
+   `OnchainUsdc` commands and events gain `block_number: Option<u64>` (optional
+   for legacy-event tolerance). This is the before-read-capture lesson from ADR
+   0015 applied onchain: the block is captured with the read, never stamped at
+   command-handling time.
+3. **Watermarks in the view.** `InventoryView` gains
+   `onchain_snapshot_block_watermarks: HashMap<Symbol, u64>` and
+   `onchain_usdc_snapshot_block_watermark: Option<u64>`, advanced when the
+   respective snapshot applies. In-memory only (the view has no table); a legacy
+   event without a block advances nothing.
+4. **Thread the fill's block into the event.**
+   `PositionCommand::AcknowledgeOnChainFill` and
+   `PositionEvent::OnChainOrderFilled` gain `block_number: Option<u64>`, sourced
+   from the `eth_getLogs` log that produced the fill (`OnchainTrade` already
+   carries it). Optional for legacy tolerance: a fill without a block applies
+   unconditionally (current behavior).
+5. **The guard.** The onchain fill arm skips a delta leg covered by the
+   corresponding watermark, logging at `info!` — an absorbed fill is normal
+   operation, not an error. The legs are checked independently: the equity
+   watermark is per-symbol, the USDC watermark venue-level.
+
+Snapshots are never blocked on this venue. The `Venue::MarketMaking => {}` arm
+in `equity_snapshot_would_apply` stays empty by design — its comment is updated
+to point here, and the pinning test
+`marketmaking_snapshot_unaffected_by_offchain_order_guards` is retained with its
+rationale corrected (snapshots stay unguarded because the _delta_ yields, not
+because no second writer exists).
+
+## Why not the offchain design
+
+- **No gate to transplant.** Offchain guard 1 keys on "a hedge order is open" —
+  the bot placed the order and knows its lifecycle. Onchain fills are
+  taker-initiated: the bot learns about them after the fact, so there is no
+  pre-fill state to gate snapshots on.
+- **Timestamps are the wrong tool here.** A guard-2-style
+  `fetched_at < last_onchain_fill_applied_at` comparison would work (both
+  host-clock readings) but is strictly worse than the block comparison: it
+  blocks snapshots (starvation risk, the ADR 0015 downside) during a delta lag
+  that is minutes rather than ~100ms, and it is approximate where the block
+  number is exact. Choosing timestamps when a causal ordering exists would
+  repeat alternative D's mistake at a larger scale.
+- **Deliberately preserved constraint:** snapshot timestamps remain non-causal
+  for fill deltas. The existing tests
+  (`fill_delta_before_snapshot_timestamp_is_still_applied`,
+  `offchain_fill_delta_before_snapshot_timestamp_updates_equity_and_cash`) pin
+  that decision and are untouched — this design orders by block number, never by
+  comparing a fill's wall-clock time against a snapshot's.
+
+## Tradeoffs & Consequences
+
+**Accepted downside: legacy events get no protection.** Fills and snapshots
+persisted before this change carry no block number, so replays and the first
+polls after deploy behave exactly as today. The race stays open until one
+post-deploy poll and one post-deploy fill have flowed through; no repair of
+history is attempted.
+
+**Freshness is never sacrificed.** Unlike the offchain guards, nothing here
+skips a snapshot, so this cannot create an RAI-1502-style staleness problem on
+the onchain venue — which is also why RAI-1502's bounded-reconciliation work
+deliberately scopes the onchain venue out.
+
+**A skipped delta leg loses its sub-poll freshness contribution.** When the
+equity leg is absorbed but the USDC leg is not (or vice versa), each leg is
+judged on its own watermark; an absorbed leg's information is already in the
+balance by definition, so nothing is lost — the asymmetry is correct, not a gap.
+
+**Event-schema changes.** Steps 2 and 4 add optional fields to persisted events
+(`InventorySnapshot` stream and `Position` stream). Both are additive with
+`#[serde(default)]`-style tolerance; serde tests assert legacy JSON against
+`json!()` literals, and `nix run .#prodVerifyMigrations` gates the deploy as
+usual.
+
+**Reorg caveat.** A reorg deeper than the fill's confirmation depth could in
+principle reorder a fill relative to a pinned read. Fills are already processed
+at the confirmation depth the bot requires everywhere else
+(`REQUIRED_CONFIRMATIONS`), and the poller reads at latest; a reorg that
+invalidates the comparison would also invalidate the fill event itself, which
+existing machinery owns. No additional handling here.
+
+## Alternatives considered
+
+**A. Transplant the offchain guards (gate MarketMaking snapshots).** Rejected:
+no open-order signal exists to gate on (see above), and blocking snapshots
+during a minutes-long delta lag maximizes the starvation downside ADR 0015
+accepted only for a ~2s window.
+
+**B. Host-clock guard 2 only (skip snapshots fetched before the last applied
+fill).** Rejected: covers only the reverse ordering, still blocks snapshots, and
+is approximate where an exact causal signal exists.
+
+**C. Do nothing; document the overlap as impossible.** Refuted by measurement:
+the delta lag is the `OrderFillMonitor` poll interval plus confirmations plus
+queue latency, and the 60s inventory poll lands inside it routinely.

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -17,6 +17,7 @@
 //! human-readable revert reasons without manual wiring.
 
 use alloy::consensus::Transaction;
+use alloy::eips::BlockId;
 use alloy::primitives::{Address, Bytes, TxHash};
 use alloy::providers::Provider;
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
@@ -494,7 +495,39 @@ pub trait Evm: Send + Sync + 'static {
     where
         Self: Sized,
     {
-        execute_call::<Registry, Call>(self.provider(), contract, call).await
+        execute_call::<Registry, Call>(self.provider(), contract, call, None).await
+    }
+
+    /// [`Evm::call`] pinned to a specific block.
+    ///
+    /// Use when several reads must observe one consistent chain state, or
+    /// when the caller records which block a value was read at: an unpinned
+    /// `eth_call` runs at whatever block the serving node considers latest,
+    /// which can differ between successive calls on a load-balanced RPC.
+    async fn call_at<Registry: IntoErrorRegistry, Call: SolCall + Send>(
+        &self,
+        contract: Address,
+        call: Call,
+        block_number: u64,
+    ) -> Result<Call::Return, EvmError>
+    where
+        Self: Sized,
+    {
+        execute_call::<Registry, Call>(
+            self.provider(),
+            contract,
+            call,
+            Some(BlockId::number(block_number)),
+        )
+        .await
+    }
+
+    /// Latest block number reported by the serving node.
+    async fn block_number(&self) -> Result<u64, EvmError>
+    where
+        Self: Sized,
+    {
+        Ok(self.provider().get_block_number().await?)
     }
 }
 
@@ -710,7 +743,7 @@ impl<Inner: Evm + ?Sized> Evm for Arc<Inner> {
     where
         Self: Sized,
     {
-        execute_call::<Registry, Call>(self.provider(), contract, call).await
+        execute_call::<Registry, Call>(self.provider(), contract, call, None).await
     }
 }
 
@@ -773,13 +806,19 @@ async fn execute_call<Registry: IntoErrorRegistry, Call: SolCall>(
     provider: &impl Provider,
     contract: Address,
     call: Call,
+    block: Option<BlockId>,
 ) -> Result<Call::Return, EvmError> {
     let calldata = call.abi_encode();
     let tx = TransactionRequest::default()
         .to(contract)
         .input(calldata.into());
 
-    match provider.call(tx).await {
+    let mut request = provider.call(tx);
+    if let Some(block) = block {
+        request = request.block(block);
+    }
+
+    match request.await {
         Ok(result) => Ok(Call::abi_decode_returns(result.as_ref())?),
         Err(rpc_err) => Err(decode_rpc_revert::<Registry>(rpc_err).await),
     }

--- a/crates/raindex/src/service.rs
+++ b/crates/raindex/src/service.rs
@@ -325,26 +325,41 @@ impl<W: Wallet> RaindexService<W> {
 
 /// Read operations that only need chain access (no signing).
 impl<E: Evm> RaindexService<E> {
+    /// Latest block number reported by the serving node. Callers pin their
+    /// subsequent balance reads to it so a multi-vault poll observes one
+    /// consistent chain state and can record which block it read at.
+    pub async fn latest_block_number(&self) -> Result<u64, RaindexError> {
+        Ok(self.evm.block_number().await?)
+    }
+
+    /// Gets the equity balance of a vault, pinned to `block_number`.
+    ///
+    /// Pinned rather than read at latest: the inventory poller sums several
+    /// vaults per token, and unpinned reads on a load-balanced RPC can
+    /// straddle a block boundary between calls. The pin also gives the
+    /// caller an exact as-of block to record alongside the balance.
     pub async fn get_equity_balance<Registry: IntoErrorRegistry>(
         &self,
         owner: Address,
         token: Address,
         vault_id: RaindexVaultId,
+        block_number: u64,
     ) -> Result<FractionalShares, RaindexError> {
         let exact = self
-            .get_vault_balance::<Registry>(owner, token, vault_id)
+            .get_vault_balance::<Registry>(owner, token, vault_id, block_number)
             .await?;
         Ok(FractionalShares::new(exact))
     }
 
-    /// Gets the USDC balance of a vault on Base.
+    /// Gets the USDC balance of a vault on Base, pinned to `block_number`.
     pub async fn get_usdc_balance<Registry: IntoErrorRegistry>(
         &self,
         owner: Address,
         vault_id: RaindexVaultId,
+        block_number: u64,
     ) -> Result<Usdc, RaindexError> {
         let exact = self
-            .get_vault_balance::<Registry>(owner, USDC_BASE, vault_id)
+            .get_vault_balance::<Registry>(owner, USDC_BASE, vault_id, block_number)
             .await?;
         Ok(Usdc::new(exact))
     }
@@ -571,16 +586,18 @@ impl<E: Evm> RaindexService<E> {
         owner: Address,
         token: Address,
         vault_id: RaindexVaultId,
+        block_number: u64,
     ) -> Result<Float, RaindexError> {
         let balance_float = self
             .evm
-            .call::<Registry, _>(
+            .call_at::<Registry, _>(
                 self.orderbook_address,
                 IRaindexV6::vaultBalance2Call {
                     owner,
                     token,
                     vaultId: vault_id.0,
                 },
+                block_number,
             )
             .await?;
 
@@ -1943,11 +1960,13 @@ mod tests {
         let local_evm = LocalEvm::new().await.unwrap();
         let service = create_test_raindex_service(&local_evm);
 
+        let block_number = service.latest_block_number().await.unwrap();
         let balance = service
             .get_equity_balance::<NoOpErrorRegistry>(
                 local_evm.wallet.address(),
                 local_evm.token_address,
                 TEST_VAULT_ID,
+                block_number,
             )
             .await
             .unwrap();
@@ -1982,11 +2001,13 @@ mod tests {
             .await
             .unwrap();
 
+        let block_number = service.latest_block_number().await.unwrap();
         let balance = service
             .get_equity_balance::<NoOpErrorRegistry>(
                 local_evm.wallet.address(),
                 local_evm.token_address,
                 TEST_VAULT_ID,
+                block_number,
             )
             .await
             .unwrap();
@@ -2036,17 +2057,83 @@ mod tests {
             .await
             .unwrap();
 
+        let block_number = service.latest_block_number().await.unwrap();
         let balance = service
             .get_equity_balance::<NoOpErrorRegistry>(
                 local_evm.wallet.address(),
                 local_evm.token_address,
                 TEST_VAULT_ID,
+                block_number,
             )
             .await
             .unwrap();
 
         let expected = FractionalShares::new(Float::parse("700".to_string()).unwrap());
         assert_eq!(balance, expected, "Expected 700 shares but got {balance:?}");
+    }
+
+    /// The pin is real, not advisory: a read pinned to a block before a
+    /// deposit must see the pre-deposit balance even though the latest state
+    /// already includes it. This is what lets the poller's recorded block
+    /// exactly bound which fills a snapshot contains (ADR 0018).
+    #[tokio::test]
+    async fn get_equity_balance_pinned_block_sees_that_blocks_state() {
+        let local_evm = LocalEvm::new().await.unwrap();
+
+        let deposit_amount = U256::from(1000) * U256::from(10).pow(U256::from(18));
+
+        local_evm
+            .approve_tokens(
+                local_evm.token_address,
+                local_evm.orderbook_address,
+                deposit_amount,
+            )
+            .await
+            .unwrap();
+
+        let service = create_test_raindex_service(&local_evm);
+        let pre_deposit_block = service.latest_block_number().await.unwrap();
+
+        service
+            .deposit::<NoOpErrorRegistry>(
+                local_evm.token_address,
+                TEST_VAULT_ID,
+                deposit_amount,
+                TEST_TOKEN_DECIMALS,
+            )
+            .await
+            .unwrap();
+
+        let post_deposit_block = service.latest_block_number().await.unwrap();
+        let balance_now = service
+            .get_equity_balance::<NoOpErrorRegistry>(
+                local_evm.wallet.address(),
+                local_evm.token_address,
+                TEST_VAULT_ID,
+                post_deposit_block,
+            )
+            .await
+            .unwrap();
+        let balance_before = service
+            .get_equity_balance::<NoOpErrorRegistry>(
+                local_evm.wallet.address(),
+                local_evm.token_address,
+                TEST_VAULT_ID,
+                pre_deposit_block,
+            )
+            .await
+            .unwrap();
+
+        let expected_now = FractionalShares::new(Float::parse("1000".to_string()).unwrap());
+        assert_eq!(
+            balance_now, expected_now,
+            "the post-deposit block must include the deposit"
+        );
+        assert_eq!(
+            balance_before,
+            FractionalShares::ZERO,
+            "a read pinned before the deposit must not include it"
+        );
     }
 
     /// Values with large exponents produce scientific notation from

--- a/src/api.rs
+++ b/src/api.rs
@@ -2866,6 +2866,7 @@ mod tests {
                     direction: Direction::Sell,
                     price_usdc: float!(10),
                     block_timestamp,
+                    block_number: None,
                     seen_at: block_timestamp,
                 },
             )
@@ -3584,6 +3585,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: block_ts,
+                    block_number: None,
                     seen_at: seen_ts,
                 },
             )

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -746,6 +746,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(420),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -1670,6 +1671,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(420),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -1749,6 +1751,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(420),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -3002,6 +3002,7 @@ pub(crate) async fn execute_acknowledge_fill(
         direction: trade.direction,
         price_usdc,
         block_timestamp,
+        block_number: trade.block_number,
     };
 
     match position.send(base_symbol, command).await {
@@ -6242,6 +6243,7 @@ mod tests {
                     direction,
                     price_usdc: float!(150),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -6646,6 +6648,7 @@ mod tests {
             direction: Direction::Buy,
             price_usdc: float!(100),
             block_timestamp: Utc::now(),
+            block_number: None,
             seen_at: Utc::now(),
         };
 
@@ -7560,6 +7563,57 @@ mod tests {
         assert!(
             position.net.inner().eq(float!(1.5)).unwrap(),
             "the re-drive must not double-count the fill"
+        );
+    }
+
+    /// The block number is the causal key for onchain fill absorption (ADR
+    /// 0018): `execute_acknowledge_fill` must carry the trade's pinned
+    /// block through to the persisted `OnChainOrderFilled` event verbatim.
+    #[tokio::test]
+    async fn acknowledge_fill_persists_the_trades_block_number() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+        let trade = OnchainTradeBuilder::default()
+            .with_symbol("wtAAPL")
+            .with_equity_token(TEST_EQUITY_TOKEN)
+            .with_amount(float!(1.5))
+            .with_log_index(60)
+            .with_block_number(4242)
+            .build();
+        let block_timestamp = trade
+            .block_timestamp
+            .expect("test trade carries a block timestamp");
+
+        execute_acknowledge_fill(
+            &cqrs.position,
+            &trade,
+            cqrs.execution_threshold,
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+
+        let payload: String = sqlx::query_scalar(
+            "SELECT payload FROM events \
+             WHERE event_type = 'PositionEvent::OnChainOrderFilled'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let event: PositionEvent = serde_json::from_str(&payload).unwrap();
+        let PositionEvent::OnChainOrderFilled { block_number, .. } = event else {
+            panic!("expected OnChainOrderFilled, got {event:?}");
+        };
+        assert_eq!(
+            block_number,
+            Some(4242),
+            "the persisted fill event must retain the trade's block number"
         );
     }
 
@@ -8946,6 +9000,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150.0),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -9057,6 +9112,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150.0),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -9178,6 +9234,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150.0),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -9332,6 +9389,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150.0),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -9368,6 +9426,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150.0),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -9397,6 +9456,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150.0),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -9438,6 +9498,7 @@ mod tests {
                         direction: Direction::Buy,
                         price_usdc: float!(150.0),
                         block_timestamp: chrono::Utc::now(),
+                        block_number: None,
                     },
                 )
                 .await
@@ -9503,6 +9564,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -9582,6 +9644,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -9787,6 +9850,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -9960,6 +10024,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(78),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -10088,6 +10153,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(420),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -10210,6 +10276,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(100),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -10313,6 +10380,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(100),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -10459,6 +10527,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(100),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -10559,6 +10628,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(400),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -10666,6 +10736,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(120),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -10813,6 +10884,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(120),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -10938,6 +11010,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(95),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -11153,6 +11226,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: onchain.price.value(),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -332,7 +332,13 @@ mod tests {
         );
         built
             .snapshot
-            .send(&id, InventorySnapshotCommand::OnchainEquity { balances })
+            .send(
+                &id,
+                InventorySnapshotCommand::OnchainEquity {
+                    balances,
+                    block_number: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -454,6 +460,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -2164,6 +2164,7 @@ mod tests {
                     direction: st0x_execution::Direction::Buy,
                     price_usdc: st0x_float_macro::float!(150),
                     block_timestamp: now,
+                    block_number: None,
                 },
             )
             .await
@@ -2181,6 +2182,7 @@ mod tests {
                     direction: st0x_execution::Direction::Buy,
                     price_usdc: st0x_float_macro::float!(150),
                     block_timestamp: now,
+                    block_number: None,
                     seen_at: now,
                 },
             )
@@ -2239,6 +2241,7 @@ mod tests {
                     direction: st0x_execution::Direction::Buy,
                     price_usdc: st0x_float_macro::float!(150),
                     block_timestamp: now,
+                    block_number: None,
                 },
             )
             .await

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -400,6 +400,7 @@ async fn build_imbalanced_inventory(imbalance: Imbalance<'_>) {
                         direction: Direction::Buy,
                         price_usdc: float!(150.0),
                         block_timestamp: Utc::now(),
+                        block_number: None,
                     },
                 )
                 .await
@@ -635,6 +636,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
                 direction: Direction::Sell,
                 price_usdc: float!(150.0),
                 block_timestamp: Utc::now(),
+                block_number: None,
             },
         )
         .await
@@ -906,6 +908,7 @@ async fn equity_onchain_imbalance_triggers_redemption() {
                 direction: Direction::Buy,
                 price_usdc: float!(150.0),
                 block_timestamp: Utc::now(),
+                block_number: None,
             },
         )
         .await
@@ -1329,6 +1332,7 @@ async fn cash_reserve_does_not_shift_rebalancing_ratio() {
             &snapshot_id,
             InventorySnapshotCommand::OnchainUsdc {
                 usdc_balance: Usdc::new(float!(500)),
+                block_number: None,
             },
         )
         .await
@@ -1638,6 +1642,7 @@ async fn mint_api_failure_produces_rejected_event() {
                 direction: Direction::Sell,
                 price_usdc: float!(150.0),
                 block_timestamp: Utc::now(),
+                block_number: None,
             },
         )
         .await
@@ -2191,6 +2196,7 @@ async fn mint_accepted_sets_offchain_inflight() {
                 direction: Direction::Sell,
                 price_usdc: float!("150.0"),
                 block_timestamp: Utc::now(),
+                block_number: None,
             },
         )
         .await
@@ -2398,6 +2404,7 @@ async fn completed_mint_clears_inflight_and_updates_inventory() {
                 direction: Direction::Sell,
                 price_usdc: float!("150.0"),
                 block_timestamp: Utc::now(),
+                block_number: None,
             },
         )
         .await

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -306,8 +306,16 @@ where
             return Ok(());
         };
 
-        self.poll_onchain_equity(snapshot_id, &registry).await?;
-        self.poll_onchain_usdc(snapshot_id, &registry).await?;
+        // One pinned block for the whole onchain cycle: every vaultBalance2
+        // read below observes this exact chain state, and the snapshot
+        // events record it so the view's block watermarks can absorb fill
+        // deltas the balances already contain.
+        let block_number = self.raindex_service.latest_block_number().await?;
+
+        self.poll_onchain_equity(snapshot_id, &registry, block_number)
+            .await?;
+        self.poll_onchain_usdc(snapshot_id, &registry, block_number)
+            .await?;
 
         Ok(())
     }
@@ -327,6 +335,7 @@ where
         &self,
         snapshot_id: &InventorySnapshotId,
         registry: &VaultRegistry,
+        block_number: u64,
     ) -> Result<(), InventoryPollingError<Exe::Error>> {
         if registry.equity_vaults.is_empty() {
             debug!(target: "inventory", "No equity vaults discovered, skipping onchain equity polling");
@@ -352,6 +361,7 @@ where
                             self.vault_owner,
                             vault.token,
                             RaindexVaultId(vault.vault_id),
+                            block_number,
                         )
                 });
 
@@ -395,7 +405,10 @@ where
         self.snapshot
             .send(
                 snapshot_id,
-                InventorySnapshotCommand::OnchainEquity { balances },
+                InventorySnapshotCommand::OnchainEquity {
+                    balances,
+                    block_number: Some(block_number),
+                },
             )
             .await?;
 
@@ -415,6 +428,7 @@ where
         &self,
         snapshot_id: &InventorySnapshotId,
         registry: &VaultRegistry,
+        block_number: u64,
     ) -> Result<(), InventoryPollingError<Exe::Error>> {
         if registry.usdc_vaults.is_empty() {
             debug!(target: "inventory", "No USDC vaults discovered, skipping onchain cash polling");
@@ -426,6 +440,7 @@ where
                 .get_usdc_balance::<OpenChainErrorRegistry>(
                     self.vault_owner,
                     RaindexVaultId(vault.vault_id),
+                    block_number,
                 )
         });
 
@@ -443,7 +458,10 @@ where
         self.snapshot
             .send(
                 snapshot_id,
-                InventorySnapshotCommand::OnchainUsdc { usdc_balance },
+                InventorySnapshotCommand::OnchainUsdc {
+                    usdc_balance,
+                    block_number: Some(block_number),
+                },
             )
             .await?;
 
@@ -2377,6 +2395,7 @@ mod tests {
         discover_usdc_vault(&pool, orderbook, order_owner, TEST_VAULT_ID).await;
 
         let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::from(100u64)); // eth_blockNumber (pinned poll block)
         asserter.push_success(&ZERO_FLOAT_HEX); // vaultBalance2 for USDC vault
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let raindex_service = create_test_raindex_service(provider);
@@ -2433,6 +2452,7 @@ mod tests {
         .await;
 
         let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::from(100u64)); // eth_blockNumber (pinned poll block)
         asserter.push_success(&ZERO_FLOAT_HEX); // vaultBalance2 for equity vault
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let raindex_service = create_test_raindex_service(provider);
@@ -2499,6 +2519,7 @@ mod tests {
         .await;
 
         let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::from(100u64)); // eth_blockNumber (pinned poll block)
         asserter.push_success(&vault_balance_hex(float!(7))); // vaultBalance2 for the equity vault
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let raindex_service = create_test_raindex_service(provider);
@@ -2551,6 +2572,7 @@ mod tests {
         .await;
 
         let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::from(100u64)); // eth_blockNumber (pinned poll block)
         asserter.push_failure_msg("RPC failure"); // vaultBalance2 for equity vault
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let raindex_service = create_test_raindex_service(provider);
@@ -2593,6 +2615,7 @@ mod tests {
         discover_usdc_vault(&pool, orderbook, order_owner, TEST_VAULT_ID).await;
 
         let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::from(100u64)); // eth_blockNumber (pinned poll block)
         asserter.push_failure_msg("RPC failure"); // vaultBalance2 for USDC vault
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let raindex_service = create_test_raindex_service(provider);
@@ -2657,6 +2680,7 @@ mod tests {
 
         let retired_balance = vault_balance_hex(float!(5));
         let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::from(100u64)); // eth_blockNumber (pinned poll block)
         asserter.push_success(&retired_balance);
         asserter.push_success(&ZERO_FLOAT_HEX);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
@@ -2710,6 +2734,7 @@ mod tests {
 
         let retired_balance = vault_balance_hex(float!(125));
         let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::from(100u64)); // eth_blockNumber (pinned poll block)
         asserter.push_success(&retired_balance);
         asserter.push_success(&ZERO_FLOAT_HEX);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
@@ -5113,7 +5138,9 @@ mod tests {
         .await;
 
         let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::from(100u64)); // tick 1 eth_blockNumber
         asserter.push_success(&vault_balance_hex(float!(7))); // tick 1
+        asserter.push_success(&serde_json::Value::from(101u64)); // tick 2 eth_blockNumber
         asserter.push_success(&vault_balance_hex(float!(7))); // tick 2, unchanged
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let raindex_service = create_test_raindex_service(provider);
@@ -5302,6 +5329,7 @@ mod tests {
         .await;
 
         let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::from(100u64)); // eth_blockNumber (pinned poll block)
         asserter.push_failure_msg("RPC failure"); // vaultBalance2 for equity vault
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let raindex_service = create_test_raindex_service(provider);
@@ -5428,6 +5456,7 @@ mod tests {
         discover_usdc_vault(&pool, orderbook, order_owner, TEST_VAULT_ID).await;
 
         let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::from(100u64)); // eth_blockNumber (pinned poll block)
         asserter.push_success(&vault_balance_hex(float!(7))); // equity vaultBalance2
         asserter.push_success(&vault_balance_hex(float!(3))); // usdc vaultBalance2
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);

--- a/src/inventory/projection.rs
+++ b/src/inventory/projection.rs
@@ -189,6 +189,7 @@ mod tests {
         let event = InventorySnapshotEvent::OnchainEquity {
             balances,
             fetched_at: Utc::now(),
+            block_number: None,
         };
 
         projection.apply(&event).await.unwrap();
@@ -366,6 +367,7 @@ mod tests {
                 &InventorySnapshotEvent::OnchainUsdc {
                     usdc_balance: Usdc::from_cents(2_000_000).unwrap(),
                     fetched_at: Utc::now(),
+                    block_number: None,
                 },
                 Utc::now(),
                 reason,
@@ -403,6 +405,7 @@ mod tests {
             .apply(&InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: Usdc::from_cents(2_000_000).unwrap(),
                 fetched_at: Utc::now(),
+                block_number: None,
             })
             .await
             .unwrap();
@@ -445,7 +448,13 @@ mod tests {
         let mut balances = BTreeMap::new();
         balances.insert(symbol("RKLB"), shares(42));
         snapshot
-            .send(&id, InventorySnapshotCommand::OnchainEquity { balances })
+            .send(
+                &id,
+                InventorySnapshotCommand::OnchainEquity {
+                    balances,
+                    block_number: None,
+                },
+            )
             .await
             .unwrap();
 

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -72,10 +72,17 @@ pub(crate) struct InventorySnapshot {
     pub(crate) onchain_equity: BTreeMap<Symbol, FractionalShares>,
     #[serde(default)]
     pub(crate) onchain_equity_fetched_at: Option<DateTime<Utc>>,
+    /// Block the latest onchain equity read was pinned to. Persisted so
+    /// hydration restores the view's block watermark across restarts.
+    #[serde(default)]
+    pub(crate) onchain_equity_block: Option<u64>,
     /// Latest onchain USDC balance
     pub(crate) onchain_usdc: Option<Usdc>,
     #[serde(default)]
     pub(crate) onchain_usdc_fetched_at: Option<DateTime<Utc>>,
+    /// Block the latest onchain USDC read was pinned to.
+    #[serde(default)]
+    pub(crate) onchain_usdc_block: Option<u64>,
     /// Latest offchain equity positions by symbol
     pub(crate) offchain_equity: BTreeMap<Symbol, FractionalShares>,
     #[serde(default)]
@@ -143,8 +150,10 @@ impl EventSourced for InventorySnapshot {
         let mut snapshot = Self {
             onchain_equity: BTreeMap::new(),
             onchain_equity_fetched_at: None,
+            onchain_equity_block: None,
             onchain_usdc: None,
             onchain_usdc_fetched_at: None,
+            onchain_usdc_block: None,
             offchain_equity: BTreeMap::new(),
             offchain_equity_fetched_at: None,
             offchain_usd_cents: None,
@@ -179,13 +188,21 @@ impl EventSourced for InventorySnapshot {
         use InventorySnapshotCommand::*;
         let now = Utc::now();
         Ok(vec![match command {
-            OnchainEquity { balances } => InventorySnapshotEvent::OnchainEquity {
+            OnchainEquity {
+                balances,
+                block_number,
+            } => InventorySnapshotEvent::OnchainEquity {
                 balances,
                 fetched_at: now,
+                block_number,
             },
-            OnchainUsdc { usdc_balance } => InventorySnapshotEvent::OnchainUsdc {
+            OnchainUsdc {
+                usdc_balance,
+                block_number,
+            } => InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance,
                 fetched_at: now,
+                block_number,
             },
             OffchainEquity {
                 positions,
@@ -272,22 +289,34 @@ impl EventSourced for InventorySnapshot {
         let now = Utc::now();
 
         match command {
-            OnchainEquity { balances } => {
+            // Dedupe on the value alone, ignoring `block_number`: an
+            // unchanged balance across polls means any fills in between
+            // netted to zero, and their deltas cancel in the view too, so a
+            // stale block watermark cannot leave the balance wrong.
+            OnchainEquity {
+                balances,
+                block_number,
+            } => {
                 if self.onchain_equity == balances {
                     return Ok(vec![]);
                 }
                 Ok(vec![InventorySnapshotEvent::OnchainEquity {
                     balances,
                     fetched_at: now,
+                    block_number,
                 }])
             }
-            OnchainUsdc { usdc_balance } => {
+            OnchainUsdc {
+                usdc_balance,
+                block_number,
+            } => {
                 if self.onchain_usdc == Some(usdc_balance) {
                     return Ok(vec![]);
                 }
                 Ok(vec![InventorySnapshotEvent::OnchainUsdc {
                     usdc_balance,
                     fetched_at: now,
+                    block_number,
                 }])
             }
             OffchainEquity {
@@ -473,6 +502,7 @@ impl InventorySnapshot {
             emit(InventorySnapshotEvent::OnchainEquity {
                 balances: self.onchain_equity.clone(),
                 fetched_at,
+                block_number: self.onchain_equity_block,
             });
         }
 
@@ -482,6 +512,7 @@ impl InventorySnapshot {
             emit(InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance,
                 fetched_at,
+                block_number: self.onchain_usdc_block,
             });
         }
 
@@ -574,22 +605,26 @@ impl InventorySnapshot {
             InventorySnapshotEvent::OnchainEquity {
                 balances,
                 fetched_at,
+                block_number,
             } if self
                 .onchain_equity_fetched_at
                 .is_none_or(|current| *fetched_at >= current) =>
             {
                 self.onchain_equity = balances.clone();
                 self.onchain_equity_fetched_at = Some(*fetched_at);
+                self.onchain_equity_block = *block_number;
             }
             InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance,
                 fetched_at,
+                block_number,
             } if self
                 .onchain_usdc_fetched_at
                 .is_none_or(|current| *fetched_at >= current) =>
             {
                 self.onchain_usdc = Some(*usdc_balance);
                 self.onchain_usdc_fetched_at = Some(*fetched_at);
+                self.onchain_usdc_block = *block_number;
             }
             InventorySnapshotEvent::OffchainEquity {
                 positions,
@@ -677,9 +712,16 @@ impl InventorySnapshot {
 pub(crate) enum InventorySnapshotCommand {
     OnchainEquity {
         balances: BTreeMap<Symbol, FractionalShares>,
+        /// Block the poller pinned this cycle's `vaultBalance2` reads to.
+        /// Captured with the read (never stamped at command-handling time),
+        /// so the view's block watermark exactly bounds which fills the
+        /// balances already contain.
+        block_number: Option<u64>,
     },
     OnchainUsdc {
         usdc_balance: Usdc,
+        /// Block the poller pinned this cycle's `vaultBalance2` reads to.
+        block_number: Option<u64>,
     },
     OffchainEquity {
         positions: BTreeMap<Symbol, FractionalShares>,
@@ -752,11 +794,22 @@ pub(crate) enum InventorySnapshotEvent {
     OnchainEquity {
         balances: BTreeMap<Symbol, FractionalShares>,
         fetched_at: DateTime<Utc>,
+        /// Block the `vaultBalance2` reads were pinned to. `None` for events
+        /// emitted before this field was added (schema
+        /// backward-compatibility); a legacy event advances no block
+        /// watermark in the view.
+        #[serde(default)]
+        block_number: Option<u64>,
     },
     #[serde(alias = "OnchainCash")]
     OnchainUsdc {
         usdc_balance: Usdc,
         fetched_at: DateTime<Utc>,
+        /// Block the `vaultBalance2` reads were pinned to. `None` for events
+        /// emitted before this field was added (schema
+        /// backward-compatibility).
+        #[serde(default)]
+        block_number: Option<u64>,
     },
     OffchainEquity {
         positions: BTreeMap<Symbol, FractionalShares>,
@@ -880,6 +933,7 @@ impl DomainEvent for InventorySnapshotEvent {
 #[cfg(test)]
 mod tests {
     use rain_math_float::Float;
+    use serde_json::json;
     use std::str::FromStr;
 
     use super::*;
@@ -942,6 +996,7 @@ mod tests {
             .given_no_previous_events()
             .when(InventorySnapshotCommand::OnchainEquity {
                 balances: balances.clone(),
+                block_number: None,
             })
             .await
             .events();
@@ -967,9 +1022,11 @@ mod tests {
             .given(vec![InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: Usdc::from_str("1000").unwrap(),
                 fetched_at: Utc::now(),
+                block_number: None,
             }])
             .when(InventorySnapshotCommand::OnchainEquity {
                 balances: balances.clone(),
+                block_number: None,
             })
             .await
             .events();
@@ -992,7 +1049,10 @@ mod tests {
 
         let events = TestHarness::<InventorySnapshot>::with(())
             .given_no_previous_events()
-            .when(InventorySnapshotCommand::OnchainUsdc { usdc_balance })
+            .when(InventorySnapshotCommand::OnchainUsdc {
+                usdc_balance,
+                block_number: None,
+            })
             .await
             .events();
 
@@ -1095,15 +1155,23 @@ mod tests {
                 vec![InventorySnapshotEvent::OnchainEquity {
                     balances: balances.clone(),
                     fetched_at,
+                    block_number: None,
                 }],
-                InventorySnapshotCommand::OnchainEquity { balances },
+                InventorySnapshotCommand::OnchainEquity {
+                    balances,
+                    block_number: None,
+                },
             ),
             (
                 vec![InventorySnapshotEvent::OnchainUsdc {
                     usdc_balance,
                     fetched_at,
+                    block_number: None,
                 }],
-                InventorySnapshotCommand::OnchainUsdc { usdc_balance },
+                InventorySnapshotCommand::OnchainUsdc {
+                    usdc_balance,
+                    block_number: None,
+                },
             ),
             (
                 vec![InventorySnapshotEvent::OffchainEquity {
@@ -1150,10 +1218,12 @@ mod tests {
             InventorySnapshotEvent::OnchainEquity {
                 balances: balances.clone(),
                 fetched_at: Utc::now(),
+                block_number: None,
             },
             InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: usdc,
                 fetched_at: Utc::now(),
+                block_number: None,
             },
         ])
         .unwrap()
@@ -1175,10 +1245,12 @@ mod tests {
             InventorySnapshotEvent::OnchainEquity {
                 balances: first_balances,
                 fetched_at: Utc::now(),
+                block_number: None,
             },
             InventorySnapshotEvent::OnchainEquity {
                 balances: second_balances.clone(),
                 fetched_at: Utc::now(),
+                block_number: None,
             },
         ])
         .unwrap()
@@ -1201,10 +1273,12 @@ mod tests {
             InventorySnapshotEvent::OnchainEquity {
                 balances: newer_balances.clone(),
                 fetched_at: newer_at,
+                block_number: None,
             },
             InventorySnapshotEvent::OnchainEquity {
                 balances: older_balances,
                 fetched_at: older_at,
+                block_number: None,
             },
         ])
         .unwrap()
@@ -1243,6 +1317,7 @@ mod tests {
             .given(vec![InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: Usdc::from_str("1000").unwrap(),
                 fetched_at: Utc::now(),
+                block_number: None,
             }])
             .when(InventorySnapshotCommand::EthereumUsdc { usdc_balance })
             .await
@@ -1891,6 +1966,7 @@ mod tests {
             .given(vec![InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: Usdc::from_str("1000").unwrap(),
                 fetched_at: Utc::now(),
+                block_number: None,
             }])
             .when(InventorySnapshotCommand::InflightEquity {
                 mints,
@@ -1947,8 +2023,10 @@ mod tests {
         let snapshot = InventorySnapshot {
             onchain_equity: BTreeMap::new(),
             onchain_equity_fetched_at: None,
+            onchain_equity_block: None,
             onchain_usdc: None,
             onchain_usdc_fetched_at: None,
+            onchain_usdc_block: None,
             offchain_equity: BTreeMap::new(),
             offchain_equity_fetched_at: None,
             offchain_usd_cents: None,
@@ -1981,8 +2059,10 @@ mod tests {
         let original = InventorySnapshot {
             onchain_equity: onchain_equity.clone(),
             onchain_equity_fetched_at: Some(now),
+            onchain_equity_block: Some(4_242),
             onchain_usdc: Some(Usdc::from_str("5000").unwrap()),
             onchain_usdc_fetched_at: Some(now),
+            onchain_usdc_block: Some(4_242),
             offchain_equity: BTreeMap::new(),
             offchain_equity_fetched_at: None,
             offchain_usd_cents: Some(42_00),
@@ -2019,6 +2099,73 @@ mod tests {
         );
         assert_eq!(reconstructed.alpaca_usdc, original.alpaca_usdc);
         assert_eq!(reconstructed.inflight_mints, original.inflight_mints);
+        assert_eq!(
+            reconstructed.onchain_equity_block, original.onchain_equity_block,
+            "hydration must carry the onchain equity block so the view's \
+             block watermark survives a restart"
+        );
+        assert_eq!(
+            reconstructed.onchain_usdc_block, original.onchain_usdc_block,
+            "hydration must carry the onchain USDC block so the view's \
+             block watermark survives a restart"
+        );
+    }
+
+    /// Events persisted before the block field existed must deserialize with
+    /// `None`, and new events must serialize the block so replays after the
+    /// next deploy see it. Serialized shapes asserted against literals.
+    #[test]
+    fn onchain_snapshot_event_block_field_roundtrips_and_tolerates_legacy() {
+        let event = InventorySnapshotEvent::OnchainUsdc {
+            usdc_balance: Usdc::from_str("5000").unwrap(),
+            fetched_at: Utc::now(),
+            block_number: Some(4_242),
+        };
+
+        let mut value = serde_json::to_value(&event).unwrap();
+        assert_eq!(value["OnchainUsdc"]["block_number"], json!(4_242));
+
+        // Strip the field to reproduce a pre-ADR-0018 event payload.
+        value["OnchainUsdc"]
+            .as_object_mut()
+            .unwrap()
+            .remove("block_number");
+        let legacy: InventorySnapshotEvent = serde_json::from_value(value).unwrap();
+        let InventorySnapshotEvent::OnchainUsdc { block_number, .. } = legacy else {
+            panic!("expected OnchainUsdc, got {legacy:?}");
+        };
+        assert_eq!(
+            block_number, None,
+            "a legacy event without the field must deserialize to None"
+        );
+    }
+
+    /// Pins the ADR 0018 dedupe decision: an unchanged balance emits no
+    /// event even when the read's block advanced. Any fills in between
+    /// netted to zero, and their deltas cancel in the view too, so the stale
+    /// watermark cannot leave the balance wrong.
+    #[tokio::test]
+    async fn unchanged_onchain_balance_dedupes_even_with_newer_block() {
+        let usdc_balance = Usdc::from_str("5000").unwrap();
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given(vec![InventorySnapshotEvent::OnchainUsdc {
+                usdc_balance,
+                fetched_at: Utc::now(),
+                block_number: Some(100),
+            }])
+            .when(InventorySnapshotCommand::OnchainUsdc {
+                usdc_balance,
+                block_number: Some(200),
+            })
+            .await
+            .events();
+
+        assert_eq!(
+            events.len(),
+            0,
+            "an unchanged balance must dedupe regardless of the newer block"
+        );
     }
 
     #[test]
@@ -2037,6 +2184,7 @@ mod tests {
         snapshot.apply_event(&InventorySnapshotEvent::OnchainUsdc {
             usdc_balance: Usdc::from_str("1000").unwrap(),
             fetched_at: later_balance_fetched_at,
+            block_number: None,
         });
 
         let inflight_event = snapshot

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -172,6 +172,30 @@ where
         Ok(onchain_inflight || offchain_inflight)
     }
 
+    /// The skip conditions of [`Self::on_snapshot`], exposed so callers that
+    /// track per-snapshot bookkeeping (the onchain USDC block watermark) can
+    /// tell whether the closure will apply or silently skip. Single source
+    /// of truth: the closure consults this same predicate.
+    fn snapshot_would_apply(&self, fetched_at: DateTime<Utc>) -> Result<bool, FloatError> {
+        if self.has_inflight()? {
+            return Ok(false);
+        }
+
+        if let Some(last_rebalancing) = self.last_rebalancing
+            && fetched_at < last_rebalancing
+        {
+            debug!(
+                target: "inventory",
+                ?fetched_at,
+                ?last_rebalancing,
+                "Rejecting stale snapshot that predates last rebalancing"
+            );
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
     fn get_venue(&self, venue: Venue) -> Option<VenueBalance<T>> {
         match venue {
             Venue::MarketMaking => self.onchain,
@@ -444,19 +468,7 @@ where
         fetched_at: DateTime<Utc>,
     ) -> Box<dyn FnOnce(Self) -> Result<Self, InventoryError<T>> + Send> {
         Box::new(move |inventory| {
-            if inventory.has_inflight()? {
-                return Ok(inventory);
-            }
-
-            if let Some(last_rebalancing) = inventory.last_rebalancing
-                && fetched_at < last_rebalancing
-            {
-                debug!(
-                    target: "inventory",
-                    ?fetched_at,
-                    ?last_rebalancing,
-                    "Rejecting stale snapshot that predates last rebalancing"
-                );
+            if !inventory.snapshot_would_apply(fetched_at)? {
                 return Ok(inventory);
             }
 
@@ -721,6 +733,17 @@ pub(crate) struct InventoryView {
     /// overwriting a correctly decremented balance with a pre-fill number.
     #[serde(default)]
     last_offchain_fill_applied_at: HashMap<Symbol, DateTime<Utc>>,
+    /// Highest block number whose `OnchainEquity` snapshot has been applied,
+    /// by symbol. Chain-native ordering, not a clock: a pinned vault read at
+    /// block N provably contains every fill at a block <= N, so an
+    /// `OnChainOrderFilled` delta covered by this watermark is already in
+    /// the balance and must be skipped (ADR 0018).
+    #[serde(default)]
+    onchain_equity_snapshot_block_watermarks: HashMap<Symbol, u64>,
+    /// Highest block number whose `OnchainUsdc` snapshot has been applied.
+    /// Venue-level: the USDC balance is one number per venue.
+    #[serde(default)]
+    onchain_usdc_snapshot_block_watermark: Option<u64>,
 }
 
 impl InventoryView {
@@ -1058,6 +1081,8 @@ impl Default for InventoryView {
             usdc: Inventory::default(),
             equities: HashMap::new(),
             last_updated: Utc::now(),
+            onchain_equity_snapshot_block_watermarks: HashMap::new(),
+            onchain_usdc_snapshot_block_watermark: None,
             buying_power_cents: None,
             withdrawable_cash_cents: None,
             offchain_gross_usd_cents: None,
@@ -1290,6 +1315,8 @@ impl InventoryView {
             offchain_equity_snapshot_watermarks: self.offchain_equity_snapshot_watermarks,
             pending_offchain_order_symbols: self.pending_offchain_order_symbols,
             last_offchain_fill_applied_at: self.last_offchain_fill_applied_at,
+            onchain_equity_snapshot_block_watermarks: self.onchain_equity_snapshot_block_watermarks,
+            onchain_usdc_snapshot_block_watermark: self.onchain_usdc_snapshot_block_watermark,
         })
     }
 
@@ -1319,6 +1346,8 @@ impl InventoryView {
             offchain_equity_snapshot_watermarks: self.offchain_equity_snapshot_watermarks,
             pending_offchain_order_symbols: self.pending_offchain_order_symbols,
             last_offchain_fill_applied_at: self.last_offchain_fill_applied_at,
+            onchain_equity_snapshot_block_watermarks: self.onchain_equity_snapshot_block_watermarks,
+            onchain_usdc_snapshot_block_watermark: self.onchain_usdc_snapshot_block_watermark,
         })
     }
 
@@ -1341,6 +1370,99 @@ impl InventoryView {
         }
 
         self
+    }
+
+    /// Advance the per-symbol onchain block watermarks after an equity
+    /// snapshot applied. A no-op for the Hedging venue (broker reads have no
+    /// block) and for legacy snapshots without a block number.
+    fn record_onchain_equity_block_watermarks<'a>(
+        mut self,
+        venue: Venue,
+        symbols: impl IntoIterator<Item = &'a Symbol>,
+        block_number: Option<u64>,
+    ) -> Self {
+        let (Venue::MarketMaking, Some(block_number)) = (venue, block_number) else {
+            return self;
+        };
+
+        for symbol in symbols {
+            let watermark = self
+                .onchain_equity_snapshot_block_watermarks
+                .entry(symbol.clone())
+                .or_insert(block_number);
+            if block_number > *watermark {
+                *watermark = block_number;
+            }
+        }
+
+        self
+    }
+
+    /// Force-set the per-symbol onchain block watermarks to a forced read's
+    /// block. Unlike [`Self::record_onchain_equity_block_watermarks`], this
+    /// bypasses the monotonic maximum: the forced balance is authoritative,
+    /// so a watermark left above the forced block would keep absorbing
+    /// fills the forced balance does not contain.
+    fn force_onchain_equity_block_watermarks<'a>(
+        mut self,
+        symbols: impl IntoIterator<Item = &'a Symbol>,
+        block_number: Option<u64>,
+    ) -> Self {
+        let Some(block_number) = block_number else {
+            return self;
+        };
+
+        for symbol in symbols {
+            self.onchain_equity_snapshot_block_watermarks
+                .insert(symbol.clone(), block_number);
+        }
+
+        self
+    }
+
+    /// Advance the venue-level onchain USDC block watermark after an
+    /// `OnchainUsdc` snapshot applied.
+    fn record_onchain_usdc_block_watermark(mut self, block_number: Option<u64>) -> Self {
+        let Some(block_number) = block_number else {
+            return self;
+        };
+
+        let advanced = self
+            .onchain_usdc_snapshot_block_watermark
+            .is_none_or(|watermark| block_number > watermark);
+        if advanced {
+            self.onchain_usdc_snapshot_block_watermark = Some(block_number);
+        }
+
+        self
+    }
+
+    /// Whether a MarketMaking equity fill delta at `block_number` is already
+    /// contained in an applied onchain snapshot (ADR 0018). Legacy fills
+    /// without a block are never treated as absorbed.
+    pub(crate) fn onchain_fill_absorbed_by_equity_snapshot(
+        &self,
+        symbol: &Symbol,
+        block_number: Option<u64>,
+    ) -> bool {
+        let Some(block_number) = block_number else {
+            return false;
+        };
+
+        self.onchain_equity_snapshot_block_watermarks
+            .get(symbol)
+            .is_some_and(|watermark| block_number <= *watermark)
+    }
+
+    /// Whether a MarketMaking USDC fill delta at `block_number` is already
+    /// contained in an applied onchain USDC snapshot (ADR 0018).
+    pub(crate) fn onchain_fill_absorbed_by_usdc_snapshot(&self, block_number: Option<u64>) -> bool {
+        let Some(block_number) = block_number else {
+            return false;
+        };
+
+        self.onchain_usdc_snapshot_block_watermark
+            .is_some_and(|watermark| block_number <= watermark)
     }
 
     /// Marks a symbol as having an open offchain order, so offchain equity
@@ -1457,10 +1579,15 @@ impl InventoryView {
             return Ok(false);
         }
 
-        // The offchain venue has a second writer (the fill delta) that the
-        // onchain venue does not; yield to it while it owns the balance.
-        // Exhaustive so a new venue forces a decision on whether it has a
-        // second writer of its own.
+        // Both venues have a second writer (the fill delta), but they are
+        // reconciled in opposite directions. Offchain: no causal signal ties
+        // a broker read to a fill, so the snapshot yields to the delta while
+        // a hedge order owns the balance (the guards below). Onchain: both
+        // writers derive from the same chain, so the DELTA yields instead --
+        // a fill covered by an applied snapshot's block watermark is skipped
+        // at the source (`onchain_fill_absorbed_by_*`, ADR 0018) and
+        // snapshots here are never blocked. Exhaustive so a new venue forces
+        // a decision on how its second writer is reconciled.
         match venue {
             Venue::MarketMaking => {}
             Venue::Hedging => {
@@ -1512,6 +1639,7 @@ impl InventoryView {
         venue: Venue,
         balances: impl IntoIterator<Item = (&'a Symbol, &'a FractionalShares)>,
         fetched_at: DateTime<Utc>,
+        block_number: Option<u64>,
         now: DateTime<Utc>,
     ) -> Result<Self, InventoryViewError> {
         let snapshot: Vec<(Symbol, FractionalShares)> = balances
@@ -1540,6 +1668,28 @@ impl InventoryView {
         let (view, applied_symbols) = snapshot.iter().chain(absent_zeroes.iter()).try_fold(
             (self, Vec::new()),
             |(view, mut applied_symbols), (symbol, snapshot_balance)| {
+                // Block ordering is authoritative for onchain reads (ADR
+                // 0018): a read pinned below the symbol's applied watermark
+                // would set a balance missing fills the watermark already
+                // absorbs. Per symbol, mirroring the `OnchainUsdc` arm's
+                // venue-level check.
+                if venue == Venue::MarketMaking
+                    && let Some(block) = block_number
+                    && view
+                        .onchain_equity_snapshot_block_watermarks
+                        .get(symbol)
+                        .is_some_and(|watermark| block < *watermark)
+                {
+                    warn!(
+                        target: "inventory",
+                        %symbol,
+                        block,
+                        "Rejecting onchain equity snapshot pinned below the \
+                         symbol's applied block watermark"
+                    );
+                    return Ok((view, applied_symbols));
+                }
+
                 let should_record_watermark =
                     view.equity_snapshot_would_apply(symbol, venue, fetched_at)?;
                 if !should_record_watermark {
@@ -1558,7 +1708,9 @@ impl InventoryView {
             },
         )?;
 
-        Ok(view.record_equity_snapshot_watermarks(venue, applied_symbols.iter(), fetched_at))
+        Ok(view
+            .record_equity_snapshot_watermarks(venue, applied_symbols.iter(), fetched_at)
+            .record_onchain_equity_block_watermarks(venue, applied_symbols.iter(), block_number))
     }
 
     /// Record the latest wallet-read USDC balance at an intermediate location.
@@ -1685,6 +1837,8 @@ impl InventoryView {
             offchain_equity_snapshot_watermarks: self.offchain_equity_snapshot_watermarks,
             pending_offchain_order_symbols: self.pending_offchain_order_symbols,
             last_offchain_fill_applied_at: self.last_offchain_fill_applied_at,
+            onchain_equity_snapshot_block_watermarks: self.onchain_equity_snapshot_block_watermarks,
+            onchain_usdc_snapshot_block_watermark: self.onchain_usdc_snapshot_block_watermark,
         })
     }
 
@@ -1715,6 +1869,8 @@ impl InventoryView {
             offchain_equity_snapshot_watermarks: self.offchain_equity_snapshot_watermarks,
             pending_offchain_order_symbols: self.pending_offchain_order_symbols,
             last_offchain_fill_applied_at: self.last_offchain_fill_applied_at,
+            onchain_equity_snapshot_block_watermarks: self.onchain_equity_snapshot_block_watermarks,
+            onchain_usdc_snapshot_block_watermark: self.onchain_usdc_snapshot_block_watermark,
         })
     }
 
@@ -2029,17 +2185,60 @@ impl InventoryView {
 
         let fetched_at = event.timestamp();
         match event {
-            OnchainEquity { balances, .. } => {
-                self.apply_equity_snapshot(Venue::MarketMaking, balances.iter(), fetched_at, now)
-            }
-
-            OnchainUsdc { usdc_balance, .. } => self.update_usdc(
-                Inventory::on_snapshot(Venue::MarketMaking, *usdc_balance, fetched_at),
+            OnchainEquity {
+                balances,
+                block_number,
+                ..
+            } => self.apply_equity_snapshot(
+                Venue::MarketMaking,
+                balances.iter(),
+                fetched_at,
+                *block_number,
                 now,
             ),
 
+            OnchainUsdc {
+                usdc_balance,
+                block_number,
+                ..
+            } => {
+                // Block ordering is authoritative for onchain reads (ADR
+                // 0018): a read pinned below the applied watermark would set
+                // a balance that does not contain fills the watermark
+                // already absorbs, understating USDC until the next poll.
+                if let (Some(block_number), Some(watermark)) =
+                    (*block_number, self.onchain_usdc_snapshot_block_watermark)
+                    && block_number < watermark
+                {
+                    warn!(
+                        target: "inventory",
+                        block_number,
+                        watermark,
+                        "Rejecting onchain USDC snapshot pinned below the \
+                         applied block watermark"
+                    );
+                    return Ok(self);
+                }
+
+                // The closure silently skips when the snapshot cannot apply
+                // (inflight, stale), so consult the same predicate first: the
+                // block watermark must only advance for balances the view
+                // actually took.
+                let applies = self.usdc.snapshot_would_apply(fetched_at)?;
+                let block_number = *block_number;
+                let view = self.update_usdc(
+                    Inventory::on_snapshot(Venue::MarketMaking, *usdc_balance, fetched_at),
+                    now,
+                )?;
+                Ok(if applies {
+                    view.record_onchain_usdc_block_watermark(block_number)
+                } else {
+                    view
+                })
+            }
+
             OffchainEquity { positions, .. } => {
-                self.apply_equity_snapshot(Venue::Hedging, positions.iter(), fetched_at, now)
+                self.apply_equity_snapshot(Venue::Hedging, positions.iter(), fetched_at, None, now)
             }
 
             OffchainEquityReconciled {
@@ -2177,6 +2376,7 @@ impl InventoryView {
             OnchainEquity {
                 balances,
                 fetched_at,
+                block_number,
             } => balances
                 .iter()
                 .try_fold(self, |view, (symbol, snapshot_balance)| {
@@ -2191,17 +2391,38 @@ impl InventoryView {
                     )
                 })
                 .map(|view| {
+                    // The forced balance is authoritative, so the block
+                    // watermark must follow it exactly instead of retaining
+                    // a higher block whose fills this balance does not
+                    // contain.
                     view.record_equity_snapshot_watermarks(
                         Venue::MarketMaking,
                         balances.keys(),
                         *fetched_at,
                     )
+                    .force_onchain_equity_block_watermarks(balances.keys(), *block_number)
                 }),
 
-            OnchainUsdc { usdc_balance, .. } => self.update_usdc(
-                Inventory::force_on_snapshot(Venue::MarketMaking, *usdc_balance, reason),
-                now,
-            ),
+            OnchainUsdc {
+                usdc_balance,
+                block_number,
+                ..
+            } => {
+                let block_number = *block_number;
+                self.update_usdc(
+                    Inventory::force_on_snapshot(Venue::MarketMaking, *usdc_balance, reason),
+                    now,
+                )
+                // Same as the equity arm above: the forced balance is
+                // authoritative, so the watermark follows it exactly rather
+                // than keeping the monotonic maximum.
+                .map(|mut view| {
+                    if let Some(block_number) = block_number {
+                        view.onchain_usdc_snapshot_block_watermark = Some(block_number);
+                    }
+                    view
+                })
+            }
 
             OffchainEquity {
                 positions,
@@ -2452,6 +2673,8 @@ mod tests {
             offchain_equity_snapshot_watermarks: HashMap::new(),
             pending_offchain_order_symbols: HashSet::new(),
             last_offchain_fill_applied_at: HashMap::new(),
+            onchain_equity_snapshot_block_watermarks: HashMap::new(),
+            onchain_usdc_snapshot_block_watermark: None,
         }
     }
 
@@ -2485,6 +2708,8 @@ mod tests {
             offchain_equity_snapshot_watermarks: HashMap::new(),
             pending_offchain_order_symbols: HashSet::new(),
             last_offchain_fill_applied_at: HashMap::new(),
+            onchain_equity_snapshot_block_watermarks: HashMap::new(),
+            onchain_usdc_snapshot_block_watermark: None,
         }
     }
 
@@ -3621,6 +3846,7 @@ mod tests {
                 &InventorySnapshotEvent::OnchainEquity {
                     balances,
                     fetched_at: now - Duration::seconds(1),
+                    block_number: None,
                 },
                 now,
             )
@@ -3628,12 +3854,303 @@ mod tests {
         assert_eq!(
             view.equity_available(&aapl, Venue::MarketMaking),
             Some(shares(60)),
-            "MarketMaking snapshots must ignore the offchain-order guards",
+            "MarketMaking snapshots must ignore the offchain-order guards: \
+             the onchain venue's second writer is reconciled by absorbing \
+             the fill delta (ADR 0018), never by blocking snapshots",
         );
         assert_eq!(
             view.equity_available(&aapl, Venue::Hedging),
             Some(shares(100)),
             "the offchain balance is untouched by an onchain snapshot",
+        );
+    }
+
+    /// The hydration path replays persisted snapshot events through
+    /// `apply_snapshot_event`, so applying onchain events with blocks must
+    /// re-establish the absorption watermarks -- this is what closes the
+    /// restart window for the onchain venue (blocks are durable, unlike the
+    /// offchain guards' local-clock state).
+    #[test]
+    fn replayed_onchain_snapshots_restore_block_watermarks() {
+        let aapl = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let view = InventoryView::default()
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OnchainEquity {
+                    balances: BTreeMap::from([(aapl.clone(), shares(60))]),
+                    fetched_at: now,
+                    block_number: Some(100),
+                },
+                now,
+            )
+            .unwrap()
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OnchainUsdc {
+                    usdc_balance: Usdc::new(float!(8500)),
+                    fetched_at: now,
+                    block_number: Some(100),
+                },
+                now,
+            )
+            .unwrap();
+
+        assert!(
+            view.onchain_fill_absorbed_by_equity_snapshot(&aapl, Some(100)),
+            "a fill at the snapshot's block is absorbed"
+        );
+        assert!(
+            !view.onchain_fill_absorbed_by_equity_snapshot(&aapl, Some(101)),
+            "a fill past the snapshot's block is not absorbed"
+        );
+        assert!(
+            !view.onchain_fill_absorbed_by_equity_snapshot(&aapl, None),
+            "a legacy fill without a block is never absorbed"
+        );
+        assert!(
+            view.onchain_fill_absorbed_by_usdc_snapshot(Some(100)),
+            "the USDC leg mirrors the equity behavior at the venue level"
+        );
+    }
+
+    /// A skipped snapshot must not advance the block watermarks: the balance
+    /// it carried was never taken, so a fill it contains is NOT yet in the
+    /// view and its delta must still apply.
+    #[test]
+    fn skipped_onchain_snapshots_advance_no_block_watermarks() {
+        let aapl = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        // Inflight at the equity inventory blocks the equity snapshot;
+        // inflight at the USDC inventory blocks the USDC snapshot.
+        let view = InventoryView::default()
+            .with_equity(aapl.clone(), shares(50), shares(50))
+            .update_equity(
+                &aapl,
+                Inventory::transfer(Venue::MarketMaking, TransferOp::Start, shares(5)),
+                now,
+            )
+            .unwrap()
+            .with_usdc_inflight(
+                Usdc::new(float!(1000)),
+                Usdc::new(float!(400)),
+                Usdc::new(float!(1000)),
+                Usdc::ZERO,
+            );
+
+        let view = view
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OnchainEquity {
+                    balances: BTreeMap::from([(aapl.clone(), shares(60))]),
+                    fetched_at: now,
+                    block_number: Some(100),
+                },
+                now,
+            )
+            .unwrap()
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OnchainUsdc {
+                    usdc_balance: Usdc::new(float!(8500)),
+                    fetched_at: now,
+                    block_number: Some(100),
+                },
+                now,
+            )
+            .unwrap();
+
+        assert!(
+            !view.onchain_fill_absorbed_by_equity_snapshot(&aapl, Some(100)),
+            "an inflight-skipped equity snapshot must not mark fills absorbed"
+        );
+        assert!(
+            !view.onchain_fill_absorbed_by_usdc_snapshot(Some(100)),
+            "an inflight-skipped USDC snapshot must not mark fills absorbed"
+        );
+    }
+
+    /// Snapshots can be delivered out of order (load-balanced RPC nodes can
+    /// serve a later request from a lagging node). An older block must never
+    /// lower an established watermark, or a fill between the two blocks
+    /// would be absorbed twice.
+    #[test]
+    fn out_of_order_onchain_snapshots_never_lower_block_watermarks() {
+        let aapl = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let apply = |view: InventoryView, block: u64, balance: i64, fetched_at: DateTime<Utc>| {
+            view.apply_snapshot_event(
+                &InventorySnapshotEvent::OnchainEquity {
+                    balances: BTreeMap::from([(aapl.clone(), shares(balance))]),
+                    fetched_at,
+                    block_number: Some(block),
+                },
+                now,
+            )
+            .unwrap()
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OnchainUsdc {
+                    usdc_balance: Usdc::new(float!(&balance.to_string())),
+                    fetched_at,
+                    block_number: Some(block),
+                },
+                now,
+            )
+            .unwrap()
+        };
+
+        // Block 200 lands first, then a late snapshot from block 100 with a
+        // fresher fetched_at. Block ordering is authoritative for onchain
+        // reads: the late lower-block snapshot must be rejected outright --
+        // its balance is missing fills the watermark already absorbs.
+        let view = apply(InventoryView::default(), 200, 60, now);
+        let view = apply(view, 100, 30, now + Duration::seconds(1));
+
+        assert_eq!(
+            view.equity_available(&aapl, Venue::MarketMaking),
+            Some(shares(60)),
+            "a below-watermark equity snapshot must not replace the balance"
+        );
+        assert_eq!(
+            view.usdc_available(Venue::MarketMaking),
+            Some(Usdc::new(float!(60))),
+            "a below-watermark USDC snapshot must not replace the balance"
+        );
+        assert!(
+            view.onchain_fill_absorbed_by_equity_snapshot(&aapl, Some(150)),
+            "the equity watermark must stay at the highest applied block"
+        );
+        assert!(
+            view.onchain_fill_absorbed_by_usdc_snapshot(Some(150)),
+            "the USDC watermark must stay at the highest applied block"
+        );
+        assert!(
+            !view.onchain_fill_absorbed_by_equity_snapshot(&aapl, Some(201)),
+            "a fill past the highest applied block is still not absorbed"
+        );
+    }
+
+    /// The recovery force path is the one writer allowed to move a balance
+    /// BELOW the block watermark, so the watermark must follow the forced
+    /// block exactly: keeping the monotonic maximum would leave fills
+    /// between the forced block and the old watermark absorbed while the
+    /// forced balance does not contain them.
+    #[test]
+    fn force_apply_resets_block_watermarks_to_the_forced_block() {
+        let aapl = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let reason = Arc::new(InventoryViewError::UsdBalanceConversion(i64::MAX));
+
+        let view = InventoryView::default()
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OnchainEquity {
+                    balances: BTreeMap::from([(aapl.clone(), shares(60))]),
+                    fetched_at: now,
+                    block_number: Some(200),
+                },
+                now,
+            )
+            .unwrap()
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OnchainUsdc {
+                    usdc_balance: Usdc::new(float!(8500)),
+                    fetched_at: now,
+                    block_number: Some(200),
+                },
+                now,
+            )
+            .unwrap();
+
+        let forced = view
+            .force_apply_snapshot_event(
+                &InventorySnapshotEvent::OnchainEquity {
+                    balances: BTreeMap::from([(aapl.clone(), shares(30))]),
+                    fetched_at: now + Duration::seconds(1),
+                    block_number: Some(100),
+                },
+                now,
+                reason.clone(),
+            )
+            .unwrap()
+            .force_apply_snapshot_event(
+                &InventorySnapshotEvent::OnchainUsdc {
+                    usdc_balance: Usdc::new(float!(4000)),
+                    fetched_at: now + Duration::seconds(1),
+                    block_number: Some(100),
+                },
+                now,
+                reason,
+            )
+            .unwrap();
+
+        assert_eq!(
+            forced.equity_available(&aapl, Venue::MarketMaking),
+            Some(shares(30)),
+            "the force path always writes the balance"
+        );
+        assert!(
+            !forced.onchain_fill_absorbed_by_equity_snapshot(&aapl, Some(150)),
+            "the equity watermark must drop to the forced block; a fill \
+             above it is not absorbed by the forced balance"
+        );
+        assert!(
+            forced.onchain_fill_absorbed_by_equity_snapshot(&aapl, Some(100)),
+            "fills at or below the forced block are absorbed"
+        );
+        assert!(
+            !forced.onchain_fill_absorbed_by_usdc_snapshot(Some(150)),
+            "the USDC watermark must drop to the forced block"
+        );
+        assert!(forced.onchain_fill_absorbed_by_usdc_snapshot(Some(100)));
+    }
+
+    /// `#[serde(default)]` on the two block-watermark fields is what keeps
+    /// a view payload persisted before this change loadable; legacy state
+    /// must deserialize with empty watermarks and absorb nothing.
+    #[test]
+    fn legacy_view_payload_without_watermark_fields_absorbs_nothing() {
+        let aapl = Symbol::new("AAPL").unwrap();
+
+        let mut payload = serde_json::to_value(InventoryView::default()).unwrap();
+        let map = payload.as_object_mut().unwrap();
+        assert!(
+            map.remove("onchain_equity_snapshot_block_watermarks")
+                .is_some(),
+            "field name drifted; this test no longer removes anything"
+        );
+        assert!(
+            map.remove("onchain_usdc_snapshot_block_watermark")
+                .is_some(),
+            "field name drifted; this test no longer removes anything"
+        );
+
+        let view: InventoryView = serde_json::from_value(payload).unwrap();
+
+        assert!(
+            !view.onchain_fill_absorbed_by_equity_snapshot(&aapl, Some(1)),
+            "legacy state without watermark fields must absorb no equity fills"
+        );
+        assert!(
+            !view.onchain_fill_absorbed_by_usdc_snapshot(Some(1)),
+            "legacy state without watermark fields must absorb no USDC fills"
+        );
+    }
+
+    /// The Hedging arm of the recorder must stay inert even if a future
+    /// call site passes a block for a broker read: chain blocks order
+    /// onchain reads only.
+    #[test]
+    fn hedging_venue_records_no_block_watermark() {
+        let aapl = Symbol::new("AAPL").unwrap();
+
+        let view = InventoryView::default().record_onchain_equity_block_watermarks(
+            Venue::Hedging,
+            [&aapl],
+            Some(100),
+        );
+
+        assert!(
+            !view.onchain_fill_absorbed_by_equity_snapshot(&aapl, Some(100)),
+            "a Hedging recording must not create an onchain block watermark"
         );
     }
 
@@ -3759,6 +4276,7 @@ mod tests {
                 &InventorySnapshotEvent::OnchainEquity {
                     balances,
                     fetched_at: now,
+                    block_number: None,
                 },
                 now,
             )
@@ -4078,6 +4596,8 @@ mod tests {
             offchain_equity_snapshot_watermarks: HashMap::new(),
             pending_offchain_order_symbols: HashSet::new(),
             last_offchain_fill_applied_at: HashMap::new(),
+            onchain_equity_snapshot_block_watermarks: HashMap::new(),
+            onchain_usdc_snapshot_block_watermark: None,
         };
 
         let dto = view.to_dto();
@@ -4133,6 +4653,8 @@ mod tests {
             offchain_equity_snapshot_watermarks: HashMap::new(),
             pending_offchain_order_symbols: HashSet::new(),
             last_offchain_fill_applied_at: HashMap::new(),
+            onchain_equity_snapshot_block_watermarks: HashMap::new(),
+            onchain_usdc_snapshot_block_watermark: None,
         };
 
         let dto = view.to_dto();

--- a/src/offchain/order/handle_rejection.rs
+++ b/src/offchain/order/handle_rejection.rs
@@ -347,6 +347,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: onchain.price.value(),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -1718,6 +1718,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: onchain.price.value(),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await

--- a/src/offchain/order/reconcile_fill.rs
+++ b/src/offchain/order/reconcile_fill.rs
@@ -210,6 +210,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: onchain.price.value(),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await

--- a/src/onchain/accumulator.rs
+++ b/src/onchain/accumulator.rs
@@ -233,6 +233,7 @@ mod tests {
                     direction,
                     price_usdc: float!(150.0),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -608,6 +609,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150.0),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -260,6 +260,7 @@ pub async fn seed_simulated_hedge_latency_history(
                         direction: Direction::Buy,
                         price_usdc: onchain_price,
                         block_timestamp,
+                        block_number: None,
                         seen_at,
                     },
                 )
@@ -534,6 +535,7 @@ pub(super) mod test_helpers {
             direction: Direction::Buy,
             price_usdc: float!(150),
             block_timestamp: timestamp(block_offset),
+            block_number: None,
             seen_at: timestamp(seen_offset),
         }
     }

--- a/src/performance/projection.rs
+++ b/src/performance/projection.rs
@@ -748,6 +748,7 @@ mod tests {
             direction: Direction::Buy,
             price_usdc: float!(150),
             block_timestamp: timestamp(0),
+            block_number: None,
             seen_at: timestamp(1),
         };
 

--- a/src/portfolio_snapshot/write.rs
+++ b/src/portfolio_snapshot/write.rs
@@ -2017,6 +2017,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp,
+                    block_number: None,
                     seen_at: block_timestamp,
                 },
             )
@@ -2088,6 +2089,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp,
+                    block_number: None,
                     seen_at: block_timestamp,
                 },
             )
@@ -2166,6 +2168,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp,
+                    block_number: None,
                     seen_at,
                 },
             )

--- a/src/position.rs
+++ b/src/position.rs
@@ -434,14 +434,18 @@ impl EventSourced for Position {
                 direction,
                 price_usdc,
                 block_timestamp,
+                block_number,
             } => Ok(Self::acknowledge_on_chain_fill_init_events(
                 symbol,
                 threshold,
-                trade_id,
-                amount,
-                direction,
-                price_usdc,
-                block_timestamp,
+                OnChainFillFacts {
+                    trade_id,
+                    amount,
+                    direction,
+                    price_usdc,
+                    block_timestamp,
+                    block_number,
+                },
                 Utc::now(),
             )),
 
@@ -454,15 +458,19 @@ impl EventSourced for Position {
                 direction,
                 price_usdc,
                 block_timestamp,
+                block_number,
                 seen_at,
             } => Ok(Self::acknowledge_on_chain_fill_init_events(
                 symbol,
                 threshold,
-                trade_id,
-                amount,
-                direction,
-                price_usdc,
-                block_timestamp,
+                OnChainFillFacts {
+                    trade_id,
+                    amount,
+                    direction,
+                    price_usdc,
+                    block_timestamp,
+                    block_number,
+                },
                 seen_at,
             )),
 
@@ -528,13 +536,17 @@ impl EventSourced for Position {
                 direction,
                 price_usdc,
                 block_timestamp,
+                block_number,
                 ..
             } => self.acknowledge_on_chain_fill_transition_events(
-                trade_id,
-                amount,
-                direction,
-                price_usdc,
-                block_timestamp,
+                OnChainFillFacts {
+                    trade_id,
+                    amount,
+                    direction,
+                    price_usdc,
+                    block_timestamp,
+                    block_number,
+                },
                 Utc::now(),
             ),
 
@@ -545,14 +557,18 @@ impl EventSourced for Position {
                 direction,
                 price_usdc,
                 block_timestamp,
+                block_number,
                 seen_at,
                 ..
             } => self.acknowledge_on_chain_fill_transition_events(
-                trade_id,
-                amount,
-                direction,
-                price_usdc,
-                block_timestamp,
+                OnChainFillFacts {
+                    trade_id,
+                    amount,
+                    direction,
+                    price_usdc,
+                    block_timestamp,
+                    block_number,
+                },
                 seen_at,
             ),
 
@@ -705,17 +721,35 @@ impl EventSourced for Position {
     }
 }
 
+/// The chain-side facts of one onchain fill, exactly as carried by the
+/// `AcknowledgeOnChainFill` command and recorded on `OnChainOrderFilled`.
+/// Groups what belongs together so the acknowledge helpers take one fill
+/// instead of a parade of its fields.
+struct OnChainFillFacts {
+    trade_id: TradeId,
+    amount: FractionalShares,
+    direction: Direction,
+    price_usdc: Float,
+    block_timestamp: DateTime<Utc>,
+    block_number: Option<u64>,
+}
+
 impl Position {
     fn acknowledge_on_chain_fill_init_events(
         symbol: Symbol,
         threshold: ExecutionThreshold,
-        trade_id: TradeId,
-        amount: FractionalShares,
-        direction: Direction,
-        price_usdc: Float,
-        block_timestamp: DateTime<Utc>,
+        fill: OnChainFillFacts,
         seen_at: DateTime<Utc>,
     ) -> Vec<PositionEvent> {
+        let OnChainFillFacts {
+            trade_id,
+            amount,
+            direction,
+            price_usdc,
+            block_timestamp,
+            block_number,
+        } = fill;
+
         vec![
             PositionEvent::Initialized {
                 symbol,
@@ -728,6 +762,7 @@ impl Position {
                 direction,
                 price_usdc,
                 block_timestamp,
+                block_number,
                 seen_at,
             },
             PositionEvent::OnChainFillApplied {
@@ -739,13 +774,18 @@ impl Position {
 
     fn acknowledge_on_chain_fill_transition_events(
         &self,
-        trade_id: TradeId,
-        amount: FractionalShares,
-        direction: Direction,
-        price_usdc: Float,
-        block_timestamp: DateTime<Utc>,
+        fill: OnChainFillFacts,
         seen_at: DateTime<Utc>,
     ) -> Result<Vec<PositionEvent>, PositionError> {
+        let OnChainFillFacts {
+            trade_id,
+            amount,
+            direction,
+            price_usdc,
+            block_timestamp,
+            block_number,
+        } = fill;
+
         // Dual guard (ADR 0010): the retained slot bridges a fill applied
         // under pre-set code and left unmarked at the deploy restart; the
         // set rejects an out-of-order / cross-process re-drive the single
@@ -764,6 +804,7 @@ impl Position {
                 direction,
                 price_usdc,
                 block_timestamp,
+                block_number,
                 seen_at,
             },
             PositionEvent::OnChainFillApplied {
@@ -1066,6 +1107,11 @@ pub enum PositionCommand {
         direction: Direction,
         price_usdc: Float,
         block_timestamp: DateTime<Utc>,
+        /// Block the fill's log was confirmed in. `None` only when neither
+        /// the log nor its receipt carried one; the inventory view then
+        /// applies the fill delta unconditionally instead of checking it
+        /// against the onchain snapshot block watermark (ADR 0018).
+        block_number: Option<u64>,
     },
     /// Test/fixture-only: identical to `AcknowledgeOnChainFill` but takes
     /// `seen_at` explicitly instead of stamping `Utc::now()`, so fixture
@@ -1080,6 +1126,7 @@ pub enum PositionCommand {
         direction: Direction,
         price_usdc: Float,
         block_timestamp: DateTime<Utc>,
+        block_number: Option<u64>,
         seen_at: DateTime<Utc>,
     },
     /// Prunes `trade_id` from the pending-acknowledgement set after its
@@ -1167,6 +1214,12 @@ pub enum PositionEvent {
         )]
         price_usdc: Float,
         block_timestamp: DateTime<Utc>,
+        /// Block the fill's log was confirmed in. `None` for events emitted
+        /// before this field was added (schema backward-compatibility) and
+        /// for fills whose log and receipt both lacked a block number; such
+        /// fills always apply their inventory delta (ADR 0018).
+        #[serde(default)]
+        block_number: Option<u64>,
         seen_at: DateTime<Utc>,
     },
     /// Records that `trade_id` was applied to the position, in the same
@@ -1314,6 +1367,7 @@ impl PartialEq for PositionEvent {
                     direction: d1,
                     price_usdc: p1,
                     block_timestamp: bt1,
+                    block_number: bn1,
                     seen_at: sa1,
                 },
                 Self::OnChainOrderFilled {
@@ -1322,12 +1376,14 @@ impl PartialEq for PositionEvent {
                     direction: d2,
                     price_usdc: p2,
                     block_timestamp: bt2,
+                    block_number: bn2,
                     seen_at: sa2,
                 },
             ) => {
                 t1 == t2
                     && a1 == a2
                     && d1 == d2
+                    && bn1 == bn2
                     && p1.eq(*p2).unwrap_or(false)
                     && bt1 == bt2
                     && sa1 == sa2
@@ -1548,6 +1604,7 @@ impl std::fmt::Debug for PositionCommand {
                 direction,
                 price_usdc,
                 block_timestamp,
+                block_number,
             } => f
                 .debug_struct("AcknowledgeOnChainFill")
                 .field("symbol", symbol)
@@ -1557,6 +1614,7 @@ impl std::fmt::Debug for PositionCommand {
                 .field("direction", direction)
                 .field("price_usdc", &DebugFloat(price_usdc))
                 .field("block_timestamp", block_timestamp)
+                .field("block_number", block_number)
                 .finish(),
             #[cfg(any(test, feature = "test-support"))]
             Self::AcknowledgeOnChainFillAt {
@@ -1567,6 +1625,7 @@ impl std::fmt::Debug for PositionCommand {
                 direction,
                 price_usdc,
                 block_timestamp,
+                block_number,
                 seen_at,
             } => f
                 .debug_struct("AcknowledgeOnChainFillAt")
@@ -1577,6 +1636,7 @@ impl std::fmt::Debug for PositionCommand {
                 .field("direction", direction)
                 .field("price_usdc", &DebugFloat(price_usdc))
                 .field("block_timestamp", block_timestamp)
+                .field("block_number", block_number)
                 .field("seen_at", seen_at)
                 .finish(),
             Self::SettleOnChainFill { trade_id } => f
@@ -1693,6 +1753,7 @@ impl std::fmt::Debug for PositionEvent {
                 direction,
                 price_usdc,
                 block_timestamp,
+                block_number,
                 seen_at,
             } => f
                 .debug_struct("OnChainOrderFilled")
@@ -1701,6 +1762,7 @@ impl std::fmt::Debug for PositionEvent {
                 .field("direction", direction)
                 .field("price_usdc", &DebugFloat(price_usdc))
                 .field("block_timestamp", block_timestamp)
+                .field("block_number", block_number)
                 .field("seen_at", seen_at)
                 .finish(),
             Self::OnChainFillApplied {
@@ -1858,6 +1920,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
             })
             .await
             .events();
@@ -1899,6 +1962,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
             })
             .await
             .events();
@@ -1939,6 +2003,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
                 seen_at,
             })
             .await
@@ -1982,6 +2047,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
             ])
@@ -1993,6 +2059,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
             })
             .await
             .then_expect_error();
@@ -2040,6 +2107,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: now,
+                    block_number: None,
                     seen_at: now,
                 },
                 PositionEvent::OnChainFillApplied {
@@ -2052,6 +2120,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: now,
+                    block_number: None,
                     seen_at: now,
                 },
                 PositionEvent::OnChainFillApplied {
@@ -2067,6 +2136,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: now,
+                block_number: None,
             })
             .await
             .then_expect_error();
@@ -2106,6 +2176,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: now,
+                block_number: None,
                 seen_at: now,
             },
             PositionEvent::OnChainOrderFilled {
@@ -2117,6 +2188,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: now,
+                block_number: None,
                 seen_at: now,
             },
         ])
@@ -2159,6 +2231,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: now,
+                block_number: None,
                 seen_at: now,
             },
             PositionEvent::OnChainFillApplied {
@@ -2175,6 +2248,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: now,
+                block_number: None,
                 seen_at: now,
             },
             PositionEvent::OnChainFillApplied {
@@ -2215,6 +2289,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: now,
+                    block_number: None,
                     seen_at: now,
                 },
                 PositionEvent::OnChainFillApplied {
@@ -2283,6 +2358,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
                 PositionEvent::OnChainOrderFilled {
@@ -2294,6 +2370,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(151),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
             ])
@@ -2335,6 +2412,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
             ])
@@ -2380,6 +2458,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
             ])
@@ -2420,6 +2499,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
                 PositionEvent::OffChainOrderPlaced {
@@ -2471,6 +2551,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
                 PositionEvent::OffChainOrderPlaced {
@@ -2520,6 +2601,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
                 PositionEvent::OffChainOrderPlaced {
@@ -2566,6 +2648,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
                 PositionEvent::OffChainOrderPlaced {
@@ -2645,6 +2728,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
                 seen_at: Utc::now(),
             },
             placed(failed_order_id),
@@ -2759,6 +2843,7 @@ mod tests {
                     direction: Direction::Sell,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
             ])
@@ -2812,6 +2897,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
                 PositionEvent::OffChainOrderPlaced {
@@ -2864,6 +2950,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
                 seen_at: Utc::now(),
             },
             PositionEvent::ManualPositionAdjusted {
@@ -2917,6 +3004,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
                 seen_at: Utc::now(),
             },
         ])
@@ -2958,6 +3046,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -3114,6 +3203,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
             ])
@@ -3164,6 +3254,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                     seen_at: Utc::now(),
                 },
             ])
@@ -3205,6 +3296,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
                 seen_at: Utc::now(),
             },
             PositionEvent::OffChainOrderPlaced {
@@ -3257,6 +3349,7 @@ mod tests {
                 direction: Direction::Sell,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
                 seen_at: Utc::now(),
             },
             PositionEvent::OffChainOrderPlaced {
@@ -3311,6 +3404,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
                 seen_at: Utc::now(),
             },
             OffChainOrderPlaced {
@@ -3369,6 +3463,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
                 seen_at: Utc::now(),
             },
             OffChainOrderPlaced {
@@ -3439,6 +3534,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
                 seen_at: Utc::now(),
             },
             OffChainOrderPlaced {
@@ -3510,6 +3606,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp: Utc::now(),
+                block_number: None,
                 seen_at: Utc::now(),
             },
             PositionEvent::OffChainOrderPlaced {
@@ -3588,6 +3685,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp,
+                block_number: None,
                 seen_at,
             },
         ])
@@ -3627,6 +3725,7 @@ mod tests {
                 direction: Direction::Sell,
                 price_usdc: float!(150),
                 block_timestamp,
+                block_number: None,
                 seen_at,
             },
         ])
@@ -3677,6 +3776,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp,
+                block_number: None,
                 seen_at: block_timestamp,
             },
             PositionEvent::ThresholdUpdated {
@@ -3771,6 +3871,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp,
+                block_number: None,
                 seen_at: block_timestamp,
             },
             PositionEvent::ManualPositionAdjusted {
@@ -3829,6 +3930,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp,
+                block_number: None,
                 seen_at: block_timestamp,
             },
             PositionEvent::ThresholdUpdated {
@@ -3878,6 +3980,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150),
                 block_timestamp,
+                block_number: None,
                 seen_at: block_timestamp,
             },
         ])
@@ -3917,6 +4020,7 @@ mod tests {
             amount: FractionalShares::new(float!(10)),
             price_usdc: float!(150),
             block_timestamp: Utc::now(),
+            block_number: None,
             seen_at: Utc::now(),
         }])
         .unwrap_err();
@@ -3949,6 +4053,7 @@ mod tests {
             direction: Direction::Buy,
             price_usdc: float!(150),
             block_timestamp,
+            block_number: None,
             seen_at,
         };
 
@@ -4334,6 +4439,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -1317,6 +1317,7 @@ mod tests {
                     direction,
                     price_usdc: float!(150.0),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1665,15 +1665,15 @@ impl RebalancingService {
         let mut inventory = self.inventory.write().await;
 
         let updated = match &event {
-            OnchainEquity { balances, .. } => inventory.clone().apply_equity_snapshot(
+            OnchainEquity {
+                balances,
+                block_number,
+                ..
+            } => inventory.clone().apply_equity_snapshot(
                 Venue::MarketMaking,
                 balances.iter(),
                 fetched_at,
-                now,
-            ),
-
-            OnchainUsdc { usdc_balance, .. } => inventory.clone().update_usdc(
-                Inventory::on_snapshot(Venue::MarketMaking, *usdc_balance, fetched_at),
+                *block_number,
                 now,
             ),
 
@@ -1681,13 +1681,18 @@ impl RebalancingService {
                 Venue::Hedging,
                 positions.iter(),
                 fetched_at,
+                None,
                 now,
             ),
 
             // `reconcile_offchain_equity` validates busyness and the hedge
             // gate under the write lock, so the generic apply path is the
-            // correct route here too.
-            OffchainEquityReconciled { .. }
+            // correct route here too. `OnchainUsdc` also routes through it
+            // (not a direct `update_usdc`) so the view's block-watermark
+            // bookkeeping for absorbed onchain fills has a single
+            // implementation.
+            OnchainUsdc { .. }
+            | OffchainEquityReconciled { .. }
             | OffchainUsd { .. }
             | OffchainCashBuyingPower { .. }
             | OffchainCashWithdrawable { .. }
@@ -2139,25 +2144,69 @@ impl Reactor for RebalancingService {
                 use PositionEvent::*;
 
                 let timestamp = event.timestamp();
-                let mut clear_pending_offchain_order = false;
                 let (equity_update, usdc_update) = match &event {
                     OnChainOrderFilled {
                         amount,
                         direction,
                         price_usdc,
+                        block_number,
                         ..
                     } => {
                         let equity_op: Operator = (*direction).into();
                         let quantity: Float = (*amount).into();
                         let usdc_value = (*price_usdc * quantity)?;
-                        (
-                            Inventory::available(Venue::MarketMaking, equity_op, *amount),
-                            Inventory::available(
-                                Venue::MarketMaking,
-                                equity_op.inverse(),
-                                Usdc::new(usdc_value),
-                            ),
-                        )
+
+                        // Each delta leg yields to a pinned onchain snapshot
+                        // that provably already contains it: a vaultBalance2
+                        // read at block N includes every fill at a block <= N
+                        // (ADR 0018). Checked and applied under one write
+                        // lock so no snapshot can advance the watermark in
+                        // between. An absorbed leg is normal operation under
+                        // load, not an error -- the poll simply observed the
+                        // fill before this event arrived.
+                        {
+                            let mut inventory = self.inventory.write().await;
+                            let apply_equity_leg = !inventory
+                                .onchain_fill_absorbed_by_equity_snapshot(&symbol, *block_number);
+                            let apply_usdc_leg =
+                                !inventory.onchain_fill_absorbed_by_usdc_snapshot(*block_number);
+
+                            if !apply_equity_leg || !apply_usdc_leg {
+                                info!(
+                                    target: "rebalance",
+                                    %symbol,
+                                    ?block_number,
+                                    apply_equity_leg,
+                                    apply_usdc_leg,
+                                    "Skipping onchain fill delta leg(s) already \
+                                     absorbed by a pinned onchain snapshot"
+                                );
+                            }
+
+                            let mut updated = inventory.clone();
+                            if apply_equity_leg {
+                                updated = updated.update_equity(
+                                    &symbol,
+                                    Inventory::available(Venue::MarketMaking, equity_op, *amount),
+                                    timestamp,
+                                )?;
+                            }
+                            if apply_usdc_leg {
+                                updated = updated.update_usdc(
+                                    Inventory::available(
+                                        Venue::MarketMaking,
+                                        equity_op.inverse(),
+                                        Usdc::new(usdc_value),
+                                    ),
+                                    timestamp,
+                                )?;
+                            }
+                            *inventory = updated;
+                        }
+
+                        self.equity_scheduler.enqueue_check(symbol).await;
+                        self.usdc_scheduler.enqueue_check().await;
+                        return Ok(());
                     }
                     OffChainOrderFilled {
                         shares_filled,
@@ -2165,16 +2214,6 @@ impl Reactor for RebalancingService {
                         price,
                         ..
                     } => {
-                        // Always clear the gate on a Filled event, even if the
-                        // inventory update below fails. A fail-closed gate would
-                        // deadlock equity rebalancing for the symbol until the
-                        // next bot restart, because the only event that could
-                        // re-clear it (a later terminal offchain event) is
-                        // itself gated. The polling cycle is the source of
-                        // truth for the broker balance, so any local
-                        // bookkeeping miss self-heals within ~60s and is bounded
-                        // to wasted rebalances, not lost capital.
-                        clear_pending_offchain_order = true;
                         let equity_op: Operator = (*direction).into();
                         let quantity: Float = shares_filled.inner().into();
                         let price_value = price.inner();
@@ -2232,6 +2271,16 @@ impl Reactor for RebalancingService {
                     }
                 };
 
+                // Only the OffChainOrderFilled arm reaches here; every other
+                // arm returns early above. Always clear the gate on a Filled
+                // event, even if the inventory update fails. A fail-closed
+                // gate would deadlock equity rebalancing for the symbol until
+                // the next bot restart, because the only event that could
+                // re-clear it (a later terminal offchain event) is itself
+                // gated. The polling cycle is the source of truth for the
+                // broker balance, so any local bookkeeping miss self-heals
+                // within ~60s and is bounded to wasted rebalances, not lost
+                // capital.
                 let inventory_result = {
                     let mut inventory = self.inventory.write().await;
                     let result = inventory
@@ -2242,50 +2291,37 @@ impl Reactor for RebalancingService {
                         *inventory = updated.clone();
                     }
 
-                    if clear_pending_offchain_order {
-                        // Release the snapshot block in the same critical
-                        // section that applied the delta, so no snapshot can
-                        // land in between and overwrite the fill just recorded.
-                        // Stamp the local clock rather than reusing `timestamp`
-                        // (the event's `broker_timestamp`): this is compared
-                        // against snapshot `fetched_at`, which is stamped from
-                        // this host's clock.
-                        inventory
-                            .clear_offchain_order_pending(&symbol, result.is_ok().then(Utc::now));
-                    }
+                    // Release the snapshot block in the same critical
+                    // section that applied the delta, so no snapshot can
+                    // land in between and overwrite the fill just recorded.
+                    // Stamp the local clock rather than reusing `timestamp`
+                    // (the event's `broker_timestamp`): this is compared
+                    // against snapshot `fetched_at`, which is stamped from
+                    // this host's clock.
+                    inventory.clear_offchain_order_pending(&symbol, result.is_ok().then(Utc::now));
 
                     result
                 };
 
-                if clear_pending_offchain_order {
-                    // The gate was cleared above regardless of inventory
-                    // outcome. See the OffChainOrderFilled arm for the
-                    // rationale.
-                    if let Err(error) = &inventory_result {
-                        warn!(
-                            target: "rebalance",
-                            %symbol,
-                            ?error,
-                            "Inventory update failed for offchain fill; clearing gate anyway and relying on next polling snapshot"
-                        );
-                    }
-                    self.equity_scheduler.enqueue_check(symbol).await;
-                    // Only re-check USDC if the cash leg actually applied.
-                    // With and_then chaining, inventory_result == Err means
-                    // neither leg was persisted, so the USDC mirror is
-                    // unchanged from before this event -- the check would
-                    // re-evaluate identical inputs and produce no new
-                    // decision. The periodic USDC scheduler tick covers
-                    // any drift the polling snapshot picks up.
-                    if inventory_result.is_ok() {
-                        self.usdc_scheduler.enqueue_check().await;
-                    }
-                    return Ok(());
+                if let Err(error) = &inventory_result {
+                    warn!(
+                        target: "rebalance",
+                        %symbol,
+                        ?error,
+                        "Inventory update failed for offchain fill; clearing gate anyway and relying on next polling snapshot"
+                    );
                 }
-
-                inventory_result?;
                 self.equity_scheduler.enqueue_check(symbol).await;
-                self.usdc_scheduler.enqueue_check().await;
+                // Only re-check USDC if the cash leg actually applied.
+                // With and_then chaining, inventory_result == Err means
+                // neither leg was persisted, so the USDC mirror is
+                // unchanged from before this event -- the check would
+                // re-evaluate identical inputs and produce no new
+                // decision. The periodic USDC scheduler tick covers
+                // any drift the polling snapshot picks up.
+                if inventory_result.is_ok() {
+                    self.usdc_scheduler.enqueue_check().await;
+                }
                 Ok::<(), RebalancingServiceError>(())
             })
             .on(|id, event| async move { self.on_mint(id, event).await })
@@ -7636,6 +7672,26 @@ mod tests {
             direction,
             price_usdc: float!(150),
             block_timestamp,
+            block_number: None,
+            seen_at: Utc::now(),
+        }
+    }
+
+    fn make_onchain_fill_in_block(
+        amount: FractionalShares,
+        direction: Direction,
+        block_number: Option<u64>,
+    ) -> PositionEvent {
+        PositionEvent::OnChainOrderFilled {
+            trade_id: TradeId {
+                tx_hash: TxHash::random(),
+                log_index: 0,
+            },
+            amount,
+            direction,
+            price_usdc: float!(150),
+            block_timestamp: Utc::now(),
+            block_number,
             seen_at: Utc::now(),
         }
     }
@@ -8171,6 +8227,7 @@ mod tests {
             InventorySnapshotEvent::OnchainEquity {
                 balances: BTreeMap::from([(symbol.clone(), shares(50))]),
                 fetched_at: snapshot_at,
+                block_number: None,
             },
         )
         .await
@@ -8214,6 +8271,7 @@ mod tests {
             InventorySnapshotEvent::OnchainEquity {
                 balances: BTreeMap::from([(symbol.clone(), shares(80))]),
                 fetched_at: newer_snapshot_at,
+                block_number: None,
             },
         )
         .await
@@ -8228,6 +8286,7 @@ mod tests {
             InventorySnapshotEvent::OnchainEquity {
                 balances: BTreeMap::from([(symbol.clone(), shares(10))]),
                 fetched_at: older_snapshot_at,
+                block_number: None,
             },
         )
         .await
@@ -8317,6 +8376,7 @@ mod tests {
             InventorySnapshotEvent::OnchainEquity {
                 balances: BTreeMap::from([(symbol.clone(), shares(50))]),
                 fetched_at: snapshot_at,
+                block_number: None,
             },
         )
         .await
@@ -8419,6 +8479,7 @@ mod tests {
             InventorySnapshotEvent::OnchainEquity {
                 balances: BTreeMap::from([(symbol.clone(), shares(100))]),
                 fetched_at: snapshot_at,
+                block_number: None,
             },
         )
         .await
@@ -9525,6 +9586,296 @@ mod tests {
         assert_eq!(onchain_usdc, usdc(11500));
     }
 
+    /// The RAI-1500 race, closed by ADR 0018: a pinned onchain snapshot at
+    /// block N already contains a fill at a block <= N, so the fill's delta
+    /// legs must be absorbed instead of re-applied on top.
+    #[tokio::test]
+    async fn onchain_fill_covered_by_pinned_snapshot_block_is_absorbed() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(10000), usdc(10000));
+
+        let reactor = make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor.clone());
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+
+        // The poll pinned at block 100 already includes the buy below: 60
+        // shares and 8500 USDC are the post-fill balances.
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            snapshot_id.clone(),
+            InventorySnapshotEvent::OnchainEquity {
+                balances: BTreeMap::from([(symbol.clone(), shares(60))]),
+                fetched_at: Utc::now(),
+                block_number: Some(100),
+            },
+        )
+        .await
+        .unwrap();
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            snapshot_id,
+            InventorySnapshotEvent::OnchainUsdc {
+                usdc_balance: usdc(8500),
+                fetched_at: Utc::now(),
+                block_number: Some(100),
+            },
+        )
+        .await
+        .unwrap();
+
+        // The delayed fill delta arrives afterwards: buy of 10 at $150 in
+        // block 100 -- exactly what the snapshot absorbed.
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_onchain_fill_in_block(shares(10), Direction::Buy, Some(100)),
+            )
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.equity_available(&symbol, Venue::MarketMaking),
+            Some(shares(60)),
+            "the snapshot at block 100 already contains the fill; 70 means \
+             the equity leg was counted twice"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(8500)),
+            "the USDC snapshot at block 100 already contains the fill's cash \
+             leg; 7000 means it was counted twice"
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
+    async fn onchain_fill_past_snapshot_block_applies_normally() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(10000), usdc(10000));
+
+        let reactor = make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor.clone());
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            snapshot_id.clone(),
+            InventorySnapshotEvent::OnchainEquity {
+                balances: BTreeMap::from([(symbol.clone(), shares(60))]),
+                fetched_at: Utc::now(),
+                block_number: Some(100),
+            },
+        )
+        .await
+        .unwrap();
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            snapshot_id,
+            InventorySnapshotEvent::OnchainUsdc {
+                usdc_balance: usdc(8500),
+                fetched_at: Utc::now(),
+                block_number: Some(100),
+            },
+        )
+        .await
+        .unwrap();
+
+        // A fill in block 101 postdates the pinned read, so both legs apply.
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_onchain_fill_in_block(shares(10), Direction::Buy, Some(101)),
+            )
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.equity_available(&symbol, Venue::MarketMaking),
+            Some(shares(70)),
+            "a fill past the snapshot block must apply its equity leg"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(7000)),
+            "a fill past the snapshot block must apply its USDC leg"
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
+    async fn legacy_onchain_fill_without_block_always_applies() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(10000), usdc(10000));
+
+        let reactor = make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor.clone());
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            snapshot_id,
+            InventorySnapshotEvent::OnchainEquity {
+                balances: BTreeMap::from([(symbol.clone(), shares(60))]),
+                fetched_at: Utc::now(),
+                block_number: Some(100),
+            },
+        )
+        .await
+        .unwrap();
+
+        // A legacy fill with no block cannot be proven absorbed, so it keeps
+        // today's behavior and applies unconditionally.
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_onchain_fill_in_block(shares(10), Direction::Buy, None),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .equity_available(&symbol, Venue::MarketMaking),
+            Some(shares(70)),
+            "a fill without a block number must never be treated as absorbed"
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_onchain_snapshot_without_block_absorbs_nothing() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(10000), usdc(10000));
+
+        let reactor = make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor.clone());
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            snapshot_id,
+            InventorySnapshotEvent::OnchainEquity {
+                balances: BTreeMap::from([(symbol.clone(), shares(60))]),
+                fetched_at: Utc::now(),
+                block_number: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_onchain_fill_in_block(shares(10), Direction::Buy, Some(100)),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .equity_available(&symbol, Venue::MarketMaking),
+            Some(shares(70)),
+            "a legacy snapshot without a block advances no watermark, so the \
+             fill must still apply"
+        );
+    }
+
+    /// The two legs are judged on their own watermarks: a fill can be
+    /// absorbed on the equity side while its cash leg still applies.
+    #[tokio::test]
+    async fn onchain_fill_legs_absorb_independently_per_watermark() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(10000), usdc(10000));
+
+        let reactor = make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor.clone());
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+
+        // Equity pinned at block 100 (contains the fill), USDC pinned at
+        // block 90 (predates it).
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            snapshot_id.clone(),
+            InventorySnapshotEvent::OnchainEquity {
+                balances: BTreeMap::from([(symbol.clone(), shares(60))]),
+                fetched_at: Utc::now(),
+                block_number: Some(100),
+            },
+        )
+        .await
+        .unwrap();
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            snapshot_id,
+            InventorySnapshotEvent::OnchainUsdc {
+                usdc_balance: usdc(10000),
+                fetched_at: Utc::now(),
+                block_number: Some(90),
+            },
+        )
+        .await
+        .unwrap();
+
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_onchain_fill_in_block(shares(10), Direction::Buy, Some(95)),
+            )
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.equity_available(&symbol, Venue::MarketMaking),
+            Some(shares(60)),
+            "the equity leg at block 95 is covered by the block-100 snapshot"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(8500)),
+            "the USDC leg at block 95 postdates the block-90 snapshot and \
+             must apply"
+        );
+        drop(inventory);
+    }
+
     #[tokio::test]
     async fn offchain_buy_updates_usdc_inventory() {
         let symbol = Symbol::new("AAPL").unwrap();
@@ -9626,6 +9977,7 @@ mod tests {
             InventorySnapshotEvent::OnchainEquity {
                 balances,
                 fetched_at: Utc::now(),
+                block_number: None,
             },
         )
         .await
@@ -11332,6 +11684,7 @@ mod tests {
             InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: usdc(900),
                 fetched_at: Utc::now(),
+                block_number: None,
             },
         )
         .await
@@ -19519,6 +19872,7 @@ mod tests {
         let onchain_event = InventorySnapshotEvent::OnchainEquity {
             balances,
             fetched_at: Utc::now(),
+            block_number: None,
         };
 
         // React to the onchain event - this should NOT trigger rebalancing
@@ -19587,6 +19941,7 @@ mod tests {
         let onchain_event = InventorySnapshotEvent::OnchainEquity {
             balances,
             fetched_at: Utc::now(),
+            block_number: None,
         };
 
         apply_and_dispatch_snapshot(reactor.clone(), id.clone(), onchain_event)
@@ -19666,6 +20021,7 @@ mod tests {
         let onchain_event = InventorySnapshotEvent::OnchainEquity {
             balances,
             fetched_at: Utc::now(),
+            block_number: None,
         };
 
         apply_and_dispatch_snapshot(reactor.clone(), id.clone(), onchain_event)
@@ -19732,6 +20088,7 @@ mod tests {
             InventorySnapshotEvent::OnchainEquity {
                 balances,
                 fetched_at: Utc::now(),
+                block_number: None,
             },
         )
         .await
@@ -20364,6 +20721,7 @@ mod tests {
             InventorySnapshotEvent::OnchainEquity {
                 balances,
                 fetched_at: Utc::now(),
+                block_number: None,
             },
         )
         .await
@@ -22846,6 +23204,7 @@ mod tests {
                 InventorySnapshotEvent::OnchainUsdc {
                     usdc_balance: usdc(500),
                     fetched_at: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -23088,6 +23447,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -23159,6 +23519,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -23192,6 +23553,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await
@@ -24188,6 +24550,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_timestamp: Utc::now(),
+                    block_number: None,
                 },
             )
             .await

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -1044,6 +1044,7 @@ mod tests {
                     direction,
                     price_usdc: float!(150.0),
                     block_timestamp: chrono::Utc::now(),
+                    block_number: None,
                 },
             )
             .await


### PR DESCRIPTION
## What

Closes RAI-1500. Implements ADR 0018: block-watermarked absorption of onchain fill deltas to eliminate the snapshot-vs-fill double-count race on the MarketMaking venue.

## Why

The inventory poller reads `vaultBalance2` every ~60 seconds and emits `OnchainEquity`/`OnchainUsdc` snapshot events. A `vaultBalance2` read includes any `ClearV3`/`TakeOrderV3` fill the moment its transaction lands on-chain. The corresponding fill delta from `OnChainOrderFilled` arrives only after `OrderFillMonitor` polls `eth_getLogs`, the `AccountForDexTrade` job runs, and the `Position` aggregate emits the event — a lag of seconds to minutes. Any inventory poll landing inside that window snapshots the post-fill vault balance, and then the delta re-applies the same fill on top. This produces either an `InsufficientAvailable` underflow or a silently wrong balance that drives needless rebalancing until the next poll.

Unlike the offchain double-count problem (ADR 0015), both writers here derive from the same chain. A vault read is unambiguous given its block number: a snapshot at block N provably contains every fill at block ≤ N. That exact causal signal exists but was previously discarded — nothing recorded the read's block, and fill events did not carry the fill's block.

## How

Rather than blocking snapshots (which would risk starvation during a minutes-long delta lag), the delta yields to the snapshot. An `OnChainOrderFilled` delta leg is skipped if a MarketMaking snapshot already provably contains it:

- **Pin and record the read block.** The Raindex service fetches the latest block number once per poll cycle and pins every `vaultBalance2` `eth_call` to it via a new `Evm::call_at` method. This also fixes a latent inconsistency where multi-vault sums could straddle a block boundary across unpinned calls.
- **Carry the block through snapshot commands and events.** `OnchainEquity` and `OnchainUsdc` commands and events gain `block_number: Option<u64>`. The field is `#[serde(default)]` for backward-compatibility with legacy events, which advance no watermark.
- **Block watermarks in** **`InventoryView`.** Two new in-memory fields — `onchain_equity_snapshot_block_watermarks: HashMap<Symbol, u64>` and `onchain_usdc_snapshot_block_watermark: Option<u64>` — are advanced when a snapshot applies. A skipped snapshot (inflight, stale) advances nothing, so a fill it contains is not incorrectly treated as absorbed.
- **Thread the fill's block into** **`PositionEvent::OnChainOrderFilled`.** `AcknowledgeOnChainFill` and `OnChainOrderFilled` gain `block_number: Option<u64>`, sourced from the `eth_getLogs` log. Legacy fills without a block apply unconditionally.
- **The guard in** **`RebalancingService`.** The `OnChainOrderFilled` arm checks both watermarks under a single write lock before applying each leg. The equity watermark is per-symbol; the USDC watermark is venue-level. Absorbed legs are logged at `info!`. The `OnchainUsdc` snapshot event is now routed through `apply_snapshot_event` (same as all other events) rather than a direct `update_usdc` call, so the USDC block watermark has a single implementation path.

The `Venue::MarketMaking => {}` arm in `equity_snapshot_would_apply` remains empty by design — its comment is updated to point to ADR 0018 and explain that snapshots are never blocked because the delta yields instead.

## Testing

- `get_equity_balance_pinned_block_sees_that_blocks_state`: integration test against a local EVM confirming that a read pinned to a pre-deposit block returns the pre-deposit balance, proving the pin is real and not advisory.
- `onchain_fill_covered_by_pinned_snapshot_block_is_absorbed`: the core RAI-1500 scenario — snapshot at block 100 followed by a fill delta at block 100 leaves balances unchanged.
- `onchain_fill_past_snapshot_block_applies_normally`: a fill at block 101 after a block-100 snapshot applies both legs in full.
- `legacy_onchain_fill_without_block_always_applies`: a fill with `block_number: None` is never treated as absorbed.
- `legacy_onchain_snapshot_without_block_absorbs_nothing`: a snapshot with `block_number: None` advances no watermark.
- `onchain_fill_legs_absorb_independently_per_watermark`: equity watermark at block 100, USDC watermark at block 90 — a fill at block 95 absorbs the equity leg and applies the USDC leg.
- `replayed_onchain_snapshots_restore_block_watermarks`: hydration via `apply_snapshot_event` re-establishes watermarks across restarts.
- `skipped_onchain_snapshots_advance_no_block_watermarks`: an inflight-blocked snapshot does not advance watermarks.
- `unchanged_onchain_balance_dedupes_even_with_newer_block`: dedupe on value alone; a stale watermark from a deduped event cannot leave the balance wrong.
- `onchain_snapshot_event_block_field_roundtrips_and_tolerates_legacy`: serialization roundtrip and legacy-JSON tolerance for the new `block_number` field.
- All existing polling tests updated with a leading `eth_blockNumber` mock response per poll cycle.

## Anything else

Legacy fills and snapshots persisted before this change carry no block number, so the race remains open until one post-deploy poll and one post-deploy fill have flowed through. No history repair is attempted. The reorg caveat (a reorg deeper than `REQUIRED_CONFIRMATIONS` could invalidate the block comparison) is owned by existing confirmation-depth machinery and requires no additional handling here.  
  
Closes [RAI-1500](https://linear.app/makeitrain/issue/RAI-1500/check-whether-the-marketmaking-venue-has-the-same-snapshot-vs-fill)

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented on-chain fills from being counted twice when they are already included in venue snapshots.
  * Improved inventory accuracy by reading all vault balances from a single, consistent blockchain block per polling cycle.
  * Preserved compatibility with existing records that lack block metadata.

* **Documentation**
  * Added documentation describing block-based protection against duplicate on-chain fill accounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->