### PR TITLE
feat: dashboard light/dark/system theme switcher

### DIFF
--- a/dashboard/src/app.html
+++ b/dashboard/src/app.html
@@ -1,8 +1,24 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>
+      // Pre-paint theme application: must stay in sync with the storage key
+      // and JSON encoding used by src/lib/theme.svelte.ts.
+      ;(() => {
+        let mode = null
+        try {
+          mode = JSON.parse(localStorage.getItem('theme-mode') ?? 'null')
+        } catch {
+          mode = null
+        }
+        const dark =
+          mode === 'dark' ||
+          (mode !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches)
+        document.documentElement.classList.toggle('dark', dark)
+      })()
+    </script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/dashboard/src/lib/components/available-inventory.svelte
+++ b/dashboard/src/lib/components/available-inventory.svelte
@@ -488,7 +488,7 @@
                     ? 'bg-green-500'
                     : dev?.style === 'low'
                       ? 'bg-red-500'
-                      : 'bg-blue-400'}"
+                      : 'bg-blue-500 dark:bg-blue-400'}"
                   style="width: {String(Math.min(cashCells.ratio * 100, 100))}%"
                 ></div>
               </div>
@@ -739,7 +739,7 @@
                     ? 'bg-green-500'
                     : dev?.style === 'low'
                       ? 'bg-red-500'
-                      : 'bg-blue-400'}"
+                      : 'bg-blue-500 dark:bg-blue-400'}"
                   style="width: {String(Math.min(row.ratio * 100, 100))}%"
                 ></div>
               </div>

--- a/dashboard/src/lib/components/header-bar.svelte
+++ b/dashboard/src/lib/components/header-bar.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte'
   import { Badge } from '$lib/components/ui/badge'
   import RecoveryGuide from '$lib/components/recovery-guide.svelte'
+  import ThemeSwitcher from '$lib/components/theme-switcher.svelte'
   import type { ConnectionState } from '$lib/websocket'
   import {
     getApiBaseUrl,
@@ -172,6 +173,8 @@
       <Badge variant={statusVariant}>
         {statusLabel}
       </Badge>
+
+      <ThemeSwitcher />
     </div>
   </div>
 </header>

--- a/dashboard/src/lib/components/log-panel.svelte
+++ b/dashboard/src/lib/components/log-panel.svelte
@@ -415,9 +415,9 @@
     switch (level.toUpperCase()) {
       case 'ERROR': return 'text-red-500'
       case 'WARN': return 'text-yellow-500'
-      case 'INFO': return 'text-blue-400'
-      case 'DEBUG': return 'text-cyan-400'
-      case 'TRACE': return 'text-purple-400'
+      case 'INFO': return 'text-blue-600 dark:text-blue-400'
+      case 'DEBUG': return 'text-cyan-600 dark:text-cyan-400'
+      case 'TRACE': return 'text-purple-600 dark:text-purple-400'
       default: return ''
     }
   }

--- a/dashboard/src/lib/components/pending-orders.svelte
+++ b/dashboard/src/lib/components/pending-orders.svelte
@@ -52,8 +52,8 @@
   const statusColor = (status: string): string => {
     switch (status) {
       case 'Pending': return 'text-yellow-500'
-      case 'Submitted': return 'text-blue-400'
-      case 'PartiallyFilled': return 'text-blue-400'
+      case 'Submitted': return 'text-blue-600 dark:text-blue-400'
+      case 'PartiallyFilled': return 'text-blue-600 dark:text-blue-400'
       default: return ''
     }
   }
@@ -61,8 +61,8 @@
   const dotColor = (status: string): string => {
     switch (status) {
       case 'Pending': return 'bg-yellow-500'
-      case 'Submitted': return 'bg-blue-400'
-      case 'PartiallyFilled': return 'bg-blue-400'
+      case 'Submitted': return 'bg-blue-500 dark:bg-blue-400'
+      case 'PartiallyFilled': return 'bg-blue-500 dark:bg-blue-400'
       default: return 'bg-muted-foreground'
     }
   }

--- a/dashboard/src/lib/components/performance-panel.svelte
+++ b/dashboard/src/lib/components/performance-panel.svelte
@@ -284,19 +284,19 @@
   const WATERFALL_CHART_CONFIG = {
     unhedged: {
       label: 'unhedged (fill -> placed)',
-      color: '#64748b'
+      color: 'var(--chart-slate)'
     },
     submission: {
       label: 'submission (placed -> accepted)',
-      color: '#38bdf8'
+      color: 'var(--chart-sky)'
     },
     executionOk: {
       label: 'execution (accepted -> filled)',
-      color: '#34d399'
+      color: 'var(--chart-emerald)'
     },
     executionFailed: {
       label: 'execution (failed)',
-      color: '#f87171'
+      color: 'var(--chart-red)'
     }
   } satisfies Chart.ChartConfig
 
