### PR TITLE
swap redemption wallet with new turnkey one (RAI-1637)

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -80,7 +80,7 @@ organization_id = "b100145e-7894-4c17-b3e7-160435f84803"
 # Also needed for CLI commands: alpaca-redeem and transfer-equity.
 # Not needed for alpaca-tokenize or alpaca-tokenization-requests.
 [tokenization]
-redemption_wallet = "0x1c66D6708914C40239D54919320b4C48cAE3D1A9"
+redemption_wallet = "0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE"
 
 # ETH/USD valuation source for bot-gas cost recording (ADR 0017). Required
 # because [rebalancing] is configured below. Both values are public (not


### PR DESCRIPTION
Linear: https://linear.app/makeitrain/issue/RAI-1637

## What

Updates the `redemption_wallet` address in the production `st0x-hedge` tokenization config from `0x1c66D6708914C40239D54919320b4C48cAE3D1A9` to `0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE`.

## Why
Issuer changed wallet, and on liquidity we only reflected the change manually by ssh'ing into prod.

## How
A single-line change to the `[tokenization]` section of the production hedge config to point to the new wallet address.

## Testing
Did it manually on prod just now and redemptions are working

## Anything else
This affects the wallet used for alpaca redemptions and equity transfers in production. Care should be taken to ensure the new address has been verified and any in-flight redemptions are accounted for before this change goes live.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the production tokenization configuration to use a new redemption wallet address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->