### PR TITLE
Restart-tainted balance guard for open-order straddling reboots

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3735,6 +3735,34 @@ warning every five consecutive skips, so an ADR 0015 guard that starves a
 balance of broker truth surfaces at production log levels before the divergence
 machinery escalates. An applied snapshot resets the streak.
 
+The same machinery closes the restart-across-an-open-order window. The aggregate
+records every poll -- including mid-order broker readings the live view's guards
+refused -- and the guard state that refused them (local-clock applied-fill
+stamps) does not survive a restart, so a hydrated balance for a symbol whose
+hedge order straddled the boot may or may not already contain the order's fill.
+Rather than guess, boot marks every gated symbol (and, because any open order
+moves Hedging cash, the venue cash balance) **restart-tainted**, seeded together
+with the open-order gate from the Position projection:
+
+- A tainted symbol's fill skips both delta legs (equity and mirrored USDC) and
+  clears the order gate without stamping an applied-fill time; a failed or
+  cancelled order leaves the taint in place, since the pre-restart portion may
+  have partially filled.
+- While tainted, equity dispatch for the symbol and USDC dispatch for the venue
+  are suppressed, exactly as under an engaged divergence gate.
+- The poller resolves the taint against broker truth: a matching quiet poll
+  proves the hydrated value and lifts the taint; a diverging quiet poll
+  escalates the forced reconcile immediately (the taint bypasses the N-poll
+  confirmation threshold -- the ambiguity was created by the boot, not a
+  transient race), and a verified heal lifts the taint. A busy symbol or venue
+  neither resolves nor escalates: the comparison is ambiguous, so the taint
+  survives until the balance is quiet.
+
+The accepted cost is that a fill during the tainted window is reflected only
+after the re-base lands -- the next successful quiet poll during market hours (a
+closed market, a failed broker poll, or a busy venue defers it), for at most the
+orders that straddled the restart -- replacing an unbounded double-count drift.
+
 ### InventoryView
 
 `InventoryView` aggregates inventory across onchain and offchain venues and

--- a/adrs/0015-single-writer-reconciliation-for-hedging-equity-balance.md
+++ b/adrs/0015-single-writer-reconciliation-for-hedging-equity-balance.md
@@ -171,7 +171,12 @@ unchanged-value dedupe suppresses subsequent polls, so the drift persists until
 the broker value changes or the next restart re-hydrates. Bounding this window
 needs the descoped retry mechanism (Follow-up work); closing it entirely would
 require the snapshot to record which fills it absorbed — the same missing
-broker-side ordering as alternative C.
+broker-side ordering as alternative C. _Addressed by RAI-1501: boot marks every
+gated symbol (and the venue cash balance) restart-tainted; a tainted fill skips
+its deltas instead of guessing, and the divergence machinery re-bases the
+balance from broker truth on the first quiet poll (taint bypasses the escalation
+threshold), bounding the drift to the next successful quiet poll during market
+hours._
 
 **It extends the lifetime of pre-existing drift.** The guard rejects the
 symbol's whole snapshot, not just the contested fill, so unrelated drift loses

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -1476,6 +1476,11 @@ async fn compact_inventory_snapshot_events(pool: &SqlitePool) -> Result<u64, sql
 /// ordering convention every caller must know about. Safe because the gate's
 /// only authoritative source at boot is the `Position` projection seeded
 /// below, and no reactors or workers run concurrently with this seam.
+///
+/// The same setter also stamps the restart taint (symbols whose hedge order
+/// straddled the restart, whose hydrated Hedging balances are therefore
+/// ambiguous): cleared with the gate on entry, seeded with the gate below.
+/// See `InventoryView::set_pending_offchain_order_symbols`.
 pub(crate) async fn restore_inventory_at_boot(
     pool: &SqlitePool,
     inventory: &Arc<BroadcastingInventory>,

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -14,7 +14,7 @@ use futures_util::future::try_join_all;
 use rain_math_float::{Float, FloatError};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::{Arc, Mutex, MutexGuard};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::{Evm, EvmError, IERC20, OpenChainErrorRegistry, USDC_BASE, USDC_ETHEREUM, Wallet};
@@ -111,6 +111,11 @@ struct InventoryDivergenceObservation {
     /// Position the broker reported, normalized (explicit zero when absent).
     fetched: FractionalShares,
     state: ObservedLedgerState,
+    /// The symbol's hydrated balance is restart-tainted: a hedge order was
+    /// open across the boot, so a confirmed divergence escalates on this
+    /// very poll instead of waiting out the threshold, and a match resolves
+    /// the taint.
+    tainted: bool,
 }
 
 /// How the view's Hedging balance relates to the broker reading.
@@ -794,6 +799,7 @@ where
         };
 
         let view = recovery.inventory.read().await;
+        let tainted = view.is_restart_cash_tainted();
         let state = if view.cash_reconciliation_busy(fetched_at)?.is_some() {
             ObservedCashLedgerState::Busy
         } else {
@@ -814,8 +820,10 @@ where
         };
         drop(view);
 
+        Self::resolve_matching_cash_taint(recovery, &state, tainted).await;
+
         let Some(escalation) =
-            self.record_cash_divergence_observation(recovery, &state, usd_balance_cents)
+            self.record_cash_divergence_observation(recovery, &state, usd_balance_cents, tainted)
         else {
             return Ok(());
         };
@@ -832,6 +840,41 @@ where
         .await
     }
 
+    /// Mirrors the equity taint resolution: a matching reading proves the
+    /// hydrated cash balance agrees with the broker, so the restart taint
+    /// lifts without an escalation. The diverging case resolves through
+    /// the escalation's verified heal instead.
+    async fn resolve_matching_cash_taint(
+        recovery: &InventoryDivergenceRecoveryCtx,
+        state: &ObservedCashLedgerState,
+        tainted: bool,
+    ) {
+        if !tainted {
+            return;
+        }
+
+        // Exhaustive so a new observed state forces a decision on whether
+        // it proves the hydrated balance: Busy is ambiguous and Divergence
+        // resolves through the escalation's verified heal.
+        match state {
+            ObservedCashLedgerState::Match => {}
+            ObservedCashLedgerState::Busy | ObservedCashLedgerState::Divergence { .. } => {
+                return;
+            }
+        }
+
+        info!(
+            target: "inventory",
+            "Restart cash taint resolved: the hydrated balance matches \
+             the broker"
+        );
+        recovery
+            .inventory
+            .write_without_broadcast()
+            .await
+            .clear_restart_cash_taint();
+    }
+
     /// Folds one poll's cash observation into the counter and the dispatch
     /// gate. Synchronous on purpose: the counter guard must never be held
     /// across an await.
@@ -840,6 +883,7 @@ where
         recovery: &InventoryDivergenceRecoveryCtx,
         state: &ObservedCashLedgerState,
         broker_cents: i64,
+        tainted: bool,
     ) -> Option<CashDivergenceEscalation> {
         let mut counter = self.lock_cash_divergence_counter();
 
@@ -862,13 +906,19 @@ where
                     broker_cents,
                     consecutive_polls = *counter,
                     threshold = recovery.threshold.get(),
+                    tainted,
                     "Offchain USD snapshot diverges from the inventory view"
                 );
 
