### PR TITLE
feat: PnL ledger read-model schema

### DIFF
--- a/adrs/0018-back-pnl-with-a-cqrs-read-model.md
+++ b/adrs/0018-back-pnl-with-a-cqrs-read-model.md
@@ -1,0 +1,233 @@
+# ADR 0018: Back /pnl with a CQRS read model instead of raw SQL over the events table
+
+- **Status:** Proposed
+- **Date:** 2026-08-05
+- **Related:** ADR 0016 (event row ID as the shared immutable ingestion cursor);
+  RAI-1072 / RAI-990 / RAI-1127 (performance and reliability stacks moved to
+  view-backed read models); found while working on RAI-1457
+
+## Context
+
+`/pnl` is the last consumer that queries the `events` table directly.
+`src/dashboard/pnl/source.rs` runs hand-written SQL with literal
+`aggregate_type` / `event_type` strings and re-parses raw JSON payloads per
+request. An event rename or payload change compiles clean and breaks `/pnl`
+silently at runtime; three such latent defects surfaced in one debugging session
+(missing broker-mock activities endpoint masking a null-`fees` report failure
+masking a decimal-overflow failure), each invisible behind the previous because
+the report fails wholesale on the first error it meets.
+
+Constraints discovered in the code, which shape any replacement:
+
+1. `asOfRowid` is a global `events.rowid` watermark, and real row IDs leak into
+   the response (`opening_rowid`/`closing_rowid`, ordering tie-breakers). Any
+   derived store must carry the genuine rowid per row.
+2. The FIFO replay folds fills in execution-timestamp order, while events arrive
+   in persistence (rowid) order. Late-arriving events (backfills, slow broker
+   reconciliation) insert into the middle of the fold and re-pair every later
+   match. Matched lots therefore cannot be materialized incrementally without
+   changing reported semantics.
+3. Reactor delivery is at-most-once: `cqrs-es` dispatches queries in a plain
+   awaited loop whose `dispatch` returns `()`, so reactor errors are logged and
+   swallowed. A read model for financial reporting cannot depend on per-event
+   delivery.
+4. Reactors receive `(id, event)` only -- no rowid, no sequence -- so rowid
+   stamping cannot come from the reactor callback.
+5. Production has a full event history; the read model must backfill it.
+6. Mint fee attribution spans events (`MintRequested` carries the symbol, the
+   terminal event carries the fee), so ingestion must process events in rowid
+   order with a small support table.
+7. Duplicate business events produce audit warnings during replay; the store
+   must keep every occurrence as its own row.
+
+Since the task was specified, `#1121` moved report arithmetic from exact `Num`
+rationals to Rain `Float` (~4us/op, revm-executed) and added replay admission
+control (`PnlReportAdmission`, 2 permits, `spawn_blocking`, excess requests
+503). This contains the replay's cost but does not reduce it; per-request cost
+still grows with history. Separately, unreported mint fees are now a counted
+"missing cost observation" (`missing_cost_observation_count`) rather than a
+report failure, an outcome the read model must be able to represent.
+
+## Decision
+
+Serve `/pnl` from a typed, append-only **PnL ledger** maintained by a
+checkpointed ingester over the event stream. The FIFO replay itself stays at
+query time, unchanged, reading ledger rows instead of raw events.
+
+```
+Store::send() commits events (source of truth: events table)
+      |
+      +--------------------------------------------+
+      |                                            |
+      v                                            v
+events table                          PnlLedgerReactor
+(never touched by pnl SQL)            deps!: [Position, TokenizedEquityMint,
+      ^                                       UsdcRebalance, BotGasReceiptCost]
+      |                                            |
+      | typed stream API                           |  nudge only
+      | (st0x-event-sorcery):                      |  (payload ignored)
+      |   events_since::<E>(pool, after)           v
+      |     -> Vec<Sequenced<E>>          PnlLedger::catch_up()
+      |   head_rowid(pool) -> i64           - serialized by async Mutex
+      +------------------------------.      - loads typed events with
+                                     |        rowid > checkpoint, per entity
+                                     |      - exhaustive match on event enums
+                                     '----> - INSERT OR IGNORE ledger rows
+                                            - checkpoint advance, same tx
+                                                   |
+                                                   v
+                                    pnl ledger tables (typed, append-only)
+                                    pnl_onchain_fill      pnl_offchain_fill
+                                    pnl_offchain_placement pnl_manual_adjustment
+                                    pnl_cost_entry        pnl_bot_gas_cost
+                                    pnl_mint_symbol       pnl_ledger_checkpoint
+                                                   |
+GET /pnl                                           |
+      |                                            v
+      +--> ensure_fresh() ---------> load rows WHERE event_rowid <= asOfRowid
+           (catch_up to head,               |
+            outside the replay              v
+            admission permit)      FIFO replay (replay.rs, algorithm unchanged,
+                                   under PnlReportAdmission + spawn_blocking)
+                                            |
+                                            v
+                                   PnlResponse (shape unchanged)
+```
+
+### Ledger tables (one sqlx migration)
+
+One row per relevant event occurrence, PK `event_rowid` (the genuine
+`events.rowid`), decimals as canonical decimal TEXT (parsed with `Float::parse`
+at read time), timestamps RFC3339 TEXT:
+
+- `pnl_onchain_fill(event_rowid, symbol, tx_hash, log_index, shares,
+  direction, price_usd, executed_at)`
+- `pnl_offchain_fill(event_rowid, symbol, offchain_order_id, shares,
+  direction, price_usd, executed_at)`
+- `pnl_offchain_placement(event_rowid, symbol, offchain_order_id,
+  placed_at)`
+- `pnl_manual_adjustment(event_rowid, symbol, target_net, price_usd NULL,
+  adjusted_at)`
+- `pnl_cost_entry(event_rowid, source, aggregate_id, symbol NULL,
+  amount_usd NULL, occurred_at)`
+  -- `amount_usd` NULL persists the "mint fees not reported" observation so the
+  read side can count it into `missing_cost_observation_count`; omitting that
+  row would silently regress the merged fix.
+- `pnl_bot_gas_cost(event_rowid, chain, tx_hash, usd_cost,
+  operation_category, symbol NULL, occurred_at)`
+- Support: `pnl_mint_symbol(aggregate_id PK, symbol)`,
+  `pnl_ledger_checkpoint(id=1, last_rowid, ledger_version)`.
+
+Duplicate business events remain distinct rows (PK is the rowid alone); dedup
+and its audit warnings stay in the replay.
+
+### Ingestion: checkpoint + catch-up, reactor as doorbell only
+
+`st0x-event-sorcery` gains a typed stream API (the only place allowed to SQL the
+`events` table):
+`events_since::<Entity>(pool, after_rowid) ->
+Vec<Sequenced<Entity>>` (rowid,
+id, sequence, typed event, filtered on `Entity::AGGREGATE_TYPE`) and
+`head_rowid(pool)`.
+
+`PnlLedger::catch_up()` (mutex-serialized): read `head_rowid`; if the checkpoint
+is at head, return; otherwise ingest `checkpoint..head` for each source entity
+via an exhaustive `match` on the typed event enum (a new or renamed variant is a
+compile error), `INSERT OR IGNORE` the rows, and advance the checkpoint in the
+same transaction -- rows and progress marker commit atomically, so every
+committed state satisfies "the ledger contains exactly the events at or below
+`last_rowid`". Large gaps (first-deploy backfill, rebuilds) are ingested in
+bounded batches, each batch's rows and checkpoint bump in their own transaction:
+peak memory stays flat and a mid-backfill crash resumes from the last batch
+instead of starting over.
+
+`PnlLedgerReactor`
+(`deps!: [Position, TokenizedEquityMint, UsdcRebalance,
+BotGasReceiptCost]`)
+ignores the delivered payload entirely and calls `catch_up()` -- a direct
+in-process call, not a queued job: correctness never depends on a nudge arriving
+(the checkpoint self-heals on the next trigger), so durable queueing would add
+latency and moving parts for redundant reliability. `/pnl` calls
+`ensure_fresh()` (a catch-up) before resolving its watermark, giving
+read-your-writes even if every nudge was swallowed; it runs outside the replay
+admission permit (async I/O, usually a no-op). The checkpoint starting at zero
+makes first-deploy backfill the same code path as steady-state ingestion. A
+`LEDGER_VERSION` mismatch at startup truncates the ledger and re-ingests (the
+rebuild path).
+
+### What does not change
+
+The FIFO replay, bucketing, dedup, warnings, diagnostics, windows, pagination,
+response shape, and `asOfRowid` semantics are preserved byte-for-byte: ledger
+rows carry genuine rowids, `event_rowid <=
+asOfRowid` selects exactly what
+`rowid <= asOfRowid` selects today, and the replay is the same code over the
+same values. Non-event inputs (`position_view`, `portfolio_snapshot`, live
+Alpaca account activities) are untouched. Business validations that fail the
+report today keep failing it at read time; ingest stores what the event says.
+
+### Input inventory
+
+Position: `OnChainOrderFilled`, `OffChainOrderFilled`, `ManualPositionAdjusted`,
+`OffChainOrderPlaced` (audit warnings only); the six remaining variants are
+explicitly skipped (no share movement). TokenizedEquityMint: `MintRequested`
+(symbol attribution), `TokensReceived`, `ProviderCompletionRecovered`.
+UsdcRebalance: `Bridged`, `BridgingCompletionRecovered`. BotGasReceiptCost:
+`Recorded`.
+
+## Consequences
+
+Positive:
+
+- No SQL in the PnL module names an aggregate type or event type; event
+  consumption is typed and exhaustively matched, so schema drift becomes a
+  compile error instead of a silent runtime report failure.
+- Ingestion is lossless and self-healing (checkpoint over the durable log)
+  despite at-most-once reactor delivery, and backfill is free.
+- Per-request input cost drops from scanning and JSON-parsing the whole event
+  log to indexed range scans over compact typed rows.
+- The ledger's append-only, rowid-stamped inputs make matched-entry memoization
+  keyed by the `asOfRowid` watermark trivially correct later (immutable inputs
+  per key; a new event is a new key). This is the designated follow-up for
+  replay cost -- explicitly whole-result caching per watermark, not
+  resume-from-baseline, which is unsound because the execution-timestamp fold
+  does not commute with rowid-order arrival.
+
+Negative / accepted:
+
+- FIFO matching stays at query time, so per-request arithmetic cost (now
+  Float-priced after #1121) is unchanged until the memoization follow-up;
+  admission control continues to bound its blast radius.
+- Every commit on the four source aggregates pays a small inline ingest in
+  `Store::send()`; if tracing shows it matters, the mitigation is debouncing
+  inside `PnlLedger` (coalescing notify), not changing the reactor contract.
+- New moving part (the checkpointed ingester) and eight new tables (six ledger,
+  two support) to operate and rebuild.
+
+Rollout: (1) event-sorcery `events_since`/`head_rowid` upstream; (2) migration +
+ingester with tests; (3) reactor + conductor wiring + startup catch-up; (4) cut
+`/pnl` over and delete the raw-SQL/JSON path, adapting `tests.rs` (existing
+tests seed raw events and keep exercising the full path through
+`ensure_fresh()`).
+
+## Alternatives considered
+
+- **Materialize the report (or matched lots) in a view table:** unsound under
+  constraint 2 (late events re-pair matches; incremental maintenance cannot
+  unfold state) and cannot serve arbitrary historical `asOfRowid` values without
+  either per-watermark storage or a second replay path that must agree forever.
+- **Payload-driven reactor writes (hedge-latency style):** acceptable for
+  gap-tolerant analytics, not for money: at-most-once delivery loses rows
+  permanently, and the payload lacks the rowid the watermark semantics require.
+- **Typed per-request replay with no tables:** kills the string literals and raw
+  SQL but re-decodes full history per request and is not a maintained read
+  model; kept only as a fallback shape if the ledger had to be descoped.
+
+## Open questions
+
+- Whether `events_since`/`head_rowid` land upstream in `st0x-event-sorcery`
+  first (the right home; the API must not foreclose upcaster support) or start
+  as a literal-free generic helper in `st0x-hedge` outside `src/dashboard/pnl/`.
+- `load_position_view`'s raw SQL over the `position_view` view table is out of
+  scope here (not the `events` table) but is a candidate follow-up via
+  `Projection` access.

--- a/migrations/20260805164942_pnl_ledger_read_model.sql
+++ b/migrations/20260805164942_pnl_ledger_read_model.sql
@@ -1,0 +1,127 @@
+-- PnL ledger: typed, append-only read model of the /pnl replay's INPUTS
+-- (ADR 0018). Maintained exclusively by the checkpointed PnlLedger ingester
+-- from typed event streams (st0x-event-sorcery `events_since`); the /pnl
+-- read path queries ONLY these tables and never the events table. The FIFO
+-- replay itself stays at query time -- these tables deliberately store no
+-- matched lots, no PnL, no derived state.
+--
+-- `event_rowid` is the GENUINE global rowid of the source row in `events`,
+-- and is the primary key everywhere: it is the `asOfRowid` watermark unit
+-- (read path filters `event_rowid <= asOfRowid`), the idempotency key for
+-- ingestion (`INSERT OR IGNORE` makes redelivery/re-ingest a no-op), and the
+-- provenance stamp surfaced in the response (`opening_rowid`/`closing_rowid`).
+-- Duplicate BUSINESS events (same trade id / order id seen twice) are
+-- deliberately kept as distinct rows: dedup and its audit warnings are replay
+-- semantics, not storage semantics.
+--
+-- Decimal columns store the exact canonical decimal strings the event
+-- payloads carry (st0x-float-serde form) and are parsed with `Float::parse`
+-- at read time. Timestamp columns store the payloads' chrono-serde RFC3339
+-- strings (`Z`-suffixed) byte-for-byte, because these strings flow into the
+-- /pnl response verbatim; unlike the hedge_* tables there is NO
+-- `LIKE '%+00:00'` format CHECK -- the replay orders by parsed value in
+-- Rust, so lexicographic ordering of these columns is never relied upon.
+
+-- One row per PositionEvent::OnChainOrderFilled: opens/closes lots on the
+-- onchain side of the FIFO replay.
+CREATE TABLE pnl_onchain_fill (
+    event_rowid INTEGER PRIMARY KEY,
+    symbol TEXT NOT NULL,
+    tx_hash TEXT NOT NULL,
+    log_index INTEGER NOT NULL,
+    shares TEXT NOT NULL,
+    direction TEXT NOT NULL CHECK (direction IN ('Buy', 'Sell')),
+    price_usd TEXT NOT NULL,
+    executed_at TEXT NOT NULL
+) STRICT;
+
+CREATE INDEX idx_pnl_onchain_fill_symbol ON pnl_onchain_fill (symbol);
+
+-- One row per PositionEvent::OffChainOrderFilled: the hedge side of the
+-- replay.
+CREATE TABLE pnl_offchain_fill (
+    event_rowid INTEGER PRIMARY KEY,
+    symbol TEXT NOT NULL,
+    offchain_order_id TEXT NOT NULL,
+    shares TEXT NOT NULL,
+    direction TEXT NOT NULL CHECK (direction IN ('Buy', 'Sell')),
+    price_usd TEXT NOT NULL,
+    executed_at TEXT NOT NULL
+) STRICT;
+
+CREATE INDEX idx_pnl_offchain_fill_symbol ON pnl_offchain_fill (symbol);
+
+-- One row per PositionEvent::OffChainOrderPlaced. No lot effect; feeds only
+-- the duplicate-placement audit warning and the replay's sample statistics.
+CREATE TABLE pnl_offchain_placement (
+    event_rowid INTEGER PRIMARY KEY,
+    symbol TEXT NOT NULL,
+    offchain_order_id TEXT NOT NULL,
+    placed_at TEXT NOT NULL
+) STRICT;
+
+-- One row per PositionEvent::ManualPositionAdjusted: clears the symbol's
+-- book and seeds a fresh lot at target_net. `price_usd` NULL mirrors the
+-- event's optional price (the replay then falls back to the symbol's last
+-- replayed price, and errors if there is none -- replay semantics,
+-- unchanged).
+CREATE TABLE pnl_manual_adjustment (
+    event_rowid INTEGER PRIMARY KEY,
+    symbol TEXT NOT NULL,
+    target_net TEXT NOT NULL,
+    price_usd TEXT,
+    adjusted_at TEXT NOT NULL
+) STRICT;
+
+-- One row per fee-bearing mint/bridge terminal event. `amount_usd` NULL
+-- persists the "provider did not report fees" observation
+-- (TokenizedEquityMint only): the read side counts those rows into
+-- missing_cost_observation_count (deduped per aggregate_id) instead of
+-- producing a cost entry -- dropping them would silently regress the
+-- unreported-fees fix. An explicit reported zero fee writes NO row at all,
+-- so NULL can only ever mean "unobserved", never "zero". CCTP rows always
+-- carry an amount.
+CREATE TABLE pnl_cost_entry (
+    event_rowid INTEGER PRIMARY KEY,
+    source TEXT NOT NULL CHECK (source IN ('tokenization_fee', 'cctp_fee')),
+    aggregate_id TEXT NOT NULL,
+    symbol TEXT,
+    amount_usd TEXT,
+    occurred_at TEXT NOT NULL,
+    CHECK (source != 'cctp_fee' OR amount_usd IS NOT NULL)
+) STRICT;
+
+-- One row per BotGasReceiptCostEvent::Recorded.
+CREATE TABLE pnl_bot_gas_cost (
+    event_rowid INTEGER PRIMARY KEY,
+    chain TEXT NOT NULL,
+    tx_hash TEXT NOT NULL,
+    usd_cost TEXT NOT NULL,
+    operation_category TEXT NOT NULL,
+    symbol TEXT,
+    occurred_at TEXT NOT NULL
+) STRICT;
+
+-- Ingestion support: MintRequested carries the mint's symbol, the fee
+-- arrives later on the terminal event of the same aggregate. Ingestion is in
+-- rowid order, so the symbol row always lands before the cost row needs it.
+CREATE TABLE pnl_mint_symbol (
+    aggregate_id TEXT PRIMARY KEY,
+    symbol TEXT NOT NULL
+) STRICT;
+
+-- The ingester's durable progress watermark: the ledger contains exactly the
+-- events with rowid <= last_rowid. Advanced in the same transaction as the
+-- rows of each ingest batch, so that invariant survives any crash.
+-- `ledger_version` mirrors the code's LEDGER_VERSION const; a mismatch at
+-- startup truncates all pnl_* tables and resets last_rowid to 0, making
+-- rebuild the same code path as first-deploy backfill. Seeded at 0/version 1:
+-- an empty ledger caught up to nothing.
+CREATE TABLE pnl_ledger_checkpoint (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    last_rowid INTEGER NOT NULL,
+    ledger_version INTEGER NOT NULL
+) STRICT;
+
+INSERT INTO pnl_ledger_checkpoint (id, last_rowid, ledger_version)
+VALUES (1, 0, 1);


