### PR TITLE
chore(config): add HOOD, ORCL, SMCI, BABA, TQQQ equities

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -486,3 +486,48 @@ extended_hours_counter_trading = "enabled"
 vault_id = "0xfab"
 tokenized_equity = "0xb6021810971714cD48572af527307Acc324ecF61"
 tokenized_equity_derivative = "0xb6D779A79E7493ed821a65D52bA419F0F6D5dD0a"
+
+[assets.equities.HOOD]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x5cEfd886dD05001c2Fc32c313E05360D07f37d8f"
+tokenized_equity_derivative = "0xd50f561322fe3235DBc9Ec8b3aB7693383d8A425"
+
+[assets.equities.ORCL]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x57573351f3fdD20a57dEE4a7f836de1cE9900d4B"
+tokenized_equity_derivative = "0xCB9571aB96aA47374eF30D8E9ACCC1cD51064726"
+
+[assets.equities.SMCI]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x8518931497d2A8f07Bc607D1D3295b398D065A65"
+tokenized_equity_derivative = "0xA759FAbbD866e6DB8bF76613C35825dC2e380bf0"
+
+[assets.equities.BABA]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x6B8fa7288dBEc7C1c62BfE59Cbd7Bec7EBF846C5"
+tokenized_equity_derivative = "0x7e5cc7eAe0455A07Ab4abf354E0f5657BA2888BD"
+
+[assets.equities.TQQQ]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xcA1A378F9a250131A2fE51c10f120FeF7EDCa56E"
+tokenized_equity_derivative = "0x295e9eCAb319006900a53b3f8D6Fcb0C131F4ada"

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -465,3 +465,48 @@ extended_hours_counter_trading = "disabled"
 vault_id = "0xfab"
 tokenized_equity = "0xb6021810971714cD48572af527307Acc324ecF61"
 tokenized_equity_derivative = "0xb6D779A79E7493ed821a65D52bA419F0F6D5dD0a"
+
+[assets.equities.HOOD]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x5cEfd886dD05001c2Fc32c313E05360D07f37d8f"
+tokenized_equity_derivative = "0xd50f561322fe3235DBc9Ec8b3aB7693383d8A425"
+
+[assets.equities.ORCL]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x57573351f3fdD20a57dEE4a7f836de1cE9900d4B"
+tokenized_equity_derivative = "0xCB9571aB96aA47374eF30D8E9ACCC1cD51064726"
+
+[assets.equities.SMCI]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x8518931497d2A8f07Bc607D1D3295b398D065A65"
+tokenized_equity_derivative = "0xA759FAbbD866e6DB8bF76613C35825dC2e380bf0"
+
+[assets.equities.BABA]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x6B8fa7288dBEc7C1c62BfE59Cbd7Bec7EBF846C5"
+tokenized_equity_derivative = "0x7e5cc7eAe0455A07Ab4abf354E0f5657BA2888BD"
+
+[assets.equities.TQQQ]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0xcA1A378F9a250131A2fE51c10f120FeF7EDCa56E"
+tokenized_equity_derivative = "0x295e9eCAb319006900a53b3f8D6Fcb0C131F4ada"


### PR DESCRIPTION
## What

- Adds `HOOD`, `ORCL`, `SMCI`, `BABA`, and `TQQQ` to `config/prod/st0x-hedge.toml`, all four flags `enabled`.
- Adds the same five to `config/staging/st0x-hedge.toml`, all four flags `disabled`.
- The tokens come from [st0x.registry#51](https://github.com/ST0x-Technology/st0x.registry/pull/51).

## Why

- The five tokens are live on Base since 2026-08-05, but the bot does not know their addresses. So it cannot recognise a fill, account for it, or hedge it.

## How

- Config only, no Rust changes. Same shape as #1097.
- `tokenized_equity` is the `t<SYM>` share token, which the registry calls the SFT. `tokenized_equity_derivative` is the `wt<SYM>` wrapper.
- I checked every pair on Base with `cast`. Each wrapper reports `symbol()` `wt<SYM>`, `decimals()` 18, and `asset()` equal to the `tokenized_equity` address in this diff. So the two fields are not flipped.
- `vault_id = "0xfab"` like every other equity.
- `pyth_feed_id` is unset on all five. We only pin a feed after we confirm it on-chain. A missing feed skips trade enrichment for analytics. Hedging is unaffected.
- staging registers the five but keeps every flag `disabled`. staging only trades RKLB.

## Testing

- `cargo nextest run -p st0x-config --all-features` -> 198/198 pass.
- `server_config_toml_is_valid` and `all_repo_config_tomls_are_valid` read the real prod and staging TOML files. So the ten new blocks are parsed and validated.
- Not hotfixed on the live prod config. Prod picks these up on the next deploy.

## Anything else

- This turns on live prod trading for all five. To hold one back, flip its prod `trading` to `disabled` before the deploy.
- `TQQQ` is a 3x leveraged ETF with a daily reset. `BABA` is an ADR, where 1 ADS is 8 ordinary shares. Worth a check that the broker fills both the same way as a common stock.
- Out of scope: the Raindex orders in `st0x.raindex-deploy`, and the issuance registration. The bot sees no fills until those orders are deployed.
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788615080&installation_model_id=19370&pr_number=1131&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1131&signature=4f1aa40f3848b4ea5d1f0886d26da987fc94a2d8653fffd38d41935b1182058f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HOOD, ORCL, SMCI, BABA, and TQQQ equity configurations.
  * Enabled production settings for rebalancing, recovery, and extended-hours trading.
  * Added staging configurations for testing these equities, including vault and contract details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Linear: [RAI-1688](https://linear.app/makeitrain/issue/RAI-1688)
