### PR TITLE
fix: treat unreported tokenization fees as missing cost observations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -349,6 +349,13 @@
                   datasette="while [ ! -f $db_path ]; do sleep 1; done; \
                     exec datasette serve $db_path -p $datasette_port -h 127.0.0.1"
 
+                  # Generated TS bindings are gitignored and nothing in this
+                  # flow refreshes them, so a worktree that predates a DTO
+                  # change serves stale bindings -- e.g. a Statement guard
+                  # missing newer variants makes the dashboard reject every
+                  # live WebSocket message in an endless reconnect loop.
+                  ${rust.st0x-dto}/bin/st0x-dto dashboard/src/lib/api
+
                   exec mprocs "$backend" "$dashboard" "$mockApi" "$datasette"
                 '';
               };

--- a/src/dashboard/pnl/costs.rs
+++ b/src/dashboard/pnl/costs.rs
@@ -7,8 +7,8 @@ use st0x_finance::{Symbol, Usd};
 use st0x_float_macro::float;
 
 use super::parsing::{
-    fmt_decimal, is_safe_symbol, nested_record, parse_internal_decimal, persisted_decimal_value,
-    text_field,
+    fmt_decimal, is_safe_symbol, nested_record, optional_persisted_decimal_value,
+    parse_internal_decimal, persisted_decimal_value, text_field,
 };
 use super::query::{PnlError, PnlFinancialFieldError};
 use super::response::{PnlCostCoverage, PnlCostSummary, PnlSummary};
@@ -525,11 +525,24 @@ fn cost_entry(
     })
 }
 
+/// One `TokenizedEquityMint` event's contribution to the cost ledger.
+enum MintCostObservation {
+    /// Event carries no fee entry: requests, intermediate steps, or a
+    /// terminal event that reported an explicit zero fee.
+    NoEntry,
+    /// Terminal event whose `fees` field (an `Option<Float>` in the event
+    /// schema, "if reported") was not reported by the provider. No entry,
+    /// but the report surfaces it via `missing_cost_observation_count`
+    /// instead of failing wholesale.
+    FeesNotReported,
+    Entry(CostEntryInternal),
+}
+
 fn parse_tokenized_equity_mint_cost_event(
     row: &CostEventRow,
     symbols_by_mint_aggregate: &mut HashMap<String, Symbol>,
     warnings: &mut Vec<String>,
-) -> Result<Option<CostEntryInternal>, PnlError> {
+) -> Result<MintCostObservation, PnlError> {
     if row.event_type == "TokenizedEquityMintEvent::MintRequested" {
         let requested = nested_record(&row.payload, "MintRequested");
         let symbol = requested.and_then(|payload| text_field(payload, "symbol"));
@@ -544,13 +557,13 @@ fn parse_tokenized_equity_mint_cost_event(
                 ));
             }
         }