-                (*counter >= recovery.threshold.get()).then_some(CashDivergenceEscalation {
-                    ledger: *ledger,
-                    consecutive_polls: *counter,
-                })
+                // A restart-tainted cash divergence is already confirmed
+                // (the ambiguity came from the boot, not a transient race),
+                // so it escalates on the first quiet diverging poll.
+                (*counter >= recovery.threshold.get() || tainted).then_some(
+                    CashDivergenceEscalation {
+                        ledger: *ledger,
+                        consecutive_polls: *counter,
+                    },
+                )
             }
         }
     }
@@ -910,6 +960,11 @@ where
         if healed {
             *self.lock_cash_divergence_counter() = 0;
             recovery.gate.release_cash();
+            recovery
+                .inventory
+                .write_without_broadcast()
+                .await
+                .clear_restart_cash_taint();
         } else if escalation.consecutive_polls >= recovery.threshold.get().saturating_mul(2) {
             // A full extra threshold window of escalations has failed to
             // heal: past transient busyness, and every failed attempt
@@ -1009,10 +1064,13 @@ where
                         symbol: symbol.clone(),
                         fetched: *fetched,
                         state,
+                        tainted: view.is_restart_tainted(symbol),
                     })
                 })
                 .collect::<Result<_, FloatError>>()?
         };
+
+        Self::resolve_matching_equity_taints(recovery, &observations).await;
 
         let escalations = self.record_divergence_observations(recovery, observations);
 
@@ -1038,6 +1096,44 @@ where
         }
 
         first_error.map_or(Ok(()), Err)
+    }
+
+    /// Lifts the restart taint for every symbol whose reading matched the
+    /// view: the hydrated number turns out to agree with broker truth, so
+    /// no escalation is needed. The diverging case resolves through the
+    /// escalation's verified heal instead.
+    async fn resolve_matching_equity_taints(
+        recovery: &InventoryDivergenceRecoveryCtx,
+        observations: &[InventoryDivergenceObservation],
+    ) {
+        // Exhaustive so a new observed state forces a decision on whether
+        // it proves the hydrated balance: Busy is ambiguous and Divergence
+        // resolves through the escalation's verified heal.
+        let resolved: Vec<&Symbol> = observations
+            .iter()
+            .filter(|observation| {
+                observation.tainted
+                    && match observation.state {
+                        ObservedLedgerState::Match => true,
+                        ObservedLedgerState::Busy | ObservedLedgerState::Divergence { .. } => false,
+                    }
+            })
+            .map(|observation| &observation.symbol)
+            .collect();
+        if resolved.is_empty() {
+            return;
+        }
+
+        let mut view = recovery.inventory.write_without_broadcast().await;
+        for symbol in resolved {
+            info!(
+                target: "inventory",
+                %symbol,
+                "Restart taint resolved: the hydrated balance matches \
+                 the broker"
+            );
+            view.clear_restart_taint(symbol);
+        }
     }
 
     /// Sends one `ReconcileOffchainEquity` escalation and settles its
@@ -1074,6 +1170,11 @@ where
         if healed {
             self.lock_divergence_counters().remove(&escalation.symbol);
             recovery.gate.release(&escalation.symbol);
+            recovery
+                .inventory
+                .write_without_broadcast()
+                .await
+                .clear_restart_taint(&escalation.symbol);
         } else if escalation.consecutive_polls >= recovery.threshold.get().saturating_mul(2) {
             // A full extra threshold window of escalations has failed to
             // heal: past transient busyness, and every failed attempt
@@ -1115,6 +1216,7 @@ where
                 symbol,
                 fetched,
                 state,
+                tainted,
             } = observation;
 
             match state {
@@ -1136,10 +1238,15 @@ where
                         broker = %fetched,
                         consecutive_polls = *count,
                         threshold = recovery.threshold.get(),
+                        tainted,
                         "Offchain snapshot diverges from the inventory view"
                     );
 
