### PR TITLE
fix: compute PnL report values in Float, not rationals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,7 +5485,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6610,7 +6610,6 @@ dependencies = [
  "cqrs-es 0.4.12",
  "flate2",
  "httpmock",
- "num-decimal",
  "num-traits",
  "proptest",
  "rain-math-float",
@@ -7086,7 +7085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8229,7 +8228,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,6 @@ futures-util = "0.3.31"
 httpmock = "0.8"
 itertools = "0.14.0"
 lazy_static = "1.5.0"
-num-decimal = { version = "0.2.5", default-features = false, features = [
-  "num-v04",
-] }
 num-traits = "0.2"
 opentelemetry = "0.30.0"
 opentelemetry-appender-tracing = "0.30.0"
@@ -194,7 +191,6 @@ futures-util.workspace = true
 httpmock = { workspace = true, optional = true }
 itertools.workspace = true
 lazy_static.workspace = true
-num-decimal.workspace = true
 num-traits.workspace = true
 metrics = "0.23"
 metrics-exporter-prometheus = { version = "0.15", default-features = false }
@@ -254,6 +250,9 @@ approx.workspace = true
 async-trait.workspace = true
 bon.workspace = true
 httpmock.workspace = true
+num-decimal = { version = "0.2.5", default-features = false, features = [
+  "num-v04",
+] }
 proptest.workspace = true
 rain-math-float.workspace = true
 regex = "1.12.3"

--- a/crates/execution/Cargo.toml
+++ b/crates/execution/Cargo.toml
@@ -24,7 +24,6 @@ chrono-tz.workspace = true
 cqrs-es.workspace = true
 flate2.workspace = true
 httpmock = { workspace = true, optional = true }
-num-decimal.workspace = true
 num-traits.workspace = true
 rain-math-float.workspace = true
 rand.workspace = true

--- a/crates/finance/src/usd.rs
+++ b/crates/finance/src/usd.rs
@@ -83,6 +83,11 @@ impl Usd {
     pub fn lt(&self, other: &Self) -> Result<bool, FloatError> {
         self.0.lt(other.0)
     }
+
+    /// Fallible greater-than comparison.
+    pub fn gt(&self, other: &Self) -> Result<bool, FloatError> {
+        self.0.gt(other.0)
+    }
 }
 
 impl HasZero for Usd {
@@ -197,6 +202,17 @@ mod tests {
     fn sub_succeeds() {
         let result = (Usd::new(float!(5)) - Usd::new(float!(2))).unwrap();
         assert!(result.inner().eq(float!(3)).unwrap());
+    }
+
+    #[test]
+    fn gt_returns_true_when_greater() {
+        assert!(Usd::new(float!(5)).gt(&Usd::new(float!(2))).unwrap());
+    }
+
+    #[test]
+    fn gt_returns_false_when_not_greater() {
+        assert!(!Usd::new(float!(2)).gt(&Usd::new(float!(5))).unwrap());
+        assert!(!Usd::new(float!(2)).gt(&Usd::new(float!(2))).unwrap());
     }
 
     #[test]

--- a/docs/float.md
+++ b/docs/float.md
@@ -90,12 +90,86 @@ let negated = (-a)?;
 | Position events     | `Decimal`                   | `Float`                   |
 | Dashboard DTOs      | `Decimal`                   | `Float`                   |
 
-## Broker API Boundary
+## Formatting for output
 
-`num_decimal::Num` is still used at the Alpaca API boundary as a private
-implementation detail inside `st0x-execution`. The broker API (via the `apca`
-crate) expects `Num` values, so conversion happens at the edge via
-`Float::format_with_scientific(false)` and string parsing.
+Use `st0x_float_serde::format_float` (or `serialize_float_as_string` in a
+`#[serde(serialize_with = ...)]`) for persistence and human-facing output. The
+helper falls back to scientific notation when plain formatting rejects an
+extreme exponent. Fixed-decimal protocol and integer-conversion boundaries may
+call `Float::format_with_scientific(false)` directly when plain decimal notation
+is part of the contract and the formatting error is propagated.
 
-These converters live in `st0x-execution` and are not part of the public API.
-`num-decimal` remains as a dependency of `st0x-execution` only.
+## Cost of an operation
+
+`Float` arithmetic is not a plain Rust op. Every `+`/`-`/`*`/`/`, comparison,
+and format ABI-encodes a call and executes it in a thread-local revm -- that is
+what buys the guarantee that results match the contracts. Measured on this
+codebase: **~4 us per op in release, ~140 us in debug**. It is cheap enough for
+report-sized workloads, but do not put it inside a hot loop that runs
+per-message.
+
+`Float` has no `PartialEq`/`Ord`; comparisons are fallible (`eq`, `lt`, `gt`,
+`min`, `max` all return `Result`). It derives `Default`, but **nothing in this
+codebase treats `Float::default()` as zero** -- use `float!(0)` from
+`st0x-float-macro`, which resolves at compile time and so stays infallible
+inside a `Default` impl.
+
+## Do not compute in any other numeric type
+
+Financial values are computed in `Float` everywhere. The former implementation
+used `num_decimal::Num` at some boundaries; references to its formatting and
+rounding behavior describe legacy persisted data, not an active dependency or an
+exception to the `Float` rule.
+
+### Persist values losslessly by default
+
+Persist `Float` values with the shared decimal-string serde helpers. Formatting
+does not round, so prices, quantities, positions, snapshots, and other audit
+facts retain their full representable precision across serialization.
+
+Round before persistence only when a field declares a fixed-decimal persistence
+contract, including both its precision and rounding mode. `src/bot_gas` is one
+such compatibility boundary: its USD cost preserves the legacy eight-decimal,
+round-half-to-even contract, then persists that already-rounded `Float`
+losslessly. Do not copy that rounding into fields without the same declared
+contract.
+
+### Equality on a type holding `Float`
+
+`Float` has no `PartialEq`, but `cqrs_es::DomainEvent` requires one on event
+types. Hand-write it, routing through `Float`'s fallible comparison:
+
+```rust
+impl PartialEq for Usd {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(other.0).unwrap_or(false)
+    }
+}
+```
+
+This fallback is limited to an unavoidable `PartialEq -> bool` adapter: the
+trait signature cannot propagate `FloatError`, and persisted domain values are
+validated before they reach equality checks. For optional prices use
+`crate::position::option_float_eq`, which is `pub(crate)` precisely so event
+equality callers reuse the same constrained adapter.
+
+Business predicates and validation must not use `unwrap_or(false)`. Propagate
+`FloatError` with `?` where possible. If a persisted, `Serialize`-able error
+enum cannot carry `FloatError` (it is not `Clone`/`Eq`/`Serialize`), map the
+failure to an explicit serializable domain error variant; do not stringify the
+source or collapse an arithmetic failure into a legitimate `false` result.
+
+Presentation boundaries (Prometheus gauges, dashboard DTOs consumed by
+JavaScript) convert out of `Float` for display. That is fine; what is not fine
+is substituting a fallback value when the conversion fails, which fabricates a
+financial number.
+
+### Why not arbitrary-precision rationals
+
+The PnL replay once accumulated in `num_decimal::Num` to stay _exact_. Exact
+arithmetic has no width bound: a 67-digit derived price (an on-chain price is
+`usdc_amount / equity_amount`, and that division rarely terminates) times an
+18-decimal share count produced an 84-digit total. Converting that back into
+`Float` for the capital calculation failed, and `/pnl` returned 500 for every
+range containing realized PnL. `Float`'s 224-bit coefficient bounds the width at
+~67 significant digits, which is far beyond what money needs.

--- a/src/api.rs
+++ b/src/api.rs
@@ -29,7 +29,8 @@ use st0x_tokenization::IssuerRequestId;
 use crate::AppState;
 use crate::dashboard::TradeProtocol;
 use crate::dashboard::pnl::{
-    PnlError, PnlQuery, PnlResponse, build_pnl_report, validate_pnl_snapshot_rowid,
+    PnlError, PnlQuery, PnlResponse, acquire_pnl_report_permit, build_pnl_report_with_permit,
+    validate_pnl_snapshot_rowid,
 };
 use crate::dashboard::transfer_loader::{InvalidTransferKind, TransferKind};
 use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
@@ -173,6 +174,8 @@ async fn pnl(
     query
         .symbol_filter(&mut Vec::new())
         .map_err(|error| (StatusCode::BAD_REQUEST, error.to_string()))?;
+    let permit =
+        acquire_pnl_report_permit(&state.pnl_report_admission).map_err(pnl_error_response)?;
     validate_pnl_snapshot_rowid(&state.pool, &query)
         .await
         .map_err(pnl_error_response)?;
@@ -192,7 +195,7 @@ async fn pnl(
         Vec::new()
     };
 
-    build_pnl_report(&state.pool, &query, activities, Utc::now())
+    build_pnl_report_with_permit(&state.pool, &query, activities, Utc::now(), permit)
         .await
         .map(Json)
         .map_err(pnl_error_response)
@@ -228,8 +231,22 @@ fn pnl_error_response(error: PnlError) -> (StatusCode, String) {
                 "Failed to build PnL report".to_string(),
             )
         }
-        PnlError::CapitalFloat(error) => {
-            error!(%error, "Failed to convert a PnL total for capital/return computation");
+        PnlError::Arithmetic(error) => {
+            error!(%error, "PnL arithmetic failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to build PnL report".to_string(),
+            )
+        }
+        PnlError::ReplayAdmission(error) => {
+            warn!(%error, "PnL report capacity exhausted");
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "PnL report capacity exhausted".to_string(),
+            )
+        }
+        PnlError::ReplayWorker(error) => {
+            error!(%error, "PnL replay worker failed");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to build PnL report".to_string(),
@@ -1936,8 +1953,78 @@ mod tests {
             )),
             recovery: Arc::new(tokio::sync::OnceCell::new()),
             resume_lock: Arc::new(ResumeLock(Mutex::new(()))),
+            pnl_report_admission: crate::dashboard::pnl::pnl_report_admission(),
             metrics_handle: crate::metrics::setup().expect("metrics setup"),
         }
+    }
+
+    #[tokio::test]
+    async fn pnl_internal_failures_return_a_stable_generic_response() {
+        let left = rain_math_float::Float::parse("1e2147483646".to_owned()).unwrap();
+        let right = rain_math_float::Float::parse("1e2".to_owned()).unwrap();
+        let arithmetic = PnlError::from((left * right).unwrap_err());
+
+        let worker = tokio::spawn(std::future::pending::<()>());
+        worker.abort();
+        let worker = PnlError::ReplayWorker(worker.await.unwrap_err());
+
+        for error in [arithmetic, worker] {
+            let (status, body) = pnl_error_response(error);
+
+            assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(body, "Failed to build PnL report");
+        }
+    }
+
+    #[tokio::test]
+    async fn pnl_route_returns_a_stable_generic_response_for_report_failures() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let state = empty_app_state(ctx).await;
+        sqlx::query(
+            "INSERT INTO portfolio_snapshot ( \
+               et_day, captured_at, location, asset, available_balance, inflight_balance, \
+               usd_mark, mark_captured_at \
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind("2026-05-15")
+        .bind("2026-05-15T04:05:00+00:00")
+        .bind("market_making")
+        .bind("USDC")
+        .bind("not-a-float")
+        .bind("0")
+        .bind("1")
+        .bind("2026-05-15T04:05:00+00:00")
+        .execute(&state.pool)
+        .await
+        .unwrap();
+
+        let response = build_app(state)
+            .oneshot(Request::builder().uri("/pnl").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body_to_string(response).await, "Failed to build PnL report");
+    }
+
+    #[tokio::test]
+    async fn pnl_route_rejects_requests_when_report_capacity_is_exhausted() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let state = empty_app_state(ctx).await;
+        let _permits = (0..crate::dashboard::pnl::MAX_CONCURRENT_PNL_REPORTS)
+            .map(|_| acquire_pnl_report_permit(&state.pnl_report_admission).unwrap())
+            .collect::<Vec<_>>();
+
+        let response = build_app(state)
+            .oneshot(Request::builder().uri("/pnl").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            body_to_string(response).await,
+            "PnL report capacity exhausted"
+        );
     }
 
     #[test]

--- a/src/bot_gas/job.rs
+++ b/src/bot_gas/job.rs
@@ -504,6 +504,7 @@ fn is_transient_rpc_error(error: &EthUsdValuationError) -> bool {
         EthUsdValuationError::Pyth(PythError::InvalidTimestamp(_))
         | EthUsdValuationError::NonPositivePrice { .. }
         | EthUsdValuationError::Decimal { .. }
+        | EthUsdValuationError::Arithmetic(_)
         | EthUsdValuationError::InvalidPublishTime(_)
         | EthUsdValuationError::ExponentOutOfRange { .. } => false,
     }
@@ -542,6 +543,7 @@ mod tests {
     use st0x_evm::PythStructs::Price;
     use st0x_evm::{Evm, EvmError};
     use st0x_finance::Symbol;
+    use st0x_float_macro::float;
 
     use super::*;
     use crate::dashboard::pnl::{PnlQuery, build_pnl_report};
@@ -1224,6 +1226,14 @@ mod tests {
             pending, 0,
             "a data error must dead-letter rather than consume the redrive window"
         );
+    }
+
+    #[test]
+    fn arithmetic_valuation_error_is_not_transient() {
+        let source = (float!(1) / float!(0)).unwrap_err();
+        let error = EthUsdValuationError::Arithmetic(source);
+
+        assert!(!is_transient_rpc_error(&error));
     }
 
     /// The other side of the same switch: an RPC failure reading the price is

--- a/src/bot_gas/mod.rs
+++ b/src/bot_gas/mod.rs
@@ -3,15 +3,16 @@ use alloy::primitives::{Address, TxHash, U256};
 use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use num_decimal::Num;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use rain_math_float::Float;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 use tracing::info;
 
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil, SendError, Store};
-use st0x_finance::Symbol;
+use st0x_finance::{HasZero, Symbol, Usd};
+use st0x_float_macro::float;
 
 mod job;
 pub(crate) mod redrive;
@@ -75,17 +76,48 @@ pub(crate) async fn pending_bot_gas_jobs(
         .collect()
 }
 
-/// Built once and reused: constructed via `Num::from` (infallible integer
-/// conversion, unlike `Num::from_str`), so re-deriving it on every
-/// `native_cost_usd` call is wasted work rather than a fallible parse.
-static WEI_PER_ETH: LazyLock<Num> = LazyLock::new(|| Num::from(1_000_000_000_000_000_000_u64));
+/// Wei per ETH, resolved at compile time so the divisor costs no fallible
+/// parse on every `native_cost_usd` call.
+const WEI_PER_ETH: Float = float!(1000000000000000000);
 
-/// Mirrors `num_decimal::Num`'s private `MAX_PRECISION` -- the crate does not
-/// expose its own constant, so this is kept in sync by hand. `serialize_num`
-/// persists a `Num` via `Display`, which rounds to this many decimals; a
-/// value must still be positive AFTER that rounding to be usable, since a
+/// Decimal places a persisted USD cost is rounded to.
+///
+/// A value must still be positive AFTER that rounding to be usable, since a
 /// value that rounds to zero would persist as an unusable zero cost.
