### PR TITLE
Cash divergence detection, reconciliation, and dispatch gating

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3702,6 +3702,39 @@ intervals:
   across cycles. The cost on a transient mismatch is at most one poll interval
   of delayed rebalancing.
 
+The Hedging cash balance has the same wedge and the same venue-level recovery
+(the `OffchainUsd` snapshot dedupes on unchanged values, the view's cash guards
+skip the events that arrive, and failed USDC-transfer cleanups stamp
+`last_rebalancing`):
+
+- **Detection**: after the equity comparison, the poller compares the broker's
+  available cash against the view's Hedging USDC and drives a single venue-level
+  counter at the same `inventory_divergence_threshold`. The venue is busy --
+  counter frozen, not reset -- while USDC is inflight, a USDC rebalance
+  aggregate is live, any hedge order is open (the cash balance is venue-level,
+  so an open order on any symbol makes the reading ambiguous), or the reading
+  was fetched before the last applied hedge fill's cash leg. The counter is
+  in-memory, so a restart resets it; startup hydration heals the view anyway.
+- **Escalation**: at the threshold the poller sends `ReconcileOffchainUsd`,
+  which always emits `OffchainUsdReconciled` carrying the broker balance (net
+  and gross), the view's diverging ledger value, and the poll count; the event
+  folds into the aggregate's offchain USD state for startup hydration.
+- **Forced reconcile on apply**: the apply re-validates the same busy taxonomy
+  under the view write lock and aborts unapplied if the venue turned busy; a
+  verified heal resets the counter and releases the gate, an aborted one keeps
+  both so the next quiet poll re-escalates immediately.
+- **Dispatch gating**: while engaged, the venue-level cash gate suppresses the
+  USDC rebalancing trigger (checked before the guard claim and again immediately
+  before dispatch) -- a bridge sized off a diverged cash balance would move the
+  wrong amount and mark the venue busy, freezing the very counter that resolves
+  the divergence.
+
+Guard-skip starvation is observable: the view tracks consecutive guard-skipped
+Hedging snapshots (per symbol for equity, venue-level for cash) and logs a
+warning every five consecutive skips, so an ADR 0015 guard that starves a
+balance of broker truth surfaces at production log levels before the divergence
+machinery escalates. An applied snapshot resets the streak.
+
 ### InventoryView
 
 `InventoryView` aggregates inventory across onchain and offchain venues and

--- a/adrs/0015-single-writer-reconciliation-for-hedging-equity-balance.md
+++ b/adrs/0015-single-writer-reconciliation-for-hedging-equity-balance.md
@@ -185,7 +185,10 @@ pending set from the events table and hydration re-bases.
 at `debug!`, so a symbol being persistently blocked produces no signal at
 production log levels. If unbounded starvation is the accepted risk, it should
 at least be observable — a `warn!` after N consecutive skips for the same symbol
-would surface it. Not implemented here.
+would surface it. Not implemented here. _Addressed by RAI-1502: the view now
+tracks consecutive guard-skipped Hedging snapshots (per symbol for equity,
+venue-level for cash) and warns every five consecutive skips; an applied
+snapshot resets the streak._
 
 **Scope.** `src/inventory/view.rs` and `src/rebalancing/trigger/mod.rs`, plus
 tests. No migration, no event-schema change, no persisted state.

--- a/src/inventory/divergence.rs
+++ b/src/inventory/divergence.rs
@@ -12,10 +12,12 @@
 
 use std::collections::HashSet;
 use std::num::NonZeroU32;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use tracing::warn;
 
 use st0x_execution::{FractionalShares, Symbol};
+use st0x_finance::Usdc;
 
 use super::BroadcastingInventory;
 
@@ -32,6 +34,13 @@ use super::BroadcastingInventory;
 #[derive(Debug, Default)]
 pub(crate) struct InventoryDivergenceGate {
     symbols: RwLock<HashSet<Symbol>>,
+    /// Venue-level flag for a detected but unresolved `OffchainUsd`
+    /// divergence. One flag, not a set: the Hedging cash balance is one
+    /// number. While engaged, the USDC rebalancing trigger skips dispatch
+    /// -- a bridge sized off a diverged cash balance moves the wrong
+    /// amount and marks the venue busy, freezing the very counter that
+    /// resolves the divergence.
+    cash: AtomicBool,
 }
 
 impl InventoryDivergenceGate {
@@ -45,6 +54,18 @@ impl InventoryDivergenceGate {
 
     pub(crate) fn is_engaged(&self, symbol: &Symbol) -> bool {
         self.read_symbols().contains(symbol)
+    }
+
+    pub(crate) fn engage_cash(&self) {
+        self.cash.store(true, Ordering::SeqCst);
+    }
+
+    pub(crate) fn release_cash(&self) {
+        self.cash.store(false, Ordering::SeqCst);
+    }
+
+    pub(crate) fn is_cash_engaged(&self) -> bool {
+        self.cash.load(Ordering::SeqCst)
     }
 
     fn read_symbols(&self) -> std::sync::RwLockReadGuard<'_, HashSet<Symbol>> {
@@ -111,6 +132,34 @@ impl std::fmt::Debug for PersistentBrokerDivergence {
             .field("symbol", symbol)
             .field("ledger_value", ledger_value)
             .field("broker_value", broker_value)
+            .field("polls", polls)
+            .finish()
+    }
+}
+
+/// The venue-level cash twin of [`PersistentBrokerDivergence`]: witness for
+/// forcing the broker's available cash over the view's Hedging USDC.
+pub(crate) struct PersistentBrokerCashDivergence {
+    /// Hedging USDC the view held; `None` when the venue was never
+    /// initialized.
+    pub(crate) ledger_usdc: Option<Usdc>,
+    pub(crate) broker_usd_cents: i64,
+    pub(crate) polls: u32,
+}
+
+// Hand-written for the same reason as `PersistentBrokerDivergence`.
+impl std::fmt::Debug for PersistentBrokerCashDivergence {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            ledger_usdc,
+            broker_usd_cents,
+            polls,
+        } = self;
+
+        formatter
+            .debug_struct("PersistentBrokerCashDivergence")
+            .field("ledger_usdc", ledger_usdc)
+            .field("broker_usd_cents", broker_usd_cents)
             .field("polls", polls)
             .finish()
     }

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -134,6 +134,28 @@ struct InventoryDivergenceEscalation {
     consecutive_polls: u32,
 }
 
+/// How the view's Hedging cash balance relates to the broker's available
+/// cash -- the venue-level twin of [`ObservedLedgerState`].
+enum ObservedCashLedgerState {
+    /// USDC inflight, an active USDC rebalance, an open hedge order, or a
+    /// reading fetched before the last applied cash fill: the comparison is
+    /// ambiguous, freeze the counter.
+    Busy,
+    Match,
+    Divergence {
+        /// The view's Hedging USDC; `None` when the venue was never
+        /// initialized.
+        ledger: Option<Usdc>,
+    },
+}
+
+/// The venue-level cash divergence counter reached the configured
+/// threshold.
+struct CashDivergenceEscalation {
+    ledger: Option<Usdc>,
+    consecutive_polls: u32,
+}
+
 /// Service that polls actual inventory from onchain vaults and offchain brokers.
 pub(crate) struct InventoryPollingService<Chain, Exe>
 where
@@ -168,6 +190,9 @@ where
     /// Consecutive diverging polls per symbol. Kept in memory on purpose: a
     /// restart resets the count, and restart hydration restores the view.
     divergence_counters: Mutex<HashMap<Symbol, u32>>,
+    /// Consecutive polls that observed a Hedging cash divergence. One
+    /// counter, venue-level: the cash balance is one number per venue.
+    cash_divergence_counter: Mutex<u32>,
     /// Stamped on every successful sub-poll fetch this run, so the
     /// daily portfolio snapshot capture can gate on FRESHNESS in addition to
     /// presence. Defaults to a fresh, empty tracker; production wiring passes
@@ -214,6 +239,7 @@ where
             reserved_cash,
             divergence_recovery: None,
             divergence_counters: Mutex::new(HashMap::new()),
+            cash_divergence_counter: Mutex::new(0),
             poll_freshness,
         }
     }
@@ -716,10 +742,207 @@ where
         // so a poll the pipeline accepted has already reached the view here
         // and reads back as a match. Whatever still diverges from the view at
         // this point was suppressed or skipped.