-                    if *count >= recovery.threshold.get() {
+                    // A restart-tainted divergence is already confirmed --
+                    // the ambiguity was created by the boot, not by a
+                    // transient race the threshold exists to filter -- so
+                    // it escalates on the first quiet diverging poll.
+                    if *count >= recovery.threshold.get() || tainted {
                         escalations.push(InventoryDivergenceEscalation {
                             symbol,
                             fetched,
@@ -5747,6 +5854,461 @@ mod tests {
             1,
             "exactly one cash escalation must have been persisted"
         );
+    }
+
+    /// Marks `symbol` restart-tainted the way the boot seam does, then
+    /// clears its order gate the way a terminal fill does -- the exact
+    /// state a restart-straddling order leaves for the poller.
+    fn taint_from_restart(view: &mut InventoryView, symbol: &Symbol) {
+        view.set_pending_offchain_order_symbols(HashSet::from([symbol.clone()]));
+        view.clear_offchain_order_pending(symbol, None);
+    }
+
+    /// A restart-tainted divergence is already confirmed, so it must not
+    /// wait out the threshold: the first quiet diverging poll escalates
+    /// with `consecutive_polls == 1`, and an unhealed escalation keeps the
+    /// taint for the next attempt.
+    #[tokio::test]
+    async fn restart_tainted_divergence_escalates_on_first_quiet_poll() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let spym = test_symbol("SPYM");
+
+        let mut view =
+            InventoryView::default().with_equity(spym.clone(), test_shares(0), test_shares(136));
+        taint_from_restart(&mut view, &spym);
+        let inventory = broadcasting_inventory(view);
+        let gate = Arc::new(InventoryDivergenceGate::default());
+        // Threshold 3: an untainted divergence would need three polls.
+        let service = reconciling_service(
+            &pool,
+            Arc::new(test_store(pool.clone(), ())),
+            inventory.clone(),
+            gate.clone(),
+            3,
+        );
+
+        service.poll_and_record().await.unwrap();
+
+        let events = reconciled_events(&pool, orderbook, order_owner).await;
+        let [
+            InventorySnapshotEvent::OffchainEquityReconciled {
+                consecutive_polls, ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("Expected exactly one reconcile escalation, got {events:?}");
+        };
+        assert_eq!(
+            *consecutive_polls, 1,
+            "a tainted divergence must escalate on the first poll, not at \
+             the threshold"
+        );
+        assert!(gate.is_engaged(&spym));
+        // No reactor is wired, so the escalation could not heal the view:
+        // the taint must survive for the next poll's re-escalation.
+        assert!(
+            inventory.read().await.is_restart_tainted(&spym),
+            "an unhealed escalation must keep the restart taint"
+        );
+    }
+
+    /// The taint bypasses the escalation threshold, never the busy freeze:
+    /// a busy symbol's comparison is ambiguous regardless of why the taint
+    /// was seeded, so a tainted busy symbol must not escalate even at
+    /// threshold 1.
+    #[tokio::test]
+    async fn restart_tainted_busy_symbol_does_not_escalate() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let spym = test_symbol("SPYM");
+
+        let mut view =
+            InventoryView::default().with_equity(spym.clone(), test_shares(0), test_shares(136));
+        taint_from_restart(&mut view, &spym);
+        let view = view.set_active_mint(spym.clone(), issuer_request_id("tainted-busy"));
+        let inventory = broadcasting_inventory(view);
+        let gate = Arc::new(InventoryDivergenceGate::default());
+        let service = reconciling_service(
+            &pool,
+            Arc::new(test_store(pool.clone(), ())),
+            inventory.clone(),
+            gate.clone(),
+            1,
+        );
+
+        service.poll_and_record().await.unwrap();
+        service.poll_and_record().await.unwrap();
+
+        assert!(
+            reconciled_events(&pool, orderbook, order_owner)
+                .await
+                .is_empty(),
+            "a tainted busy symbol must stay frozen, not escalate against \
+             an ambiguous balance"
+        );
+        assert!(
+            inventory.read().await.is_restart_tainted(&spym),
+            "the frozen taint must survive for resolution once the symbol \
+             is quiet"
+        );
+    }
+
+    /// The cash twin: `record_cash_divergence_observation` has the same
+    /// Busy-before-tainted arm ordering, and a tainted busy venue must not
+    /// escalate either.
+    #[tokio::test]
+    async fn restart_tainted_busy_cash_venue_does_not_escalate() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let spym = test_symbol("SPYM");
+
+        let mut view =
+            InventoryView::default().with_usdc(Usdc::ZERO, Usdc::from_cents(50_000).unwrap());
+        taint_from_restart(&mut view, &spym);
+        let view = view.set_active_usdc_rebalance(UsdcRebalanceId(Uuid::new_v4()));
+        let inventory = broadcasting_inventory(view);
+        let gate = Arc::new(InventoryDivergenceGate::default());
+        let service = reconciling_service(
+            &pool,
+            Arc::new(test_store(pool.clone(), ())),
+            inventory.clone(),
+            gate.clone(),
+            1,
+        );
+
+        service.poll_and_record().await.unwrap();
+        service.poll_and_record().await.unwrap();
+
+        assert!(
+            cash_reconciled_events(&pool, orderbook, order_owner)
+                .await
+                .is_empty(),
+            "a tainted busy cash venue must stay frozen, not escalate \
+             against an ambiguous balance"
+        );
+        assert!(
+            inventory.read().await.is_restart_cash_tainted(),
+            "the frozen cash taint must survive for resolution once the \
+             venue is quiet"
+        );
+    }
+
+    /// Taint resolution is per symbol: with two tainted symbols where one
+    /// matches the broker and one diverges, only the matching symbol's
+    /// taint lifts, only the diverging symbol escalates, and the diverging
+    /// symbol's taint survives its unhealed escalation.
+    #[tokio::test]
+    async fn restart_taint_resolves_per_symbol_not_wholesale() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let spym = test_symbol("SPYM");
+        let aapl = test_symbol("AAPL");
+
+        // SPYM's hydrated balance agrees with the zero-position broker;
+        // AAPL holds a phantom 136.
+        let mut view = InventoryView::default()
+            .with_equity(spym.clone(), test_shares(0), test_shares(0))
+            .with_equity(aapl.clone(), test_shares(0), test_shares(136));
+        view.set_pending_offchain_order_symbols(HashSet::from([spym.clone(), aapl.clone()]));
+        view.clear_offchain_order_pending(&spym, None);
+        view.clear_offchain_order_pending(&aapl, None);
+        let inventory = broadcasting_inventory(view);
+        let gate = Arc::new(InventoryDivergenceGate::default());
+        let service = reconciling_service(
+            &pool,
+            Arc::new(test_store(pool.clone(), ())),
+            inventory.clone(),
+            gate.clone(),
+            3,
+        )
+        .with_configured_equity_symbols(configured_symbols(&["SPYM", "AAPL"]));
+
+        service.poll_and_record().await.unwrap();
+
+        let events = reconciled_events(&pool, orderbook, order_owner).await;
+        let [InventorySnapshotEvent::OffchainEquityReconciled { symbol, .. }] = events.as_slice()
+        else {
+            panic!("Expected exactly one reconcile escalation, got {events:?}");
+        };
+        assert_eq!(
+            symbol, &aapl,
+            "only the diverging symbol may escalate; a SPYM event means the \
+             matching symbol was escalated wholesale"
+        );
+
+        let view = inventory.read().await;
+        assert!(
+            !view.is_restart_tainted(&spym),
+            "the matching symbol's taint must resolve"
+        );
+        assert!(
+            view.is_restart_tainted(&aapl),
+            "the diverging symbol's taint must survive its unhealed \
+             escalation, not be cleared alongside the matching symbol's"
+        );
+        drop(view);
+        assert!(!gate.is_engaged(&spym));
+        assert!(gate.is_engaged(&aapl));
+    }
+
+    /// The full post-restart resolution: the aggregate already stores the
+    /// broker value (recorded mid-order before the restart), so the
+    /// ordinary poll dedupes to no event and only the taint-driven
+    /// escalation can re-base the view -- within a single poll.
+    #[tokio::test]
+    async fn restart_tainted_divergence_heals_and_clears_taint_within_one_poll() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let spym = test_symbol("SPYM");
+        let now = Utc::now();
+
+        // Hydration outcome: the view holds the pre-fill 136 while the
+        // aggregate (and the broker) hold zero.
+        let mut view =
+            InventoryView::default().with_equity(spym.clone(), test_shares(0), test_shares(136));
+        taint_from_restart(&mut view, &spym);
+        let inventory = broadcasting_inventory(view);
+        let gate = Arc::new(InventoryDivergenceGate::default());
+
+        // The pre-restart poll recorded the broker's zero in the aggregate
+        // (persisted via a plain store: pre-restart events do not replay
+        // through the live projection), so the post-boot poll dedupes to no
+        // event.
+        test_store::<InventorySnapshot>(pool.clone(), ())
+            .send(
+                &InventorySnapshotId {
+                    orderbook,
+                    owner: order_owner,
+                },
+                InventorySnapshotCommand::OffchainEquity {
+                    positions: BTreeMap::from([(spym.clone(), FractionalShares::ZERO)]),
+                    fetched_at: now - chrono::Duration::seconds(60),
+                },
+            )
+            .await
+            .unwrap();
+
+        let snapshot_store = StoreBuilder::<InventorySnapshot>::new(pool.clone())
+            .with(Arc::new(InventoryProjection::new(inventory.clone())))
+            .build(())
+            .await
+            .unwrap();
+
+        let service =
+            reconciling_service(&pool, snapshot_store, inventory.clone(), gate.clone(), 3);
+
+        service.poll_and_record().await.unwrap();
+
+        assert_eq!(
+            inventory
+                .read()
+                .await
+                .equity_available(&spym, Venue::Hedging),
+            Some(FractionalShares::ZERO),
+            "the tainted balance must converge to broker truth within one poll"
+        );
+        assert!(
+            !inventory.read().await.is_restart_tainted(&spym),
+            "a verified heal must resolve the restart taint"
+        );
+        assert!(
+            !gate.is_engaged(&spym),
+            "the healed escalation must lift the transfer gate"
+        );
+        assert_eq!(
+            reconciled_events(&pool, orderbook, order_owner).await.len(),
+            1,
+            "exactly one escalation must have been needed"
+        );
+    }
+
+    /// The hydrated number can also turn out correct (the persisted
+    /// snapshot had absorbed the fill): a matching poll must resolve the
+    /// taint without escalating anything.
+    #[tokio::test]
+    async fn restart_taint_resolves_on_matching_poll_without_escalation() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let spym = test_symbol("SPYM");
+
+        let mut view =
+            InventoryView::default().with_equity(spym.clone(), test_shares(0), test_shares(0));
+        taint_from_restart(&mut view, &spym);
+        let inventory = broadcasting_inventory(view);
+        let gate = Arc::new(InventoryDivergenceGate::default());
+        let service = reconciling_service(
+            &pool,
+            Arc::new(test_store(pool.clone(), ())),
+            inventory.clone(),
+            gate.clone(),
+            3,
+        );
+
+        service.poll_and_record().await.unwrap();
+
+        assert!(
+            reconciled_events(&pool, orderbook, order_owner)
+                .await
+                .is_empty(),
+            "a matching tainted poll must not escalate"
+        );
+        assert!(
+            !inventory.read().await.is_restart_tainted(&spym),
+            "a matching poll proves the hydrated balance and must resolve \
+             the taint"
+        );
+        assert!(!gate.is_engaged(&spym));
+    }
+
+    /// The cash twin of the unhealed-escalation persistence assertion in
+    /// `restart_tainted_divergence_escalates_on_first_quiet_poll`: the
+    /// escalation fires on the first quiet poll, but with no reactor wired
+    /// it cannot heal the view, and an unhealed escalation must keep the
+    /// cash taint -- clearing it is reserved for a verified heal.
+    #[tokio::test]
+    async fn restart_tainted_cash_divergence_keeps_taint_when_unhealed() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let spym = test_symbol("SPYM");
+
+        let mut view =
+            InventoryView::default().with_usdc(Usdc::ZERO, Usdc::from_cents(50_000).unwrap());
+        taint_from_restart(&mut view, &spym);
+        let inventory = broadcasting_inventory(view);
+        let gate = Arc::new(InventoryDivergenceGate::default());
+        // Threshold 3: an untainted divergence would need three polls.
+        let service = reconciling_service(
+            &pool,
+            Arc::new(test_store(pool.clone(), ())),
+            inventory.clone(),
+            gate.clone(),
+            3,
+        );
+
+        service.poll_and_record().await.unwrap();
+
+        let events = cash_reconciled_events(&pool, orderbook, order_owner).await;
+        let [
+            InventorySnapshotEvent::OffchainUsdReconciled {
+                consecutive_polls, ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("Expected exactly one cash reconcile escalation, got {events:?}");
+        };
+        assert_eq!(
+            *consecutive_polls, 1,
+            "a tainted cash divergence must escalate on the first poll, not \
+             at the threshold"
+        );
+        assert!(gate.is_cash_engaged());
+        assert!(
+            inventory.read().await.is_restart_cash_tainted(),
+            "an unhealed cash escalation must keep the restart cash taint"
+        );
+    }
+
+    /// Cash twin of the one-poll heal: the hydrated Hedging cash diverges
+    /// from the broker, the aggregate dedupes the ordinary snapshot, and
+    /// the cash taint escalates immediately instead of waiting out the
+    /// threshold.
+    #[tokio::test]
+    async fn restart_tainted_cash_divergence_heals_within_one_poll() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let spym = test_symbol("SPYM");
+        let phantom = Usdc::from_cents(50_000).unwrap();
+        let now = Utc::now();
+
+        let mut view = InventoryView::default().with_usdc(Usdc::ZERO, phantom);
+        taint_from_restart(&mut view, &spym);
+        let inventory = broadcasting_inventory(view);
+        let gate = Arc::new(InventoryDivergenceGate::default());
+
+        // Pre-restart aggregate state, persisted without the projection so
+        // the view keeps its hydrated phantom (see the equity twin above).
+        test_store::<InventorySnapshot>(pool.clone(), ())
+            .send(
+                &InventorySnapshotId {
+                    orderbook,
+                    owner: order_owner,
+                },
+                InventorySnapshotCommand::OffchainUsd {
+                    usd_balance_cents: 0,
+                    gross_usd_cents: None,
+                    fetched_at: now - chrono::Duration::seconds(60),
+                },
+            )
+            .await
+            .unwrap();
+
+        let snapshot_store = StoreBuilder::<InventorySnapshot>::new(pool.clone())
+            .with(Arc::new(InventoryProjection::new(inventory.clone())))
+            .build(())
+            .await
+            .unwrap();
+
+        let service =
+            reconciling_service(&pool, snapshot_store, inventory.clone(), gate.clone(), 3);
+
+        service.poll_and_record().await.unwrap();
+
+        assert_eq!(
+            inventory.read().await.usdc_available(Venue::Hedging),
+            Some(Usdc::ZERO),
+            "the tainted cash balance must converge to broker truth within \
+             one poll"
+        );
+        assert!(
+            !inventory.read().await.is_restart_cash_tainted(),
+            "a verified cash heal must resolve the restart cash taint"
+        );
+        assert!(!gate.is_cash_engaged());
+        let events = cash_reconciled_events(&pool, orderbook, order_owner).await;
+        let [
+            InventorySnapshotEvent::OffchainUsdReconciled {
+                consecutive_polls, ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("Expected exactly one cash escalation, got {events:?}");
+        };
+        assert_eq!(*consecutive_polls, 1);
+    }
+
+    #[tokio::test]
+    async fn restart_cash_taint_resolves_on_matching_poll() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let spym = test_symbol("SPYM");
+
+        let mut view = InventoryView::default().with_usdc(Usdc::ZERO, Usdc::ZERO);
+        taint_from_restart(&mut view, &spym);
+        let inventory = broadcasting_inventory(view);
+        let gate = Arc::new(InventoryDivergenceGate::default());
+        let service = reconciling_service(
+            &pool,
+            Arc::new(test_store(pool.clone(), ())),
+            inventory.clone(),
+            gate.clone(),
+            3,
+        );
+
+        service.poll_and_record().await.unwrap();
+
+        assert!(
+            cash_reconciled_events(&pool, orderbook, order_owner)
+                .await
+                .is_empty(),
+            "a matching tainted cash poll must not escalate"
+        );
+        assert!(
+            !inventory.read().await.is_restart_cash_tainted(),
+            "a matching poll proves the hydrated cash balance and must \
+             resolve the cash taint"
+        );
+        assert!(!gate.is_cash_engaged());
     }
 
     // PollFreshness stamping. The constructor requires a caller-owned handle

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -784,6 +784,26 @@ pub(crate) struct InventoryView {
     /// Venue-level: the USDC balance is one number per venue.
     #[serde(default)]
     onchain_usdc_snapshot_block_watermark: Option<u64>,
+    /// Symbols whose hydrated Hedging balance is ambiguous because a hedge
+    /// order was open across the restart. The aggregate records every poll
+    /// -- including mid-order reads the live view's guards refused -- and
+    /// the guard state that refused them (`last_offchain_fill_applied_at`,
+    /// a local-clock reading) does not survive restart, so at boot there is
+    /// no way to know whether the hydrated number already absorbed the
+    /// order's fill. While tainted: the fill's deltas are skipped (they may
+    /// already be in the hydrated number) and equity dispatch for the
+    /// symbol is suppressed; the poller re-bases the balance from broker
+    /// truth (a matching poll, an applied snapshot, or an immediate
+    /// reconcile escalation) and clears the taint.
+    #[serde(default)]
+    restart_tainted_offchain_symbols: HashSet<Symbol>,
+    /// Venue-level cash analogue of `restart_tainted_offchain_symbols`: an
+    /// open hedge order at boot makes the hydrated Hedging cash balance
+    /// equally ambiguous (the fill's mirrored USDC delta may or may not be
+    /// in it). While set, USDC dispatch is suppressed and the poller
+    /// re-bases the cash balance the same way.
+    #[serde(default)]
+    restart_tainted_offchain_cash: bool,
 }
 
 impl InventoryView {
@@ -1142,6 +1162,8 @@ impl Default for InventoryView {
             offchain_equity_snapshot_watermarks: HashMap::new(),
             pending_offchain_order_symbols: HashSet::new(),
             last_offchain_fill_applied_at: HashMap::new(),
+            restart_tainted_offchain_symbols: HashSet::new(),
+            restart_tainted_offchain_cash: false,
         }
     }
 }
