### PR TITLE
fix: regenerate DTO bindings before launching the simulation dashboard

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -349,6 +349,13 @@
                   datasette="while [ ! -f $db_path ]; do sleep 1; done; \
                     exec datasette serve $db_path -p $datasette_port -h 127.0.0.1"
 
+                  # Generated TS bindings are gitignored and nothing in this
+                  # flow refreshes them, so a worktree that predates a DTO
+                  # change serves stale bindings -- e.g. a Statement guard
+                  # missing newer variants makes the dashboard reject every
+                  # live WebSocket message in an endless reconnect loop.
+                  ${rust.st0x-dto}/bin/st0x-dto dashboard/src/lib/api
+
                   exec mprocs "$backend" "$dashboard" "$mockApi" "$datasette"
                 '';
               };


### PR DESCRIPTION
## What

Regenerates the TypeScript DTO bindings (`nix run .#st0x-dto`'s binary) as part of every `mkSimulation` script, right before launching the mprocs panes.

## Why

Generated bindings under `dashboard/src/lib/api/` are gitignored and only refreshed by the CI flow (`nix run .#ci`) or manual invocation -- nothing in `nix run .#simulate*` does it. A worktree whose on-disk bindings predate a DTO change serves stale files to the simulation's dashboard dev server. Concretely: a `StatementGuard.ts` generated before the `Statement::TradeUpdate` variant existed rejects every live `trade_update` WebSocket frame, putting the dashboard into an endless "WebSocket connection error / Reconnecting" loop -- one reconnect per simulated trade, with a healthy backend. Cost us a debugging session to trace to the stale artifact.

## How

One line in `mkSimulation` (plus a comment): run the nix-built `st0x-dto` binary against `dashboard/src/lib/api` before `exec mprocs`. Uses the same generator invocation as the `ci` script, so simulation and CI can't drift.

## Testing

Script-only change to the simulation launcher; exercised by launching `nix run .#simulate-14d` -- bindings now refresh on every start (verified by the previously-missing `trade_update` tag appearing in `StatementGuard.ts` and the dashboard WebSocket staying connected across live trades).

## Screenshots

N/A

## Anything else

Found while debugging the simulated PnL stack (see the three stacked fixes below this branch). Stacked on `pnl-capital-precision` for convenience; the change is independent and can be moved onto master with `gt move --onto master` if independent merging is preferred.