-        self.detect_offchain_divergences(snapshot_id, &positions, fetched_at)
+        //
+        // The two detectors are independent concerns: a failed equity
+        // escalation must not skip the cash comparison for the tick (the
+        // cash counter would neither increment nor reset), so both run and
+        // the first error is reported -- the same attempt-everything policy
+        // the equity detector applies to its per-symbol escalations.
+        let equity_result = self
+            .detect_offchain_divergences(snapshot_id, &positions, fetched_at)
+            .await;
+        let cash_result = self
+            .detect_offchain_cash_divergence(
+                snapshot_id,
+                available_usd_cents,
+                gross_usd_cents,
+                fetched_at,
+            )
+            .await;
+
+        equity_result.and(cash_result)
+    }
+
+    /// The venue-level cash twin of [`Self::detect_offchain_divergences`]:
+    /// compares the broker's available cash against the view's Hedging USDC
+    /// across consecutive polls and escalates a forced reconcile at the
+    /// same threshold. Runs independently of event emission, so it is the
+    /// bounded path back to broker truth even when the aggregate's
+    /// unchanged-value dedupe or the view's cash guards suppress the
+    /// ordinary snapshot.
+    async fn detect_offchain_cash_divergence(
+        &self,
+        snapshot_id: &InventorySnapshotId,
+        usd_balance_cents: i64,
+        gross_usd_cents: Option<i64>,
+        fetched_at: DateTime<Utc>,
+    ) -> Result<(), InventoryPollingError<Exe::Error>> {
+        // The equity detector already warns when recovery is unconfigured;
+        // a second warning per poll would only add noise.
+        let Some(recovery) = &self.divergence_recovery else {
+            return Ok(());
+        };
+
+        let Some(broker_usdc) = Usdc::from_cents(usd_balance_cents) else {
+            warn!(
+                target: "inventory",
+                usd_balance_cents,
+                "Skipping cash divergence detection: broker cents not \
+                 representable as USDC"
+            );
+            return Ok(());
+        };
+
+        let view = recovery.inventory.read().await;
+        let state = if view.cash_reconciliation_busy(fetched_at)?.is_some() {
+            ObservedCashLedgerState::Busy
+        } else {
+            let ledger = view.usdc_available(Venue::Hedging);
+            let matches = match ledger {
+                Some(ledger_usdc) => ledger_usdc.eq(&broker_usdc)?,
+                // Nothing in the view and nothing at the broker is
+                // agreement; a nonzero broker reading against an
+                // uninitialized venue counts.
+                None => broker_usdc.eq(&Usdc::ZERO)?,
+            };
+
+            if matches {
+                ObservedCashLedgerState::Match
+            } else {
+                ObservedCashLedgerState::Divergence { ledger }
+            }
+        };
+        drop(view);
+
+        let Some(escalation) =
+            self.record_cash_divergence_observation(recovery, &state, usd_balance_cents)
+        else {
+            return Ok(());
+        };
+
+        self.escalate_cash_divergence(
+            recovery,
+            snapshot_id,
+            usd_balance_cents,
+            gross_usd_cents,
+            broker_usdc,
+            escalation,
+            fetched_at,
+        )
+        .await
+    }
+
+    /// Folds one poll's cash observation into the counter and the dispatch
+    /// gate. Synchronous on purpose: the counter guard must never be held
+    /// across an await.
+    fn record_cash_divergence_observation(
+        &self,
+        recovery: &InventoryDivergenceRecoveryCtx,
+        state: &ObservedCashLedgerState,
+        broker_cents: i64,
+    ) -> Option<CashDivergenceEscalation> {
+        let mut counter = self.lock_cash_divergence_counter();
+
+        match state {
+            ObservedCashLedgerState::Busy => None,
+            ObservedCashLedgerState::Match => {
+                if *counter != 0 {
+                    *counter = 0;
+                    recovery.gate.release_cash();
+                }
+                None
+            }
+            ObservedCashLedgerState::Divergence { ledger } => {
+                *counter += 1;
+                recovery.gate.engage_cash();
+
+                warn!(
+                    target: "inventory",
+                    ?ledger,
+                    broker_cents,
+                    consecutive_polls = *counter,
+                    threshold = recovery.threshold.get(),
+                    "Offchain USD snapshot diverges from the inventory view"
+                );
+
+                (*counter >= recovery.threshold.get()).then_some(CashDivergenceEscalation {
+                    ledger: *ledger,
+                    consecutive_polls: *counter,
+                })
+            }
+        }
+    }
+
+    /// Sends one `ReconcileOffchainUsd` escalation and settles its counter
+    /// and gate: released when the view reads back the broker value, kept
+    /// engaged when the apply aborted.
+    async fn escalate_cash_divergence(
+        &self,
+        recovery: &InventoryDivergenceRecoveryCtx,
+        snapshot_id: &InventorySnapshotId,
+        usd_balance_cents: i64,
+        gross_usd_cents: Option<i64>,
+        broker_usdc: Usdc,
+        escalation: CashDivergenceEscalation,
+        fetched_at: DateTime<Utc>,
+    ) -> Result<(), InventoryPollingError<Exe::Error>> {
+        self.snapshot
+            .send(
+                snapshot_id,
+                InventorySnapshotCommand::ReconcileOffchainUsd {
+                    usd_balance_cents,
+                    gross_usd_cents,
+                    fetched_at,
+                    ledger_usdc: escalation.ledger,
+                    consecutive_polls: escalation.consecutive_polls,
+                },
+            )
             .await?;
 
+        let healed = {
+            let view = recovery.inventory.read().await;
+            match view.usdc_available(Venue::Hedging) {
+                Some(ledger) => ledger.eq(&broker_usdc)?,
+                None => false,
+            }
+        };
+
+        if healed {
+            *self.lock_cash_divergence_counter() = 0;
+            recovery.gate.release_cash();
+        } else if escalation.consecutive_polls >= recovery.threshold.get().saturating_mul(2) {
+            // A full extra threshold window of escalations has failed to
+            // heal: past transient busyness, and every failed attempt
+            // appends another reconcile event. Needs an operator.
+            error!(
+                target: "inventory",
+                broker_cents = usd_balance_cents,
+                consecutive_polls = escalation.consecutive_polls,
+                "Cash reconcile escalations persistently fail to heal the \
+                 view"
+            );
+        } else {
+            warn!(
+                target: "inventory",
+                broker_cents = usd_balance_cents,
+                "Cash reconcile escalation did not heal the view; keeping \
+                 the dispatch gate engaged and the counter at the threshold"
+            );
+        }
+
         Ok(())
+    }
+
+    fn lock_cash_divergence_counter(&self) -> MutexGuard<'_, u32> {
+        self.cash_divergence_counter
+            .lock()
+            .unwrap_or_else(|poisoned| {
+                warn!(
+                    target: "inventory",
+                    "Cash divergence counter was poisoned; recovering state"
+                );
+                poisoned.into_inner()
+            })
     }
 
     /// Compare each fetched broker position against the view's Hedging
@@ -1366,6 +1589,7 @@ mod tests {
         BroadcastingInventory, InventoryDivergenceGate, InventoryProjection, InventoryView,
     };
     use crate::test_utils::setup_test_db;
+    use crate::usdc_rebalance::UsdcRebalanceId;
     use crate::vault_registry::{VaultRegistry, VaultRegistryCommand};
 
     #[derive(Clone, Default)]