-const PERSISTED_DECIMAL_PRECISION: usize = 8;
+const PERSISTED_DECIMAL_PRECISION: u8 = 8;
+
+/// Half of the smallest unit at `PERSISTED_DECIMAL_PRECISION` (`0.5 * 1e-8`).
+const PERSISTED_PRECISION_HALF_UNIT: Float = float!(0.000000005);
+
+/// Smallest unit at `PERSISTED_DECIMAL_PRECISION` (`1e-8`).
+const PERSISTED_PRECISION_UNIT: Float = float!(0.00000001);
+
+/// Rounds a USD cost to the precision it is persisted at, using
+/// round-half-to-even to preserve the legacy persistence contract.
+///
+/// `Float::to_fixed_decimal_lossy` truncates toward zero rather than
+/// rounding (see docs/float.md). Every caller passes a non-negative cost, so
+/// the truncated fixed-point value supplies both the lower neighbor and the
+/// retained digit used to break an exact tie. The result is exactly
+/// representable at `PERSISTED_DECIMAL_PRECISION` decimals.
+fn round_to_persisted_precision(value: Float) -> Result<Float, rain_math_float::FloatError> {
+    let (fixed, lossless) = value.to_fixed_decimal_lossy(PERSISTED_DECIMAL_PRECISION)?;
+    let truncated = Float::from_fixed_decimal(fixed, PERSISTED_DECIMAL_PRECISION)?;
+    if lossless {
+        return Ok(truncated);
+    }
+
+    let remainder = (value - truncated)?;
+    let above_half = remainder.gt(PERSISTED_PRECISION_HALF_UNIT)?;
+    let exact_tie = remainder.eq(PERSISTED_PRECISION_HALF_UNIT)?;
+    let retained_digit_is_odd = fixed % U256::from(2) == U256::from(1);
+
+    if above_half || (exact_tie && retained_digit_is_odd) {
+        truncated + PERSISTED_PRECISION_UNIT
+    } else {
+        Ok(truncated)
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum BotGasCostError {
@@ -100,8 +132,10 @@ pub(crate) enum BotGasCostError {
     Decimal {
         field: &'static str,
         #[source]
-        source: num_decimal::ParseNumError,
+        source: rain_math_float::FloatError,
     },
+    #[error("bot gas arithmetic failed: {0}")]
+    Arithmetic(#[from] rain_math_float::FloatError),
     #[error(transparent)]
     InvalidReceiptCost(#[from] BotGasReceiptCostError),
 }
@@ -178,12 +212,16 @@ impl fmt::Display for BotGasOperationCategory {
 
 #[derive(Debug, Clone)]
 pub(crate) struct EthUsdPrice {
-    pub(crate) price: Num,
+    pub(crate) price: Usd,
     pub(crate) source: String,
     pub(crate) observed_at: DateTime<Utc>,
     pub(crate) block_number: Option<u64>,
 }
 
+/// `Usd` provides its own `Serialize`/`Deserialize` (decimal-string, see
+/// docs/float.md) and a hand-written `PartialEq`/`Eq` routed through
+/// `Float`'s fallible comparison, so every field on this struct -- including
+/// `eth_usd_price` and `usd_cost` -- derives both directly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct BotGasReceiptCost {
     pub(crate) chain: BotGasChain,
@@ -192,31 +230,14 @@ pub(crate) struct BotGasReceiptCost {
     pub(crate) gas_used: u64,
     pub(crate) effective_gas_price_wei: u128,
     pub(crate) native_cost_wei: U256,
-    #[serde(serialize_with = "serialize_num", deserialize_with = "deserialize_num")]
-    pub(crate) eth_usd_price: Num,
+    pub(crate) eth_usd_price: Usd,
     pub(crate) eth_usd_price_source: String,
     pub(crate) eth_usd_price_at: DateTime<Utc>,
     pub(crate) eth_usd_price_block_number: Option<u64>,
-    #[serde(serialize_with = "serialize_num", deserialize_with = "deserialize_num")]
-    pub(crate) usd_cost: Num,
+    pub(crate) usd_cost: Usd,
     pub(crate) operation_category: BotGasOperationCategory,
     pub(crate) symbol: Option<Symbol>,
     pub(crate) occurred_at: DateTime<Utc>,
-}
-
-fn serialize_num<S>(value: &Num, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(&value.to_string())
-}
-
-fn deserialize_num<'de, D>(deserializer: D) -> Result<Num, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value = String::deserialize(deserializer)?;
-    Num::from_str(&value).map_err(serde::de::Error::custom)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -256,6 +277,18 @@ impl FromStr for BotGasReceiptCostId {
     }
 }
 
+fn validate_positive_comparison(
+    comparison: &Result<bool, rain_math_float::FloatError>,
+    non_positive: BotGasReceiptCostError,
+    comparison_failed: BotGasReceiptCostError,
+) -> Result<(), BotGasReceiptCostError> {
+    match comparison {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(non_positive),
+        Err(_) => Err(comparison_failed),
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
 pub(crate) enum BotGasReceiptCostError {
     #[error("receipt gas used must be positive")]
@@ -266,8 +299,12 @@ pub(crate) enum BotGasReceiptCostError {
     ZeroNativeCost,
     #[error("ETH/USD valuation must be positive")]
     NonPositiveEthUsdPrice,
+    #[error("failed to compare ETH/USD valuation with zero")]
+    EthUsdPriceComparisonFailed,
     #[error("receipt USD cost must be positive")]
     NonPositiveUsdCost,
+    #[error("failed to compare receipt USD cost with zero")]
+    UsdCostComparisonFailed,
     #[error("receipt cost conflicts with the immutable fact already recorded")]
     ConflictingReceiptCost,
 }
@@ -294,9 +331,11 @@ impl BotGasReceiptCost {
         if receipt.effective_gas_price == 0 {
             return Err(BotGasReceiptCostError::ZeroEffectiveGasPrice.into());
         }
-        if !eth_usd_price.price.is_positive() {
-            return Err(BotGasReceiptCostError::NonPositiveEthUsdPrice.into());
-        }
+        validate_positive_comparison(
+            &eth_usd_price.price.gt(&Usd::ZERO),
+            BotGasReceiptCostError::NonPositiveEthUsdPrice,
+            BotGasReceiptCostError::EthUsdPriceComparisonFailed,
+        )?;
 
         let effective_gas_price_wei = receipt.effective_gas_price;
         let native_cost_wei = U256::from(receipt.gas_used)
@@ -304,7 +343,7 @@ impl BotGasReceiptCost {
             .ok_or(BotGasCostError::NativeCostOverflow {
                 tx_hash: receipt.transaction_hash,
             })?;
-        let usd_cost = native_cost_usd(native_cost_wei, &eth_usd_price.price)?;
+        let usd_cost = native_cost_usd(native_cost_wei, eth_usd_price.price)?;
 
         let cost = Self {
             chain,
@@ -338,8 +377,8 @@ impl BotGasReceiptCost {
     /// and everything sourced from it: `eth_usd_price_source`,
     /// `eth_usd_price_at`, `eth_usd_price_block_number`, `usd_cost`), which a
     /// retry can legitimately recompute differently: they round-trip lossily
-    /// through persistence (`serialize_num` rounds to
-    /// `num_decimal::MAX_PRECISION`), and an Ethereum receipt's valuation is
+    /// through persistence (rounded to `PERSISTED_DECIMAL_PRECISION` before
+    /// it is written), and an Ethereum receipt's valuation is
     /// deliberately pinned to the Base chain head at recording time (ADR
     /// 0017), which can differ between attempts. A repeated `Record` for the
     /// same receipt is therefore idempotent as long as the facts that came
@@ -403,21 +442,21 @@ impl BotGasReceiptCost {
         if self.native_cost_wei.is_zero() {
             return Err(BotGasReceiptCostError::ZeroNativeCost);
         }
-        if !self.eth_usd_price.is_positive() {
-            return Err(BotGasReceiptCostError::NonPositiveEthUsdPrice);
-        }
-        // Validated against the value as it will actually be PERSISTED
-        // (rounded to `PERSISTED_DECIMAL_PRECISION`), not the full-precision
-        // value computed here: a sufficiently small positive cost can round
-        // down to exactly zero once persisted even though it is positive at
-        // full precision, which would silently write an unusable zero cost.
-        if !self
-            .usd_cost
-            .round_with(PERSISTED_DECIMAL_PRECISION)
-            .is_positive()
-        {
-            return Err(BotGasReceiptCostError::NonPositiveUsdCost);
-        }
+        validate_positive_comparison(
+            &self.eth_usd_price.gt(&Usd::ZERO),
+            BotGasReceiptCostError::NonPositiveEthUsdPrice,
+            BotGasReceiptCostError::EthUsdPriceComparisonFailed,
+        )?;
+        // `usd_cost` is rounded to `PERSISTED_DECIMAL_PRECISION` when it is
+        // built, so the stored value already IS the value that gets
+        // persisted. A sufficiently small positive cost rounds to exactly
+        // zero there, and this rejects it rather than writing an unusable
+        // zero cost.
+        validate_positive_comparison(
+            &self.usd_cost.gt(&Usd::ZERO),
+            BotGasReceiptCostError::NonPositiveUsdCost,
+            BotGasReceiptCostError::UsdCostComparisonFailed,
+        )?;
 
         Ok(())
     }
@@ -530,14 +569,17 @@ impl BotGasCostLedger {
     }
 }
 
-fn parse_num(field: &'static str, value: &str) -> Result<Num, BotGasCostError> {
-    Num::from_str(value).map_err(|source| BotGasCostError::Decimal { field, source })
+fn parse_float(field: &'static str, value: &str) -> Result<Float, BotGasCostError> {
+    Float::parse(value.to_owned()).map_err(|source| BotGasCostError::Decimal { field, source })
 }
 
-fn native_cost_usd(native_cost_wei: U256, eth_usd_price: &Num) -> Result<Num, BotGasCostError> {
-    let native_cost_wei = parse_num("native_cost_wei", &native_cost_wei.to_string())?;
+fn native_cost_usd(native_cost_wei: U256, eth_usd_price: Usd) -> Result<Usd, BotGasCostError> {
+    let native_cost_wei = parse_float("native_cost_wei", &native_cost_wei.to_string())?;
+    let cost = ((native_cost_wei / WEI_PER_ETH)? * eth_usd_price.inner())?;
 
-    Ok(&(&native_cost_wei / &*WEI_PER_ETH) * eth_usd_price)
+    round_to_persisted_precision(cost)
+        .map(Usd::new)
+        .map_err(BotGasCostError::Arithmetic)
 }
 
 #[cfg(test)]
@@ -547,8 +589,10 @@ mod tests {
     use alloy::primitives::{Address, TxHash};
     use alloy::rpc::types::TransactionReceipt;
     use chrono::TimeZone;
+    use serde_json::json;
 
     use st0x_event_sorcery::{LifecycleError, TestHarness};
+    use st0x_float_serde::format_float;
 
     use super::*;
 
@@ -578,7 +622,7 @@ mod tests {
 
     fn price() -> EthUsdPrice {
         EthUsdPrice {
-            price: Num::from_str("2000").unwrap(),
+            price: Usd::new(float!(2000)),
             source: "eth_usd_valuation_feed".to_owned(),
             observed_at: Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap(),
             block_number: Some(123),
@@ -600,7 +644,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(cost.native_cost_wei, U256::from(21_000_000_000_000u128));
-        assert_eq!(cost.usd_cost.to_string(), "0.042");
+        assert_eq!(format_float(&cost.usd_cost.inner()).unwrap(), "0.042");
     }
 
     #[test]
@@ -670,7 +714,7 @@ mod tests {
         let bot = Address::repeat_byte(0x01);
         for value in ["0", "-1"] {
             let mut price = price();
-            price.price = Num::from_str(value).unwrap();
+            price.price = Usd::new(Float::parse(value.to_owned()).unwrap());
 
             let error = BotGasReceiptCost::from_receipt(
                 &receipt(bot),
@@ -695,8 +739,35 @@ mod tests {
         }
     }
 
+    #[test]
+    fn receipt_cost_preserves_float_comparison_failures() {
+        let comparison = Err(rain_math_float::FloatError::InvalidHex(
+            "comparison failure fixture".to_owned(),
+        ));
+
+        assert_eq!(
+            validate_positive_comparison(
+                &comparison,
+                BotGasReceiptCostError::NonPositiveEthUsdPrice,
+                BotGasReceiptCostError::EthUsdPriceComparisonFailed,
+            ),
+            Err(BotGasReceiptCostError::EthUsdPriceComparisonFailed)
+        );
+
+        assert_eq!(
+            validate_positive_comparison(
+                &Err(rain_math_float::FloatError::InvalidHex(
+                    "comparison failure fixture".to_owned(),
+                )),
+                BotGasReceiptCostError::NonPositiveUsdCost,
+                BotGasReceiptCostError::UsdCostComparisonFailed,
+            ),
+            Err(BotGasReceiptCostError::UsdCostComparisonFailed)
+        );
+    }
+
     /// A `usd_cost` that is positive at full precision but rounds down to
-    /// exactly zero once persisted (`serialize_num` rounds to
+    /// exactly zero once persisted (`round_to_persisted_precision` rounds to
     /// `PERSISTED_DECIMAL_PRECISION` decimals) must be rejected at record
     /// time, not silently written as an unusable zero cost.
     #[test]
@@ -708,7 +779,7 @@ mod tests {
         let mut dust_price = price();
         // native_cost_wei = 1, so usd_cost = 1e-18 * dust_price -- far below
         // PERSISTED_DECIMAL_PRECISION (8 decimals) but still strictly positive.
-        dust_price.price = Num::from_str("0.000001").unwrap();
+        dust_price.price = Usd::new(float!(0.000001));
 
         let cost = BotGasReceiptCost::from_receipt(
             &dust_receipt,
@@ -732,19 +803,12 @@ mod tests {
         );
     }
 
-    /// `validate()` guards against a `usd_cost` that persists as zero by
-    /// calling `round_with(PERSISTED_DECIMAL_PRECISION)`, a hand-copied
-    /// mirror of `num_decimal::Num`'s private `MAX_PRECISION` (the crate
-    /// does not expose it). The actual persisted value instead goes through
-    /// `serialize_num`'s `value.to_string()` (`Num`'s `Display`, which
-    /// internally rounds via the same `round_with` at its own `MAX_PRECISION`).
-    /// This binds the two: for values straddling the 8-decimal boundary,
-    /// `round_with(PERSISTED_DECIMAL_PRECISION)` must agree with the actual
-    /// serialize-then-reparse round-trip, so a future `num-decimal` version
-    /// bump that changes `MAX_PRECISION` fails this test loudly instead of
-    /// silently letting `validate()` and persistence disagree.
+    /// `validate()` must check the same rounded value that the event store can
+    /// later deserialize.
     #[test]
-    fn persisted_decimal_precision_matches_actual_serialization_rounding() {
+    fn rounded_usd_cost_survives_the_persistence_roundtrip() {
+        let bot = Address::repeat_byte(0x01);
+
         for value in [
             "0.000000004999999995",
             "0.000000005000000005",
@@ -752,18 +816,100 @@ mod tests {
             "0.0000000049",
             "123.123456785",
         ] {
-            let num = Num::from_str(value).unwrap();
+            let rounded =
+                round_to_persisted_precision(Float::parse(value.to_owned()).unwrap()).unwrap();
+            let mut cost = BotGasReceiptCost::from_receipt(
+                &receipt(bot),
+                bot,
+                BotGasChain::Base,
+                BotGasOperationCategory::VaultDeposit,
+                None,
+                price(),
+                Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 1).unwrap(),
+            )
+            .unwrap();
+            cost.usd_cost = Usd::new(rounded);
 
-            let rounded_via_validate = num.round_with(PERSISTED_DECIMAL_PRECISION);
-            let round_tripped_via_persistence = Num::from_str(&num.to_string()).unwrap();
+            let persisted = serde_json::to_vec(&BotGasReceiptCostEvent::Recorded { cost }).unwrap();
+            let rehydrated: BotGasReceiptCostEvent = serde_json::from_slice(&persisted).unwrap();
+            let BotGasReceiptCostEvent::Recorded { cost: rehydrated } = rehydrated;
 
-            assert_eq!(
-                rounded_via_validate, round_tripped_via_persistence,
-                "PERSISTED_DECIMAL_PRECISION ({PERSISTED_DECIMAL_PRECISION}) has drifted from \
-                 num_decimal::Num's actual Display/serialization precision for input {value} -- \
-                 validate()'s zero-cost guard no longer matches what gets persisted"
+            assert!(
+                rounded.eq(rehydrated.usd_cost.inner()).unwrap(),
+                "a value rounded to PERSISTED_DECIMAL_PRECISION ({PERSISTED_DECIMAL_PRECISION}) \
+                 must survive event serialization unchanged (input {value})"
             );
         }
+    }
+
+    /// The unit constants are hand-written literals because `float!` cannot
+    /// derive them from `PERSISTED_DECIMAL_PRECISION` at compile time. This
+    /// pins all three values together so a precision change cannot silently
+    /// break rounding thresholds.
+    #[test]
+    fn persisted_precision_constants_match_the_declared_precision() {
+        let derived_unit = (0..PERSISTED_DECIMAL_PRECISION)
+            .try_fold(float!(1), |value, _| value / float!(10))
+            .unwrap();
+        let derived_half_unit = (derived_unit / float!(2)).unwrap();
+
+        assert!(
+            PERSISTED_PRECISION_UNIT.eq(derived_unit).unwrap(),
+            "PERSISTED_PRECISION_UNIT must equal 10^-PERSISTED_DECIMAL_PRECISION"
+        );
+        assert!(
+            PERSISTED_PRECISION_HALF_UNIT.eq(derived_half_unit).unwrap(),
+            "PERSISTED_PRECISION_HALF_UNIT must be half of PERSISTED_PRECISION_UNIT"
+        );
+    }
+
+    #[test]
+    fn round_to_persisted_precision_preserves_legacy_half_even_rounding() {
+        for (value, expected) in [
+            ("0.000000004999999995", "0"),
+            ("0.000000005000000005", "0.00000001"),
+            ("123.12345678499999995", "123.12345678"),
+            ("123.123456785", "123.12345678"),
+            ("123.12345678500000005", "123.12345679"),
+            ("123.123456795", "123.1234568"),
+            ("0.999999995", "1"),
+            (
+                "1234567890123456789012345678901234567890.123456785",
+                "1234567890123456789012345678901234567890.12345678",
+            ),
+        ] {
+            let rounded =
+                round_to_persisted_precision(Float::parse(value.to_owned()).unwrap()).unwrap();
+            let expected = Float::parse(expected.to_owned()).unwrap();
+
+            assert!(
+                rounded.eq(expected).unwrap(),
+                "input {value} must round half-to-even to {}, got {}",
+                format_float(&expected).unwrap(),
+                format_float(&rounded).unwrap()
+            );
+        }
+    }
+
+    /// A `native_cost_wei` and `eth_usd_price` that are each individually
+    /// valid can still make `native_cost_usd`'s multiplication overflow
+    /// `Float`'s 32-bit exponent (see docs/float.md's "Why not
+    /// arbitrary-precision rationals" section). That failure must surface as
+    /// `BotGasCostError::Arithmetic`, not a panic or a silently wrong cost.
+    #[test]
+    fn native_cost_usd_arithmetic_overflow_surfaces_as_arithmetic_error() {
+        // A sparse (single significant digit) but huge wei amount: `Float`
+        // parses it losslessly (unlike `U256::MAX`, whose 78 significant
+        // digits exceed `Float`'s ~67-digit coefficient and fail to parse
+        // outright), and dividing it by `WEI_PER_ETH` still leaves an
+        // exponent large enough that multiplying by `extreme_price` overflows
+        // `Float`'s 32-bit exponent.
+        let sparse_huge_wei = U256::from(10u64).pow(U256::from(60u64));
+        let extreme_price = Usd::new(Float::parse("1e2147483646".to_owned()).unwrap());
+
+        let error = native_cost_usd(sparse_huge_wei, extreme_price).unwrap_err();
+
+        assert!(matches!(error, BotGasCostError::Arithmetic(_)));
     }
 
     #[tokio::test]
@@ -821,21 +967,21 @@ mod tests {
     }
 
     /// Reproduces the real production idempotency scenario described on
-    /// `matches_immutable_receipt_facts`: a retried job's full-precision
-    /// valuation disagreeing with the persisted, rounded one must still be
-    /// treated as the same fact. Realistic gas/price inputs (not the
-    /// contrived clean numbers used elsewhere in this module) produce a
-    /// value with more than 8 decimal places, so this exercises the actual
-    /// lossy round-trip rather than an input that happens to survive it
-    /// unchanged.
+    /// `matches_immutable_receipt_facts`: a retried job whose valuation
+    /// disagrees with the persisted one must still be treated as the same
+    /// fact. Since the cost is now rounded to persistence precision when it is
+    /// built, the persisted value round-trips exactly and rounding is no
+    /// longer a source of disagreement -- but an Ethereum receipt's valuation
+    /// is pinned to the Base chain head at recording time (ADR 0017), which
+    /// still can differ between attempts. That is the case pinned here.
     #[tokio::test]
-    async fn identical_retry_is_idempotent_despite_lossy_usd_valuation_roundtrip() {
+    async fn identical_retry_is_idempotent_despite_differing_usd_valuation() {
         let bot = Address::repeat_byte(0x01);
         let mut realistic_receipt = receipt(bot);
         realistic_receipt.gas_used = 150_000;
         realistic_receipt.effective_gas_price = 5_000_257;
         let realistic_price = EthUsdPrice {
-            price: Num::from_str("2000.12345678").unwrap(),
+            price: Usd::new(float!(2000.12345678)),
             source: "eth_usd_valuation_feed".to_owned(),
             observed_at: Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap(),
             block_number: Some(123),
@@ -852,15 +998,22 @@ mod tests {
         )
         .unwrap();
 
-        // Simulate persistence's lossy round-trip through `serialize_num`.
-        let rehydrated_usd_cost = Num::from_str(&freshly_computed.usd_cost.to_string()).unwrap();
-        assert_ne!(
-            rehydrated_usd_cost, freshly_computed.usd_cost,
-            "test fixture must exercise the lossy round-trip; adjust the gas/price inputs \
-             if this assertion starts failing"
+        // The cost is rounded when it is built, so persistence is lossless:
+        // this is the property the explicit rounding buys, and losing it would
+        // silently reintroduce the mismatch the exclusion list works around.
+        let round_tripped =
+            Float::parse(format_float(&freshly_computed.usd_cost.inner()).unwrap()).unwrap();
+        assert!(
+            round_tripped.eq(freshly_computed.usd_cost.inner()).unwrap(),
+            "a persisted usd_cost must survive the serialization round-trip unchanged"
         );
+
+        // A retry can still land on a different valuation (ADR 0017), and the
+        // receipt facts alone must decide idempotency.
         let mut rehydrated = freshly_computed.clone();
-        rehydrated.usd_cost = rehydrated_usd_cost;
+        rehydrated.usd_cost = (freshly_computed.usd_cost + Usd::new(float!(0.00000001))).unwrap();
+        rehydrated.eth_usd_price =
+            (freshly_computed.eth_usd_price + Usd::new(float!(0.01))).unwrap();
 
         TestHarness::<BotGasReceiptCost>::with(())
             .given(vec![BotGasReceiptCostEvent::Recorded { cost: rehydrated }])
@@ -884,7 +1037,7 @@ mod tests {
             Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 1).unwrap(),
         )
         .unwrap();
-        cost.usd_cost = Num::from_str("0").unwrap();
+        cost.usd_cost = Usd::ZERO;
 
         let error = TestHarness::<BotGasReceiptCost>::with(())
             .given_no_previous_events()
@@ -896,5 +1049,62 @@ mod tests {
             error,
             LifecycleError::Apply(BotGasReceiptCostError::NonPositiveUsdCost)
         ));
+    }
+
+    /// Legacy `BotGasReceiptCostEvent::Recorded` payloads persisted before
+    /// this crate switched `eth_usd_price`/`usd_cost` from
+    /// `num_decimal::Num`'s `Display` (a plain decimal string, rounded to 8
+    /// dp) to `Float::parse` must still deserialize under the new
+    /// deserializer, or aggregate replay of an already-persisted cost fails
+    /// closed at boot. Builds a real payload via serde and overwrites the two
+    /// numeric fields: `usd_cost` in the reduced-fraction shape `Num`'s
+    /// `BigRational`-backed `Display` actually wrote (it reduces to lowest
+    /// terms, so it never zero-pads), and `eth_usd_price` deliberately
+    /// zero-padded to also cover that shape, which `Num`'s `Display` never
+    /// produced but the deserializer must still accept.
+    #[test]
+    fn deserializes_legacy_num_formatted_persisted_payload() {
+        let bot = Address::repeat_byte(0x01);
+        let cost = BotGasReceiptCost::from_receipt(
+            &receipt(bot),
+            bot,
+            BotGasChain::Base,
+            BotGasOperationCategory::VaultDeposit,
+            None,
+            price(),
+            Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 1).unwrap(),
+        )
+        .unwrap();
+        let mut payload = serde_json::to_value(&cost).unwrap();
+        payload["eth_usd_price"] = json!("3421.87000000");
+        payload["usd_cost"] = json!("0.00042135");
+
+        let legacy: BotGasReceiptCost = serde_json::from_value(payload).unwrap();
+
+        assert!(legacy.eth_usd_price.eq(&Usd::new(float!(3421.87))).unwrap());
+        assert!(legacy.usd_cost.eq(&Usd::new(float!(0.00042135))).unwrap());
+    }
+
+    /// Same legacy-format check for an integer-valued price with no
+    /// fractional part, the other shape `Num`'s `Display` produced.
+    #[test]
+    fn deserializes_legacy_integer_valued_persisted_payload() {
+        let bot = Address::repeat_byte(0x01);
+        let cost = BotGasReceiptCost::from_receipt(
+            &receipt(bot),
+            bot,
+            BotGasChain::Base,
+            BotGasOperationCategory::VaultDeposit,
+            None,
+            price(),
+            Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 1).unwrap(),
+        )
+        .unwrap();
+        let mut payload = serde_json::to_value(&cost).unwrap();
+        payload["eth_usd_price"] = json!("3400");
+
+        let legacy: BotGasReceiptCost = serde_json::from_value(payload).unwrap();
+
+        assert!(legacy.eth_usd_price.eq(&Usd::new(float!(3400))).unwrap());
     }
 }

--- a/src/bot_gas/valuation.rs
+++ b/src/bot_gas/valuation.rs
@@ -41,30 +41,27 @@
 //! cheap startup probe) and where to look first if Base bot-gas costs stop
 //! recording entirely.
 //!
-//! # Why `Num`, not `Float`, for this module's USD values
+//! # Persisted USD values
 //!
-//! `EthUsdPrice.price` and `BotGasReceiptCost.usd_cost` are typed
-//! `num_decimal::Num`, not `rain_math_float::Float` -- the project's usual
-//! convention for financial arithmetic (see docs/float.md). This is a
-//! deliberate exception, not an oversight: `usd_cost` (and the `Num` shape
-//! this module produces to compute it) is a *persisted* field on
-//! `BotGasReceiptCost`, serialized via `serialize_num`/`deserialize_num`
-//! (`crate::bot_gas`) into the CQRS event log. Switching the type now would
-//! change the persisted event shape for every already-recorded
-//! `BotGasReceiptCostEvent::Recorded` event, which is a migration-class
-//! change, not a local refactor -- out of scope for this fixer pass. If a
-//! future change revisits this, it needs a migration plan for existing
-//! events, not just a type swap here.
+//! `EthUsdPrice.price` and `BotGasReceiptCost.usd_cost` are `st0x_finance::Usd`
+//! (see docs/float.md), the established newtype for an offchain dollar amount.
+//! They are *persisted* fields on `BotGasReceiptCost`, serialized as decimal
+//! strings into the CQRS event log, so `usd_cost` is rounded to
+//! `PERSISTED_DECIMAL_PRECISION` when it is built rather than relying on
+//! formatting to round it. Changing that precision, or how the rounding is
+//! applied, changes what future events persist and needs a
+//! `verify-migrations` run against real events.
 
 use alloy::eips::BlockId;
 use alloy::primitives::{Address, B256, U256};
 use alloy::providers::Provider;
 use alloy::transports::{RpcError, TransportErrorKind};
 use chrono::{DateTime, TimeDelta, Utc};
-use num_decimal::Num;
-use std::str::FromStr;
-use std::sync::LazyLock;
+use rain_math_float::Float;
 use tracing::warn;
+
+use st0x_finance::Usd;
+use st0x_float_macro::float;
 
 use super::{BotGasChain, EthUsdPrice};
 use crate::onchain::pyth::{PythError, extract_pyth_price_at};
@@ -72,11 +69,9 @@ use crate::onchain::pyth::{PythError, extract_pyth_price_at};
 /// Descriptive source string persisted on every recorded cost fact.
 const PYTH_SOURCE: &str = "pyth:base:getPriceUnsafe";
 
-/// Built once and reused by `scale_price_to_num`'s exponent-scaling loop:
-/// constructed via `Num::from` (infallible integer conversion, unlike
-/// `Num::from_str`), so re-deriving them on every price read is wasted work.
-static TEN: LazyLock<Num> = LazyLock::new(|| Num::from(10_u8));
-static ONE: LazyLock<Num> = LazyLock::new(|| Num::from(1_u8));
+/// Reused by the exponent-scaling loop without runtime decimal parsing.
+const TEN: Float = float!(10);
+const ONE: Float = float!(1);
 
 /// A Pyth price older than this relative to the receipt's `occurred_at` is
 /// recorded with a warning rather than rejected (ADR 0017: record + warn, no
@@ -107,8 +102,12 @@ pub(crate) enum EthUsdValuationError {
     Decimal {
         value: String,
         #[source]
-        source: num_decimal::ParseNumError,
+        source: rain_math_float::FloatError,
     },
+    /// Scaling is bounded to 18 powers of ten over an `i64` mantissa, so
+    /// accepted Pyth inputs remain well within `Float`'s coefficient range.
+    #[error("ETH/USD valuation arithmetic failed: {0}")]
+    Arithmetic(#[from] rain_math_float::FloatError),
     #[error("invalid ETH/USD Pyth publish time {0}")]
     InvalidPublishTime(U256),
     #[error("ETH/USD Pyth price exponent {expo} outside the plausible range -18..=0")]
@@ -181,8 +180,8 @@ where
         );
     }
 
-    let value = scale_price_to_num(price.price, price.expo)?;
-    if !value.is_positive() {
+    let value = scale_price_to_float(price.price, price.expo)?;
+    if !value.gt(float!(0))? {
         return Err(EthUsdValuationError::NonPositivePrice {
             price: price.price,
             expo: price.expo,
@@ -190,41 +189,41 @@ where
     }
 
     Ok(EthUsdPrice {
-        price: value,
+        price: Usd::new(value),
         source: PYTH_SOURCE.to_owned(),
         observed_at,
         block_number: Some(block_number),
     })
 }
 
-fn parse_num(value: &str) -> Result<Num, EthUsdValuationError> {
-    Num::from_str(value).map_err(|source| EthUsdValuationError::Decimal {
+fn parse_float(value: &str) -> Result<Float, EthUsdValuationError> {
+    Float::parse(value.to_owned()).map_err(|source| EthUsdValuationError::Decimal {
         value: value.to_owned(),
         source,
     })
 }
 
-/// Scales a raw Pyth `(price, expo)` pair into a decimal `Num`, i.e.
-/// `price * 10^expo`. Exact (no floating point): `Num` is a rational type.
-fn scale_price_to_num(price: i64, expo: i32) -> Result<Num, EthUsdValuationError> {
+/// Scales a raw Pyth `(price, expo)` pair into `price * 10^expo`.
+///
+/// `Float` carries a 224-bit coefficient, so an ETH/USD price at Pyth's 10^-8
+/// exponent is represented without loss.
+fn scale_price_to_float(price: i64, expo: i32) -> Result<Float, EthUsdValuationError> {
     if !PLAUSIBLE_EXPO_RANGE.contains(&expo) {
         return Err(EthUsdValuationError::ExponentOutOfRange { expo });
     }
 
-    let mantissa = parse_num(&price.to_string())?;
+    let mantissa = parse_float(&price.to_string())?;
     if expo == 0 {
         return Ok(mantissa);
     }
 
-    let scale = (0..expo.unsigned_abs()).try_fold(ONE.clone(), |acc, _| {
-        Ok::<Num, EthUsdValuationError>(&acc * &*TEN)
-    })?;
+    let scale = (0..expo.unsigned_abs()).try_fold(ONE, |acc, _| acc * TEN)?;
 
     // `PLAUSIBLE_EXPO_RANGE` and the `expo == 0` early return above already
     // establish `expo < 0` here, so this only ever divides. Pyth's on-chain
     // prices use negative exponents (10^-8 for ETH/USD); a positive-exponent
     // feed would need `PLAUSIBLE_EXPO_RANGE` widened and this branch back.
-    Ok(&mantissa / &scale)
+    Ok((mantissa / scale)?)
 }
 
 #[cfg(test)]
@@ -240,6 +239,8 @@ mod tests {
 
     use st0x_evm::IPyth::getPriceUnsafeCall;
     use st0x_evm::PythStructs::Price;
+
+    use st0x_float_serde::format_float;
 
     use super::*;
 
@@ -290,7 +291,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.block_number, Some(123));
-        assert_eq!(result.price.to_string(), "2000");
+        assert_eq!(format_float(&result.price.inner()).unwrap(), "2000");
         assert_eq!(result.source, "pyth:base:getPriceUnsafe");
     }
 
@@ -409,7 +410,10 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(result.price.to_string(), "1857.65949113");
+        assert_eq!(
+            format_float(&result.price.inner()).unwrap(),
+            "1857.65949113"
+        );
         assert_eq!(result.source, "pyth:base:getPriceUnsafe");
     }
 
@@ -573,14 +577,14 @@ mod tests {
     }
 
     #[test]
-    fn scale_price_to_num_accepts_the_real_eth_usd_exponent() {
-        let value = scale_price_to_num(200_000_000_000, -8).unwrap();
-        assert_eq!(value.to_string(), "2000");
+    fn scale_price_to_float_accepts_the_real_eth_usd_exponent() {
+        let value = scale_price_to_float(200_000_000_000, -8).unwrap();
+        assert_eq!(format_float(&value).unwrap(), "2000");
     }
 
     #[test]
-    fn scale_price_to_num_rejects_an_implausible_exponent() {
-        let error = scale_price_to_num(1, i32::MIN).unwrap_err();
+    fn scale_price_to_float_rejects_an_implausible_exponent() {
+        let error = scale_price_to_float(1, i32::MIN).unwrap_err();
 
         assert!(matches!(
             error,

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -638,6 +638,7 @@ mod tests {
             settings: empty_settings(),
             recovery: Arc::new(tokio::sync::OnceCell::new()),
             resume_lock: Arc::new(crate::api::ResumeLock(tokio::sync::Mutex::new(()))),
+            pnl_report_admission: pnl::pnl_report_admission(),
             metrics_handle: crate::metrics::setup().expect("metrics setup"),
         }
     }

--- a/src/dashboard/pnl/builder.rs
+++ b/src/dashboard/pnl/builder.rs
@@ -1,15 +1,15 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-
 use chrono::NaiveDate;
-use num_decimal::Num;
+use rain_math_float::Float;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use st0x_execution::alpaca_broker_api::AccountActivity;
 use st0x_finance::Symbol;
+use st0x_float_macro::float;
 
 use super::ATTRIBUTION_METHOD;
 use super::costs::{
     AccountingEffect, CostCategory, CostEntryInternal, build_alpaca_activity_cost_entries,
-    build_cost_entries, summarize_cost_entries, with_costs,
+    build_cost_entries, summarize_cost_entries, validated_cost_magnitude, with_costs,
 };
 use super::diagnostics::append_replay_diagnostics;
 use super::parsing::{fmt_decimal, is_safe_symbol, ordered_position_events};
@@ -18,7 +18,7 @@ use super::replay::{
     add_summary, apply_manual_position_adjustment, apply_offchain_fill, apply_offchain_placement,
     apply_onchain_fill, finalize_book, merge_symbol_replay_exposure, parse_offchain_fill,
     parse_onchain_fill, reset_symbol_costs, summary_from_entries, summary_to_dto,
-    symbol_summary_to_dto, with_direct_symbol_costs, with_replay_exposure,
+    with_direct_symbol_costs, with_replay_exposure,
 };
 use super::response::{PnlCapitalSummary, PnlCostEntry, PnlResponse};
 use super::samples::{build_available_range, build_sample_stats, parse_position_view};
@@ -30,56 +30,73 @@ use super::state::{
 };
 use super::windows::build_windows;
 
-fn tokenization_fee_overlap_key(entry: &CostEntryInternal) -> Option<(Symbol, String, String)> {
+fn tokenization_fee_overlap_key(
+    entry: &CostEntryInternal,
+) -> Result<Option<(Symbol, String, String)>, PnlError> {
     if entry.category != CostCategory::TokenizationFee || entry.effect != AccountingEffect::Cost {
-        return None;
+        return Ok(None);
     }
 
-    Some((
-        entry.symbol.clone()?,
+    let Some(symbol) = entry.symbol.clone() else {
+        return Ok(None);
+    };
+
+    Ok(Some((
+        symbol,
         date_key(&entry.occurred_at),
-        fmt_decimal(&entry.amount_usd),
-    ))
+        fmt_decimal(entry.amount_usd.inner())?,
+    )))
 }
 
-fn alpaca_fee_overlap_key(entry: &CostEntryInternal) -> Option<(Symbol, String, String)> {
+fn alpaca_fee_overlap_key(
+    entry: &CostEntryInternal,
+) -> Result<Option<(Symbol, String, String)>, PnlError> {
     if entry.category != CostCategory::BrokerFee || entry.effect != AccountingEffect::Cost {
-        return None;
+        return Ok(None);
     }
 
-    Some((
-        entry.symbol.clone()?,
+    let Some(symbol) = entry.symbol.clone() else {
+        return Ok(None);
+    };
+
+    Ok(Some((
+        symbol,
         date_key(&entry.occurred_at),
-        fmt_decimal(&entry.amount_usd),
-    ))
+        fmt_decimal(entry.amount_usd.inner())?,
+    )))
 }
 
 fn remove_tokenization_fee_overlaps(
     tokenization_entries: &[CostEntryInternal],
     alpaca_entries: Vec<CostEntryInternal>,
     warnings: &mut Vec<String>,
-) -> Vec<CostEntryInternal> {
-    let tokenization_fee_keys: HashSet<_> = tokenization_entries
+) -> Result<Vec<CostEntryInternal>, PnlError> {
+    let tokenization_fee_keys = tokenization_entries
         .iter()
-        .filter_map(tokenization_fee_overlap_key)
-        .collect();
-
-    alpaca_entries
+        .map(tokenization_fee_overlap_key)
+        .collect::<Result<Vec<_>, PnlError>>()?
         .into_iter()
-        .filter(|entry| {
-            let Some(key) = alpaca_fee_overlap_key(entry) else {
-                return true;
-            };
-            if tokenization_fee_keys.contains(&key) {
-                warnings.push(format!(
-                    "Skipped overlapping Alpaca broker fee {} because a persisted tokenization fee already covers {} on {} for {}",
-                    entry.aggregate_id, key.0, key.1, key.2
-                ));
-                return false;
-            }
-            true
-        })
-        .collect()
+        .flatten()
+        .collect::<HashSet<_>>();
+
+    let mut retained = Vec::with_capacity(alpaca_entries.len());
+    for entry in alpaca_entries {
+        let Some(key) = alpaca_fee_overlap_key(&entry)? else {
+            retained.push(entry);
+            continue;
+        };
+        if tokenization_fee_keys.contains(&key) {
+            warnings.push(format!(
+                "Skipped overlapping Alpaca broker fee {} because a persisted tokenization fee already covers {} on {} for {}",
+                entry.aggregate_id, key.0, key.1, key.2
+            ));
+            continue;
+        }
+
+        retained.push(entry);
+    }
+
+    Ok(retained)
 }
 
 /// Builds the `/pnl` response from already-loaded rows and returns net realized
@@ -93,7 +110,7 @@ pub(crate) fn build_pnl_response_from_rows(
     query: &PnlQuery,
     symbols: &BTreeSet<String>,
     mut warnings: Vec<String>,
-) -> Result<(PnlResponse, BTreeMap<NaiveDate, Num>), PnlError> {
+) -> Result<(PnlResponse, BTreeMap<NaiveDate, Float>), PnlError> {
     let event_rows = if symbols.is_empty() {
         event_rows
     } else {
@@ -131,7 +148,7 @@ pub(crate) fn build_pnl_response_from_rows(
         match row.event_type.as_str() {
             "PositionEvent::OnChainOrderFilled" => {
                 if let Some(fill) = parse_onchain_fill(&row, &mut warnings)? {
-                    apply_onchain_fill(book, &fill, &mut entries, &mut warnings);
+                    apply_onchain_fill(book, &fill, &mut entries, &mut warnings)?;
                 }
             }
             "PositionEvent::OffChainOrderPlaced" => {
@@ -145,7 +162,7 @@ pub(crate) fn build_pnl_response_from_rows(
                         &mut entries,
                         &mut warnings,
                         &mut unmatched_offchain_allocations,
-                    );
+                    )?;
                 }
             }
             "PositionEvent::ManualPositionAdjusted" => {
@@ -167,16 +184,16 @@ pub(crate) fn build_pnl_response_from_rows(
                 &position_nets,
                 &mut warnings,
                 &mut position_replay_deltas,
-            );
-            add_summary(&mut full_total, &book.summary);
-            replay_symbols.push(symbol_summary_to_dto(&symbol, &book.summary));
+            )?;
+            add_summary(&mut full_total, &book.summary)?;
+            replay_symbols.push((symbol, book.summary.clone()));
         }
     }
     append_replay_diagnostics(
         &mut warnings,
         &unmatched_offchain_allocations,
         &position_replay_deltas,
-    );
+    )?;
 
     let mut filtered_entries: Vec<_> = entries
         .into_iter()
@@ -200,7 +217,7 @@ pub(crate) fn build_pnl_response_from_rows(
         .extend(build_bot_gas_cost_entries(bot_gas_rows, &mut warnings)?);
     let alpaca_entries = build_alpaca_activity_cost_entries(alpaca_activities, &mut warnings)?;
     let alpaca_entries =
-        remove_tokenization_fee_overlaps(&cost_replay.entries, alpaca_entries, &mut warnings);
+        remove_tokenization_fee_overlaps(&cost_replay.entries, alpaca_entries, &mut warnings)?;
     cost_replay.entries.extend(alpaca_entries);
 
     let mut filtered_cost_entries: Vec<_> = cost_replay
@@ -229,35 +246,37 @@ pub(crate) fn build_pnl_response_from_rows(
     let cost_summary = summarize_cost_entries(
         &filtered_cost_entries,
         cost_replay.missing_cost_observation_count,
-    );
-    let mut daily_net_realized_pnl_usd = BTreeMap::<NaiveDate, Num>::new();
+    )?;
+    let mut daily_net_realized_pnl_usd = BTreeMap::<NaiveDate, Float>::new();
     for entry in &filtered_entries {
         let day = et_day_key(&entry.closed_at).ok_or_else(|| PnlError::InvalidDate {
             field: "closedAt",
             value: entry.closed_at.clone(),
         })?;
-        *daily_net_realized_pnl_usd.entry(day).or_default() += &entry.realized_pnl_usd;
+        let running = daily_net_realized_pnl_usd.entry(day).or_insert(float!(0));
+        *running = (*running + entry.realized_pnl_usd)?;
     }
     for entry in &filtered_cost_entries {
         let amount = match entry.effect {
-            AccountingEffect::Cost => -entry.amount_usd.clone(),
-            AccountingEffect::Revenue => entry.amount_usd.clone(),
-            AccountingEffect::None => Num::default(),
+            AccountingEffect::Cost => (float!(0) - entry.amount_usd.inner())?,
+            AccountingEffect::Revenue => entry.amount_usd.inner(),
+            AccountingEffect::None => float!(0),
         };
         let day = et_day_key(&entry.occurred_at).ok_or_else(|| PnlError::InvalidDate {
             field: "occurredAt",
             value: entry.occurred_at.clone(),
         })?;
-        *daily_net_realized_pnl_usd.entry(day).or_default() += amount;
+        let running = daily_net_realized_pnl_usd.entry(day).or_insert(float!(0));
+        *running = (*running + amount)?;
     }
-    let filtered = summary_from_entries(&filtered_entries);
-    let replay_summary = summary_to_dto(&full_total);
+    let filtered = summary_from_entries(&filtered_entries)?;
+    let replay_summary = summary_to_dto(&full_total)?;
     let (summary, _net_realized_pnl_usd) = with_costs(
         with_replay_exposure(filtered.summary, replay_summary),
         &cost_summary,
     )?;
     let symbols_with_exposure =
-        merge_symbol_replay_exposure(filtered.symbols, replay_symbols.into_iter());
+        merge_symbol_replay_exposure(filtered.symbols, replay_symbols.into_iter())?;
     let symbols_with_costs = with_direct_symbol_costs(
         reset_symbol_costs(symbols_with_exposure),
         &filtered_cost_entries,
@@ -268,11 +287,11 @@ pub(crate) fn build_pnl_response_from_rows(
     symbol_universe.extend(symbols_with_costs.iter().map(|row| row.symbol.clone()));
     let symbol_universe: Vec<_> = symbol_universe.into_iter().collect();
 
-    let windows = build_windows(&filtered_entries, &symbol_universe);
+    let windows = build_windows(&filtered_entries, &symbol_universe)?;
     let cost_entries = filtered_cost_entries
         .iter()
-        .map(PnlCostEntry::from)
-        .collect();
+        .map(PnlCostEntry::try_from)
+        .collect::<Result<Vec<_>, PnlError>>()?;
 
     Ok((
         PnlResponse {
@@ -324,6 +343,15 @@ fn build_bot_gas_cost_entries(
             let amount_usd = match super::parsing::parse_internal_decimal(
                 "bot_gas_cost.usd_cost",
                 &row.usd_cost,
+            ) {
+                Ok(amount_usd) => amount_usd,
+                Err(error) => return Some(Err(error)),
+            };
+            let amount_usd = match validated_cost_magnitude(
+                amount_usd,
+                row.rowid,
+                "BotGasCost",
+                row.operation_category.clone(),
             ) {
                 Ok(amount_usd) => amount_usd,
                 Err(error) => return Some(Err(error)),

--- a/src/dashboard/pnl/costs.rs
+++ b/src/dashboard/pnl/costs.rs
@@ -1,14 +1,14 @@
 //! Cost and revenue classification for backend PnL reports.
-use num_decimal::Num;
+use rain_math_float::Float;
 use std::collections::{HashMap, HashSet};
-use std::str::FromStr;
 
 use st0x_execution::alpaca_broker_api::AccountActivity;
-use st0x_finance::Symbol;
+use st0x_finance::{Symbol, Usd};
+use st0x_float_macro::float;
 
 use super::parsing::{
-    abs_decimal, fmt_decimal, is_safe_symbol, nested_record, parse_internal_decimal,
-    persisted_decimal_value, text_field,
+    fmt_decimal, is_safe_symbol, nested_record, parse_internal_decimal, persisted_decimal_value,
+    text_field,
 };
 use super::query::{PnlError, PnlFinancialFieldError};
 use super::response::{PnlCostCoverage, PnlCostSummary, PnlSummary};
@@ -102,7 +102,7 @@ pub(crate) struct CostEntryInternal {
     pub(crate) category: CostCategory,
     pub(crate) accounting_bucket: AccountingBucket,
     pub(crate) effect: AccountingEffect,
-    pub(crate) amount_usd: Num,
+    pub(crate) amount_usd: CostMagnitude,
     pub(crate) occurred_at: String,
     pub(crate) aggregate_type: String,
     pub(crate) aggregate_id: String,
@@ -111,37 +111,94 @@ pub(crate) struct CostEntryInternal {
     pub(crate) detail: String,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CostMagnitude(Usd);
+
+impl CostMagnitude {
+    pub(crate) fn inner(self) -> Float {
+        self.0.inner()
+    }
+}
+
+pub(crate) fn validated_cost_magnitude(
+    amount_usd: Float,
+    event_rowid: i64,
+    aggregate_type: &'static str,
+    event_type: String,
+) -> Result<CostMagnitude, PnlError> {
+    if amount_usd.lt(float!(0))? {
+        return Err(PnlError::MalformedPayload {
+            rowid: event_rowid,
+            aggregate_type,
+            event_type,
+            reason: "negative cost magnitude",
+        });
+    }
+
+    Ok(CostMagnitude(Usd::new(amount_usd)))
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct CostSummaryAcc {
-    pub(crate) counter_trade_costs_usd: Num,
-    pub(crate) onchain_netting_costs_usd: Num,
-    pub(crate) directional_exposure_costs_usd: Num,
-    pub(crate) generic_costs_usd: Num,
-    pub(crate) generic_revenue_usd: Num,
-    pub(crate) dividend_revenue_usd: Num,
-    pub(crate) offchain_execution_fees_usd: Num,
-    pub(crate) tokenization_fees_usd: Num,
-    pub(crate) cctp_fees_usd: Num,
-    pub(crate) conversion_slippage_usd: Num,
-    pub(crate) oracle_write_cost_usd: Num,
-    pub(crate) broker_fees_usd: Num,
-    pub(crate) regulatory_fees_usd: Num,
-    pub(crate) margin_interest_usd: Num,
-    pub(crate) bot_gas_usd: Num,
-    pub(crate) wallet_transfer_fees_usd: Num,
-    pub(crate) unclassified_costs_usd: Num,
+    pub(crate) counter_trade_costs_usd: Float,
+    pub(crate) onchain_netting_costs_usd: Float,
+    pub(crate) directional_exposure_costs_usd: Float,
+    pub(crate) generic_costs_usd: Float,
+    pub(crate) generic_revenue_usd: Float,
+    pub(crate) dividend_revenue_usd: Float,
+    pub(crate) offchain_execution_fees_usd: Float,
+    pub(crate) tokenization_fees_usd: Float,
+    pub(crate) cctp_fees_usd: Float,
+    pub(crate) conversion_slippage_usd: Float,
+    pub(crate) oracle_write_cost_usd: Float,
+    pub(crate) broker_fees_usd: Float,
+    pub(crate) regulatory_fees_usd: Float,
+    pub(crate) margin_interest_usd: Float,
+    pub(crate) bot_gas_usd: Float,
+    pub(crate) wallet_transfer_fees_usd: Float,
+    pub(crate) unclassified_costs_usd: Float,
     pub(crate) missing_cost_observation_count: usize,
     pub(crate) broker_fee_entry_count: usize,
     pub(crate) margin_interest_entry_count: usize,
     pub(crate) dividend_activity_entry_count: usize,
 }
 
-fn signed_category_amount(effect: AccountingEffect, amount: &Num) -> Num {
-    match effect {
-        AccountingEffect::Cost => -amount.clone(),
-        AccountingEffect::Revenue => amount.clone(),
-        AccountingEffect::None => Num::default(),
+/// See `SummaryAcc`: `Float` has no meaningful derived `Default`, so the
+/// compile-time zero keeps this accumulator infallibly constructible.
+impl Default for CostSummaryAcc {
+    fn default() -> Self {
+        Self {
+            counter_trade_costs_usd: float!(0),
+            onchain_netting_costs_usd: float!(0),
+            directional_exposure_costs_usd: float!(0),
+            generic_costs_usd: float!(0),
+            generic_revenue_usd: float!(0),
+            dividend_revenue_usd: float!(0),
+            offchain_execution_fees_usd: float!(0),
+            tokenization_fees_usd: float!(0),
+            cctp_fees_usd: float!(0),
+            conversion_slippage_usd: float!(0),
+            oracle_write_cost_usd: float!(0),
+            broker_fees_usd: float!(0),
+            regulatory_fees_usd: float!(0),
+            margin_interest_usd: float!(0),
+            bot_gas_usd: float!(0),
+            wallet_transfer_fees_usd: float!(0),
+            unclassified_costs_usd: float!(0),
+            missing_cost_observation_count: 0,
+            broker_fee_entry_count: 0,
+            margin_interest_entry_count: 0,
+            dividend_activity_entry_count: 0,
+        }
     }
+}
+
+fn signed_category_amount(effect: AccountingEffect, amount: Float) -> Result<Float, PnlError> {
+    Ok(match effect {
+        AccountingEffect::Cost => (float!(0) - amount)?,
+        AccountingEffect::Revenue => amount,
+        AccountingEffect::None => float!(0),
+    })
 }
 
 fn add_cost(
@@ -149,41 +206,48 @@ fn add_cost(
     category: CostCategory,
     accounting_bucket: AccountingBucket,
     effect: AccountingEffect,
-    amount: &Num,
-) {
+    amount: Float,
+) -> Result<(), PnlError> {
     match (effect, accounting_bucket) {
         (AccountingEffect::Cost, AccountingBucket::CounterTrade) => {
-            summary.counter_trade_costs_usd += amount;
+            summary.counter_trade_costs_usd = (summary.counter_trade_costs_usd + amount)?;
         }
         (AccountingEffect::Cost, AccountingBucket::OnchainNetting) => {
-            summary.onchain_netting_costs_usd += amount;
+            summary.onchain_netting_costs_usd = (summary.onchain_netting_costs_usd + amount)?;
         }
         (AccountingEffect::Cost, AccountingBucket::DirectionalExposure) => {
-            summary.directional_exposure_costs_usd += amount;
+            summary.directional_exposure_costs_usd =
+                (summary.directional_exposure_costs_usd + amount)?;
         }
         (AccountingEffect::Cost, _) => {
-            summary.generic_costs_usd += amount;
+            summary.generic_costs_usd = (summary.generic_costs_usd + amount)?;
         }
         (AccountingEffect::Revenue, AccountingBucket::DividendRevenue) => {
-            summary.dividend_revenue_usd += amount;
+            summary.dividend_revenue_usd = (summary.dividend_revenue_usd + amount)?;
         }
         (AccountingEffect::Revenue, _) => {
-            summary.generic_revenue_usd += amount;
+            summary.generic_revenue_usd = (summary.generic_revenue_usd + amount)?;
         }
         (AccountingEffect::None, _) => {}
     }
 
-    let signed_amount = signed_category_amount(effect, amount);
+    let signed_amount = signed_category_amount(effect, amount)?;
     match category {
-        CostCategory::TokenizationFee => summary.tokenization_fees_usd += &signed_amount,
-        CostCategory::CctpFee => summary.cctp_fees_usd += &signed_amount,
-        CostCategory::BotGas => summary.bot_gas_usd += amount,
+        CostCategory::TokenizationFee => {
+            summary.tokenization_fees_usd = (summary.tokenization_fees_usd + signed_amount)?;
+        }
+        CostCategory::CctpFee => {
+            summary.cctp_fees_usd = (summary.cctp_fees_usd + signed_amount)?;
+        }
+        CostCategory::BotGas => {
+            summary.bot_gas_usd = (summary.bot_gas_usd + amount)?;
+        }
         CostCategory::BrokerFee => {
-            summary.broker_fees_usd += &signed_amount;
+            summary.broker_fees_usd = (summary.broker_fees_usd + signed_amount)?;
             summary.broker_fee_entry_count += 1;
         }
         CostCategory::MarginInterest => {
-            summary.margin_interest_usd += &signed_amount;
+            summary.margin_interest_usd = (summary.margin_interest_usd + signed_amount)?;
             summary.margin_interest_entry_count += 1;
         }
         CostCategory::DividendIncome => {
@@ -191,16 +255,20 @@ fn add_cost(
         }
         CostCategory::CashCredit => {}
     }
+
+    Ok(())
 }
 
-fn total_tracked_costs(summary: &CostSummaryAcc) -> Num {
-    &(&(&summary.counter_trade_costs_usd + &summary.onchain_netting_costs_usd)
-        + &summary.directional_exposure_costs_usd)
-        + &summary.generic_costs_usd
+fn total_tracked_costs(summary: &CostSummaryAcc) -> Result<Float, PnlError> {
+    Ok(
+        (((summary.counter_trade_costs_usd + summary.onchain_netting_costs_usd)?
+            + summary.directional_exposure_costs_usd)?
+            + summary.generic_costs_usd)?,
+    )
 }
 
-fn total_tracked_revenue(summary: &CostSummaryAcc) -> Num {
-    &summary.dividend_revenue_usd + &summary.generic_revenue_usd
+fn total_tracked_revenue(summary: &CostSummaryAcc) -> Result<Float, PnlError> {
+    Ok((summary.dividend_revenue_usd + summary.generic_revenue_usd)?)
 }
 
 fn included_when_observed(count: usize) -> &'static str {
@@ -211,8 +279,8 @@ fn included_when_observed(count: usize) -> &'static str {
     }
 }
 
-fn fmt_signed_category_amount(value: &Num) -> String {
-    fmt_decimal(&abs_decimal(value))
+fn fmt_signed_category_amount(value: Float) -> Result<String, PnlError> {
+    fmt_decimal(value.abs()?)
 }
 
 fn coverage(
@@ -220,41 +288,44 @@ fn coverage(
     bucket: AccountingBucket,
     effect: AccountingEffect,
     status: &'static str,
-    amount: &Num,
+    amount: Float,
     note: &'static str,
-) -> PnlCostCoverage {
-    PnlCostCoverage {
+) -> Result<PnlCostCoverage, PnlError> {
+    Ok(PnlCostCoverage {
         source,
         accounting_bucket: bucket.as_str(),
         effect: effect.as_str(),
         status,
-        amount_usd: fmt_signed_category_amount(amount),
+        amount_usd: fmt_signed_category_amount(amount)?,
         note,
-    }
+    })
 }
 
-fn cost_summary_to_dto(summary: &CostSummaryAcc, cost_entry_count: usize) -> PnlCostSummary {
+fn cost_summary_to_dto(
+    summary: &CostSummaryAcc,
+    cost_entry_count: usize,
+) -> Result<PnlCostSummary, PnlError> {
     let offchain_execution_fees =
-        &summary.offchain_execution_fees_usd + &summary.regulatory_fees_usd;
-    PnlCostSummary {
-        total_tracked_costs_usd: fmt_decimal(&total_tracked_costs(summary)),
-        total_tracked_revenue_usd: fmt_decimal(&total_tracked_revenue(summary)),
-        counter_trade_costs_usd: fmt_decimal(&summary.counter_trade_costs_usd),
-        onchain_netting_costs_usd: fmt_decimal(&summary.onchain_netting_costs_usd),
-        directional_exposure_costs_usd: fmt_decimal(&summary.directional_exposure_costs_usd),
-        generic_costs_usd: fmt_decimal(&summary.generic_costs_usd),
-        dividend_revenue_usd: fmt_decimal(&summary.dividend_revenue_usd),
-        offchain_execution_fees_usd: fmt_signed_category_amount(&offchain_execution_fees),
-        tokenization_fees_usd: fmt_signed_category_amount(&summary.tokenization_fees_usd),
-        cctp_fees_usd: fmt_signed_category_amount(&summary.cctp_fees_usd),
-        conversion_slippage_usd: fmt_decimal(&summary.conversion_slippage_usd),
-        oracle_write_cost_usd: fmt_decimal(&summary.oracle_write_cost_usd),
-        broker_fees_usd: fmt_signed_category_amount(&summary.broker_fees_usd),
-        regulatory_fees_usd: fmt_decimal(&summary.regulatory_fees_usd),
-        margin_interest_usd: fmt_signed_category_amount(&summary.margin_interest_usd),
-        bot_gas_usd: fmt_decimal(&summary.bot_gas_usd),
-        wallet_transfer_fees_usd: fmt_decimal(&summary.wallet_transfer_fees_usd),
-        unclassified_costs_usd: fmt_decimal(&summary.unclassified_costs_usd),
+        (summary.offchain_execution_fees_usd + summary.regulatory_fees_usd)?;
+    Ok(PnlCostSummary {
+        total_tracked_costs_usd: fmt_decimal(total_tracked_costs(summary)?)?,
+        total_tracked_revenue_usd: fmt_decimal(total_tracked_revenue(summary)?)?,
+        counter_trade_costs_usd: fmt_decimal(summary.counter_trade_costs_usd)?,
+        onchain_netting_costs_usd: fmt_decimal(summary.onchain_netting_costs_usd)?,
+        directional_exposure_costs_usd: fmt_decimal(summary.directional_exposure_costs_usd)?,
+        generic_costs_usd: fmt_decimal(summary.generic_costs_usd)?,
+        dividend_revenue_usd: fmt_decimal(summary.dividend_revenue_usd)?,
+        offchain_execution_fees_usd: fmt_signed_category_amount(offchain_execution_fees)?,
+        tokenization_fees_usd: fmt_signed_category_amount(summary.tokenization_fees_usd)?,
+        cctp_fees_usd: fmt_signed_category_amount(summary.cctp_fees_usd)?,
+        conversion_slippage_usd: fmt_decimal(summary.conversion_slippage_usd)?,
+        oracle_write_cost_usd: fmt_decimal(summary.oracle_write_cost_usd)?,
+        broker_fees_usd: fmt_signed_category_amount(summary.broker_fees_usd)?,
+        regulatory_fees_usd: fmt_decimal(summary.regulatory_fees_usd)?,
+        margin_interest_usd: fmt_signed_category_amount(summary.margin_interest_usd)?,
+        bot_gas_usd: fmt_decimal(summary.bot_gas_usd)?,
+        wallet_transfer_fees_usd: fmt_decimal(summary.wallet_transfer_fees_usd)?,
+        unclassified_costs_usd: fmt_decimal(summary.unclassified_costs_usd)?,
         cost_entry_count,
         missing_cost_observation_count: summary.missing_cost_observation_count,
         coverage: vec![
@@ -263,97 +334,97 @@ fn cost_summary_to_dto(summary: &CostSummaryAcc, cost_entry_count: usize) -> Pnl
                 AccountingBucket::CounterTrade,
                 AccountingEffect::Cost,
                 included_when_observed(summary.broker_fee_entry_count),
-                &summary.broker_fees_usd,
+                summary.broker_fees_usd,
                 "Read from Alpaca account activity fee rows. These rows are not subtype-classified for now and are not allocated to symbols unless Alpaca supplies a symbol.",
-            ),
+            )?,
             coverage(
                 "On-chain netting execution costs",
                 AccountingBucket::OnchainNetting,
                 AccountingEffect::None,
                 "zero",
-                &summary.onchain_netting_costs_usd,
+                summary.onchain_netting_costs_usd,
                 "Passive on-chain fills do not create bot-paid trade execution costs for the on-chain netting bucket.",
-            ),
+            )?,
             coverage(
                 "Directional drift direct costs",
                 AccountingBucket::DirectionalExposure,
                 AccountingEffect::None,
                 "zero",
-                &summary.directional_exposure_costs_usd,
+                summary.directional_exposure_costs_usd,
                 "Raw inventory drift is price movement on held exposure; it has no direct execution cost by itself.",
-            ),
+            )?,
             coverage(
                 "Tokenization fees",
                 AccountingBucket::Generic,
                 AccountingEffect::Cost,
                 "included",
-                &summary.tokenization_fees_usd,
+                summary.tokenization_fees_usd,
                 "Read from TokenizedEquityMint terminal events when Alpaca reports fees.",
-            ),
+            )?,
             coverage(
                 "CCTP fees",
                 AccountingBucket::Generic,
                 AccountingEffect::Cost,
                 "included",
-                &summary.cctp_fees_usd,
+                summary.cctp_fees_usd,
                 "Read from UsdcRebalance bridge completion events as fee_collected.",
-            ),
+            )?,
             coverage(
                 "USD/USDC reporting basis",
                 AccountingBucket::Generic,
                 AccountingEffect::None,
                 "zero",
-                &summary.conversion_slippage_usd,
+                summary.conversion_slippage_usd,
                 "USD and USDC are treated as equivalent for reporting; conversion basis is not modeled as PnL. Only explicit persisted fees are deducted.",
-            ),
+            )?,
             coverage(
                 "Oracle writes",
                 AccountingBucket::Generic,
                 AccountingEffect::None,
                 "zero",
-                &summary.oracle_write_cost_usd,
+                summary.oracle_write_cost_usd,
                 "Current setup does not pay oracle write cost through the bot.",
-            ),
+            )?,
             coverage(
                 "Dividend income",
                 AccountingBucket::DividendRevenue,
                 AccountingEffect::Revenue,
                 included_when_observed(summary.dividend_activity_entry_count),
-                &summary.dividend_revenue_usd,
+                summary.dividend_revenue_usd,
                 "Dividend-bearing stock revenue increases net PnL when Alpaca dividend activity rows are available.",
-            ),
+            )?,
             coverage(
                 "Margin interest",
                 AccountingBucket::Generic,
                 AccountingEffect::Cost,
                 included_when_observed(summary.margin_interest_entry_count),
-                &summary.margin_interest_usd,
+                summary.margin_interest_usd,
                 "Included when Alpaca account activity interest rows are available; negative rows are costs and positive rows are credits.",
-            ),
+            )?,
             coverage(
                 "Bot gas",
                 AccountingBucket::Generic,
                 AccountingEffect::Cost,
-                included_when_observed(usize::from(!summary.bot_gas_usd.is_zero())),
-                &summary.bot_gas_usd,
+                included_when_observed(usize::from(!summary.bot_gas_usd.is_zero()?)),
+                summary.bot_gas_usd,
                 "Read from persisted bot-paid transaction receipts after gas-payer classification and ETH/USD valuation.",
-            ),
+            )?,
             coverage(
                 "Wallet transfer fees",
                 AccountingBucket::Generic,
                 AccountingEffect::Cost,
                 "not_ingested",
-                &summary.wallet_transfer_fees_usd,
+                summary.wallet_transfer_fees_usd,
                 "Alpaca wallet fee fields are not currently persisted into the event stream.",
-            ),
+            )?,
         ],
-    }
+    })
 }
 
 pub(crate) fn summarize_cost_entries(
     entries: &[CostEntryInternal],
     missing_cost_observation_count: usize,
-) -> PnlCostSummary {
+) -> Result<PnlCostSummary, PnlError> {
     let mut summary = CostSummaryAcc {
         missing_cost_observation_count,
         ..CostSummaryAcc::default()
@@ -365,8 +436,8 @@ pub(crate) fn summarize_cost_entries(
             entry.category,
             entry.accounting_bucket,
             entry.effect,
-            &entry.amount_usd,
-        );
+            entry.amount_usd.inner(),
+        )?;
     }
 
     cost_summary_to_dto(&summary, entries.len())
@@ -379,7 +450,7 @@ pub(crate) fn summarize_cost_entries(
 pub(crate) fn with_costs(
     summary: PnlSummary,
     costs: &PnlCostSummary,
-) -> Result<(PnlSummary, Num), PnlError> {
+) -> Result<(PnlSummary, Float), PnlError> {
     let gross = parse_internal_decimal("summary.totalPnlUsd", &summary.total_pnl_usd)?;
     let tracked_costs =
         parse_internal_decimal("costs.totalTrackedCostsUsd", &costs.total_tracked_costs_usd)?;
@@ -387,42 +458,71 @@ pub(crate) fn with_costs(
         "costs.totalTrackedRevenueUsd",
         &costs.total_tracked_revenue_usd,
     )?;
-    let net = &(&gross - &tracked_costs) + &tracked_revenue;
+    let net = ((gross - tracked_costs)? + tracked_revenue)?;
 
     Ok((
         PnlSummary {
-            gross_realized_pnl_usd: fmt_decimal(&gross),
-            tracked_costs_usd: fmt_decimal(&tracked_costs),
-            tracked_revenue_usd: fmt_decimal(&tracked_revenue),
-            net_realized_pnl_usd: fmt_decimal(&net),
+            gross_realized_pnl_usd: fmt_decimal(gross)?,
+            tracked_costs_usd: fmt_decimal(tracked_costs)?,
+            tracked_revenue_usd: fmt_decimal(tracked_revenue)?,
+            net_realized_pnl_usd: fmt_decimal(net)?,
             ..summary
         },
         net,
     ))
 }
 
-fn cost_entry(
-    row: &CostEventRow,
+#[derive(Debug, Clone, Copy)]
+struct CostEntryDefinition {
+    aggregate_type: &'static str,
     category: CostCategory,
     accounting_bucket: AccountingBucket,
     effect: AccountingEffect,
-    amount_usd: Num,
+    detail: &'static str,
+}
+
+const TOKENIZATION_FEE_ENTRY: CostEntryDefinition = CostEntryDefinition {
+    aggregate_type: "TokenizedEquityMint",
+    category: CostCategory::TokenizationFee,
+    accounting_bucket: AccountingBucket::Generic,
+    effect: AccountingEffect::Cost,
+    detail: "Alpaca tokenization fee reported by tokenization provider",
+};
+
+const CCTP_FEE_ENTRY: CostEntryDefinition = CostEntryDefinition {
+    aggregate_type: "UsdcRebalance",
+    category: CostCategory::CctpFee,
+    accounting_bucket: AccountingBucket::Generic,
+    effect: AccountingEffect::Cost,
+    detail: "CCTP fee_collected from bridge mint",
+};
+
+fn cost_entry(
+    row: &CostEventRow,
+    definition: CostEntryDefinition,
+    amount_usd: Float,
     occurred_at: String,
-    detail: &str,
     symbol: Option<Symbol>,
-) -> CostEntryInternal {
-    CostEntryInternal {
-        category,
-        accounting_bucket,
-        effect,
+) -> Result<CostEntryInternal, PnlError> {
+    let amount_usd = validated_cost_magnitude(
+        amount_usd,
+        row.rowid,
+        definition.aggregate_type,
+        row.event_type.clone(),
+    )?;
+
+    Ok(CostEntryInternal {
+        category: definition.category,
+        accounting_bucket: definition.accounting_bucket,
+        effect: definition.effect,
         amount_usd,
         occurred_at,
-        aggregate_type: row.aggregate_type.clone(),
+        aggregate_type: definition.aggregate_type.to_owned(),
         aggregate_id: row.aggregate_id.clone(),
         event_rowid: row.rowid,
         symbol,
-        detail: detail.to_owned(),
-    }
+        detail: definition.detail.to_owned(),
+    })
 }
 
 fn parse_tokenized_equity_mint_cost_event(
@@ -483,20 +583,17 @@ fn parse_tokenized_equity_mint_cost_event(
         return Err(malformed_cost_payload(row, "missing tokenization fees"));
     };
 
-    if fees.is_zero() {
+    if fees.is_zero()? {
         return Ok(None);
     }
 
     let entry = cost_entry(
         row,
-        CostCategory::TokenizationFee,
-        AccountingBucket::Generic,
-        AccountingEffect::Cost,
+        TOKENIZATION_FEE_ENTRY,
         fees,
         occurred_at,
-        "Alpaca tokenization fee reported by tokenization provider",
         symbols_by_mint_aggregate.get(&row.aggregate_id).cloned(),
-    );
+    )?;
     Ok(Some(entry))
 }
 
@@ -536,20 +633,17 @@ fn parse_usdc_rebalance_cost_event(
         ));
     };
 
-    if fee_collected.is_zero() {
+    if fee_collected.is_zero()? {
         return Ok(None);
     }
 
     Ok(Some(cost_entry(
         row,
-        CostCategory::CctpFee,
-        AccountingBucket::Generic,
-        AccountingEffect::Cost,
+        CCTP_FEE_ENTRY,
         fee_collected,
         occurred_at,
-        "CCTP fee_collected from bridge mint",
         None,
-    )))
+    )?))
 }
 
 pub(crate) struct CostReplay {
@@ -631,65 +725,66 @@ fn activity_timestamp(activity: &AccountActivity) -> Option<String> {
 
 fn classify_activity(
     activity_type: &str,
-    signed_amount: &Num,
-) -> Option<(CostCategory, AccountingBucket, AccountingEffect)> {
+    signed_amount: Float,
+) -> Result<Option<(CostCategory, AccountingBucket, AccountingEffect)>, PnlError> {
     // Treat Alpaca `net_amount` as the signed broker-cash delta for the account activity row:
     // negative values decrease cash and positive values increase cash. The broker docs enumerate
     // activity codes but do not publish a status/sign matrix for every activity, so unknown
     // activity/status values fail the report instead of being silently skipped.
     if FEE_ACTIVITY_TYPES.contains(&activity_type) {
-        return Some((
+        return Ok(Some((
             CostCategory::BrokerFee,
             AccountingBucket::CounterTrade,
-            if signed_amount.is_negative() {
+            if signed_amount.lt(float!(0))? {
                 AccountingEffect::Cost
             } else {
                 AccountingEffect::Revenue
             },
-        ));
+        )));
     }
 
     if INTEREST_ACTIVITY_TYPES.contains(&activity_type) {
-        return Some((
+        return Ok(Some((
             CostCategory::MarginInterest,
             AccountingBucket::Generic,
-            if signed_amount.is_negative() {
+            if signed_amount.lt(float!(0))? {
                 AccountingEffect::Cost
             } else {
                 AccountingEffect::Revenue
             },
-        ));
+        )));
     }
 
     if DIVIDEND_ACTIVITY_TYPES.contains(&activity_type) {
-        return Some((
+        let is_negative = signed_amount.lt(float!(0))?;
+        return Ok(Some((
             CostCategory::DividendIncome,
-            if signed_amount.is_negative() {
+            if is_negative {
                 AccountingBucket::Generic
             } else {
                 AccountingBucket::DividendRevenue
             },
-            if signed_amount.is_negative() {
+            if is_negative {
                 AccountingEffect::Cost
             } else {
                 AccountingEffect::Revenue
             },
-        ));
+        )));
     }
 
     if CASH_CREDIT_ACTIVITY_TYPES.contains(&activity_type) {
-        return Some((
+        return Ok(Some((
             CostCategory::CashCredit,
             AccountingBucket::Generic,
-            if signed_amount.is_negative() {
+            if signed_amount.lt(float!(0))? {
                 AccountingEffect::Cost
             } else {
                 AccountingEffect::Revenue
             },
-        ));
+        )));
     }
 
-    None
+    Ok(None)
 }
 
 fn activity_detail(activity: &AccountActivity) -> String {
@@ -742,7 +837,7 @@ fn malformed_alpaca_activity(
     }
 }
 
-fn parse_alpaca_net_amount(activity: &AccountActivity, rowid: i64) -> Result<Num, PnlError> {
+fn parse_alpaca_net_amount(activity: &AccountActivity, rowid: i64) -> Result<Float, PnlError> {
     let Some(net_amount) = activity.net_amount.as_deref() else {
         return Err(malformed_alpaca_activity(
             activity,
@@ -751,13 +846,13 @@ fn parse_alpaca_net_amount(activity: &AccountActivity, rowid: i64) -> Result<Num
         ));
     };
 
-    Num::from_str(net_amount).map_err(|error| PnlError::InvalidFinancialField {
+    Float::parse(net_amount.to_owned()).map_err(|error| PnlError::InvalidFinancialField {
         rowid,
         aggregate_type: "AlpacaAccountActivity",
         event_type: activity.activity_type.clone(),
         field: "net_amount",
         value: net_amount.to_owned(),
-        source: PnlFinancialFieldError::InvalidDecimal(error),
+        source: PnlFinancialFieldError::InvalidDecimal(Box::new(error)),
     })
 }
 
@@ -817,8 +912,10 @@ pub(crate) fn build_alpaca_activity_cost_entries(
                 Ok(amount) => amount,
                 Err(error) => return Some(Err(error)),
             };
-            if signed_amount.is_zero() {
-                return None;
+            match signed_amount.is_zero() {
+                Ok(true) => return None,
+                Ok(false) => {}
+                Err(error) => return Some(Err(error.into())),
             }
             if let Some(currency) = activity.currency.as_deref()
                 && !currency.eq_ignore_ascii_case("USD")
@@ -852,9 +949,11 @@ pub(crate) fn build_alpaca_activity_cost_entries(
                     }
                 }
             }
-            let Some((category, accounting_bucket, effect)) =
-                classify_activity(&activity.activity_type, &signed_amount)
-            else {
+            let classified = match classify_activity(&activity.activity_type, signed_amount) {
+                Ok(classified) => classified,
+                Err(error) => return Some(Err(error)),
+            };
+            let Some((category, accounting_bucket, effect)) = classified else {
                 return Some(Err(malformed_alpaca_activity(
                     activity,
                     event_rowid,
@@ -862,11 +961,24 @@ pub(crate) fn build_alpaca_activity_cost_entries(
                 )));
             };
 
+            let amount_usd = match signed_amount.abs() {
+                Ok(amount) => match validated_cost_magnitude(
+                    amount,
+                    event_rowid,
+                    "AlpacaAccountActivity",
+                    activity.activity_type.clone(),
+                ) {
+                    Ok(amount) => amount,
+                    Err(error) => return Some(Err(error)),
+                },
+                Err(error) => return Some(Err(error.into())),
+            };
+
             Some(Ok(CostEntryInternal {
                 category,
                 accounting_bucket,
                 effect,
-                amount_usd: abs_decimal(&signed_amount),
+                amount_usd,
                 occurred_at,
                 aggregate_type: "AlpacaAccountActivity".to_owned(),
                 aggregate_id: activity.id.clone(),

--- a/src/dashboard/pnl/diagnostics.rs
+++ b/src/dashboard/pnl/diagnostics.rs
@@ -1,21 +1,50 @@
 //! Replay diagnostics for PnL report warnings.
-use num_decimal::Num;
-use st0x_finance::Symbol;
+use rain_math_float::Float;
 use std::collections::{HashMap, HashSet};
 
+use st0x_finance::Symbol;
+use st0x_float_macro::float;
+
 use super::parsing::fmt_decimal;
+use super::query::PnlError;
 use super::state::{PositionReplayDelta, UnmatchedOffchainAllocation};
 
-fn allocation_summary_text(allocations: &[UnmatchedOffchainAllocation]) -> Option<String> {
+const ALLOCATION_FORMATTING_WARNING: &str =
+    "Allocation note unavailable: failed to format diagnostic values";
+const RECONCILIATION_FORMATTING_WARNING: &str =
+    "Reconciliation note unavailable: failed to format diagnostic values";
+
+fn diagnostic_decimal(
+    result: Result<String, PnlError>,
+    formatting_warning: &'static str,
+    warnings: &mut Vec<String>,
+) -> Option<String> {
+    result.map_or_else(
+        |_| {
+            if !warnings.iter().any(|warning| warning == formatting_warning) {
+                warnings.push(formatting_warning.to_owned());
+            }
+            None
+        },
+        Some,
+    )
+}
+
+fn allocation_summary_text(
+    allocations: &[UnmatchedOffchainAllocation],
+    warnings: &mut Vec<String>,
+) -> Result<Option<String>, PnlError> {
     if allocations.is_empty() {
-        return None;
+        return Ok(None);
     }
 
-    let mut by_symbol: HashMap<Symbol, (HashSet<String>, Num)> = HashMap::new();
+    let mut by_symbol: HashMap<Symbol, (HashSet<String>, Float)> = HashMap::new();
     for allocation in allocations {
-        let (fill_ids, shares) = by_symbol.entry(allocation.symbol.clone()).or_default();
+        let (fill_ids, shares) = by_symbol
+            .entry(allocation.symbol.clone())
+            .or_insert_with(|| (HashSet::new(), float!(0)));
         fill_ids.insert(allocation.fill_id.clone());
-        *shares += &allocation.shares;
+        *shares = (*shares + allocation.shares)?;
     }
 
     let mut details: Vec<_> = by_symbol.into_iter().collect();
@@ -23,26 +52,36 @@ fn allocation_summary_text(allocations: &[UnmatchedOffchainAllocation]) -> Optio
     let symbol_details = details
         .into_iter()
         .map(|(symbol, (fill_ids, shares))| {
-            format!(
-                "{}: {} shares across {} fills",
-                symbol,
-                fmt_decimal(&shares),
-                fill_ids.len()
+            diagnostic_decimal(fmt_decimal(shares), ALLOCATION_FORMATTING_WARNING, warnings).map(
+                |shares| {
+                    format!(
+                        "{}: {} shares across {} fills",
+                        symbol,
+                        shares,
+                        fill_ids.len()
+                    )
+                },
             )
         })
-        .collect::<Vec<_>>()
-        .join("; ");
+        .collect::<Option<Vec<_>>>();
+    let Some(symbol_details) = symbol_details else {
+        return Ok(None);
+    };
+    let symbol_details = symbol_details.join("; ");
 
-    Some(format!(
+    Ok(Some(format!(
         "Allocation note: {} offchain fills opened offchain-origin inventory outside the intended \
          onchain-to-offchain hedge flow ({}). Those shares are carried in the FIFO ledger so later \
          fills can close them.",
         allocations.len(),
         symbol_details
-    ))
+    )))
 }
 
-fn position_replay_delta_text(deltas: &[PositionReplayDelta]) -> Option<String> {
+fn position_replay_delta_text(
+    deltas: &[PositionReplayDelta],
+    warnings: &mut Vec<String>,
+) -> Option<String> {
     if deltas.is_empty() {
         return None;
     }
@@ -52,15 +91,25 @@ fn position_replay_delta_text(deltas: &[PositionReplayDelta]) -> Option<String> 
     let details = sorted
         .iter()
         .map(|delta| {
-            format!(
+            let replay = diagnostic_decimal(
+                fmt_decimal(delta.replay_net),
+                RECONCILIATION_FORMATTING_WARNING,
+                warnings,
+            )?;
+            let position = diagnostic_decimal(
+                fmt_decimal(delta.position_net),
+                RECONCILIATION_FORMATTING_WARNING,
+                warnings,
+            )?;
+
+            Some(format!(
                 "{}: replay {}, position_view {}",
-                delta.symbol,
-                fmt_decimal(&delta.replay_net),
-                fmt_decimal(&delta.position_net)
-            )
+                delta.symbol, replay, position
+            ))
         })
-        .collect::<Vec<_>>()
-        .join("; ");
+        .collect::<Option<Vec<_>>>();
+    let details = details?;
+    let details = details.join("; ");
 
     Some(format!(
         "Reconciliation note: replayed open lots differ from position_view for {} symbols ({}). \
@@ -75,12 +124,33 @@ pub(crate) fn append_replay_diagnostics(
     warnings: &mut Vec<String>,
     unmatched_offchain_allocations: &[UnmatchedOffchainAllocation],
     position_replay_deltas: &[PositionReplayDelta],
-) {
-    if let Some(text) = allocation_summary_text(unmatched_offchain_allocations) {
+) -> Result<(), PnlError> {
+    if let Some(text) = allocation_summary_text(unmatched_offchain_allocations, warnings)? {
         warnings.push(text);
     }
 
-    if let Some(text) = position_replay_delta_text(position_replay_deltas) {
+    if let Some(text) = position_replay_delta_text(position_replay_deltas, warnings) {
         warnings.push(text);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagnostic_formatting_failure_adds_an_advisory_warning() {
+        let mut warnings = Vec::new();
+        let error = PnlError::InvalidDate {
+            field: "test",
+            value: "invalid".to_owned(),
+        };
+
+        let text = diagnostic_decimal(Err(error), ALLOCATION_FORMATTING_WARNING, &mut warnings);
+
+        assert_eq!(text, None);
+        assert_eq!(warnings, [ALLOCATION_FORMATTING_WARNING]);
     }
 }

--- a/src/dashboard/pnl/mod.rs
+++ b/src/dashboard/pnl/mod.rs
@@ -1,4 +1,7 @@
 //! Backend PnL report builder for the dashboard.
+use rain_math_float::Float;
+
+use st0x_float_macro::float;
 
 mod builder;
 mod costs;
@@ -18,12 +21,20 @@ mod tests;
 
 pub(crate) use query::{PnlError, PnlQuery};
 pub(crate) use response::PnlResponse;
-pub(crate) use source::{build_pnl_report, validate_pnl_snapshot_rowid};
+#[cfg(test)]
+pub(crate) use source::{MAX_CONCURRENT_PNL_REPORTS, build_pnl_report};
+pub(crate) use source::{
+    PnlReportAdmission, acquire_pnl_report_permit, build_pnl_report_with_permit,
+    pnl_report_admission, validate_pnl_snapshot_rowid,
+};
 
 const ATTRIBUTION_METHOD: &str = "backend_position_fill_replay_fifo";
 const COUNTER_TRADE_THRESHOLD_SECONDS: i64 = 300;
 const SAFE_SYMBOL_CHARS: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-";
-const EPSILON: &str = "0.000001";
+/// Tolerance for the replay's self-audit comparisons. Resolved at compile
+/// time, so a malformed literal is a build failure rather than a panic in a
+/// request handler.
+const EPSILON: Float = float!(0.000001);
 
 const ATTRIBUTION_WARNING: &str = "PnL source: realized gross replay from persisted backend fill events. Fills are ordered by \
      execution timestamp and replayed through per-symbol FIFO inventory lots for accounting and \

--- a/src/dashboard/pnl/parsing.rs
+++ b/src/dashboard/pnl/parsing.rs
@@ -1,10 +1,7 @@
 //! Parsing helpers for persisted PnL event payloads and report decimals.
 use chrono::{DateTime, Utc};
-use num_decimal::Num;
-use num_decimal::num_bigint::BigInt;
-use num_traits::Zero;
+use rain_math_float::Float;
 use serde_json::Value;
-use std::str::FromStr;
 
 use super::SAFE_SYMBOL_CHARS;
 use super::query::{PnlError, PnlFinancialFieldError};
@@ -50,7 +47,7 @@ pub(crate) fn persisted_decimal_field(
     row: &PositionEventRow,
     payload: &Value,
     key: &'static str,
-) -> Result<Option<Num>, PnlError> {
+) -> Result<Option<Float>, PnlError> {
     persisted_decimal_value(row.rowid, "Position", row.event_type.clone(), payload, key)
 }
 
@@ -58,7 +55,7 @@ pub(crate) fn optional_persisted_decimal_field(
     row: &PositionEventRow,
     payload: &Value,
     key: &'static str,
-) -> Result<Option<Num>, PnlError> {
+) -> Result<Option<Float>, PnlError> {
     optional_persisted_decimal_value(row.rowid, "Position", row.event_type.clone(), payload, key)
 }
 
@@ -68,7 +65,7 @@ pub(crate) fn persisted_decimal_value(
     event_type: String,
     payload: &Value,
     key: &'static str,
-) -> Result<Option<Num>, PnlError> {
+) -> Result<Option<Float>, PnlError> {
     persisted_decimal_value_with_null_policy(rowid, aggregate_type, event_type, payload, key, false)
 }
 
@@ -78,7 +75,7 @@ pub(crate) fn optional_persisted_decimal_value(
     event_type: String,
     payload: &Value,
     key: &'static str,
-) -> Result<Option<Num>, PnlError> {
+) -> Result<Option<Float>, PnlError> {
     persisted_decimal_value_with_null_policy(rowid, aggregate_type, event_type, payload, key, true)
 }
 
@@ -89,7 +86,7 @@ fn persisted_decimal_value_with_null_policy(
     payload: &Value,
     key: &'static str,
     null_allowed: bool,
-) -> Result<Option<Num>, PnlError> {
+) -> Result<Option<Float>, PnlError> {
     let value = match payload.get(key) {
         None => return Ok(None),
         Some(Value::Null) if null_allowed => return Ok(None),
@@ -107,7 +104,7 @@ fn persisted_decimal_value_with_null_policy(
         }
     };
 
-    Num::from_str(&value)
+    Float::parse(value.clone())
         .map(Some)
         .map_err(|error| PnlError::InvalidFinancialField {
             rowid,
@@ -115,7 +112,7 @@ fn persisted_decimal_value_with_null_policy(
             event_type,
             field: key,
             value,
-            source: PnlFinancialFieldError::InvalidDecimal(error),
+            source: PnlFinancialFieldError::InvalidDecimal(Box::new(error)),
         })
 }
 
@@ -174,92 +171,21 @@ pub(crate) fn ordered_position_events(
     Ok(sortable.into_iter().map(|(_, _, row)| row).collect())
 }
 
-pub(crate) fn fmt_decimal(value: &Num) -> String {
-    let (mut numerator, denominator): (BigInt, BigInt) = value.clone().into();
-    if numerator.is_zero() {
-        return "0".to_owned();
-    }
-
-    let negative = numerator.sign() == num_decimal::num_bigint::Sign::Minus;
-    if negative {
-        numerator = -numerator;
-    }
-
-    let mut denominator = denominator;
-    let twos = factor_count(&mut denominator, 2);
-    let fives = factor_count(&mut denominator, 5);
-    assert!(
-        denominator == BigInt::from(1),
-        "PnL decimal output must be a finite decimal: {value:?}"
-    );
-
-    let scale = twos.max(fives);
-    let scaled = multiply_factor(
-        multiply_factor(numerator, 2, scale - twos),
-        5,
-        scale - fives,
-    );
-    let mut digits = scaled.to_string();
-
-    if scale > 0 {
-        if digits.len() <= scale {
-            digits.insert_str(0, &"0".repeat(scale + 1 - digits.len()));
-        }
-        let dot_index = digits.len() - scale;
-        digits.insert(dot_index, '.');
-        while digits.ends_with('0') {
-            digits.pop();
-        }
-        if digits.ends_with('.') {
-            digits.pop();
-        }
-    }
-
-    if negative {
-        format!("-{digits}")
-    } else {
-        digits
-    }
+/// Formats a report value as a decimal string.
+///
+/// `Float` carries a 224-bit coefficient, wide enough for any report value.
+/// Delegates to the shared formatter rather than calling
+/// `format_with_scientific(false)` directly: that rejects exponents below
+/// -76, which a small residual PnL value reaches, and the shared helper
+/// falls back to scientific notation instead of losing the value.
+pub(crate) fn fmt_decimal(value: Float) -> Result<String, PnlError> {
+    Ok(st0x_float_serde::format_float(&value)?)
 }
 
-fn factor_count(value: &mut BigInt, factor: u8) -> usize {
-    let factor = BigInt::from(factor);
-    let mut count = 0;
-    while (&*value % &factor).is_zero() {
-        *value /= &factor;
-        count += 1;
-    }
-    count
-}
-
-fn multiply_factor(mut value: BigInt, factor: u8, count: usize) -> BigInt {
-    let factor = BigInt::from(factor);
-    for _ in 0..count {
-        value *= &factor;
-    }
-    value
-}
-
-pub(crate) fn abs_decimal(value: &Num) -> Num {
-    if value.is_negative() {
-        -value.clone()
-    } else {
-        value.clone()
-    }
-}
-
-pub(crate) fn min_decimal(left: &Num, right: &Num) -> Num {
-    if left <= right {
-        left.clone()
-    } else {
-        right.clone()
-    }
-}
-
-pub(crate) fn parse_internal_decimal(field: &'static str, value: &str) -> Result<Num, PnlError> {
-    Num::from_str(value).map_err(|source| PnlError::InvalidInternalDecimal {
+pub(crate) fn parse_internal_decimal(field: &'static str, value: &str) -> Result<Float, PnlError> {
+    Float::parse(value.to_owned()).map_err(|source| PnlError::InvalidInternalDecimal {
         field,
         value: value.to_owned(),
-        source,
+        source: Box::new(source),
     })
 }

--- a/src/dashboard/pnl/query.rs
+++ b/src/dashboard/pnl/query.rs
@@ -13,8 +13,11 @@ const ALPACA_ACTIVITY_FETCH_PADDING_DAYS: i64 = 7;
 pub(crate) enum PnlFinancialFieldError {
     #[error("expected string or number")]
     InvalidJsonType,
+    // Boxed: `FloatError` embeds revm's `EVMError`/`HaltReason`, which makes
+    // it far larger than every other payload here, and this error is returned
+    // from most of the module's functions.
     #[error("invalid decimal: {0}")]
-    InvalidDecimal(#[source] num_decimal::ParseNumError),
+    InvalidDecimal(#[source] Box<rain_math_float::FloatError>),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -64,7 +67,7 @@ pub(crate) enum PnlError {
         field: &'static str,
         value: String,
         #[source]
-        source: num_decimal::ParseNumError,
+        source: Box<rain_math_float::FloatError>,
     },
     #[error("invalid symbol filter: {value}")]
     InvalidSymbolFilter { value: String },
@@ -72,8 +75,43 @@ pub(crate) enum PnlError {
     Database(#[from] sqlx::Error),
     #[error("failed to load portfolio snapshot data for capital/return computation: {0}")]
     PortfolioSnapshot(#[from] crate::portfolio_snapshot::ReadError),
-    #[error("failed to convert a PnL total for capital/return computation: {0}")]
-    CapitalFloat(#[from] rain_math_float::FloatError),
+    #[error("PnL arithmetic failed: {0}")]
+    Arithmetic(#[source] Box<ArithmeticFailure>),
+    #[error("PnL report admission capacity exhausted: {0}")]
+    ReplayAdmission(#[from] tokio::sync::TryAcquireError),
+    #[error("PnL replay worker failed: {0}")]
+    ReplayWorker(#[from] tokio::task::JoinError),
+}
+
+/// A `Float` arithmetic/comparison/formatting failure, tagged with the source
+/// location of the `?` that converted it. Nearly every function in this
+/// module is fallible on `Float` now, so the location -- not a hand-picked
+/// "operation" label -- is what actually distinguishes one failure site from
+/// another (cost summary vs. FIFO replay vs. capital block vs. window
+/// aggregation) when `/pnl` logs a 500. `#[track_caller]` on the `From` impl
+/// below makes `Location::caller()` resolve to the exact `?` call site, not
+/// this impl's own body. A handful of arithmetic accumulator helpers
+/// (`replay.rs`'s `add_venue_notional`/`add_realized_pnl`/`add_summary`) are
+/// invoked from more than one pipeline stage; those are themselves marked
+/// `#[track_caller]` so the location forwards one frame further, to the
+/// stage that called the helper, rather than to a line inside the shared
+/// helper that is identical regardless of which stage triggered it.
+#[derive(Debug, thiserror::Error)]
+#[error("{location}: {source}")]
+pub(crate) struct ArithmeticFailure {
+    pub(super) location: &'static std::panic::Location<'static>,
+    #[source]
+    source: Box<rain_math_float::FloatError>,
+}
+
+impl From<rain_math_float::FloatError> for PnlError {
+    #[track_caller]
+    fn from(error: rain_math_float::FloatError) -> Self {
+        Self::Arithmetic(Box::new(ArithmeticFailure {
+            location: std::panic::Location::caller(),
+            source: Box::new(error),
+        }))
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/src/dashboard/pnl/replay.rs
+++ b/src/dashboard/pnl/replay.rs
@@ -1,12 +1,12 @@
-use std::collections::{BTreeSet, HashMap, VecDeque};
-use std::str::FromStr;
+use rain_math_float::Float;
+use std::collections::{HashMap, VecDeque};
 
-use num_decimal::Num;
 use st0x_finance::Symbol;
+use st0x_float_macro::float;
 
 use super::costs::{AccountingEffect, CostEntryInternal};
 use super::parsing::{
-    abs_decimal, direction_field, fmt_decimal, min_decimal, nested_record, number_text_field,
+    direction_field, fmt_decimal, nested_record, number_text_field,
     optional_persisted_decimal_field, parse_internal_decimal, persisted_decimal_field, text_field,
 };
 use super::query::PnlError;
@@ -25,30 +25,54 @@ fn lot_side_to_direction(side: LotSide) -> Direction {
     }
 }
 
-fn add_venue_notional(summary: &mut SummaryAcc, venue: Venue, notional: &Num) {
+// `#[track_caller]`: called from both the FIFO replay path
+// (`match_fill_against_lots`) and the window/total aggregation path
+// (`summary_from_entries`). Without it, a `FloatError` converted by the `?`
+// below always reports this function's own line, so a failure in one stage
+// is indistinguishable from a failure in the other; with it, the location
+// captured by `PnlError::Arithmetic` (see query.rs's `ArithmeticFailure`)
+// forwards to whichever call site invoked this helper.
+#[track_caller]
+fn add_venue_notional(
+    summary: &mut SummaryAcc,
+    venue: Venue,
+    notional: Float,
+) -> Result<(), PnlError> {
     match venue {
-        Venue::Onchain => summary.onchain_notional_usd += notional,
-        Venue::Offchain => summary.offchain_notional_usd += notional,
+        Venue::Onchain => summary.onchain_notional_usd = (summary.onchain_notional_usd + notional)?,
+        Venue::Offchain => {
+            summary.offchain_notional_usd = (summary.offchain_notional_usd + notional)?;
+        }
         Venue::Manual => {}
     }
+
+    Ok(())
 }
 
-fn add_realized_pnl(summary: &mut SummaryAcc, bucket: PnlBucket, value: &Num) {
+// Same multi-caller reasoning as `add_venue_notional` above: shared by the
+// FIFO replay path and the window/total aggregation path.
+#[track_caller]
+fn add_realized_pnl(
+    summary: &mut SummaryAcc,
+    bucket: PnlBucket,
+    value: Float,
+) -> Result<(), PnlError> {
     match bucket {
         PnlBucket::CounterTrade => {
-            summary.counter_trade_pnl_usd += value;
-            summary.realized_pnl_usd += value;
+            summary.counter_trade_pnl_usd = (summary.counter_trade_pnl_usd + value)?;
         }
         PnlBucket::OnchainNetting => {
-            summary.onchain_netting_pnl_usd += value;
-            summary.realized_pnl_usd += value;
+            summary.onchain_netting_pnl_usd = (summary.onchain_netting_pnl_usd + value)?;
         }
         PnlBucket::DirectionalExposure => {
-            summary.directional_imbalance_excess_pnl_usd += value;
-            summary.directional_exposure_pnl_usd += value;
-            summary.realized_pnl_usd += value;
+            summary.directional_imbalance_excess_pnl_usd =
+                (summary.directional_imbalance_excess_pnl_usd + value)?;
+            summary.directional_exposure_pnl_usd = (summary.directional_exposure_pnl_usd + value)?;
         }
     }
+    summary.realized_pnl_usd = (summary.realized_pnl_usd + value)?;
+
+    Ok(())
 }
 
 fn malformed_position_payload(row: &PositionEventRow, reason: &'static str) -> PnlError {
@@ -62,10 +86,10 @@ fn malformed_position_payload(row: &PositionEventRow, reason: &'static str) -> P
 
 fn ensure_positive_fill_decimal(
     row: &PositionEventRow,
-    value: &Num,
+    value: &Float,
     reason: &'static str,
 ) -> Result<(), PnlError> {
-    if value.is_zero() || value.is_negative() {
+    if value.is_zero()? || value.lt(float!(0))? {
         return Err(malformed_position_payload(row, reason));
     }
 
@@ -196,12 +220,12 @@ pub(crate) fn apply_manual_position_adjustment(
     book.original_onchain_shares.clear();
     book.matched_onchain_shares.clear();
 
-    if target_net.is_zero() {
+    if target_net.is_zero()? {
         return Ok(());
     }
 
     let event_price = optional_persisted_decimal_field(row, adjusted, "price_usdc")?;
-    let price = event_price.clone().or_else(|| book.last_price_usdc.clone());
+    let price = event_price.or(book.last_price_usdc);
     let Some(price) = price else {
         return Err(malformed_position_payload(
             row,
@@ -212,7 +236,7 @@ pub(crate) fn apply_manual_position_adjustment(
         book.last_price_usdc = Some(event_price);
     }
 
-    let side = if target_net.is_negative() {
+    let side = if target_net.lt(float!(0))? {
         LotSide::Short
     } else {
         LotSide::Long
@@ -220,7 +244,7 @@ pub(crate) fn apply_manual_position_adjustment(
     let lot = Lot {
         trade_id: format!("manual-position-adjustment:{}", row.rowid),
         side,
-        remaining_shares: abs_decimal(&target_net),
+        remaining_shares: target_net.abs()?,
         price,
         opened_at: adjusted_at,
         opened_rowid: row.rowid,
@@ -250,7 +274,7 @@ fn parse_offchain_placement_id(
     order_id
 }
 
-fn open_residual_lot(book: &mut SymbolBook, fill: &Fill, remaining: Num) {
+fn open_residual_lot(book: &mut SymbolBook, fill: &Fill, remaining: Float) {
     let side = if fill.direction == Direction::Buy {
         LotSide::Long
     } else {
@@ -260,7 +284,7 @@ fn open_residual_lot(book: &mut SymbolBook, fill: &Fill, remaining: Num) {
         trade_id: fill.id.clone(),
         side,
         remaining_shares: remaining,
-        price: fill.price.clone(),
+        price: fill.price,
         opened_at: fill.executed_at.clone(),
         opened_rowid: fill.rowid,
         opened_venue: fill.venue,
@@ -277,17 +301,17 @@ pub(crate) fn apply_onchain_fill(
     fill: &Fill,
     entries: &mut Vec<PnlEntry>,
     warnings: &mut Vec<String>,
-) {
+) -> Result<(), PnlError> {
     if book.seen_onchain_fill_ids.contains(&fill.id) {
         warnings.push(format!(
             "PnL audit error: duplicate onchain trade_id {} for {} was skipped",
             fill.id, fill.symbol
         ));
-        return;
+        return Ok(());
     }
 
     book.seen_onchain_fill_ids.insert(fill.id.clone());
-    book.last_price_usdc = Some(fill.price.clone());
+    book.last_price_usdc = Some(fill.price);
     book.summary.onchain_fill_count += 1;
     let source_lots = if fill.direction == Direction::Buy {
         &mut book.short_lots
@@ -301,17 +325,19 @@ pub(crate) fn apply_onchain_fill(
         &mut book.matched_onchain_shares,
         entries,
         PnlBucket::OnchainNetting,
-    );
-    if remaining.is_zero() {
-        return;
+    )?;
+    if remaining.is_zero()? {
+        return Ok(());
     }
 
     let original = book
         .original_onchain_shares
         .entry(fill.id.clone())
-        .or_default();
-    *original += &remaining;
+        .or_insert(float!(0));
+    *original = (*original + remaining)?;
     open_residual_lot(book, fill, remaining);
+
+    Ok(())
 }
 
 pub(crate) fn apply_offchain_placement(
@@ -340,13 +366,13 @@ pub(crate) fn apply_offchain_fill(
     entries: &mut Vec<PnlEntry>,
     warnings: &mut Vec<String>,
     unmatched_offchain_allocations: &mut Vec<UnmatchedOffchainAllocation>,
-) {
+) -> Result<(), PnlError> {
     if book.seen_offchain_fill_ids.contains(&fill.id) {
         warnings.push(format!(
             "PnL audit error: duplicate offchain fill {} for {} was skipped",
             fill.id, fill.symbol
         ));
-        return;
+        return Ok(());
     }
 
     book.seen_offchain_fill_ids.insert(fill.id.clone());
@@ -363,34 +389,36 @@ pub(crate) fn apply_offchain_fill(
         &mut book.matched_onchain_shares,
         entries,
         PnlBucket::CounterTrade,
-    );
+    )?;
 
-    if !remaining.is_zero() {
+    if !remaining.is_zero()? {
         unmatched_offchain_allocations.push(UnmatchedOffchainAllocation {
             symbol: fill.symbol.clone(),
             fill_id: fill.id.clone(),
-            shares: remaining.clone(),
+            shares: remaining,
         });
         open_residual_lot(book, fill, remaining);
     }
+
+    Ok(())
 }
 
 fn match_fill_against_lots(
     fill: &Fill,
     source_lots: &mut VecDeque<Lot>,
     summary: &mut SummaryAcc,
-    matched_onchain_shares: &mut HashMap<String, Num>,
+    matched_onchain_shares: &mut HashMap<String, Float>,
     entries: &mut Vec<PnlEntry>,
     bucket: PnlBucket,
-) -> Num {
-    let mut remaining = fill.shares.clone();
+) -> Result<Float, PnlError> {
+    let mut remaining = fill.shares;
 
-    while !remaining.is_zero() {
+    while !remaining.is_zero()? {
         let Some(mut front_lot) = source_lots.pop_front() else {
             break;
         };
-        let matched_shares = min_decimal(&remaining, &front_lot.remaining_shares);
-        if matched_shares.is_zero() {
+        let matched_shares = remaining.min(front_lot.remaining_shares)?;
+        if matched_shares.is_zero()? {
             continue;
         }
 
@@ -408,36 +436,36 @@ fn match_fill_against_lots(
         };
 
         let spread = if front_lot.side == LotSide::Long {
-            &fill.price - &front_lot.price
+            (fill.price - front_lot.price)?
         } else {
-            &front_lot.price - &fill.price
+            (front_lot.price - fill.price)?
         };
-        let realized_pnl = &matched_shares * &spread;
-        let opening_notional = &matched_shares * &front_lot.price;
-        let closing_notional = &matched_shares * &fill.price;
+        let realized_pnl = (matched_shares * spread)?;
+        let opening_notional = (matched_shares * front_lot.price)?;
+        let closing_notional = (matched_shares * fill.price)?;
 
-        front_lot.remaining_shares -= &matched_shares;
-        if !front_lot.remaining_shares.is_zero() {
+        front_lot.remaining_shares = (front_lot.remaining_shares - matched_shares)?;
+        if !front_lot.remaining_shares.is_zero()? {
             source_lots.push_front(front_lot.clone());
         }
 
-        add_realized_pnl(summary, effective_bucket, &realized_pnl);
-        summary.matched_shares += &matched_shares;
-        add_venue_notional(summary, front_lot.opened_venue, &opening_notional);
-        add_venue_notional(summary, fill.venue, &closing_notional);
+        add_realized_pnl(summary, effective_bucket, realized_pnl)?;
+        summary.matched_shares = (summary.matched_shares + matched_shares)?;
+        add_venue_notional(summary, front_lot.opened_venue, opening_notional)?;
+        add_venue_notional(summary, fill.venue, closing_notional)?;
         summary.matched_lot_count += 1;
 
         if front_lot.opened_venue == Venue::Onchain {
             let matched = matched_onchain_shares
                 .entry(front_lot.trade_id.clone())
-                .or_default();
-            *matched += &matched_shares;
+                .or_insert(float!(0));
+            *matched = (*matched + matched_shares)?;
         }
 
         let opening_direction = lot_side_to_direction(front_lot.side);
         let closing_direction = fill.direction;
-        let opening_price_text = fmt_decimal(&front_lot.price);
-        let closing_price_text = fmt_decimal(&fill.price);
+        let opening_price_text = fmt_decimal(front_lot.price)?;
+        let closing_price_text = fmt_decimal(fill.price)?;
         let onchain_direction = text_for_venue(
             Venue::Onchain,
             &front_lot,
@@ -495,13 +523,13 @@ fn match_fill_against_lots(
             closing_venue: fill.venue,
             opening_direction,
             closing_direction,
-            opening_price_usd: front_lot.price.clone(),
-            closing_price_usd: fill.price.clone(),
+            opening_price_usd: front_lot.price,
+            closing_price_usd: fill.price,
             onchain_trade_id,
             offchain_order_id,
             onchain_direction,
             offchain_direction,
-            shares: matched_shares.clone(),
+            shares: matched_shares,
             onchain_price_usdc: onchain_price_text,
             offchain_price_usd: offchain_price_text,
             spread_usd: spread,
@@ -512,10 +540,10 @@ fn match_fill_against_lots(
             attribution_method: ATTRIBUTION_METHOD,
         });
 
-        remaining -= &matched_shares;
+        remaining = (remaining - matched_shares)?;
     }
 
-    remaining
+    Ok(remaining)
 }
 
 fn text_for_venue(
@@ -534,149 +562,173 @@ fn text_for_venue(
     }
 }
 
-fn finalize_lots(summary: &mut SummaryAcc, lots: &VecDeque<Lot>) {
+fn finalize_lots(summary: &mut SummaryAcc, lots: &VecDeque<Lot>) -> Result<(), PnlError> {
     for lot in lots {
-        let notional = &lot.remaining_shares * &lot.price;
+        let notional = (lot.remaining_shares * lot.price)?;
         match lot.side {
             LotSide::Long => {
-                summary.open_long_shares += &lot.remaining_shares;
-                summary.open_long_notional_usd += &notional;
+                summary.open_long_shares = (summary.open_long_shares + lot.remaining_shares)?;
+                summary.open_long_notional_usd = (summary.open_long_notional_usd + notional)?;
                 if lot.opened_venue == Venue::Offchain {
-                    summary.unmatched_offchain_buy_shares += &lot.remaining_shares;
-                    summary.unmatched_offchain_buy_notional_usd += &notional;
+                    summary.unmatched_offchain_buy_shares =
+                        (summary.unmatched_offchain_buy_shares + lot.remaining_shares)?;
+                    summary.unmatched_offchain_buy_notional_usd =
+                        (summary.unmatched_offchain_buy_notional_usd + notional)?;
                     summary.unmatched_offchain_fill_count += 1;
                 }
             }
             LotSide::Short => {
-                summary.open_short_shares += &lot.remaining_shares;
-                summary.open_short_notional_usd += &notional;
+                summary.open_short_shares = (summary.open_short_shares + lot.remaining_shares)?;
+                summary.open_short_notional_usd = (summary.open_short_notional_usd + notional)?;
                 if lot.opened_venue == Venue::Offchain {
-                    summary.unmatched_offchain_sell_shares += &lot.remaining_shares;
-                    summary.unmatched_offchain_sell_notional_usd += &notional;
+                    summary.unmatched_offchain_sell_shares =
+                        (summary.unmatched_offchain_sell_shares + lot.remaining_shares)?;
+                    summary.unmatched_offchain_sell_notional_usd =
+                        (summary.unmatched_offchain_sell_notional_usd + notional)?;
                     summary.unmatched_offchain_fill_count += 1;
                 }
             }
         }
         summary.open_lot_count += 1;
     }
+
+    Ok(())
 }
 
 pub(crate) fn finalize_book(
     symbol: &Symbol,
     book: &mut SymbolBook,
-    position_nets: &HashMap<Symbol, Num>,
+    position_nets: &HashMap<Symbol, Float>,
     warnings: &mut Vec<String>,
     position_replay_deltas: &mut Vec<PositionReplayDelta>,
-) {
-    finalize_lots(&mut book.summary, &book.long_lots);
-    finalize_lots(&mut book.summary, &book.short_lots);
+) -> Result<(), PnlError> {
+    finalize_lots(&mut book.summary, &book.long_lots)?;
+    finalize_lots(&mut book.summary, &book.short_lots)?;
 
-    let epsilon = match Num::from_str(EPSILON) {
-        Ok(value) => value,
-        Err(error) => panic!("EPSILON must be a valid decimal: {error}"),
-    };
     for (trade_id, matched_shares) in &book.matched_onchain_shares {
         if let Some(original_shares) = book.original_onchain_shares.get(trade_id) {
-            let excess = matched_shares - original_shares;
-            if excess > epsilon {
+            let excess = (*matched_shares - *original_shares)?;
+            if excess.gt(EPSILON)? {
                 warnings.push(format!(
                     "PnL audit error: onchain lot {} for {} matched {} shares above original {}",
                     trade_id,
                     symbol,
-                    fmt_decimal(matched_shares),
-                    fmt_decimal(original_shares)
+                    fmt_decimal(*matched_shares)?,
+                    fmt_decimal(*original_shares)?
                 ));
             }
         }
     }
 
     if let Some(position_net) = position_nets.get(symbol) {
-        let replay_net = &book.summary.open_long_shares - &book.summary.open_short_shares;
-        let delta = &replay_net - position_net;
-        if abs_decimal(&delta) > epsilon {
+        let replay_net = (book.summary.open_long_shares - book.summary.open_short_shares)?;
+        let delta = (replay_net - *position_net)?;
+        if delta.abs()?.gt(EPSILON)? {
             position_replay_deltas.push(PositionReplayDelta {
                 symbol: symbol.to_owned(),
                 replay_net,
-                position_net: position_net.clone(),
+                position_net: *position_net,
             });
         }
     }
+
+    Ok(())
 }
 
-pub(crate) fn add_summary(target: &mut SummaryAcc, source: &SummaryAcc) {
-    target.counter_trade_pnl_usd += &source.counter_trade_pnl_usd;
-    target.onchain_netting_pnl_usd += &source.onchain_netting_pnl_usd;
-    target.directional_inventory_baseline_pnl_usd += &source.directional_inventory_baseline_pnl_usd;
-    target.directional_imbalance_excess_pnl_usd += &source.directional_imbalance_excess_pnl_usd;
-    target.directional_exposure_pnl_usd += &source.directional_exposure_pnl_usd;
-    target.realized_pnl_usd += &source.realized_pnl_usd;
-    target.matched_shares += &source.matched_shares;
-    target.onchain_notional_usd += &source.onchain_notional_usd;
-    target.offchain_notional_usd += &source.offchain_notional_usd;
-    target.open_long_shares += &source.open_long_shares;
-    target.open_short_shares += &source.open_short_shares;
-    target.open_long_notional_usd += &source.open_long_notional_usd;
-    target.open_short_notional_usd += &source.open_short_notional_usd;
-    target.unmatched_offchain_buy_shares += &source.unmatched_offchain_buy_shares;
-    target.unmatched_offchain_sell_shares += &source.unmatched_offchain_sell_shares;
-    target.unmatched_offchain_buy_notional_usd += &source.unmatched_offchain_buy_notional_usd;
-    target.unmatched_offchain_sell_notional_usd += &source.unmatched_offchain_sell_notional_usd;
+// Same multi-caller reasoning as `add_venue_notional` above: shared by the
+// grand-total accumulation in `builder.rs` and the per-symbol aggregation in
+// `summary_from_entries` below.
+#[track_caller]
+pub(crate) fn add_summary(target: &mut SummaryAcc, source: &SummaryAcc) -> Result<(), PnlError> {
+    target.counter_trade_pnl_usd = (target.counter_trade_pnl_usd + source.counter_trade_pnl_usd)?;
+    target.onchain_netting_pnl_usd =
+        (target.onchain_netting_pnl_usd + source.onchain_netting_pnl_usd)?;
+    target.directional_inventory_baseline_pnl_usd = (target
+        .directional_inventory_baseline_pnl_usd
+        + source.directional_inventory_baseline_pnl_usd)?;
+    target.directional_imbalance_excess_pnl_usd = (target.directional_imbalance_excess_pnl_usd
+        + source.directional_imbalance_excess_pnl_usd)?;
+    target.directional_exposure_pnl_usd =
+        (target.directional_exposure_pnl_usd + source.directional_exposure_pnl_usd)?;
+    target.realized_pnl_usd = (target.realized_pnl_usd + source.realized_pnl_usd)?;
+    target.matched_shares = (target.matched_shares + source.matched_shares)?;
+    target.onchain_notional_usd = (target.onchain_notional_usd + source.onchain_notional_usd)?;
+    target.offchain_notional_usd = (target.offchain_notional_usd + source.offchain_notional_usd)?;
+    target.open_long_shares = (target.open_long_shares + source.open_long_shares)?;
+    target.open_short_shares = (target.open_short_shares + source.open_short_shares)?;
+    target.open_long_notional_usd =
+        (target.open_long_notional_usd + source.open_long_notional_usd)?;
+    target.open_short_notional_usd =
+        (target.open_short_notional_usd + source.open_short_notional_usd)?;
+    target.unmatched_offchain_buy_shares =
+        (target.unmatched_offchain_buy_shares + source.unmatched_offchain_buy_shares)?;
+    target.unmatched_offchain_sell_shares =
+        (target.unmatched_offchain_sell_shares + source.unmatched_offchain_sell_shares)?;
+    target.unmatched_offchain_buy_notional_usd =
+        (target.unmatched_offchain_buy_notional_usd + source.unmatched_offchain_buy_notional_usd)?;
+    target.unmatched_offchain_sell_notional_usd = (target.unmatched_offchain_sell_notional_usd
+        + source.unmatched_offchain_sell_notional_usd)?;
     target.onchain_fill_count += source.onchain_fill_count;
     target.offchain_fill_count += source.offchain_fill_count;
     target.matched_lot_count += source.matched_lot_count;
     target.open_lot_count += source.open_lot_count;
     target.unmatched_offchain_fill_count += source.unmatched_offchain_fill_count;
+
+    Ok(())
 }
 
-pub(crate) fn summary_to_dto(summary: &SummaryAcc) -> PnlSummary {
-    let directional_exposure_pnl = &summary.directional_inventory_baseline_pnl_usd
-        + &summary.directional_imbalance_excess_pnl_usd;
-    let total_pnl = &(&(&summary.counter_trade_pnl_usd + &summary.onchain_netting_pnl_usd)
-        + &summary.directional_inventory_baseline_pnl_usd)
-        + &summary.directional_imbalance_excess_pnl_usd;
-    let inventory_drift_shares = &summary.open_long_shares - &summary.open_short_shares;
-    let inventory_drift_usd = &summary.open_long_notional_usd - &summary.open_short_notional_usd;
+pub(crate) fn summary_to_dto(summary: &SummaryAcc) -> Result<PnlSummary, PnlError> {
+    let directional_exposure_pnl = (summary.directional_inventory_baseline_pnl_usd
+        + summary.directional_imbalance_excess_pnl_usd)?;
+    let total_pnl = (((summary.counter_trade_pnl_usd + summary.onchain_netting_pnl_usd)?
+        + summary.directional_inventory_baseline_pnl_usd)?
+        + summary.directional_imbalance_excess_pnl_usd)?;
+    let inventory_drift_shares = (summary.open_long_shares - summary.open_short_shares)?;
+    let inventory_drift_usd = (summary.open_long_notional_usd - summary.open_short_notional_usd)?;
     let unmatched_offchain_shares =
-        &summary.unmatched_offchain_buy_shares + &summary.unmatched_offchain_sell_shares;
-    let unmatched_offchain_notional = &summary.unmatched_offchain_buy_notional_usd
-        + &summary.unmatched_offchain_sell_notional_usd;
+        (summary.unmatched_offchain_buy_shares + summary.unmatched_offchain_sell_shares)?;
+    let unmatched_offchain_notional = (summary.unmatched_offchain_buy_notional_usd
+        + summary.unmatched_offchain_sell_notional_usd)?;
 
-    PnlSummary {
-        counter_trade_pnl_usd: fmt_decimal(&summary.counter_trade_pnl_usd),
-        onchain_netting_pnl_usd: fmt_decimal(&summary.onchain_netting_pnl_usd),
+    Ok(PnlSummary {
+        counter_trade_pnl_usd: fmt_decimal(summary.counter_trade_pnl_usd)?,
+        onchain_netting_pnl_usd: fmt_decimal(summary.onchain_netting_pnl_usd)?,
         directional_inventory_baseline_pnl_usd: fmt_decimal(
-            &summary.directional_inventory_baseline_pnl_usd,
-        ),
+            summary.directional_inventory_baseline_pnl_usd,
+        )?,
         directional_imbalance_excess_pnl_usd: fmt_decimal(
-            &summary.directional_imbalance_excess_pnl_usd,
-        ),
-        directional_exposure_pnl_usd: fmt_decimal(&directional_exposure_pnl),
-        total_pnl_usd: fmt_decimal(&total_pnl),
-        gross_realized_pnl_usd: fmt_decimal(&total_pnl),
+            summary.directional_imbalance_excess_pnl_usd,
+        )?,
+        directional_exposure_pnl_usd: fmt_decimal(directional_exposure_pnl)?,
+        total_pnl_usd: fmt_decimal(total_pnl)?,
+        gross_realized_pnl_usd: fmt_decimal(total_pnl)?,
         tracked_costs_usd: "0".to_owned(),
         tracked_revenue_usd: "0".to_owned(),
-        net_realized_pnl_usd: fmt_decimal(&total_pnl),
-        realized_pnl_usd: fmt_decimal(&summary.realized_pnl_usd),
-        matched_shares: fmt_decimal(&summary.matched_shares),
-        onchain_notional_usd: fmt_decimal(&summary.onchain_notional_usd),
-        offchain_notional_usd: fmt_decimal(&summary.offchain_notional_usd),
-        inventory_drift_shares: fmt_decimal(&inventory_drift_shares),
-        inventory_drift_usd: fmt_decimal(&inventory_drift_usd),
-        open_long_shares: fmt_decimal(&summary.open_long_shares),
-        open_short_shares: fmt_decimal(&summary.open_short_shares),
-        unmatched_offchain_shares: fmt_decimal(&unmatched_offchain_shares),
-        unmatched_offchain_notional_usd: fmt_decimal(&unmatched_offchain_notional),
+        net_realized_pnl_usd: fmt_decimal(total_pnl)?,
+        realized_pnl_usd: fmt_decimal(summary.realized_pnl_usd)?,
+        matched_shares: fmt_decimal(summary.matched_shares)?,
+        onchain_notional_usd: fmt_decimal(summary.onchain_notional_usd)?,
+        offchain_notional_usd: fmt_decimal(summary.offchain_notional_usd)?,
+        inventory_drift_shares: fmt_decimal(inventory_drift_shares)?,
+        inventory_drift_usd: fmt_decimal(inventory_drift_usd)?,
+        open_long_shares: fmt_decimal(summary.open_long_shares)?,
+        open_short_shares: fmt_decimal(summary.open_short_shares)?,
+        unmatched_offchain_shares: fmt_decimal(unmatched_offchain_shares)?,
+        unmatched_offchain_notional_usd: fmt_decimal(unmatched_offchain_notional)?,
         onchain_fill_count: summary.onchain_fill_count,
         offchain_fill_count: summary.offchain_fill_count,
         matched_lot_count: summary.matched_lot_count,
         open_lot_count: summary.open_lot_count,
         unmatched_offchain_fill_count: summary.unmatched_offchain_fill_count,
-    }
+    })
 }
 
-pub(crate) fn symbol_summary_to_dto(symbol: &Symbol, summary: &SummaryAcc) -> PnlSymbolSummary {
-    let dto = summary_to_dto(summary);
-    PnlSymbolSummary {
+pub(crate) fn symbol_summary_to_dto(
+    symbol: &Symbol,
+    summary: &SummaryAcc,
+) -> Result<PnlSymbolSummary, PnlError> {
+    let dto = summary_to_dto(summary)?;
+    Ok(PnlSymbolSummary {
         symbol: symbol.clone(),
         counter_trade_pnl_usd: dto.counter_trade_pnl_usd,
         onchain_netting_pnl_usd: dto.onchain_netting_pnl_usd,
@@ -699,7 +751,7 @@ pub(crate) fn symbol_summary_to_dto(symbol: &Symbol, summary: &SummaryAcc) -> Pn
         onchain_fill_count: dto.onchain_fill_count,
         offchain_fill_count: dto.offchain_fill_count,
         unmatched_offchain_fill_count: dto.unmatched_offchain_fill_count,
-    }
+    })
 }
 
 pub(crate) fn with_replay_exposure(filtered: PnlSummary, replay: PnlSummary) -> PnlSummary {
@@ -731,48 +783,48 @@ fn with_symbol_replay_exposure(
     }
 }
 
-fn empty_symbol_summary(symbol: &Symbol) -> PnlSymbolSummary {
+fn empty_symbol_summary(symbol: &Symbol) -> Result<PnlSymbolSummary, PnlError> {
     symbol_summary_to_dto(symbol, &SummaryAcc::default())
 }
 
-fn is_nonzero_text(value: &str) -> bool {
-    Num::from_str(value).is_ok_and(|parsed| !parsed.is_zero())
-}
+fn has_replay_exposure(summary: &SummaryAcc) -> Result<bool, PnlError> {
+    let inventory_drift_shares = (summary.open_long_shares - summary.open_short_shares)?;
+    let inventory_drift_usd = (summary.open_long_notional_usd - summary.open_short_notional_usd)?;
+    let unmatched_offchain_shares =
+        (summary.unmatched_offchain_buy_shares + summary.unmatched_offchain_sell_shares)?;
 
-fn has_replay_exposure(summary: &PnlSymbolSummary) -> bool {
-    is_nonzero_text(&summary.inventory_drift_shares)
-        || is_nonzero_text(&summary.inventory_drift_usd)
-        || is_nonzero_text(&summary.open_long_shares)
-        || is_nonzero_text(&summary.open_short_shares)
-        || is_nonzero_text(&summary.unmatched_offchain_shares)
-        || summary.unmatched_offchain_fill_count > 0
+    Ok(!inventory_drift_shares.is_zero()?
+        || !inventory_drift_usd.is_zero()?
+        || !summary.open_long_shares.is_zero()?
+        || !summary.open_short_shares.is_zero()?
+        || !unmatched_offchain_shares.is_zero()?
+        || summary.unmatched_offchain_fill_count > 0)
 }
 
 pub(crate) fn merge_symbol_replay_exposure(
     filtered_symbols: Vec<PnlSymbolSummary>,
-    replay_symbols: impl Iterator<Item = PnlSymbolSummary>,
-) -> Vec<PnlSymbolSummary> {
+    replay_symbols: impl Iterator<Item = (Symbol, SummaryAcc)>,
+) -> Result<Vec<PnlSymbolSummary>, PnlError> {
     let mut by_symbol: HashMap<Symbol, PnlSymbolSummary> = filtered_symbols
         .into_iter()
         .map(|row| (row.symbol.clone(), row))
         .collect();
 
-    for replay in replay_symbols {
-        let existing = by_symbol.remove(&replay.symbol);
-        if existing.is_some() || has_replay_exposure(&replay) {
-            by_symbol.insert(
-                replay.symbol.clone(),
-                with_symbol_replay_exposure(
-                    existing.unwrap_or_else(|| empty_symbol_summary(&replay.symbol)),
-                    replay,
-                ),
-            );
+    for (symbol, replay) in replay_symbols {
+        let existing = by_symbol.remove(&symbol);
+        if existing.is_some() || has_replay_exposure(&replay)? {
+            let base = match existing {
+                Some(existing) => existing,
+                None => empty_symbol_summary(&symbol)?,
+            };
+            let replay = symbol_summary_to_dto(&symbol, &replay)?;
+            by_symbol.insert(symbol, with_symbol_replay_exposure(base, replay));
         }
     }
 
     let mut rows: Vec<_> = by_symbol.into_values().collect();
     rows.sort_by(|left, right| left.symbol.cmp(&right.symbol));
-    rows
+    Ok(rows)
 }
 
 pub(crate) fn reset_symbol_costs(symbols: Vec<PnlSymbolSummary>) -> Vec<PnlSymbolSummary> {
@@ -792,20 +844,29 @@ pub(crate) fn with_direct_symbol_costs(
     symbols: Vec<PnlSymbolSummary>,
     cost_entries: &[CostEntryInternal],
 ) -> Result<Vec<PnlSymbolSummary>, PnlError> {
-    let mut costs_by_symbol: HashMap<Symbol, Num> = HashMap::new();
-    let mut revenue_by_symbol: HashMap<Symbol, Num> = HashMap::new();
+    let mut amounts_by_symbol: HashMap<Symbol, (Float, Float)> = HashMap::new();
     for entry in cost_entries {
         let Some(symbol) = &entry.symbol else {
             continue;
         };
-        if entry.effect == AccountingEffect::Revenue {
-            *revenue_by_symbol.entry(symbol.clone()).or_default() += &entry.amount_usd;
-        } else if entry.effect == AccountingEffect::Cost {
-            *costs_by_symbol.entry(symbol.clone()).or_default() += &entry.amount_usd;
+        match entry.effect {
+            AccountingEffect::Revenue => {
+                let amounts = amounts_by_symbol
+                    .entry(symbol.clone())
+                    .or_insert((float!(0), float!(0)));
+                amounts.1 = (amounts.1 + entry.amount_usd.inner())?;
+            }
+            AccountingEffect::Cost => {
+                let amounts = amounts_by_symbol
+                    .entry(symbol.clone())
+                    .or_insert((float!(0), float!(0)));
+                amounts.0 = (amounts.0 + entry.amount_usd.inner())?;
+            }
+            AccountingEffect::None => {}
         }
     }
 
-    if costs_by_symbol.is_empty() && revenue_by_symbol.is_empty() {
+    if amounts_by_symbol.is_empty() {
         return Ok(symbols);
     }
 
@@ -813,24 +874,20 @@ pub(crate) fn with_direct_symbol_costs(
         .into_iter()
         .map(|row| (row.symbol.clone(), row))
         .collect();
-    let mut affected_symbols: BTreeSet<Symbol> = costs_by_symbol.keys().cloned().collect();
-    affected_symbols.extend(revenue_by_symbol.keys().cloned());
-
-    for symbol in affected_symbols {
-        let existing = by_symbol
-            .remove(&symbol)
-            .unwrap_or_else(|| empty_symbol_summary(&symbol));
+    for (symbol, (cost, revenue)) in amounts_by_symbol {
+        let existing = match by_symbol.remove(&symbol) {
+            Some(existing) => existing,
+            None => empty_symbol_summary(&symbol)?,
+        };
         let gross = parse_internal_decimal("symbol.totalPnlUsd", &existing.total_pnl_usd)?;
-        let cost = costs_by_symbol.remove(&symbol).unwrap_or_default();
-        let revenue = revenue_by_symbol.remove(&symbol).unwrap_or_default();
-        let net = &(&gross - &cost) + &revenue;
+        let net = ((gross - cost)? + revenue)?;
         by_symbol.insert(
             symbol.clone(),
             PnlSymbolSummary {
-                gross_realized_pnl_usd: fmt_decimal(&gross),
-                tracked_costs_usd: fmt_decimal(&cost),
-                tracked_revenue_usd: fmt_decimal(&revenue),
-                net_realized_pnl_usd: fmt_decimal(&net),
+                gross_realized_pnl_usd: fmt_decimal(gross)?,
+                tracked_costs_usd: fmt_decimal(cost)?,
+                tracked_revenue_usd: fmt_decimal(revenue)?,
+                net_realized_pnl_usd: fmt_decimal(net)?,
                 ..existing
             },
         );
@@ -841,45 +898,31 @@ pub(crate) fn with_direct_symbol_costs(
     Ok(rows)
 }
 
-pub(crate) fn summary_from_entries(entries: &[PnlEntry]) -> SummaryAndSymbols {
+pub(crate) fn summary_from_entries(entries: &[PnlEntry]) -> Result<SummaryAndSymbols, PnlError> {
     let mut total = SummaryAcc::default();
     let mut per_symbol: HashMap<Symbol, SummaryAcc> = HashMap::new();
 
     for entry in entries {
         let summary = per_symbol.entry(entry.symbol.clone()).or_default();
-        let shares = entry.shares.clone();
-        let opening_notional = &shares * &entry.opening_price_usd;
-        let closing_notional = &shares * &entry.closing_price_usd;
-        let pnl = entry.realized_pnl_usd.clone();
+        let shares = entry.shares;
+        let opening_notional = (shares * entry.opening_price_usd)?;
+        let closing_notional = (shares * entry.closing_price_usd)?;
+        let pnl = entry.realized_pnl_usd;
 
-        summary.matched_shares += &shares;
+        summary.matched_shares = (summary.matched_shares + shares)?;
         if entry.opening_venue == Venue::Onchain {
-            add_venue_notional(summary, Venue::Onchain, &opening_notional);
+            add_venue_notional(summary, Venue::Onchain, opening_notional)?;
         } else if entry.opening_venue == Venue::Offchain {
-            add_venue_notional(summary, Venue::Offchain, &opening_notional);
+            add_venue_notional(summary, Venue::Offchain, opening_notional)?;
         }
         if entry.closing_venue == Venue::Onchain {
-            add_venue_notional(summary, Venue::Onchain, &closing_notional);
+            add_venue_notional(summary, Venue::Onchain, closing_notional)?;
         } else if entry.closing_venue == Venue::Offchain {
-            add_venue_notional(summary, Venue::Offchain, &closing_notional);
+            add_venue_notional(summary, Venue::Offchain, closing_notional)?;
         }
         summary.matched_lot_count += 1;
 
-        match entry.pnl_bucket {
-            PnlBucket::CounterTrade => {
-                summary.counter_trade_pnl_usd += &pnl;
-                summary.realized_pnl_usd += &pnl;
-            }
-            PnlBucket::OnchainNetting => {
-                summary.onchain_netting_pnl_usd += &pnl;
-                summary.realized_pnl_usd += &pnl;
-            }
-            PnlBucket::DirectionalExposure => {
-                summary.directional_imbalance_excess_pnl_usd += &pnl;
-                summary.directional_exposure_pnl_usd += &pnl;
-                summary.realized_pnl_usd += &pnl;
-            }
-        }
+        add_realized_pnl(summary, entry.pnl_bucket, pnl)?;
     }
 
     let mut symbols: Vec<_> = per_symbol.into_iter().collect();
@@ -887,13 +930,13 @@ pub(crate) fn summary_from_entries(entries: &[PnlEntry]) -> SummaryAndSymbols {
     let symbols = symbols
         .into_iter()
         .map(|(symbol, summary)| {
-            add_summary(&mut total, &summary);
+            add_summary(&mut total, &summary)?;
             symbol_summary_to_dto(&symbol, &summary)
         })
-        .collect();
+        .collect::<Result<Vec<_>, PnlError>>()?;
 
-    SummaryAndSymbols {
-        summary: summary_to_dto(&total),
+    Ok(SummaryAndSymbols {
+        summary: summary_to_dto(&total)?,
         symbols,
-    }
+    })
 }

--- a/src/dashboard/pnl/response.rs
+++ b/src/dashboard/pnl/response.rs
@@ -1,18 +1,11 @@
 //! Serializable DTOs for the backend PnL report endpoint.
-use num_decimal::Num;
+use rain_math_float::Float;
 use serde::{Serialize, Serializer};
 use st0x_finance::Symbol;
 
 use super::costs::CostEntryInternal;
 use super::parsing::fmt_decimal;
 use super::state::{Direction, PnlBucket, Venue};
-
-fn serialize_decimal<S>(value: &Num, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(&fmt_decimal(value))
-}
 
 #[expect(
     clippy::trivially_copy_pass_by_ref,
@@ -182,22 +175,22 @@ pub(crate) struct PnlEntry {
     pub(crate) opening_direction: Direction,
     #[serde(serialize_with = "serialize_direction")]
     pub(crate) closing_direction: Direction,
-    #[serde(serialize_with = "serialize_decimal")]
-    pub(crate) opening_price_usd: Num,
-    #[serde(serialize_with = "serialize_decimal")]
-    pub(crate) closing_price_usd: Num,
+    #[serde(serialize_with = "st0x_float_serde::serialize_float_as_string")]
+    pub(crate) opening_price_usd: Float,
+    #[serde(serialize_with = "st0x_float_serde::serialize_float_as_string")]
+    pub(crate) closing_price_usd: Float,
     pub(crate) onchain_trade_id: String,
     pub(crate) offchain_order_id: String,
     pub(crate) onchain_direction: String,
     pub(crate) offchain_direction: String,
-    #[serde(serialize_with = "serialize_decimal")]
-    pub(crate) shares: Num,
+    #[serde(serialize_with = "st0x_float_serde::serialize_float_as_string")]
+    pub(crate) shares: Float,
     pub(crate) onchain_price_usdc: String,
     pub(crate) offchain_price_usd: String,
-    #[serde(serialize_with = "serialize_decimal")]
-    pub(crate) spread_usd: Num,
-    #[serde(serialize_with = "serialize_decimal")]
-    pub(crate) realized_pnl_usd: Num,
+    #[serde(serialize_with = "st0x_float_serde::serialize_float_as_string")]
+    pub(crate) spread_usd: Float,
+    #[serde(serialize_with = "st0x_float_serde::serialize_float_as_string")]
+    pub(crate) realized_pnl_usd: Float,
     pub(crate) elapsed_seconds: i64,
     pub(crate) counter_trade_threshold_seconds: i64,
     pub(crate) delayed_counter_trade: bool,
@@ -242,20 +235,22 @@ pub(crate) struct PnlCostEntry {
     pub(crate) detail: String,
 }
 
-impl From<&CostEntryInternal> for PnlCostEntry {
-    fn from(value: &CostEntryInternal) -> Self {
-        Self {
+impl TryFrom<&CostEntryInternal> for PnlCostEntry {
+    type Error = super::query::PnlError;
+
+    fn try_from(value: &CostEntryInternal) -> Result<Self, Self::Error> {
+        Ok(Self {
             category: value.category.as_str(),
             accounting_bucket: value.accounting_bucket.as_str(),
             effect: value.effect.as_str(),
-            amount_usd: fmt_decimal(&value.amount_usd),
+            amount_usd: fmt_decimal(value.amount_usd.inner())?,
             occurred_at: value.occurred_at.clone(),
             aggregate_type: value.aggregate_type.clone(),
             aggregate_id: value.aggregate_id.clone(),
             event_rowid: value.event_rowid,
             symbol: value.symbol.clone(),
             detail: value.detail.clone(),
-        }
+        })
     }
 }
 

--- a/src/dashboard/pnl/samples.rs
+++ b/src/dashboard/pnl/samples.rs
@@ -1,7 +1,6 @@
+use rain_math_float::Float;
 use std::collections::{BTreeSet, HashMap};
-use std::str::FromStr;
 
-use num_decimal::Num;
 use st0x_finance::Symbol;
 
 use super::parsing::{is_safe_symbol, position_event_replay_timestamp};
@@ -13,7 +12,7 @@ use super::state::{PositionEventRow, PositionViewRow, SampleStatsAcc};
 pub(crate) fn parse_position_view(
     rows: &[PositionViewRow],
     warnings: &mut Vec<String>,
-) -> Result<(HashMap<Symbol, Num>, Vec<Symbol>), PnlError> {
+) -> Result<(HashMap<Symbol, Float>, Vec<Symbol>), PnlError> {
     let mut position_nets = HashMap::new();
     let mut symbols = BTreeSet::new();
 
@@ -32,7 +31,7 @@ pub(crate) fn parse_position_view(
 
         symbols.insert(symbol.clone());
         if let Some(net_position) = &row.net_position {
-            match Num::from_str(net_position) {
+            match Float::parse(net_position.clone()) {
                 Ok(value) => {
                     position_nets.insert(symbol, value);
                 }
@@ -43,7 +42,7 @@ pub(crate) fn parse_position_view(
                         event_type: "position_view".to_owned(),
                         field: "net_position",
                         value: net_position.clone(),
-                        source: PnlFinancialFieldError::InvalidDecimal(error),
+                        source: PnlFinancialFieldError::InvalidDecimal(Box::new(error)),
                     });
                 }
             }

--- a/src/dashboard/pnl/source.rs
+++ b/src/dashboard/pnl/source.rs
@@ -4,15 +4,20 @@ use chrono_tz::America::New_York;
 use rain_math_float::Float;
 use sqlx::{QueryBuilder, Sqlite, SqlitePool, Transaction};
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::task;
 
 use st0x_execution::alpaca_broker_api::AccountActivity;
 use st0x_float_serde::format_float;
 
 use crate::bot_gas::BotGasReceiptCostEvent;
-use crate::portfolio_snapshot::{CAPTURE_BUFFER, EtDayRange, capital_summary, load_portfolio_days};
+use crate::portfolio_snapshot::{
+    CAPTURE_BUFFER, EtDayRange, capital_summary, evaluate_portfolio_days, load_portfolio_day_rows,
+};
 
 use super::builder::build_pnl_response_from_rows;
-use super::parsing::{fmt_decimal, parse_payload_string};
+use super::parsing::parse_payload_string;
 use super::query::{PnlError, PnlQuery};
 use super::response::{PnlCapitalSummary, PnlResponse};
 use super::state::{BotGasCostRow, CostEventRow, PositionEventRow, PositionViewRow};
@@ -21,11 +26,75 @@ use super::{
     COST_WARNING, SYMBOL_FILTERED_CAPITAL_WARNING,
 };
 
+pub(crate) const MAX_CONCURRENT_PNL_REPORTS: usize = 2;
+
+#[derive(Clone)]
+pub(crate) struct PnlReportAdmission(Arc<Semaphore>);
+
+impl PnlReportAdmission {
+    fn new() -> Self {
+        Self(Arc::new(Semaphore::new(MAX_CONCURRENT_PNL_REPORTS)))
+    }
+
+    fn try_acquire(&self) -> Result<OwnedSemaphorePermit, tokio::sync::TryAcquireError> {
+        self.0.clone().try_acquire_owned()
+    }
+}
+
+pub(crate) fn pnl_report_admission() -> PnlReportAdmission {
+    PnlReportAdmission::new()
+}
+
+pub(crate) fn acquire_pnl_report_permit(
+    admission: &PnlReportAdmission,
+) -> Result<OwnedSemaphorePermit, PnlError> {
+    Ok(admission.try_acquire()?)
+}
+
+pub(super) async fn run_pnl_replay_with_permit<T, F>(
+    permit: OwnedSemaphorePermit,
+    replay: F,
+) -> Result<(T, OwnedSemaphorePermit), PnlError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, PnlError> + Send + 'static,
+{
+    let (result, permit) = task::spawn_blocking(move || (replay(), permit)).await?;
+
+    Ok((result?, permit))
+}
+
+#[cfg(test)]
+pub(super) async fn run_pnl_replay<T, F>(replay: F) -> Result<T, PnlError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, PnlError> + Send + 'static,
+{
+    let admission = pnl_report_admission();
+    let permit = acquire_pnl_report_permit(&admission)?;
+    run_pnl_replay_with_permit(permit, replay)
+        .await
+        .map(|(result, _permit)| result)
+}
+
+#[cfg(test)]
 pub(crate) async fn build_pnl_report(
     pool: &SqlitePool,
     query: &PnlQuery,
     alpaca_activities: Vec<AccountActivity>,
     now: DateTime<Utc>,
+) -> Result<PnlResponse, PnlError> {
+    let admission = pnl_report_admission();
+    let permit = acquire_pnl_report_permit(&admission)?;
+    build_pnl_report_with_permit(pool, query, alpaca_activities, now, permit).await
+}
+
+pub(crate) async fn build_pnl_report_with_permit(
+    pool: &SqlitePool,
+    query: &PnlQuery,
+    alpaca_activities: Vec<AccountActivity>,
+    now: DateTime<Utc>,
+    permit: OwnedSemaphorePermit,
 ) -> Result<PnlResponse, PnlError> {
     let mut warnings = vec![
         ATTRIBUTION_WARNING.to_owned(),
@@ -46,16 +115,21 @@ pub(crate) async fn build_pnl_report(
     let bot_gas_rows = load_bot_gas_costs(&mut tx, resolved_rowid.resolved).await?;
     tx.commit().await?;
 
-    let (mut response, daily_net_realized_pnl_usd) = build_pnl_response_from_rows(
-        event_rows,
-        &position_rows,
-        &cost_rows,
-        &bot_gas_rows,
-        &alpaca_activities,
-        &effective_query,
-        &symbols,
-        warnings,
-    )?;
+    let replay_symbols = symbols.clone();
+    let ((mut response, daily_net_realized_pnl_usd), permit) =
+        run_pnl_replay_with_permit(permit, move || {
+            build_pnl_response_from_rows(
+                event_rows,
+                &position_rows,
+                &cost_rows,
+                &bot_gas_rows,
+                &alpaca_activities,
+                &effective_query,
+                &replay_symbols,
+                warnings,
+            )
+        })
+        .await?;
 
     apply_capital_summary(
         pool,
@@ -65,6 +139,7 @@ pub(crate) async fn build_pnl_report(
         &daily_net_realized_pnl_usd,
         &mut response,
         now,
+        permit,
     )
     .await?;
 
@@ -86,9 +161,10 @@ async fn apply_capital_summary(
     query: &PnlQuery,
     resolved_rowid: &ResolvedRowid,
     symbols: &BTreeSet<String>,
-    daily_net_realized_pnl_usd: &BTreeMap<NaiveDate, num_decimal::Num>,
+    daily_net_realized_pnl_usd: &BTreeMap<NaiveDate, Float>,
     response: &mut PnlResponse,
     now: DateTime<Utc>,
+    permit: OwnedSemaphorePermit,
 ) -> Result<(), PnlError> {
     if resolved_rowid.resolved != resolved_rowid.max {
         response.warnings.push(format!(
@@ -119,48 +195,50 @@ async fn apply_capital_summary(
         latest_capture_day(now)?,
     )
     .await?;
-    let days = load_portfolio_days(pool, et_day_range).await?;
-    let daily_net_realized_pnl_usd = daily_net_realized_pnl_usd
-        .iter()
-        .map(|(day, pnl)| Ok((*day, Float::parse(fmt_decimal(pnl))?)))
-        .collect::<Result<BTreeMap<_, _>, PnlError>>()?;
-    let capital = capital_summary(&days, &daily_net_realized_pnl_usd)?;
+    let day_rows = load_portfolio_day_rows(pool, et_day_range).await?;
+    let daily_net_realized_pnl_usd = daily_net_realized_pnl_usd.clone();
+    let (((capital_summary, capital_warnings), capital_note), _permit) =
+        run_pnl_replay_with_permit(permit, move || {
+            let days = evaluate_portfolio_days(day_rows)?;
+            let capital = capital_summary(&days, &daily_net_realized_pnl_usd)?;
+            let capital_note = if capital.average_deployed_capital_usd.is_some() {
+                CAPITAL_AVAILABLE_NOTE
+            } else {
+                CAPITAL_UNAVAILABLE_NOTE
+            };
+            let capital_response = PnlCapitalSummary {
+                average_deployed_capital_usd: capital
+                    .average_deployed_capital_usd
+                    .as_ref()
+                    .map(format_float)
+                    .transpose()?,
+                annualized_return_pct: capital
+                    .annualized_return_pct
+                    .as_ref()
+                    .map(format_float)
+                    .transpose()?,
+                coverage_days: capital.coverage_days,
+                sample_days: capital.sample_days,
+                first_snapshot_day: capital.first_snapshot_day.map(|day| day.to_string()),
+                last_snapshot_day: capital.last_snapshot_day.map(|day| day.to_string()),
+                excluded_days: capital
+                    .excluded_days
+                    .into_iter()
+                    .map(|day| super::response::PnlCapitalExcludedDay {
+                        et_day: day.et_day.to_string(),
+                        kind: day.reason.kind(),
+                        reason: day.reason.describe(),
+                    })
+                    .collect(),
+            };
 
-    response.warnings.extend(capital.warnings);
-    response.warnings.push(
-        if capital.average_deployed_capital_usd.is_some() {
-            CAPITAL_AVAILABLE_NOTE
-        } else {
-            CAPITAL_UNAVAILABLE_NOTE
-        }
-        .to_owned(),
-    );
+            Ok(((capital_response, capital.warnings), capital_note))
+        })
+        .await?;
 
-    response.capital = PnlCapitalSummary {
-        average_deployed_capital_usd: capital
-            .average_deployed_capital_usd
-            .as_ref()
-            .map(format_float)
-            .transpose()?,
-        annualized_return_pct: capital
-            .annualized_return_pct
-            .as_ref()
-            .map(format_float)
-            .transpose()?,
-        coverage_days: capital.coverage_days,
-        sample_days: capital.sample_days,
-        first_snapshot_day: capital.first_snapshot_day.map(|day| day.to_string()),
-        last_snapshot_day: capital.last_snapshot_day.map(|day| day.to_string()),
-        excluded_days: capital
-            .excluded_days
-            .into_iter()
-            .map(|day| super::response::PnlCapitalExcludedDay {
-                et_day: day.et_day.to_string(),
-                kind: day.reason.kind(),
-                reason: day.reason.describe(),
-            })
-            .collect(),
-    };
+    response.warnings.extend(capital_warnings);
+    response.warnings.push(capital_note.to_owned());
+    response.capital = capital_summary;
 
     Ok(())
 }
@@ -182,7 +260,7 @@ pub(crate) fn latest_capture_day(now: DateTime<Utc>) -> Result<NaiveDate, PnlErr
 async fn complete_capital_range(
     pool: &SqlitePool,
     mut range: EtDayRange,
-    daily_net_realized_pnl_usd: &BTreeMap<NaiveDate, num_decimal::Num>,
+    daily_net_realized_pnl_usd: &BTreeMap<NaiveDate, Float>,
     report_through: NaiveDate,
 ) -> Result<EtDayRange, PnlError> {
     if range.from.is_none() {
@@ -428,7 +506,7 @@ async fn load_bot_gas_costs(
             rowid,
             chain: cost.chain.to_string(),
             tx_hash: cost.tx_hash.to_string(),
-            usd_cost: cost.usd_cost.to_string(),
+            usd_cost: format_float(&cost.usd_cost.inner())?,
             operation_category: cost.operation_category.to_string(),
             symbol: cost.symbol.map(|symbol| symbol.to_string()),
             occurred_at: cost.occurred_at.to_rfc3339(),

--- a/src/dashboard/pnl/state.rs
+++ b/src/dashboard/pnl/state.rs
@@ -1,8 +1,10 @@
 //! Internal reporting state for the backend PnL replay ledger.
-use num_decimal::Num;
+use rain_math_float::Float;
 use serde_json::Value;
-use st0x_finance::Symbol;
 use std::collections::{HashMap, HashSet, VecDeque};
+
+use st0x_finance::Symbol;
+use st0x_float_macro::float;
 
 use super::response::{PnlSummary, PnlSymbolSummary};
 
@@ -66,9 +68,9 @@ pub(crate) struct Fill {
     pub(crate) rowid: i64,
     pub(crate) id: String,
     pub(crate) symbol: Symbol,
-    pub(crate) shares: Num,
+    pub(crate) shares: Float,
     pub(crate) direction: Direction,
-    pub(crate) price: Num,
+    pub(crate) price: Float,
     pub(crate) executed_at: String,
     pub(crate) venue: Venue,
 }
@@ -77,41 +79,70 @@ pub(crate) struct Fill {
 pub(crate) struct Lot {
     pub(crate) trade_id: String,
     pub(crate) side: LotSide,
-    pub(crate) remaining_shares: Num,
-    pub(crate) price: Num,
+    pub(crate) remaining_shares: Float,
+    pub(crate) price: Float,
     pub(crate) opened_at: String,
     pub(crate) opened_rowid: i64,
     pub(crate) opened_venue: Venue,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub(crate) struct SummaryAcc {
-    // Report-only accumulator values stay as `Num` so persisted decimal payloads can be replayed
-    // exactly and formatted losslessly for the dashboard. They are converted only to DTO strings and
-    // are not written back into core trading, inventory, or onchain domain state where `Usd`/`Float`
-    // remain canonical.
-    pub(crate) counter_trade_pnl_usd: Num,
-    pub(crate) onchain_netting_pnl_usd: Num,
-    pub(crate) directional_inventory_baseline_pnl_usd: Num,
-    pub(crate) directional_imbalance_excess_pnl_usd: Num,
-    pub(crate) directional_exposure_pnl_usd: Num,
-    pub(crate) realized_pnl_usd: Num,
-    pub(crate) matched_shares: Num,
-    pub(crate) onchain_notional_usd: Num,
-    pub(crate) offchain_notional_usd: Num,
-    pub(crate) open_long_shares: Num,
-    pub(crate) open_short_shares: Num,
-    pub(crate) open_long_notional_usd: Num,
-    pub(crate) open_short_notional_usd: Num,
-    pub(crate) unmatched_offchain_buy_shares: Num,
-    pub(crate) unmatched_offchain_sell_shares: Num,
-    pub(crate) unmatched_offchain_buy_notional_usd: Num,
-    pub(crate) unmatched_offchain_sell_notional_usd: Num,
+    pub(crate) counter_trade_pnl_usd: Float,
+    pub(crate) onchain_netting_pnl_usd: Float,
+    pub(crate) directional_inventory_baseline_pnl_usd: Float,
+    pub(crate) directional_imbalance_excess_pnl_usd: Float,
+    pub(crate) directional_exposure_pnl_usd: Float,
+    pub(crate) realized_pnl_usd: Float,
+    pub(crate) matched_shares: Float,
+    pub(crate) onchain_notional_usd: Float,
+    pub(crate) offchain_notional_usd: Float,
+    pub(crate) open_long_shares: Float,
+    pub(crate) open_short_shares: Float,
+    pub(crate) open_long_notional_usd: Float,
+    pub(crate) open_short_notional_usd: Float,
+    pub(crate) unmatched_offchain_buy_shares: Float,
+    pub(crate) unmatched_offchain_sell_shares: Float,
+    pub(crate) unmatched_offchain_buy_notional_usd: Float,
+    pub(crate) unmatched_offchain_sell_notional_usd: Float,
     pub(crate) onchain_fill_count: usize,
     pub(crate) offchain_fill_count: usize,
     pub(crate) matched_lot_count: usize,
     pub(crate) open_lot_count: usize,
     pub(crate) unmatched_offchain_fill_count: usize,
+}
+
+/// `Float` has no meaningful derived `Default`, and `Float::zero()` is
+/// fallible because it evaluates in the EVM. `float!(0)` resolves the same
+/// zero at compile time, so the accumulator stays infallibly constructible
+/// and `entry().or_default()` keeps working across the replay.
+impl Default for SummaryAcc {
+    fn default() -> Self {
+        Self {
+            counter_trade_pnl_usd: float!(0),
+            onchain_netting_pnl_usd: float!(0),
+            directional_inventory_baseline_pnl_usd: float!(0),
+            directional_imbalance_excess_pnl_usd: float!(0),
+            directional_exposure_pnl_usd: float!(0),
+            realized_pnl_usd: float!(0),
+            matched_shares: float!(0),
+            onchain_notional_usd: float!(0),
+            offchain_notional_usd: float!(0),
+            open_long_shares: float!(0),
+            open_short_shares: float!(0),
+            open_long_notional_usd: float!(0),
+            open_short_notional_usd: float!(0),
+            unmatched_offchain_buy_shares: float!(0),
+            unmatched_offchain_sell_shares: float!(0),
+            unmatched_offchain_buy_notional_usd: float!(0),
+            unmatched_offchain_sell_notional_usd: float!(0),
+            onchain_fill_count: 0,
+            offchain_fill_count: 0,
+            matched_lot_count: 0,
+            open_lot_count: 0,
+            unmatched_offchain_fill_count: 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -121,9 +152,9 @@ pub(crate) struct SymbolBook {
     pub(crate) seen_onchain_fill_ids: HashSet<String>,
     pub(crate) seen_offchain_placement_ids: HashSet<String>,
     pub(crate) seen_offchain_fill_ids: HashSet<String>,
-    pub(crate) original_onchain_shares: HashMap<String, Num>,
-    pub(crate) matched_onchain_shares: HashMap<String, Num>,
-    pub(crate) last_price_usdc: Option<Num>,
+    pub(crate) original_onchain_shares: HashMap<String, Float>,
+    pub(crate) matched_onchain_shares: HashMap<String, Float>,
+    pub(crate) last_price_usdc: Option<Float>,
     pub(crate) summary: SummaryAcc,
 }
 
@@ -131,14 +162,14 @@ pub(crate) struct SymbolBook {
 pub(crate) struct UnmatchedOffchainAllocation {
     pub(crate) symbol: Symbol,
     pub(crate) fill_id: String,
-    pub(crate) shares: Num,
+    pub(crate) shares: Float,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct PositionReplayDelta {
     pub(crate) symbol: Symbol,
-    pub(crate) replay_net: Num,
-    pub(crate) position_net: Num,
+    pub(crate) replay_net: Float,
+    pub(crate) position_net: Float,
 }
 
 #[derive(Debug, Clone)]

--- a/src/dashboard/pnl/tests.rs
+++ b/src/dashboard/pnl/tests.rs
@@ -1,26 +1,44 @@
 use std::collections::BTreeSet;
 use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::mpsc::TryRecvError;
+use std::time::Duration;
 
-use alloy::primitives::{Address, TxHash, U256};
+use alloy::primitives::{Address, B256, TxHash, U256};
 use chrono::{NaiveDate, TimeZone, Utc};
 use num_decimal::Num;
+use num_decimal::num_bigint::{BigInt, Sign};
+use num_traits::Zero;
+use proptest::prelude::*;
+use rain_math_float::Float;
 use serde_json::Value;
 use sqlx::SqlitePool;
 use sqlx::sqlite::SqlitePoolOptions;
 
 use st0x_execution::alpaca_broker_api::AccountActivity;
-use st0x_finance::Symbol;
+use st0x_finance::{Symbol, Usd};
+use st0x_float_macro::float;
 
 use super::builder::build_pnl_response_from_rows;
+use super::costs::{
+    AccountingBucket, AccountingEffect, CostCategory, CostEntryInternal, validated_cost_magnitude,
+};
 use super::parsing::{fmt_decimal, parse_payload_string, parse_timestamp};
 use super::query::{PnlCounterTradingFilter, PnlError, PnlMarketSessionFilter, PnlQuery};
+use super::replay::{add_summary, with_direct_symbol_costs};
 use super::response::{PnlResponse, PnlSymbolSummary, PnlWindow, PnlWindowSymbol};
-use super::state::{
-    BotGasCostRow, CostEventRow, Direction, PnlBucket, PositionEventRow, PositionViewRow, Venue,
+use super::source::{
+    MAX_CONCURRENT_PNL_REPORTS, acquire_pnl_report_permit, build_pnl_report, pnl_report_admission,
+    run_pnl_replay, run_pnl_replay_with_permit,
 };
+use super::state::{
+    BotGasCostRow, CostEventRow, Direction, PnlBucket, PositionEventRow, PositionViewRow,
+    SummaryAcc, Venue,
+};
+use super::windows::build_windows;
 use super::{
     ATTRIBUTION_WARNING, BASELINE_WARNING, CAPITAL_AVAILABLE_NOTE, CAPITAL_UNAVAILABLE_NOTE,
-    COST_WARNING, SYMBOL_FILTERED_CAPITAL_WARNING, build_pnl_report, validate_pnl_snapshot_rowid,
+    COST_WARNING, SYMBOL_FILTERED_CAPITAL_WARNING, validate_pnl_snapshot_rowid,
 };
 use crate::bot_gas::{
     BotGasChain, BotGasOperationCategory, BotGasReceiptCost, BotGasReceiptCostEvent,
@@ -256,22 +274,132 @@ fn malformed_persisted_payloads_are_rejected() {
 
 #[test]
 fn decimal_formatting_preserves_accounting_precision() {
-    assert_eq!(fmt_decimal(&Num::from_str("100").unwrap()), "100");
+    assert_eq!(fmt_decimal(float!(0)).unwrap(), "0");
+    assert_eq!(fmt_decimal(float!(-0.1)).unwrap(), "-0.1");
+    assert_eq!(fmt_decimal(float!(100)).unwrap(), "100");
+    assert_eq!(fmt_decimal(float!(0.0000000001)).unwrap(), "0.0000000001");
     assert_eq!(
-        fmt_decimal(&Num::from_str("0.0000000001").unwrap()),
-        "0.0000000001"
-    );
-    assert_eq!(
-        fmt_decimal(&Num::from_str("0.0000000000000000001").unwrap()),
+        fmt_decimal(float!(0.0000000000000000001)).unwrap(),
         "0.0000000000000000001"
     );
 
-    let high_precision_product = &Num::from_str("0.123456789012345678").unwrap()
-        * &Num::from_str("0.000000000000000001").unwrap();
+    // 18 significant digits and 36 digits after the decimal point, comfortably
+    // inside `Float`'s 224-bit coefficient, so the product is still exact.
+    // This is the property the report actually needs: enough precision that
+    // accounting values survive a multiply, not unbounded precision.
+    let high_precision_product =
+        (float!(0.123456789012345678) * float!(0.000000000000000001)).unwrap();
     assert_eq!(
-        fmt_decimal(&high_precision_product),
+        fmt_decimal(high_precision_product).unwrap(),
         "0.000000000000000000123456789012345678"
     );
+}
+
+fn decimal_text(mantissa: u64, scale: u32) -> String {
+    if scale == 0 {
+        return mantissa.to_string();
+    }
+
+    let divisor = 10_u64.pow(scale);
+    let integer_part = mantissa / divisor;
+    let fractional_part = mantissa % divisor;
+    format!(
+        "{integer_part}.{fractional_part:0>width$}",
+        width = usize::try_from(scale).unwrap()
+    )
+}
+
+fn legacy_fmt_decimal(value: &Num) -> String {
+    let (mut numerator, denominator): (BigInt, BigInt) = value.clone().into();
+    if numerator.is_zero() {
+        return "0".to_owned();
+    }
+
+    let negative = numerator.sign() == Sign::Minus;
+    if negative {
+        numerator = -numerator;
+    }
+
+    let mut denominator = denominator;
+    let twos = legacy_factor_count(&mut denominator, 2);
+    let fives = legacy_factor_count(&mut denominator, 5);
+    assert_eq!(denominator, BigInt::from(1));
+
+    let scale = twos.max(fives);
+    let scaled = legacy_multiply_factor(
+        legacy_multiply_factor(numerator, 2, scale - twos),
+        5,
+        scale - fives,
+    );
+    let mut digits = scaled.to_string();
+
+    if scale > 0 {
+        if digits.len() <= scale {
+            digits.insert_str(0, &"0".repeat(scale + 1 - digits.len()));
+        }
+        digits.insert(digits.len() - scale, '.');
+        while digits.ends_with('0') {
+            digits.pop();
+        }
+        if digits.ends_with('.') {
+            digits.pop();
+        }
+    }
+
+    if negative {
+        format!("-{digits}")
+    } else {
+        digits
+    }
+}
+
+fn legacy_factor_count(value: &mut BigInt, factor: u8) -> usize {
+    let factor = BigInt::from(factor);
+    let mut count = 0;
+    while (&*value % &factor).is_zero() {
+        *value /= &factor;
+        count += 1;
+    }
+    count
+}
+
+fn legacy_multiply_factor(mut value: BigInt, factor: u8, count: usize) -> BigInt {
+    let factor = BigInt::from(factor);
+    for _ in 0..count {
+        value *= &factor;
+    }
+    value
+}
+
+proptest! {
+    #[test]
+    fn float_pnl_arithmetic_matches_the_legacy_num_pipeline(
+        opening_mantissa in 1_u64..=1_000_000_000_000,
+        closing_mantissa in 1_u64..=1_000_000_000_000,
+        shares_mantissa in 1_u64..=1_000_000_000_000_000_000,
+        opening_scale in 0_u32..=8,
+        closing_scale in 0_u32..=8,
+        shares_scale in 0_u32..=18,
+    ) {
+        let opening = decimal_text(opening_mantissa, opening_scale);
+        let closing = decimal_text(closing_mantissa, closing_scale);
+        let shares = decimal_text(shares_mantissa, shares_scale);
+
+        let legacy_opening = Num::from_str(&opening).unwrap();
+        let legacy_closing = Num::from_str(&closing).unwrap();
+        let legacy_shares = Num::from_str(&shares).unwrap();
+        let legacy_pnl = (&legacy_closing - &legacy_opening) * &legacy_shares;
+
+        let float_opening = Float::parse(opening).unwrap();
+        let float_closing = Float::parse(closing).unwrap();
+        let float_shares = Float::parse(shares).unwrap();
+        let float_pnl = ((float_closing - float_opening).unwrap() * float_shares).unwrap();
+
+        prop_assert_eq!(
+            fmt_decimal(float_pnl).unwrap(),
+            legacy_fmt_decimal(&legacy_pnl)
+        );
+    }
 }
 
 #[test]
@@ -499,11 +627,11 @@ fn bot_gas_recorded(rowid: i64) -> CostEventRow {
         gas_used: 21_000,
         effective_gas_price_wei: 1_000_000_000,
         native_cost_wei: U256::from(21_000_000_000_000u128),
-        eth_usd_price: Num::from_str("2000").unwrap(),
+        eth_usd_price: Usd::new(float!(2000)),
         eth_usd_price_source: "eth_usd_valuation_feed".to_owned(),
         eth_usd_price_at: Utc.with_ymd_and_hms(2026, 5, 15, 14, 0, 0).unwrap(),
         eth_usd_price_block_number: Some(123),
-        usd_cost: Num::from_str("0.042").unwrap(),
+        usd_cost: Usd::new(float!(0.042)),
         operation_category: BotGasOperationCategory::VaultDeposit,
         symbol: Some(Symbol::new("RKLB").unwrap()),
         occurred_at: Utc.with_ymd_and_hms(2026, 5, 15, 14, 0, 1).unwrap(),
@@ -1116,21 +1244,26 @@ async fn source_loader_excludes_bot_gas_recorded_after_snapshot() {
 
 #[tokio::test]
 async fn source_loader_rejects_non_positive_persisted_bot_gas_cost() {
-    let mut bot_gas = bot_gas_recorded(1);
-    bot_gas.payload["Recorded"]["cost"]["usd_cost"] = serde_json::json!("0");
-    let pool = pnl_test_pool_with_costs(Vec::new(), position_rows(), vec![bot_gas]).await;
+    for usd_cost in ["0", "-0.042"] {
+        let mut bot_gas = bot_gas_recorded(1);
+        bot_gas.payload["Recorded"]["cost"]["usd_cost"] = serde_json::json!(usd_cost);
+        let pool = pnl_test_pool_with_costs(Vec::new(), position_rows(), vec![bot_gas]).await;
 
-    let error = build_pnl_report(&pool, &query(), Vec::new(), Utc::now())
-        .await
-        .unwrap_err();
+        let error = build_pnl_report(&pool, &query(), Vec::new(), Utc::now())
+            .await
+            .unwrap_err();
 
-    assert!(matches!(
-        error,
-        PnlError::InvalidBotGasReceiptCost {
-            source: crate::bot_gas::BotGasReceiptCostError::NonPositiveUsdCost,
-            ..
-        }
-    ));
+        assert!(
+            matches!(
+                error,
+                PnlError::InvalidBotGasReceiptCost {
+                    source: crate::bot_gas::BotGasReceiptCostError::NonPositiveUsdCost,
+                    ..
+                }
+            ),
+            "unexpected result for persisted USD cost {usd_cost}"
+        );
+    }
 }
 
 #[tokio::test]
@@ -2156,6 +2289,73 @@ fn broker_fees_and_interest_categories_net_debits_against_credits() {
 }
 
 #[test]
+fn alpaca_net_amount_parses_the_official_account_activity_sample() {
+    // Alpaca documents `net_amount` as a signed string<number>. This is the public DIV sample
+    // from https://docs.alpaca.markets/us/docs/account-activities, not a live-account capture.
+    let activity: AccountActivity = serde_json::from_value(serde_json::json!({
+        "activity_type": "DIV",
+        "id": "20190801011955195::5f596936-6f23-4cef-bdf1-3806aae57dbf",
+        "date": "2019-08-01",
+        "net_amount": "1.02",
+        "symbol": "T",
+        "cusip": "C00206R102",
+        "qty": "2",
+        "per_share_amount": "0.51"
+    }))
+    .unwrap();
+
+    let report = report_with(
+        Vec::new(),
+        vec![position_row("T", "0")],
+        Vec::new(),
+        vec![activity],
+        PnlQuery {
+            from_date: Some("2019-08-01".to_owned()),
+            to_date: Some("2019-08-01".to_owned()),
+            ..query()
+        },
+        BTreeSet::new(),
+    );
+
+    assert_eq!(report.costs.dividend_revenue_usd, "1.02");
+    assert_eq!(report.summary.tracked_revenue_usd, "1.02");
+    assert_eq!(report.summary.net_realized_pnl_usd, "1.02");
+    assert_eq!(report.cost_entries[0].amount_usd, "1.02");
+    assert_eq!(
+        report.cost_entries[0].symbol.as_ref().map(Symbol::as_str),
+        Some("T")
+    );
+}
+
+#[test]
+fn alpaca_net_amount_deserializes_signed_cost_values() {
+    let activity: AccountActivity = serde_json::from_value(serde_json::json!({
+        "activity_type": "INT",
+        "id": "interest-1",
+        "date": "2019-08-01",
+        "net_amount": "-0.25"
+    }))
+    .unwrap();
+
+    let report = report_with(
+        Vec::new(),
+        position_rows(),
+        Vec::new(),
+        vec![activity],
+        PnlQuery {
+            from_date: Some("2019-08-01".to_owned()),
+            to_date: Some("2019-08-01".to_owned()),
+            ..query()
+        },
+        BTreeSet::new(),
+    );
+
+    assert_eq!(report.costs.margin_interest_usd, "0.25");
+    assert_eq!(report.summary.tracked_costs_usd, "0.25");
+    assert_eq!(report.summary.net_realized_pnl_usd, "-0.25");
+}
+
+#[test]
 fn matches_legacy_frontend_sql_fixture_for_stable_report_fields() {
     let report = report_with(
         vec![
@@ -2250,8 +2450,8 @@ fn assert_legacy_fixture_entries(report: &PnlResponse) {
                 entry.pnl_bucket.as_str(),
                 entry.opening_rowid,
                 entry.closing_rowid,
-                fmt_decimal(&entry.shares),
-                fmt_decimal(&entry.realized_pnl_usd),
+                fmt_decimal(entry.shares).unwrap(),
+                fmt_decimal(entry.realized_pnl_usd).unwrap(),
             ))
             .collect::<Vec<_>>(),
         vec![
@@ -2396,6 +2596,57 @@ fn includes_tokenization_and_cctp_cost_events() {
     assert_eq!(report.symbols[0].symbol, "RKLB");
     assert_eq!(report.symbols[0].tracked_costs_usd, "0.4");
     assert_eq!(report.symbols[0].net_realized_pnl_usd, "-0.4");
+}
+
+#[test]
+fn negative_persisted_fees_fail_instead_of_reversing_their_accounting_effect() {
+    let tokenization_error = report_with_result(
+        Vec::new(),
+        position_rows(),
+        vec![
+            tokenized_mint_requested(1, "mint-1", "RKLB"),
+            tokenized_tokens_received(2, "mint-1", "-0.40", "2026-05-15T14:02:00Z"),
+        ],
+        Vec::new(),
+        query(),
+        BTreeSet::new(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        tokenization_error,
+        PnlError::MalformedPayload {
+            rowid: 2,
+            aggregate_type: "TokenizedEquityMint",
+            reason: "negative cost magnitude",
+            ..
+        }
+    ));
+
+    let cctp_error = report_with_result(
+        Vec::new(),
+        position_rows(),
+        vec![usdc_bridged(
+            3,
+            "rebalance-1",
+            "-0.10",
+            "2026-05-15T14:03:00Z",
+        )],
+        Vec::new(),
+        query(),
+        BTreeSet::new(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        cctp_error,
+        PnlError::MalformedPayload {
+            rowid: 3,
+            aggregate_type: "UsdcRebalance",
+            reason: "negative cost magnitude",
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -2770,6 +3021,66 @@ async fn return_uses_only_pnl_from_days_with_usable_capital() {
     assert_eq!(report.capital.excluded_days[0].et_day, "2026-05-16");
 }
 
+/// The values below are the ones observed in staging. The exact PnL product
+/// has 83 digits after the decimal point; `Float` rounds it to its coefficient
+/// width, which produces the 69-digit fractional value asserted below.
+#[tokio::test]
+async fn high_precision_derived_prices_do_not_break_the_capital_calculation() {
+    const DERIVED_PRICE: &str =
+        "67.00624805750459748856363881732286752146489897172918857984356872411";
+
+    let pool = pnl_test_pool(
+        vec![
+            onchain_fill(
+                1,
+                "RKLB",
+                "Sell",
+                DERIVED_PRICE,
+                "0.029847962456751639",
+                "2026-05-15T14:00:00Z",
+            ),
+            offchain_buy(2, "2026-05-15T14:01:00Z", "66.888", "0.029847962456751639"),
+        ],
+        position_rows(),
+    )
+    .await;
+    for et_day in ["2026-05-15", "2026-05-16"] {
+        insert_portfolio_snapshot_row(
+            &pool,
+            et_day,
+            "market_making",
+            "USDC",
+            "1000",
+            Some("1"),
+            Some("2026-05-15T04:05:00+00:00"),
+        )
+        .await;
+    }
+
+    let report = build_pnl_report(
+        &pool,
+        &PnlQuery {
+            from_date: Some("2026-05-15".to_owned()),
+            to_date: Some("2026-05-16".to_owned()),
+            ..query()
+        },
+        Vec::new(),
+        Utc::now(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        report.summary.net_realized_pnl_usd,
+        "0.003529463580981034737734078937903677127959821450972181328726353205256"
+    );
+    assert_eq!(
+        report.capital.average_deployed_capital_usd.as_deref(),
+        Some("1000")
+    );
+    assert_eq!(report.capital.sample_days, 2);
+}
+
 #[tokio::test]
 async fn return_excludes_signed_cost_effects_from_days_without_usable_capital() {
     let pool = pnl_test_pool_with_costs(
@@ -3011,5 +3322,331 @@ async fn build_pnl_report_as_of_rowid_non_current_omits_capital_with_warning() {
             .warnings
             .iter()
             .any(|warning| { warning.contains("not a historical view as of rowid 1") })
+    );
+}
+
+/// Packs the recorded exponent directly because parsing a decimal string
+/// normalizes it and does not exercise the formatter's scientific fallback.
+fn extreme_exponent_float() -> Float {
+    let mut bytes = [0u8; 32];
+    bytes[..4].copy_from_slice(&(-77i32).to_be_bytes());
+    bytes[4..24].fill(0x00);
+    bytes[24..32].copy_from_slice(&9_999_999_910_959_448_i64.to_be_bytes());
+    Float::from_raw(B256::from(bytes))
+}
+
+#[test]
+fn fmt_decimal_formats_and_roundtrips_an_extreme_exponent_value() {
+    let value = extreme_exponent_float();
+
+    let formatted = fmt_decimal(value).unwrap();
+
+    assert_eq!(
+        formatted,
+        "0.00000000000000000000000000000000000000000000000000000000000009999999910959448"
+    );
+    let roundtripped = Float::parse(formatted).unwrap();
+    assert!(roundtripped.eq(value).unwrap());
+}
+
+#[test]
+fn complete_pnl_response_serializes_extreme_exponents_as_strings() {
+    let mut report = report(vec![
+        onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
+        offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
+    ]);
+    let value = extreme_exponent_float();
+    let expected = fmt_decimal(value).unwrap();
+    let entry = &mut report.entries[0];
+    entry.opening_price_usd = value;
+    entry.closing_price_usd = value;
+    entry.shares = value;
+    entry.spread_usd = value;
+    entry.realized_pnl_usd = value;
+
+    let response = serde_json::to_value(&report).unwrap();
+    let entry = &response["entries"][0];
+
+    for field in [
+        "openingPriceUsd",
+        "closingPriceUsd",
+        "shares",
+        "spreadUsd",
+        "realizedPnlUsd",
+    ] {
+        assert_eq!(entry[field], serde_json::Value::String(expected.clone()));
+    }
+}
+
+fn max_positive_float_text() -> String {
+    st0x_float_serde::format_float(&Float::max_positive_value().unwrap()).unwrap()
+}
+
+#[test]
+fn cost_summarization_surfaces_float_overflow_as_arithmetic_error() {
+    let amount = max_positive_float_text();
+    let error = report_with_result(
+        Vec::new(),
+        position_rows(),
+        Vec::new(),
+        vec![
+            account_activity("div-1", "DIV", &amount, None, "2026-05-15T14:00:00Z"),
+            account_activity("div-2", "DIV", &amount, None, "2026-05-15T14:01:00Z"),
+        ],
+        query(),
+        BTreeSet::new(),
+    )
+    .unwrap_err();
+
+    let PnlError::Arithmetic(failure) = error else {
+        panic!("expected arithmetic error, got {error:?}");
+    };
+    assert_eq!(failure.location.file(), "src/dashboard/pnl/costs.rs");
+}
+
+#[test]
+fn daily_report_aggregation_surfaces_float_overflow_as_arithmetic_error() {
+    let amount = max_positive_float_text();
+    let error = report_with_result(
+        vec![
+            onchain_sell(1, &amount, "2026-05-15T14:00:00Z"),
+            offchain_buy(2, "2026-05-15T14:01:00Z", "1", "1"),
+        ],
+        position_rows(),
+        Vec::new(),
+        vec![account_activity(
+            "div-1",
+            "DIV",
+            &amount,
+            None,
+            "2026-05-15T14:02:00Z",
+        )],
+        query(),
+        BTreeSet::new(),
+    )
+    .unwrap_err();
+
+    let PnlError::Arithmetic(failure) = error else {
+        panic!("expected arithmetic error, got {error:?}");
+    };
+    assert_eq!(failure.location.file(), "src/dashboard/pnl/builder.rs");
+}
+
+#[test]
+fn window_aggregation_surfaces_float_overflow_as_arithmetic_error() {
+    let mut report = report(vec![
+        onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
+        offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
+    ]);
+    let mut entry = report.entries.pop().unwrap();
+    entry.realized_pnl_usd = Float::max_positive_value().unwrap();
+    let entries = [entry.clone(), entry];
+    let error = build_windows(&entries, &[Symbol::new("RKLB").unwrap()]).unwrap_err();
+
+    let PnlError::Arithmetic(failure) = error else {
+        panic!("expected arithmetic error, got {error:?}");
+    };
+    assert_eq!(failure.location.file(), "src/dashboard/pnl/windows.rs");
+}
+
+/// A price and share count whose exponents sum past `i32::MAX` must surface
+/// as an arithmetic error rather than panic or produce a fabricated report.
+#[tokio::test]
+async fn float_exponent_overflow_in_the_replay_pipeline_surfaces_as_arithmetic_error() {
+    let extreme_price = "1e2147483646";
+
+    let error = report_result(vec![
+        onchain_fill(
+            1,
+            "RKLB",
+            "Sell",
+            extreme_price,
+            "1e2",
+            "2026-05-15T14:00:00Z",
+        ),
+        offchain_buy(2, "2026-05-15T14:01:00Z", extreme_price, "1e2"),
+    ])
+    .unwrap_err();
+
+    assert!(matches!(error, PnlError::Arithmetic(_)));
+}
+
+#[test]
+fn report_includes_a_replay_only_open_position_in_symbol_summaries() {
+    let report = report_with(
+        vec![offchain_buy(1, "2026-05-15T14:01:00Z", "15", "2")],
+        vec![position_row("RKLB", "2")],
+        Vec::new(),
+        Vec::new(),
+        query(),
+        BTreeSet::new(),
+    );
+
+    assert_eq!(report.symbols.len(), 1);
+    assert_eq!(report.symbols[0].symbol.as_str(), "RKLB");
+    assert_eq!(report.symbols[0].inventory_drift_shares, "2");
+    assert_eq!(report.symbols[0].inventory_drift_usd, "30");
+    assert_eq!(report.symbols[0].open_long_shares, "2");
+}
+
+#[test]
+fn non_accounting_cost_entries_do_not_create_symbol_rows() {
+    let entry = CostEntryInternal {
+        category: CostCategory::CashCredit,
+        accounting_bucket: AccountingBucket::Generic,
+        effect: AccountingEffect::None,
+        amount_usd: validated_cost_magnitude(
+            float!(0),
+            1,
+            "AlpacaAccountActivity",
+            "CSD".to_owned(),
+        )
+        .unwrap(),
+        occurred_at: "2026-05-15T14:00:00Z".to_owned(),
+        aggregate_type: "AlpacaAccountActivity".to_owned(),
+        aggregate_id: "activity-1".to_owned(),
+        event_rowid: 1,
+        symbol: Some(Symbol::new("RKLB").unwrap()),
+        detail: "non-accounting fixture".to_owned(),
+    };
+
+    let symbols = with_direct_symbol_costs(Vec::new(), &[entry]).unwrap();
+
+    assert!(symbols.is_empty());
+}
+
+/// Proves that replay work does not block a current-thread Tokio runtime.
+///
+/// The controller waits for async progress outside the runtime thread. If the
+/// replay closure runs inline, the deadline expires; the controller then
+/// releases and joins the blocked runtime before the test fails.
+#[test]
+fn pnl_replay_runs_off_the_async_runtime_worker() {
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let (progress_tx, progress_rx) = std::sync::mpsc::channel();
+    let runtime_thread = std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(async move {
+                let replay = run_pnl_replay(move || {
+                    started_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    Ok(())
+                });
+                let observe_async_progress = async move {
+                    loop {
+                        match started_rx.try_recv() {
+                            Ok(()) => break,
+                            Err(TryRecvError::Empty) => tokio::task::yield_now().await,
+                            Err(TryRecvError::Disconnected) => {
+                                panic!("replay worker exited before starting")
+                            }
+                        }
+                    }
+                    progress_tx.send(()).unwrap();
+                };
+
+                let (result, ()) = tokio::join!(replay, observe_async_progress);
+                result.unwrap();
+            });
+    });
+
+    let progress = progress_rx.recv_timeout(Duration::from_secs(5));
+    let release = release_tx.send(());
+    let runtime = runtime_thread.join();
+
+    assert!(
+        matches!(progress, Ok(())),
+        "async runtime made no progress before the deadline: {progress:?}"
+    );
+    release.unwrap();
+    runtime.unwrap();
+}
+
+#[tokio::test]
+async fn canceled_pnl_replay_holds_its_permit_until_blocking_work_finishes() {
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let replay = tokio::spawn(run_pnl_replay_with_permit(
+        semaphore.clone().acquire_owned().await.unwrap(),
+        move || {
+            started_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+            Ok::<(), PnlError>(())
+        },
+    ));
+
+    started_rx.await.unwrap();
+    replay.abort();
+    assert!(replay.await.unwrap_err().is_cancelled());
+    let early_permit = semaphore.clone().try_acquire_owned();
+    let blocking_work_still_holds_permit =
+        matches!(&early_permit, Err(tokio::sync::TryAcquireError::NoPermits));
+    drop(early_permit);
+    release_tx.send(()).unwrap();
+    let _replacement_permit = semaphore.acquire_owned().await.unwrap();
+
+    assert!(blocking_work_still_holds_permit);
+}
+
+#[test]
+fn pnl_report_admission_rejects_excess_work_without_queuing() {
+    let admission = pnl_report_admission();
+    let mut permits = (0..MAX_CONCURRENT_PNL_REPORTS)
+        .map(|_| acquire_pnl_report_permit(&admission).unwrap())
+        .collect::<Vec<_>>();
+
+    let error = acquire_pnl_report_permit(&admission).unwrap_err();
+    assert!(matches!(error, PnlError::ReplayAdmission(_)));
+
+    drop(permits.pop().unwrap());
+    let _replacement = acquire_pnl_report_permit(&admission).unwrap();
+}
+
+#[tokio::test]
+async fn pnl_replay_releases_permits_after_errors_and_panics() {
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+    let error = run_pnl_replay_with_permit::<(), _>(
+        semaphore.clone().acquire_owned().await.unwrap(),
+        || {
+            Err(PnlError::InvalidDate {
+                field: "test",
+                value: "invalid".to_owned(),
+            })
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(error, PnlError::InvalidDate { .. }));
+
+    let error =
+        run_pnl_replay_with_permit::<(), _>(semaphore.clone().try_acquire_owned().unwrap(), || {
+            panic!("test worker panic")
+        })
+        .await
+        .unwrap_err();
+    assert!(matches!(error, PnlError::ReplayWorker(_)));
+    let _released_permit = semaphore.try_acquire_owned().unwrap();
+}
+
+/// Shared accumulators must retain the originating pipeline call site.
+#[test]
+fn shared_summary_accumulator_reports_distinguishable_locations_per_call_site() {
+    let overflowing = SummaryAcc {
+        counter_trade_pnl_usd: Float::max_positive_value().unwrap(),
+        ..SummaryAcc::default()
+    };
+
+    let first_error = add_summary(&mut overflowing.clone(), &overflowing).unwrap_err();
+    let second_error = add_summary(&mut overflowing.clone(), &overflowing).unwrap_err();
+
+    assert_ne!(
+        first_error.to_string(),
+        second_error.to_string(),
+        "two distinct call sites into the same shared accumulator must report \
+         distinguishable locations, not collapse to the helper's own internal line"
     );
 }

--- a/src/dashboard/pnl/windows.rs
+++ b/src/dashboard/pnl/windows.rs
@@ -1,12 +1,13 @@
-use std::collections::{BTreeSet, HashMap};
-
 use chrono::{NaiveDate, SecondsFormat, TimeZone, Utc};
 use chrono_tz::America::New_York;
-use num_decimal::Num;
-use st0x_finance::Symbol;
+use std::collections::{BTreeSet, HashMap};
 use tracing::warn;
 
+use st0x_finance::Symbol;
+use st0x_float_macro::float;
+
 use super::parsing::fmt_decimal;
+use super::query::PnlError;
 use super::response::{PnlEntry, PnlWindow, PnlWindowSymbol};
 use super::sessions::{counter_trading_session_for_iso, date_key, market_session_for_iso};
 use super::state::PnlBucket;
@@ -47,7 +48,10 @@ fn et_day_boundary(date: &str, is_end: bool) -> String {
         )
 }
 
-pub(crate) fn build_windows(entries: &[PnlEntry], symbols: &[Symbol]) -> Vec<PnlWindow> {
+pub(crate) fn build_windows(
+    entries: &[PnlEntry],
+    symbols: &[Symbol],
+) -> Result<Vec<PnlWindow>, PnlError> {
     let mut by_date: HashMap<String, Vec<&PnlEntry>> = HashMap::new();
     for entry in entries {
         by_date
@@ -102,9 +106,9 @@ pub(crate) fn build_windows(entries: &[PnlEntry], symbols: &[Symbol]) -> Vec<Pnl
                         entries_by_symbol.get(symbol).map_or(&[][..], Vec::as_slice),
                     )
                 })
-                .collect();
+                .collect::<Result<Vec<_>, PnlError>>()?;
 
-            PnlWindow {
+            Ok(PnlWindow {
                 window_id: date.clone(),
                 start_at: et_day_boundary(&date, false),
                 end_at: et_day_boundary(&date, true),
@@ -114,39 +118,39 @@ pub(crate) fn build_windows(entries: &[PnlEntry], symbols: &[Symbol]) -> Vec<Pnl
                 counter_trading_session,
                 granularity: "day",
                 symbols: rows,
-            }
+            })
         })
         .collect()
 }
 
-fn window_symbol_row(symbol: &Symbol, entries: &[&PnlEntry]) -> PnlWindowSymbol {
-    let mut counter_trade = Num::default();
-    let mut onchain_netting = Num::default();
-    let directional_baseline = Num::default();
-    let mut directional_excess = Num::default();
+fn window_symbol_row(symbol: &Symbol, entries: &[&PnlEntry]) -> Result<PnlWindowSymbol, PnlError> {
+    let mut counter_trade = float!(0);
+    let mut onchain_netting = float!(0);
+    let directional_baseline = float!(0);
+    let mut directional_excess = float!(0);
 
     for entry in entries {
         if entry.symbol != *symbol {
             continue;
         }
-        let pnl = entry.realized_pnl_usd.clone();
+        let pnl = entry.realized_pnl_usd;
         match entry.pnl_bucket {
-            PnlBucket::CounterTrade => counter_trade += &pnl,
-            PnlBucket::OnchainNetting => onchain_netting += &pnl,
-            PnlBucket::DirectionalExposure => directional_excess += &pnl,
+            PnlBucket::CounterTrade => counter_trade = (counter_trade + pnl)?,
+            PnlBucket::OnchainNetting => onchain_netting = (onchain_netting + pnl)?,
+            PnlBucket::DirectionalExposure => directional_excess = (directional_excess + pnl)?,
         }
     }
 
-    let directional_exposure = &directional_baseline + &directional_excess;
+    let directional_exposure = (directional_baseline + directional_excess)?;
     let total =
-        &(&(&counter_trade + &onchain_netting) + &directional_baseline) + &directional_excess;
-    PnlWindowSymbol {
+        (((counter_trade + onchain_netting)? + directional_baseline)? + directional_excess)?;
+    Ok(PnlWindowSymbol {
         symbol: symbol.clone(),
-        counter_trade_pnl_usd: fmt_decimal(&counter_trade),
-        onchain_netting_pnl_usd: fmt_decimal(&onchain_netting),
-        directional_inventory_baseline_pnl_usd: fmt_decimal(&directional_baseline),
-        directional_imbalance_excess_pnl_usd: fmt_decimal(&directional_excess),
-        directional_exposure_pnl_usd: fmt_decimal(&directional_exposure),
-        total_pnl_usd: fmt_decimal(&total),
-    }
+        counter_trade_pnl_usd: fmt_decimal(counter_trade)?,
+        onchain_netting_pnl_usd: fmt_decimal(onchain_netting)?,
+        directional_inventory_baseline_pnl_usd: fmt_decimal(directional_baseline)?,
+        directional_imbalance_excess_pnl_usd: fmt_decimal(directional_excess)?,
+        directional_exposure_pnl_usd: fmt_decimal(directional_exposure)?,
+        total_pnl_usd: fmt_decimal(total)?,
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ pub(crate) struct AppState {
     pub(crate) settings: st0x_dto::Settings,
     pub(crate) recovery: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
     pub(crate) resume_lock: Arc<api::ResumeLock>,
+    pub(crate) pnl_report_admission: dashboard::pnl::PnlReportAdmission,
     pub(crate) metrics_handle: PrometheusHandle,
 }
 
@@ -239,6 +240,7 @@ async fn run_bot_session_inner(
         settings: dashboard::settings_from_ctx(&ctx),
         recovery: recovery_cell.clone(),
         resume_lock,
+        pnl_report_admission: dashboard::pnl::pnl_report_admission(),
         metrics_handle,
     };
     let server_supervisor = spawn_server_supervisor(state, &pools, main_listener, board_listener);

--- a/src/portfolio_snapshot/mod.rs
+++ b/src/portfolio_snapshot/mod.rs
@@ -48,7 +48,11 @@ pub(crate) mod read;
 pub(crate) mod write;
 
 pub(crate) use projection::PortfolioSnapshotProjection;
-pub(crate) use read::{EtDayRange, ReadError, capital_summary, load_portfolio_days};
+#[cfg(test)]
+pub(crate) use read::load_portfolio_days;
+pub(crate) use read::{
+    EtDayRange, ReadError, capital_summary, evaluate_portfolio_days, load_portfolio_day_rows,
+};
 pub(crate) use write::{
     CAPTURE_BUFFER, PortfolioSnapshotCtx, PortfolioSnapshotJob, PortfolioSnapshotJobQueue,
     bootstrap_portfolio_snapshot,

--- a/src/portfolio_snapshot/read.rs
+++ b/src/portfolio_snapshot/read.rs
@@ -83,6 +83,8 @@ pub(crate) enum ReadError {
     SampleDaysOverflow { sample_days: usize },
     #[error("portfolio snapshot date range overflowed after {day}")]
     DateRangeOverflow { day: NaiveDate },
+    #[error("portfolio snapshot evaluation worker failed: {0}")]
+    Worker(#[from] tokio::task::JoinError),
 }
 
 /// Why a day was excluded from the capital sample.
@@ -188,13 +190,40 @@ struct RawBalanceRow {
     mark_captured_at: Option<DateTime<Utc>>,
 }
 
-/// Loads every `portfolio_snapshot` row in `et_day_range` (inclusive both
-/// ends; each side `None` leaves that end of the range open), grouped and
-/// evaluated per ET day.
+#[derive(sqlx::FromRow)]
+struct PersistedBalanceRow {
+    et_day: String,
+    location: String,
+    asset: String,
+    available_balance: String,
+    inflight_balance: String,
+    usd_mark: Option<String>,
+    mark_captured_at: Option<String>,
+}
+
+pub(crate) struct PortfolioDayRows {
+    rows: Vec<PersistedBalanceRow>,
+    from: Option<NaiveDate>,
+    to: Option<NaiveDate>,
+}
+
+/// Test wrapper that loads and evaluates portfolio rows by ET day.
+#[cfg(test)]
 pub(crate) async fn load_portfolio_days(
     pool: &SqlitePool,
     et_day_range: EtDayRange,
 ) -> Result<Vec<PortfolioDay>, ReadError> {
+    let day_rows = load_portfolio_day_rows(pool, et_day_range).await?;
+
+    tokio::task::spawn_blocking(move || evaluate_portfolio_days(day_rows)).await?
+}
+
+/// Loads every `portfolio_snapshot` row in `et_day_range`. Both bounds are
+/// inclusive; `None` leaves the corresponding end of the range open.
+pub(crate) async fn load_portfolio_day_rows(
+    pool: &SqlitePool,
+    et_day_range: EtDayRange,
+) -> Result<PortfolioDayRows, ReadError> {
     let mut query = QueryBuilder::<Sqlite>::new(
         "SELECT et_day, location, asset, available_balance, inflight_balance, usd_mark, \
          mark_captured_at \
@@ -217,25 +246,33 @@ pub(crate) async fn load_portfolio_days(
     query.push(" ORDER BY et_day ASC, asset ASC");
 
     let rows = query
-        .build_query_as::<(
-            String,
-            String,
-            String,
-            String,
-            String,
-            Option<String>,
-            Option<String>,
-        )>()
+        .build_query_as::<PersistedBalanceRow>()
         .fetch_all(pool)
         .await?;
 
+    Ok(PortfolioDayRows { rows, from, to })
+}
+
+pub(crate) fn evaluate_portfolio_days(
+    day_rows: PortfolioDayRows,
+) -> Result<Vec<PortfolioDay>, ReadError> {
+    let PortfolioDayRows { rows, from, to } = day_rows;
     let mut by_day: BTreeMap<NaiveDate, Vec<RawBalanceRow>> = BTreeMap::new();
-    for (et_day, location, asset, available, inflight, usd_mark, mark_captured_at) in rows {
+    for row in rows {
+        let PersistedBalanceRow {
+            et_day,
+            location,
+            asset,
+            available_balance,
+            inflight_balance,
+            usd_mark,
+            mark_captured_at,
+        } = row;
         let et_day = parse_et_day(&et_day)?;
         parse_portfolio_location(&location)?;
         let asset = parse_portfolio_asset(&asset)?;
-        let available = parse_float_string_or_hex(&available)?;
-        let inflight = parse_float_string_or_hex(&inflight)?;
+        let available = parse_float_string_or_hex(&available_balance)?;
+        let inflight = parse_float_string_or_hex(&inflight_balance)?;
         let usd_mark = usd_mark
             .as_deref()
             .map(parse_float_string_or_hex)


### PR DESCRIPTION
## What

- Closes [RAI-1623](https://linear.app/makeitrain/issue/RAI-1623/compute-pnl-report-values-in-float-so-pnl-stops-500ing-on-ranges-with).
- Moves the `/pnl` replay, costs, windows, and capital inputs from `Num` rationals to Rain `Float`.
- Moves bot-gas Ether to US dollar (ETH/USD) valuation and persisted costs to `Usd`.
- Runs synchronous PnL work on bounded blocking workers and returns HTTP 503 when capacity is full.
- Removes `num-decimal` from the workspace.

## Why

- A 67-digit derived price and an 18-decimal share count produced an 84-digit rational total.
- Converting that total back to `Float` made `/pnl` return HTTP 500 for ranges with realized PnL.
- Rain `Float` operations run synchronously through revm, so concurrent reports must not occupy Tokio workers.

## How

- `Float` flows through persisted parsing, first-in-first-out replay, cost aggregation, windows, diagnostics, and response formatting.
- The shared semaphore permits two concurrent reports. It rejects excess work before database and broker input loading.
- Owned permits cover blocking work after request cancellation. `spawn_blocking` handles replay and snapshot evaluation.
- `PnlError` preserves arithmetic call sites. The API maps worker failures to a stable HTTP 500 response.
- Bot-gas costs round half-to-even to eight decimal places before lossless decimal-string persistence.
- Legacy bot-gas payloads still deserialize, so this change does not need a database migration.
- `st0x_float_serde::format_float` handles extreme exponents without fabricating or dropping a value.

## Testing

- Added the staging regression that caused the `/pnl` outage.
- Added route tests for admission, cancellation, worker isolation, stable failures, and HTTP 503 responses.
- Added tests for extreme exponents, arithmetic failures, negative costs, half-even rounding, persistence, and legacy payloads.
- `nix run .#ci` passed with 4,212 tests passed and 6 skipped. Clippy, formatting, dashboard lint, and Svelte checks also passed.

## Screenshots

N/A

## Anything else

- The final review pass found no high or critical issues. It left one medium and five low findings.
- The medium finding is that response `Float` serialization still runs synchronously after the admission permit is released.
- No database migration is included because the persisted bot-gas JSON shape stays unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788447557&installation_model_id=19370&pr_number=1121&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1121&signature=fe5821d854f1dac02215de060d78773405bd24e32008f4e7d8977181c32e5e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced numerical precision and consistent rounding across PnL calculations, gas-cost valuation, and financial data processing.
  * Improved arithmetic validation, error handling, and reporting for calculations and persisted values.
  * Added controlled concurrency for PnL report generation, including clearer capacity-limit responses.
  * Improved portfolio snapshot processing and recovery from background worker failures.
  * Improved classification of non-retryable calculation errors.

* **Documentation**
  * Expanded guidance on float formatting, comparisons, rounding, persistence, and API boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