@@ -1364,6 +1386,8 @@ impl InventoryView {
             offchain_equity_snapshot_skip_streaks: self.offchain_equity_snapshot_skip_streaks,
             offchain_usd_snapshot_skip_streak: self.offchain_usd_snapshot_skip_streak,
             offchain_usd_snapshot_watermark: self.offchain_usd_snapshot_watermark,
+            restart_tainted_offchain_symbols: self.restart_tainted_offchain_symbols,
+            restart_tainted_offchain_cash: self.restart_tainted_offchain_cash,
         })
     }
 
@@ -1399,6 +1423,8 @@ impl InventoryView {
             offchain_equity_snapshot_skip_streaks: self.offchain_equity_snapshot_skip_streaks,
             offchain_usd_snapshot_skip_streak: self.offchain_usd_snapshot_skip_streak,
             offchain_usd_snapshot_watermark: self.offchain_usd_snapshot_watermark,
+            restart_tainted_offchain_symbols: self.restart_tainted_offchain_symbols,
+            restart_tainted_offchain_cash: self.restart_tainted_offchain_cash,
         })
     }
 
@@ -1548,8 +1574,41 @@ impl InventoryView {
 
     /// Replaces the set of symbols with an open offchain order, for rebuilding
     /// it from the `Position` projection at startup.
+    ///
+    /// Also stamps the restart taint from the same set: a symbol whose hedge
+    /// order straddled the restart has an ambiguous hydrated Hedging balance
+    /// (see `restart_tainted_offchain_symbols`), and any open order taints
+    /// the venue-level cash balance. One entry point keeps the gate and the
+    /// taint impossible to desynchronize -- this setter is only called from
+    /// the boot seam (`restore_inventory_at_boot`), where the taint is
+    /// definitionally "the gate as of boot".
     pub(crate) fn set_pending_offchain_order_symbols(&mut self, symbols: HashSet<Symbol>) {
+        self.restart_tainted_offchain_cash = !symbols.is_empty();
+        self.restart_tainted_offchain_symbols.clone_from(&symbols);
         self.pending_offchain_order_symbols = symbols;
+    }
+
+    /// Whether `symbol`'s Hedging balance is restart-tainted (hydrated while
+    /// its hedge order was open, so the order's fill may already be in it).
+    pub(crate) fn is_restart_tainted(&self, symbol: &Symbol) -> bool {
+        self.restart_tainted_offchain_symbols.contains(symbol)
+    }
+
+    /// Whether the Hedging cash balance is restart-tainted.
+    pub(crate) fn is_restart_cash_tainted(&self) -> bool {
+        self.restart_tainted_offchain_cash
+    }
+
+    /// Resolves a symbol's restart taint: the poller observed the view in
+    /// agreement with the broker, or a forced reconcile verifiably re-based
+    /// the balance from broker truth.
+    pub(crate) fn clear_restart_taint(&mut self, symbol: &Symbol) {
+        self.restart_tainted_offchain_symbols.remove(symbol);
+    }
+
+    /// Resolves the venue-level cash restart taint.
+    pub(crate) fn clear_restart_cash_taint(&mut self) {
+        self.restart_tainted_offchain_cash = false;
     }
 
     /// Releases the snapshot block for a symbol whose offchain order reached a
@@ -1627,6 +1686,8 @@ impl InventoryView {
             pending_offchain_order_symbols: self.pending_offchain_order_symbols.clone(),
             last_offchain_fill_applied_at: self.last_offchain_fill_applied_at.clone(),
             last_offchain_cash_fill_applied_at: self.last_offchain_cash_fill_applied_at,
+            restart_tainted_offchain_symbols: self.restart_tainted_offchain_symbols.clone(),
+            restart_tainted_offchain_cash: self.restart_tainted_offchain_cash,
             ..Self::default()
         }
     }