### PR DESCRIPTION
## What

Part of RAI-1506 (PR 1/3 of the ADR 0018 stack: schema -> ingester/reactor -> read-path cutover).

Adds ADR 0018 ("Back /pnl with a CQRS read model") and the ledger schema migration it specifies.

## Why

`/pnl` currently re-parses every persisted event payload (raw SQL over `events` + JSON string extraction) on every request. ADR 0018 replaces that with a typed, checkpointed read model; this PR lays down the decision record and the tables.

## How

Eight append-only STRICT `pnl_*` tables: onchain fills, offchain fills, offchain placements, manual adjustments, cost entries, bot gas costs, mint-symbol attribution, and the ingestion checkpoint (seeded at version 1, rowid 0). Every row carries its source `event_rowid`, preserving `asOfRowid` watermark semantics. `pnl_cost_entry.amount_usd` is nullable so "provider did not report fees" persists as a first-class missing-cost observation, with a CHECK forbidding that shape for CCTP fees. Directions are constrained to `('Buy','Sell')`.

## Testing

`sqlx db reset -y` applies cleanly; the tables are exercised end-to-end by the ingester and read-path PRs stacked on top.

## Screenshots

N/A

## Anything else

Nothing writes these tables yet -- the ingester lands in the next PR of the stack.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788635325&installation_model_id=19370&pr_number=1134&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1134&signature=913a99d61edca2b85f2551272e9d2dec9be419702c6327e2dd34501b61676079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured PnL ledger covering on-chain and off-chain trades, placements, manual adjustments, fees, gas costs, and mint symbols.
  * Preserved event ordering, duplicate occurrences, precise timestamps, and nullable fee information for accurate PnL reporting.
  * Added checkpoint tracking to support incremental updates and reliable recovery.

* **Documentation**
  * Documented the proposed PnL reporting architecture, migration approach, rollout steps, and operational considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->