### PR TITLE
Guard offchain USD snapshots against hedge fill double-counting

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3502,7 +3502,14 @@ know about cross-venue inventory.
   watermark at the forced block. Legacy fills or snapshots without a block
   number keep the unguarded behavior
 - `PositionEvent::OffChainOrderFilled` - Updates available balances (trading
-  activity)
+  activity): the equity delta plus a mirrored USDC delta at the Hedging venue.
+  Applying the fill stamps both the symbol's applied-fill time and the
+  venue-level applied-cash-fill time; `OffchainUsd` snapshots are skipped while
+  any hedge order is open or when fetched before that stamp, because the
+  broker's cash reading comes from the same `get_inventory()` read as the equity
+  positions and double-counts the fill in the same window the ADR 0015 equity
+  guards close (the cash balance is venue-level, so its open-order guard is
+  venue-wide rather than per-symbol)
 - `TokenizedEquityMintEvent::MintAccepted` - Moves shares to inflight (leaving
   Alpaca)
 - `TokenizedEquityMintEvent::TokensReceived` - Moves from inflight to Raindex

--- a/adrs/0015-single-writer-reconciliation-for-hedging-equity-balance.md
+++ b/adrs/0015-single-writer-reconciliation-for-hedging-equity-balance.md
@@ -254,7 +254,11 @@ Out of scope here; each is its own change.
    Hedging venue, and the `OffchainUsd` snapshot comes from the _same_
    `get_inventory()` call, so it is double-counted in exactly the same window.
    Only the equity leg is guarded here. The cash balance is venue-level rather