@@ -330,15 +330,15 @@
   const PERCENTILE_CHART_CONFIG = {
     p50Ms: {
       label: 'p50',
-      color: '#34d399'
+      color: 'var(--chart-emerald)'
     },
     p90Ms: {
       label: 'p90',
-      color: '#fbbf24'
+      color: 'var(--chart-amber)'
     },
     p99Ms: {
       label: 'p99',
-      color: '#f87171'
+      color: 'var(--chart-red)'
     }
   } satisfies Chart.ChartConfig
 
@@ -369,27 +369,27 @@
   const ATTESTATION_CHART_CONFIG = {
     durationMs: {
       label: 'Attestation time',
-      color: '#fbbf24'
+      color: 'var(--chart-amber)'
     }
   } satisfies Chart.ChartConfig
 
   const BLOCK_LAG_CHART_CONFIG = {
     maxLagBlocks: {
       label: 'Block lag',
-      color: '#38bdf8'
+      color: 'var(--chart-sky)'
     }
   } satisfies Chart.ChartConfig
 
   const STAGE_COLORS: Record<RebalanceStageName, string> = {
-    conversion: '#c084fc',
-    withdrawal: '#38bdf8',
-    burn: '#fb923c',
-    attestation: '#fbbf24',
-    mint: '#34d399',
-    deposit: '#818cf8'
+    conversion: 'var(--chart-purple)',
+    withdrawal: 'var(--chart-sky)',
+    burn: 'var(--chart-orange)',
+    attestation: 'var(--chart-amber)',
+    mint: 'var(--chart-emerald)',
+    deposit: 'var(--chart-indigo)'
   }
 
-  const REBALANCE_FAILED_COLOR = '#f87171'
+  const REBALANCE_FAILED_COLOR = 'var(--chart-red)'
 
   // Segment order is fixed (conversion -> withdrawal -> burn -> attestation ->
   // mint -> deposit) and matches AlpacaToBase's chronological pipeline, but
@@ -453,7 +453,7 @@
     // invisible or shorter-than-real bar.
     unmeasuredMs: {
       label: 'unaccounted elapsed',
-      color: '#64748b'
+      color: 'var(--chart-slate)'
     }
   } satisfies Chart.ChartConfig
 
@@ -501,18 +501,18 @@
   const EQUITY_ROW_HEIGHT_PX = 28
 
   const EQUITY_STAGE_COLORS: Record<EquityStageName, string> = {
-    mint_acceptance: '#c084fc',
-    mint_receipt: '#38bdf8',
-    mint_wrap: '#fb923c',
-    mint_deposit: '#34d399',
-    redemption_withdraw: '#818cf8',
-    redemption_unwrap: '#f472b6',
-    redemption_send: '#facc15',
-    redemption_detection: '#22d3ee',
-    redemption_completion: '#a3e635'
+    mint_acceptance: 'var(--chart-purple)',
+    mint_receipt: 'var(--chart-sky)',
+    mint_wrap: 'var(--chart-orange)',
+    mint_deposit: 'var(--chart-emerald)',
+    redemption_withdraw: 'var(--chart-indigo)',
+    redemption_unwrap: 'var(--chart-pink)',
+    redemption_send: 'var(--chart-yellow)',
+    redemption_detection: 'var(--chart-cyan)',
+    redemption_completion: 'var(--chart-lime)'
   }
 