@@ -2014,6 +2075,8 @@ impl InventoryView {
             offchain_equity_snapshot_skip_streaks: self.offchain_equity_snapshot_skip_streaks,
             offchain_usd_snapshot_skip_streak: self.offchain_usd_snapshot_skip_streak,
             offchain_usd_snapshot_watermark: self.offchain_usd_snapshot_watermark,
+            restart_tainted_offchain_symbols: self.restart_tainted_offchain_symbols,
+            restart_tainted_offchain_cash: self.restart_tainted_offchain_cash,
         })
     }
 
@@ -2050,6 +2113,8 @@ impl InventoryView {
             offchain_equity_snapshot_skip_streaks: self.offchain_equity_snapshot_skip_streaks,
             offchain_usd_snapshot_skip_streak: self.offchain_usd_snapshot_skip_streak,
             offchain_usd_snapshot_watermark: self.offchain_usd_snapshot_watermark,
+            restart_tainted_offchain_symbols: self.restart_tainted_offchain_symbols,
+            restart_tainted_offchain_cash: self.restart_tainted_offchain_cash,
         })
     }
 
@@ -3014,6 +3079,8 @@ mod tests {
             offchain_equity_snapshot_skip_streaks: HashMap::new(),
             offchain_usd_snapshot_skip_streak: 0,
             offchain_usd_snapshot_watermark: None,
+            restart_tainted_offchain_symbols: HashSet::new(),
+            restart_tainted_offchain_cash: false,
         }
     }
 
@@ -3053,6 +3120,8 @@ mod tests {
             offchain_equity_snapshot_skip_streaks: HashMap::new(),
             offchain_usd_snapshot_skip_streak: 0,
             offchain_usd_snapshot_watermark: None,
+            restart_tainted_offchain_symbols: HashSet::new(),
+            restart_tainted_offchain_cash: false,
         }
     }
 
@@ -5030,6 +5099,8 @@ mod tests {
             offchain_equity_snapshot_skip_streaks: HashMap::new(),
             offchain_usd_snapshot_skip_streak: 0,
             offchain_usd_snapshot_watermark: None,
+            restart_tainted_offchain_symbols: HashSet::new(),
+            restart_tainted_offchain_cash: false,
         };
 
         let dto = view.to_dto();
@@ -5091,6 +5162,8 @@ mod tests {
             offchain_equity_snapshot_skip_streaks: HashMap::new(),
             offchain_usd_snapshot_skip_streak: 0,
             offchain_usd_snapshot_watermark: None,
+            restart_tainted_offchain_symbols: HashSet::new(),
+            restart_tainted_offchain_cash: false,
         };
 
         let dto = view.to_dto();