-   than per-symbol, so it needs a different mechanism.
+   than per-symbol, so it needs a different mechanism. _Addressed by RAI-1499:
+   the `OffchainUsd` command now carries the before-read `fetched_at`, and the
+   view skips (and force-skips) the venue cash snapshot while any hedge order is
+   open or when the reading predates the venue-level applied-cash-fill stamp
+   recorded with the fill._
 3. **Parallel state elsewhere.** `InventoryView` and `RebalancingService` hold
    several other overlapping representations: `active_mints` vs `mint_tracking`,
    `active_redemptions` vs `redemption_tracking`, and `active_usdc_rebalance` vs

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -675,6 +675,7 @@ where
                 InventorySnapshotCommand::OffchainUsd {
                     usd_balance_cents: available_usd_cents,
                     gross_usd_cents,
+                    fetched_at,
                 },
             )
             .await?;

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -227,10 +227,11 @@ impl EventSourced for InventorySnapshot {
             OffchainUsd {
                 usd_balance_cents,
                 gross_usd_cents,
+                fetched_at,
             } => InventorySnapshotEvent::OffchainUsd {
                 usd_balance_cents,
                 gross_usd_cents,
-                fetched_at: now,
+                fetched_at,
             },
             OffchainCashBuyingPower {
                 cash_buying_power_cents,
@@ -351,6 +352,7 @@ impl EventSourced for InventorySnapshot {
             OffchainUsd {
                 usd_balance_cents,
                 gross_usd_cents,
+                fetched_at,
             } => {
                 if self.offchain_usd_cents == Some(usd_balance_cents)
                     && self.offchain_gross_usd_cents == gross_usd_cents
@@ -360,7 +362,7 @@ impl EventSourced for InventorySnapshot {
                 Ok(vec![InventorySnapshotEvent::OffchainUsd {
                     usd_balance_cents,
                     gross_usd_cents,
-                    fetched_at: now,
+                    fetched_at,
                 }])
             }
             OffchainCashBuyingPower {
@@ -755,6 +757,13 @@ pub(crate) enum InventorySnapshotCommand {
         /// Gross USD balance before reserve subtraction. `None` when no
         /// cash reserve is configured, so the dashboard hides the row.
         gross_usd_cents: Option<i64>,
+        /// Captured by the poller before issuing the broker read, so the
+        /// event's stamp lower-bounds the broker's as-of time -- the same
+        /// before-read contract as `OffchainEquity`. Stamping at
+        /// command-handling time would let a pre-fill read outrun a fill
+        /// applied in between, defeating the view's applied-cash-fill guard
+        /// (ADR 0015 guard 2, transplanted to the venue-level cash balance).
+        fetched_at: DateTime<Utc>,
     },
     OffchainCashBuyingPower {
         cash_buying_power_cents: Option<i64>,
@@ -1103,6 +1112,7 @@ mod tests {
             .when(InventorySnapshotCommand::OffchainUsd {
                 usd_balance_cents,
                 gross_usd_cents: None,
+                fetched_at: Utc::now(),
             })
             .await
             .events();
@@ -1192,6 +1202,7 @@ mod tests {
                 InventorySnapshotCommand::OffchainUsd {
                     usd_balance_cents,
                     gross_usd_cents: None,
+                    fetched_at,
                 },
             ),
         ];
@@ -2137,6 +2148,68 @@ mod tests {
         assert_eq!(
             block_number, None,
             "a legacy event without the field must deserialize to None"
+        );
+    }
+
+    /// The `OffchainUsd` event must carry the poller's before-read stamp,
+    /// not a command-handling-time stamp: a command-time stamp postdates the
+    /// broker read, so a pre-fill read handled after the fill applied would
+    /// slip past the view's applied-cash-fill guard and resurrect the
+    /// pre-fill balance (the ADR 0015 before-read-capture contract,
+    /// transplanted to the cash leg).
+    #[tokio::test]
+    async fn offchain_usd_event_carries_the_commands_before_read_stamp() {
+        let before_read = Utc::now() - chrono::Duration::seconds(5);
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given_no_previous_events()
+            .when(InventorySnapshotCommand::OffchainUsd {
+                usd_balance_cents: 500_000,
+                gross_usd_cents: None,
+                fetched_at: before_read,
+            })
+            .await
+            .events();
+
+        let [InventorySnapshotEvent::OffchainUsd { fetched_at, .. }] = events.as_slice() else {
+            panic!("expected exactly one OffchainUsd event, got {events:?}");
+        };
+        assert_eq!(
+            *fetched_at, before_read,
+            "the event must carry the command's before-read stamp verbatim"
+        );
+    }
+
+    /// Same contract on the transition path: the test above starts from an
+    /// empty aggregate, so it only pins `initialize`. A prior event routes
+    /// this one through `transition`, whose changed-value arm must also
+    /// carry the command's stamp verbatim rather than restamping at
+    /// command-handling time.
+    #[tokio::test]
+    async fn offchain_usd_transition_carries_the_commands_before_read_stamp() {
+        let before_read = Utc::now() - chrono::Duration::seconds(5);
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given(vec![InventorySnapshotEvent::OffchainUsd {
+                usd_balance_cents: 400_000,
+                gross_usd_cents: None,
+                fetched_at: Utc::now() - chrono::Duration::seconds(60),
+            }])
+            .when(InventorySnapshotCommand::OffchainUsd {
+                usd_balance_cents: 500_000,
+                gross_usd_cents: None,
+                fetched_at: before_read,
+            })
+            .await
+            .events();
+
+        let [InventorySnapshotEvent::OffchainUsd { fetched_at, .. }] = events.as_slice() else {
+            panic!("expected exactly one OffchainUsd event, got {events:?}");
+        };
+        assert_eq!(
+            *fetched_at, before_read,
+            "the transition arm must carry the command's before-read stamp \
+             verbatim"
         );
     }
 

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -733,6 +733,16 @@ pub(crate) struct InventoryView {
     /// overwriting a correctly decremented balance with a pre-fill number.
     #[serde(default)]
     last_offchain_fill_applied_at: HashMap<Symbol, DateTime<Utc>>,
+    /// Local-clock time at which the most recent offchain fill's mirrored
+    /// USDC delta was applied to this view -- the venue-level cash analogue
+    /// of `last_offchain_fill_applied_at`. Venue-level because the Hedging
+    /// cash balance is one number, not per-symbol: a hedge fill on ANY
+    /// symbol moves it, so the guard keying on this field must be equally
+    /// broad. Same clock contract as the equity map: compared against
+    /// snapshot `fetched_at`, so it must be read from the host clock that
+    /// stamps it.
+    #[serde(default)]
+    last_offchain_cash_fill_applied_at: Option<DateTime<Utc>>,
     /// Highest block number whose `OnchainEquity` snapshot has been applied,
     /// by symbol. Chain-native ordering, not a clock: a pinned vault read at
     /// block N provably contains every fill at a block <= N, so an
@@ -1083,6 +1093,7 @@ impl Default for InventoryView {
             last_updated: Utc::now(),
             onchain_equity_snapshot_block_watermarks: HashMap::new(),
             onchain_usdc_snapshot_block_watermark: None,
+            last_offchain_cash_fill_applied_at: None,
             buying_power_cents: None,
             withdrawable_cash_cents: None,
             offchain_gross_usd_cents: None,
@@ -1317,6 +1328,7 @@ impl InventoryView {
             last_offchain_fill_applied_at: self.last_offchain_fill_applied_at,
             onchain_equity_snapshot_block_watermarks: self.onchain_equity_snapshot_block_watermarks,
             onchain_usdc_snapshot_block_watermark: self.onchain_usdc_snapshot_block_watermark,
+            last_offchain_cash_fill_applied_at: self.last_offchain_cash_fill_applied_at,
         })
     }
 
@@ -1348,6 +1360,7 @@ impl InventoryView {
             last_offchain_fill_applied_at: self.last_offchain_fill_applied_at,
             onchain_equity_snapshot_block_watermarks: self.onchain_equity_snapshot_block_watermarks,
             onchain_usdc_snapshot_block_watermark: self.onchain_usdc_snapshot_block_watermark,
+            last_offchain_cash_fill_applied_at: self.last_offchain_cash_fill_applied_at,
         })
     }
 
@@ -1495,6 +1508,12 @@ impl InventoryView {
     /// reading, never the event's `broker_timestamp`: it is compared against
     /// snapshot `fetched_at`, which the snapshot aggregate stamps from this
     /// host's clock, so mixing the two would compare two unsynchronized clocks.
+    /// `applied_fill_at` being `Some` records the fill application time on
+    /// BOTH the symbol's equity guard and the venue-level cash guard: the
+    /// fill's equity and mirrored-USDC legs apply atomically (`and_then`
+    /// chaining in the reactor), so a stamped equity fill always implies a
+    /// stamped cash fill. One entry point keeps the two stamps impossible to
+    /// desynchronize.
     pub(crate) fn clear_offchain_order_pending(
         &mut self,
         symbol: &Symbol,
@@ -1505,6 +1524,7 @@ impl InventoryView {
         if let Some(applied_fill_at) = applied_fill_at {
             self.last_offchain_fill_applied_at
                 .insert(symbol.clone(), applied_fill_at);
+            self.last_offchain_cash_fill_applied_at = Some(applied_fill_at);
         }
     }
 
@@ -1553,8 +1573,45 @@ impl InventoryView {
             equities,
             pending_offchain_order_symbols: self.pending_offchain_order_symbols.clone(),
             last_offchain_fill_applied_at: self.last_offchain_fill_applied_at.clone(),
+            last_offchain_cash_fill_applied_at: self.last_offchain_cash_fill_applied_at,
             ..Self::default()
         }
+    }
+
+    /// The Hedging cash-balance twin of the ADR 0015 guards in
+    /// [`Self::equity_snapshot_would_apply`]: the hedge fill applies a
+    /// mirrored USDC delta at the Hedging venue, and the `OffchainUsd`
+    /// snapshot comes from the same broker read as the equity positions, so
+    /// the cash leg double-counts in exactly the window the equity guards
+    /// close. The cash balance is venue-level, so guard 1 broadens from
+    /// per-symbol membership to "any hedge order open" -- an open order on
+    /// ANY symbol makes the venue's cash reading ambiguous.
+    fn offchain_usd_snapshot_would_apply(&self, fetched_at: DateTime<Utc>) -> bool {
+        if !self.pending_offchain_order_symbols.is_empty() {
+            debug!(
+                target: "inventory",
+                pending_symbols = ?self.pending_offchain_order_symbols,
+                ?fetched_at,
+                "Skipping offchain USD snapshot: a hedge order is still open",
+            );
+            return false;
+        }
+
+        if self
+            .last_offchain_cash_fill_applied_at
+            .is_some_and(|applied_at| fetched_at < applied_at)
+        {
+            debug!(
+                target: "inventory",
+                ?fetched_at,
+                last_cash_fill_applied_at = ?self.last_offchain_cash_fill_applied_at,
+                "Skipping offchain USD snapshot fetched before the last \
+                 applied hedge fill's cash leg",
+            );
+            return false;
+        }
+
+        true
     }
 
     fn equity_snapshot_watermark(&self, symbol: &Symbol, venue: Venue) -> Option<DateTime<Utc>> {
@@ -1839,6 +1896,7 @@ impl InventoryView {
             last_offchain_fill_applied_at: self.last_offchain_fill_applied_at,
             onchain_equity_snapshot_block_watermarks: self.onchain_equity_snapshot_block_watermarks,
             onchain_usdc_snapshot_block_watermark: self.onchain_usdc_snapshot_block_watermark,
+            last_offchain_cash_fill_applied_at: self.last_offchain_cash_fill_applied_at,
         })
     }
 
@@ -1871,6 +1929,7 @@ impl InventoryView {
             last_offchain_fill_applied_at: self.last_offchain_fill_applied_at,
             onchain_equity_snapshot_block_watermarks: self.onchain_equity_snapshot_block_watermarks,
             onchain_usdc_snapshot_block_watermark: self.onchain_usdc_snapshot_block_watermark,
+            last_offchain_cash_fill_applied_at: self.last_offchain_cash_fill_applied_at,
         })
     }
 
@@ -2261,6 +2320,12 @@ impl InventoryView {
                 gross_usd_cents,
                 ..
             } => {
+                // Gross is skipped along with the net balance: both come
+                // from the same ambiguous broker read.
+                if !self.offchain_usd_snapshot_would_apply(fetched_at) {
+                    return Ok(self);
+                }
+
                 let usdc = Usdc::from_cents(*usd_balance_cents)
                     .ok_or(InventoryViewError::UsdBalanceConversion(*usd_balance_cents))?;
                 let updated = self.update_usdc(
@@ -2481,6 +2546,22 @@ impl InventoryView {
                 gross_usd_cents,
                 ..
             } => {
+                // The force path bypasses the staleness guards, not the
+                // ownership one (mirrors the OffchainEquity arm above):
+                // while any hedge order is open, the fill delta owns the
+                // venue cash balance, and force-writing the ambiguous
+                // mid-order reading would re-open the double-count on the
+                // recovery path.
+                if !self.pending_offchain_order_symbols.is_empty() {
+                    warn!(
+                        target: "inventory",
+                        pending_symbols = ?self.pending_offchain_order_symbols,
+                        "Skipping forced offchain USD snapshot: a hedge \
+                         order is still open",
+                    );
+                    return Ok(self);
+                }
+
                 let usdc = Usdc::from_cents(*usd_balance_cents)
                     .ok_or(InventoryViewError::UsdBalanceConversion(*usd_balance_cents))?;
                 let updated = self.update_usdc(
@@ -2675,6 +2756,7 @@ mod tests {
             last_offchain_fill_applied_at: HashMap::new(),
             onchain_equity_snapshot_block_watermarks: HashMap::new(),
             onchain_usdc_snapshot_block_watermark: None,
+            last_offchain_cash_fill_applied_at: None,
         }
     }
 
@@ -2710,6 +2792,7 @@ mod tests {
             last_offchain_fill_applied_at: HashMap::new(),
             onchain_equity_snapshot_block_watermarks: HashMap::new(),
             onchain_usdc_snapshot_block_watermark: None,
+            last_offchain_cash_fill_applied_at: None,
         }
     }
 
@@ -4255,6 +4338,91 @@ mod tests {
         );
     }
 
+    /// The cash twin of the force-path gate above: while any hedge order is
+    /// open, `force_apply_snapshot_event` must not write the venue-level
+    /// `OffchainUsd` reading -- the fill delta owns the cash balance and the
+    /// mid-order reading is ambiguous.
+    #[test]
+    fn force_apply_offchain_usd_respects_open_hedge_gate() {
+        let aapl = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let mut view = InventoryView::default()
+            .with_equity(aapl.clone(), shares(20), shares(100))
+            .with_usdc(Usdc::new(float!(5000)), Usdc::new(float!(5000)));
+        view.mark_offchain_order_pending(aapl.clone());
+
+        let reason = Arc::new(InventoryViewError::UsdBalanceConversion(0));
+        let event = InventorySnapshotEvent::OffchainUsd {
+            usd_balance_cents: 999_900,
+            gross_usd_cents: Some(999_900),
+            fetched_at: now,
+        };
+
+        let gated = view
+            .clone()
+            .force_apply_snapshot_event(&event, now, reason.clone())
+            .unwrap();
+        assert_eq!(
+            gated.usdc_available(Venue::Hedging),
+            Some(Usdc::new(float!(5000))),
+            "the force path must not write the venue cash while a hedge \
+             order is open"
+        );
+        assert_eq!(
+            gated.offchain_gross_usd_cents, None,
+            "the gross reading comes from the same ambiguous read and must \
+             be skipped with it"
+        );
+
+        view.clear_offchain_order_pending(&aapl, None);
+        let ungated = view
+            .force_apply_snapshot_event(&event, now, reason)
+            .unwrap();
+        assert_eq!(
+            ungated.usdc_available(Venue::Hedging),
+            Some(Usdc::new(float!(9999))),
+            "with no order open the force path applies normally"
+        );
+    }
+
+    /// The venue-level cash guard state must survive the recovery reset the
+    /// same way the equity guard state does: it is fed by Position events
+    /// and nothing re-seeds it after startup.
+    #[test]
+    fn reset_preserves_cash_fill_guard() {
+        let aapl = Symbol::new("AAPL").unwrap();
+        let applied_at = Utc::now();
+
+        let mut view = InventoryView::default()
+            .with_equity(aapl.clone(), shares(20), shares(100))
+            .with_usdc(Usdc::new(float!(5000)), Usdc::new(float!(5000)));
+        view.clear_offchain_order_pending(&aapl, Some(applied_at));
+
+        let reset = view.reset_preserving_offchain_order_state();
+
+        // With no order open, only the preserved cash-fill time can reject
+        // this pre-fill reading. Had the reset dropped it, the snapshot
+        // would initialize the wiped venue to the stale value.
+        let healed = reset
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OffchainUsd {
+                    usd_balance_cents: 500_000,
+                    gross_usd_cents: None,
+                    fetched_at: applied_at - Duration::seconds(1),
+                },
+                applied_at,
+            )
+            .unwrap();
+        assert_eq!(
+            healed.usdc_available(Venue::Hedging),
+            None,
+            "a cash snapshot predating the preserved applied-fill time must \
+             still be rejected after the reset; Some means the guard was \
+             wiped"
+        );
+    }
+
     #[test]
     fn onchain_snapshot_zeroes_symbol_absent_from_complete_snapshot() {
         // The same complete-snapshot semantics apply to the onchain venue: a
@@ -4598,6 +4766,7 @@ mod tests {
             last_offchain_fill_applied_at: HashMap::new(),
             onchain_equity_snapshot_block_watermarks: HashMap::new(),
             onchain_usdc_snapshot_block_watermark: None,
+            last_offchain_cash_fill_applied_at: None,
         };
 
         let dto = view.to_dto();
@@ -4655,6 +4824,7 @@ mod tests {
             last_offchain_fill_applied_at: HashMap::new(),
             onchain_equity_snapshot_block_watermarks: HashMap::new(),
             onchain_usdc_snapshot_block_watermark: None,
+            last_offchain_cash_fill_applied_at: None,
         };
 
         let dto = view.to_dto();

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -23067,6 +23067,278 @@ mod tests {
         );
     }
 
+    /// The cash twin of the equity race above (RAI-1499): a broker poll
+    /// inside the fill window reports cash that already includes the fill's
+    /// proceeds. The `OffchainUsd` snapshot must be skipped while the hedge
+    /// order is open so the fill's mirrored USDC delta is not applied on top
+    /// of a balance that already contains it.
+    #[tokio::test]
+    async fn offchain_cash_snapshot_absorbing_a_sell_fill_is_not_applied_twice() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        // Pre-fill: $5000 cash, 100 shares offchain.
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(100))
+            .with_usdc(usdc(5000), usdc(5000));
+
+        let trigger = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        harness
+            .receive::<Position>(symbol.clone(), make_offchain_placed(offchain_order_id))
+            .await
+            .unwrap();
+
+        // The poll lands after the broker executed the sell: cash already
+        // shows the +$1500 proceeds. Must be skipped -- the order is open.
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+        harness
+            .receive::<InventorySnapshot>(
+                snapshot_id.clone(),
+                InventorySnapshotEvent::OffchainUsd {
+                    usd_balance_cents: 650_000,
+                    gross_usd_cents: None,
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Only now does the fill event arrive: sell 10 @ $150.
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_offchain_fill(shares(10), Direction::Sell),
+            )
+            .await
+            .unwrap();
+
+        let hedging_usdc = trigger
+            .inventory
+            .read()
+            .await
+            .usdc_available(Venue::Hedging);
+        assert_eq!(
+            hedging_usdc,
+            Some(usdc(6500)),
+            "the snapshot already contained the sell's proceeds, so the fill \
+             delta must be the only application; 8000 means the cash leg was \
+             counted twice"
+        );
+
+        // A fresh post-fill poll confirms without changing anything.
+        harness
+            .receive::<InventorySnapshot>(
+                snapshot_id,
+                InventorySnapshotEvent::OffchainUsd {
+                    usd_balance_cents: 650_000,
+                    gross_usd_cents: None,
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .usdc_available(Venue::Hedging),
+            Some(usdc(6500)),
+            "the next unblocked poll confirms the fill-applied balance"
+        );
+    }
+
+    #[tokio::test]
+    async fn offchain_cash_snapshot_absorbing_a_buy_fill_is_not_applied_twice() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(100))
+            .with_usdc(usdc(5000), usdc(5000));
+
+        let trigger = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        harness
+            .receive::<Position>(symbol.clone(), make_offchain_placed(offchain_order_id))
+            .await
+            .unwrap();
+
+        // Post-execution poll: the buy's -$1500 is already debited.
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+        harness
+            .receive::<InventorySnapshot>(
+                snapshot_id,
+                InventorySnapshotEvent::OffchainUsd {
+                    usd_balance_cents: 350_000,
+                    gross_usd_cents: None,
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_offchain_fill(shares(10), Direction::Buy),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .usdc_available(Venue::Hedging),
+            Some(usdc(3500)),
+            "the snapshot already contained the buy's debit, so the fill \
+             delta must be the only application; 2000 means the cash leg was \
+             counted twice"
+        );
+    }
+
+    /// The reverse ordering for the cash leg: a poll read before the fill
+    /// whose snapshot event lands after the fill was applied must not
+    /// resurrect the pre-fill cash balance.
+    #[tokio::test]
+    async fn cash_snapshot_fetched_before_applied_fill_does_not_overwrite_it() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(100))
+            .with_usdc(usdc(5000), usdc(5000));
+
+        let trigger = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        harness
+            .receive::<Position>(symbol.clone(), make_offchain_placed(offchain_order_id))
+            .await
+            .unwrap();
+
+        // Captured before the fill is applied, so it predates the
+        // local-clock stamp the fill records on the cash guard.
+        let pre_fill = Utc::now();
+
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_offchain_fill(shares(10), Direction::Sell),
+            )
+            .await
+            .unwrap();
+
+        // The stale poll reports the pre-fill $5000 with a pre-fill stamp.
+        // The gate is already clear, so only guard 2 can catch this.
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+        harness
+            .receive::<InventorySnapshot>(
+                snapshot_id.clone(),
+                InventorySnapshotEvent::OffchainUsd {
+                    usd_balance_cents: 500_000,
+                    gross_usd_cents: None,
+                    fetched_at: pre_fill,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .usdc_available(Venue::Hedging),
+            Some(usdc(6500)),
+            "a cash snapshot fetched before the applied fill must not \
+             resurrect the pre-fill balance"
+        );
+
+        // A genuinely fresh poll applies normally. 6600 is deliberately
+        // distinct so application is observable.
+        harness
+            .receive::<InventorySnapshot>(
+                snapshot_id,
+                InventorySnapshotEvent::OffchainUsd {
+                    usd_balance_cents: 660_000,
+                    gross_usd_cents: None,
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .usdc_available(Venue::Hedging),
+            Some(usdc(6600)),
+            "a cash snapshot fetched after the applied fill must apply"
+        );
+    }
+
+    /// The cash guard is venue-level: an open hedge order on ANY symbol
+    /// makes the venue's cash reading ambiguous, because the fill that may
+    /// already be baked into it belongs to whichever symbol is trading.
+    #[tokio::test]
+    async fn open_order_on_any_symbol_blocks_the_venue_cash_snapshot() {
+        let trading = Symbol::new("TSLA").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(trading.clone(), shares(20), shares(100))
+            .with_usdc(usdc(5000), usdc(5000));
+
+        let trigger = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        harness
+            .receive::<Position>(
+                trading.clone(),
+                make_offchain_placed(OffchainOrderId::new()),
+            )
+            .await
+            .unwrap();
+
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+        harness
+            .receive::<InventorySnapshot>(
+                snapshot_id,
+                InventorySnapshotEvent::OffchainUsd {
+                    usd_balance_cents: 999_900,
+                    gross_usd_cents: None,
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .usdc_available(Venue::Hedging),
+            Some(usdc(5000)),
+            "TSLA's open hedge order must block the venue-level cash \
+             snapshot even though no other symbol is involved"
+        );
+    }
+
     /// Recovery must leave a gated symbol holding the balance the fill delta
     /// owns. The reset wipes balances and the force path skips gated
     /// symbols, so unless the delta-owned balance is carried across the


### PR DESCRIPTION
## What

Closes [RAI-1499](https://linear.app/makeitrain/issue/RAI-1499/offchain-cash-balance-double-counts-a-hedge-fill-in-the-poll-overlap). Extends the ADR 0015 double-count protection to the Hedging venue's cash (USDC) balance.

## Why

When a hedge fill executes, the broker's `get_inventory()` response reflects the fill's cash impact immediately. Because the `OffchainUsd` snapshot is read from the same call as the equity positions, a poll that lands inside the fill window already contains the fill's proceeds or debit. If the fill's mirrored USDC delta is then also applied as a `PositionEvent::OffChainOrderFilled`, the cash balance is counted twice. The equity leg was already guarded by ADR 0015, but the cash leg had no equivalent protection.

## How

The fix introduces two guards for `OffchainUsd` snapshots, mirroring the existing per-symbol equity guards but operating at the venue level, since the Hedging cash balance is a single number that moves on any hedge fill regardless of symbol:

**Guard 1 — open order gate:** While any hedge order is open (`pending_offchain_order_symbols` is non-empty), `OffchainUsd` snapshots are skipped entirely, including on the force-apply recovery path. An open order on any symbol makes the venue's cash reading ambiguous.

**Guard 2 — before-read stamp:** The poller now captures a `fetched_at` timestamp before issuing the broker read and passes it through `InventorySnapshotCommand::OffchainUsd` into the event. The view records a `last_offchain_cash_fill_applied_at` timestamp when a fill is applied and rejects any `OffchainUsd` snapshot whose `fetched_at` predates that stamp. This catches the reverse-ordering case where a stale poll's event arrives after the fill has already been applied.

The `last_offchain_cash_fill_applied_at` stamp is set inside `clear_offchain_order_pending` alongside the existing per-symbol equity stamp, keeping the two impossible to desynchronize. It is also preserved across the recovery reset, matching the equity guard's behavior.

The `fetched_at` field is now set from the command rather than at command-handling time, closing the window where a pre-fill read handled after the fill could slip past the guard with a post-fill timestamp.

## Testing

Four new integration tests cover the key scenarios:

- A cash snapshot absorbed during an open sell order is not applied on top of the fill delta (sell and buy variants).
- A cash snapshot fetched before the fill but delivered after it does not resurrect the pre-fill balance.
- An open hedge order on any symbol blocks the venue-level cash snapshot, not just the symbol being traded.
- The force-apply path respects the open-order gate.
- The cash fill guard survives the recovery reset.

A unit test pins that `OffchainUsd` events carry the command's before-read stamp verbatim rather than a command-handling-time stamp.

## Anything else

The SPEC and ADR 0015 are updated to document the resolution. The ADR previously noted the cash double-count as an open gap; it now records that RAI-1499 addressed it via the venue-level `fetched_at` and applied-cash-fill stamp mechanism.

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved off-chain cash and equity accounting around hedge fills.
  * Prevented duplicate, stale, or premature cash snapshots from overwriting fill-adjusted balances.
  * Blocked cash snapshot application while hedge orders remain open.
  * Preserved accurate fill timestamps across updates, clearing, and recovery flows.

* **Tests**
  * Added regression coverage for fresh, stale, duplicate, and blocked cash snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->