-        return Ok(None);
+        return Ok(MintCostObservation::NoEntry);
     }
 
     let terminal_key = match row.event_type.as_str() {
         "TokenizedEquityMintEvent::TokensReceived" => "TokensReceived",
         "TokenizedEquityMintEvent::ProviderCompletionRecovered" => "ProviderCompletionRecovered",
-        _ => return Ok(None),
+        _ => return Ok(MintCostObservation::NoEntry),
     };
 
     let Some(terminal) = nested_record(&row.payload, terminal_key) else {
@@ -565,7 +578,10 @@ fn parse_tokenized_equity_mint_cost_event(
     } else {
         text_field(terminal, "recovered_at")
     };
-    let fees = persisted_decimal_value(
+    // `fees` is `Option<Float>` in the event schema ("if reported") with
+    // `#[serde(default)]`, so both an explicit null and an absent key are
+    // legitimate persisted shapes meaning "provider did not report fees".
+    let fees = optional_persisted_decimal_value(
         row.rowid,
         "TokenizedEquityMint",
         row.event_type.clone(),
@@ -580,11 +596,11 @@ fn parse_tokenized_equity_mint_cost_event(
     };
 
     let Some(fees) = fees else {
-        return Err(malformed_cost_payload(row, "missing tokenization fees"));
+        return Ok(MintCostObservation::FeesNotReported);
     };
 
     if fees.is_zero()? {
-        return Ok(None);
+        return Ok(MintCostObservation::NoEntry);
     }
 
     let entry = cost_entry(
@@ -594,7 +610,7 @@ fn parse_tokenized_equity_mint_cost_event(
         occurred_at,
         symbols_by_mint_aggregate.get(&row.aggregate_id).cloned(),
     )?;
-    Ok(Some(entry))
+    Ok(MintCostObservation::Entry(entry))
 }
 
 fn parse_usdc_rebalance_cost_event(
@@ -658,7 +674,8 @@ pub(crate) fn build_cost_entries(
     let mut entries = Vec::new();
     let mut symbols_by_mint_aggregate = HashMap::new();
     let mut counted_tokenization_fee_aggregates = HashSet::new();
-    let missing_cost_observation_count = 0;
+    let mut unreported_fee_aggregates = HashSet::new();
+    let mut missing_cost_observation_count = 0;
     let mut sorted = rows.to_vec();
     sorted.sort_by_key(|row| row.rowid);
 
@@ -673,19 +690,26 @@ pub(crate) fn build_cost_entries(
 
         match row.aggregate_type.as_str() {
             "TokenizedEquityMint" => {
-                let entry = parse_tokenized_equity_mint_cost_event(
+                match parse_tokenized_equity_mint_cost_event(
                     &row,
                     &mut symbols_by_mint_aggregate,
                     warnings,
-                )?;
-                if let Some(entry) = entry {
-                    if counted_tokenization_fee_aggregates.insert(row.aggregate_id.clone()) {
-                        entries.push(entry);
-                    } else {
-                        warnings.push(format!(
-                            "Skipped duplicate tokenization fee for mint aggregate {}",
-                            row.aggregate_id
-                        ));
+                )? {
+                    MintCostObservation::NoEntry => {}
+                    MintCostObservation::FeesNotReported => {
+                        if unreported_fee_aggregates.insert(row.aggregate_id.clone()) {
+                            missing_cost_observation_count += 1;
+                        }
+                    }
+                    MintCostObservation::Entry(entry) => {
+                        if counted_tokenization_fee_aggregates.insert(row.aggregate_id.clone()) {
+                            entries.push(entry);
+                        } else {
+                            warnings.push(format!(
+                                "Skipped duplicate tokenization fee for mint aggregate {}",
+                                row.aggregate_id
+                            ));
+                        }
                     }
                 }
             }

--- a/src/dashboard/pnl/tests.rs
+++ b/src/dashboard/pnl/tests.rs
@@ -1676,6 +1676,31 @@ fn wrong_typed_tokenization_fee_decimals_fail_the_report() {
     ));
 }
 
+/// `TokensReceived.fees` is `Option<Float>` in the event schema ("if
+/// reported"), so persisted events legitimately carry `fees: null`. The
+/// report must treat that as a missing cost observation -- skipping the
+/// entry and counting it -- not fail wholesale, which blanks /pnl for as
+/// long as the event exists.
+#[test]
+fn null_tokenization_fees_are_missing_observations_not_fatal() {
+    let mut cost = tokenized_tokens_received(11, "mint-1", "0.25", "2026-05-15T12:02:00Z");
+    cost.payload["TokensReceived"]["fees"] = serde_json::json!(null);
+
+    let report = report_with_result(
+        Vec::new(),
+        position_rows(),
+        vec![tokenized_mint_requested(10, "mint-1", "RKLB"), cost],
+        Vec::new(),
+        query(),
+        BTreeSet::new(),
+    )
+    .unwrap();
+
+    assert_eq!(report.costs.tokenization_fees_usd, "0");
+    assert_eq!(report.cost_entries.len(), 0);
+    assert_eq!(report.costs.missing_cost_observation_count, 1);
+}
+
 #[test]
 fn missing_tokenization_fee_fields_fail_the_report() {
     let mut missing_fees = tokenized_tokens_received(11, "mint-1", "0.25", "2026-05-15T12:02:00Z");

--- a/src/dashboard/pnl/tests.rs
+++ b/src/dashboard/pnl/tests.rs
@@ -1701,15 +1701,18 @@ fn null_tokenization_fees_are_missing_observations_not_fatal() {
     assert_eq!(report.costs.missing_cost_observation_count, 1);
 }
 
+/// Events persisted before the `fees` field existed deserialize through
+/// `#[serde(default)]` in the aggregate, so an absent key is the same
+/// "not reported" case as an explicit null.
 #[test]
-fn missing_tokenization_fee_fields_fail_the_report() {
+fn absent_tokenization_fees_are_missing_observations_not_fatal() {
     let mut missing_fees = tokenized_tokens_received(11, "mint-1", "0.25", "2026-05-15T12:02:00Z");
     missing_fees.payload["TokensReceived"]
         .as_object_mut()
         .unwrap()
         .remove("fees");
 
-    let error = report_with_result(
+    let report = report_with_result(
         Vec::new(),
         position_rows(),
         vec![tokenized_mint_requested(10, "mint-1", "RKLB"), missing_fees],
@@ -1717,16 +1720,15 @@ fn missing_tokenization_fee_fields_fail_the_report() {
         query(),
         BTreeSet::new(),
     )
-    .unwrap_err();
-    assert!(matches!(
-        error,
-        PnlError::MalformedPayload {
-            rowid: 11,
-            reason: "missing tokenization fees",
-            ..
-        }
-    ));
+    .unwrap();
 
+    assert_eq!(report.costs.tokenization_fees_usd, "0");
+    assert_eq!(report.cost_entries.len(), 0);
+    assert_eq!(report.costs.missing_cost_observation_count, 1);
+}
+
+#[test]
+fn missing_tokenization_fee_timestamp_fails_the_report() {
     let mut missing_timestamp =
         tokenized_tokens_received(12, "mint-2", "0.25", "2026-05-15T12:02:00Z");
     missing_timestamp.payload["TokensReceived"]


### PR DESCRIPTION
## What

Makes `/pnl` treat a `TokenizedEquityMint` terminal event with unreported `fees` (`null` or absent) as a missing cost observation -- skipped and counted in `missing_cost_observation_count` -- instead of failing the whole report.

## Why

`TokensReceived.fees` is `Option<Float>` in the event schema ("Tokenization fees charged by Alpaca (if reported)") with `#[serde(default)]`, so persisted events legitimately carry `fees: null`. The PnL cost parser read the field with the null-rejecting decimal parser, so a single such event permanently broke `/pnl`:

> failed to parse persisted financial field fees at row 1353 (TokenizedEquityMint/TokenizedEquityMintEvent::TokensReceived): null (expected string or number)

Found in the simulated stack right after #<mock-PR> unblocked the activities fetch (until then `/pnl` died earlier, masking this), but the bug is production-relevant: any real mint whose provider does not report fees blanks the PnL dashboard for as long as the event exists -- and events are immutable.

## How

- `parse_tokenized_equity_mint_cost_event` now returns a typed `MintCostObservation` (`NoEntry` / `FeesNotReported` / `Entry`) and reads `fees` with the null-tolerant parser. `null` and absent both mean "provider did not report fees".
- `build_cost_entries` counts `FeesNotReported` into the previously always-zero `missing_cost_observation_count`, deduped per mint aggregate to mirror the fee-entry dedup, so the report stays honest about unobservable costs instead of dying.
- Still fatal (unchanged): wrong-typed `fees` values (e.g. an array), missing `received_at`/`recovered_at` timestamps, and everything on the `UsdcRebalance` path (`fee_collected` is a required field there).

## Testing

Red test first (first commit): `null_tokenization_fees_are_missing_observations_not_fatal` reproduces the production error, then pins the new behavior (report succeeds, no fee entry, `missing_cost_observation_count == 1`).

Adapted, not dropped: the absent-`fees` half of `missing_tokenization_fee_fields_fail_the_report` asserted the old fatal behavior, which contradicted the event schema's `#[serde(default)]`; it is now `absent_tokenization_fees_are_missing_observations_not_fatal` (skip + count). The missing-timestamp half lives on unchanged as `missing_tokenization_fee_timestamp_fails_the_report`.

`cargo nextest run -p st0x-hedge -E 'test(pnl)'` and `cargo clippy -p st0x-hedge --all-targets` are clean.

## Screenshots

N/A

## Anything else

Stacked on the broker-mock activities PR only because that fix unmasked this one in the simulated stack; the code areas are disjoint, so it can be moved onto master (`gt move --onto master`) if independent merging is preferred. This whole raw-JSON parsing layer is slated for replacement by the typed PnL read model design (`PNL_CQRS_READ_MODEL.org`), where typed events make the `Option<Float>` handling structural.