@@ -6497,6 +6570,57 @@ mod tests {
             view.offchain_equity_snapshot_skip_streaks.get(&spym),
             None,
             "an applied snapshot must clear the symbol's skip streak"
+        );
+    }
+
+    /// The boot seeding entry point stamps the restart taint together with
+    /// the gate, and the seam's entry clear (empty set) drops both.
+    #[test]
+    fn set_pending_offchain_order_symbols_stamps_restart_taint() {
+        let spym = Symbol::new("SPYM").unwrap();
+        let aapl = Symbol::new("AAPL").unwrap();
+
+        let mut view = InventoryView::default();
+        view.set_pending_offchain_order_symbols(HashSet::from([spym.clone()]));
+
+        assert!(view.is_restart_tainted(&spym));
+        assert!(
+            !view.is_restart_tainted(&aapl),
+            "a symbol without an open order at boot must not be tainted"
+        );
+        assert!(
+            view.is_restart_cash_tainted(),
+            "any open order at boot taints the venue-level cash balance"
+        );
+
+        view.set_pending_offchain_order_symbols(HashSet::new());
+        assert!(
+            !view.is_restart_tainted(&spym),
+            "the seam's entry clear must drop the taint with the gate"
+        );
+        assert!(!view.is_restart_cash_tainted());
+    }
+
+    /// Snapshot-error recovery resets the view; like the gate state it is
+    /// seeded with, the restart taint is derived from boot-time Position
+    /// state and nothing re-seeds it, so it must survive the reset.
+    #[test]
+    fn reset_preserves_restart_taint() {
+        let spym = Symbol::new("SPYM").unwrap();
+
+        let mut view = InventoryView::default().with_equity(spym.clone(), shares(0), shares(136));
+        view.set_pending_offchain_order_symbols(HashSet::from([spym.clone()]));
+        view.clear_offchain_order_pending(&spym, None);
+
+        let reset = view.reset_preserving_offchain_order_state();
+
+        assert!(
+            reset.is_restart_tainted(&spym),
+            "the recovery reset must preserve the restart taint"
+        );
+        assert!(
+            reset.is_restart_cash_tainted(),
+            "the recovery reset must preserve the cash restart taint"
         );
     }
 }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -2263,7 +2263,11 @@ impl Reactor for RebalancingService {
                         // the symbol's pending-offchain-order gate; nudge an
                         // immediate equity check rather than waiting a poll cycle.
                         // No fill was applied, so nothing bars the next snapshot
-                        // from taking the balance back over.
+                        // from taking the balance back over. A restart taint
+                        // deliberately survives this arm: the pre-restart
+                        // portion of the order may have partially filled, so
+                        // the balance stays ambiguous until the poller
+                        // re-bases it from broker truth.
                         self.inventory
                             .write_without_broadcast()
                             .await
@@ -2289,14 +2293,49 @@ impl Reactor for RebalancingService {
                 };
 
                 // Only the OffChainOrderFilled arm reaches here; every other
-                // arm returns early above. Always clear the gate on a Filled
-                // event, even if the inventory update fails. A fail-closed
-                // gate would deadlock equity rebalancing for the symbol until
-                // the next bot restart, because the only event that could
-                // re-clear it (a later terminal offchain event) is itself
-                // gated. The polling cycle is the source of truth for the
-                // broker balance, so any local bookkeeping miss self-heals
-                // within ~60s and is bounded to wasted rebalances, not lost
+                // arm returns early above.
+                //
+                // A restart-tainted symbol's hydrated balance may already
+                // contain this fill (the aggregate recorded mid-order polls
+                // the pre-restart view refused, and the guard state that
+                // refused them did not survive the restart), so applying the
+                // delta risks double-counting it. Skip both legs and clear
+                // the gate with no fill stamp -- nothing was applied, so
+                // nothing bars the next snapshot. The taint itself stays:
+                // the poller resolves it by re-basing from broker truth (a
+                // matching poll or an immediate reconcile escalation),
+                // bounding the drift to the next successful quiet broker
+                // poll during market hours. The check-here,
+                // apply-below split is race-free: taint is only ever seeded
+                // at boot (before reactors run), so it cannot appear between
+                // this check and the apply, and while it is set the open
+                // order marks the symbol busy, which keeps the poller from
+                // resolving it before this handler clears the gate.
+                {
+                    let mut inventory = self.inventory.write().await;
+                    if inventory.is_restart_tainted(&symbol) {
+                        warn!(
+                            target: "rebalance",
+                            %symbol,
+                            "Skipping offchain fill deltas for restart-tainted \
+                             symbol; the poller re-bases the balance from \
+                             broker truth"
+                        );
+                        inventory.clear_offchain_order_pending(&symbol, None);
+                        drop(inventory);
+                        self.equity_scheduler.enqueue_check(symbol).await;
+                        return Ok(());
+                    }
+                }
+
+                // Always clear the gate on a Filled event, even if the
+                // inventory update fails. A fail-closed gate would deadlock
+                // equity rebalancing for the symbol until the next bot
+                // restart, because the only event that could re-clear it (a
+                // later terminal offchain event) is itself gated. The
+                // polling cycle is the source of truth for the broker
+                // balance, so any local bookkeeping miss self-heals within
+                // ~60s and is bounded to wasted rebalances, not lost
                 // capital.
                 let inventory_result = {
                     let mut inventory = self.inventory.write().await;
@@ -2450,6 +2489,14 @@ impl RebalancingService {
             .read()
             .await
             .has_pending_offchain_order(symbol)
+    }
+
+    async fn is_restart_tainted(&self, symbol: &Symbol) -> bool {
+        self.inventory.read().await.is_restart_tainted(symbol)
+    }
+
+    async fn is_restart_cash_tainted(&self) -> bool {
+        self.inventory.read().await.is_restart_cash_tainted()
     }
 
     async fn build_equity_operation(
@@ -2850,6 +2897,20 @@ impl RebalancingService {
             return Ok(());
         }
 
+        // A restart-tainted balance is suspect for the same reason -- the
+        // hydrated number may or may not contain the straddling order's
+        // fill -- so it must not size a transfer until the poller re-bases
+        // it from broker truth (the next successful quiet broker poll).
+        if self.is_restart_tainted(symbol).await {
+            warn!(
+                target: "rebalance",
+                %symbol,
+                "Skipped equity trigger: balance is restart-tainted pending \
+                 broker re-base"
+            );
+            return Ok(());
+        }
+
         let Some(guard) = self.try_claim_equity_guard_for_transfer(symbol) else {
             debug!(target: "rebalance", %symbol, "Skipped equity trigger: already in progress");
             return Ok(());
@@ -2895,6 +2956,8 @@ impl RebalancingService {
             return Ok(());
         }
 
+        // The restart taint needs no matching re-check: it is only seeded
+        // at boot, so it cannot appear during the build.
         if self.divergence_gate.is_engaged(symbol) {
             warn!(
                 target: "rebalance",
@@ -2964,12 +3027,23 @@ impl RebalancingService {
         // A pending cash divergence means the Hedging USDC balance the
         // imbalance math reads is suspect: a bridge sized off it moves the
         // wrong amount and marks the venue busy, freezing the very counter
-        // that resolves the divergence. Skip until the poller clears it.
+        // that resolves the divergence. Skip until the poller clears it. A
+        // restart-tainted cash balance is suspect for the same reason (the
+        // hydrated number may or may not contain a straddling fill's cash
+        // leg), with the same resolution path.
         if self.divergence_gate.is_cash_engaged() {
             warn!(
                 target: "rebalance",
                 "Skipped USDC trigger: unresolved cash snapshot divergence \
                  pending reconciliation"
+            );
+            return;
+        }
+        if self.is_restart_cash_tainted().await {
+            warn!(
+                target: "rebalance",
+                "Skipped USDC trigger: cash balance is restart-tainted \
+                 pending broker re-base"
             );
             return;
         }
@@ -2992,7 +3066,9 @@ impl RebalancingService {
 
         // Re-check immediately before dispatch: the poller may have engaged
         // the cash gate during the awaits in the imbalance build (mirrors
-        // the equity trigger's pre-dispatch re-checks).
+        // the equity trigger's pre-dispatch re-checks). The restart taint
+        // needs no re-check: it is only seeded at boot, so it cannot appear
+        // during the build.
         if self.divergence_gate.is_cash_engaged() {
             warn!(
                 target: "rebalance",
@@ -23982,6 +24058,300 @@ mod tests {
             "a symbol with an open hedge order must still hydrate its \
              offchain balance from the persisted snapshot; None means the \
              seeded gate blocked hydration"
+        );
+        assert!(
+            trigger.is_restart_tainted(&symbol).await,
+            "a symbol whose hedge order straddled the restart must boot \
+             restart-tainted: its hydrated balance may already contain the \
+             order's fill"
+        );
+        assert!(
+            trigger.is_restart_cash_tainted().await,
+            "an open hedge order at boot must taint the venue-level cash \
+             balance too"
+        );
+    }
+
+    /// A boot with no open hedge orders must leave nothing tainted: the
+    /// taint exists only for the restart-straddling-order ambiguity.
+    #[tokio::test]
+    async fn boot_without_open_orders_seeds_no_restart_taint() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let trigger = make_trigger_with_inventory(InventoryView::default()).await;
+        let pool = crate::test_utils::setup_test_db().await;
+
+        let projection = Projection::<Position>::sqlite(pool.clone());
+        projection.catch_up().await.unwrap();
+
+        crate::conductor::restore_inventory_at_boot(
+            &pool,
+            &trigger.inventory,
+            Some(&trigger),
+            &projection,
+        )
+        .await
+        .unwrap();
+
+        assert!(!trigger.is_restart_tainted(&symbol).await);
+        assert!(!trigger.is_restart_cash_tainted().await);
+    }
+
+    /// The headline RAI-1501 race: a hedge order straddles a restart, and
+    /// the persisted snapshot already recorded the mid-order broker number
+    /// (the aggregate records every poll; the guard state that refused the
+    /// ambiguous apply did not survive the restart). When the still-open
+    /// order's fill is discovered after boot, applying the delta on top of
+    /// the hydrated number would double-count it. The tainted fill must
+    /// skip its deltas, clear the gate, and leave the taint for the poller
+    /// to resolve against broker truth.
+    #[tokio::test]
+    async fn restart_across_open_order_does_not_double_apply_fill() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let trigger = make_trigger_with_inventory(InventoryView::default()).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let pool = crate::test_utils::setup_test_db().await;
+
+        // Persisted state from the previous run: the snapshot recorded 90 --
+        // the post-fill broker reading for a Sell 10 from 100 (the broker's
+        // qty_available moves at order acceptance, before we observe the
+        // fill) -- while the order was still open.
+        let snapshot_store = test_store::<InventorySnapshot>(pool.clone(), ());
+        snapshot_store
+            .send(
+                &InventorySnapshotId {
+                    orderbook: TEST_ORDERBOOK,
+                    owner: TEST_ORDER_OWNER,
+                },
+                InventorySnapshotCommand::OffchainEquity {
+                    positions: BTreeMap::from([(symbol.clone(), shares(90))]),
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let position_store = test_store::<Position>(pool.clone(), ());
+        position_store
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 1,
+                    },
+                    amount: shares(10),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: Utc::now(),
+                    block_number: None,
+                },
+            )
+            .await
+            .unwrap();
+        position_store
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id: OffchainOrderId::new(),
+                    shares: Positive::new(shares(10)).unwrap(),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+        let projection = Projection::<Position>::sqlite(pool.clone());
+        projection.catch_up().await.unwrap();
+
+        crate::conductor::restore_inventory_at_boot(
+            &pool,
+            &trigger.inventory,
+            Some(&trigger),
+            &projection,
+        )
+        .await
+        .unwrap();
+
+        // The still-open order's fill is discovered after boot.
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_offchain_fill(shares(10), Direction::Sell),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .equity_available(&symbol, Venue::Hedging),
+            Some(shares(90)),
+            "the tainted fill's delta must be skipped; 80 means it was \
+             double-applied on top of a hydrated number that already \
+             contained it"
+        );
+        assert!(
+            !trigger.has_pending_offchain_order(&symbol).await,
+            "the terminal fill must still clear the hedge-order gate"
+        );
+        assert!(
+            trigger.is_restart_tainted(&symbol).await,
+            "the taint must survive the fill so the poller re-bases the \
+             balance from broker truth"
+        );
+        let processed = equity::drain_pending_equity_jobs(&trigger).await.unwrap();
+        assert_eq!(
+            processed, 1,
+            "the skipped fill still enqueues an equity recheck (dispatch is \
+             gated on the taint, not the check)"
+        );
+    }
+
+    /// The tainted-fill skip must not disturb the untainted cash mirror
+    /// either, and Failed/Cancelled must leave the taint for the poller
+    /// (the pre-restart portion of the order may have partially filled).
+    #[tokio::test]
+    async fn restart_tainted_fill_skips_both_legs_and_failed_keeps_taint() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let mut view = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(60))
+            .with_usdc(usdc(500), usdc(500));
+        view.set_pending_offchain_order_symbols(HashSet::from([symbol.clone()]));
+
+        let trigger = make_trigger_with_inventory_and_registry(view, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_offchain_fill(shares(10), Direction::Sell),
+            )
+            .await
+            .unwrap();
+
+        {
+            let view = trigger.inventory.read().await;
+            assert_eq!(
+                view.equity_available(&symbol, Venue::Hedging),
+                Some(shares(60)),
+                "the tainted fill's equity leg must be skipped"
+            );
+            assert_eq!(
+                view.usdc_available(Venue::Hedging),
+                Some(usdc(500)),
+                "the tainted fill's mirrored cash leg must be skipped with it"
+            );
+            assert!(!view.has_pending_offchain_order(&symbol));
+            assert!(view.is_restart_tainted(&symbol));
+            drop(view);
+        }
+
+        // A later order on the same still-tainted symbol fails: the gate
+        // clears but the taint stays until the poller re-bases.
+        harness
+            .receive::<Position>(symbol.clone(), make_offchain_placed(offchain_order_id))
+            .await
+            .unwrap();
+        harness
+            .receive::<Position>(symbol.clone(), make_offchain_failed(offchain_order_id))
+            .await
+            .unwrap();
+
+        let view = trigger.inventory.read().await;
+        assert!(!view.has_pending_offchain_order(&symbol));
+        assert!(
+            view.is_restart_tainted(&symbol),
+            "a failed order must not resolve the taint; only broker truth \
+             (the poller) can"
+        );
+        drop(view);
+    }
+
+    /// A restart-tainted balance must not size an equity transfer: the
+    /// hydrated number may or may not contain the straddling order's fill.
+    #[tokio::test]
+    async fn restart_taint_suppresses_equity_transfer_dispatch() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let mut view = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(80))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000));
+        // Taint without an open order: the state a tainted fill leaves
+        // behind (gate cleared, taint pending poller resolution).
+        view.set_pending_offchain_order_symbols(HashSet::from([symbol.clone()]));
+        view.clear_offchain_order_pending(&symbol, None);
+
+        let reactor = make_trigger_with_inventory_and_registry(view, &symbol).await;
+        let trigger = reactor.clone();
+
+        EquityRebalancingCheck {
+            symbol: symbol.clone(),
+        }
+        .perform(&trigger)
+        .await
+        .unwrap();
+        assert_eq!(
+            count_pending_equity_mint_jobs(&trigger).await,
+            0,
+            "a restart-tainted symbol must not dispatch an equity transfer"
+        );
+
+        // The poller re-based the balance and resolved the taint.
+        trigger
+            .inventory
+            .write_without_broadcast()
+            .await
+            .clear_restart_taint(&symbol);
+
+        EquityRebalancingCheck {
+            symbol: symbol.clone(),
+        }
+        .perform(&trigger)
+        .await
+        .unwrap();
+        let dispatched = take_pending_equity_mint_jobs(&trigger).await;
+        let [job] = dispatched.as_slice() else {
+            panic!("Expected exactly one mint job after taint resolution, got {dispatched:?}");
+        };
+        assert_eq!(job.symbol, symbol);
+    }
+
+    /// The cash twin: a restart-tainted Hedging cash balance must not size
+    /// a USDC bridge.
+    #[tokio::test]
+    async fn restart_cash_taint_suppresses_usdc_transfer_dispatch() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        // 900 onchain, 100 offchain -> TooMuchOnchain would dispatch.
+        let mut view = InventoryView::default().with_usdc(usdc(900), usdc(100));
+        view.set_pending_offchain_order_symbols(HashSet::from([symbol.clone()]));
+        view.clear_offchain_order_pending(&symbol, None);
+
+        let reactor = make_trigger_with_inventory(view).await;
+        let trigger = reactor.clone();
+
+        trigger.check_and_trigger_usdc().await;
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&trigger).await,
+            0,
+            "a restart-tainted cash balance must not dispatch a USDC transfer"
+        );
+
+        trigger
+            .inventory
+            .write_without_broadcast()
+            .await
+            .clear_restart_cash_taint();
+
+        trigger.check_and_trigger_usdc().await;
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&trigger).await,
+            1,
+            "resolving the cash taint must restore USDC dispatch"
         );
     }
 