-  const EQUITY_FAILED_COLOR = '#f87171'
+  const EQUITY_FAILED_COLOR = 'var(--chart-red)'
 
   const EQUITY_CHART_CONFIG = {
     mintAcceptanceOk: {
@@ -591,7 +591,7 @@
     // -- covers both in-progress and completed-but-recovered operations.
     unmeasuredMs: {
       label: 'unaccounted elapsed',
-      color: '#64748b'
+      color: 'var(--chart-slate)'
     }
   } satisfies Chart.ChartConfig
 
@@ -873,7 +873,7 @@
           {#each reliability.current?.logTargets ?? [] as row (`${row.target}:${row.level}`)}
             <div class="flex items-center gap-2 text-xs">
               <span
-                class={`w-12 shrink-0 font-semibold ${row.level === 'ERROR' ? 'text-red-400' : 'text-amber-400'}`}
+                class={`w-12 shrink-0 font-semibold ${row.level === 'ERROR' ? 'text-red-600 dark:text-red-400' : 'text-amber-600 dark:text-amber-400'}`}
               >
                 {row.level}
               </span>
@@ -889,7 +889,7 @@
                     y={14 - (bucketCount / Math.max(1, ...row.sparkline)) * 12 - 1}
                     width="4"
                     height={(bucketCount / Math.max(1, ...row.sparkline)) * 12 + 1}
-                    fill={row.level === 'ERROR' ? '#f87171' : '#fbbf24'}
+                    style:fill={row.level === 'ERROR' ? 'var(--chart-red)' : 'var(--chart-amber)'}
                     opacity={bucketCount === 0 ? 0.15 : 0.9}
                   />
                 {/each}
@@ -911,7 +911,7 @@
 
       {#if reliability.current !== null && reliability.current.failureEvents.length > 0}
         <div class="mt-4 border-t pt-2">
-          <p class="mb-1 text-xs font-medium text-red-400">Lifecycle failures (money-at-risk)</p>
+          <p class="mb-1 text-xs font-medium text-red-600 dark:text-red-400">Lifecycle failures (money-at-risk)</p>
           {#each reliability.current.failureEvents as failure (failure.eventType)}
             <div class="flex items-center gap-2 text-xs">
               <span class="w-72 shrink-0 truncate font-mono">{failure.eventType}</span>
@@ -940,7 +940,7 @@
     </Card.Header>
     <Card.Content>
       {#if (chartRebalances.current?.skippedOperations ?? 0) > 0}
-        <p class="mb-2 text-xs text-amber-400">
+        <p class="mb-2 text-xs text-amber-600 dark:text-amber-400">
           {chartRebalances.current?.skippedOperations} operations excluded (unparseable timing).
         </p>
       {/if}
@@ -1069,7 +1069,7 @@
     </Card.Header>
     <Card.Content>
       {#if (chartEquityTimings.current?.skippedOperations ?? 0) > 0}
-        <p class="mb-2 text-xs text-amber-400">
+        <p class="mb-2 text-xs text-amber-600 dark:text-amber-400">
           {chartEquityTimings.current?.skippedOperations} operations excluded (unparseable timing).
         </p>
       {/if}
@@ -1182,10 +1182,10 @@
           class="mt-4 flex flex-wrap gap-x-4 gap-y-1 border-t pt-2 text-xs text-muted-foreground"
         >
           <span>{poll.cycles} poll cycles</span>
-          <span class={poll.errors > 0 ? 'text-red-400' : ''}>
+          <span class={poll.errors > 0 ? 'text-red-600 dark:text-red-400' : ''}>
             {poll.errors} errors
           </span>
-          <span class={poll.skippedTicks > 0 ? 'text-amber-400' : ''}>
+          <span class={poll.skippedTicks > 0 ? 'text-amber-600 dark:text-amber-400' : ''}>
             {poll.skippedTicks} skipped ticks
           </span>
           {#if poll.duration}
@@ -1233,7 +1233,7 @@
                     y={14 - bar.height - 1}
                     width="4"
                     height={bar.height + 1}
-                    fill={bar.hasErrors ? '#f87171' : '#38bdf8'}
+                    style:fill={bar.hasErrors ? 'var(--chart-red)' : 'var(--chart-sky)'}
                     opacity="0.9"
                   />
                 {/each}
@@ -1242,7 +1242,7 @@
                 {row.calls} calls
               </span>
               <span
-                class={`w-16 shrink-0 text-right tabular-nums ${row.errors > 0 ? 'text-red-400' : 'text-muted-foreground'}`}
+                class={`w-16 shrink-0 text-right tabular-nums ${row.errors > 0 ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground'}`}
               >
                 {row.errors} err
               </span>

--- a/dashboard/src/lib/components/pnl-panel.svelte
+++ b/dashboard/src/lib/components/pnl-panel.svelte
@@ -104,12 +104,18 @@
     directionalImbalanceExcessPnlUsd: 'Directional realized'
   }
   const streamColors: Record<PnlStreamKey, string> = {
-    counterTradePnlUsd: '#38bdf8',
-    onchainNettingPnlUsd: '#22c55e',
-    directionalInventoryBaselinePnlUsd: '#f59e0b',
-    directionalImbalanceExcessPnlUsd: '#f43f5e'
+    counterTradePnlUsd: 'var(--chart-sky)',
+    onchainNettingPnlUsd: 'var(--chart-green)',
+    directionalInventoryBaselinePnlUsd: 'var(--chart-amber)',
+    directionalImbalanceExcessPnlUsd: 'var(--chart-rose)'
   }
-  const assetColors = ['#38bdf8', '#f59e0b', '#22c55e', '#f43f5e', '#a78bfa']
+  const assetColors = [
+    'var(--chart-sky)',
+    'var(--chart-amber)',
+    'var(--chart-green)',
+    'var(--chart-rose)',
+    'var(--chart-violet)'
+  ]
   const formulaRows = [
     {
       label: 'Counter-trade PnL',
@@ -416,7 +422,7 @@
   const costStatusClass = (status: string): string => {
     if (status === 'included') return 'text-green-500'
     if (status === 'zero') return 'text-muted-foreground'
-    return 'text-red-400'
+    return 'text-red-600 dark:text-red-400'
   }
   const costStatusLabel = (status: string): string => status.replaceAll('_', ' ')
   const costCategoryLabel = (entry: PnlCostEntry): string => entry.category.replaceAll('_', ' ')
@@ -425,7 +431,7 @@
     effect === 'revenue'
       ? 'text-green-500'
       : effect === 'cost'
-        ? 'text-red-400'
+        ? 'text-red-600 dark:text-red-400'
         : 'text-muted-foreground'
 
   const shortId = (id: string): string => {
@@ -627,7 +633,8 @@
   const labelY = barChartHeight - 18
   const rotateLabel = (x: number): string => `rotate(-45 ${String(x)} ${String(labelY)})`
 
-  const assetColor = (index: number): string => assetColors[index % assetColors.length] ?? '#94a3b8'
+  const assetColor = (index: number): string =>
+    assetColors[index % assetColors.length] ?? 'var(--chart-slate)'
   const assetColorForSymbol = (symbol: string): string =>
     assetColor(Math.max(0, chartSymbolUniverse.indexOf(symbol)))
 
@@ -806,7 +813,7 @@
       return {
         key,
         label: firstSegment?.label ?? key,
-        color: firstSegment?.color ?? '#94a3b8',
+        color: firstSegment?.color ?? 'var(--chart-slate)',
         path: [...top, ...bottom].join(' '),
         points
       }
@@ -981,7 +988,7 @@
         {#each presetButtons as preset (preset.value)}
           <button
             class="px-2 py-1 hover:bg-accent {selectedPreset.current === preset.value
-              ? 'bg-amber-500/20 text-amber-200'
+              ? 'bg-amber-500/20 text-amber-700 dark:text-amber-200'
               : 'bg-background'}"
             onclick={() => {
               applyRangePreset(preset.value)
@@ -1032,7 +1039,7 @@
       <div class="inline-flex overflow-hidden rounded border text-xs">
         <button
           class="px-2 py-1 hover:bg-accent {marketSessionFilter.current === 'all'
-            ? 'bg-amber-500/20 text-amber-200'
+            ? 'bg-amber-500/20 text-amber-700 dark:text-amber-200'
             : 'bg-background'}"
           onclick={() => {
             setMarketSessionFilter('all')
@@ -1040,7 +1047,7 @@
         >
         <button
           class="border-l px-2 py-1 hover:bg-accent {marketSessionFilter.current === 'pre'
-            ? 'bg-amber-500/20 text-amber-200'
+            ? 'bg-amber-500/20 text-amber-700 dark:text-amber-200'
             : 'bg-background'}"
           onclick={() => {
             setMarketSessionFilter('pre')
@@ -1048,7 +1055,7 @@
         >
         <button
           class="border-l px-2 py-1 hover:bg-accent {marketSessionFilter.current === 'rth'
-            ? 'bg-amber-500/20 text-amber-200'
+            ? 'bg-amber-500/20 text-amber-700 dark:text-amber-200'
             : 'bg-background'}"
           onclick={() => {
             setMarketSessionFilter('rth')
@@ -1056,7 +1063,7 @@
         >
         <button
           class="border-l px-2 py-1 hover:bg-accent {marketSessionFilter.current === 'post'
-            ? 'bg-amber-500/20 text-amber-200'
+            ? 'bg-amber-500/20 text-amber-700 dark:text-amber-200'
             : 'bg-background'}"
           onclick={() => {
             setMarketSessionFilter('post')
@@ -1064,7 +1071,7 @@
         >
         <button
           class="border-l px-2 py-1 hover:bg-accent {marketSessionFilter.current === 'overnight'
-            ? 'bg-amber-500/20 text-amber-200'
+            ? 'bg-amber-500/20 text-amber-700 dark:text-amber-200'
             : 'bg-background'}"
           onclick={() => {
             setMarketSessionFilter('overnight')
@@ -1072,7 +1079,7 @@
         >
         <button
           class="border-l px-2 py-1 hover:bg-accent {marketSessionFilter.current === 'weekend'
-            ? 'bg-amber-500/20 text-amber-200'
+            ? 'bg-amber-500/20 text-amber-700 dark:text-amber-200'
             : 'bg-background'}"
           onclick={() => {
             setMarketSessionFilter('weekend')
@@ -1231,7 +1238,7 @@
 
         <div class="rounded-lg border bg-card/60 p-3">
           <div class="text-xs text-muted-foreground">Tracked Costs</div>
-          <div class="mt-1 font-mono text-xl font-semibold text-red-400">
+          <div class="mt-1 font-mono text-xl font-semibold text-red-600 dark:text-red-400">
             {fmtUsd(summary.trackedCostsUsd)}
           </div>
           <div class="mt-1 text-xs text-muted-foreground">
@@ -1356,7 +1363,7 @@
                 <Table.Row class={selectedAsset === row.symbol ? 'bg-amber-500/10' : ''}>
                   <Table.Cell>
                     <button
-                      class="font-mono text-xs font-semibold text-foreground hover:text-amber-200"
+                      class="font-mono text-xs font-semibold text-foreground hover:text-amber-700 dark:hover:text-amber-200"
                       onclick={() => {
                         selectAsset(row.symbol)
                       }}
@@ -1369,7 +1376,7 @@
                   >
                     {fmtSignedUsd(row.grossRealizedPnlUsd)}
                   </Table.Cell>
-                  <Table.Cell class="text-right font-mono text-xs text-red-400">
+                  <Table.Cell class="text-right font-mono text-xs text-red-600 dark:text-red-400">
                     {fmtUsd(row.trackedCostsUsd)}
                   </Table.Cell>
                   <Table.Cell
@@ -1505,7 +1512,7 @@
                       </Table.Cell>
                       <Table.Cell
                         class="text-right font-mono text-[11px] {entry.delayedCounterTrade
-                          ? 'text-amber-300'
+                          ? 'text-amber-600 dark:text-amber-300'
                           : 'text-muted-foreground'}"
                       >
                         {fmtDuration(entry.elapsedSeconds)}
@@ -1533,7 +1540,7 @@
 
       {#if report.current.warnings.length > 0}
         <details
-          class="mt-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-100"
+          class="mt-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-900 dark:text-amber-100"
         >
           <summary class="cursor-pointer select-none font-semibold">
             Debug ({report.current.warnings.length})
@@ -1726,7 +1733,7 @@
                       width={segment.width}
                       height={segment.height}
                       rx="3"
-                      fill={segment.color}
+                      style:fill={segment.color}
                       opacity="0.82"
                     />
                   {/if}
@@ -1818,7 +1825,7 @@
                       width={segment.width}
                       height={segment.height}
                       rx="3"
-                      fill={segment.color}
+                      style:fill={segment.color}
                       opacity="0.82"
                     />
                   {/if}
@@ -1901,13 +1908,13 @@
               >
 
               {#each byAssetArea.layers as layer (layer.key)}
-                <polygon points={layer.path} fill={layer.color} opacity="0.3" />
+                <polygon points={layer.path} style:fill={layer.color} opacity="0.3" />
                 <polyline
                   points={layer.points
                     .map((point) => `${point.x.toFixed(1)},${point.y1.toFixed(1)}`)
                     .join(' ')}
                   fill="none"
-                  stroke={layer.color}
+                  style:stroke={layer.color}
                   stroke-width="1.6"
                   opacity="0.9"
                 />
@@ -1989,13 +1996,13 @@
               >
 
               {#each byMethodArea.layers as layer (layer.key)}
-                <polygon points={layer.path} fill={layer.color} opacity="0.3" />
+                <polygon points={layer.path} style:fill={layer.color} opacity="0.3" />
                 <polyline
                   points={layer.points
                     .map((point) => `${point.x.toFixed(1)},${point.y1.toFixed(1)}`)
                     .join(' ')}
                   fill="none"
-                  stroke={layer.color}
+                  style:stroke={layer.color}
                   stroke-width="1.6"
                   opacity="0.9"
                 />

--- a/dashboard/src/lib/components/theme-switcher.svelte
+++ b/dashboard/src/lib/components/theme-switcher.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import Sun from '@lucide/svelte/icons/sun'
+  import Moon from '@lucide/svelte/icons/moon'
+  import SunMoon from '@lucide/svelte/icons/sun-moon'
+
+  import { Button } from '$lib/components/ui/button'
+  import { themeMode, type ThemeMode } from '$lib/theme.svelte'
+
+  const labels: Record<ThemeMode, string> = {
+    light: 'Theme: light',
+    dark: 'Theme: dark',
+    system: 'Theme: system'
+  }
+
+  const label = $derived(labels[themeMode.current])
+</script>
+
+<Button
+  variant="ghost"
+  size="icon-sm"
+  title={label}
+  aria-label={label}
+  onclick={() => {
+    themeMode.cycle()
+  }}
+>
+  {#if themeMode.current === 'light'}
+    <Sun />
+  {:else if themeMode.current === 'dark'}
+    <Moon />
+  {:else}
+    <SunMoon />
+  {/if}
+</Button>

--- a/dashboard/src/lib/components/theme-switcher.test.ts
+++ b/dashboard/src/lib/components/theme-switcher.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { THEME_MODE_STORAGE_KEY } from '$lib/theme.svelte'
+
+// theme-switcher renders from the module-level theme singleton, so each test
+// seeds storage and imports a fresh module graph before mounting. The svelte
+// runtime must come from the same fresh graph as the component, otherwise
+// mount() and the component disagree on the active effect context.
+const mountSwitcher = async (storedValue?: string) => {
+  vi.resetModules()
+  localStorage.clear()
+  if (storedValue !== undefined) {
+    localStorage.setItem(THEME_MODE_STORAGE_KEY, storedValue)
+  }
+  const { mount, tick, unmount } = await import('svelte')
+  const { default: ThemeSwitcher } = await import('./theme-switcher.svelte')
+  const target = document.createElement('div')
+  document.body.appendChild(target)
+  const component = mount(ThemeSwitcher, { target })
+  return {
+    target,
+    tick,
+    dispose: () => {
+      void unmount(component)
+    }
+  }
+}
+
+describe('ThemeSwitcher', () => {
+  it('labels the button with the system mode by default', async () => {
+    const { target, dispose } = await mountSwitcher()
+    try {
+      const button = target.querySelector('button')
+      expect(button?.getAttribute('aria-label')).toBe('Theme: system')
+    } finally {
+      dispose()
+    }
+  })
+
+  it('renders the icon of a stored explicit mode', async () => {
+    const { target, dispose } = await mountSwitcher(JSON.stringify('dark'))
+    try {
+      expect(target.querySelector('button')?.getAttribute('aria-label')).toBe('Theme: dark')
+      expect(target.innerHTML).toContain('lucide-moon')
+      expect(target.innerHTML).not.toContain('lucide-sun')
+    } finally {
+      dispose()
+    }
+  })
+
+  it('cycles system -> light on click and persists the choice', async () => {
+    const { target, tick, dispose } = await mountSwitcher()
+    try {
+      expect(target.innerHTML).toContain('lucide-sun-moon')
+
+      target.querySelector('button')?.click()
+      await tick()
+
+      expect(target.querySelector('button')?.getAttribute('aria-label')).toBe('Theme: light')
+      expect(target.innerHTML).toContain('lucide-sun')
+      expect(target.innerHTML).not.toContain('lucide-moon')
+      expect(localStorage.getItem(THEME_MODE_STORAGE_KEY)).toBe(JSON.stringify('light'))
+    } finally {
+      dispose()
+    }
+  })
+})

--- a/dashboard/src/lib/components/trade-history-panel.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.svelte
@@ -674,7 +674,7 @@
                 href={getExplorerTxUrl(txHash)}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+                class="inline-flex items-center gap-1 text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
               >
                 {txHash.slice(0, 10)}...{txHash.slice(-8)}
                 <svg
@@ -748,7 +748,7 @@
                             href={getExplorerTxUrl(value)}
                             target="_blank"
                             rel="noopener noreferrer"
-                            class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+                            class="inline-flex items-center gap-1 text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
                           >
                             {value.slice(0, 10)}...{value.slice(-8)}
                             <svg

--- a/dashboard/src/lib/components/transfer-panel.svelte
+++ b/dashboard/src/lib/components/transfer-panel.svelte
@@ -658,7 +658,7 @@
                                 href={getExplorerTxUrl(value)}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+                                class="inline-flex items-center gap-1 text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
                               >
                                 {value.slice(0, 10)}...{value.slice(-8)}
                                 <svg
@@ -682,7 +682,7 @@
                                   href={getExplorerTxUrl(txHash)}
                                   target="_blank"
                                   rel="noopener noreferrer"
-                                  class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+                                  class="inline-flex items-center gap-1 text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
                                 >
                                   {txHash.slice(0, 10)}...{txHash.slice(-8)}
                                   <svg

--- a/dashboard/src/lib/theme.svelte.test.ts
+++ b/dashboard/src/lib/theme.svelte.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { nextThemeMode, resolveTheme, THEME_MODE_STORAGE_KEY } from './theme.svelte'
+
+// The persisted store is a module-level singleton, so tests that exercise
+// storage interplay import a fresh module instance after seeding storage.
+const setupThemeModule = async (storedValue?: string) => {
+  vi.resetModules()
+  localStorage.clear()
+  if (storedValue !== undefined) {
+    localStorage.setItem(THEME_MODE_STORAGE_KEY, storedValue)
+  }
+  return import('./theme.svelte')
+}
+
+describe('resolveTheme', () => {
+  it('follows the OS preference in system mode', () => {
+    expect(resolveTheme('system', true)).toBe('dark')
+    expect(resolveTheme('system', false)).toBe('light')
+  })
+
+  it('ignores the OS preference in explicit modes', () => {
+    expect(resolveTheme('light', true)).toBe('light')
+    expect(resolveTheme('dark', false)).toBe('dark')
+  })
+})
+
+describe('nextThemeMode', () => {
+  it('cycles system -> light -> dark -> system', () => {
+    expect(nextThemeMode('system')).toBe('light')
+    expect(nextThemeMode('light')).toBe('dark')
+    expect(nextThemeMode('dark')).toBe('system')
+  })
+})
+
+describe('themeMode', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('defaults to system when nothing is stored', async () => {
+    const { themeMode } = await setupThemeModule()
+
+    expect(themeMode.current).toBe('system')
+  })
+
+  it('restores a stored mode', async () => {
+    const { themeMode } = await setupThemeModule(JSON.stringify('dark'))
+
+    expect(themeMode.current).toBe('dark')
+  })
+
+  it('falls back to system on corrupted storage content', async () => {
+    const { themeMode } = await setupThemeModule('not-json{')
+
+    expect(themeMode.current).toBe('system')
+  })
+
+  it('falls back to system on valid JSON that is not a theme mode', async () => {
+    const { themeMode } = await setupThemeModule(JSON.stringify('purple'))
+
+    expect(themeMode.current).toBe('system')
+  })
+
+  it('persists cycled modes to storage as JSON', async () => {
+    const { themeMode } = await setupThemeModule()
+
+    themeMode.cycle()
+
+    expect(themeMode.current).toBe('light')
+    expect(localStorage.getItem(THEME_MODE_STORAGE_KEY)).toBe(JSON.stringify('light'))
+
+    themeMode.cycle()
+
+    expect(themeMode.current).toBe('dark')
+    expect(localStorage.getItem(THEME_MODE_STORAGE_KEY)).toBe(JSON.stringify('dark'))
+  })
+})
+
+describe('resolvedTheme', () => {
+  it('resolves an explicit stored mode without consulting the OS', async () => {
+    const { resolvedTheme } = await setupThemeModule(JSON.stringify('light'))
+
+    expect(resolvedTheme.current).toBe('light')
+  })
+})

--- a/dashboard/src/lib/theme.svelte.ts
+++ b/dashboard/src/lib/theme.svelte.ts
@@ -1,0 +1,70 @@
+// Theme mode selection (light / dark / system) persisted in localStorage.
+//
+// The stored key and JSON encoding must stay in sync with the pre-paint
+// inline script in src/app.html, which applies the `.dark` class before
+// SvelteKit hydrates to avoid a flash of the wrong theme.
+
+import { MediaQuery } from 'svelte/reactivity'
+import { PersistedState } from 'runed'
+
+import { tryCatch, unwrapOr } from '$lib/fp'
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+
+export type ResolvedTheme = 'light' | 'dark'
+
+export const THEME_MODE_STORAGE_KEY = 'theme-mode'
+
+export const resolveTheme = (mode: ThemeMode, prefersDark: boolean): ResolvedTheme => {
+  if (mode === 'system') {
+    return prefersDark ? 'dark' : 'light'
+  }
+
+  return mode
+}
+
+const NEXT_THEME_MODE: Record<ThemeMode, ThemeMode> = {
+  system: 'light',
+  light: 'dark',
+  dark: 'system'
+}
+
+export const nextThemeMode = (mode: ThemeMode): ThemeMode => NEXT_THEME_MODE[mode]
+
+const isThemeMode = (value: unknown): value is ThemeMode =>
+  value === 'light' || value === 'dark' || value === 'system'
+
+// Falls back to system mode on corrupted or foreign storage content instead
+// of trusting it. PersistedState assigns whatever deserialize returns, so the
+// fallback must be a valid mode rather than undefined.
+const deserializeThemeMode = (raw: string): ThemeMode => {
+  const parsed = unwrapOr(
+    tryCatch((): unknown => JSON.parse(raw)),
+    undefined
+  )
+  return isThemeMode(parsed) ? parsed : 'system'
+}
+
+const storedMode = new PersistedState<ThemeMode>(THEME_MODE_STORAGE_KEY, 'system', {
+  serializer: {
+    serialize: JSON.stringify,
+    deserialize: deserializeThemeMode
+  }
+})
+
+const prefersDark = new MediaQuery('(prefers-color-scheme: dark)')
+
+export const themeMode = {
+  get current(): ThemeMode {
+    return storedMode.current
+  },
+  cycle(): void {
+    storedMode.current = nextThemeMode(storedMode.current)
+  }
+}
+
+export const resolvedTheme = {
+  get current(): ResolvedTheme {
+    return resolveTheme(storedMode.current, prefersDark.current)
+  }
+}

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -4,9 +4,15 @@
   import type { Snippet } from 'svelte'
   import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query'
 
+  import { resolvedTheme } from '$lib/theme.svelte'
+
   const { children }: { children: Snippet } = $props()
 
   const queryClient = new QueryClient()
+
+  $effect(() => {
+    document.documentElement.classList.toggle('dark', resolvedTheme.current === 'dark')
+  })
 </script>
 
 <svelte:head><link rel="icon" href={favicon} /></svelte:head>

--- a/dashboard/src/routes/layout.css
+++ b/dashboard/src/routes/layout.css
@@ -5,6 +5,7 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+  color-scheme: light;
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.141 0.005 285.823);
@@ -37,9 +38,25 @@
   --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
   --sidebar-border: oklch(0.92 0.004 286.32);
   --sidebar-ring: oklch(0.705 0.015 286.067);
+  --chart-slate: #475569;
+  --chart-sky: #0284c7;
+  --chart-emerald: #059669;
+  --chart-red: #dc2626;
+  --chart-amber: #d97706;
+  --chart-purple: #9333ea;
+  --chart-orange: #ea580c;
+  --chart-indigo: #4f46e5;
+  --chart-pink: #db2777;
+  --chart-yellow: #ca8a04;
+  --chart-cyan: #0891b2;
+  --chart-lime: #65a30d;
+  --chart-green: #16a34a;
+  --chart-rose: #e11d48;
+  --chart-violet: #7c3aed;
 }
 
 .dark {
+  color-scheme: dark;
   --background: oklch(0.141 0.005 285.823);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.21 0.006 285.885);
@@ -71,6 +88,21 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.552 0.016 285.938);
+  --chart-slate: #64748b;
+  --chart-sky: #38bdf8;
+  --chart-emerald: #34d399;
+  --chart-red: #f87171;
+  --chart-amber: #fbbf24;
+  --chart-purple: #c084fc;
+  --chart-orange: #fb923c;
+  --chart-indigo: #818cf8;
+  --chart-pink: #f472b6;
+  --chart-yellow: #facc15;
+  --chart-cyan: #22d3ee;
+  --chart-lime: #a3e635;
+  --chart-green: #22c55e;
+  --chart-rose: #f43f5e;
+  --chart-violet: #a78bfa;
 }
 
 @theme inline {


### PR DESCRIPTION
## What

Adds a light/dark/system theme mode switcher to the dashboard. Previously the `.dark` class was hardcoded in `app.html`, so the light token set defined in `layout.css` was unreachable.

- New `$lib/theme.svelte.ts`: theme mode store (`light` / `dark` / `system`) persisted in localStorage via Runed `PersistedState`, with `system` following `prefers-color-scheme` live via Svelte's `MediaQuery`. Corrupted or foreign storage content falls back to `system`.
- Pre-paint inline script in `app.html` applies the stored mode before hydration -- no flash of the wrong theme on load.
- Compact cycling icon button (sun / moon / sun-moon) in the header bar, built from the existing shadcn-svelte `Button` + `@lucide/svelte` icons. Default when nothing is stored: system.
- Tokenizes styles that bypassed the theme and would break in light mode:
  - Chart hexes in `performance-panel` and `pnl-panel` now reference new `--chart-<hue>` variables defined per theme in `layout.css` (dark values keep the current palette; light gets 600-level counterparts of the same hues). Raw SVG `fill=`/`stroke=` attributes switched to `style:fill`/`style:stroke` so `var()` resolves reliably.
  - Dark-tuned Tailwind literals (`text-blue-400`, `text-amber-200`, etc.) get a light-readable value plus a `dark:` restore of the exact current class.
  - `color-scheme` declared per theme for native controls/scrollbars.

## Why

The dashboard was dark-only. Light mode support needs both a real mode system (instead of a hardcoded class) and an audit of styles that assumed a dark background.

## How

No new dependency: Runed (already a dependency) provides persistence + cross-tab sync, and `svelte/reactivity`'s `MediaQuery` covers live OS-theme tracking, so `bun.lock`/`bun.nix` are untouched. The root layout `$effect` toggles `.dark` on `<html>`; the `app.html` inline script mirrors the same storage key/encoding for pre-paint. Layout, components, and chart structure are unchanged -- only color sourcing moved to theme-aware tokens.

Known minor dark-mode shifts from token unification: PnL stream/asset amber `#f59e0b` -> `#fbbf24`, and the `#94a3b8` fallback -> `#64748b` (both same-hue neighbors).

## Testing

- `src/lib/theme.svelte.test.ts`: mode resolution, cycle order, default, storage round-trip, corrupted-storage fallback.
- `src/lib/components/theme-switcher.test.ts`: mounted-component tests for label/icon per mode and click-to-cycle persistence.
- `bun run lint`, `bun run check`, `bun run test:run` (324 tests) all clean.
- Verified the compiled CSS from the mock-mode dev server contains both theme blocks for `--chart-*` and the generated `dark:` variant utilities.

## Screenshots

<!-- Light/dark screenshots to be added from the running dashboard. -->


![Screenshot from 2026-08-04 16-38-46.png](https://app.graphite.com/user-attachments/assets/0f3af6d2-5f51-457e-b4de-825050deb056.png)

![Screenshot from 2026-08-04 16-32-38.png](https://app.graphite.com/user-attachments/assets/36f81131-95a3-4451-9d28-b5ca443c5157.png)

## Anything else

- 500-level Tailwind literals (`text-green-500`, `bg-amber-500`, ...) were left as-is: they read acceptably on both backgrounds and touching them would blow up the diff.
- The dialog `backdrop:bg-black/50` overlays and the destructive `text-white` in stock shadcn button/badge variants are intentional in both themes.
- Pre-existing, out of scope: mock mode does not stub `/pnl`, so the PnL page 404s under `PUBLIC_DASHBOARD_MOCK_MODE=1`; the repo has ~40 files failing `prettier --check` unrelated to this change (only files this PR dirtied were formatted).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a theme switcher supporting light, dark, and system modes.
  - Theme preferences are saved and restored automatically.
  - The dashboard now follows the operating system’s dark-mode preference when selected.
  - Added accessible labels and icons for the theme control.

- **Improvements**
  - Updated charts, status indicators, logs, links, and alerts for clearer light- and dark-mode contrast.
  - Added theme-aware chart colors and browser color-scheme support.

- **Tests**
  - Added coverage for theme selection, persistence, system preferences, and invalid settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->