@@ -5092,6 +5316,436 @@ mod tests {
         assert!(
             !gate.is_engaged(&spym),
             "the sent escalation must lift the transfer gate"
+        );
+    }
+
+    async fn cash_reconciled_events(
+        pool: &SqlitePool,
+        orderbook: Address,
+        order_owner: Address,
+    ) -> Vec<InventorySnapshotEvent> {
+        load_snapshot_events(pool, orderbook, order_owner)
+            .await
+            .into_iter()
+            .filter(|event| matches!(event, InventorySnapshotEvent::OffchainUsdReconciled { .. }))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn cash_divergence_escalates_at_exactly_threshold_polls() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let phantom = Usdc::from_cents(50_000).unwrap();
+
+        // Phantom $500 at Hedging while the broker reports zero cash. No
+        // reactor is wired, so the view never changes and every poll
+        // diverges.
+        let inventory =
+            broadcasting_inventory(InventoryView::default().with_usdc(Usdc::ZERO, phantom));
+        let gate = Arc::new(InventoryDivergenceGate::default());
+        let service = reconciling_service(
+            &pool,
+            Arc::new(test_store(pool.clone(), ())),
+            inventory.clone(),
+            gate.clone(),
+            3,
+        );
+
+        service.poll_and_record().await.unwrap();
+        assert!(
+            gate.is_cash_engaged(),
+            "the first diverging poll must engage the cash dispatch gate"
+        );
+
+        service.poll_and_record().await.unwrap();
+        assert!(
+            cash_reconciled_events(&pool, orderbook, order_owner)
+                .await
+                .is_empty(),
+            "below the threshold no cash escalation may fire"
+        );
+
+        service.poll_and_record().await.unwrap();
+        let events = cash_reconciled_events(&pool, orderbook, order_owner).await;
+        let [event] = events.as_slice() else {
+            panic!("Expected exactly one cash reconcile escalation, got {events:?}");
+        };
+        let InventorySnapshotEvent::OffchainUsdReconciled {
+            usd_balance_cents,
+            ledger_usdc,
+            consecutive_polls,
+            ..
+        } = event
+        else {
+            panic!("Expected OffchainUsdReconciled, got {event:?}");
+        };
+        assert_eq!(*usd_balance_cents, 0);
+        assert_eq!(*ledger_usdc, Some(phantom));
+        assert_eq!(*consecutive_polls, 3);
+        assert!(
+            gate.is_cash_engaged(),
+            "an escalation that did not heal the view must keep the gate engaged"
+        );
+
+        // The counter survives an unhealed escalation: the next diverging
+        // poll re-escalates immediately instead of starting a fresh count.
+        service.poll_and_record().await.unwrap();
+        let events = cash_reconciled_events(&pool, orderbook, order_owner).await;
+        assert_eq!(
+            events.len(),
+            2,
+            "an unhealed cash escalation must re-escalate on the next diverging poll"
+        );
+        let InventorySnapshotEvent::OffchainUsdReconciled {
+            consecutive_polls, ..
+        } = &events[1]
+        else {
+            panic!("Expected OffchainUsdReconciled, got {:?}", events[1]);
+        };
+        assert_eq!(
+            *consecutive_polls, 4,
+            "the kept counter must keep counting, not restart from one"
+        );
+        assert!(
+            gate.is_cash_engaged(),
+            "the gate must stay engaged while the view remains diverged"
+        );
+    }
+
+    #[tokio::test]
+    async fn cash_divergence_counter_resets_on_matching_poll() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let phantom = Usdc::from_cents(50_000).unwrap();
+
+        let inventory =
+            broadcasting_inventory(InventoryView::default().with_usdc(Usdc::ZERO, phantom));
+        let gate = Arc::new(InventoryDivergenceGate::default());
+        let service = reconciling_service(
+            &pool,
+            Arc::new(test_store(pool.clone(), ())),
+            inventory.clone(),
+            gate.clone(),
+            2,
+        );
+
+        service.poll_and_record().await.unwrap();
+        assert!(gate.is_cash_engaged());
+
+        // The view catches up to the broker: the next poll matches,
+        // resetting the counter and lifting the gate.
+        {
+            let mut view = inventory.write().await;
+            *view = InventoryView::default().with_usdc(Usdc::ZERO, Usdc::ZERO);
+        }
+        service.poll_and_record().await.unwrap();
+        assert!(
+            !gate.is_cash_engaged(),
+            "a matching poll must reset the counter and lift the cash gate"
+        );
+
+        // The phantom returns: with the counter reset, the next poll is
+        // count 1 (no escalation at threshold 2) and only the one after
+        // escalates.
+        {
+            let mut view = inventory.write().await;
+            *view = InventoryView::default().with_usdc(Usdc::ZERO, phantom);
+        }
+        service.poll_and_record().await.unwrap();
+        assert!(
+            cash_reconciled_events(&pool, orderbook, order_owner)
+                .await
+                .is_empty(),
+            "the reset counter must restart from one, not resume at two"
+        );
+
+        service.poll_and_record().await.unwrap();
+        assert_eq!(
+            cash_reconciled_events(&pool, orderbook, order_owner)
+                .await
+                .len(),
+            1,
+            "the second consecutive divergence after the reset escalates"
+        );
+    }
+
+    /// The cash twin of [`assert_counter_frozen_while_busy`]: one diverging
+    /// poll (count 1), busy polls that must neither count nor escalate while
+    /// keeping the gate engaged, then release and a final diverging poll
+    /// that escalates with `consecutive_polls == 2`.
+    async fn assert_cash_counter_frozen_while_busy(
+        make_busy: impl Fn(InventoryView) -> InventoryView,
+        clear_busy: impl Fn(InventoryView) -> InventoryView,
+    ) {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let phantom = Usdc::from_cents(50_000).unwrap();
+
+        let inventory =
+            broadcasting_inventory(InventoryView::default().with_usdc(Usdc::ZERO, phantom));
+        let gate = Arc::new(InventoryDivergenceGate::default());
+        let service = reconciling_service(
+            &pool,
+            Arc::new(test_store(pool.clone(), ())),
+            inventory.clone(),
+            gate.clone(),
+            2,
+        );
+
+        service.poll_and_record().await.unwrap();
+        assert!(gate.is_cash_engaged());
+
+        {
+            let mut view = inventory.write().await;
+            *view = make_busy(view.clone());
+        }
+        service.poll_and_record().await.unwrap();
+        service.poll_and_record().await.unwrap();
+        assert!(
+            cash_reconciled_events(&pool, orderbook, order_owner)
+                .await
+                .is_empty(),
+            "busy polls must not count toward the threshold"
+        );
+        assert!(
+            gate.is_cash_engaged(),
+            "the gate must stay engaged while the counter is frozen"
+        );
+
+        {
+            let mut view = inventory.write().await;
+            *view = clear_busy(view.clone());
+        }
+        service.poll_and_record().await.unwrap();
+        let events = cash_reconciled_events(&pool, orderbook, order_owner).await;
+        let [
+            InventorySnapshotEvent::OffchainUsdReconciled {
+                consecutive_polls, ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("Expected exactly one cash reconcile escalation, got {events:?}");
+        };
+        assert_eq!(
+            *consecutive_polls, 2,
+            "the busy window must freeze the counter, not reset it"
+        );
+    }
+
+    #[tokio::test]
+    async fn cash_divergence_counter_frozen_while_usdc_inflight() {
+        assert_cash_counter_frozen_while_busy(
+            |view| {
+                view.update_usdc(
+                    crate::inventory::Inventory::set_inflight(
+                        Venue::Hedging,
+                        Usdc::from_cents(1_000).unwrap(),
+                    ),
+                    Utc::now(),
+                )
+                .unwrap()
+            },
+            |view| {
+                view.update_usdc(
+                    crate::inventory::Inventory::set_inflight(Venue::Hedging, Usdc::ZERO),
+                    Utc::now(),
+                )
+                .unwrap()
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn cash_divergence_counter_frozen_while_usdc_rebalance_active() {
+        assert_cash_counter_frozen_while_busy(
+            |view| view.set_active_usdc_rebalance(UsdcRebalanceId(Uuid::new_v4())),
+            InventoryView::clear_active_usdc_rebalance,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn cash_divergence_counter_frozen_while_hedge_order_pending() {
+        assert_cash_counter_frozen_while_busy(
+            |mut view| {
+                view.mark_offchain_order_pending(test_symbol("SPYM"));
+                view
+            },
+            |mut view| {
+                view.clear_offchain_order_pending(&test_symbol("SPYM"), None);
+                view
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn cash_divergence_counter_frozen_while_cash_fill_applied_after_reading() {
+        // A cash-fill stamp in the future stands in for a fill whose cash
+        // leg applied between the broker read and the comparison: every
+        // poll's fetched_at predates it, so the reading is stale and must
+        // freeze the counter. Moving the stamp into the past releases it.
+        assert_cash_counter_frozen_while_busy(
+            |mut view| {
+                view.clear_offchain_order_pending(
+                    &test_symbol("SPYM"),
+                    Some(Utc::now() + chrono::Duration::hours(1)),
+                );
+                view
+            },
+            |mut view| {
+                view.clear_offchain_order_pending(
+                    &test_symbol("SPYM"),
+                    Some(Utc::now() - chrono::Duration::hours(1)),
+                );
+                view
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn uninitialized_cash_venue_with_zero_broker_reading_does_not_diverge() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+
+        // No USDC entry in the view and zero cash at the broker: the
+        // comparison must read as a match, not count toward escalation.
+        let inventory = broadcasting_inventory(InventoryView::default());
+        let gate = Arc::new(InventoryDivergenceGate::default());
+        let service = reconciling_service(
+            &pool,
+            Arc::new(test_store(pool.clone(), ())),
+            inventory,
+            gate.clone(),
+            1,
+        );
+
+        service.poll_and_record().await.unwrap();
+
+        assert!(
+            cash_reconciled_events(&pool, orderbook, order_owner)
+                .await
+                .is_empty(),
+            "an uninitialized cash venue with a zero broker reading must not escalate"
+        );
+        assert!(
+            !gate.is_cash_engaged(),
+            "an uninitialized cash venue with a zero broker reading must not engage the gate"
+        );
+    }
+
+    /// The cash twin of `phantom_hedging_credit_self_heals_within_threshold_polls`:
+    /// a transfer cleanup credited Hedging cash the broker never received and
+    /// stamped `last_rebalancing`; the aggregate already stores the true
+    /// zero, so every identical poll dedups to no event. The view must
+    /// converge to the broker's zero within the configured number of polls,
+    /// with the USDC dispatch gate engaged until the divergence resolves.
+    #[tokio::test]
+    async fn phantom_hedging_cash_self_heals_within_threshold_polls() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let phantom = Usdc::from_cents(50_000).unwrap();
+        let threshold = 3u32;
+        let now = Utc::now();
+
+        // Phantom cash at Hedging, guard armed by clear_usdc_inflight.
+        let view = InventoryView::default()
+            .with_usdc(Usdc::ZERO, phantom)
+            .clear_usdc_inflight(Venue::Hedging, now)
+            .unwrap();
+        let inventory = broadcasting_inventory(view);
+        let gate = Arc::new(InventoryDivergenceGate::default());
+
+        let snapshot_store = StoreBuilder::<InventorySnapshot>::new(pool.clone())
+            .with(Arc::new(InventoryProjection::new(inventory.clone())))
+            .build(())
+            .await
+            .unwrap();
+
+        // The aggregate already stores the true zero, recorded by a poll
+        // that predates the guard stamp (the view skipped it as stale), so
+        // every later identical poll dedups to no event.
+        snapshot_store
+            .send(
+                &InventorySnapshotId {
+                    orderbook,
+                    owner: order_owner,
+                },
+                InventorySnapshotCommand::OffchainUsd {
+                    usd_balance_cents: 0,
+                    gross_usd_cents: None,
+                    fetched_at: now - chrono::Duration::seconds(60),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            inventory.read().await.usdc_available(Venue::Hedging),
+            Some(phantom),
+            "precondition: the staleness guard must keep the phantom cash in the view"
+        );
+
+        let service = reconciling_service(
+            &pool,
+            snapshot_store,
+            inventory.clone(),
+            gate.clone(),
+            threshold,
+        );
+
+        service.poll_and_record().await.unwrap();
+        assert_eq!(
+            inventory.read().await.usdc_available(Venue::Hedging),
+            Some(phantom),
+            "one diverging poll must not yet reconcile"
+        );
+        assert!(
+            gate.is_cash_engaged(),
+            "an unresolved cash divergence must gate USDC dispatch"
+        );
+
+        // A failed cleanup stamps last_rebalancing again between polls.
+        {
+            let mut view = inventory.write().await;
+            *view = view
+                .clone()
+                .clear_usdc_inflight(Venue::Hedging, Utc::now())
+                .unwrap();
+        }
+
+        service.poll_and_record().await.unwrap();
+        assert_eq!(
+            inventory.read().await.usdc_available(Venue::Hedging),
+            Some(phantom),
+            "two diverging polls must not yet reconcile"
+        );
+        assert!(gate.is_cash_engaged());
+
+        // The final poll reaches the threshold and escalates.
+        service.poll_and_record().await.unwrap();
+
+        assert_eq!(
+            inventory.read().await.usdc_available(Venue::Hedging),
+            Some(Usdc::ZERO),
+            "the view must converge to the broker cash value within threshold polls"
+        );
+        assert_eq!(
+            inventory.read().await.usdc_inflight(Venue::Hedging),
+            Some(Usdc::ZERO),
+            "the reconcile leaves no residual cash inflight"
+        );
+        assert!(
+            !gate.is_cash_engaged(),
+            "the healed escalation must lift the USDC dispatch gate"
+        );
+
+        let events = cash_reconciled_events(&pool, orderbook, order_owner).await;
+        assert_eq!(
+            events.len(),
+            1,
+            "exactly one cash escalation must have been persisted"
         );
     }
 

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -224,6 +224,19 @@ impl EventSourced for InventorySnapshot {
                 ledger_position,
                 consecutive_polls,
             },
+            ReconcileOffchainUsd {
+                usd_balance_cents,
+                gross_usd_cents,
+                fetched_at,
+                ledger_usdc,
+                consecutive_polls,
+            } => InventorySnapshotEvent::OffchainUsdReconciled {
+                usd_balance_cents,
+                gross_usd_cents,
+                fetched_at,
+                ledger_usdc,
+                consecutive_polls,
+            },
             OffchainUsd {
                 usd_balance_cents,
                 gross_usd_cents,
@@ -347,6 +360,22 @@ impl EventSourced for InventorySnapshot {
                 position,
                 fetched_at,
                 ledger_position,
+                consecutive_polls,
+            }]),
+            // Like its equity twin: always emits, bypassing the value
+            // dedupe -- the state it corrects is "stored value already
+            // correct, view never received it".
+            ReconcileOffchainUsd {
+                usd_balance_cents,
+                gross_usd_cents,
+                fetched_at,
+                ledger_usdc,
+                consecutive_polls,
+            } => Ok(vec![InventorySnapshotEvent::OffchainUsdReconciled {
+                usd_balance_cents,
+                gross_usd_cents,
+                fetched_at,
+                ledger_usdc,
                 consecutive_polls,
             }]),
             OffchainUsd {
@@ -665,10 +694,27 @@ impl InventorySnapshot {
                 self.offchain_gross_usd_cents = *gross_usd_cents;
                 self.offchain_usd_fetched_at = Some(*fetched_at);
             }
+            // Folds like `OffchainUsd`: same fields, same monotonic
+            // `fetched_at` guard, so startup hydration replays the
+            // reconciled value.
+            InventorySnapshotEvent::OffchainUsdReconciled {
+                usd_balance_cents,
+                gross_usd_cents,
+                fetched_at,
+                ..
+            } if self
+                .offchain_usd_fetched_at
+                .is_none_or(|current| *fetched_at >= current) =>
+            {
+                self.offchain_usd_cents = Some(*usd_balance_cents);
+                self.offchain_gross_usd_cents = *gross_usd_cents;
+                self.offchain_usd_fetched_at = Some(*fetched_at);
+            }
             InventorySnapshotEvent::OnchainEquity { .. }
             | InventorySnapshotEvent::OnchainUsdc { .. }
             | InventorySnapshotEvent::OffchainEquity { .. }
             | InventorySnapshotEvent::OffchainEquityReconciled { .. }
+            | InventorySnapshotEvent::OffchainUsdReconciled { .. }
             | InventorySnapshotEvent::OffchainUsd { .. } => {}
             InventorySnapshotEvent::OffchainCashBuyingPower {
                 cash_buying_power_cents,
@@ -749,6 +795,25 @@ pub(crate) enum InventorySnapshotCommand {
         /// divergence was detected; `None` when the venue was never
         /// initialized in the view.
         ledger_position: Option<FractionalShares>,
+        /// Consecutive polls that observed the divergence.
+        consecutive_polls: u32,
+    },
+    /// The venue-level cash twin of `ReconcileOffchainEquity`: force record
+    /// the available cash the broker reported after the poller confirmed a
+    /// persistent divergence between the broker and the view. Like its
+    /// equity twin, handling this command always emits its event -- the
+    /// wedge it corrects is precisely "stored value already correct, view
+    /// never received it".
+    ReconcileOffchainUsd {
+        /// Available (post-reserve) cash the broker reported, in cents.
+        usd_balance_cents: i64,
+        /// Gross cash from the same read, before reserve subtraction.
+        gross_usd_cents: Option<i64>,
+        /// Stamped by the poller before the broker read.
+        fetched_at: DateTime<Utc>,
+        /// Hedging USDC the view held when the divergence was detected;
+        /// `None` when the venue was never initialized in the view.
+        ledger_usdc: Option<Usdc>,
         /// Consecutive polls that observed the divergence.
         consecutive_polls: u32,
     },
@@ -838,6 +903,19 @@ pub(crate) enum InventorySnapshotEvent {
         /// Consecutive polls that observed the divergence.
         consecutive_polls: u32,
     },
+    /// Forced venue-level cash reconciliation, emitted after the poller
+    /// confirmed a persistent divergence between the broker's available
+    /// cash and the view's Hedging USDC. Folds into `offchain_usd_cents`
+    /// the same way `OffchainUsd` does.
+    OffchainUsdReconciled {
+        usd_balance_cents: i64,
+        gross_usd_cents: Option<i64>,
+        fetched_at: DateTime<Utc>,
+        /// Hedging USDC the view held when the divergence was detected.
+        ledger_usdc: Option<Usdc>,
+        /// Consecutive polls that observed the divergence.
+        consecutive_polls: u32,
+    },
     #[serde(alias = "OffchainCash")]
     OffchainUsd {
         #[serde(alias = "cash_balance_cents")]
@@ -892,6 +970,7 @@ impl InventorySnapshotEvent {
             | Self::OnchainUsdc { fetched_at, .. }
             | Self::OffchainEquity { fetched_at, .. }
             | Self::OffchainEquityReconciled { fetched_at, .. }
+            | Self::OffchainUsdReconciled { fetched_at, .. }
             | Self::OffchainUsd { fetched_at, .. }
             | Self::OffchainCashBuyingPower { fetched_at, .. }
             | Self::OffchainCashWithdrawable { fetched_at, .. }
@@ -911,6 +990,9 @@ impl DomainEvent for InventorySnapshotEvent {
             Self::OnchainEquity { .. } => "InventorySnapshotEvent::OnchainEquity".to_string(),
             Self::OnchainUsdc { .. } => "InventorySnapshotEvent::OnchainUsdc".to_string(),
             Self::OffchainEquity { .. } => "InventorySnapshotEvent::OffchainEquity".to_string(),
+            Self::OffchainUsdReconciled { .. } => {
+                "InventorySnapshotEvent::OffchainUsdReconciled".to_string()
+            }
             Self::OffchainEquityReconciled { .. } => {
                 "InventorySnapshotEvent::OffchainEquityReconciled".to_string()
             }
@@ -2396,5 +2478,122 @@ mod tests {
             "a reconcile fetched before the stored snapshot must not fold"
         );
         assert_eq!(state.offchain_equity_fetched_at, Some(stored_at));
+    }
+
+    #[tokio::test]
+    async fn reconcile_offchain_usd_emits_even_when_balance_matches_stored_state() {
+        let stored_at = Utc::now();
+        let fetched_at = stored_at + chrono::Duration::seconds(60);
+
+        // The stored state already holds the correct zero, the case where
+        // the OffchainUsd dedup would emit no event.
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given(vec![InventorySnapshotEvent::OffchainUsd {
+                usd_balance_cents: 0,
+                gross_usd_cents: Some(0),
+                fetched_at: stored_at,
+            }])
+            .when(InventorySnapshotCommand::ReconcileOffchainUsd {
+                usd_balance_cents: 0,
+                gross_usd_cents: Some(0),
+                fetched_at,
+                ledger_usdc: Some(Usdc::from_str("500").unwrap()),
+                consecutive_polls: 3,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1, "cash reconcile must always emit");
+        let InventorySnapshotEvent::OffchainUsdReconciled {
+            usd_balance_cents,
+            gross_usd_cents,
+            fetched_at: event_fetched_at,
+            ledger_usdc,
+            consecutive_polls,
+        } = &events[0]
+        else {
+            panic!("Expected OffchainUsdReconciled event, got {:?}", events[0]);
+        };
+        assert_eq!(*usd_balance_cents, 0);
+        assert_eq!(*gross_usd_cents, Some(0));
+        assert_eq!(event_fetched_at, &fetched_at);
+        assert_eq!(*ledger_usdc, Some(Usdc::from_str("500").unwrap()));
+        assert_eq!(*consecutive_polls, 3);
+    }
+
+    #[test]
+    fn usd_reconciled_event_folds_into_offchain_usd_for_hydration() {
+        let stored_at = Utc::now();
+        let reconciled_at = stored_at + chrono::Duration::seconds(60);
+
+        let state = replay::<InventorySnapshot>(vec![
+            InventorySnapshotEvent::OffchainUsd {
+                usd_balance_cents: 50_000,
+                gross_usd_cents: Some(60_000),
+                fetched_at: stored_at,
+            },
+            InventorySnapshotEvent::OffchainUsdReconciled {
+                usd_balance_cents: 0,
+                gross_usd_cents: Some(0),
+                fetched_at: reconciled_at,
+                ledger_usdc: Some(Usdc::from_str("500").unwrap()),
+                consecutive_polls: 3,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            state.offchain_usd_cents,
+            Some(0),
+            "the reconciled balance must fold to the broker value"
+        );
+        assert_eq!(state.offchain_gross_usd_cents, Some(0));
+        assert_eq!(state.offchain_usd_fetched_at, Some(reconciled_at));
+
+        // Startup hydration replays the reconciled value, not the diverged one.
+        let hydrated = state
+            .hydration_events()
+            .into_iter()
+            .find(|event| matches!(event, InventorySnapshotEvent::OffchainUsd { .. }))
+            .expect("expected offchain usd hydration event");
+        let InventorySnapshotEvent::OffchainUsd {
+            usd_balance_cents, ..
+        } = hydrated
+        else {
+            panic!("Expected OffchainUsd event");
+        };
+        assert_eq!(usd_balance_cents, 0);
+    }
+
+    #[test]
+    fn stale_usd_reconciled_event_does_not_regress_offchain_usd() {
+        let stored_at = Utc::now();
+        let stale_at = stored_at - chrono::Duration::seconds(60);
+
+        let state = replay::<InventorySnapshot>(vec![
+            InventorySnapshotEvent::OffchainUsd {
+                usd_balance_cents: 50_000,
+                gross_usd_cents: Some(60_000),
+                fetched_at: stored_at,
+            },
+            InventorySnapshotEvent::OffchainUsdReconciled {
+                usd_balance_cents: 0,
+                gross_usd_cents: Some(0),
+                fetched_at: stale_at,
+                ledger_usdc: None,
+                consecutive_polls: 3,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            state.offchain_usd_cents,
+            Some(50_000),
+            "a cash reconcile fetched before the stored snapshot must not fold"
+        );
+        assert_eq!(state.offchain_gross_usd_cents, Some(60_000));
+        assert_eq!(state.offchain_usd_fetched_at, Some(stored_at));
     }
 }

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -17,7 +17,7 @@ use st0x_finance::{Usd, Usdc};
 use st0x_tokenization::IssuerRequestId;
 use st0x_wrapper::{RatioError, UnderlyingPerWrapped};
 
-use super::divergence::PersistentBrokerDivergence;
+use super::divergence::{PersistentBrokerCashDivergence, PersistentBrokerDivergence};
 use super::snapshot::InventorySnapshotEvent;
 use super::venue_balance::{InventoryError, VenueBalance};
 use crate::equity_redemption::RedemptionAggregateId;
@@ -631,6 +631,13 @@ impl PartialEq for PortfolioBalanceRow {
 
 /// Venues paired with their [`PortfolioLocation`] counterpart, in the fixed
 /// order [`InventoryView::to_portfolio_snapshot_rows`] emits them.
+/// Warn cadence for guard-starved offchain snapshots: every this many
+/// consecutive skips of a symbol's Hedging equity snapshot (or of the
+/// venue-level `OffchainUsd` snapshot), a `warn!` surfaces the starvation
+/// that ADR 0015 accepted but left invisible at production log levels.
+/// Observability only -- never changes which snapshots apply.
+const OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY: u32 = 5;
+
 const PORTFOLIO_VENUES: [(Venue, PortfolioLocation); 2] = [
     (Venue::MarketMaking, PortfolioLocation::MarketMaking),
     (Venue::Hedging, PortfolioLocation::Hedging),
@@ -743,6 +750,29 @@ pub(crate) struct InventoryView {
     /// stamps it.
     #[serde(default)]
     last_offchain_cash_fill_applied_at: Option<DateTime<Utc>>,
+    /// Consecutive skipped Hedging equity snapshots per symbol, reset when
+    /// one applies. Pure observability: ADR 0015 accepted that its guards
+    /// can starve a symbol's snapshots but noted the starvation was
+    /// invisible at production log levels; these streaks surface it as a
+    /// `warn!` every [`OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY`] consecutive
+    /// skips.
+    #[serde(default)]
+    offchain_equity_snapshot_skip_streaks: HashMap<Symbol, u32>,
+    /// Consecutive `OffchainUsd` snapshots skipped by the venue-level cash
+    /// guards, reset when one passes them.
+    #[serde(default)]
+    offchain_usd_snapshot_skip_streak: u32,
+    /// `fetched_at` of the freshest applied Hedging cash snapshot (ordinary
+    /// or reconciled) -- the venue-level cash twin of
+    /// `offchain_equity_snapshot_watermarks`. Consulted by
+    /// `reconcile_offchain_usd`: an ordinary snapshot that applied between
+    /// the escalation send and the reconcile apply owns the balance, and
+    /// the reconcile's older broker reading must not overwrite it. The
+    /// venue's other stamps cannot stand in -- the applied-cash-fill time
+    /// tracks fills, not snapshots, and `last_rebalancing` is exactly what
+    /// the reconcile's force path bypasses.
+    #[serde(default)]
+    offchain_usd_snapshot_watermark: Option<DateTime<Utc>>,
     /// Highest block number whose `OnchainEquity` snapshot has been applied,
     /// by symbol. Chain-native ordering, not a clock: a pinned vault read at
     /// block N provably contains every fill at a block <= N, so an
@@ -1094,6 +1124,9 @@ impl Default for InventoryView {
             onchain_equity_snapshot_block_watermarks: HashMap::new(),
             onchain_usdc_snapshot_block_watermark: None,
             last_offchain_cash_fill_applied_at: None,
+            offchain_equity_snapshot_skip_streaks: HashMap::new(),
+            offchain_usd_snapshot_skip_streak: 0,
+            offchain_usd_snapshot_watermark: None,
             buying_power_cents: None,
             withdrawable_cash_cents: None,
             offchain_gross_usd_cents: None,
@@ -1201,7 +1234,6 @@ impl InventoryView {
     }
 
     /// Returns the USDC available balance at the given venue.
-    #[cfg(test)]
     pub(crate) fn usdc_available(&self, venue: Venue) -> Option<Usdc> {
         match venue {
             Venue::MarketMaking => self.usdc.onchain.map(VenueBalance::available),
@@ -1329,6 +1361,9 @@ impl InventoryView {
             onchain_equity_snapshot_block_watermarks: self.onchain_equity_snapshot_block_watermarks,
             onchain_usdc_snapshot_block_watermark: self.onchain_usdc_snapshot_block_watermark,
             last_offchain_cash_fill_applied_at: self.last_offchain_cash_fill_applied_at,
+            offchain_equity_snapshot_skip_streaks: self.offchain_equity_snapshot_skip_streaks,
+            offchain_usd_snapshot_skip_streak: self.offchain_usd_snapshot_skip_streak,
+            offchain_usd_snapshot_watermark: self.offchain_usd_snapshot_watermark,
         })
     }
 
@@ -1361,6 +1396,9 @@ impl InventoryView {
             onchain_equity_snapshot_block_watermarks: self.onchain_equity_snapshot_block_watermarks,
             onchain_usdc_snapshot_block_watermark: self.onchain_usdc_snapshot_block_watermark,
             last_offchain_cash_fill_applied_at: self.last_offchain_cash_fill_applied_at,
+            offchain_equity_snapshot_skip_streaks: self.offchain_equity_snapshot_skip_streaks,
+            offchain_usd_snapshot_skip_streak: self.offchain_usd_snapshot_skip_streak,
+            offchain_usd_snapshot_watermark: self.offchain_usd_snapshot_watermark,
         })
     }
 
@@ -1445,6 +1483,21 @@ impl InventoryView {
             .is_none_or(|watermark| block_number > watermark);
         if advanced {
             self.onchain_usdc_snapshot_block_watermark = Some(block_number);
+        }
+
+        self
+    }
+
+    /// Records an applied Hedging cash snapshot's `fetched_at`, keeping the
+    /// watermark monotonic: unlike the equity path, the ordinary cash apply
+    /// does not gate on this watermark, so an older-but-applying reading
+    /// must not lower it.
+    fn record_offchain_usd_snapshot_watermark(mut self, fetched_at: DateTime<Utc>) -> Self {
+        let advanced = self
+            .offchain_usd_snapshot_watermark
+            .is_none_or(|watermark| fetched_at > watermark);
+        if advanced {
+            self.offchain_usd_snapshot_watermark = Some(fetched_at);
         }
 
         self
@@ -1576,6 +1629,64 @@ impl InventoryView {
             last_offchain_cash_fill_applied_at: self.last_offchain_cash_fill_applied_at,
             ..Self::default()
         }
+    }
+
+    /// Note a skipped Hedging equity snapshot for `symbol`, warning every
+    /// [`OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY`] consecutive skips. ADR 0015
+    /// accepted guard starvation but left it invisible at production log
+    /// levels; this is the missing signal. MarketMaking skips are not
+    /// tracked: that venue's snapshots are only ever skipped by transfer
+    /// inflight, which is already observable state.
+    fn note_offchain_equity_snapshot_skip(mut self, symbol: &Symbol, venue: Venue) -> Self {
+        if venue != Venue::Hedging {
+            return self;
+        }
+
+        let streak = self
+            .offchain_equity_snapshot_skip_streaks
+            .entry(symbol.clone())
+            .or_insert(0);
+        *streak += 1;
+
+        if streak.is_multiple_of(OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY) {
+            warn!(
+                target: "inventory",
+                %symbol,
+                consecutive_skips = *streak,
+                "Offchain equity snapshots for this symbol keep being \
+                 skipped; its Hedging balance is not receiving broker truth"
+            );
+        }
+
+        self
+    }
+
+    fn reset_offchain_equity_snapshot_skip(mut self, symbol: &Symbol, venue: Venue) -> Self {
+        if venue == Venue::Hedging {
+            self.offchain_equity_snapshot_skip_streaks.remove(symbol);
+        }
+        self
+    }
+
+    /// Note an `OffchainUsd` snapshot skipped by the venue-level cash
+    /// guards, warning every [`OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY`]
+    /// consecutive skips.
+    fn note_offchain_usd_snapshot_skip(mut self) -> Self {
+        self.offchain_usd_snapshot_skip_streak += 1;
+
+        if self
+            .offchain_usd_snapshot_skip_streak
+            .is_multiple_of(OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY)
+        {
+            warn!(
+                target: "inventory",
+                consecutive_skips = self.offchain_usd_snapshot_skip_streak,
+                "Offchain USD snapshots keep being skipped; the Hedging cash \
+                 balance is not receiving broker truth"
+            );
+        }
+
+        self
     }
 
     /// The Hedging cash-balance twin of the ADR 0015 guards in
@@ -1750,14 +1861,17 @@ impl InventoryView {
                 let should_record_watermark =
                     view.equity_snapshot_would_apply(symbol, venue, fetched_at)?;
                 if !should_record_watermark {
+                    let view = view.note_offchain_equity_snapshot_skip(symbol, venue);
                     return Ok::<_, InventoryViewError>((view, applied_symbols));
                 }
 
-                let view = view.update_equity(
-                    symbol,
-                    Inventory::on_snapshot(venue, *snapshot_balance, fetched_at),
-                    now,
-                )?;
+                let view = view
+                    .update_equity(
+                        symbol,
+                        Inventory::on_snapshot(venue, *snapshot_balance, fetched_at),
+                        now,
+                    )?
+                    .reset_offchain_equity_snapshot_skip(symbol, venue);
 
                 applied_symbols.push(symbol.clone());
 
@@ -1897,6 +2011,9 @@ impl InventoryView {
             onchain_equity_snapshot_block_watermarks: self.onchain_equity_snapshot_block_watermarks,
             onchain_usdc_snapshot_block_watermark: self.onchain_usdc_snapshot_block_watermark,
             last_offchain_cash_fill_applied_at: self.last_offchain_cash_fill_applied_at,
+            offchain_equity_snapshot_skip_streaks: self.offchain_equity_snapshot_skip_streaks,
+            offchain_usd_snapshot_skip_streak: self.offchain_usd_snapshot_skip_streak,
+            offchain_usd_snapshot_watermark: self.offchain_usd_snapshot_watermark,
         })
     }
 
@@ -1930,6 +2047,9 @@ impl InventoryView {
             onchain_equity_snapshot_block_watermarks: self.onchain_equity_snapshot_block_watermarks,
             onchain_usdc_snapshot_block_watermark: self.onchain_usdc_snapshot_block_watermark,
             last_offchain_cash_fill_applied_at: self.last_offchain_cash_fill_applied_at,
+            offchain_equity_snapshot_skip_streaks: self.offchain_equity_snapshot_skip_streaks,
+            offchain_usd_snapshot_skip_streak: self.offchain_usd_snapshot_skip_streak,
+            offchain_usd_snapshot_watermark: self.offchain_usd_snapshot_watermark,
         })
     }
 
@@ -2224,6 +2344,100 @@ impl InventoryView {
         Ok(view.record_equity_snapshot_watermarks(Venue::Hedging, [symbol], fetched_at))
     }
 
+    /// Why cash divergence recovery must leave the venue alone this poll --
+    /// the venue-level twin of [`Self::equity_reconciliation_busy`], shared
+    /// by detection (freezes the counter) and the forced apply (aborts) so
+    /// the two can never disagree. Reuses [`EquityReconcileBusy`]: the busy
+    /// taxonomy is identical, only the scope widens from one symbol to the
+    /// venue.
+    pub(crate) fn cash_reconciliation_busy(
+        &self,
+        fetched_at: DateTime<Utc>,
+    ) -> Result<Option<EquityReconcileBusy>, FloatError> {
+        if self.usdc.has_inflight()? || self.active_usdc_rebalance.is_some() {
+            return Ok(Some(EquityReconcileBusy::Transfer));
+        }
+
+        if !self.pending_offchain_order_symbols.is_empty() {
+            return Ok(Some(EquityReconcileBusy::PendingHedgeOrder));
+        }
+
+        if self
+            .last_offchain_cash_fill_applied_at
+            .is_some_and(|filled_at| fetched_at < filled_at)
+        {
+            return Ok(Some(EquityReconcileBusy::FillAfterFetch));
+        }
+
+        Ok(None)
+    }
+
+    /// The venue-level cash twin of [`Self::reconcile_offchain_equity`]:
+    /// force the broker's available cash over the view's Hedging USDC after
+    /// the poller confirmed a persistent divergence. Aborts while the venue
+    /// is busy; the poller re-escalates once it is quiet.
+    pub(crate) fn reconcile_offchain_usd(
+        self,
+        usd_balance_cents: i64,
+        gross_usd_cents: Option<i64>,
+        ledger_usdc: Option<Usdc>,
+        consecutive_polls: u32,
+        fetched_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Result<Self, InventoryViewError> {
+        if self
+            .offchain_usd_snapshot_watermark
+            .is_some_and(|watermark| fetched_at <= watermark)
+        {
+            warn!(
+                target: "inventory",
+                "Aborting offchain USD reconcile: a fresher cash snapshot \
+                 already applied"
+            );
+            return Ok(self);
+        }
+
+        if let Some(reason) = self.cash_reconciliation_busy(fetched_at)? {
+            warn!(
+                target: "inventory",
+                ?reason,
+                "Aborting offchain USD reconcile; the poller will \
+                 re-escalate once the venue is quiet"
+            );
+            return Ok(self);
+        }
+
+        let broker_usdc = Usdc::from_cents(usd_balance_cents)
+            .ok_or(InventoryViewError::UsdBalanceConversion(usd_balance_cents))?;
+
+        error!(
+            target: "inventory",
+            ledger = ?ledger_usdc,
+            broker_cents = usd_balance_cents,
+            polls = consecutive_polls,
+            "Force-reconciling offchain USD after persistent snapshot \
+             divergence"
+        );
+
+        let witness = PersistentBrokerCashDivergence {
+            ledger_usdc,
+            broker_usd_cents: usd_balance_cents,
+            polls: consecutive_polls,
+        };
+
+        let view = self.update_usdc(
+            Inventory::force_on_snapshot(Venue::Hedging, broker_usdc, witness),
+            now,
+        )?;
+
+        Ok(Self {
+            offchain_gross_usd_cents: gross_usd_cents,
+            offchain_usd_snapshot_skip_streak: 0,
+            ..view
+        }
+        .record_offchain_usd_snapshot_watermark(fetched_at))
+    }
+
     /// Fold an [`InventorySnapshotEvent`] into this view under normal
     /// operation. Uses [`Inventory::on_snapshot`], which silently
     /// ignores stale snapshots (fetched before the last rebalancing)
@@ -2321,9 +2535,14 @@ impl InventoryView {
                 ..
             } => {
                 // Gross is skipped along with the net balance: both come
-                // from the same ambiguous broker read.
-                if !self.offchain_usd_snapshot_would_apply(fetched_at) {
-                    return Ok(self);
+                // from the same ambiguous broker read. The inventory-level
+                // predicate mirrors what `on_snapshot` would silently skip
+                // (inflight, stale), so those skips count toward the streak
+                // instead of vanishing.
+                if !self.offchain_usd_snapshot_would_apply(fetched_at)
+                    || !self.usdc.snapshot_would_apply(fetched_at)?
+                {
+                    return Ok(self.note_offchain_usd_snapshot_skip());
                 }
 
                 let usdc = Usdc::from_cents(*usd_balance_cents)
@@ -2334,9 +2553,26 @@ impl InventoryView {
                 )?;
                 Ok(Self {
                     offchain_gross_usd_cents: *gross_usd_cents,
+                    offchain_usd_snapshot_skip_streak: 0,
                     ..updated
-                })
+                }
+                .record_offchain_usd_snapshot_watermark(fetched_at))
             }
+
+            OffchainUsdReconciled {
+                usd_balance_cents,
+                gross_usd_cents,
+                ledger_usdc,
+                consecutive_polls,
+                ..
+            } => self.reconcile_offchain_usd(
+                *usd_balance_cents,
+                *gross_usd_cents,
+                *ledger_usdc,
+                *consecutive_polls,
+                fetched_at,
+                now,
+            ),
 
             OffchainCashBuyingPower {
                 cash_buying_power_cents,
@@ -2541,10 +2777,27 @@ impl InventoryView {
                 now,
             ),
 
+            // Same routing as the equity reconcile: the cash reconcile
+            // validates venue busyness itself.
+            OffchainUsdReconciled {
+                usd_balance_cents,
+                gross_usd_cents,
+                ledger_usdc,
+                consecutive_polls,
+                fetched_at,
+            } => self.reconcile_offchain_usd(
+                *usd_balance_cents,
+                *gross_usd_cents,
+                *ledger_usdc,
+                *consecutive_polls,
+                *fetched_at,
+                now,
+            ),
+
             OffchainUsd {
                 usd_balance_cents,
                 gross_usd_cents,
-                ..
+                fetched_at,
             } => {
                 // The force path bypasses the staleness guards, not the
                 // ownership one (mirrors the OffchainEquity arm above):
@@ -2571,7 +2824,8 @@ impl InventoryView {
                 Ok(Self {
                     offchain_gross_usd_cents: *gross_usd_cents,
                     ..updated
-                })
+                }
+                .record_offchain_usd_snapshot_watermark(*fetched_at))
             }
 
             OffchainCashBuyingPower {
@@ -2757,6 +3011,9 @@ mod tests {
             onchain_equity_snapshot_block_watermarks: HashMap::new(),
             onchain_usdc_snapshot_block_watermark: None,
             last_offchain_cash_fill_applied_at: None,
+            offchain_equity_snapshot_skip_streaks: HashMap::new(),
+            offchain_usd_snapshot_skip_streak: 0,
+            offchain_usd_snapshot_watermark: None,
         }
     }
 
@@ -2793,6 +3050,9 @@ mod tests {
             onchain_equity_snapshot_block_watermarks: HashMap::new(),
             onchain_usdc_snapshot_block_watermark: None,
             last_offchain_cash_fill_applied_at: None,
+            offchain_equity_snapshot_skip_streaks: HashMap::new(),
+            offchain_usd_snapshot_skip_streak: 0,
+            offchain_usd_snapshot_watermark: None,
         }
     }
 
@@ -4767,6 +5027,9 @@ mod tests {
             onchain_equity_snapshot_block_watermarks: HashMap::new(),
             onchain_usdc_snapshot_block_watermark: None,
             last_offchain_cash_fill_applied_at: None,
+            offchain_equity_snapshot_skip_streaks: HashMap::new(),
+            offchain_usd_snapshot_skip_streak: 0,
+            offchain_usd_snapshot_watermark: None,
         };
 
         let dto = view.to_dto();
@@ -4825,6 +5088,9 @@ mod tests {
             onchain_equity_snapshot_block_watermarks: HashMap::new(),
             onchain_usdc_snapshot_block_watermark: None,
             last_offchain_cash_fill_applied_at: None,
+            offchain_equity_snapshot_skip_streaks: HashMap::new(),
+            offchain_usd_snapshot_skip_streak: 0,
+            offchain_usd_snapshot_watermark: None,
         };
 
         let dto = view.to_dto();
@@ -5794,6 +6060,443 @@ mod tests {
                 .equity_reconciliation_busy(&spym, now + Duration::seconds(2))
                 .unwrap(),
             None
+        );
+    }
+
+    fn usdc_cents(cents: i64) -> Usdc {
+        Usdc::from_cents(cents).unwrap()
+    }
+
+    fn usd_reconciled_event(
+        broker_cents: i64,
+        ledger: Option<Usdc>,
+        fetched_at: DateTime<Utc>,
+    ) -> InventorySnapshotEvent {
+        InventorySnapshotEvent::OffchainUsdReconciled {
+            usd_balance_cents: broker_cents,
+            gross_usd_cents: Some(broker_cents),
+            fetched_at,
+            ledger_usdc: ledger,
+            consecutive_polls: 3,
+        }
+    }
+
+    /// A phantom Hedging cash balance protected by a freshly stamped
+    /// `last_rebalancing` that ordinary snapshots cannot pierce. The
+    /// reconcile event must force the broker value through, clear inflight,
+    /// and carry the gross reading with the net.
+    #[test]
+    fn cash_reconcile_forces_broker_value_through_guard() {
+        let now = Utc::now();
+        let view = InventoryView::default()
+            .with_usdc(Usdc::ZERO, usdc_cents(50_000))
+            .clear_usdc_inflight(Venue::Hedging, now)
+            .unwrap();
+
+        let wedged = view
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OffchainUsd {
+                    usd_balance_cents: 0,
+                    gross_usd_cents: Some(0),
+                    fetched_at: now - Duration::seconds(1),
+                },
+                now,
+            )
+            .unwrap();
+        assert_eq!(
+            wedged.usdc_available(Venue::Hedging),
+            Some(usdc_cents(50_000)),
+            "precondition: the ordinary cash snapshot path must stay wedged"
+        );
+        assert_eq!(
+            wedged.offchain_gross_usd_cents, None,
+            "a skipped cash snapshot must not apply its gross reading either"
+        );
+
+        let healed = wedged
+            .apply_snapshot_event(
+                &usd_reconciled_event(0, Some(usdc_cents(50_000)), now + Duration::seconds(1)),
+                now,
+            )
+            .unwrap();
+        assert_eq!(
+            healed.usdc_available(Venue::Hedging),
+            Some(Usdc::ZERO),
+            "the reconcile must force the broker cash value through the guard"
+        );
+        assert_eq!(
+            healed.usdc_inflight(Venue::Hedging),
+            Some(Usdc::ZERO),
+            "the force path clears Hedging cash inflight"
+        );
+        assert_eq!(
+            healed.offchain_gross_usd_cents,
+            Some(0),
+            "the reconcile applies the gross reading alongside the net"
+        );
+    }
+
+    /// The cash twin of `reconcile_aborts_when_watermark_is_newer_than_reading`:
+    /// an ordinary cash snapshot that applied between the escalation send
+    /// and the reconcile apply owns the balance, and the reconcile's older
+    /// broker reading must not overwrite it, at or below the watermark.
+    #[test]
+    fn cash_reconcile_aborts_when_watermark_is_newer_than_reading() {
+        let now = Utc::now();
+
+        let view = InventoryView::default()
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OffchainUsd {
+                    usd_balance_cents: 50_000,
+                    gross_usd_cents: Some(50_000),
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        let older = view
+            .clone()
+            .apply_snapshot_event(
+                &usd_reconciled_event(0, Some(usdc_cents(50_000)), now - Duration::seconds(1)),
+                now,
+            )
+            .unwrap();
+        assert_eq!(
+            older.usdc_available(Venue::Hedging),
+            Some(usdc_cents(50_000)),
+            "a cash reconcile older than the watermark must not overwrite \
+             the fresher snapshot"
+        );
+        assert_eq!(
+            older.offchain_gross_usd_cents,
+            Some(50_000),
+            "the aborted reconcile must not overwrite the fresher gross \
+             reading either"
+        );
+
+        let at_watermark = view
+            .apply_snapshot_event(&usd_reconciled_event(0, Some(usdc_cents(50_000)), now), now)
+            .unwrap();
+        assert_eq!(
+            at_watermark.usdc_available(Venue::Hedging),
+            Some(usdc_cents(50_000)),
+            "a cash reconcile at the watermark must be rejected like the \
+             ordinary path"
+        );
+    }
+
+    /// An applied cash reconcile stamps the watermark itself: redelivering
+    /// the same reconcile event (same `fetched_at`) must be rejected by the
+    /// freshness guard instead of force-writing again.
+    #[test]
+    fn cash_reconcile_stamps_the_watermark_it_checks() {
+        let now = Utc::now();
+
+        let healed = InventoryView::default()
+            .with_usdc(Usdc::ZERO, usdc_cents(50_000))
+            .apply_snapshot_event(&usd_reconciled_event(0, Some(usdc_cents(50_000)), now), now)
+            .unwrap();
+        assert_eq!(
+            healed.usdc_available(Venue::Hedging),
+            Some(Usdc::ZERO),
+            "precondition: the first reconcile must apply"
+        );
+
+        // A fill delta lands after the heal; a replay of the same reconcile
+        // reading must not overwrite it with the pre-fill broker value.
+        let after_fill = healed
+            .update_usdc(
+                Inventory::available(Venue::Hedging, Operator::Add, usdc_cents(1_000)),
+                now,
+            )
+            .unwrap()
+            .apply_snapshot_event(&usd_reconciled_event(0, Some(usdc_cents(50_000)), now), now)
+            .unwrap();
+        assert_eq!(
+            after_fill.usdc_available(Venue::Hedging),
+            Some(usdc_cents(1_000)),
+            "a replayed reconcile at its own watermark must be rejected"
+        );
+    }
+
+    #[test]
+    fn cash_reconcile_aborts_while_usdc_inflight() {
+        let now = Utc::now();
+        let view = InventoryView::default().with_usdc_inflight(
+            Usdc::ZERO,
+            Usdc::ZERO,
+            usdc_cents(50_000),
+            usdc_cents(10_000),
+        );
+
+        let result = view
+            .apply_snapshot_event(&usd_reconciled_event(0, Some(usdc_cents(50_000)), now), now)
+            .unwrap();
+
+        assert_eq!(
+            result.usdc_available(Venue::Hedging),
+            Some(usdc_cents(50_000)),
+            "the reconcile must abort while a USDC transfer owns the balance"
+        );
+        assert_eq!(
+            result.usdc_inflight(Venue::Hedging),
+            Some(usdc_cents(10_000)),
+            "the aborted reconcile must not clear the live inflight"
+        );
+    }
+
+    #[test]
+    fn cash_reconcile_aborts_while_usdc_rebalance_active() {
+        let now = Utc::now();
+        let view = InventoryView::default()
+            .with_usdc(Usdc::ZERO, usdc_cents(50_000))
+            .set_active_usdc_rebalance(UsdcRebalanceId(Uuid::new_v4()));
+
+        let result = view
+            .apply_snapshot_event(&usd_reconciled_event(0, Some(usdc_cents(50_000)), now), now)
+            .unwrap();
+
+        assert_eq!(
+            result.usdc_available(Venue::Hedging),
+            Some(usdc_cents(50_000)),
+            "the reconcile must abort while a USDC rebalance aggregate is live"
+        );
+    }
+
+    /// The venue-level twin of `reconcile_respects_open_hedge_gate`: an open
+    /// hedge order on ANY symbol makes the venue's cash reading ambiguous,
+    /// and the aborted reconcile must not burn the watermark.
+    #[test]
+    fn cash_reconcile_aborts_while_any_hedge_order_open() {
+        let spym = Symbol::new("SPYM").unwrap();
+        let now = Utc::now();
+
+        let mut view = InventoryView::default().with_usdc(Usdc::ZERO, usdc_cents(50_000));
+        view.mark_offchain_order_pending(spym.clone());
+
+        let gated = view
+            .apply_snapshot_event(&usd_reconciled_event(0, None, now), now)
+            .unwrap();
+        assert_eq!(
+            gated.usdc_available(Venue::Hedging),
+            Some(usdc_cents(50_000)),
+            "an open hedge order owns the cash balance; the reconcile must abort"
+        );
+
+        let mut released = gated;
+        released.clear_offchain_order_pending(&spym, None);
+        let healed = released
+            .apply_snapshot_event(&usd_reconciled_event(0, None, now), now)
+            .unwrap();
+        assert_eq!(
+            healed.usdc_available(Venue::Hedging),
+            Some(Usdc::ZERO),
+            "the reconcile must apply once the hedge order terminated"
+        );
+    }
+
+    #[test]
+    fn cash_reconcile_aborts_when_reading_predates_last_applied_cash_fill() {
+        let spym = Symbol::new("SPYM").unwrap();
+        let fetched_at = Utc::now();
+        let fill_applied_at = fetched_at + Duration::seconds(1);
+
+        let mut view = InventoryView::default().with_usdc(Usdc::ZERO, usdc_cents(40_000));
+        view.clear_offchain_order_pending(&spym, Some(fill_applied_at));
+
+        let result = view
+            .apply_snapshot_event(
+                &usd_reconciled_event(0, Some(usdc_cents(40_000)), fetched_at),
+                fill_applied_at,
+            )
+            .unwrap();
+
+        assert_eq!(
+            result.usdc_available(Venue::Hedging),
+            Some(usdc_cents(40_000)),
+            "the reconcile must abort when a cash fill applied after the \
+             reading was fetched"
+        );
+    }
+
+    #[test]
+    fn cash_reconciliation_busy_covers_each_busy_source() {
+        let spym = Symbol::new("SPYM").unwrap();
+        let now = Utc::now();
+
+        let not_busy = InventoryView::default().with_usdc(Usdc::ZERO, usdc_cents(50_000));
+        assert_eq!(not_busy.cash_reconciliation_busy(now).unwrap(), None);
+
+        let inflight = not_busy.clone().with_usdc_inflight(
+            Usdc::ZERO,
+            Usdc::ZERO,
+            usdc_cents(50_000),
+            usdc_cents(1_000),
+        );
+        assert_eq!(
+            inflight.cash_reconciliation_busy(now).unwrap(),
+            Some(EquityReconcileBusy::Transfer)
+        );
+
+        let rebalancing = not_busy
+            .clone()
+            .set_active_usdc_rebalance(UsdcRebalanceId(Uuid::new_v4()));
+        assert_eq!(
+            rebalancing.cash_reconciliation_busy(now).unwrap(),
+            Some(EquityReconcileBusy::Transfer)
+        );
+
+        let mut hedging = not_busy.clone();
+        hedging.mark_offchain_order_pending(spym.clone());
+        assert_eq!(
+            hedging.cash_reconciliation_busy(now).unwrap(),
+            Some(EquityReconcileBusy::PendingHedgeOrder)
+        );
+
+        let mut fill_applied_after_reading = not_busy;
+        fill_applied_after_reading
+            .clear_offchain_order_pending(&spym, Some(now + Duration::seconds(1)));
+        assert_eq!(
+            fill_applied_after_reading
+                .cash_reconciliation_busy(now)
+                .unwrap(),
+            Some(EquityReconcileBusy::FillAfterFetch)
+        );
+        assert_eq!(
+            fill_applied_after_reading
+                .cash_reconciliation_busy(now + Duration::seconds(2))
+                .unwrap(),
+            None
+        );
+    }
+
+    /// ADR 0015 accepted guard starvation but left it invisible at
+    /// production log levels; the skip streak is the missing signal. The
+    /// warn must fire only at the cadence, not on every skip.
+    #[test]
+    #[tracing_test::traced_test]
+    fn offchain_usd_snapshot_skip_streak_warns_at_cadence() {
+        let spym = Symbol::new("SPYM").unwrap();
+        let now = Utc::now();
+
+        let mut view = InventoryView::default().with_usdc(Usdc::ZERO, usdc_cents(50_000));
+        view.mark_offchain_order_pending(spym);
+
+        let snapshot = InventorySnapshotEvent::OffchainUsd {
+            usd_balance_cents: 0,
+            gross_usd_cents: Some(0),
+            fetched_at: now,
+        };
+
+        for _ in 0..(OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY - 1) {
+            view = view.apply_snapshot_event(&snapshot, now).unwrap();
+        }
+        assert_eq!(
+            view.offchain_usd_snapshot_skip_streak,
+            OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY - 1
+        );
+        assert!(
+            !logs_contain("Offchain USD snapshots keep being skipped"),
+            "below the cadence no starvation warning may fire"
+        );
+
+        let view = view.apply_snapshot_event(&snapshot, now).unwrap();
+        assert_eq!(
+            view.offchain_usd_snapshot_skip_streak,
+            OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY
+        );
+        assert!(
+            logs_contain("Offchain USD snapshots keep being skipped"),
+            "the warn must fire once the streak reaches the cadence"
+        );
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn offchain_usd_snapshot_skip_streak_resets_on_apply() {
+        let spym = Symbol::new("SPYM").unwrap();
+        let now = Utc::now();
+
+        let mut view = InventoryView::default().with_usdc(Usdc::ZERO, usdc_cents(50_000));
+        view.mark_offchain_order_pending(spym.clone());
+
+        let snapshot = InventorySnapshotEvent::OffchainUsd {
+            usd_balance_cents: 0,
+            gross_usd_cents: Some(0),
+            fetched_at: now,
+        };
+
+        for _ in 0..(OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY - 1) {
+            view = view.apply_snapshot_event(&snapshot, now).unwrap();
+        }
+
+        // An applied snapshot ends the starvation streak: the guard lifted
+        // and broker truth reached the balance.
+        view.clear_offchain_order_pending(&spym, None);
+        view = view.apply_snapshot_event(&snapshot, now).unwrap();
+        assert_eq!(
+            view.offchain_usd_snapshot_skip_streak, 0,
+            "an applied snapshot must reset the skip streak"
+        );
+
+        view.mark_offchain_order_pending(spym);
+        for _ in 0..(OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY - 1) {
+            view = view.apply_snapshot_event(&snapshot, now).unwrap();
+        }
+        assert!(
+            !logs_contain("Offchain USD snapshots keep being skipped"),
+            "interrupted streaks must not accumulate across an apply"
+        );
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn offchain_equity_snapshot_skip_streak_warns_at_cadence() {
+        let spym = Symbol::new("SPYM").unwrap();
+        let now = Utc::now();
+
+        let mut view = InventoryView::default().with_equity(spym.clone(), shares(0), shares(10));
+        view.mark_offchain_order_pending(spym.clone());
+
+        let snapshot = InventorySnapshotEvent::OffchainEquity {
+            positions: BTreeMap::from([(spym.clone(), shares(0))]),
+            fetched_at: now,
+        };
+
+        for _ in 0..(OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY - 1) {
+            view = view.apply_snapshot_event(&snapshot, now).unwrap();
+        }
+        assert!(
+            !logs_contain("Offchain equity snapshots for this symbol keep being"),
+            "below the cadence no starvation warning may fire"
+        );
+
+        view = view.apply_snapshot_event(&snapshot, now).unwrap();
+        assert_eq!(
+            view.offchain_equity_snapshot_skip_streaks.get(&spym),
+            Some(&OFFCHAIN_SNAPSHOT_SKIP_WARN_EVERY)
+        );
+        assert!(
+            logs_contain("Offchain equity snapshots for this symbol keep being"),
+            "the warn must fire once the symbol's streak reaches the cadence"
+        );
+
+        // An applied snapshot drops the symbol's streak entirely.
+        view.clear_offchain_order_pending(&spym, None);
+        let view = view
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OffchainEquity {
+                    positions: BTreeMap::from([(spym.clone(), shares(0))]),
+                    fetched_at: now + Duration::seconds(1),
+                },
+                now,
+            )
+            .unwrap();
+        assert_eq!(
+            view.offchain_equity_snapshot_skip_streaks.get(&spym),
+            None,
+            "an applied snapshot must clear the symbol's skip streak"
         );
     }
 }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1685,14 +1685,14 @@ impl RebalancingService {
                 now,
             ),
 
-            // `reconcile_offchain_equity` validates busyness and the hedge
-            // gate under the write lock, so the generic apply path is the
-            // correct route here too. `OnchainUsdc` also routes through it
-            // (not a direct `update_usdc`) so the view's block-watermark
-            // bookkeeping for absorbed onchain fills has a single
-            // implementation.
+            // The reconcile arms validate busyness themselves under the
+            // write lock, so the generic apply path is the correct route
+            // here too. `OnchainUsdc` also routes through it (not a direct
+            // `update_usdc`) so the view's block-watermark bookkeeping for
+            // absorbed onchain fills has a single implementation.
             OnchainUsdc { .. }
             | OffchainEquityReconciled { .. }
+            | OffchainUsdReconciled { .. }
             | OffchainUsd { .. }
             | OffchainCashBuyingPower { .. }
             | OffchainCashWithdrawable { .. }
@@ -1757,16 +1757,24 @@ impl RebalancingService {
         };
 
         // The recovery reset below drops the active mints/redemptions and
-        // inflight state that `reconcile_offchain_equity` revalidates, so a
-        // forced retry would pass vacuously against empty state. Drop the
-        // event instead: the poller's read-back keeps the gate and counter,
-        // and the next quiet poll re-escalates with a fresh reading.
+        // inflight state that the reconcile arms revalidate, so a forced
+        // retry would pass vacuously against empty state. Drop the event
+        // instead: the poller's read-back keeps the gate and counter, and
+        // the next quiet poll re-escalates with a fresh reading.
         if let OffchainEquityReconciled { symbol, .. } = &event {
             warn!(
                 target: "rebalance",
                 %symbol,
                 ?inventory_error,
                 "Skipping force-apply recovery for a reconcile event"
+            );
+            return Ok(());
+        }
+        if let OffchainUsdReconciled { .. } = &event {
+            warn!(
+                target: "rebalance",
+                ?inventory_error,
+                "Skipping force-apply recovery for a cash reconcile event"
             );
             return Ok(());
         }
@@ -1819,12 +1827,13 @@ impl RebalancingService {
                 now,
             ),
 
-            // `OffchainEquityReconciled` never reaches here at runtime -- the
-            // early return above drops it before this match. It is listed only
-            // to keep the match exhaustive.
+            // The reconcile events never reach here at runtime -- the early
+            // return above drops them before this match. They are listed
+            // only to keep the match exhaustive.
             OnchainEquity { .. }
             | OffchainEquity { .. }
             | OffchainEquityReconciled { .. }
+            | OffchainUsdReconciled { .. }
             | OffchainUsd { .. }
             | OffchainCashBuyingPower { .. }
             | OffchainCashWithdrawable { .. }
@@ -1896,6 +1905,11 @@ impl RebalancingService {
             }
             // Global USDC snapshots: one USDC check.
             //
+            // OffchainUsdReconciled: a healed venue-level cash reconcile
+            // changes USDC imbalance math the same way an ordinary cash
+            // snapshot does; an aborted one enqueues a check that reads
+            // the unchanged view and triggers nothing.
+            //
             // OffchainCashWithdrawable feeds the Alpaca-to-Base capacity
             // gate (`withdrawable_cash_cents - reserved`). After the
             // trigger skips with `MissingWithdrawableCash` because the
@@ -1903,7 +1917,10 @@ impl RebalancingService {
             // brings rebalancing back online — without scheduling on it,
             // the imbalance would remain unresolved until some unrelated
             // USDC balance event happened to arrive.
-            OnchainUsdc { .. } | OffchainUsd { .. } | OffchainCashWithdrawable { .. } => {
+            OnchainUsdc { .. }
+            | OffchainUsd { .. }
+            | OffchainUsdReconciled { .. }
+            | OffchainCashWithdrawable { .. } => {
                 self.usdc_scheduler.enqueue_check().await;
             }
             // Wrapped equity in the bot wallet (outside Raindex) triggers
@@ -2944,6 +2961,19 @@ impl RebalancingService {
             return;
         };
 
+        // A pending cash divergence means the Hedging USDC balance the
+        // imbalance math reads is suspect: a bridge sized off it moves the
+        // wrong amount and marks the venue busy, freezing the very counter
+        // that resolves the divergence. Skip until the poller clears it.
+        if self.divergence_gate.is_cash_engaged() {
+            warn!(
+                target: "rebalance",
+                "Skipped USDC trigger: unresolved cash snapshot divergence \
+                 pending reconciliation"
+            );
+            return;
+        }
+
         let Some(guard) = self.try_claim_usdc_guard() else {
             debug!(target: "rebalance", "Skipped USDC trigger: already in progress");
             return;
@@ -2959,6 +2989,18 @@ impl RebalancingService {
         .inspect_err(|skip| debug!(target: "rebalance", ?skip, "Skipped USDC trigger")) else {
             return;
         };
+
+        // Re-check immediately before dispatch: the poller may have engaged
+        // the cash gate during the awaits in the imbalance build (mirrors
+        // the equity trigger's pre-dispatch re-checks).
+        if self.divergence_gate.is_cash_engaged() {
+            warn!(
+                target: "rebalance",
+                "Skipped USDC trigger before dispatch: cash snapshot \
+                 divergence detected during operation sizing"
+            );
+            return;
+        }
 
         let dispatched = match operation {
             UsdcRebalanceOperation::BaseToAlpaca { amount } => {
@@ -22531,6 +22573,183 @@ mod tests {
             busy,
             Some(EquityReconcileBusy::Transfer),
             "the active mint must survive the skipped recovery"
+        );
+    }
+
+    /// The cash twin of `divergence_gate_suppresses_equity_transfer_dispatch`:
+    /// an engaged cash gate must suppress USDC dispatch (a bridge sized off
+    /// a diverged balance moves the wrong amount and freezes the divergence
+    /// counter), and releasing it restores dispatch.
+    #[tokio::test]
+    async fn cash_divergence_gate_suppresses_usdc_transfer_dispatch() {
+        // 900 onchain, 100 offchain = 90% ratio -> TooMuchOnchain would
+        // dispatch a TransferUsdcToHedging job.
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
+        let reactor = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
+
+        trigger.divergence_gate().engage_cash();
+
+        trigger.check_and_trigger_usdc().await;
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&trigger).await,
+            0,
+            "an engaged cash gate must not dispatch a USDC transfer"
+        );
+
+        trigger.divergence_gate().release_cash();
+
+        trigger.check_and_trigger_usdc().await;
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&trigger).await,
+            1,
+            "releasing the cash gate must restore USDC dispatch"
+        );
+    }
+
+    /// With rebalancing enabled, `OffchainUsdReconciled` reaches the view
+    /// through the reactor's `on_snapshot` arm. The stuck cash state must
+    /// recover through that route and enqueue one follow-up USDC check.
+    #[tokio::test]
+    async fn usd_reconcile_event_via_reactor_heals_stuck_view_and_enqueues_usdc_check() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        // Phantom cash at Hedging with last_rebalancing stamped: ordinary
+        // cash snapshots fetched before the stamp are rejected.
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(500), usdc(500))
+            .clear_usdc_inflight(Venue::Hedging, now)
+            .unwrap();
+
+        let reactor = make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+        let id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+        let pool = trigger.usdc_scheduler.queue().pool().clone();
+
+        // Precondition: the ordinary arm stays rejected through the reactor.
+        apply_and_dispatch_snapshot(
+            reactor.clone(),
+            id.clone(),
+            InventorySnapshotEvent::OffchainUsd {
+                usd_balance_cents: 0,
+                gross_usd_cents: None,
+                fetched_at: now - chrono::Duration::seconds(1),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .usdc_available(Venue::Hedging),
+            Some(usdc(500)),
+            "precondition: the ordinary cash snapshot must still be rejected"
+        );
+
+        let pending_before: i64 = sqlx_apalis::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type LIKE '%UsdcRebalancingCheck'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("count pending usdc-check jobs before reconcile");
+
+        apply_and_dispatch_snapshot(
+            reactor.clone(),
+            id,
+            InventorySnapshotEvent::OffchainUsdReconciled {
+                usd_balance_cents: 0,
+                gross_usd_cents: Some(0),
+                fetched_at: now + chrono::Duration::seconds(1),
+                ledger_usdc: Some(usdc(500)),
+                consecutive_polls: 3,
+            },
+        )
+        .await
+        .unwrap();
+
+        let (available, inflight) = {
+            let view = trigger.inventory.read().await;
+            (
+                view.usdc_available(Venue::Hedging),
+                view.usdc_inflight(Venue::Hedging),
+            )
+        };
+        assert_eq!(
+            available,
+            Some(Usdc::ZERO),
+            "the reconcile must apply the broker cash value through the reactor route"
+        );
+        assert_eq!(
+            inflight,
+            Some(Usdc::ZERO),
+            "the reconcile clears Hedging cash inflight"
+        );
+
+        let pending_after: i64 = sqlx_apalis::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type LIKE '%UsdcRebalancingCheck'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("count pending usdc-check jobs after reconcile");
+        assert!(
+            pending_after > pending_before,
+            "a cash reconcile must enqueue a follow-up USDC check (before: \
+             {pending_before}, after: {pending_after})"
+        );
+    }
+
+    /// The cash twin of
+    /// `snapshot_recovery_skips_reconcile_event_leaving_view_untouched`:
+    /// the force-apply recovery resets the view, dropping exactly the busy
+    /// state `reconcile_offchain_usd` revalidates, so recovery must skip the
+    /// event; the poller re-escalates on its own.
+    #[tokio::test]
+    async fn snapshot_recovery_skips_usd_reconcile_event_leaving_view_untouched() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(0), usdc(500))
+            .set_active_usdc_rebalance(UsdcRebalanceId(Uuid::new_v4()));
+
+        let trigger = make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+
+        trigger
+            .on_snapshot_recovery(
+                RebalancingServiceError::Inventory(InventoryViewError::UsdBalanceConversion(
+                    i64::MAX,
+                )),
+                InventorySnapshotEvent::OffchainUsdReconciled {
+                    usd_balance_cents: 0,
+                    gross_usd_cents: Some(0),
+                    fetched_at: Utc::now(),
+                    ledger_usdc: Some(usdc(500)),
+                    consecutive_polls: 3,
+                },
+            )
+            .await
+            .unwrap();
+
+        let (available, busy) = {
+            let view = trigger.inventory.read().await;
+            (
+                view.usdc_available(Venue::Hedging),
+                view.cash_reconciliation_busy(Utc::now()).unwrap(),
+            )
+        };
+        assert_eq!(
+            available,
+            Some(usdc(500)),
+            "recovery must not force-apply a cash reconcile against the reset view"
+        );
+        assert_eq!(
+            busy,
+            Some(EquityReconcileBusy::Transfer),
+            "the active USDC rebalance must survive the skipped recovery"
         );
     }
 


### PR DESCRIPTION
## What

Closes [RAI-1502](https://linear.app/makeitrain/issue/RAI-1502/a-skipped-or-stale-offchain-snapshot-must-self-correct-within-a) . Extends the ADR 0015 single-writer reconciliation machinery to cover the Hedging venue's cash (USDC) balance, mirroring the existing per-symbol equity divergence detection and forced reconcile.

## Why

The equity reconciliation path (ADR 0015) already handles persistent divergences between broker-reported equity positions and the inventory view, but the Hedging cash balance had no equivalent. The same wedge scenarios that can strand an equity balance — unchanged-value deduplication in the aggregate, staleness guards in the view, failed USDC-transfer cleanups re-stamping `last_rebalancing` — can equally strand the Hedging USDC balance with no bounded recovery path. A USDC rebalancing trigger sized off a diverged cash balance would bridge the wrong amount and mark the venue busy, freezing the very counter needed to resolve the divergence.

Additionally, ADR 0015 acknowledged that guard starvation (a symbol's snapshots being persistently skipped) was invisible at production log levels. That gap is addressed here for both equity and cash.

## How

**Divergence gate**: `InventoryDivergenceGate` gains a venue-level `cash: AtomicBool` alongside the per-symbol equity set. `engage_cash` / `release_cash` / `is_cash_engaged` manage it. While engaged, the USDC rebalancing trigger skips dispatch at two points: before claiming the guard and again immediately before dispatch.

**Detection and escalation**: `InventoryPollingService` gains a `cash_divergence_counter` (a single `Mutex<u32>`, venue-level). After each broker poll, `detect_offchain_cash_divergence` compares the broker's available cash against `view.usdc_available(Venue::Hedging)`. The counter is frozen (not reset) while the venue is busy — USDC inflight, an active USDC rebalance aggregate, any open hedge order, or a reading fetched before the last applied cash fill's timestamp. At the configured `inventory_divergence_threshold`, the poller sends `ReconcileOffchainUsd`. If the view reads back the broker value after the command applies, the counter resets and the gate releases; otherwise both are kept so the next quiet poll re-escalates immediately.

**New command and event**: `InventorySnapshotCommand::ReconcileOffchainUsd` and `InventorySnapshotEvent::OffchainUsdReconciled` are added. The command always emits its event (bypassing value deduplication), and the event folds into `offchain_usd_cents` with the same monotonic `fetched_at` guard as `OffchainUsd`, so startup hydration replays the reconciled value correctly.

**Force-apply in the view**: `InventoryView::reconcile_offchain_usd` re-validates the busy taxonomy under the write lock and aborts if the venue turned busy between detection and apply. A verified apply uses `Inventory::force_on_snapshot` to push the broker value through the staleness guard, clears `offchain_usd_snapshot_skip_streak`, and carries the gross reading alongside the net.

**Reactor routing**: `OffchainUsdReconciled` is added to the reactor's generic apply arm (which validates busyness itself), to the USDC check scheduler arm (a healed reconcile changes imbalance math the same way an ordinary cash snapshot does), and to the force-apply recovery skip list (recovery resets the view, dropping the busy state the reconcile revalidates, so the event is dropped and the poller re-escalates).

**Guard-skip starvation observability**: `InventoryView` tracks `offchain_equity_snapshot_skip_streaks` (per symbol) and `offchain_usd_snapshot_skip_streak` (venue-level). Both warn every five consecutive skips and reset when a snapshot successfully applies. The `OffchainUsd` skip predicate is also extended to catch skips that `on_snapshot` would silently discard, so those count toward the streak rather than vanishing.

## Testing

- `cash_divergence_escalates_at_exactly_threshold_polls`: verifies the counter reaches the threshold before escalating, that an unhealed escalation keeps the counter and gate, and that subsequent polls keep counting rather than restarting.
- `cash_divergence_counter_resets_on_matching_poll`: verifies the counter and gate reset on a matching poll and that the count restarts from one afterward.
- `assert_cash_counter_frozen_while_busy` (shared helper) with four specializations: USDC inflight, active USDC rebalance, open hedge order, and a cash fill applied after the reading. Each verifies the counter is frozen (not reset) during the busy window and resumes correctly once cleared.
- `uninitialized_cash_venue_with_zero_broker_reading_does_not_diverge`: an uninitialized view against a zero broker reading must not escalate or engage the gate.
- `phantom_hedging_cash_self_heals_within_threshold_polls`: end-to-end test of the full wedge scenario — phantom cash protected by a staleness guard, aggregate deduplication preventing ordinary event emission, forced reconcile at the threshold, view convergence, and gate release.
- Snapshot aggregate tests: `ReconcileOffchainUsd` always emits even when the stored balance already matches; `OffchainUsdReconciled` folds correctly for hydration; a stale reconcile event does not regress the stored balance.
- View-level tests: `cash_reconcile_forces_broker_value_through_guard`, abort cases for each busy source, `cash_reconciliation_busy_covers_each_busy_source`.
- Skip-streak tests: `offchain_usd_snapshot_skip_streak_warns_at_cadence`, `offchain_usd_snapshot_skip_streak_resets_on_apply`, `offchain_equity_snapshot_skip_streak_warns_at_cadence`.
- Trigger tests: `cash_divergence_gate_suppresses_usdc_transfer_dispatch`, `usd_reconcile_event_via_reactor_heals_stuck_view_and_enqueues_usdc_check`, `snapshot_recovery_skips_usd_reconcile_event_leaving_view_untouched`.

## Anything else

The ADR 0015 open item noting that guard starvation was unobservable at production log levels is now marked addressed in `adrs/0015-single-writer-reconciliation-for-hedging-equity-balance.md`. The SPEC is updated with the full cash divergence detection, escalation, forced-reconcile, and dispatch-gating specification, including the skip-streak observability guarantee.

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated recovery for persistent discrepancies between broker cash and recorded Hedging USDC balances.
  * Reconciliation now records broker, ledger, gross cash, timestamp, and divergence details for accurate state recovery.
  * USDC rebalancing pauses while cash discrepancies are being reconciled and resumes after verification.
* **Bug Fixes**
  * Improved handling of stale or busy cash and equity snapshots.
  * Added periodic warnings when snapshots are repeatedly skipped, improving operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->