### PR TITLE
fix: quantize daily PnL for capital conversion instead of overflowing Float

### DIFF
--- a/src/dashboard/pnl/parsing.rs
+++ b/src/dashboard/pnl/parsing.rs
@@ -4,6 +4,7 @@ use num_decimal::Num;
 use num_decimal::num_bigint::BigInt;
 use num_traits::Zero;
 use serde_json::Value;
+use std::cmp::Ordering;
 use std::str::FromStr;
 
 use super::SAFE_SYMBOL_CHARS;
@@ -238,6 +239,42 @@ fn multiply_factor(mut value: BigInt, factor: u8, count: usize) -> BigInt {
         value *= &factor;
     }
     value
+}
+
+/// Rounds a rational to at most `fraction_digits` decimal places,
+/// half-to-even. Used only at reporting boundaries where the exact value
+/// must fit a bounded-precision representation (see the capital conversion
+/// in `source.rs`); core PnL arithmetic stays exact.
+pub(crate) fn quantize_decimal(value: &Num, fraction_digits: u32) -> Num {
+    let (numerator, denominator): (BigInt, BigInt) = value.clone().into();
+    let scale = BigInt::from(10).pow(fraction_digits);
+    let scaled = numerator * &scale;
+
+    let mut quotient = &scaled / &denominator;
+    let remainder = &scaled % &denominator;
+
+    let negative = scaled.sign() == num_decimal::num_bigint::Sign::Minus;
+    let twice_abs_remainder = if remainder.sign() == num_decimal::num_bigint::Sign::Minus {
+        -remainder
+    } else {
+        remainder
+    } * BigInt::from(2);
+    let abs_denominator = if denominator.sign() == num_decimal::num_bigint::Sign::Minus {
+        -denominator
+    } else {
+        denominator
+    };
+
+    let rounds_away_from_zero = match twice_abs_remainder.cmp(&abs_denominator) {
+        Ordering::Greater => true,
+        Ordering::Equal => !(&quotient % BigInt::from(2)).is_zero(),
+        Ordering::Less => false,
+    };
+    if rounds_away_from_zero {
+        quotient += BigInt::from(if negative { -1 } else { 1 });
+    }
+
+    Num::new(quotient, scale)
 }
 
 pub(crate) fn abs_decimal(value: &Num) -> Num {

--- a/src/dashboard/pnl/source.rs
+++ b/src/dashboard/pnl/source.rs
@@ -12,7 +12,7 @@ use crate::bot_gas::BotGasReceiptCostEvent;
 use crate::portfolio_snapshot::{CAPTURE_BUFFER, EtDayRange, capital_summary, load_portfolio_days};
 
 use super::builder::build_pnl_response_from_rows;
-use super::parsing::{fmt_decimal, parse_payload_string};
+use super::parsing::{fmt_decimal, parse_payload_string, quantize_decimal};
 use super::query::{PnlError, PnlQuery};
 use super::response::{PnlCapitalSummary, PnlResponse};
 use super::state::{BotGasCostRow, CostEventRow, PositionEventRow, PositionViewRow};
@@ -20,6 +20,11 @@ use super::{
     ATTRIBUTION_WARNING, BASELINE_WARNING, CAPITAL_AVAILABLE_NOTE, CAPITAL_UNAVAILABLE_NOTE,
     COST_WARNING, SYMBOL_FILTERED_CAPITAL_WARNING,
 };
+
+/// Fractional digits kept when converting exact daily PnL rationals to
+/// `Float` for the capital computation. 18 matches the finest scale of
+/// onchain token amounts; beyond it a return percentage carries no meaning.
+const CAPITAL_PNL_FRACTION_DIGITS: u32 = 18;
 
 pub(crate) async fn build_pnl_report(
     pool: &SqlitePool,
@@ -120,9 +125,19 @@ async fn apply_capital_summary(
     )
     .await?;
     let days = load_portfolio_days(pool, et_day_range).await?;
+    // The exact rational daily PnL can need more significant digits than
+    // `Float` can represent at all (fill shares and prices multiply digit
+    // counts), which fails `Float::parse` with `ParseDecimalOverflow`.
+    // Quantize to 18 fractional digits (round-half-even) for this conversion
+    // only: the value feeds the capital/return ratios, where the bounded
+    // 5e-19 USD/day rounding error is far below meaningful resolution. Every
+    // other report figure stays exact.
     let daily_net_realized_pnl_usd = daily_net_realized_pnl_usd
         .iter()
-        .map(|(day, pnl)| Ok((*day, Float::parse(fmt_decimal(pnl))?)))
+        .map(|(day, pnl)| {
+            let quantized = quantize_decimal(pnl, CAPITAL_PNL_FRACTION_DIGITS);
+            Ok((*day, Float::parse(fmt_decimal(&quantized))?))
+        })
         .collect::<Result<BTreeMap<_, _>, PnlError>>()?;
     let capital = capital_summary(&days, &daily_net_realized_pnl_usd)?;
 

--- a/src/dashboard/pnl/tests.rs
+++ b/src/dashboard/pnl/tests.rs
@@ -12,7 +12,7 @@ use st0x_execution::alpaca_broker_api::AccountActivity;
 use st0x_finance::Symbol;
 
 use super::builder::build_pnl_response_from_rows;
-use super::parsing::{fmt_decimal, parse_payload_string, parse_timestamp};
+use super::parsing::{fmt_decimal, parse_payload_string, parse_timestamp, quantize_decimal};
 use super::query::{PnlCounterTradingFilter, PnlError, PnlMarketSessionFilter, PnlQuery};
 use super::response::{PnlResponse, PnlSymbolSummary, PnlWindow, PnlWindowSymbol};
 use super::state::{
@@ -2785,6 +2785,26 @@ async fn high_precision_daily_pnl_does_not_fail_capital_computation() {
         Some("1000".to_owned())
     );
     assert_eq!(report.capital.sample_days, 1);
+}
+
+/// Pins the rounding the capital conversion applies: half-to-even at the
+/// requested scale, values already at or below the scale pass through
+/// losslessly, negatives mirror positives.
+#[test]
+fn quantize_decimal_rounds_half_even_at_the_requested_scale() {
+    let cases = [
+        ("0.0000000000000000015", "0.000000000000000002"),
+        ("0.0000000000000000025", "0.000000000000000002"),
+        ("-0.0000000000000000015", "-0.000000000000000002"),
+        ("-0.0000000000000000025", "-0.000000000000000002"),
+        ("0.0000000000000000005", "0"),
+        ("1.5", "1.5"),
+        ("-150.000000000000000001", "-150.000000000000000001"),
+    ];
+    for (input, expected) in cases {
+        let quantized = quantize_decimal(&Num::from_str(input).unwrap(), 18);
+        assert_eq!(fmt_decimal(&quantized), expected, "input {input}");
+    }
 }
 
 #[tokio::test]

--- a/src/dashboard/pnl/tests.rs
+++ b/src/dashboard/pnl/tests.rs
@@ -2741,6 +2741,52 @@ async fn build_pnl_report_populates_capital_when_snapshots_exist() {
     );
 }
 
+/// Fill shares and prices carry full `Float` precision, so the exact
+/// rational daily PnL (`shares x spread`) can need more significant digits
+/// than `Float` can represent at all (>76). The capital computation converts
+/// that value to `Float`; the conversion must not fail the whole report with
+/// `ParseDecimalOverflow` (surfaces as `PnlError::CapitalFloat`).
+#[tokio::test]
+async fn high_precision_daily_pnl_does_not_fail_capital_computation() {
+    let shares = "0.1234567890123456789012345678901234567891";
+    let sell_price = "150.1111111111111111111111111111111111111111";
+    let pool = pnl_test_pool(
+        vec![
+            onchain_fill(
+                1,
+                "RKLB",
+                "Sell",
+                sell_price,
+                shares,
+                "2026-05-15T14:00:00Z",
+            ),
+            offchain_fill(2, "RKLB", "Buy", "2026-05-15T14:01:00Z", "150", shares),
+        ],
+        position_rows(),
+    )
+    .await;
+    insert_portfolio_snapshot_row(
+        &pool,
+        "2026-05-15",
+        "market_making",
+        "USDC",
+        "1000",
+        Some("1"),
+        Some("2026-05-15T04:05:00+00:00"),
+    )
+    .await;
+
+    let report = build_pnl_report(&pool, &query(), Vec::new(), Utc::now())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        report.capital.average_deployed_capital_usd,
+        Some("1000".to_owned())
+    );
+    assert_eq!(report.capital.sample_days, 1);
+}
+
 #[tokio::test]
 async fn return_uses_only_pnl_from_days_with_usable_capital() {
     let pool = pnl_test_pool(


### PR DESCRIPTION
## What

Quantizes the per-day net-realized-PnL values to 18 fractional digits (round-half-even) before converting them from exact rationals (`Num`) to `Float` for the capital/return-on-capital computation, so `/pnl` no longer fails with `ParseDecimalOverflow` when the exact daily sum needs more significant digits than `Float` can represent.

## Why

The FIFO replay computes PnL in exact rational arithmetic. Fills carry full-precision `Float` shares and prices, so products like `shares x spread` multiply digit counts and an exact daily sum can legitimately require more significant digits (>76) than the `Float` type can hold at all. The previous code parsed the full-precision string:

> Failed to convert a PnL total for capital/return computation: Decimal Float error selector: Err(0x0fdc2635) -- ParseDecimalOverflow(uint256)

which failed the entire report. Surfaced in the simulated stack after the two preceding fixes in this stack unblocked `/pnl` far enough to reach the capital path; the bug is production-relevant for the same reason (real fills carry the same precision).

## Blast radius of the rounding (why this stays within the no-precision-truncation policy in spirit)

- The quantization happens at a single local conversion inside `apply_capital_summary`, feeding `capital_summary()` -- whose only production caller is this PnL path. Nothing else consumes the daily-PnL map.
- Within the response it affects only the `capital` section -- effectively `annualized_return_pct` (average deployed capital comes from portfolio snapshot USD marks, not from these values).
- Every other response field (`summary`, per-symbol summaries, `entries`, `cost_entries`, `windows`) continues through the exact `Num` pipeline, formatted losslessly, byte-for-byte as before.
- Nothing is persisted: the map is per-request and dropped. No trading, hedging, or rebalancing path reads `/pnl`; money-moving domain state is untouched by construction.
- The rounding error is bounded at 5e-19 USD per day, far below any meaningful resolution of a percentage-return metric; the rounding semantics are pinned by test.
- The alternative -- exact rational capital math -- is not achievable: annualized return requires a real-number `pow`, and the status quo ("fail the whole report forever once precision accumulates") is the worse violation of report integrity.

## Testing

Red test first (first commit): `high_precision_daily_pnl_does_not_fail_capital_computation` builds a report over fills whose exact PnL products exceed `Float`'s representable precision, plus a portfolio-snapshot day, through `build_pnl_report` -- previously failed with `PnlError::CapitalFloat`, now must succeed with a populated `capital` section. The companion test `quantize_decimal_rounds_half_even_at_the_requested_scale` pins the rounding table (ties to even in both signs, sub-scale values pass through losslessly).

## Screenshots

N/A

## Anything else

Third `/pnl` defect surfaced today by the same simulated-stack session, each unmasked by fixing the previous one (missing broker-mock activities endpoint -> null tokenization fees -> this). The report fails wholesale on the first error it meets, so each single oddity presents as a full endpoint outage. The typed CQRS read-model design (`PNL_CQRS_READ_MODEL.org`) addresses the parsing-fragility class of these; this stack fixes the acute cases.