### PR DESCRIPTION
## What

Closes [RAI-1501](https://linear.app/makeitrain/issue/RAI-1501/restart-across-an-open-hedge-order-can-transiently-double-count-the). Introduces restart taint to eliminate the double-count drift window that arises when a hedge order straddles a bot restart.

## Why

The aggregate records every broker poll, including mid-order readings that the live view's fill guards refused to apply. Those guards rely on a local-clock `last_offchain_fill_applied_at` stamp that does not survive a restart. After boot, the hydrated Hedging balance for a symbol whose hedge order was open at shutdown may or may not already contain the order's fill — there is no way to know. Without this fix, applying the fill delta on top of a hydrated number that already absorbed it produces an unbounded double-count drift.

## How

At boot, `set_pending_offchain_order_symbols` now stamps a restart taint alongside the order gate for every symbol with an open hedge order, and sets a venue-level cash taint because any open order also moves the Hedging USDC balance. The taint is seeded in one place (the boot seam) so the gate and the taint cannot desynchronize.

While a symbol is tainted:

- A discovered fill skips both the equity delta and the mirrored USDC delta, clears the order gate without recording an applied-fill timestamp, and leaves the taint in place. A failed or cancelled order also leaves the taint, since the pre-restart portion may have partially filled.
- Equity dispatch for the symbol and USDC dispatch for the venue are suppressed, exactly as under an engaged divergence gate.

The poller resolves the taint against broker truth:

- A matching quiet poll proves the hydrated value and lifts the taint immediately, without escalating.
- A diverging quiet poll escalates a forced reconcile on the first poll rather than waiting out the N-poll confirmation threshold — the ambiguity was created by the boot, not a transient race — and a verified heal lifts the taint.

The accepted cost is that a fill during the tainted window is reflected only after the re-base lands, at most one poll interval later, for at most the orders that straddled the restart.

## Testing

Five new integration tests cover the full resolution matrix:

- `restart_tainted_divergence_escalates_on_first_quiet_poll` — a tainted divergence escalates at `consecutive_polls == 1` regardless of the configured threshold, and an unhealed escalation keeps the taint.
- `restart_tainted_divergence_heals_and_clears_taint_within_one_poll` — the full post-restart path: aggregate dedupes the ordinary snapshot, the taint-driven escalation re-bases the view from broker truth, and the taint and gate are both cleared within a single poll.
- `restart_taint_resolves_on_matching_poll_without_escalation` — a matching poll proves the hydrated balance and lifts the taint with no escalation event emitted.
- `restart_tainted_cash_divergence_heals_within_one_poll` and `restart_cash_taint_resolves_on_matching_poll` — cash twins of the equity tests.

Four new reactor tests cover the suppression and fill-skip behaviour:

- `restart_across_open_order_does_not_double_apply_fill` — the headline race: a tainted fill's delta is skipped, the gate clears, and the taint survives for the poller.
- `restart_tainted_fill_skips_both_legs_and_failed_keeps_taint` — both the equity and cash legs are skipped together, and a subsequent failed order does not resolve the taint.
- `restart_taint_suppresses_equity_transfer_dispatch` — equity transfers are blocked while tainted and resume after the poller resolves the taint.
- `restart_cash_taint_suppresses_usdc_transfer_dispatch` — USDC bridge dispatch is blocked while the cash taint is set and resumes after it is cleared.

Two unit tests cover the view directly: `set_pending_offchain_order_symbols_stamps_restart_taint` and `reset_preserves_restart_taint`.

## Anything else

The taint fields are `#[serde(default)]` so existing serialized views deserialize cleanly with no taint set. The boot-without-open-orders path is explicitly tested to confirm nothing is tainted when there is no ambiguity.  
  
Closes [RAI-1504](https://linear.app/makeitrain/issue/RAI-1504/close-the-remaining-inventory-reconciliation-gaps-surfaced-by-rai-682)

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inventory reconciliation after restarts when hedge orders were still open.
  - Ambiguous equity and cash balances are now temporarily protected from fill-based updates and rebalancing.
  - Broker balances are rechecked to confirm values or trigger immediate reconciliation.
  - Failed and cancelled orders remain protected when partial fills may have occurred.
  - Reconciliation automatically resumes after balances are confirmed and taint is cleared.

- **Documentation**
  - Added guidance describing restart recovery and balance reconciliation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->