### PR TITLE
feat: serve /pnl from the PnL ledger read model

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -3,6 +3,7 @@
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use alloy::primitives::U256;
 use axum::Json;
@@ -160,6 +161,17 @@ async fn health() -> Json<HealthResponse> {
     })
 }
 
+/// Deadline for bringing the PnL ledger current on the `/pnl` request path.
+/// Catch-up work is proportional to the un-ingested backlog, not to the
+/// request, and concurrent requests serialize on the ledger's internal mutex
+/// before any admission control -- so past this deadline the request sheds
+/// with 503 instead of queueing behind ingestion. The boot-path catch-up
+/// stays unbounded: first-deploy backfill may legitimately exceed any
+/// request deadline. Cancellation is safe because each ingest batch commits
+/// its rows and checkpoint atomically; an elapsed deadline only rolls back
+/// the in-flight batch.
+const PNL_CATCH_UP_TIMEOUT: Duration = Duration::from_secs(10);
+
 async fn pnl(
     State(state): State<AppState>,
     Query(query): Query<PnlQuery>,
@@ -173,11 +185,19 @@ async fn pnl(
     query
         .symbol_filter(&mut Vec::new())
         .map_err(|error| (StatusCode::BAD_REQUEST, error.to_string()))?;
+    let head = tokio::time::timeout(PNL_CATCH_UP_TIMEOUT, state.pnl_ledger.catch_up())
+        .await
+        .map_err(|_elapsed| {
+            warn!("PnL ledger catch-up exceeded its request deadline");
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "PnL ledger catch-up timed out".to_string(),
+            )
+        })?
+        .map_err(|error| pnl_error_response(PnlError::Ledger(error)))?;
+    validate_pnl_snapshot_rowid(head, &query).map_err(pnl_error_response)?;
     let permit =
         acquire_pnl_report_permit(&state.pnl_report_admission).map_err(pnl_error_response)?;
-    validate_pnl_snapshot_rowid(&state.pool, &query)
-        .await
-        .map_err(pnl_error_response)?;
 
     let activities = if let BrokerCtx::AlpacaBrokerApi(alpaca_auth) = &state.ctx.broker {
         alpaca_auth
@@ -194,7 +214,7 @@ async fn pnl(
         Vec::new()
     };
 
-    build_pnl_report_with_permit(&state.pool, &query, activities, Utc::now(), permit)
+    build_pnl_report_with_permit(&state.pool, &query, activities, Utc::now(), permit, head)
         .await
         .map(Json)
         .map_err(pnl_error_response)
@@ -205,12 +225,18 @@ fn pnl_error_response(error: PnlError) -> (StatusCode, String) {
         PnlError::InvalidDate { .. }
         | PnlError::InvalidSnapshotRowid { .. }
         | PnlError::InvalidSymbolFilter { .. } => (StatusCode::BAD_REQUEST, error.to_string()),
-        PnlError::InvalidPayload { .. }
-        | PnlError::InvalidBotGasReceiptCost { .. }
+        PnlError::InvalidLedgerRow { .. }
         | PnlError::MalformedPayload { .. }
         | PnlError::InvalidFinancialField { .. }
         | PnlError::InvalidInternalDecimal { .. } => {
-            error!(%error, "Failed to build PnL report from persisted payload");
+            error!(%error, "Failed to build PnL report from ledger data");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to build PnL report".to_string(),
+            )
+        }
+        PnlError::Ledger(error) => {
+            error!(%error, "PnL ledger ingestion failed");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to build PnL report".to_string(),
@@ -1894,6 +1920,7 @@ mod tests {
         AppState {
             settings: dashboard::settings_from_ctx(&ctx),
             ctx,
+            pnl_ledger: Arc::new(crate::dashboard::pnl::PnlLedger::new(pool.clone())),
             pool,
             event_sender: sender.clone(),
             inventory: Arc::new(BroadcastingInventory::new(

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -61,7 +61,7 @@ use crate::bot_gas::{
 use crate::conductor::exit::{ConductorExit, ConductorExitError, MonitorTaskError};
 use crate::conductor::job::{BACKPRESSURE_RESCHEDULE_LIMIT, BackpressureStreak};
 use crate::conductor::monitor::order_fills::{CutoffProbe, probe_cutoff_block_support};
-use crate::dashboard::pnl::{PnlLedger, PnlLedgerReactor};
+use crate::dashboard::pnl::{LedgerHead, PnlLedger, PnlLedgerReactor};
 use crate::dashboard::{Broadcaster, DashboardTradeDelivery};
 use crate::equity_redemption::{
     EquityRedemption, interrupted_redemption_ids, symbols_with_stuck_redemptions,
@@ -770,15 +770,32 @@ fn publish_recovery_handle(
     });
 }
 
+/// Handles the conductor shares with the axum server's `AppState`: the
+/// dashboard event stream, the broadcasting inventory, the recovery cell the
+/// conductor populates for `/transfers/resume`, and the PnL ledger whose
+/// ingestion both sides drive.
+pub(crate) struct ServerHandles {
+    pub(crate) event_sender: broadcast::Sender<Statement>,
+    pub(crate) inventory: Arc<BroadcastingInventory>,
+    pub(crate) recovery_cell: Arc<tokio::sync::OnceCell<crate::api::RecoveryHandle>>,
+    pub(crate) pnl_ledger: Arc<PnlLedger>,
+}
+
 impl Conductor {
     pub(crate) async fn run<E>(
         executor_ctx: impl TryIntoExecutor<Executor = E>,
         ctx: Ctx,
-        pools: DatabasePools,
-        event_sender: broadcast::Sender<Statement>,
-        inventory: Arc<BroadcastingInventory>,
+        DatabasePools {
+            cqrs: pool,
+            apalis: apalis_pool,
+        }: DatabasePools,
+        ServerHandles {
+            event_sender,
+            inventory,
+            recovery_cell,
+            pnl_ledger,
+        }: ServerHandles,
         shutdown_token: CancellationToken,
-        recovery_cell: Arc<tokio::sync::OnceCell<crate::api::RecoveryHandle>>,
         #[cfg(any(test, feature = "test-support"))]
         failure_injector: crate::conductor::job::FailureInjector,
     ) -> anyhow::Result<()>
@@ -787,11 +804,6 @@ impl Conductor {
         TradeAccountingError: From<E::Error>,
         crate::offchain::order::JobError: From<E::Error>,
     {
-        let DatabasePools {
-            cqrs: pool,
-            apalis: apalis_pool,
-        } = pools;
-
         let (executor, provider, telemetry_writer, telemetry) =
             setup_instrumentation(executor_ctx, &ctx.evm, pool.clone()).await?;
         let cache = SymbolCache::default();
@@ -802,7 +814,7 @@ impl Conductor {
         let onchain_trade =
             setup_onchain_trade_store(&pool, dashboard_delivery.broadcaster.clone()).await?;
 
-        let pnl_ledger_reactor = setup_pnl_ledger(&pool).await?;
+        let pnl_ledger_reactor = setup_pnl_ledger(pnl_ledger).await?;
 
         let (record_bot_gas_receipt_cost_queue, record_bot_gas_receipt_cost_ctx) =
             setup_bot_gas_receipt_cost(&pool, &apalis_pool, &ctx, pnl_ledger_reactor.clone())
@@ -1229,18 +1241,19 @@ fn build_unwrapped_equity_recovery_ctx(
     }))
 }
 
-/// Builds the PnL ledger read model and brings it up to the event-log head
-/// (ADR 0018). Runs before any store is built so the returned doorbell
-/// reactor can be registered on every source aggregate's framework. The
+/// Brings the PnL ledger read model up to the event-log head (ADR 0018).
+/// Runs before any store is built so the returned doorbell reactor can be
+/// registered on every source aggregate's framework. The ledger instance is
+/// shared with `AppState` (the /pnl handler calls `catch_up` per request);
+/// sharing keeps ingestion serialized on the instance's internal mutex. The
 /// startup catch-up performs first-deploy backfill and `LEDGER_VERSION`
 /// rebuilds here, at boot, so that cost can never land inside a command
 /// dispatch or a /pnl request; on a normal restart it is a no-op (the bot is
 /// the sole writer of its database, so no events accumulate while it is
 /// down).
-async fn setup_pnl_ledger(pool: &SqlitePool) -> anyhow::Result<Arc<PnlLedgerReactor>> {
-    let ledger = Arc::new(PnlLedger::new(pool.clone()));
+async fn setup_pnl_ledger(ledger: Arc<PnlLedger>) -> anyhow::Result<Arc<PnlLedgerReactor>> {
     let started_at = Instant::now();
-    let head = ledger.catch_up().await?;
+    let LedgerHead(head) = ledger.catch_up().await?;
     info!(
         target: "startup",
         head,

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -702,6 +702,7 @@ mod tests {
             ctx: create_test_ctx_with_order_owner(address!(
                 "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             )),
+            pnl_ledger: Arc::new(pnl::PnlLedger::new(pool.clone())),
             pool,
             event_sender: sender.clone(),
             inventory: Arc::new(BroadcastingInventory::new(

--- a/src/dashboard/pnl/builder.rs
+++ b/src/dashboard/pnl/builder.rs
@@ -26,7 +26,7 @@ use super::sessions::{
     date_key, et_day_key, matches_cost_date_filter, matches_cost_symbol_filter, matches_date_filter,
 };
 use super::state::{
-    BotGasCostRow, CostEventRow, PositionEventRow, PositionViewRow, SummaryAcc, SymbolBook,
+    BotGasCostRow, CostLedgerRow, PositionLedgerRow, PositionViewRow, SummaryAcc, SymbolBook,
 };
 use super::windows::build_windows;
 
@@ -102,9 +102,9 @@ fn remove_tokenization_fee_overlaps(
 /// Builds the `/pnl` response from already-loaded rows and returns net realized
 /// PnL bucketed by ET accounting day for the aligned capital calculation.
 pub(crate) fn build_pnl_response_from_rows(
-    event_rows: Vec<PositionEventRow>,
+    event_rows: Vec<PositionLedgerRow>,
     position_rows: &[PositionViewRow],
-    cost_rows: &[CostEventRow],
+    cost_rows: &[CostLedgerRow],
     bot_gas_rows: &[BotGasCostRow],
     alpaca_activities: &[AccountActivity],
     query: &PnlQuery,
@@ -116,7 +116,7 @@ pub(crate) fn build_pnl_response_from_rows(
     } else {
         event_rows
             .into_iter()
-            .filter(|row| symbols.contains(&row.symbol))
+            .filter(|row| symbols.contains(row.symbol()))
             .collect()
     };
     let (position_nets, position_symbols) = parse_position_view(position_rows, &mut warnings)?;
@@ -128,47 +128,44 @@ pub(crate) fn build_pnl_response_from_rows(
     let mut position_replay_deltas = Vec::new();
 
     for row in ordered_position_events(event_rows)? {
-        if !is_safe_symbol(&row.symbol) {
+        if !is_safe_symbol(row.symbol()) {
             warnings.push(format!(
                 "Skipped unsafe position event symbol in backend PnL response: {}",
-                row.symbol
+                row.symbol()
             ));
             continue;
         }
 
-        let Ok(symbol) = Symbol::new(row.symbol.clone()) else {
+        let Ok(symbol) = Symbol::new(row.symbol().to_owned()) else {
             warnings.push(format!(
                 "Skipped invalid position event symbol in backend PnL response: {}",
-                row.symbol
+                row.symbol()
             ));
             continue;
         };
 
         let book = books.entry(symbol).or_default();
-        match row.event_type.as_str() {
-            "PositionEvent::OnChainOrderFilled" => {
-                if let Some(fill) = parse_onchain_fill(&row, &mut warnings)? {
-                    apply_onchain_fill(book, &fill, &mut entries, &mut warnings)?;
-                }
+        match &row {
+            PositionLedgerRow::OnchainFill(fill_row) => {
+                let fill = parse_onchain_fill(fill_row)?;
+                apply_onchain_fill(book, &fill, &mut entries, &mut warnings)?;
             }
-            "PositionEvent::OffChainOrderPlaced" => {
-                apply_offchain_placement(book, &row, &mut warnings);
+            PositionLedgerRow::OffchainPlacement(placement) => {
+                apply_offchain_placement(book, placement, &mut warnings);
             }
-            "PositionEvent::OffChainOrderFilled" => {
-                if let Some(fill) = parse_offchain_fill(&row, &mut warnings)? {
-                    apply_offchain_fill(
-                        book,
-                        &fill,
-                        &mut entries,
-                        &mut warnings,
-                        &mut unmatched_offchain_allocations,
-                    )?;
-                }
+            PositionLedgerRow::OffchainFill(fill_row) => {
+                let fill = parse_offchain_fill(fill_row)?;
+                apply_offchain_fill(
+                    book,
+                    &fill,
+                    &mut entries,
+                    &mut warnings,
+                    &mut unmatched_offchain_allocations,
+                )?;
             }
-            "PositionEvent::ManualPositionAdjusted" => {
-                apply_manual_position_adjustment(book, &row, &mut warnings)?;
+            PositionLedgerRow::ManualAdjustment(adjustment) => {
+                apply_manual_position_adjustment(book, adjustment)?;
             }
-            _ => {}
         }
     }
 

--- a/src/dashboard/pnl/costs.rs
+++ b/src/dashboard/pnl/costs.rs
@@ -1,18 +1,15 @@
 //! Cost and revenue classification for backend PnL reports.
 use rain_math_float::Float;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use st0x_execution::alpaca_broker_api::AccountActivity;
 use st0x_finance::{Symbol, Usd};
 use st0x_float_macro::float;
 
-use super::parsing::{
-    fmt_decimal, is_safe_symbol, nested_record, optional_persisted_decimal_value,
-    parse_internal_decimal, persisted_decimal_value, text_field,
-};
-use super::query::{PnlError, PnlFinancialFieldError};
+use super::parsing::{fmt_decimal, is_safe_symbol, parse_internal_decimal, parse_ledger_decimal};
+use super::query::{LEDGER_ROW_EVENT_TYPE, PnlError, PnlFinancialFieldError};
 use super::response::{PnlCostCoverage, PnlCostSummary, PnlSummary};
-use super::state::CostEventRow;
+use super::state::{CostLedgerRow, CostSource};
 
 const FEE_ACTIVITY_TYPES: &[&str] = &["FEE", "PTC"];
 const INTEREST_ACTIVITY_TYPES: &[&str] = &["INT"];
@@ -24,15 +21,6 @@ const DIVIDEND_ACTIVITY_TYPES: &[&str] = &[
     "DIV", "DIVCGL", "DIVCGS", "DIVNRA", "DIVROC", "DIVTXEX", "CGD", "CIL",
 ];
 const CASH_CREDIT_ACTIVITY_TYPES: &[&str] = &["CSD"];
-
-fn malformed_cost_payload(row: &CostEventRow, reason: &'static str) -> PnlError {
-    PnlError::MalformedPayload {
-        rowid: row.rowid,
-        aggregate_type: "CostEvent",
-        event_type: row.event_type.clone(),
-        reason,
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CostCategory {
@@ -497,169 +485,55 @@ const CCTP_FEE_ENTRY: CostEntryDefinition = CostEntryDefinition {
     detail: "CCTP fee_collected from bridge mint",
 };
 
-fn cost_entry(
-    row: &CostEventRow,
+/// Converts one fee-bearing ledger row into a cost entry. The symbol was
+/// attributed at ingestion (`pnl_mint_symbol`); an unsafe or invalid stored
+/// symbol degrades to no attribution with a warning, as the payload path did.
+fn ledger_cost_entry(
+    row: &CostLedgerRow,
     definition: CostEntryDefinition,
-    amount_usd: Float,
-    occurred_at: String,
-    symbol: Option<Symbol>,
+    amount: &str,
+    warnings: &mut Vec<String>,
 ) -> Result<CostEntryInternal, PnlError> {
+    let amount_usd = parse_ledger_decimal("pnl_cost_entry", row.event_rowid, "amount_usd", amount)?;
     let amount_usd = validated_cost_magnitude(
         amount_usd,
-        row.rowid,
+        row.event_rowid,
         definition.aggregate_type,
-        row.event_type.clone(),
+        LEDGER_ROW_EVENT_TYPE.to_owned(),
     )?;
+    let symbol = match row.symbol.as_deref() {
+        Some(symbol_text) if is_safe_symbol(symbol_text) => Symbol::new(symbol_text.to_owned())
+            .map_or_else(
+                |_| {
+                    warnings.push(format!(
+                        "Skipped invalid tokenization cost symbol in backend PnL response: \
+                         {symbol_text}"
+                    ));
+                    None
+                },
+                Some,
+            ),
+        Some(symbol_text) => {
+            warnings.push(format!(
+                "Skipped unsafe tokenization cost symbol in backend PnL response: {symbol_text}"
+            ));
+            None
+        }
+        None => None,
+    };
 
     Ok(CostEntryInternal {
         category: definition.category,
         accounting_bucket: definition.accounting_bucket,
         effect: definition.effect,
         amount_usd,
-        occurred_at,
+        occurred_at: row.occurred_at.clone(),
         aggregate_type: definition.aggregate_type.to_owned(),
         aggregate_id: row.aggregate_id.clone(),
-        event_rowid: row.rowid,
+        event_rowid: row.event_rowid,
         symbol,
         detail: definition.detail.to_owned(),
     })
-}
-
-/// One `TokenizedEquityMint` event's contribution to the cost ledger.
-enum MintCostObservation {
-    /// Event carries no fee entry: requests, intermediate steps, or a
-    /// terminal event that reported an explicit zero fee.
-    NoEntry,
-    /// Terminal event whose `fees` field (an `Option<Float>` in the event
-    /// schema, "if reported") was not reported by the provider. No entry,
-    /// but the report surfaces it via `missing_cost_observation_count`
-    /// instead of failing wholesale.
-    FeesNotReported,
-    Entry(CostEntryInternal),
-}
-
-fn parse_tokenized_equity_mint_cost_event(
-    row: &CostEventRow,
-    symbols_by_mint_aggregate: &mut HashMap<String, Symbol>,
-    warnings: &mut Vec<String>,
-) -> Result<MintCostObservation, PnlError> {
-    if row.event_type == "TokenizedEquityMintEvent::MintRequested" {
-        let requested = nested_record(&row.payload, "MintRequested");
-        let symbol = requested.and_then(|payload| text_field(payload, "symbol"));
-        if let Some(symbol) = symbol {
-            if is_safe_symbol(&symbol) {
-                if let Ok(symbol) = Symbol::new(symbol) {
-                    symbols_by_mint_aggregate.insert(row.aggregate_id.clone(), symbol);
-                }
-            } else {
-                warnings.push(format!(
-                    "Skipped unsafe tokenization cost symbol in backend PnL response: {symbol}"
-                ));
-            }
-        }
-        return Ok(MintCostObservation::NoEntry);
-    }
-
-    let terminal_key = match row.event_type.as_str() {
-        "TokenizedEquityMintEvent::TokensReceived" => "TokensReceived",
-        "TokenizedEquityMintEvent::ProviderCompletionRecovered" => "ProviderCompletionRecovered",
-        _ => return Ok(MintCostObservation::NoEntry),
-    };
-
-    let Some(terminal) = nested_record(&row.payload, terminal_key) else {
-        return Err(malformed_cost_payload(
-            row,
-            "missing tokenization terminal payload",
-        ));
-    };
-
-    let occurred_at = if terminal_key == "TokensReceived" {
-        text_field(terminal, "received_at")
-    } else {
-        text_field(terminal, "recovered_at")
-    };
-    // `fees` is `Option<Float>` in the event schema ("if reported") with
-    // `#[serde(default)]`, so both an explicit null and an absent key are
-    // legitimate persisted shapes meaning "provider did not report fees".
-    let fees = optional_persisted_decimal_value(
-        row.rowid,
-        "TokenizedEquityMint",
-        row.event_type.clone(),
-        terminal,
-        "fees",
-    )?;
-    let Some(occurred_at) = occurred_at else {
-        return Err(malformed_cost_payload(
-            row,
-            "missing tokenization fee timestamp",
-        ));
-    };
-
-    let Some(fees) = fees else {
-        return Ok(MintCostObservation::FeesNotReported);
-    };
-
-    if fees.is_zero()? {
-        return Ok(MintCostObservation::NoEntry);
-    }
-
-    let entry = cost_entry(
-        row,
-        TOKENIZATION_FEE_ENTRY,
-        fees,
-        occurred_at,
-        symbols_by_mint_aggregate.get(&row.aggregate_id).cloned(),
-    )?;
-    Ok(MintCostObservation::Entry(entry))
-}
-
-fn parse_usdc_rebalance_cost_event(
-    row: &CostEventRow,
-    _warnings: &mut Vec<String>,
-) -> Result<Option<CostEntryInternal>, PnlError> {
-    let bridge_key = match row.event_type.as_str() {
-        "UsdcRebalanceEvent::Bridged" => "Bridged",
-        "UsdcRebalanceEvent::BridgingCompletionRecovered" => "BridgingCompletionRecovered",
-        _ => return Ok(None),
-    };
-
-    let bridged = nested_record(&row.payload, bridge_key);
-    let Some(bridged) = bridged else {
-        return Err(malformed_cost_payload(row, "missing CCTP bridge payload"));
-    };
-    let fee_collected = persisted_decimal_value(
-        row.rowid,
-        "UsdcRebalance",
-        row.event_type.clone(),
-        bridged,
-        "fee_collected",
-    )?;
-    let occurred_at = {
-        if bridge_key == "Bridged" {
-            text_field(bridged, "minted_at")
-        } else {
-            text_field(bridged, "recovered_at")
-        }
-    };
-
-    let (Some(fee_collected), Some(occurred_at)) = (fee_collected, occurred_at) else {
-        return Err(malformed_cost_payload(
-            row,
-            "missing CCTP fee_collected or timestamp",
-        ));
-    };
-
-    if fee_collected.is_zero()? {
-        return Ok(None);
-    }
-
-    Ok(Some(cost_entry(
-        row,
-        CCTP_FEE_ENTRY,
-        fee_collected,
-        occurred_at,
-        None,
-    )?))
 }
 
 pub(crate) struct CostReplay {
@@ -668,61 +542,47 @@ pub(crate) struct CostReplay {
 }
 
 pub(crate) fn build_cost_entries(
-    rows: &[CostEventRow],
+    rows: &[CostLedgerRow],
     warnings: &mut Vec<String>,
 ) -> Result<CostReplay, PnlError> {
     let mut entries = Vec::new();
-    let mut symbols_by_mint_aggregate = HashMap::new();
     let mut counted_tokenization_fee_aggregates = HashSet::new();
     let mut unreported_fee_aggregates = HashSet::new();
     let mut missing_cost_observation_count = 0;
-    let mut sorted = rows.to_vec();
-    sorted.sort_by_key(|row| row.rowid);
 
-    for row in sorted {
-        if row.payload.is_null() {
-            warnings.push(format!(
-                "Skipped malformed cost event row {}: invalid payload",
-                row.rowid
-            ));
-            continue;
-        }
-
-        match row.aggregate_type.as_str() {
-            "TokenizedEquityMint" => {
-                match parse_tokenized_equity_mint_cost_event(
-                    &row,
-                    &mut symbols_by_mint_aggregate,
-                    warnings,
-                )? {
-                    MintCostObservation::NoEntry => {}
-                    MintCostObservation::FeesNotReported => {
-                        if unreported_fee_aggregates.insert(row.aggregate_id.clone()) {
-                            missing_cost_observation_count += 1;
-                        }
-                    }
-                    MintCostObservation::Entry(entry) => {
-                        if counted_tokenization_fee_aggregates.insert(row.aggregate_id.clone()) {
-                            entries.push(entry);
-                        } else {
-                            warnings.push(format!(
-                                "Skipped duplicate tokenization fee for mint aggregate {}",
-                                row.aggregate_id
-                            ));
-                        }
-                    }
+    for row in rows {
+        match (row.source, row.amount_usd.as_deref()) {
+            (CostSource::TokenizationFee, None) => {
+                if unreported_fee_aggregates.insert(row.aggregate_id.clone()) {
+                    missing_cost_observation_count += 1;
                 }
             }
-            "UsdcRebalance" => {
-                if let Some(entry) = parse_usdc_rebalance_cost_event(&row, warnings)? {
-                    entries.push(entry);
+            (CostSource::TokenizationFee, Some(amount)) => {
+                if counted_tokenization_fee_aggregates.insert(row.aggregate_id.clone()) {
+                    entries.push(ledger_cost_entry(
+                        row,
+                        TOKENIZATION_FEE_ENTRY,
+                        amount,
+                        warnings,
+                    )?);
+                } else {
+                    warnings.push(format!(
+                        "Skipped duplicate tokenization fee for mint aggregate {}",
+                        row.aggregate_id
+                    ));
                 }
             }
-            other => {
-                warnings.push(format!(
-                    "Skipped unsupported cost event row {} with aggregate_type {}",
-                    row.rowid, other
-                ));
+            (CostSource::CctpFee, Some(amount)) => {
+                entries.push(ledger_cost_entry(row, CCTP_FEE_ENTRY, amount, warnings)?);
+            }
+            // The ledger schema forbids this shape (`CHECK (source != 'cctp_fee'
+            // OR amount_usd IS NOT NULL)`), so hitting it means a corrupt row.
+            (CostSource::CctpFee, None) => {
+                return Err(PnlError::InvalidLedgerRow {
+                    table: "pnl_cost_entry",
+                    rowid: row.event_rowid,
+                    reason: "cctp fee row missing amount",
+                });
             }
         }
     }

--- a/src/dashboard/pnl/ledger.rs
+++ b/src/dashboard/pnl/ledger.rs
@@ -53,6 +53,24 @@ pub(crate) const LEDGER_VERSION: i64 = 1;
 /// a mid-backfill crash resumes from the last batch.
 const INGEST_BATCH: NonZeroU32 = NonZeroU32::new(1_000).unwrap();
 
+/// Text stored in the ledger's `direction` columns -- the exact values the
+/// migration's CHECK constraints admit and the read side parses back.
+pub(crate) const DIRECTION_BUY_TEXT: &str = "Buy";
+pub(crate) const DIRECTION_SELL_TEXT: &str = "Sell";
+
+/// `pnl_cost_entry.source` discriminators -- the exact values the
+/// migration's CHECK admits and the read side parses back.
+pub(crate) const TOKENIZATION_FEE_SOURCE: &str = "tokenization_fee";
+pub(crate) const CCTP_FEE_SOURCE: &str = "cctp_fee";
+
+/// Event-log head returned by [`PnlLedger::catch_up`]. Holding one is proof
+/// the ledger has been caught up through that rowid, which is what makes an
+/// `asOfRowid` watermark resolved against it meaningful -- the read path's
+/// signatures accept this type rather than a raw `i64` so a stale or
+/// computed rowid cannot slip in by accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LedgerHead(pub(crate) i64);
+
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum PnlLedgerError {
     #[error("ledger database access failed")]
@@ -106,14 +124,14 @@ impl PnlLedger {
     /// `pnl_ledger_checkpoint_lag_events` gauge -- which holds the stuck
     /// backlog size when ingestion cannot advance -- an operator can alert on
     /// a wedged ledger without reading logs.
-    pub(crate) async fn catch_up(&self) -> Result<i64, PnlLedgerError> {
+    pub(crate) async fn catch_up(&self) -> Result<LedgerHead, PnlLedgerError> {
         let _serialized = self.ingest.lock().await;
         let result = self.ingest_to_head().await;
         if result.is_err() {
             counter!("pnl_ledger_catch_up_failures_total").increment(1);
         }
 
-        result
+        result.map(LedgerHead)
     }
 
     async fn ingest_to_head(&self) -> Result<i64, PnlLedgerError> {
@@ -320,8 +338,8 @@ fn canonical_timestamp(at: &DateTime<Utc>) -> String {
 
 fn direction_text(direction: Direction) -> &'static str {
     match direction {
-        Direction::Buy => "Buy",
-        Direction::Sell => "Sell",
+        Direction::Buy => DIRECTION_BUY_TEXT,
+        Direction::Sell => DIRECTION_SELL_TEXT,
     }
 }
 
@@ -346,9 +364,10 @@ async fn ingest_position(
             seen_at: _,
         } => {
             sqlx::query(
-                "INSERT OR IGNORE INTO pnl_onchain_fill \
+                "INSERT INTO pnl_onchain_fill \
                  (event_rowid, symbol, tx_hash, log_index, shares, direction, price_usd, executed_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) \
+                 ON CONFLICT(event_rowid) DO NOTHING",
             )
             .bind(rowid)
             .bind(symbol.to_string())
@@ -367,9 +386,10 @@ async fn ingest_position(
             ..
         } => {
             sqlx::query(
-                "INSERT OR IGNORE INTO pnl_offchain_placement \
+                "INSERT INTO pnl_offchain_placement \
                  (event_rowid, symbol, offchain_order_id, placed_at) \
-                 VALUES (?1, ?2, ?3, ?4)",
+                 VALUES (?1, ?2, ?3, ?4) \
+                 ON CONFLICT(event_rowid) DO NOTHING",
             )
             .bind(rowid)
             .bind(symbol.to_string())
@@ -387,9 +407,10 @@ async fn ingest_position(
             ..
         } => {
             sqlx::query(
-                "INSERT OR IGNORE INTO pnl_offchain_fill \
+                "INSERT INTO pnl_offchain_fill \
                  (event_rowid, symbol, offchain_order_id, shares, direction, price_usd, executed_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+                 ON CONFLICT(event_rowid) DO NOTHING",
             )
             .bind(rowid)
             .bind(symbol.to_string())
@@ -409,9 +430,10 @@ async fn ingest_position(
         } => {
             let price = price_usdc.map(|price| format_float(&price)).transpose()?;
             sqlx::query(
-                "INSERT OR IGNORE INTO pnl_manual_adjustment \
+                "INSERT INTO pnl_manual_adjustment \
                  (event_rowid, symbol, target_net, price_usd, adjusted_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                 VALUES (?1, ?2, ?3, ?4, ?5) \
+                 ON CONFLICT(event_rowid) DO NOTHING",
             )
             .bind(rowid)
             .bind(symbol.to_string())
@@ -513,11 +535,13 @@ async fn insert_mint_fee(
     }
 
     sqlx::query(
-        "INSERT OR IGNORE INTO pnl_cost_entry \
+        "INSERT INTO pnl_cost_entry \
          (event_rowid, source, aggregate_id, symbol, amount_usd, occurred_at) \
-         VALUES (?1, 'tokenization_fee', ?2, ?3, ?4, ?5)",
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+         ON CONFLICT(event_rowid) DO NOTHING",
     )
     .bind(rowid)
+    .bind(TOKENIZATION_FEE_SOURCE)
     .bind(aggregate_id)
     .bind(symbol)
     .bind(amount)
@@ -573,11 +597,13 @@ async fn ingest_rebalance(
     }
 
     sqlx::query(
-        "INSERT OR IGNORE INTO pnl_cost_entry \
+        "INSERT INTO pnl_cost_entry \
          (event_rowid, source, aggregate_id, symbol, amount_usd, occurred_at) \
-         VALUES (?1, 'cctp_fee', ?2, NULL, ?3, ?4)",
+         VALUES (?1, ?2, ?3, NULL, ?4, ?5) \
+         ON CONFLICT(event_rowid) DO NOTHING",
     )
     .bind(rowid)
+    .bind(CCTP_FEE_SOURCE)
     .bind(id.to_string())
     .bind(format_float(&fee_collected.inner())?)
     .bind(canonical_timestamp(&occurred_at))
@@ -596,9 +622,10 @@ async fn ingest_bot_gas(
     cost.validate()?;
 
     sqlx::query(
-        "INSERT OR IGNORE INTO pnl_bot_gas_cost \
+        "INSERT INTO pnl_bot_gas_cost \
          (event_rowid, chain, tx_hash, usd_cost, operation_category, symbol, occurred_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+         ON CONFLICT(event_rowid) DO NOTHING",
     )
     .bind(rowid)
     .bind(cost.chain.to_string())
@@ -621,7 +648,7 @@ mod tests {
     use uuid::Uuid;
 
     use st0x_config::ExecutionThreshold;
-    use st0x_event_sorcery::{DomainEvent, StoreBuilder};
+    use st0x_event_sorcery::StoreBuilder;
     use st0x_execution::{ExecutorOrderId, SupportedExecutor};
     use st0x_finance::{FractionalShares, Positive, Symbol, Usd, Usdc};
     use st0x_float_macro::float;
@@ -629,32 +656,10 @@ mod tests {
     use crate::bot_gas::{BotGasChain, BotGasOperationCategory};
     use crate::offchain::order::OffchainOrderId;
     use crate::position::{PositionCommand, TradeId, TriggerReason};
-    use crate::test_utils::setup_test_db;
+    use crate::test_utils::{persist_event, setup_test_db};
     use crate::usdc_rebalance::UsdcRebalanceId;
 
     use super::*;
-
-    async fn persist<Entity: EventSourced>(
-        pool: &SqlitePool,
-        aggregate_id: &str,
-        sequence: i64,
-        event: &Entity::Event,
-    ) {
-        sqlx::query(
-            "INSERT INTO events (aggregate_type, aggregate_id, sequence, \
-             event_type, event_version, payload, metadata) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, '{}')",
-        )
-        .bind(Entity::AGGREGATE_TYPE)
-        .bind(aggregate_id)
-        .bind(sequence)
-        .bind(event.event_type())
-        .bind(event.event_version())
-        .bind(serde_json::to_string(event).unwrap())
-        .execute(pool)
-        .await
-        .unwrap();
-    }
 
     fn timestamp(minute: u32) -> DateTime<Utc> {
         Utc.with_ymd_and_hms(2026, 5, 15, 14, minute, 0).unwrap()
@@ -713,8 +718,8 @@ mod tests {
         let gas_id = format!("base:{}", gas.tx_hash);
 
         let fill = onchain_fill(7, 0);
-        persist::<Position>(&pool, "AAPL", 1, &fill).await;
-        persist::<Position>(
+        persist_event::<Position>(&pool, "AAPL", 1, &fill).await;
+        persist_event::<Position>(
             &pool,
             "AAPL",
             2,
@@ -731,7 +736,7 @@ mod tests {
             },
         )
         .await;
-        persist::<Position>(
+        persist_event::<Position>(
             &pool,
             "AAPL",
             3,
@@ -745,7 +750,7 @@ mod tests {
             },
         )
         .await;
-        persist::<Position>(
+        persist_event::<Position>(
             &pool,
             "AAPL",
             4,
@@ -758,7 +763,7 @@ mod tests {
             },
         )
         .await;
-        persist::<TokenizedEquityMint>(
+        persist_event::<TokenizedEquityMint>(
             &pool,
             &mint_id,
             1,
@@ -770,7 +775,7 @@ mod tests {
             },
         )
         .await;
-        persist::<TokenizedEquityMint>(
+        persist_event::<TokenizedEquityMint>(
             &pool,
             &mint_id,
             2,
@@ -782,7 +787,7 @@ mod tests {
             },
         )
         .await;
-        persist::<UsdcRebalance>(
+        persist_event::<UsdcRebalance>(
             &pool,
             &rebalance_id,
             1,
@@ -794,7 +799,7 @@ mod tests {
             },
         )
         .await;
-        persist::<BotGasReceiptCost>(
+        persist_event::<BotGasReceiptCost>(
             &pool,
             &gas_id,
             1,
@@ -803,7 +808,7 @@ mod tests {
         .await;
 
         let ledger = PnlLedger::new(pool.clone());
-        let head = ledger.catch_up().await.unwrap();
+        let LedgerHead(head) = ledger.catch_up().await.unwrap();
 
         assert_eq!(head, head_rowid(&pool).await.unwrap());
         assert_eq!(ledger.checkpoint().await.unwrap(), head);
@@ -872,7 +877,7 @@ mod tests {
     #[tokio::test]
     async fn catch_up_is_idempotent() {
         let pool = setup_test_db().await;
-        persist::<Position>(&pool, "AAPL", 1, &onchain_fill(1, 0)).await;
+        persist_event::<Position>(&pool, "AAPL", 1, &onchain_fill(1, 0)).await;
 
         let ledger = PnlLedger::new(pool.clone());
         let first_head = ledger.catch_up().await.unwrap();
@@ -889,7 +894,7 @@ mod tests {
     async fn small_batches_page_through_mixed_streams() {
         let pool = setup_test_db().await;
         let mint_id = Uuid::new_v4().to_string();
-        persist::<TokenizedEquityMint>(
+        persist_event::<TokenizedEquityMint>(
             &pool,
             &mint_id,
             1,
@@ -902,7 +907,7 @@ mod tests {
         )
         .await;
         for sequence in 1..=5 {
-            persist::<Position>(
+            persist_event::<Position>(
                 &pool,
                 "AAPL",
                 sequence,
@@ -910,7 +915,7 @@ mod tests {
             )
             .await;
         }
-        persist::<TokenizedEquityMint>(
+        persist_event::<TokenizedEquityMint>(
             &pool,
             &mint_id,
             2,
@@ -924,7 +929,7 @@ mod tests {
         .await;
 
         let ledger = PnlLedger::with_batch_size(pool.clone(), NonZeroU32::new(2).unwrap());
-        let head = ledger.catch_up().await.unwrap();
+        let LedgerHead(head) = ledger.catch_up().await.unwrap();
 
         assert_eq!(ledger.checkpoint().await.unwrap(), head);
         assert_eq!(count(&pool, "pnl_onchain_fill").await, 5);
@@ -940,16 +945,16 @@ mod tests {
     #[tokio::test]
     async fn version_mismatch_truncates_and_rebuilds() {
         let pool = setup_test_db().await;
-        persist::<Position>(&pool, "AAPL", 1, &onchain_fill(1, 0)).await;
+        persist_event::<Position>(&pool, "AAPL", 1, &onchain_fill(1, 0)).await;
 
         let ledger = PnlLedger::new(pool.clone());
-        let head = ledger.catch_up().await.unwrap();
+        let LedgerHead(head) = ledger.catch_up().await.unwrap();
         sqlx::query("UPDATE pnl_ledger_checkpoint SET ledger_version = 99 WHERE id = 1")
             .execute(&pool)
             .await
             .unwrap();
 
-        let rebuilt_head = ledger.catch_up().await.unwrap();
+        let LedgerHead(rebuilt_head) = ledger.catch_up().await.unwrap();
 
         assert_eq!(rebuilt_head, head);
         assert_eq!(count(&pool, "pnl_onchain_fill").await, 1);
@@ -967,7 +972,7 @@ mod tests {
         let pool = setup_test_db().await;
         let unreported_mint = Uuid::new_v4().to_string();
         let zero_fee_mint = Uuid::new_v4().to_string();
-        persist::<TokenizedEquityMint>(
+        persist_event::<TokenizedEquityMint>(
             &pool,
             &unreported_mint,
             1,
@@ -979,7 +984,7 @@ mod tests {
             },
         )
         .await;
-        persist::<TokenizedEquityMint>(
+        persist_event::<TokenizedEquityMint>(
             &pool,
             &zero_fee_mint,
             1,
@@ -1007,8 +1012,8 @@ mod tests {
     #[tokio::test]
     async fn duplicate_business_events_are_distinct_rows() {
         let pool = setup_test_db().await;
-        persist::<Position>(&pool, "AAPL", 1, &onchain_fill(7, 0)).await;
-        persist::<Position>(&pool, "AAPL", 2, &onchain_fill(7, 1)).await;
+        persist_event::<Position>(&pool, "AAPL", 1, &onchain_fill(7, 0)).await;
+        persist_event::<Position>(&pool, "AAPL", 2, &onchain_fill(7, 1)).await;
 
         PnlLedger::new(pool.clone()).catch_up().await.unwrap();
 
@@ -1069,6 +1074,47 @@ mod tests {
         );
     }
 
+    /// A row the schema rejects must fail ingestion loudly and pin the
+    /// checkpoint -- never be skipped with the checkpoint advancing past it,
+    /// which would permanently drop a committed event from the ledger. No
+    /// typed event can violate today's schema, so the test simulates future
+    /// ingester/schema drift by rebuilding the fill table with a CHECK no
+    /// real direction satisfies before ingesting a genuine event. This is
+    /// what `ON CONFLICT(event_rowid) DO NOTHING` buys over
+    /// `INSERT OR IGNORE`: only duplicate rowids no-op; constraint
+    /// violations abort the batch.
+    #[tokio::test]
+    async fn constraint_violating_row_fails_ingestion_without_advancing_checkpoint() {
+        let pool = setup_test_db().await;
+        sqlx::query("DROP TABLE pnl_onchain_fill")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE pnl_onchain_fill (
+                 event_rowid INTEGER PRIMARY KEY,
+                 symbol TEXT NOT NULL,
+                 tx_hash TEXT NOT NULL,
+                 log_index INTEGER NOT NULL,
+                 shares TEXT NOT NULL,
+                 direction TEXT NOT NULL CHECK (direction IN ('Neither')),
+                 price_usd TEXT NOT NULL,
+                 executed_at TEXT NOT NULL
+             ) STRICT",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        persist_event::<Position>(&pool, "AAPL", 1, &onchain_fill(7, 0)).await;
+
+        let ledger = PnlLedger::new(pool.clone());
+        let error = ledger.catch_up().await.unwrap_err();
+
+        assert!(matches!(error, PnlLedgerError::Database(_)));
+        assert_eq!(ledger.checkpoint().await.unwrap(), 0);
+        assert_eq!(count(&pool, "pnl_onchain_fill").await, 0);
+    }
+
     /// An invalid persisted gas cost fails ingestion closed: the batch rolls
     /// back and the checkpoint does not advance, so the failure is loud and
     /// re-hit until fixed rather than silently skipped.
@@ -1078,7 +1124,7 @@ mod tests {
         let mut cost = gas_cost();
         cost.usd_cost = Usd::new(float!(0));
         let gas_id = format!("base:{}", cost.tx_hash);
-        persist::<BotGasReceiptCost>(
+        persist_event::<BotGasReceiptCost>(
             &pool,
             &gas_id,
             1,

--- a/src/dashboard/pnl/mod.rs
+++ b/src/dashboard/pnl/mod.rs
@@ -20,7 +20,7 @@ mod windows;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use ledger::{PnlLedger, PnlLedgerReactor};
+pub(crate) use ledger::{LedgerHead, PnlLedger, PnlLedgerReactor};
 pub(crate) use query::{PnlError, PnlQuery};
 pub(crate) use response::PnlResponse;
 #[cfg(test)]

--- a/src/dashboard/pnl/parsing.rs
+++ b/src/dashboard/pnl/parsing.rs
@@ -1,15 +1,10 @@
-//! Parsing helpers for persisted PnL event payloads and report decimals.
+//! Parsing helpers for ledger-row decimals, timestamps, and report output.
 use chrono::{DateTime, Utc};
 use rain_math_float::Float;
-use serde_json::Value;
 
 use super::SAFE_SYMBOL_CHARS;
-use super::query::{PnlError, PnlFinancialFieldError};
-use super::state::{Direction, PositionEventRow};
-
-pub(crate) fn parse_payload_string(payload: &str) -> Result<Value, serde_json::Error> {
-    serde_json::from_str(payload)
-}
+use super::query::{LEDGER_ROW_EVENT_TYPE, PnlError, PnlFinancialFieldError};
+use super::state::PositionLedgerRow;
 
 pub(crate) fn parse_timestamp(value: &str) -> Option<DateTime<Utc>> {
     DateTime::parse_from_rfc3339(value)
@@ -24,146 +19,44 @@ pub(crate) fn is_safe_symbol(symbol: &str) -> bool {
             .all(|character| SAFE_SYMBOL_CHARS.contains(character))
 }
 
-pub(crate) fn nested_record<'a>(payload: &'a Value, key: &str) -> Option<&'a Value> {
-    payload.get(key).filter(|value| value.is_object())
-}
-
-pub(crate) fn text_field(payload: &Value, key: &str) -> Option<String> {
-    payload.get(key).and_then(|value| match value {
-        Value::String(text) => Some(text.clone()),
-        _ => None,
+/// Parses a canonical decimal string stored in a ledger column. Failure
+/// means the ledger row is corrupt (the ingester only writes `format_float`
+/// output), so the report fails closed with the row's provenance.
+pub(crate) fn parse_ledger_decimal(
+    table: &'static str,
+    rowid: i64,
+    field: &'static str,
+    value: &str,
+) -> Result<Float, PnlError> {
+    Float::parse(value.to_owned()).map_err(|error| PnlError::InvalidFinancialField {
+        rowid,
+        aggregate_type: table,
+        event_type: LEDGER_ROW_EVENT_TYPE.to_owned(),
+        field,
+        value: value.to_owned(),
+        source: PnlFinancialFieldError::InvalidDecimal(Box::new(error)),
     })
 }
 
-pub(crate) fn number_text_field(payload: &Value, key: &str) -> Option<String> {
-    payload.get(key).and_then(|value| match value {
-        Value::String(text) => Some(text.clone()),
-        Value::Number(number) => Some(number.to_string()),
-        _ => None,
-    })
-}
-
-pub(crate) fn persisted_decimal_field(
-    row: &PositionEventRow,
-    payload: &Value,
-    key: &'static str,
-) -> Result<Option<Float>, PnlError> {
-    persisted_decimal_value(row.rowid, "Position", row.event_type.clone(), payload, key)
-}
-
-pub(crate) fn optional_persisted_decimal_field(
-    row: &PositionEventRow,
-    payload: &Value,
-    key: &'static str,
-) -> Result<Option<Float>, PnlError> {
-    optional_persisted_decimal_value(row.rowid, "Position", row.event_type.clone(), payload, key)
-}
-
-pub(crate) fn persisted_decimal_value(
-    rowid: i64,
-    aggregate_type: &'static str,
-    event_type: String,
-    payload: &Value,
-    key: &'static str,
-) -> Result<Option<Float>, PnlError> {
-    persisted_decimal_value_with_null_policy(rowid, aggregate_type, event_type, payload, key, false)
-}
-
-pub(crate) fn optional_persisted_decimal_value(
-    rowid: i64,
-    aggregate_type: &'static str,
-    event_type: String,
-    payload: &Value,
-    key: &'static str,
-) -> Result<Option<Float>, PnlError> {
-    persisted_decimal_value_with_null_policy(rowid, aggregate_type, event_type, payload, key, true)
-}
-
-fn persisted_decimal_value_with_null_policy(
-    rowid: i64,
-    aggregate_type: &'static str,
-    event_type: String,
-    payload: &Value,
-    key: &'static str,
-    null_allowed: bool,
-) -> Result<Option<Float>, PnlError> {
-    let value = match payload.get(key) {
-        None => return Ok(None),
-        Some(Value::Null) if null_allowed => return Ok(None),
-        Some(Value::String(text)) => text.clone(),
-        Some(Value::Number(number)) => number.to_string(),
-        Some(value) => {
-            return Err(PnlError::InvalidFinancialField {
-                rowid,
-                aggregate_type,
-                event_type,
-                field: key,
-                value: value.to_string(),
-                source: PnlFinancialFieldError::InvalidJsonType,
-            });
-        }
-    };
-
-    Float::parse(value.clone())
-        .map(Some)
-        .map_err(|error| PnlError::InvalidFinancialField {
-            rowid,
-            aggregate_type,
-            event_type,
-            field: key,
-            value,
-            source: PnlFinancialFieldError::InvalidDecimal(Box::new(error)),
-        })
-}
-
-pub(crate) fn direction_field(payload: &Value, key: &str) -> Option<Direction> {
-    match text_field(payload, key)?.as_str() {
-        "Buy" | "buy" => Some(Direction::Buy),
-        "Sell" | "sell" => Some(Direction::Sell),
-        _ => None,
-    }
-}
-
-pub(crate) fn position_event_replay_timestamp(row: &PositionEventRow) -> Option<String> {
-    match row.event_type.as_str() {
-        "PositionEvent::OnChainOrderFilled" => nested_record(&row.payload, "OnChainOrderFilled")
-            .and_then(|filled| text_field(filled, "block_timestamp")),
-        "PositionEvent::OffChainOrderFilled" => nested_record(&row.payload, "OffChainOrderFilled")
-            .and_then(|filled| text_field(filled, "broker_timestamp")),
-        "PositionEvent::OffChainOrderPlaced" => nested_record(&row.payload, "OffChainOrderPlaced")
-            .and_then(|placed| text_field(placed, "placed_at")),
-        "PositionEvent::ManualPositionAdjusted" => {
-            nested_record(&row.payload, "ManualPositionAdjusted")
-                .and_then(|adjusted| text_field(adjusted, "adjusted_at"))
-        }
-        _ => None,
-    }
-}
-
+/// Sorts the ledger rows into replay order: execution timestamp first, event
+/// rowid as the deterministic tie-breaker. Timestamps are always present on
+/// ledger rows (typed at ingestion); an unparseable one means a corrupt row
+/// and fails the report with its provenance.
 pub(crate) fn ordered_position_events(
-    rows: Vec<PositionEventRow>,
-) -> Result<Vec<PositionEventRow>, PnlError> {
+    rows: Vec<PositionLedgerRow>,
+) -> Result<Vec<PositionLedgerRow>, PnlError> {
     let mut sortable: Vec<_> = rows
         .into_iter()
         .map(|row| {
-            let timestamp = position_event_replay_timestamp(&row).ok_or_else(|| {
-                PnlError::MalformedPayload {
-                    rowid: row.rowid,
-                    aggregate_type: "Position",
-                    event_type: row.event_type.clone(),
-                    reason: "missing replay timestamp",
-                }
-            })?;
-            let timestamp_ms = parse_timestamp(&timestamp)
+            let timestamp_ms = parse_timestamp(row.replay_timestamp())
                 .map(|parsed| parsed.timestamp_millis())
-                .ok_or_else(|| PnlError::MalformedPayload {
-                    rowid: row.rowid,
-                    aggregate_type: "Position",
-                    event_type: row.event_type.clone(),
+                .ok_or_else(|| PnlError::InvalidLedgerRow {
+                    table: "pnl position rows",
+                    rowid: row.event_rowid(),
                     reason: "invalid replay timestamp",
                 })?;
 
-            Ok((timestamp_ms, row.rowid, row))
+            Ok((timestamp_ms, row.event_rowid(), row))
         })
         .collect::<Result<Vec<_>, PnlError>>()?;
 

--- a/src/dashboard/pnl/query.rs
+++ b/src/dashboard/pnl/query.rs
@@ -11,8 +11,6 @@ const ALPACA_ACTIVITY_FETCH_PADDING_DAYS: i64 = 7;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum PnlFinancialFieldError {
-    #[error("expected string or number")]
-    InvalidJsonType,
     // Boxed: `FloatError` embeds revm's `EVMError`/`HaltReason`, which makes
     // it far larger than every other payload here, and this error is returned
     // from most of the module's functions.
@@ -20,25 +18,24 @@ pub(crate) enum PnlFinancialFieldError {
     InvalidDecimal(#[source] Box<rain_math_float::FloatError>),
 }
 
+/// Sentinel `event_type` for errors raised from typed ledger rows, which --
+/// unlike the raw payloads the pre-ADR-0018 path parsed -- carry no
+/// per-event type string of their own.
+pub(crate) const LEDGER_ROW_EVENT_TYPE: &str = "ledger_row";
+
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum PnlError {
     #[error("invalid {field}: {value}")]
     InvalidDate { field: &'static str, value: String },
     #[error("invalid asOfRowid: {value}")]
     InvalidSnapshotRowid { value: i64 },
-    #[error("failed to parse persisted PnL payload at row {rowid} ({aggregate_type}/{event_type})")]
-    InvalidPayload {
+    #[error("PnL ledger ingestion failed: {0}")]
+    Ledger(#[from] super::ledger::PnlLedgerError),
+    #[error("invalid PnL ledger row in {table} at event row {rowid}: {reason}")]
+    InvalidLedgerRow {
+        table: &'static str,
         rowid: i64,
-        aggregate_type: String,
-        event_type: String,
-        #[source]
-        source: serde_json::Error,
-    },
-    #[error("invalid bot gas receipt cost at event row {rowid}")]
-    InvalidBotGasReceiptCost {
-        rowid: i64,
-        #[source]
-        source: crate::bot_gas::BotGasReceiptCostError,
+        reason: &'static str,
     },
     #[error(
         "malformed persisted PnL payload at row {rowid} ({aggregate_type}/{event_type}): {reason}"

--- a/src/dashboard/pnl/replay.rs
+++ b/src/dashboard/pnl/replay.rs
@@ -5,16 +5,14 @@ use st0x_finance::Symbol;
 use st0x_float_macro::float;
 
 use super::costs::{AccountingEffect, CostEntryInternal};
-use super::parsing::{
-    direction_field, fmt_decimal, nested_record, number_text_field,
-    optional_persisted_decimal_field, parse_internal_decimal, persisted_decimal_field, text_field,
-};
+use super::parsing::{fmt_decimal, parse_internal_decimal, parse_ledger_decimal};
 use super::query::PnlError;
 use super::response::{PnlEntry, PnlSummary, PnlSymbolSummary};
 use super::sessions::seconds_between;
 use super::state::{
-    Direction, Fill, Lot, LotSide, PnlBucket, PositionEventRow, PositionReplayDelta, SummaryAcc,
-    SummaryAndSymbols, SymbolBook, UnmatchedOffchainAllocation, Venue,
+    Direction, Fill, Lot, LotSide, ManualAdjustmentRow, OffchainFillRow, OffchainPlacementRow,
+    OnchainFillRow, PnlBucket, PositionReplayDelta, SummaryAcc, SummaryAndSymbols, SymbolBook,
+    UnmatchedOffchainAllocation, Venue,
 };
 use super::{ATTRIBUTION_METHOD, COUNTER_TRADE_THRESHOLD_SECONDS, EPSILON};
 
@@ -75,145 +73,93 @@ fn add_realized_pnl(
     Ok(())
 }
 
-fn malformed_position_payload(row: &PositionEventRow, reason: &'static str) -> PnlError {
-    PnlError::MalformedPayload {
-        rowid: row.rowid,
-        aggregate_type: "Position",
-        event_type: row.event_type.clone(),
+fn corrupt_ledger_row(table: &'static str, rowid: i64, reason: &'static str) -> PnlError {
+    PnlError::InvalidLedgerRow {
+        table,
+        rowid,
         reason,
     }
 }
 
 fn ensure_positive_fill_decimal(
-    row: &PositionEventRow,
+    table: &'static str,
+    rowid: i64,
     value: &Float,
     reason: &'static str,
 ) -> Result<(), PnlError> {
     if value.is_zero()? || value.lt(float!(0))? {
-        return Err(malformed_position_payload(row, reason));
+        return Err(corrupt_ledger_row(table, rowid, reason));
     }
 
     Ok(())
 }
 
-pub(crate) fn parse_onchain_fill(
-    row: &PositionEventRow,
-    _warnings: &mut Vec<String>,
-) -> Result<Option<Fill>, PnlError> {
-    let Some(filled) = nested_record(&row.payload, "OnChainOrderFilled") else {
-        return Err(malformed_position_payload(
-            row,
-            "missing OnChainOrderFilled",
-        ));
-    };
+pub(crate) fn parse_onchain_fill(row: &OnchainFillRow) -> Result<Fill, PnlError> {
+    const TABLE: &str = "pnl_onchain_fill";
+    let shares = parse_ledger_decimal(TABLE, row.event_rowid, "shares", &row.shares)?;
+    let price = parse_ledger_decimal(TABLE, row.event_rowid, "price_usd", &row.price_usd)?;
+    ensure_positive_fill_decimal(
+        TABLE,
+        row.event_rowid,
+        &shares,
+        "non-positive onchain fill shares",
+    )?;
+    ensure_positive_fill_decimal(
+        TABLE,
+        row.event_rowid,
+        &price,
+        "non-positive onchain fill price",
+    )?;
 
-    let amount = persisted_decimal_field(row, filled, "amount")?;
-    let direction = direction_field(filled, "direction");
-    let price = persisted_decimal_field(row, filled, "price_usdc")?;
-    let executed_at = text_field(filled, "block_timestamp");
-    let trade_id = nested_record(filled, "trade_id");
-    let tx_hash = trade_id.and_then(|id| text_field(id, "tx_hash"));
-    let log_index = trade_id.and_then(|id| number_text_field(id, "log_index"));
-
-    let (
-        Some(amount),
-        Some(direction),
-        Some(price),
-        Some(executed_at),
-        Some(tx_hash),
-        Some(log_index),
-    ) = (amount, direction, price, executed_at, tx_hash, log_index)
-    else {
-        return Err(malformed_position_payload(
-            row,
-            "incomplete OnChainOrderFilled payload",
-        ));
-    };
-
-    ensure_positive_fill_decimal(row, &amount, "non-positive OnChainOrderFilled amount")?;
-    ensure_positive_fill_decimal(row, &price, "non-positive OnChainOrderFilled price_usdc")?;
-
-    Ok(Some(Fill {
-        rowid: row.rowid,
-        id: format!("{tx_hash}:{log_index}"),
+    Ok(Fill {
+        rowid: row.event_rowid,
+        id: format!("{}:{}", row.tx_hash, row.log_index),
         symbol: Symbol::new(row.symbol.clone())
-            .map_err(|_| malformed_position_payload(row, "invalid OnChainOrderFilled symbol"))?,
-        shares: amount,
-        direction,
+            .map_err(|_| corrupt_ledger_row(TABLE, row.event_rowid, "invalid symbol"))?,
+        shares,
+        direction: row.direction,
         price,
-        executed_at,
+        executed_at: row.executed_at.clone(),
         venue: Venue::Onchain,
-    }))
+    })
 }
 
-pub(crate) fn parse_offchain_fill(
-    row: &PositionEventRow,
-    _warnings: &mut Vec<String>,
-) -> Result<Option<Fill>, PnlError> {
-    let Some(filled) = nested_record(&row.payload, "OffChainOrderFilled") else {
-        return Err(malformed_position_payload(
-            row,
-            "missing OffChainOrderFilled",
-        ));
-    };
-
-    let order_id = text_field(filled, "offchain_order_id");
-    let shares = persisted_decimal_field(row, filled, "shares_filled")?;
-    let direction = direction_field(filled, "direction");
-    let price = persisted_decimal_field(row, filled, "price")?;
-    let executed_at = text_field(filled, "broker_timestamp");
-
-    let (Some(order_id), Some(shares), Some(direction), Some(price), Some(executed_at)) =
-        (order_id, shares, direction, price, executed_at)
-    else {
-        return Err(malformed_position_payload(
-            row,
-            "incomplete OffChainOrderFilled payload",
-        ));
-    };
-
+pub(crate) fn parse_offchain_fill(row: &OffchainFillRow) -> Result<Fill, PnlError> {
+    const TABLE: &str = "pnl_offchain_fill";
+    let shares = parse_ledger_decimal(TABLE, row.event_rowid, "shares", &row.shares)?;
+    let price = parse_ledger_decimal(TABLE, row.event_rowid, "price_usd", &row.price_usd)?;
     ensure_positive_fill_decimal(
-        row,
+        TABLE,
+        row.event_rowid,
         &shares,
-        "non-positive OffChainOrderFilled shares_filled",
+        "non-positive offchain fill shares",
     )?;
-    ensure_positive_fill_decimal(row, &price, "non-positive OffChainOrderFilled price")?;
+    ensure_positive_fill_decimal(
+        TABLE,
+        row.event_rowid,
+        &price,
+        "non-positive offchain fill price",
+    )?;
 
-    Ok(Some(Fill {
-        rowid: row.rowid,
-        id: order_id,
+    Ok(Fill {
+        rowid: row.event_rowid,
+        id: row.offchain_order_id.clone(),
         symbol: Symbol::new(row.symbol.clone())
-            .map_err(|_| malformed_position_payload(row, "invalid OffChainOrderFilled symbol"))?,
+            .map_err(|_| corrupt_ledger_row(TABLE, row.event_rowid, "invalid symbol"))?,
         shares,
-        direction,
+        direction: row.direction,
         price,
-        executed_at,
+        executed_at: row.executed_at.clone(),
         venue: Venue::Offchain,
-    }))
+    })
 }
 
 pub(crate) fn apply_manual_position_adjustment(
     book: &mut SymbolBook,
-    row: &PositionEventRow,
-    warnings: &mut Vec<String>,
+    row: &ManualAdjustmentRow,
 ) -> Result<(), PnlError> {
-    let Some(adjusted) = nested_record(&row.payload, "ManualPositionAdjusted") else {
-        warnings.push(format!(
-            "Skipped malformed manual position adjustment {}: missing ManualPositionAdjusted",
-            row.symbol
-        ));
-        return Ok(());
-    };
-
-    let target_net = persisted_decimal_field(row, adjusted, "target_net")?;
-    let adjusted_at = text_field(adjusted, "adjusted_at");
-    let (Some(target_net), Some(adjusted_at)) = (target_net, adjusted_at) else {
-        warnings.push(format!(
-            "Skipped malformed manual position adjustment {}: incomplete payload",
-            row.symbol
-        ));
-        return Ok(());
-    };
+    const TABLE: &str = "pnl_manual_adjustment";
+    let target_net = parse_ledger_decimal(TABLE, row.event_rowid, "target_net", &row.target_net)?;
 
     book.long_lots.clear();
     book.short_lots.clear();
@@ -224,12 +170,17 @@ pub(crate) fn apply_manual_position_adjustment(
         return Ok(());
     }
 
-    let event_price = optional_persisted_decimal_field(row, adjusted, "price_usdc")?;
+    let event_price = row
+        .price_usd
+        .as_deref()
+        .map(|price| parse_ledger_decimal(TABLE, row.event_rowid, "price_usd", price))
+        .transpose()?;
     let price = event_price.or(book.last_price_usdc);
     let Some(price) = price else {
-        return Err(malformed_position_payload(
-            row,
-            "nonzero ManualPositionAdjusted missing price_usdc and no prior replay price",
+        return Err(corrupt_ledger_row(
+            TABLE,
+            row.event_rowid,
+            "nonzero manual adjustment missing price_usd and no prior replay price",
         ));
     };
     if let Some(event_price) = event_price {
@@ -242,12 +193,12 @@ pub(crate) fn apply_manual_position_adjustment(
         LotSide::Long
     };
     let lot = Lot {
-        trade_id: format!("manual-position-adjustment:{}", row.rowid),
+        trade_id: format!("manual-position-adjustment:{}", row.event_rowid),
         side,
         remaining_shares: target_net.abs()?,
         price,
-        opened_at: adjusted_at,
-        opened_rowid: row.rowid,
+        opened_at: row.adjusted_at.clone(),
+        opened_rowid: row.event_rowid,
         opened_venue: Venue::Manual,
     };
 
@@ -257,21 +208,6 @@ pub(crate) fn apply_manual_position_adjustment(
     }
 
     Ok(())
-}
-
-fn parse_offchain_placement_id(
-    row: &PositionEventRow,
-    warnings: &mut Vec<String>,
-) -> Option<String> {
-    let placed = nested_record(&row.payload, "OffChainOrderPlaced");
-    let order_id = placed.and_then(|value| text_field(value, "offchain_order_id"));
-    if order_id.is_none() {
-        warnings.push(format!(
-            "Skipped malformed position offchain placement {}: incomplete payload",
-            row.symbol
-        ));
-    }
-    order_id
 }
 
 fn open_residual_lot(book: &mut SymbolBook, fill: &Fill, remaining: Float) {
@@ -342,22 +278,22 @@ pub(crate) fn apply_onchain_fill(
 
 pub(crate) fn apply_offchain_placement(
     book: &mut SymbolBook,
-    row: &PositionEventRow,
+    row: &OffchainPlacementRow,
     warnings: &mut Vec<String>,
 ) {
-    let Some(order_id) = parse_offchain_placement_id(row, warnings) else {
-        return;
-    };
-
-    if book.seen_offchain_placement_ids.contains(&order_id) {
+    if book
+        .seen_offchain_placement_ids
+        .contains(&row.offchain_order_id)
+    {
         warnings.push(format!(
             "PnL audit error: duplicate offchain placement {} for {} was skipped",
-            order_id, row.symbol
+            row.offchain_order_id, row.symbol
         ));
         return;
     }
 
-    book.seen_offchain_placement_ids.insert(order_id);
+    book.seen_offchain_placement_ids
+        .insert(row.offchain_order_id.clone());
 }
 
 pub(crate) fn apply_offchain_fill(

--- a/src/dashboard/pnl/samples.rs
+++ b/src/dashboard/pnl/samples.rs
@@ -3,11 +3,11 @@ use std::collections::{BTreeSet, HashMap};
 
 use st0x_finance::Symbol;
 
-use super::parsing::{is_safe_symbol, position_event_replay_timestamp};
+use super::parsing::is_safe_symbol;
 use super::query::{PnlError, PnlFinancialFieldError, PnlQuery};
 use super::response::{PnlAvailableRange, PnlSampleStats, PnlSampleSymbolStats};
 use super::sessions::{date_key, matches_date_bounds_for_iso, matches_trade_filters};
-use super::state::{PositionEventRow, PositionViewRow, SampleStatsAcc};
+use super::state::{PositionLedgerRow, PositionViewRow, SampleStatsAcc, Venue};
 
 pub(crate) fn parse_position_view(
     rows: &[PositionViewRow],
@@ -52,11 +52,25 @@ pub(crate) fn parse_position_view(
     Ok((position_nets, symbols.into_iter().collect()))
 }
 
-fn add_sample_fill(sample: &mut SampleStatsAcc, event_type: &str, timestamp: &str) {
-    if event_type == "PositionEvent::OnChainOrderFilled" {
-        sample.onchain_fill_count += 1;
-    } else if event_type == "PositionEvent::OffChainOrderFilled" {
-        sample.offchain_fill_count += 1;
+/// The fill venue and execution timestamp of a ledger row, or `None` for the
+/// non-fill kinds (placements, manual adjustments) that sample stats and the
+/// available range ignore.
+fn fill_timestamp(row: &PositionLedgerRow) -> Option<(Venue, &str)> {
+    match row {
+        PositionLedgerRow::OnchainFill(fill) => Some((Venue::Onchain, fill.executed_at.as_str())),
+        PositionLedgerRow::OffchainFill(fill) => Some((Venue::Offchain, fill.executed_at.as_str())),
+        PositionLedgerRow::OffchainPlacement(_) | PositionLedgerRow::ManualAdjustment(_) => None,
+    }
+}
+
+fn add_sample_fill(sample: &mut SampleStatsAcc, venue: Venue, timestamp: &str) {
+    match venue {
+        Venue::Onchain => sample.onchain_fill_count += 1,
+        Venue::Offchain => sample.offchain_fill_count += 1,
+        // `fill_timestamp` yields fills only, and manual adjustments are not
+        // fills; a manual venue can only mean a future caller bug, and it
+        // must not count into either fill bucket.
+        Venue::Manual => {}
     }
 
     if sample
@@ -76,44 +90,39 @@ fn add_sample_fill(sample: &mut SampleStatsAcc, event_type: &str, timestamp: &st
 }
 
 pub(crate) fn build_sample_stats(
-    rows: &[PositionEventRow],
+    rows: &[PositionLedgerRow],
     query: &PnlQuery,
     warnings: &mut Vec<String>,
 ) -> PnlSampleStats {
     let mut by_symbol: HashMap<Symbol, SampleStatsAcc> = HashMap::new();
     for row in rows {
-        if row.event_type != "PositionEvent::OnChainOrderFilled"
-            && row.event_type != "PositionEvent::OffChainOrderFilled"
-        {
-            continue;
-        }
-
-        if !is_safe_symbol(&row.symbol) {
-            warnings.push(format!(
-                "Skipped unsafe sample stats symbol in backend PnL response: {}",
-                row.symbol
-            ));
-            continue;
-        }
-
-        let Some(timestamp) = position_event_replay_timestamp(row) else {
-            warnings.push(format!(
-                "Skipped sample stats row {} for {}: missing fill timestamp",
-                row.rowid, row.symbol
-            ));
+        let Some((venue, timestamp)) = fill_timestamp(row) else {
             continue;
         };
-        if !matches_date_bounds_for_iso(&timestamp, query)
-            || !matches_trade_filters(&timestamp, query)
+
+        if !is_safe_symbol(row.symbol()) {
+            warnings.push(format!(
+                "Skipped unsafe sample stats symbol in backend PnL response: {}",
+                row.symbol()
+            ));
+            continue;
+        }
+
+        if !matches_date_bounds_for_iso(timestamp, query)
+            || !matches_trade_filters(timestamp, query)
         {
             continue;
         }
 
-        let Ok(symbol) = Symbol::new(row.symbol.clone()) else {
+        let Ok(symbol) = Symbol::new(row.symbol().to_owned()) else {
+            warnings.push(format!(
+                "Skipped invalid sample stats symbol in backend PnL response: {}",
+                row.symbol()
+            ));
             continue;
         };
         let sample = by_symbol.entry(symbol).or_default();
-        add_sample_fill(sample, &row.event_type, &timestamp);
+        add_sample_fill(sample, venue, timestamp);
     }
 
     let mut symbols: Vec<_> = by_symbol.into_iter().collect();
@@ -147,46 +156,33 @@ pub(crate) fn build_sample_stats(
 }
 
 pub(crate) fn build_available_range(
-    rows: &[PositionEventRow],
+    rows: &[PositionLedgerRow],
     warnings: &mut Vec<String>,
 ) -> PnlAvailableRange {
     let mut first_at: Option<String> = None;
     let mut last_at: Option<String> = None;
 
     for row in rows {
-        if row.event_type != "PositionEvent::OnChainOrderFilled"
-            && row.event_type != "PositionEvent::OffChainOrderFilled"
-        {
-            continue;
-        }
-
-        if !is_safe_symbol(&row.symbol) {
-            warnings.push(format!(
-                "Skipped unsafe available range symbol in backend PnL response: {}",
-                row.symbol
-            ));
-            continue;
-        }
-
-        let Some(timestamp) = position_event_replay_timestamp(row) else {
-            warnings.push(format!(
-                "Skipped available range row {} for {}: missing fill timestamp",
-                row.rowid, row.symbol
-            ));
+        let Some((_, timestamp)) = fill_timestamp(row) else {
             continue;
         };
 
+        if !is_safe_symbol(row.symbol()) {
+            warnings.push(format!(
+                "Skipped unsafe available range symbol in backend PnL response: {}",
+                row.symbol()
+            ));
+            continue;
+        }
+
         if first_at
             .as_deref()
-            .is_none_or(|current| timestamp.as_str() < current)
+            .is_none_or(|current| timestamp < current)
         {
-            first_at = Some(timestamp.clone());
+            first_at = Some(timestamp.to_owned());
         }
-        if last_at
-            .as_deref()
-            .is_none_or(|current| timestamp.as_str() > current)
-        {
-            last_at = Some(timestamp);
+        if last_at.as_deref().is_none_or(|current| timestamp > current) {
+            last_at = Some(timestamp.to_owned());
         }
     }
 

--- a/src/dashboard/pnl/source.rs
+++ b/src/dashboard/pnl/source.rs
@@ -1,8 +1,14 @@
-//! SQLite and broker-backed source loading for backend PnL reports.
+//! Ledger and broker-backed source loading for backend PnL reports.
+//!
+//! Replay inputs come from the typed, append-only `pnl_*` ledger tables
+//! maintained by [`super::ledger::PnlLedger`] (ADR 0018) -- never from the
+//! `events` table. Freshness is guaranteed by running the ledger's
+//! `catch_up()` before resolving the `asOfRowid` watermark, outside the
+//! replay admission permit.
 use chrono::{DateTime, Days, NaiveDate, NaiveTime, Utc};
 use chrono_tz::America::New_York;
 use rain_math_float::Float;
-use sqlx::{QueryBuilder, Sqlite, SqlitePool, Transaction};
+use sqlx::{QueryBuilder, Sqlite, SqlitePool};
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
@@ -11,16 +17,20 @@ use tokio::task;
 use st0x_execution::alpaca_broker_api::AccountActivity;
 use st0x_float_serde::format_float;
 
-use crate::bot_gas::BotGasReceiptCostEvent;
 use crate::portfolio_snapshot::{
     CAPTURE_BUFFER, EtDayRange, capital_summary, evaluate_portfolio_days, load_portfolio_day_rows,
 };
 
 use super::builder::build_pnl_response_from_rows;
-use super::parsing::parse_payload_string;
+use super::ledger::{
+    CCTP_FEE_SOURCE, DIRECTION_BUY_TEXT, DIRECTION_SELL_TEXT, LedgerHead, TOKENIZATION_FEE_SOURCE,
+};
 use super::query::{PnlError, PnlQuery};
 use super::response::{PnlCapitalSummary, PnlResponse};
-use super::state::{BotGasCostRow, CostEventRow, PositionEventRow, PositionViewRow};
+use super::state::{
+    BotGasCostRow, CostLedgerRow, CostSource, Direction, ManualAdjustmentRow, OffchainFillRow,
+    OffchainPlacementRow, OnchainFillRow, PositionLedgerRow, PositionViewRow,
+};
 use super::{
     ATTRIBUTION_WARNING, BASELINE_WARNING, CAPITAL_AVAILABLE_NOTE, CAPITAL_UNAVAILABLE_NOTE,
     COST_WARNING, SYMBOL_FILTERED_CAPITAL_WARNING,
@@ -84,17 +94,25 @@ pub(crate) async fn build_pnl_report(
     alpaca_activities: Vec<AccountActivity>,
     now: DateTime<Utc>,
 ) -> Result<PnlResponse, PnlError> {
+    let ledger = super::ledger::PnlLedger::new(pool.clone());
+    let head = ledger.catch_up().await?;
     let admission = pnl_report_admission();
     let permit = acquire_pnl_report_permit(&admission)?;
-    build_pnl_report_with_permit(pool, query, alpaca_activities, now, permit).await
+    build_pnl_report_with_permit(pool, query, alpaca_activities, now, permit, head).await
 }
 
+/// `head` is the event-log head returned by the ledger's `catch_up()`, which
+/// the caller MUST have run before acquiring the replay permit: freshness is
+/// async I/O and must not burn a blocking-replay slot, and the resolved
+/// `asOfRowid` watermark is only meaningful once the ledger contains
+/// everything at or below it.
 pub(crate) async fn build_pnl_report_with_permit(
     pool: &SqlitePool,
     query: &PnlQuery,
     alpaca_activities: Vec<AccountActivity>,
     now: DateTime<Utc>,
     permit: OwnedSemaphorePermit,
+    head: LedgerHead,
 ) -> Result<PnlResponse, PnlError> {
     let mut warnings = vec![
         ATTRIBUTION_WARNING.to_owned(),
@@ -102,18 +120,16 @@ pub(crate) async fn build_pnl_report_with_permit(
         COST_WARNING.to_owned(),
     ];
     let symbols = query.symbol_filter(&mut warnings)?;
-    let mut tx = pool.begin().await?;
-    let resolved_rowid = effective_as_of_rowid(&mut tx, query).await?;
+    let resolved_rowid = resolve_as_of_rowid(query, head)?;
     let effective_query = PnlQuery {
         as_of_rowid: Some(resolved_rowid.resolved),
         ..query.clone()
     };
 
-    let event_rows = load_position_events(&mut tx, &symbols, resolved_rowid.resolved).await?;
-    let position_rows = load_position_view(&mut tx).await?;
-    let cost_rows = load_cost_events(&mut tx, resolved_rowid.resolved).await?;
-    let bot_gas_rows = load_bot_gas_costs(&mut tx, resolved_rowid.resolved).await?;
-    tx.commit().await?;
+    let event_rows = load_position_rows(pool, &symbols, resolved_rowid.resolved).await?;
+    let position_rows = load_position_view(pool).await?;
+    let cost_rows = load_cost_rows(pool, resolved_rowid.resolved).await?;
+    let bot_gas_rows = load_bot_gas_rows(pool, resolved_rowid.resolved).await?;
 
     let replay_symbols = symbols.clone();
     let ((mut response, daily_net_realized_pnl_usd), permit) =
@@ -286,48 +302,42 @@ async fn complete_capital_range(
     Ok(range)
 }
 
-pub(crate) async fn validate_pnl_snapshot_rowid(
-    pool: &SqlitePool,
+/// Validates a user-supplied `asOfRowid` against the ledger head returned by
+/// `catch_up()`.
+pub(crate) fn validate_pnl_snapshot_rowid(
+    LedgerHead(head): LedgerHead,
     query: &PnlQuery,
 ) -> Result<(), PnlError> {
-    let Some(as_of_rowid) = query.as_of_rowid else {
-        return Ok(());
-    };
-
-    let mut tx = pool.begin().await?;
-    let max_rowid = max_event_rowid(&mut tx).await?;
-    tx.commit().await?;
-
-    check_as_of_rowid(as_of_rowid, max_rowid)
+    query
+        .as_of_rowid
+        .map_or(Ok(()), |as_of_rowid| check_as_of_rowid(as_of_rowid, head))
 }
 
-/// The effective `as_of_rowid` alongside the current max event rowid, so
-/// callers can tell whether the resolved value is the live head (needed for
-/// the capital as-of-rowid caveat). A named pair rather than a bare
-/// `(i64, i64)` prevents the two rowids from being transposed at a call site.
+/// The effective `as_of_rowid` alongside the current head, so callers can
+/// tell whether the resolved value is the live head (needed for the capital
+/// as-of-rowid caveat). A named pair rather than a bare `(i64, i64)`
+/// prevents the two rowids from being transposed at a call site.
 struct ResolvedRowid {
     resolved: i64,
     max: i64,
 }
 
-/// Resolves the effective `as_of_rowid`.
-async fn effective_as_of_rowid(
-    tx: &mut Transaction<'_, Sqlite>,
+/// Resolves the effective `as_of_rowid` against the caught-up ledger head.
+fn resolve_as_of_rowid(
     query: &PnlQuery,
+    LedgerHead(head): LedgerHead,
 ) -> Result<ResolvedRowid, PnlError> {
-    let max_rowid = max_event_rowid(tx).await?;
-
     if let Some(as_of_rowid) = query.as_of_rowid {
-        check_as_of_rowid(as_of_rowid, max_rowid)?;
+        check_as_of_rowid(as_of_rowid, head)?;
         return Ok(ResolvedRowid {
             resolved: as_of_rowid,
-            max: max_rowid,
+            max: head,
         });
     }
 
     Ok(ResolvedRowid {
-        resolved: max_rowid,
-        max: max_rowid,
+        resolved: head,
+        max: head,
     })
 }
 
@@ -339,77 +349,143 @@ fn check_as_of_rowid(as_of_rowid: i64, max_rowid: i64) -> Result<(), PnlError> {
     Ok(())
 }
 
-async fn max_event_rowid(tx: &mut Transaction<'_, Sqlite>) -> Result<i64, PnlError> {
-    let (max_rowid,) = sqlx::query_as::<_, (Option<i64>,)>("SELECT MAX(rowid) FROM events")
-        .fetch_one(&mut **tx)
-        .await?;
+fn push_symbol_filter(query: &mut QueryBuilder<Sqlite>, symbols: &BTreeSet<String>) {
+    if symbols.is_empty() {
+        return;
+    }
 
-    Ok(max_rowid.unwrap_or(0))
+    query.push(" AND symbol IN (");
+    let mut separated = query.separated(", ");
+    for symbol in symbols {
+        separated.push_bind(symbol.clone());
+    }
+    separated.push_unseparated(")");
 }
 
-async fn load_position_events(
-    tx: &mut Transaction<'_, Sqlite>,
+fn ledger_direction(
+    table: &'static str,
+    rowid: i64,
+    direction: &str,
+) -> Result<Direction, PnlError> {
+    match direction {
+        DIRECTION_BUY_TEXT => Ok(Direction::Buy),
+        DIRECTION_SELL_TEXT => Ok(Direction::Sell),
+        _ => Err(PnlError::InvalidLedgerRow {
+            table,
+            rowid,
+            reason: "unknown direction",
+        }),
+    }
+}
+
+/// Loads all four position row kinds from the ledger at or below the
+/// watermark, merged in global rowid order -- the same stream shape the raw
+/// events query produced, already typed.
+async fn load_position_rows(
+    pool: &SqlitePool,
     symbols: &BTreeSet<String>,
     as_of_rowid: i64,
-) -> Result<Vec<PositionEventRow>, PnlError> {
-    let mut query = QueryBuilder::<Sqlite>::new(
-        "SELECT rowid, aggregate_id AS symbol, event_type, payload \
-         FROM events \
-         WHERE aggregate_type = 'Position' \
-           AND event_type IN ( \
-             'PositionEvent::OnChainOrderFilled', \
-             'PositionEvent::OffChainOrderPlaced', \
-             'PositionEvent::OffChainOrderFilled', \
-             'PositionEvent::ManualPositionAdjusted' \
-           ) \
-           AND rowid <= ",
+) -> Result<Vec<PositionLedgerRow>, PnlError> {
+    let mut rows = Vec::new();
+
+    let mut onchain = QueryBuilder::<Sqlite>::new(
+        "SELECT event_rowid, symbol, tx_hash, log_index, shares, direction, price_usd, \
+         executed_at FROM pnl_onchain_fill WHERE event_rowid <= ",
     );
-    query.push_bind(as_of_rowid);
-    if !symbols.is_empty() {
-        query.push(" AND aggregate_id IN (");
-        let mut separated = query.separated(", ");
-        for symbol in symbols {
-            separated.push_bind(symbol);
-        }
-        separated.push_unseparated(")");
-    }
-    query.push(" ORDER BY rowid ASC");
-
-    let rows = query
-        .build_query_as::<(i64, String, String, String)>()
-        .fetch_all(&mut **tx)
-        .await?;
-
-    let mut events = Vec::with_capacity(rows.len());
-    for (rowid, symbol, event_type, payload) in rows {
-        let payload =
-            parse_payload_string(&payload).map_err(|source| PnlError::InvalidPayload {
-                rowid,
-                aggregate_type: "Position".to_owned(),
-                event_type: event_type.clone(),
-                source,
-            })?;
-        events.push(PositionEventRow {
-            rowid,
+    onchain.push_bind(as_of_rowid);
+    push_symbol_filter(&mut onchain, symbols);
+    for (event_rowid, symbol, tx_hash, log_index, shares, direction, price_usd, executed_at) in
+        onchain
+            .build_query_as::<(i64, String, String, i64, String, String, String, String)>()
+            .fetch_all(pool)
+            .await?
+    {
+        rows.push(PositionLedgerRow::OnchainFill(OnchainFillRow {
+            event_rowid,
             symbol,
-            event_type,
-            payload,
-        });
+            tx_hash,
+            log_index,
+            shares,
+            direction: ledger_direction("pnl_onchain_fill", event_rowid, &direction)?,
+            price_usd,
+            executed_at,
+        }));
     }
 
-    Ok(events)
+    let mut offchain = QueryBuilder::<Sqlite>::new(
+        "SELECT event_rowid, symbol, offchain_order_id, shares, direction, price_usd, \
+         executed_at FROM pnl_offchain_fill WHERE event_rowid <= ",
+    );
+    offchain.push_bind(as_of_rowid);
+    push_symbol_filter(&mut offchain, symbols);
+    for (event_rowid, symbol, offchain_order_id, shares, direction, price_usd, executed_at) in
+        offchain
+            .build_query_as::<(i64, String, String, String, String, String, String)>()
+            .fetch_all(pool)
+            .await?
+    {
+        rows.push(PositionLedgerRow::OffchainFill(OffchainFillRow {
+            event_rowid,
+            symbol,
+            offchain_order_id,
+            shares,
+            direction: ledger_direction("pnl_offchain_fill", event_rowid, &direction)?,
+            price_usd,
+            executed_at,
+        }));
+    }
+
+    let mut placements = QueryBuilder::<Sqlite>::new(
+        "SELECT event_rowid, symbol, offchain_order_id, placed_at \
+         FROM pnl_offchain_placement WHERE event_rowid <= ",
+    );
+    placements.push_bind(as_of_rowid);
+    push_symbol_filter(&mut placements, symbols);
+    for (event_rowid, symbol, offchain_order_id, placed_at) in placements
+        .build_query_as::<(i64, String, String, String)>()
+        .fetch_all(pool)
+        .await?
+    {
+        rows.push(PositionLedgerRow::OffchainPlacement(OffchainPlacementRow {
+            event_rowid,
+            symbol,
+            offchain_order_id,
+            placed_at,
+        }));
+    }
+
+    let mut adjustments = QueryBuilder::<Sqlite>::new(
+        "SELECT event_rowid, symbol, target_net, price_usd, adjusted_at \
+         FROM pnl_manual_adjustment WHERE event_rowid <= ",
+    );
+    adjustments.push_bind(as_of_rowid);
+    push_symbol_filter(&mut adjustments, symbols);
+    for (event_rowid, symbol, target_net, price_usd, adjusted_at) in adjustments
+        .build_query_as::<(i64, String, String, Option<String>, String)>()
+        .fetch_all(pool)
+        .await?
+    {
+        rows.push(PositionLedgerRow::ManualAdjustment(ManualAdjustmentRow {
+            event_rowid,
+            symbol,
+            target_net,
+            price_usd,
+            adjusted_at,
+        }));
+    }
+
+    rows.sort_by_key(PositionLedgerRow::event_rowid);
+    Ok(rows)
 }
 
-async fn load_position_view(
-    tx: &mut Transaction<'_, Sqlite>,
-) -> Result<Vec<PositionViewRow>, PnlError> {
+async fn load_position_view(pool: &SqlitePool) -> Result<Vec<PositionViewRow>, PnlError> {
     let rows = sqlx::query_as::<_, (String, Option<String>)>(
         "SELECT symbol, net_position \
          FROM position_view \
          WHERE symbol IS NOT NULL \
          ORDER BY symbol ASC",
     )
-    .fetch_all(&mut **tx)
+    .fetch_all(pool)
     .await?;
 
     Ok(rows
@@ -421,97 +497,76 @@ async fn load_position_view(
         .collect())
 }
 
-async fn load_cost_events(
-    tx: &mut Transaction<'_, Sqlite>,
+async fn load_cost_rows(
+    pool: &SqlitePool,
     as_of_rowid: i64,
-) -> Result<Vec<CostEventRow>, PnlError> {
-    let rows = sqlx::query_as::<_, (i64, String, String, String, String)>(
-        "SELECT rowid, aggregate_type, aggregate_id, event_type, payload \
-         FROM events \
-         WHERE rowid <= ? \
-           AND ( \
-             ( \
-               aggregate_type = 'TokenizedEquityMint' \
-               AND event_type IN ( \
-                 'TokenizedEquityMintEvent::MintRequested', \
-                 'TokenizedEquityMintEvent::TokensReceived', \
-                 'TokenizedEquityMintEvent::ProviderCompletionRecovered' \
-               ) \
-             ) \
-             OR ( \
-               aggregate_type = 'UsdcRebalance' \
-               AND event_type IN ( \
-                 'UsdcRebalanceEvent::Bridged', \
-                 'UsdcRebalanceEvent::BridgingCompletionRecovered' \
-               ) \
-             ) \
-           ) \
-         ORDER BY rowid ASC",
+) -> Result<Vec<CostLedgerRow>, PnlError> {
+    let rows = sqlx::query_as::<_, (i64, String, String, Option<String>, Option<String>, String)>(
+        "SELECT event_rowid, source, aggregate_id, symbol, amount_usd, occurred_at \
+         FROM pnl_cost_entry \
+         WHERE event_rowid <= ? \
+         ORDER BY event_rowid ASC",
     )
     .bind(as_of_rowid)
-    .fetch_all(&mut **tx)
+    .fetch_all(pool)
     .await?;
 
-    let mut events = Vec::with_capacity(rows.len());
-    for (rowid, aggregate_type, aggregate_id, event_type, payload) in rows {
-        let payload =
-            parse_payload_string(&payload).map_err(|source| PnlError::InvalidPayload {
-                rowid,
-                aggregate_type: aggregate_type.clone(),
-                event_type: event_type.clone(),
-                source,
-            })?;
-        events.push(CostEventRow {
-            rowid,
-            aggregate_type,
-            aggregate_id,
-            event_type,
-            payload,
-        });
-    }
+    rows.into_iter()
+        .map(
+            |(event_rowid, source, aggregate_id, symbol, amount_usd, occurred_at)| {
+                let source = match source.as_str() {
+                    TOKENIZATION_FEE_SOURCE => CostSource::TokenizationFee,
+                    CCTP_FEE_SOURCE => CostSource::CctpFee,
+                    _ => {
+                        return Err(PnlError::InvalidLedgerRow {
+                            table: "pnl_cost_entry",
+                            rowid: event_rowid,
+                            reason: "unknown cost source",
+                        });
+                    }
+                };
 
-    Ok(events)
+                Ok(CostLedgerRow {
+                    event_rowid,
+                    source,
+                    aggregate_id,
+                    symbol,
+                    amount_usd,
+                    occurred_at,
+                })
+            },
+        )
+        .collect()
 }
 
-async fn load_bot_gas_costs(
-    tx: &mut Transaction<'_, Sqlite>,
+async fn load_bot_gas_rows(
+    pool: &SqlitePool,
     as_of_rowid: i64,
 ) -> Result<Vec<BotGasCostRow>, PnlError> {
-    let rows = sqlx::query_as::<_, (i64, String)>(
-        "SELECT rowid, payload \
-         FROM events \
-         WHERE aggregate_type = 'BotGasReceiptCost' \
-           AND event_type = 'BotGasReceiptCostEvent::Recorded' \
-           AND rowid <= ? \
-         ORDER BY rowid ASC",
+    let rows = sqlx::query_as::<_, (i64, String, String, String, String, Option<String>, String)>(
+        "SELECT event_rowid, chain, tx_hash, usd_cost, operation_category, symbol, occurred_at \
+         FROM pnl_bot_gas_cost \
+         WHERE event_rowid <= ? \
+         ORDER BY event_rowid ASC",
     )
     .bind(as_of_rowid)
-    .fetch_all(&mut **tx)
+    .fetch_all(pool)
     .await?;
 
-    let mut costs = Vec::with_capacity(rows.len());
-    for (rowid, payload) in rows {
-        let event = parse_payload_string(&payload)
-            .and_then(serde_json::from_value::<BotGasReceiptCostEvent>)
-            .map_err(|source| PnlError::InvalidPayload {
-                rowid,
-                aggregate_type: "BotGasReceiptCost".to_owned(),
-                event_type: "BotGasReceiptCostEvent::Recorded".to_owned(),
-                source,
-            })?;
-        let BotGasReceiptCostEvent::Recorded { cost } = event;
-        cost.validate()
-            .map_err(|source| PnlError::InvalidBotGasReceiptCost { rowid, source })?;
-        costs.push(BotGasCostRow {
-            rowid,
-            chain: cost.chain.to_string(),
-            tx_hash: cost.tx_hash.to_string(),
-            usd_cost: format_float(&cost.usd_cost.inner())?,
-            operation_category: cost.operation_category.to_string(),
-            symbol: cost.symbol.map(|symbol| symbol.to_string()),
-            occurred_at: cost.occurred_at.to_rfc3339(),
-        });
-    }
-
-    Ok(costs)
+    Ok(rows
+        .into_iter()
+        .map(
+            |(rowid, chain, tx_hash, usd_cost, operation_category, symbol, occurred_at)| {
+                BotGasCostRow {
+                    rowid,
+                    chain,
+                    tx_hash,
+                    usd_cost,
+                    operation_category,
+                    symbol,
+                    occurred_at,
+                }
+            },
+        )
+        .collect())
 }

--- a/src/dashboard/pnl/state.rs
+++ b/src/dashboard/pnl/state.rs
@@ -1,6 +1,5 @@
 //! Internal reporting state for the backend PnL replay ledger.
 use rain_math_float::Float;
-use serde_json::Value;
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use st0x_finance::Symbol;
@@ -172,12 +171,89 @@ pub(crate) struct PositionReplayDelta {
     pub(crate) position_net: Float,
 }
 
+/// One replay-input row loaded from the PnL ledger: one of the four position
+/// row kinds, already typed at ingestion (ADR 0018). Decimal fields stay as
+/// the canonical strings the ledger stores so the replay's parse/validation
+/// layer and the response's verbatim timestamp passthrough are unchanged.
 #[derive(Debug, Clone)]
-pub(crate) struct PositionEventRow {
-    pub(crate) rowid: i64,
+pub(crate) enum PositionLedgerRow {
+    OnchainFill(OnchainFillRow),
+    OffchainFill(OffchainFillRow),
+    OffchainPlacement(OffchainPlacementRow),
+    ManualAdjustment(ManualAdjustmentRow),
+}
+
+impl PositionLedgerRow {
+    pub(crate) fn event_rowid(&self) -> i64 {
+        match self {
+            Self::OnchainFill(row) => row.event_rowid,
+            Self::OffchainFill(row) => row.event_rowid,
+            Self::OffchainPlacement(row) => row.event_rowid,
+            Self::ManualAdjustment(row) => row.event_rowid,
+        }
+    }
+
+    pub(crate) fn symbol(&self) -> &str {
+        match self {
+            Self::OnchainFill(row) => &row.symbol,
+            Self::OffchainFill(row) => &row.symbol,
+            Self::OffchainPlacement(row) => &row.symbol,
+            Self::ManualAdjustment(row) => &row.symbol,
+        }
+    }
+
+    /// The execution timestamp the replay orders by: `block_timestamp` for
+    /// onchain fills, `broker_timestamp` for offchain fills, `placed_at` /
+    /// `adjusted_at` for the rest -- the same per-kind choice
+    /// `position_event_replay_timestamp` made against raw payloads.
+    pub(crate) fn replay_timestamp(&self) -> &str {
+        match self {
+            Self::OnchainFill(row) => &row.executed_at,
+            Self::OffchainFill(row) => &row.executed_at,
+            Self::OffchainPlacement(row) => &row.placed_at,
+            Self::ManualAdjustment(row) => &row.adjusted_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OnchainFillRow {
+    pub(crate) event_rowid: i64,
     pub(crate) symbol: String,
-    pub(crate) event_type: String,
-    pub(crate) payload: Value,
+    pub(crate) tx_hash: String,
+    pub(crate) log_index: i64,
+    pub(crate) shares: String,
+    pub(crate) direction: Direction,
+    pub(crate) price_usd: String,
+    pub(crate) executed_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OffchainFillRow {
+    pub(crate) event_rowid: i64,
+    pub(crate) symbol: String,
+    pub(crate) offchain_order_id: String,
+    pub(crate) shares: String,
+    pub(crate) direction: Direction,
+    pub(crate) price_usd: String,
+    pub(crate) executed_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OffchainPlacementRow {
+    pub(crate) event_rowid: i64,
+    pub(crate) symbol: String,
+    pub(crate) offchain_order_id: String,
+    pub(crate) placed_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ManualAdjustmentRow {
+    pub(crate) event_rowid: i64,
+    pub(crate) symbol: String,
+    pub(crate) target_net: String,
+    pub(crate) price_usd: Option<String>,
+    pub(crate) adjusted_at: String,
 }
 
 #[derive(Debug, Clone)]
@@ -186,13 +262,24 @@ pub(crate) struct PositionViewRow {
     pub(crate) net_position: Option<String>,
 }
 
+/// Which fee stream a ledger cost row came from (`pnl_cost_entry.source`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CostSource {
+    TokenizationFee,
+    CctpFee,
+}
+
+/// One `pnl_cost_entry` row. `amount_usd` `None` is the persisted "provider
+/// did not report fees" observation (tokenization only): counted into
+/// `missing_cost_observation_count` instead of producing a cost entry.
 #[derive(Debug, Clone)]
-pub(crate) struct CostEventRow {
-    pub(crate) rowid: i64,
-    pub(crate) aggregate_type: String,
+pub(crate) struct CostLedgerRow {
+    pub(crate) event_rowid: i64,
+    pub(crate) source: CostSource,
     pub(crate) aggregate_id: String,
-    pub(crate) event_type: String,
-    pub(crate) payload: Value,
+    pub(crate) symbol: Option<String>,
+    pub(crate) amount_usd: Option<String>,
+    pub(crate) occurred_at: String,
 }
 
 #[derive(Debug, Clone)]

--- a/src/dashboard/pnl/tests.rs
+++ b/src/dashboard/pnl/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::mpsc::TryRecvError;
@@ -11,19 +11,20 @@ use num_decimal::num_bigint::{BigInt, Sign};
 use num_traits::Zero;
 use proptest::prelude::*;
 use rain_math_float::Float;
-use serde_json::Value;
 use sqlx::SqlitePool;
-use sqlx::sqlite::SqlitePoolOptions;
+use uuid::Uuid;
 
+use st0x_execution::ExecutorOrderId;
 use st0x_execution::alpaca_broker_api::AccountActivity;
-use st0x_finance::{Symbol, Usd};
+use st0x_finance::{FractionalShares, Positive, Symbol, Usd, Usdc};
 use st0x_float_macro::float;
 
 use super::builder::build_pnl_response_from_rows;
 use super::costs::{
     AccountingBucket, AccountingEffect, CostCategory, CostEntryInternal, validated_cost_magnitude,
 };
-use super::parsing::{fmt_decimal, parse_payload_string, parse_timestamp};
+use super::ledger::{LedgerHead, PnlLedgerError};
+use super::parsing::{fmt_decimal, parse_timestamp};
 use super::query::{PnlCounterTradingFilter, PnlError, PnlMarketSessionFilter, PnlQuery};
 use super::replay::{add_summary, with_direct_symbol_costs};
 use super::response::{PnlResponse, PnlSymbolSummary, PnlWindow, PnlWindowSymbol};
@@ -32,8 +33,8 @@ use super::source::{
     run_pnl_replay, run_pnl_replay_with_permit,
 };
 use super::state::{
-    BotGasCostRow, CostEventRow, Direction, PnlBucket, PositionEventRow, PositionViewRow,
-    SummaryAcc, Venue,
+    BotGasCostRow, CostLedgerRow, CostSource, Direction, ManualAdjustmentRow, OffchainFillRow,
+    OnchainFillRow, PnlBucket, PositionLedgerRow, PositionViewRow, SummaryAcc, Venue,
 };
 use super::windows::build_windows;
 use super::{
@@ -41,109 +42,91 @@ use super::{
     COST_WARNING, SYMBOL_FILTERED_CAPITAL_WARNING, validate_pnl_snapshot_rowid,
 };
 use crate::bot_gas::{
-    BotGasChain, BotGasOperationCategory, BotGasReceiptCost, BotGasReceiptCostEvent,
+    BotGasChain, BotGasOperationCategory, BotGasReceiptCost, BotGasReceiptCostError,
+    BotGasReceiptCostEvent,
 };
+use crate::offchain::order::OffchainOrderId;
 use crate::portfolio_snapshot::EtDayRange;
+use crate::position::{Position, PositionEvent, TradeId};
+use crate::test_utils::{persist_event, setup_test_db};
+use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintEvent};
+use crate::usdc_rebalance::{UsdcRebalance, UsdcRebalanceEvent, UsdcRebalanceId};
 
-fn event(rowid: i64, symbol: &str, event_type: &str, payload: Value) -> PositionEventRow {
-    PositionEventRow {
-        rowid,
-        symbol: symbol.to_owned(),
-        event_type: event_type.to_owned(),
-        payload,
-    }
+fn seed_rebalance(fee: &str, timestamp: &str) -> SeedEvent {
+    SeedEvent::Rebalance(
+        UsdcRebalanceId(Uuid::new_v4()).to_string(),
+        bridged_event(fee, timestamp),
+    )
 }
 
 fn onchain_fill(
     rowid: i64,
     symbol: &str,
-    direction: &str,
+    direction: Direction,
     price: &str,
     shares: &str,
     timestamp: &str,
-) -> PositionEventRow {
-    event(
-        rowid,
-        symbol,
-        "PositionEvent::OnChainOrderFilled",
-        serde_json::json!({
-            "OnChainOrderFilled": {
-                "amount": shares,
-                "direction": direction,
-                "price_usdc": price,
-                "block_timestamp": timestamp,
-                "trade_id": {
-                    "tx_hash": format!("0x{rowid}"),
-                    "log_index": 0
-                }
-            }
-        }),
-    )
+) -> PositionLedgerRow {
+    PositionLedgerRow::OnchainFill(OnchainFillRow {
+        event_rowid: rowid,
+        symbol: symbol.to_owned(),
+        tx_hash: format!("0x{rowid}"),
+        log_index: 0,
+        shares: shares.to_owned(),
+        direction,
+        price_usd: price.to_owned(),
+        executed_at: timestamp.to_owned(),
+    })
 }
 
-fn onchain_sell(rowid: i64, price: &str, timestamp: &str) -> PositionEventRow {
-    onchain_fill(rowid, "RKLB", "Sell", price, "1", timestamp)
+fn onchain_sell(rowid: i64, price: &str, timestamp: &str) -> PositionLedgerRow {
+    onchain_fill(rowid, "RKLB", Direction::Sell, price, "1", timestamp)
 }
 
-fn onchain_buy(rowid: i64, price: &str, timestamp: &str) -> PositionEventRow {
-    onchain_fill(rowid, "RKLB", "Buy", price, "1", timestamp)
+fn onchain_buy(rowid: i64, price: &str, timestamp: &str) -> PositionLedgerRow {
+    onchain_fill(rowid, "RKLB", Direction::Buy, price, "1", timestamp)
 }
 
 fn offchain_fill(
     rowid: i64,
     symbol: &str,
-    direction: &str,
+    direction: Direction,
     timestamp: &str,
     price: &str,
     shares: &str,
-) -> PositionEventRow {
-    event(
-        rowid,
-        symbol,
-        "PositionEvent::OffChainOrderFilled",
-        serde_json::json!({
-            "OffChainOrderFilled": {
-                "offchain_order_id": format!("alpaca-{rowid}"),
-                "shares_filled": shares,
-                "direction": direction,
-                "price": price,
-                "broker_timestamp": timestamp
-            }
-        }),
-    )
+) -> PositionLedgerRow {
+    PositionLedgerRow::OffchainFill(OffchainFillRow {
+        event_rowid: rowid,
+        symbol: symbol.to_owned(),
+        offchain_order_id: format!("alpaca-{rowid}"),
+        shares: shares.to_owned(),
+        direction,
+        price_usd: price.to_owned(),
+        executed_at: timestamp.to_owned(),
+    })
 }
 
-fn offchain_buy(rowid: i64, timestamp: &str, price: &str, shares: &str) -> PositionEventRow {
-    offchain_fill(rowid, "RKLB", "Buy", timestamp, price, shares)
+fn offchain_buy(rowid: i64, timestamp: &str, price: &str, shares: &str) -> PositionLedgerRow {
+    offchain_fill(rowid, "RKLB", Direction::Buy, timestamp, price, shares)
 }
 
-fn offchain_sell(rowid: i64, timestamp: &str, price: &str, shares: &str) -> PositionEventRow {
-    offchain_fill(rowid, "RKLB", "Sell", timestamp, price, shares)
+fn offchain_sell(rowid: i64, timestamp: &str, price: &str, shares: &str) -> PositionLedgerRow {
+    offchain_fill(rowid, "RKLB", Direction::Sell, timestamp, price, shares)
 }
 
 fn manual_adjustment(
     rowid: i64,
     target_net: &str,
-    price_usdc: Option<&str>,
+    price_usd: Option<&str>,
     timestamp: &str,
-) -> PositionEventRow {
-    let mut payload = serde_json::json!({
-        "ManualPositionAdjusted": {
-            "previous_net": "0",
-            "target_net": target_net,
-            "reason": "test repair",
-            "adjusted_at": timestamp
-        }
-    });
-    if let Some(price_usdc) = price_usdc {
-        payload["ManualPositionAdjusted"]["price_usdc"] = serde_json::json!(price_usdc);
-    }
-    event(
-        rowid,
-        "RKLB",
-        "PositionEvent::ManualPositionAdjusted",
-        payload,
-    )
+) -> PositionLedgerRow {
+    PositionLedgerRow::ManualAdjustment(ManualAdjustmentRow {
+        event_rowid: rowid,
+        symbol: "RKLB".to_owned(),
+        target_net: target_net.to_owned(),
+        price_usd: price_usd.map(str::to_owned),
+        adjusted_at: timestamp.to_owned(),
+    })
 }
 
 fn position_rows() -> Vec<PositionViewRow> {
@@ -262,14 +245,6 @@ fn et_day_range_leaves_lower_bound_open_when_only_to_date_set() {
     let EtDayRange { from, to } = query.et_day_range().unwrap();
     assert_eq!(from, None);
     assert_eq!(to, Some(NaiveDate::from_ymd_opt(2026, 5, 15).unwrap()));
-}
-
-#[test]
-fn malformed_persisted_payloads_are_rejected() {
-    let error = parse_payload_string("{not-json").unwrap_err();
-    assert_eq!(error.classify(), serde_json::error::Category::Syntax);
-    assert_eq!(error.line(), 1);
-    assert_eq!(error.column(), 2);
 }
 
 #[test]
@@ -415,16 +390,22 @@ fn invalid_persisted_financial_fields_fail_the_report() {
         error,
         PnlError::InvalidFinancialField {
             rowid: 1,
-            field: "price_usdc",
+            field: "price_usd",
             ..
         }
     ));
 }
 
 #[test]
-fn wrong_typed_persisted_fill_decimals_fail_the_report() {
-    let mut row = onchain_sell(1, "10", "2026-05-15T14:00:00Z");
-    row.payload["OnChainOrderFilled"]["amount"] = serde_json::json!(true);
+fn corrupt_ledger_fill_decimals_fail_the_report() {
+    let row = onchain_fill(
+        1,
+        "RKLB",
+        Direction::Sell,
+        "10",
+        "not-a-decimal",
+        "2026-05-15T14:00:00Z",
+    );
 
     let error = report_result(vec![row]).unwrap_err();
 
@@ -432,27 +413,7 @@ fn wrong_typed_persisted_fill_decimals_fail_the_report() {
         error,
         PnlError::InvalidFinancialField {
             rowid: 1,
-            field: "amount",
-            ..
-        }
-    ));
-}
-
-#[test]
-fn missing_persisted_fill_fields_fail_the_report() {
-    let mut row = onchain_sell(1, "10", "2026-05-15T14:00:00Z");
-    row.payload["OnChainOrderFilled"]
-        .as_object_mut()
-        .unwrap()
-        .remove("amount");
-
-    let error = report_result(vec![row]).unwrap_err();
-
-    assert!(matches!(
-        error,
-        PnlError::MalformedPayload {
-            rowid: 1,
-            reason: "incomplete OnChainOrderFilled payload",
+            field: "shares",
             ..
         }
     ));
@@ -460,15 +421,21 @@ fn missing_persisted_fill_fields_fail_the_report() {
 
 #[test]
 fn non_positive_onchain_fill_values_fail_the_report() {
-    let mut zero_amount = onchain_sell(1, "10", "2026-05-15T14:00:00Z");
-    zero_amount.payload["OnChainOrderFilled"]["amount"] = serde_json::json!("0");
-    let error = report_result(vec![zero_amount]).unwrap_err();
+    let zero_shares = onchain_fill(
+        1,
+        "RKLB",
+        Direction::Sell,
+        "10",
+        "0",
+        "2026-05-15T14:00:00Z",
+    );
+    let error = report_result(vec![zero_shares]).unwrap_err();
     assert!(matches!(
         error,
-        PnlError::MalformedPayload {
+        PnlError::InvalidLedgerRow {
+            table: "pnl_onchain_fill",
             rowid: 1,
-            reason: "non-positive OnChainOrderFilled amount",
-            ..
+            reason: "non-positive onchain fill shares",
         }
     ));
 
@@ -476,10 +443,10 @@ fn non_positive_onchain_fill_values_fail_the_report() {
     let error = report_result(vec![negative_price]).unwrap_err();
     assert!(matches!(
         error,
-        PnlError::MalformedPayload {
+        PnlError::InvalidLedgerRow {
+            table: "pnl_onchain_fill",
             rowid: 2,
-            reason: "non-positive OnChainOrderFilled price_usdc",
-            ..
+            reason: "non-positive onchain fill price",
         }
     ));
 }
@@ -490,10 +457,10 @@ fn non_positive_offchain_fill_values_fail_the_report() {
     let error = report_result(vec![zero_shares]).unwrap_err();
     assert!(matches!(
         error,
-        PnlError::MalformedPayload {
+        PnlError::InvalidLedgerRow {
+            table: "pnl_offchain_fill",
             rowid: 1,
-            reason: "non-positive OffChainOrderFilled shares_filled",
-            ..
+            reason: "non-positive offchain fill shares",
         }
     ));
 
@@ -501,24 +468,23 @@ fn non_positive_offchain_fill_values_fail_the_report() {
     let error = report_result(vec![negative_price]).unwrap_err();
     assert!(matches!(
         error,
-        PnlError::MalformedPayload {
+        PnlError::InvalidLedgerRow {
+            table: "pnl_offchain_fill",
             rowid: 2,
-            reason: "non-positive OffChainOrderFilled price",
-            ..
+            reason: "non-positive offchain fill price",
         }
     ));
 }
 
 #[test]
 fn invalid_replay_timestamps_fail_the_report() {
-    let mut row = onchain_sell(1, "10", "2026-05-15T14:00:00Z");
-    row.payload["OnChainOrderFilled"]["block_timestamp"] = serde_json::json!("not-a-timestamp");
+    let row = onchain_sell(1, "10", "not-a-timestamp");
 
     let error = report_result(vec![row]).unwrap_err();
 
     assert!(matches!(
         error,
-        PnlError::MalformedPayload {
+        PnlError::InvalidLedgerRow {
             rowid: 1,
             reason: "invalid replay timestamp",
             ..
@@ -533,96 +499,124 @@ fn position_row(symbol: &str, net_position: &str) -> PositionViewRow {
     }
 }
 
-fn cost_event(
+fn tokenization_fee(
     rowid: i64,
-    aggregate_type: &str,
     aggregate_id: &str,
-    event_type: &str,
-    payload: Value,
-) -> CostEventRow {
-    CostEventRow {
-        rowid,
-        aggregate_type: aggregate_type.to_owned(),
+    fees: Option<&str>,
+    timestamp: &str,
+) -> CostLedgerRow {
+    CostLedgerRow {
+        event_rowid: rowid,
+        source: CostSource::TokenizationFee,
         aggregate_id: aggregate_id.to_owned(),
-        event_type: event_type.to_owned(),
-        payload,
+        symbol: Some("RKLB".to_owned()),
+        amount_usd: fees.map(str::to_owned),
+        occurred_at: timestamp.to_owned(),
     }
 }
 
-fn tokenized_mint_requested(rowid: i64, aggregate_id: &str, symbol: &str) -> CostEventRow {
-    cost_event(
-        rowid,
-        "TokenizedEquityMint",
-        aggregate_id,
-        "TokenizedEquityMintEvent::MintRequested",
-        serde_json::json!({
-            "MintRequested": {
-                "symbol": symbol
-            }
-        }),
-    )
+fn cctp_fee(rowid: i64, aggregate_id: &str, fee: &str, timestamp: &str) -> CostLedgerRow {
+    CostLedgerRow {
+        event_rowid: rowid,
+        source: CostSource::CctpFee,
+        aggregate_id: aggregate_id.to_owned(),
+        symbol: None,
+        amount_usd: Some(fee.to_owned()),
+        occurred_at: timestamp.to_owned(),
+    }
 }
 
-fn tokenized_tokens_received(
-    rowid: i64,
-    aggregate_id: &str,
-    fees: &str,
+fn exec_direction(direction: Direction) -> st0x_execution::Direction {
+    match direction {
+        Direction::Buy => st0x_execution::Direction::Buy,
+        Direction::Sell => st0x_execution::Direction::Sell,
+    }
+}
+
+fn onchain_fill_event(
+    direction: Direction,
+    price: &str,
+    shares: &str,
     timestamp: &str,
-) -> CostEventRow {
-    cost_event(
-        rowid,
-        "TokenizedEquityMint",
-        aggregate_id,
-        "TokenizedEquityMintEvent::TokensReceived",
-        serde_json::json!({
-            "TokensReceived": {
-                "received_at": timestamp,
-                "fees": fees
-            }
-        }),
-    )
+) -> PositionEvent {
+    PositionEvent::OnChainOrderFilled {
+        trade_id: TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 0,
+        },
+        amount: FractionalShares::new(Float::parse(shares.to_owned()).unwrap()),
+        direction: exec_direction(direction),
+        price_usdc: Float::parse(price.to_owned()).unwrap(),
+        block_timestamp: parse_timestamp(timestamp).unwrap(),
+        block_number: None,
+        seen_at: parse_timestamp(timestamp).unwrap(),
+    }
 }
 
-fn tokenized_provider_completion_recovered(
-    rowid: i64,
-    aggregate_id: &str,
-    fees: &str,
+fn offchain_fill_event(
+    direction: Direction,
+    price: &str,
+    shares: &str,
     timestamp: &str,
-) -> CostEventRow {
-    cost_event(
-        rowid,
-        "TokenizedEquityMint",
-        aggregate_id,
-        "TokenizedEquityMintEvent::ProviderCompletionRecovered",
-        serde_json::json!({
-            "ProviderCompletionRecovered": {
-                "recovered_at": timestamp,
-                "fees": fees
-            }
-        }),
-    )
+) -> PositionEvent {
+    PositionEvent::OffChainOrderFilled {
+        offchain_order_id: OffchainOrderId::new(),
+        shares_filled: Positive::new(FractionalShares::new(
+            Float::parse(shares.to_owned()).unwrap(),
+        ))
+        .unwrap(),
+        direction: exec_direction(direction),
+        executor_order_id: ExecutorOrderId::new("broker-1"),
+        price: Usd::new(Float::parse(price.to_owned()).unwrap()),
+        broker_timestamp: parse_timestamp(timestamp).unwrap(),
+    }
 }
 
-fn usdc_bridged(rowid: i64, aggregate_id: &str, fee: &str, timestamp: &str) -> CostEventRow {
-    cost_event(
-        rowid,
-        "UsdcRebalance",
-        aggregate_id,
-        "UsdcRebalanceEvent::Bridged",
-        serde_json::json!({
-            "Bridged": {
-                "minted_at": timestamp,
-                "fee_collected": fee
-            }
-        }),
-    )
+fn manual_adjustment_event(
+    target_net: &str,
+    price_usdc: Option<&str>,
+    timestamp: &str,
+) -> PositionEvent {
+    PositionEvent::ManualPositionAdjusted {
+        previous_net: FractionalShares::new(float!(0)),
+        target_net: FractionalShares::new(Float::parse(target_net.to_owned()).unwrap()),
+        reason: "test repair".to_owned(),
+        price_usdc: price_usdc.map(|price| Float::parse(price.to_owned()).unwrap()),
+        adjusted_at: parse_timestamp(timestamp).unwrap(),
+    }
 }
 
-fn bot_gas_recorded(rowid: i64) -> CostEventRow {
-    let tx_hash = TxHash::repeat_byte(0xab);
-    let cost = BotGasReceiptCost {
+fn mint_requested_event(symbol: &str, timestamp: &str) -> TokenizedEquityMintEvent {
+    TokenizedEquityMintEvent::MintRequested {
+        symbol: Symbol::new(symbol).unwrap(),
+        quantity: float!(1),
+        wallet: Address::repeat_byte(0x22),
+        requested_at: parse_timestamp(timestamp).unwrap(),
+    }
+}
+
+fn tokens_received_event(fees: Option<&str>, timestamp: &str) -> TokenizedEquityMintEvent {
+    TokenizedEquityMintEvent::TokensReceived {
+        tx_hash: TxHash::random(),
+        shares_minted: U256::from(1_000_000_000_000_000_000_u128),
+        fees: fees.map(|fee| Float::parse(fee.to_owned()).unwrap()),
+        received_at: parse_timestamp(timestamp).unwrap(),
+    }
+}
+
+fn bridged_event(fee: &str, timestamp: &str) -> UsdcRebalanceEvent {
+    UsdcRebalanceEvent::Bridged {
+        mint_tx_hash: TxHash::random(),
+        amount_received: Usdc::new(float!(998.5)),
+        fee_collected: Usdc::new(Float::parse(fee.to_owned()).unwrap()),
+        minted_at: parse_timestamp(timestamp).unwrap(),
+    }
+}
+
+fn bot_gas_cost(usd_cost: Float) -> BotGasReceiptCost {
+    BotGasReceiptCost {
         chain: BotGasChain::Base,
-        tx_hash,
+        tx_hash: TxHash::repeat_byte(0xab),
         receipt_from: Address::repeat_byte(0x11),
         gas_used: 21_000,
         effective_gas_price_wei: 1_000_000_000,
@@ -631,18 +625,27 @@ fn bot_gas_recorded(rowid: i64) -> CostEventRow {
         eth_usd_price_source: "eth_usd_valuation_feed".to_owned(),
         eth_usd_price_at: Utc.with_ymd_and_hms(2026, 5, 15, 14, 0, 0).unwrap(),
         eth_usd_price_block_number: Some(123),
-        usd_cost: Usd::new(float!(0.042)),
+        usd_cost: Usd::new(usd_cost),
         operation_category: BotGasOperationCategory::VaultDeposit,
         symbol: Some(Symbol::new("RKLB").unwrap()),
         occurred_at: Utc.with_ymd_and_hms(2026, 5, 15, 14, 0, 1).unwrap(),
-    };
+    }
+}
 
-    cost_event(
-        rowid,
-        "BotGasReceiptCost",
-        &format!("base:{tx_hash}"),
-        "BotGasReceiptCostEvent::Recorded",
-        serde_json::to_value(BotGasReceiptCostEvent::Recorded { cost }).unwrap(),
+/// One event to seed into the real `events` table for pool-backed tests.
+/// Rowids are assigned by SQLite in insertion order, so seed order is the
+/// rowid order the ledger ingests and watermarks by.
+enum SeedEvent {
+    Position(&'static str, PositionEvent),
+    Mint(String, TokenizedEquityMintEvent),
+    Rebalance(String, UsdcRebalanceEvent),
+    BotGas(String, BotGasReceiptCostEvent),
+}
+
+fn seed_bot_gas(cost: BotGasReceiptCost) -> SeedEvent {
+    SeedEvent::BotGas(
+        format!("base:{}", cost.tx_hash),
+        BotGasReceiptCostEvent::Recorded { cost },
     )
 }
 
@@ -688,12 +691,12 @@ fn date_only_account_activity(
 }
 
 fn report_with(
-    events: Vec<PositionEventRow>,
-    position_rows: Vec<PositionViewRow>,
-    cost_rows: Vec<CostEventRow>,
-    alpaca_activities: Vec<AccountActivity>,
-    query: PnlQuery,
-    symbols: BTreeSet<String>,
+    events: Vec<PositionLedgerRow>,
+    position_rows: &[PositionViewRow],
+    cost_rows: &[CostLedgerRow],
+    alpaca_activities: &[AccountActivity],
+    query: &PnlQuery,
+    symbols: &BTreeSet<String>,
 ) -> PnlResponse {
     report_with_result(
         events,
@@ -707,50 +710,23 @@ fn report_with(
 }
 
 fn report_with_result(
-    events: Vec<PositionEventRow>,
-    position_rows: Vec<PositionViewRow>,
-    cost_rows: Vec<CostEventRow>,
-    alpaca_activities: Vec<AccountActivity>,
-    query: PnlQuery,
-    symbols: BTreeSet<String>,
+    events: Vec<PositionLedgerRow>,
+    position_rows: &[PositionViewRow],
+    cost_rows: &[CostLedgerRow],
+    alpaca_activities: &[AccountActivity],
+    query: &PnlQuery,
+    symbols: &BTreeSet<String>,
 ) -> Result<PnlResponse, PnlError> {
-    struct ReportInput {
-        events: Vec<PositionEventRow>,
-        position_rows: Vec<PositionViewRow>,
-        cost_rows: Vec<CostEventRow>,
-        bot_gas_rows: Vec<BotGasCostRow>,
-        alpaca_activities: Vec<AccountActivity>,
-        query: PnlQuery,
-        symbols: BTreeSet<String>,
-    }
-
-    let input = ReportInput {
-        events,
-        position_rows,
-        cost_rows,
-        bot_gas_rows: Vec::new(),
-        alpaca_activities,
-        query,
-        symbols,
-    };
-    let ReportInput {
-        events,
-        position_rows,
-        cost_rows,
-        bot_gas_rows,
-        alpaca_activities,
-        query,
-        symbols,
-    } = input;
+    let bot_gas_rows: Vec<BotGasCostRow> = Vec::new();
 
     build_pnl_response_from_rows(
         events,
-        &position_rows,
-        &cost_rows,
+        position_rows,
+        cost_rows,
         &bot_gas_rows,
-        &alpaca_activities,
-        &query,
-        &symbols,
+        alpaca_activities,
+        query,
+        symbols,
         vec![
             ATTRIBUTION_WARNING.to_owned(),
             BASELINE_WARNING.to_owned(),
@@ -760,90 +736,43 @@ fn report_with_result(
     .map(|(response, _daily_net_realized_pnl_usd)| response)
 }
 
-async fn pnl_test_pool(
-    events: Vec<PositionEventRow>,
-    positions: Vec<PositionViewRow>,
-) -> SqlitePool {
-    pnl_test_pool_with_costs(events, positions, Vec::new()).await
-}
+/// Seeds a fully migrated database with real typed events (which the ledger
+/// ingests on `build_pnl_report`'s catch-up) and `position_view` rows.
+async fn pnl_test_pool(seed: Vec<SeedEvent>, positions: Vec<PositionViewRow>) -> SqlitePool {
+    let pool = setup_test_db().await;
+    let mut sequences: HashMap<String, i64> = HashMap::new();
+    let mut next_sequence = |aggregate_id: &str| {
+        let sequence = sequences.entry(aggregate_id.to_owned()).or_insert(0);
+        *sequence += 1;
+        *sequence
+    };
 
-async fn pnl_test_pool_with_costs(
-    events: Vec<PositionEventRow>,
-    positions: Vec<PositionViewRow>,
-    cost_rows: Vec<CostEventRow>,
-) -> SqlitePool {
-    let pool = SqlitePoolOptions::new()
-        .max_connections(1)
-        .connect("sqlite::memory:")
-        .await
-        .unwrap();
-
-    sqlx::query(
-        "CREATE TABLE events ( \
-           aggregate_type TEXT NOT NULL, \
-           aggregate_id TEXT NOT NULL, \
-           event_type TEXT NOT NULL, \
-           payload TEXT NOT NULL \
-         )",
-    )
-    .execute(&pool)
-    .await
-    .unwrap();
-    sqlx::query("CREATE TABLE position_view (symbol TEXT, net_position TEXT)")
-        .execute(&pool)
-        .await
-        .unwrap();
-    // Empty by default: build_pnl_report's capital computation reads this
-    // table unconditionally, so it must exist even when a test doesn't
-    // seed any snapshot rows (capital is then omitted with a warning).
-    sqlx::query(
-        "CREATE TABLE portfolio_snapshot ( \
-           et_day TEXT NOT NULL, \
-           captured_at TEXT NOT NULL, \
-           location TEXT NOT NULL, \
-           asset TEXT NOT NULL, \
-           available_balance TEXT NOT NULL, \
-           inflight_balance TEXT NOT NULL, \
-           usd_mark TEXT, \
-           mark_captured_at TEXT, \
-           PRIMARY KEY (et_day, location, asset) \
-         )",
-    )
-    .execute(&pool)
-    .await
-    .unwrap();
-
-    for row in events {
-        sqlx::query(
-            "INSERT INTO events (aggregate_type, aggregate_id, event_type, payload) \
-             VALUES ('Position', ?, ?, ?)",
-        )
-        .bind(row.symbol)
-        .bind(row.event_type)
-        .bind(row.payload.to_string())
-        .execute(&pool)
-        .await
-        .unwrap();
-    }
-
-    for row in cost_rows {
-        sqlx::query(
-            "INSERT INTO events (aggregate_type, aggregate_id, event_type, payload) \
-             VALUES (?, ?, ?, ?)",
-        )
-        .bind(row.aggregate_type)
-        .bind(row.aggregate_id)
-        .bind(row.event_type)
-        .bind(row.payload.to_string())
-        .execute(&pool)
-        .await
-        .unwrap();
+    for event in seed {
+        match event {
+            SeedEvent::Position(symbol, event) => {
+                persist_event::<Position>(&pool, symbol, next_sequence(symbol), &event).await;
+            }
+            SeedEvent::Mint(id, event) => {
+                persist_event::<TokenizedEquityMint>(&pool, &id, next_sequence(&id), &event).await;
+            }
+            SeedEvent::Rebalance(id, event) => {
+                persist_event::<UsdcRebalance>(&pool, &id, next_sequence(&id), &event).await;
+            }
+            SeedEvent::BotGas(id, event) => {
+                persist_event::<BotGasReceiptCost>(&pool, &id, next_sequence(&id), &event).await;
+            }
+        }
     }
 
     for row in positions {
-        sqlx::query("INSERT INTO position_view (symbol, net_position) VALUES (?, ?)")
-            .bind(row.symbol)
-            .bind(row.net_position)
+        // symbol/net_position are STORED generated columns over the Lifecycle
+        // payload, so seeding goes through the payload JSON.
+        sqlx::query("INSERT INTO position_view (view_id, version, payload) VALUES (?1, 1, ?2)")
+            .bind(row.symbol.clone())
+            .bind(
+                serde_json::json!({"Live": {"symbol": row.symbol, "net": row.net_position}})
+                    .to_string(),
+            )
             .execute(&pool)
             .await
             .unwrap();
@@ -852,7 +781,7 @@ async fn pnl_test_pool_with_costs(
     pool
 }
 
-fn report_result(events: Vec<PositionEventRow>) -> Result<PnlResponse, PnlError> {
+fn report_result(events: Vec<PositionLedgerRow>) -> Result<PnlResponse, PnlError> {
     build_pnl_response_from_rows(
         events,
         &position_rows(),
@@ -870,14 +799,14 @@ fn report_result(events: Vec<PositionEventRow>) -> Result<PnlResponse, PnlError>
     .map(|(response, _daily_net_realized_pnl_usd)| response)
 }
 
-fn report(events: Vec<PositionEventRow>) -> PnlResponse {
+fn report(events: Vec<PositionLedgerRow>) -> PnlResponse {
     report_with(
         events,
-        position_rows(),
-        Vec::new(),
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[],
+        &[],
+        &query(),
+        &BTreeSet::new(),
     )
 }
 
@@ -1051,8 +980,7 @@ fn manual_position_adjustment_resets_open_lots_before_later_fills() {
 
 #[test]
 fn zero_manual_position_adjustment_allows_null_price() {
-    let mut row = manual_adjustment(1, "0", None, "2026-05-15T13:30:00Z");
-    row.payload["ManualPositionAdjusted"]["price_usdc"] = serde_json::Value::Null;
+    let row = manual_adjustment(1, "0", None, "2026-05-15T13:30:00Z");
 
     let report = report(vec![row]);
 
@@ -1081,25 +1009,23 @@ fn manual_position_adjustment_seeds_priced_target_exposure() {
 
 #[test]
 fn nonzero_manual_position_adjustment_rejects_null_price() {
-    let mut row = manual_adjustment(1, "-1", None, "2026-05-15T13:30:00Z");
-    row.payload["ManualPositionAdjusted"]["price_usdc"] = serde_json::Value::Null;
+    let row = manual_adjustment(1, "-1", None, "2026-05-15T13:30:00Z");
 
     let error = report_result(vec![row]).unwrap_err();
 
     assert!(matches!(
         error,
-        PnlError::MalformedPayload {
+        PnlError::InvalidLedgerRow {
+            table: "pnl_manual_adjustment",
             rowid: 1,
-            reason: "nonzero ManualPositionAdjusted missing price_usdc and no prior replay price",
-            ..
+            reason: "nonzero manual adjustment missing price_usd and no prior replay price",
         }
     ));
 }
 
 #[test]
-fn wrong_typed_manual_adjustment_decimals_fail_the_report() {
-    let mut row = manual_adjustment(1, "0", None, "2026-05-15T13:30:00Z");
-    row.payload["ManualPositionAdjusted"]["target_net"] = serde_json::json!({});
+fn corrupt_manual_adjustment_decimals_fail_the_report() {
+    let row = manual_adjustment(1, "not-a-decimal", None, "2026-05-15T13:30:00Z");
 
     let error = report_result(vec![row]).unwrap_err();
 
@@ -1117,9 +1043,18 @@ fn wrong_typed_manual_adjustment_decimals_fail_the_report() {
 async fn source_loader_includes_manual_position_adjustments() {
     let pool = pnl_test_pool(
         vec![
-            onchain_sell(1, "10", "2026-05-15T13:00:00Z"),
-            manual_adjustment(2, "0", None, "2026-05-15T13:30:00Z"),
-            offchain_buy(3, "2026-05-15T14:00:00Z", "8", "1"),
+            SeedEvent::Position(
+                "RKLB",
+                onchain_fill_event(Direction::Sell, "10", "1", "2026-05-15T13:00:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                manual_adjustment_event("0", None, "2026-05-15T13:30:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                offchain_fill_event(Direction::Buy, "8", "1", "2026-05-15T14:00:00Z"),
+            ),
         ],
         vec![position_row("RKLB", "1")],
     )
@@ -1136,11 +1071,13 @@ async fn source_loader_includes_manual_position_adjustments() {
 }
 
 #[tokio::test]
-async fn source_loader_rejects_malformed_persisted_payload_text() {
+async fn ledger_ingestion_rejects_malformed_persisted_payload_text() {
     let pool = pnl_test_pool(Vec::new(), position_rows()).await;
     sqlx::query(
-        "INSERT INTO events (aggregate_type, aggregate_id, event_type, payload) \
-         VALUES ('Position', 'RKLB', 'PositionEvent::OnChainOrderFilled', '{not-json')",
+        "INSERT INTO events (aggregate_type, aggregate_id, sequence, \
+         event_type, event_version, payload, metadata) \
+         VALUES ('Position', 'RKLB', 1, 'PositionEvent::OnChainOrderFilled', '1.0', \
+         '{not-json', '{}')",
     )
     .execute(&pool)
     .await
@@ -1150,26 +1087,48 @@ async fn source_loader_rejects_malformed_persisted_payload_text() {
         .await
         .unwrap_err();
 
-    assert!(matches!(
-        error,
-        PnlError::InvalidPayload {
-            rowid: 1,
-            ref aggregate_type,
-            ref event_type,
-            ..
-        } if aggregate_type == "Position" && event_type == "PositionEvent::OnChainOrderFilled"
-    ));
+    assert!(matches!(error, PnlError::Ledger(PnlLedgerError::Stream(_))));
+}
+
+/// A structurally valid payload missing required event fields fails at
+/// ingestion (typed deserialization), the layer that replaced the old
+/// per-field payload parsing in the report path.
+#[tokio::test]
+async fn ledger_ingestion_rejects_incomplete_event_payload() {
+    let pool = pnl_test_pool(Vec::new(), position_rows()).await;
+    sqlx::query(
+        "INSERT INTO events (aggregate_type, aggregate_id, sequence, \
+         event_type, event_version, payload, metadata) \
+         VALUES ('Position', 'RKLB', 1, 'PositionEvent::OnChainOrderFilled', '1.0', \
+         '{\"OnChainOrderFilled\":{}}', '{}')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let error = build_pnl_report(&pool, &query(), Vec::new(), Utc::now())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, PnlError::Ledger(PnlLedgerError::Stream(_))));
 }
 
 #[tokio::test]
 async fn source_loader_includes_persisted_cost_events() {
-    let pool = pnl_test_pool_with_costs(
-        Vec::new(),
-        position_rows(),
+    let mint_id = Uuid::new_v4().to_string();
+    let pool = pnl_test_pool(
         vec![
-            tokenized_mint_requested(10, "mint-1", "RKLB"),
-            tokenized_tokens_received(11, "mint-1", "0.25", "2026-05-15T12:02:00Z"),
+            SeedEvent::Mint(
+                mint_id.clone(),
+                mint_requested_event("RKLB", "2026-05-15T12:00:00Z"),
+            ),
+            SeedEvent::Mint(
+                mint_id,
+                tokens_received_event(Some("0.25"), "2026-05-15T12:02:00Z"),
+            ),
+            seed_rebalance("0.10", "2026-05-15T12:03:00Z"),
         ],
+        position_rows(),
     )
     .await;
 
@@ -1177,21 +1136,33 @@ async fn source_loader_includes_persisted_cost_events() {
         .await
         .unwrap();
 
-    assert_eq!(report.summary.tracked_costs_usd, "0.25");
+    assert_eq!(report.summary.tracked_costs_usd, "0.35");
     assert_eq!(report.costs.tokenization_fees_usd, "0.25");
-    assert_eq!(report.cost_entries.len(), 1);
-    assert_eq!(report.cost_entries[0].aggregate_type, "TokenizedEquityMint");
+    assert_eq!(report.costs.cctp_fees_usd, "0.1");
+    assert_eq!(report.cost_entries.len(), 2);
+    assert_eq!(report.cost_entries[0].aggregate_type, "UsdcRebalance");
+    assert_eq!(report.cost_entries[1].aggregate_type, "TokenizedEquityMint");
+    assert_eq!(
+        report.cost_entries[1].symbol.as_ref().map(Symbol::as_str),
+        Some("RKLB")
+    );
 }
 
 #[tokio::test]
 async fn source_loader_includes_persisted_bot_gas_costs() {
-    let pool = pnl_test_pool_with_costs(
+    let pool = pnl_test_pool(
         vec![
-            onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
-            offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
+            SeedEvent::Position(
+                "RKLB",
+                onchain_fill_event(Direction::Sell, "10", "1", "2026-05-15T14:00:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                offchain_fill_event(Direction::Buy, "8", "1", "2026-05-15T14:01:00Z"),
+            ),
+            seed_bot_gas(bot_gas_cost(float!(0.042))),
         ],
         position_rows(),
-        vec![bot_gas_recorded(3)],
     )
     .await;
 
@@ -1214,13 +1185,19 @@ async fn source_loader_includes_persisted_bot_gas_costs() {
 
 #[tokio::test]
 async fn source_loader_excludes_bot_gas_recorded_after_snapshot() {
-    let pool = pnl_test_pool_with_costs(
+    let pool = pnl_test_pool(
         vec![
-            onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
-            offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
+            SeedEvent::Position(
+                "RKLB",
+                onchain_fill_event(Direction::Sell, "10", "1", "2026-05-15T14:00:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                offchain_fill_event(Direction::Buy, "8", "1", "2026-05-15T14:01:00Z"),
+            ),
+            seed_bot_gas(bot_gas_cost(float!(0.042))),
         ],
         position_rows(),
-        vec![bot_gas_recorded(3)],
     )
     .await;
 
@@ -1243,11 +1220,9 @@ async fn source_loader_excludes_bot_gas_recorded_after_snapshot() {
 }
 
 #[tokio::test]
-async fn source_loader_rejects_non_positive_persisted_bot_gas_cost() {
-    for usd_cost in ["0", "-0.042"] {
-        let mut bot_gas = bot_gas_recorded(1);
-        bot_gas.payload["Recorded"]["cost"]["usd_cost"] = serde_json::json!(usd_cost);
-        let pool = pnl_test_pool_with_costs(Vec::new(), position_rows(), vec![bot_gas]).await;
+async fn ledger_ingestion_rejects_non_positive_persisted_bot_gas_cost() {
+    for usd_cost in [float!(0), float!(-0.042)] {
+        let pool = pnl_test_pool(vec![seed_bot_gas(bot_gas_cost(usd_cost))], position_rows()).await;
 
         let error = build_pnl_report(&pool, &query(), Vec::new(), Utc::now())
             .await
@@ -1256,30 +1231,46 @@ async fn source_loader_rejects_non_positive_persisted_bot_gas_cost() {
         assert!(
             matches!(
                 error,
-                PnlError::InvalidBotGasReceiptCost {
-                    source: crate::bot_gas::BotGasReceiptCostError::NonPositiveUsdCost,
-                    ..
-                }
+                PnlError::Ledger(PnlLedgerError::InvalidBotGasCost(
+                    BotGasReceiptCostError::NonPositiveUsdCost
+                ))
             ),
-            "unexpected result for persisted USD cost {usd_cost}"
+            "unexpected result for persisted USD cost {usd_cost:?}"
         );
     }
 }
 
 #[tokio::test]
 async fn source_loader_respects_as_of_rowid_for_position_and_cost_events() {
-    let pool = pnl_test_pool_with_costs(
+    let mint_id = Uuid::new_v4().to_string();
+    let pool = pnl_test_pool(
         vec![
-            onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
-            offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
-            onchain_sell(3, "20", "2026-05-15T15:00:00Z"),
-            offchain_buy(4, "2026-05-15T15:01:00Z", "17", "1"),
+            SeedEvent::Position(
+                "RKLB",
+                onchain_fill_event(Direction::Sell, "10", "1", "2026-05-15T14:00:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                offchain_fill_event(Direction::Buy, "8", "1", "2026-05-15T14:01:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                onchain_fill_event(Direction::Sell, "20", "1", "2026-05-15T15:00:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                offchain_fill_event(Direction::Buy, "17", "1", "2026-05-15T15:01:00Z"),
+            ),
+            SeedEvent::Mint(
+                mint_id.clone(),
+                mint_requested_event("RKLB", "2026-05-15T12:00:00Z"),
+            ),
+            SeedEvent::Mint(
+                mint_id,
+                tokens_received_event(Some("0.25"), "2026-05-15T12:02:00Z"),
+            ),
         ],
         position_rows(),
-        vec![
-            tokenized_mint_requested(10, "mint-1", "RKLB"),
-            tokenized_tokens_received(11, "mint-1", "0.25", "2026-05-15T12:02:00Z"),
-        ],
     )
     .await;
 
@@ -1305,7 +1296,10 @@ async fn source_loader_respects_as_of_rowid_for_position_and_cost_events() {
 #[tokio::test]
 async fn source_loader_rejects_future_as_of_rowid() {
     let pool = pnl_test_pool(
-        vec![onchain_sell(1, "10", "2026-05-15T14:00:00Z")],
+        vec![SeedEvent::Position(
+            "RKLB",
+            onchain_fill_event(Direction::Sell, "10", "1", "2026-05-15T14:00:00Z"),
+        )],
         position_rows(),
     )
     .await;
@@ -1325,22 +1319,15 @@ async fn source_loader_rejects_future_as_of_rowid() {
     assert!(matches!(error, PnlError::InvalidSnapshotRowid { value: 2 }));
 }
 
-#[tokio::test]
-async fn snapshot_preflight_rejects_future_as_of_rowid() {
-    let pool = pnl_test_pool(
-        vec![onchain_sell(1, "10", "2026-05-15T14:00:00Z")],
-        position_rows(),
-    )
-    .await;
-
+#[test]
+fn snapshot_preflight_rejects_future_as_of_rowid() {
     let error = validate_pnl_snapshot_rowid(
-        &pool,
+        LedgerHead(1),
         &PnlQuery {
             as_of_rowid: Some(2),
             ..query()
         },
     )
-    .await
     .unwrap_err();
 
     assert!(matches!(error, PnlError::InvalidSnapshotRowid { value: 2 }));
@@ -1382,15 +1369,15 @@ fn paginates_entries_without_changing_filtered_summary() {
             onchain_sell(3, "20", "2026-05-15T15:00:00Z"),
             offchain_buy(4, "2026-05-15T15:01:00Z", "17", "1"),
         ],
-        position_rows(),
-        Vec::new(),
-        Vec::new(),
-        PnlQuery {
+        &position_rows(),
+        &[],
+        &[],
+        &PnlQuery {
             limit: Some(1),
             offset: Some(0),
             ..query()
         },
-        BTreeSet::new(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.total, 2);
@@ -1408,14 +1395,14 @@ fn counter_trading_filter_keeps_rth_closes_only() {
             onchain_sell(3, "20", "2026-05-15T13:59:00Z"),
             offchain_buy(4, "2026-05-15T14:00:00Z", "17", "1"),
         ],
-        position_rows(),
-        Vec::new(),
-        Vec::new(),
-        PnlQuery {
+        &position_rows(),
+        &[],
+        &[],
+        &PnlQuery {
             counter_trading_filter: Some(PnlCounterTradingFilter::CounterTradingActive),
             ..query()
         },
-        BTreeSet::new(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.total_pnl_usd, "3");
@@ -1433,14 +1420,14 @@ fn counter_trading_filter_keeps_inactive_closes_only() {
             onchain_sell(3, "20", "2026-05-15T14:00:00Z"),
             offchain_buy(4, "2026-05-15T14:01:00Z", "17", "1"),
         ],
-        position_rows(),
-        Vec::new(),
-        Vec::new(),
-        PnlQuery {
+        &position_rows(),
+        &[],
+        &[],
+        &PnlQuery {
             counter_trading_filter: Some(PnlCounterTradingFilter::CounterTradingInactive),
             ..query()
         },
-        BTreeSet::new(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.total_pnl_usd, "2");
@@ -1461,14 +1448,14 @@ fn market_session_filter_is_independent_from_counter_trading_filter() {
             onchain_sell(3, "20", "2026-05-15T14:00:00Z"),
             offchain_buy(4, "2026-05-15T14:01:00Z", "17", "1"),
         ],
-        position_rows(),
-        Vec::new(),
-        Vec::new(),
-        PnlQuery {
+        &position_rows(),
+        &[],
+        &[],
+        &PnlQuery {
             market_session_filter: Some(PnlMarketSessionFilter::Rth),
             ..query()
         },
-        BTreeSet::new(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.total_pnl_usd, "3");
@@ -1510,14 +1497,14 @@ fn available_range_ignores_selected_date_and_session_filters() {
             onchain_sell(2, "11", "2026-05-15T14:00:00Z"),
             offchain_buy(3, "2026-05-16T14:00:00Z", "9", "1"),
         ],
-        position_rows(),
-        Vec::new(),
-        Vec::new(),
-        PnlQuery {
+        &position_rows(),
+        &[],
+        &[],
+        &PnlQuery {
             market_session_filter: Some(PnlMarketSessionFilter::Rth),
             ..query()
         },
-        BTreeSet::new(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(
@@ -1551,14 +1538,14 @@ fn filters_sample_stats_by_selected_market_session() {
             onchain_sell(3, "20", "2026-05-15T14:00:00Z"),
             offchain_buy(4, "2026-05-15T14:01:00Z", "17", "1"),
         ],
-        position_rows(),
-        Vec::new(),
-        Vec::new(),
-        PnlQuery {
+        &position_rows(),
+        &[],
+        &[],
+        &PnlQuery {
             market_session_filter: Some(PnlMarketSessionFilter::Pre),
             ..query()
         },
-        BTreeSet::new(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(
@@ -1581,17 +1568,17 @@ fn deducts_account_level_alpaca_fees_from_aggregate_only() {
             onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
             offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
         ],
-        position_rows(),
-        Vec::new(),
-        vec![account_activity(
+        &position_rows(),
+        &[],
+        &[account_activity(
             "fee-1",
             "FEE",
             "-0.25",
             None,
             "2026-05-15T14:02:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.gross_realized_pnl_usd, "2");
@@ -1610,34 +1597,38 @@ fn tracked_costs_follow_counter_trading_session_filter() {
             onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
             offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
         ],
-        position_rows(),
-        vec![
-            tokenized_mint_requested(10, "mint-1", "RKLB"),
-            tokenized_tokens_received(11, "mint-1", "0.25", "2026-05-15T12:02:00Z"),
-        ],
-        Vec::new(),
-        PnlQuery {
+        &position_rows(),
+        &[tokenization_fee(
+            11,
+            "mint-1",
+            Some("0.25"),
+            "2026-05-15T12:02:00Z",
+        )],
+        &[],
+        &PnlQuery {
             counter_trading_filter: Some(PnlCounterTradingFilter::CounterTradingActive),
             ..query()
         },
-        BTreeSet::new(),
+        &BTreeSet::new(),
     );
     let inactive_report = report_with(
         vec![
             onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
             offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
         ],
-        position_rows(),
-        vec![
-            tokenized_mint_requested(10, "mint-1", "RKLB"),
-            tokenized_tokens_received(11, "mint-1", "0.25", "2026-05-15T12:02:00Z"),
-        ],
-        Vec::new(),
-        PnlQuery {
+        &position_rows(),
+        &[tokenization_fee(
+            11,
+            "mint-1",
+            Some("0.25"),
+            "2026-05-15T12:02:00Z",
+        )],
+        &[],
+        &PnlQuery {
             counter_trading_filter: Some(PnlCounterTradingFilter::CounterTradingInactive),
             ..query()
         },
-        BTreeSet::new(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(active_report.summary.gross_realized_pnl_usd, "2");
@@ -1652,17 +1643,16 @@ fn tracked_costs_follow_counter_trading_session_filter() {
 }
 
 #[test]
-fn wrong_typed_tokenization_fee_decimals_fail_the_report() {
-    let mut cost = tokenized_tokens_received(11, "mint-1", "0.25", "2026-05-15T12:02:00Z");
-    cost.payload["TokensReceived"]["fees"] = serde_json::json!([]);
+fn corrupt_tokenization_fee_decimals_fail_the_report() {
+    let cost = tokenization_fee(11, "mint-1", Some("not-a-decimal"), "2026-05-15T12:02:00Z");
 
     let error = report_with_result(
         Vec::new(),
-        position_rows(),
-        vec![tokenized_mint_requested(10, "mint-1", "RKLB"), cost],
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[cost],
+        &[],
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 
@@ -1670,29 +1660,28 @@ fn wrong_typed_tokenization_fee_decimals_fail_the_report() {
         error,
         PnlError::InvalidFinancialField {
             rowid: 11,
-            field: "fees",
+            field: "amount_usd",
             ..
         }
     ));
 }
 
 /// `TokensReceived.fees` is `Option<Float>` in the event schema ("if
-/// reported"), so persisted events legitimately carry `fees: null`. The
+/// reported"), so the ledger persists a NULL `amount_usd` for that case. The
 /// report must treat that as a missing cost observation -- skipping the
 /// entry and counting it -- not fail wholesale, which blanks /pnl for as
-/// long as the event exists.
+/// long as the row exists.
 #[test]
 fn null_tokenization_fees_are_missing_observations_not_fatal() {
-    let mut cost = tokenized_tokens_received(11, "mint-1", "0.25", "2026-05-15T12:02:00Z");
-    cost.payload["TokensReceived"]["fees"] = serde_json::json!(null);
+    let cost = tokenization_fee(11, "mint-1", None, "2026-05-15T12:02:00Z");
 
     let report = report_with_result(
         Vec::new(),
-        position_rows(),
-        vec![tokenized_mint_requested(10, "mint-1", "RKLB"), cost],
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[cost],
+        &[],
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap();
 
@@ -1701,75 +1690,40 @@ fn null_tokenization_fees_are_missing_observations_not_fatal() {
     assert_eq!(report.costs.missing_cost_observation_count, 1);
 }
 
-/// Events persisted before the `fees` field existed deserialize through
-/// `#[serde(default)]` in the aggregate, so an absent key is the same
-/// "not reported" case as an explicit null.
+/// Multiple fee-bearing events of one mint aggregate each produce a ledger
+/// row; when none reports fees, the mint still counts as exactly one missing
+/// observation.
 #[test]
-fn absent_tokenization_fees_are_missing_observations_not_fatal() {
-    let mut missing_fees = tokenized_tokens_received(11, "mint-1", "0.25", "2026-05-15T12:02:00Z");
-    missing_fees.payload["TokensReceived"]
-        .as_object_mut()
-        .unwrap()
-        .remove("fees");
-
+fn repeated_missing_tokenization_fees_count_once_per_mint() {
     let report = report_with_result(
         Vec::new(),
-        position_rows(),
-        vec![tokenized_mint_requested(10, "mint-1", "RKLB"), missing_fees],
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
-    )
-    .unwrap();
-
-    assert_eq!(report.costs.tokenization_fees_usd, "0");
-    assert_eq!(report.cost_entries.len(), 0);
-    assert_eq!(report.costs.missing_cost_observation_count, 1);
-}
-
-#[test]
-fn missing_tokenization_fee_timestamp_fails_the_report() {
-    let mut missing_timestamp =
-        tokenized_tokens_received(12, "mint-2", "0.25", "2026-05-15T12:02:00Z");
-    missing_timestamp.payload["TokensReceived"]
-        .as_object_mut()
-        .unwrap()
-        .remove("received_at");
-
-    let error = report_with_result(
-        Vec::new(),
-        position_rows(),
-        vec![
-            tokenized_mint_requested(10, "mint-2", "RKLB"),
-            missing_timestamp,
+        &position_rows(),
+        &[
+            tokenization_fee(11, "mint-1", None, "2026-05-15T12:02:00Z"),
+            tokenization_fee(12, "mint-1", None, "2026-05-15T12:03:00Z"),
         ],
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &[],
+        &query(),
+        &BTreeSet::new(),
     )
-    .unwrap_err();
-    assert!(matches!(
-        error,
-        PnlError::MalformedPayload {
-            rowid: 12,
-            reason: "missing tokenization fee timestamp",
-            ..
-        }
-    ));
+    .unwrap();
+
+    assert_eq!(report.costs.tokenization_fees_usd, "0");
+    assert_eq!(report.cost_entries.len(), 0);
+    assert_eq!(report.costs.missing_cost_observation_count, 1);
 }
 
 #[test]
-fn wrong_typed_cctp_fee_decimals_fail_the_report() {
-    let mut cost = usdc_bridged(11, "bridge-1", "0.25", "2026-05-15T12:02:00Z");
-    cost.payload["Bridged"]["fee_collected"] = serde_json::json!({});
+fn corrupt_cctp_fee_decimals_fail_the_report() {
+    let cost = cctp_fee(11, "bridge-1", "not-a-decimal", "2026-05-15T12:02:00Z");
 
     let error = report_with_result(
         Vec::new(),
-        position_rows(),
-        vec![cost],
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[cost],
+        &[],
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 
@@ -1777,59 +1731,42 @@ fn wrong_typed_cctp_fee_decimals_fail_the_report() {
         error,
         PnlError::InvalidFinancialField {
             rowid: 11,
-            field: "fee_collected",
+            field: "amount_usd",
             ..
         }
     ));
 }
 
+/// The ledger schema forbids a CCTP fee row without an amount (`CHECK`), so
+/// encountering one at query time is a corrupt-row failure, not a missing
+/// observation.
 #[test]
-fn missing_cctp_fee_fields_fail_the_report() {
-    let mut missing_fee = usdc_bridged(11, "bridge-1", "0.25", "2026-05-15T12:02:00Z");
-    missing_fee.payload["Bridged"]
-        .as_object_mut()
-        .unwrap()
-        .remove("fee_collected");
+fn missing_cctp_fee_amount_fails_the_report() {
+    let missing_fee = CostLedgerRow {
+        event_rowid: 11,
+        source: CostSource::CctpFee,
+        aggregate_id: "bridge-1".to_owned(),
+        symbol: None,
+        amount_usd: None,
+        occurred_at: "2026-05-15T12:02:00Z".to_owned(),
+    };
 
     let error = report_with_result(
         Vec::new(),
-        position_rows(),
-        vec![missing_fee],
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[missing_fee],
+        &[],
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
+
     assert!(matches!(
         error,
-        PnlError::MalformedPayload {
+        PnlError::InvalidLedgerRow {
+            table: "pnl_cost_entry",
             rowid: 11,
-            reason: "missing CCTP fee_collected or timestamp",
-            ..
-        }
-    ));
-
-    let mut missing_timestamp = usdc_bridged(12, "bridge-2", "0.25", "2026-05-15T12:02:00Z");
-    missing_timestamp.payload["Bridged"]
-        .as_object_mut()
-        .unwrap()
-        .remove("minted_at");
-
-    let error = report_with_result(
-        Vec::new(),
-        position_rows(),
-        vec![missing_timestamp],
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
-    )
-    .unwrap_err();
-    assert!(matches!(
-        error,
-        PnlError::MalformedPayload {
-            rowid: 12,
-            reason: "missing CCTP fee_collected or timestamp",
-            ..
+            reason: "cctp fee row missing amount",
         }
     ));
 }
@@ -1838,34 +1775,34 @@ fn missing_cctp_fee_fields_fail_the_report() {
 fn date_only_alpaca_activities_are_not_forced_into_session_filters() {
     let all_sessions = report_with(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![date_only_account_activity(
+        &position_rows(),
+        &[],
+        &[date_only_account_activity(
             "fee-date-only",
             "FEE",
             "-0.25",
             None,
             "2026-05-15",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
     let active_only = report_with(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![date_only_account_activity(
+        &position_rows(),
+        &[],
+        &[date_only_account_activity(
             "fee-date-only",
             "FEE",
             "-0.25",
             None,
             "2026-05-15",
         )],
-        PnlQuery {
+        &PnlQuery {
             counter_trading_filter: Some(PnlCounterTradingFilter::CounterTradingActive),
             ..query()
         },
-        BTreeSet::new(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(all_sessions.summary.tracked_costs_usd, "0.25");
@@ -1878,17 +1815,17 @@ fn date_only_alpaca_activities_are_not_forced_into_session_filters() {
 fn adds_symbol_dividends_to_aggregate_and_symbol_net_pnl() {
     let report = report_with(
         Vec::new(),
-        vec![position_row("SGOV", "0")],
-        Vec::new(),
-        vec![account_activity(
+        &[position_row("SGOV", "0")],
+        &[],
+        &[account_activity(
             "div-1",
             "DIV",
             "1.25",
             Some("SGOV"),
             "2026-05-15T14:02:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.gross_realized_pnl_usd, "0");
@@ -1904,17 +1841,17 @@ fn adds_symbol_dividends_to_aggregate_and_symbol_net_pnl() {
 fn capital_gain_distributions_are_tracked_as_dividend_revenue() {
     let report = report_with(
         Vec::new(),
-        vec![position_row("SGOV", "0")],
-        Vec::new(),
-        vec![account_activity(
+        &[position_row("SGOV", "0")],
+        &[],
+        &[account_activity(
             "cgd-1",
             "CGD",
             "1.25",
             Some("SGOV"),
             "2026-05-15T14:02:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_revenue_usd, "1.25");
@@ -1926,17 +1863,17 @@ fn capital_gain_distributions_are_tracked_as_dividend_revenue() {
 fn cash_in_lieu_rows_are_tracked_as_dividend_revenue() {
     let report = report_with(
         Vec::new(),
-        vec![position_row("SGOV", "0")],
-        Vec::new(),
-        vec![account_activity(
+        &[position_row("SGOV", "0")],
+        &[],
+        &[account_activity(
             "cil-1",
             "CIL",
             "0.42",
             Some("SGOV"),
             "2026-05-15T14:02:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_revenue_usd, "0.42");
@@ -1951,11 +1888,11 @@ fn non_usd_alpaca_activities_fail_the_report() {
 
     let error = report_with_result(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![activity],
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[],
+        &[activity],
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 
@@ -1982,11 +1919,11 @@ fn canceled_alpaca_activities_are_skipped() {
 
     let report = report_with(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![activity],
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[],
+        &[activity],
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0");
@@ -2011,11 +1948,11 @@ fn corrected_alpaca_activities_are_included() {
 
     let report = report_with(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![activity],
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[],
+        &[activity],
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0.25");
@@ -2026,17 +1963,17 @@ fn corrected_alpaca_activities_are_included() {
 fn records_negative_dividend_rows_as_account_costs() {
     let report = report_with(
         Vec::new(),
-        vec![position_row("SGOV", "0")],
-        Vec::new(),
-        vec![account_activity(
+        &[position_row("SGOV", "0")],
+        &[],
+        &[account_activity(
             "div-tax-1",
             "DIVNRA",
             "-0.15",
             Some("SGOV"),
             "2026-05-15T14:02:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0.15");
@@ -2061,11 +1998,11 @@ fn malformed_alpaca_activity_amounts_fail_the_report() {
 
     let error = report_with_result(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![missing_amount],
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[],
+        &[missing_amount],
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
     assert!(matches!(
@@ -2079,17 +2016,17 @@ fn malformed_alpaca_activity_amounts_fail_the_report() {
 
     let error = report_with_result(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![account_activity(
+        &position_rows(),
+        &[],
+        &[account_activity(
             "bad-amount-1",
             "FEE",
             "not-a-decimal",
             None,
             "2026-05-15T14:03:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
     assert!(matches!(
@@ -2117,11 +2054,11 @@ fn malformed_alpaca_activity_timestamps_and_types_fail_the_report() {
 
     let error = report_with_result(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![missing_timestamp],
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[],
+        &[missing_timestamp],
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
     assert!(matches!(
@@ -2135,17 +2072,17 @@ fn malformed_alpaca_activity_timestamps_and_types_fail_the_report() {
 
     let error = report_with_result(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![account_activity(
+        &position_rows(),
+        &[],
+        &[account_activity(
             "unknown-1",
             "UNKNOWN",
             "-0.5",
             None,
             "2026-05-15T14:04:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
     assert!(matches!(
@@ -2167,11 +2104,11 @@ fn malformed_alpaca_activity_timestamps_and_types_fail_the_report() {
     unsupported_status.status = Some("pending_review".to_owned());
     let error = report_with_result(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![unsupported_status],
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[],
+        &[unsupported_status],
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
     assert!(matches!(
@@ -2188,17 +2125,17 @@ fn malformed_alpaca_activity_timestamps_and_types_fail_the_report() {
 fn zero_alpaca_activity_amounts_are_ignored() {
     let report = report_with(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![account_activity(
+        &position_rows(),
+        &[],
+        &[account_activity(
             "zero-fee-1",
             "FEE",
             "0",
             None,
             "2026-05-15T14:03:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0");
@@ -2210,17 +2147,17 @@ fn zero_alpaca_activity_amounts_are_ignored() {
 fn records_pass_through_credits_as_counter_trade_revenue() {
     let report = report_with(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![account_activity(
+        &position_rows(),
+        &[],
+        &[account_activity(
             "pass-through-credit-1",
             "PTC",
             "0.12",
             None,
             "2026-05-15T14:02:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0");
@@ -2234,17 +2171,17 @@ fn records_pass_through_credits_as_counter_trade_revenue() {
 fn records_positive_fee_rows_as_counter_trade_revenue() {
     let report = report_with(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![account_activity(
+        &position_rows(),
+        &[],
+        &[account_activity(
             "fee-credit-1",
             "FEE",
             "0.12",
             None,
             "2026-05-15T14:02:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0");
@@ -2258,17 +2195,17 @@ fn records_positive_fee_rows_as_counter_trade_revenue() {
 fn records_cash_disbursement_rows_as_generic_revenue() {
     let report = report_with(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![account_activity(
+        &position_rows(),
+        &[],
+        &[account_activity(
             "cash-credit-1",
             "CSD",
             "1.00",
             None,
             "2026-05-15T14:02:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0");
@@ -2282,9 +2219,9 @@ fn records_cash_disbursement_rows_as_generic_revenue() {
 fn broker_fees_and_interest_categories_net_debits_against_credits() {
     let report = report_with(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![
+        &position_rows(),
+        &[],
+        &[
             account_activity("fee-debit-1", "FEE", "-0.25", None, "2026-05-15T14:02:00Z"),
             account_activity("fee-credit-1", "FEE", "0.25", None, "2026-05-15T14:03:00Z"),
             account_activity(
@@ -2302,8 +2239,8 @@ fn broker_fees_and_interest_categories_net_debits_against_credits() {
                 "2026-05-15T14:05:00Z",
             ),
         ],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0.75");
@@ -2333,15 +2270,15 @@ fn alpaca_net_amount_parses_the_official_account_activity_sample() {
 
     let report = report_with(
         Vec::new(),
-        vec![position_row("T", "0")],
-        Vec::new(),
-        vec![activity],
-        PnlQuery {
+        &[position_row("T", "0")],
+        &[],
+        &[activity],
+        &PnlQuery {
             from_date: Some("2019-08-01".to_owned()),
             to_date: Some("2019-08-01".to_owned()),
             ..query()
         },
-        BTreeSet::new(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.costs.dividend_revenue_usd, "1.02");
@@ -2366,15 +2303,15 @@ fn alpaca_net_amount_deserializes_signed_cost_values() {
 
     let report = report_with(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![activity],
-        PnlQuery {
+        &position_rows(),
+        &[],
+        &[activity],
+        &PnlQuery {
             from_date: Some("2019-08-01".to_owned()),
             to_date: Some("2019-08-01".to_owned()),
             ..query()
         },
-        BTreeSet::new(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.costs.margin_interest_usd, "0.25");
@@ -2394,18 +2331,24 @@ fn matches_legacy_frontend_sql_fixture_for_stable_report_fields() {
             offchain_buy(6, "2026-05-15T14:10:01Z", "25", "1"),
             offchain_buy(7, "2026-05-15T14:11:00Z", "12", "1"),
             onchain_sell(8, "15", "2026-05-15T14:12:00Z"),
-            onchain_fill(9, "SPYM", "Buy", "80", "2", "2026-05-15T14:13:00Z"),
-            offchain_fill(10, "SPYM", "Sell", "2026-05-15T14:14:00Z", "85", "1.5"),
+            onchain_fill(9, "SPYM", Direction::Buy, "80", "2", "2026-05-15T14:13:00Z"),
+            offchain_fill(
+                10,
+                "SPYM",
+                Direction::Sell,
+                "2026-05-15T14:14:00Z",
+                "85",
+                "1.5",
+            ),
         ],
-        vec![position_row("RKLB", "0"), position_row("SPYM", "0.5")],
-        vec![
-            tokenized_mint_requested(20, "mint-rklb-1", "RKLB"),
-            tokenized_tokens_received(21, "mint-rklb-1", "0.25", "2026-05-15T14:15:00Z"),
-            usdc_bridged(22, "rebalance-1", "0.01", "2026-05-15T14:16:00Z"),
+        &[position_row("RKLB", "0"), position_row("SPYM", "0.5")],
+        &[
+            tokenization_fee(21, "mint-rklb-1", Some("0.25"), "2026-05-15T14:15:00Z"),
+            cctp_fee(22, "rebalance-1", "0.01", "2026-05-15T14:16:00Z"),
         ],
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &[],
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_legacy_fixture_summary(&report);
@@ -2582,17 +2525,17 @@ fn assert_legacy_fixture_windows(report: &PnlResponse) {
 fn records_margin_interest_as_generic_account_cost() {
     let report = report_with(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![account_activity(
+        &position_rows(),
+        &[],
+        &[account_activity(
             "interest-1",
             "INT",
             "-0.50",
             None,
             "2026-05-15T14:02:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0.5");
@@ -2605,15 +2548,14 @@ fn records_margin_interest_as_generic_account_cost() {
 fn includes_tokenization_and_cctp_cost_events() {
     let report = report_with(
         Vec::new(),
-        position_rows(),
-        vec![
-            tokenized_mint_requested(1, "mint-1", "RKLB"),
-            tokenized_tokens_received(2, "mint-1", "0.40", "2026-05-15T14:02:00Z"),
-            usdc_bridged(3, "rebalance-1", "0.10", "2026-05-15T14:03:00Z"),
+        &position_rows(),
+        &[
+            tokenization_fee(2, "mint-1", Some("0.40"), "2026-05-15T14:02:00Z"),
+            cctp_fee(3, "rebalance-1", "0.10", "2026-05-15T14:03:00Z"),
         ],
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &[],
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0.5");
@@ -2629,14 +2571,16 @@ fn includes_tokenization_and_cctp_cost_events() {
 fn negative_persisted_fees_fail_instead_of_reversing_their_accounting_effect() {
     let tokenization_error = report_with_result(
         Vec::new(),
-        position_rows(),
-        vec![
-            tokenized_mint_requested(1, "mint-1", "RKLB"),
-            tokenized_tokens_received(2, "mint-1", "-0.40", "2026-05-15T14:02:00Z"),
-        ],
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[tokenization_fee(
+            2,
+            "mint-1",
+            Some("-0.40"),
+            "2026-05-15T14:02:00Z",
+        )],
+        &[],
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 
@@ -2652,16 +2596,11 @@ fn negative_persisted_fees_fail_instead_of_reversing_their_accounting_effect() {
 
     let cctp_error = report_with_result(
         Vec::new(),
-        position_rows(),
-        vec![usdc_bridged(
-            3,
-            "rebalance-1",
-            "-0.10",
-            "2026-05-15T14:03:00Z",
-        )],
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &position_rows(),
+        &[cctp_fee(3, "rebalance-1", "-0.10", "2026-05-15T14:03:00Z")],
+        &[],
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 
@@ -2680,15 +2619,14 @@ fn negative_persisted_fees_fail_instead_of_reversing_their_accounting_effect() {
 fn de_duplicates_recovered_tokenization_fee_by_mint_identity() {
     let report = report_with(
         Vec::new(),
-        position_rows(),
-        vec![
-            tokenized_mint_requested(1, "mint-1", "RKLB"),
-            tokenized_tokens_received(2, "mint-1", "0.40", "2026-05-15T14:02:00Z"),
-            tokenized_provider_completion_recovered(3, "mint-1", "0.40", "2026-05-15T14:03:00Z"),
+        &position_rows(),
+        &[
+            tokenization_fee(2, "mint-1", Some("0.40"), "2026-05-15T14:02:00Z"),
+            tokenization_fee(3, "mint-1", Some("0.40"), "2026-05-15T14:03:00Z"),
         ],
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &[],
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0.4");
@@ -2703,20 +2641,22 @@ fn de_duplicates_recovered_tokenization_fee_by_mint_identity() {
 fn de_duplicates_overlapping_alpaca_fee_against_tokenization_fee() {
     let report = report_with(
         Vec::new(),
-        position_rows(),
-        vec![
-            tokenized_mint_requested(1, "mint-1", "RKLB"),
-            tokenized_tokens_received(2, "mint-1", "0.40", "2026-05-15T14:02:00Z"),
-        ],
-        vec![account_activity(
+        &position_rows(),
+        &[tokenization_fee(
+            2,
+            "mint-1",
+            Some("0.40"),
+            "2026-05-15T14:02:00Z",
+        )],
+        &[account_activity(
             "alpaca-fee-1",
             "FEE",
             "-0.40",
             Some("RKLB"),
             "2026-05-15T16:30:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0.4");
@@ -2740,11 +2680,11 @@ fn keeps_symbol_universe_separate_from_filtered_pnl_rows() {
             onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
             offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
         ],
-        vec![position_row("RKLB", "0"), position_row("SPYM", "0")],
-        Vec::new(),
-        Vec::new(),
-        query(),
-        symbols,
+        &[position_row("RKLB", "0"), position_row("SPYM", "0")],
+        &[],
+        &[],
+        &query(),
+        &symbols,
     );
 
     assert_eq!(
@@ -2768,17 +2708,17 @@ fn symbol_filter_excludes_unallocated_account_level_costs() {
             onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
             offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
         ],
-        position_rows(),
-        Vec::new(),
-        vec![account_activity(
+        &position_rows(),
+        &[],
+        &[account_activity(
             "fee-1",
             "FEE",
             "-0.25",
             None,
             "2026-05-15T14:02:00Z",
         )],
-        query(),
-        symbols,
+        &query(),
+        &symbols,
     );
 
     assert_eq!(report.summary.tracked_costs_usd, "0");
@@ -2790,22 +2730,26 @@ fn symbol_filter_excludes_unallocated_account_level_costs() {
 fn drops_unsafe_symbols_from_replay_rows_and_position_view() {
     let report = report_with(
         vec![
-            PositionEventRow {
-                symbol: "RKLB'); DROP TABLE events; --".to_owned(),
-                ..onchain_sell(1, "10", "2026-05-15T14:00:00Z")
-            },
+            onchain_fill(
+                1,
+                "RKLB'); DROP TABLE events; --",
+                Direction::Sell,
+                "10",
+                "1",
+                "2026-05-15T14:00:00Z",
+            ),
             onchain_sell(2, "10", "2026-05-15T14:00:00Z"),
             offchain_buy(3, "2026-05-15T14:01:00Z", "8", "1"),
         ],
-        vec![
+        &[
             position_row("RKLB", "0"),
             position_row("SPYM", "0"),
             position_row("BAD';--", "0"),
         ],
-        Vec::new(),
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &[],
+        &[],
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.summary.counter_trade_pnl_usd, "2");
@@ -2877,14 +2821,14 @@ fn reports_position_view_reconciliation_delta() {
 fn invalid_position_view_decimal_fails_the_report() {
     let error = report_with_result(
         Vec::new(),
-        vec![PositionViewRow {
+        &[PositionViewRow {
             symbol: "RKLB".to_owned(),
             net_position: Some("not-a-decimal".to_owned()),
         }],
-        Vec::new(),
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &[],
+        &[],
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 
@@ -2996,12 +2940,30 @@ async fn build_pnl_report_populates_capital_when_snapshots_exist() {
 async fn return_uses_only_pnl_from_days_with_usable_capital() {
     let pool = pnl_test_pool(
         vec![
-            onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
-            offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
-            onchain_sell(3, "110", "2026-05-16T14:00:00Z"),
-            offchain_buy(4, "2026-05-16T14:01:00Z", "10", "1"),
-            onchain_sell(5, "10", "2026-05-17T14:00:00Z"),
-            offchain_buy(6, "2026-05-17T14:01:00Z", "8", "1"),
+            SeedEvent::Position(
+                "RKLB",
+                onchain_fill_event(Direction::Sell, "10", "1", "2026-05-15T14:00:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                offchain_fill_event(Direction::Buy, "8", "1", "2026-05-15T14:01:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                onchain_fill_event(Direction::Sell, "110", "1", "2026-05-16T14:00:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                offchain_fill_event(Direction::Buy, "10", "1", "2026-05-16T14:01:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                onchain_fill_event(Direction::Sell, "10", "1", "2026-05-17T14:00:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                offchain_fill_event(Direction::Buy, "8", "1", "2026-05-17T14:01:00Z"),
+            ),
         ],
         position_rows(),
     )
@@ -3058,15 +3020,24 @@ async fn high_precision_derived_prices_do_not_break_the_capital_calculation() {
 
     let pool = pnl_test_pool(
         vec![
-            onchain_fill(
-                1,
+            SeedEvent::Position(
                 "RKLB",
-                "Sell",
-                DERIVED_PRICE,
-                "0.029847962456751639",
-                "2026-05-15T14:00:00Z",
+                onchain_fill_event(
+                    Direction::Sell,
+                    DERIVED_PRICE,
+                    "0.029847962456751639",
+                    "2026-05-15T14:00:00Z",
+                ),
             ),
-            offchain_buy(2, "2026-05-15T14:01:00Z", "66.888", "0.029847962456751639"),
+            SeedEvent::Position(
+                "RKLB",
+                offchain_fill_event(
+                    Direction::Buy,
+                    "66.888",
+                    "0.029847962456751639",
+                    "2026-05-15T14:01:00Z",
+                ),
+            ),
         ],
         position_rows(),
     )
@@ -3110,13 +3081,19 @@ async fn high_precision_derived_prices_do_not_break_the_capital_calculation() {
 
 #[tokio::test]
 async fn return_excludes_signed_cost_effects_from_days_without_usable_capital() {
-    let pool = pnl_test_pool_with_costs(
-        Vec::new(),
-        position_rows(),
+    let mint_id = Uuid::new_v4().to_string();
+    let pool = pnl_test_pool(
         vec![
-            tokenized_mint_requested(1, "mint-excluded-day", "RKLB"),
-            tokenized_tokens_received(2, "mint-excluded-day", "100", "2026-05-16T14:02:00Z"),
+            SeedEvent::Mint(
+                mint_id.clone(),
+                mint_requested_event("RKLB", "2026-05-16T14:00:00Z"),
+            ),
+            SeedEvent::Mint(
+                mint_id,
+                tokens_received_event(Some("100"), "2026-05-16T14:02:00Z"),
+            ),
         ],
+        position_rows(),
     )
     .await;
     for et_day in ["2026-05-15", "2026-05-17"] {
@@ -3310,8 +3287,14 @@ async fn build_pnl_report_empty_symbol_param_preserves_capital() {
 async fn build_pnl_report_as_of_rowid_non_current_omits_capital_with_warning() {
     let pool = pnl_test_pool(
         vec![
-            onchain_sell(1, "10", "2026-05-15T14:00:00Z"),
-            offchain_buy(2, "2026-05-15T14:01:00Z", "8", "1"),
+            SeedEvent::Position(
+                "RKLB",
+                onchain_fill_event(Direction::Sell, "10", "1", "2026-05-15T14:00:00Z"),
+            ),
+            SeedEvent::Position(
+                "RKLB",
+                offchain_fill_event(Direction::Buy, "8", "1", "2026-05-15T14:01:00Z"),
+            ),
         ],
         position_rows(),
     )
@@ -3414,14 +3397,14 @@ fn cost_summarization_surfaces_float_overflow_as_arithmetic_error() {
     let amount = max_positive_float_text();
     let error = report_with_result(
         Vec::new(),
-        position_rows(),
-        Vec::new(),
-        vec![
+        &position_rows(),
+        &[],
+        &[
             account_activity("div-1", "DIV", &amount, None, "2026-05-15T14:00:00Z"),
             account_activity("div-2", "DIV", &amount, None, "2026-05-15T14:01:00Z"),
         ],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 
@@ -3439,17 +3422,17 @@ fn daily_report_aggregation_surfaces_float_overflow_as_arithmetic_error() {
             onchain_sell(1, &amount, "2026-05-15T14:00:00Z"),
             offchain_buy(2, "2026-05-15T14:01:00Z", "1", "1"),
         ],
-        position_rows(),
-        Vec::new(),
-        vec![account_activity(
+        &position_rows(),
+        &[],
+        &[account_activity(
             "div-1",
             "DIV",
             &amount,
             None,
             "2026-05-15T14:02:00Z",
         )],
-        query(),
-        BTreeSet::new(),
+        &query(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 
@@ -3486,7 +3469,7 @@ async fn float_exponent_overflow_in_the_replay_pipeline_surfaces_as_arithmetic_e
         onchain_fill(
             1,
             "RKLB",
-            "Sell",
+            Direction::Sell,
             extreme_price,
             "1e2",
             "2026-05-15T14:00:00Z",
@@ -3502,11 +3485,11 @@ async fn float_exponent_overflow_in_the_replay_pipeline_surfaces_as_arithmetic_e
 fn report_includes_a_replay_only_open_position_in_symbol_summaries() {
     let report = report_with(
         vec![offchain_buy(1, "2026-05-15T14:01:00Z", "15", "2")],
-        vec![position_row("RKLB", "2")],
-        Vec::new(),
-        Vec::new(),
-        query(),
-        BTreeSet::new(),
+        &[position_row("RKLB", "2")],
+        &[],
+        &[],
+        &query(),
+        &BTreeSet::new(),
     );
 
     assert_eq!(report.symbols.len(), 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,7 @@ pub(crate) struct AppState {
     pub(crate) recovery: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
     pub(crate) resume_lock: Arc<api::ResumeLock>,
     pub(crate) pnl_report_admission: dashboard::pnl::PnlReportAdmission,
+    pub(crate) pnl_ledger: Arc<dashboard::pnl::PnlLedger>,
     pub(crate) metrics_handle: PrometheusHandle,
 }
 
@@ -232,6 +233,11 @@ async fn run_bot_session_inner(
         apalis: apalis_pool,
     };
 
+    // One shared ledger instance: the conductor's boot catch-up/reactor and
+    // the /pnl handler's per-request catch-up serialize on its internal
+    // ingestion mutex instead of racing as separate ingesters.
+    let pnl_ledger = Arc::new(dashboard::pnl::PnlLedger::new(pools.cqrs.clone()));
+
     let state = AppState {
         ctx: ctx.clone(),
         pool: pools.cqrs.clone(),
@@ -241,16 +247,20 @@ async fn run_bot_session_inner(
         recovery: recovery_cell.clone(),
         resume_lock,
         pnl_report_admission: dashboard::pnl::pnl_report_admission(),
+        pnl_ledger: pnl_ledger.clone(),
         metrics_handle,
     };
     let server_supervisor = spawn_server_supervisor(state, &pools, main_listener, board_listener);
     let bot_task = tokio::spawn(Box::pin(run_conductor_session(
         ctx,
         pools,
-        event_sender,
-        inventory,
+        conductor::ServerHandles {
+            event_sender,
+            inventory,
+            recovery_cell,
+            pnl_ledger,
+        },
         shutdown_token.clone(),
-        recovery_cell,
         #[cfg(any(test, feature = "test-support"))]
         failure_injector,
     )));
@@ -512,10 +522,8 @@ fn check_bot_result(result: Result<anyhow::Result<()>, JoinError>) -> anyhow::Re
 async fn run_conductor_session(
     ctx: Ctx,
     pools: DatabasePools,
-    event_sender: broadcast::Sender<Statement>,
-    inventory: Arc<inventory::BroadcastingInventory>,
+    server: conductor::ServerHandles,
     shutdown_token: tokio_util::sync::CancellationToken,
-    recovery_cell: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> anyhow::Result<()> {
     let result = match ctx.broker.clone() {
@@ -526,10 +534,8 @@ async fn run_conductor_session(
                 MockExecutorCtx,
                 ctx,
                 pools,
-                event_sender,
-                inventory,
+                server,
                 shutdown_token,
-                recovery_cell,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector,
             ))
@@ -541,10 +547,8 @@ async fn run_conductor_session(
                 alpaca_auth,
                 ctx,
                 pools,
-                event_sender,
-                inventory,
+                server,
                 shutdown_token,
-                recovery_cell,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector,
             ))
@@ -745,13 +749,16 @@ mod tests {
         let error = Box::pin(run_conductor_session(
             ctx,
             DatabasePools {
-                cqrs: pool,
+                cqrs: pool.clone(),
                 apalis: apalis_pool,
             },
-            create_test_event_sender(),
-            create_test_inventory(),
+            conductor::ServerHandles {
+                event_sender: create_test_event_sender(),
+                inventory: create_test_inventory(),
+                recovery_cell: Arc::new(tokio::sync::OnceCell::new()),
+                pnl_ledger: Arc::new(dashboard::pnl::PnlLedger::new(pool)),
+            },
             tokio_util::sync::CancellationToken::new(),
-            Arc::new(tokio::sync::OnceCell::new()),
             FailureInjector::new(),
         ))
         .await
@@ -775,13 +782,16 @@ mod tests {
         let error = Box::pin(run_conductor_session(
             ctx,
             DatabasePools {
-                cqrs: pool,
+                cqrs: pool.clone(),
                 apalis: apalis_pool,
             },
-            create_test_event_sender(),
-            create_test_inventory(),
+            conductor::ServerHandles {
+                event_sender: create_test_event_sender(),
+                inventory: create_test_inventory(),
+                recovery_cell: Arc::new(tokio::sync::OnceCell::new()),
+                pnl_ledger: Arc::new(dashboard::pnl::PnlLedger::new(pool)),
+            },
             tokio_util::sync::CancellationToken::new(),
-            Arc::new(tokio::sync::OnceCell::new()),
             FailureInjector::new(),
         ))
         .await

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -16,6 +16,7 @@ use std::sync::{Condvar, LazyLock, Mutex};
 use std::time::Duration;
 
 use st0x_config::{EquitiesConfig, EquityAssetConfig, OperationMode};
+use st0x_event_sorcery::{DomainEvent, EventSourced};
 use st0x_execution::{Direction, FractionalShares, Positive, Symbol};
 
 use crate::bindings::IRaindexV6::{EvaluableV4, IOV2, OrderV4};
@@ -323,6 +324,38 @@ pub(crate) async fn setup_test_apalis_pool() -> apalis_sqlite::SqlitePool {
 /// Creates an in-memory SQLite database with all migrations applied.
 pub(crate) async fn setup_test_db() -> SqlitePool {
     setup_test_pools().await.0
+}
+
+/// Persists a typed event directly into the `events` table.
+///
+/// Deliberate, fixture-only deviation from the "never write the events table
+/// directly" rule: the PnL ledger ingester's input contract is the persisted
+/// event log itself, and its tests need exact control over rowids,
+/// per-aggregate sequences, and cross-stream interleavings that command
+/// choreography cannot express (multi-batch paging, historical event shapes,
+/// a single event whose command would emit siblings). The command path is
+/// covered end-to-end by the registered-reactor and manifest wiring tests,
+/// which seed through `Store::send`. Production code must never do this.
+pub(crate) async fn persist_event<Entity: EventSourced>(
+    pool: &SqlitePool,
+    aggregate_id: &str,
+    sequence: i64,
+    event: &Entity::Event,
+) {
+    sqlx::query(
+        "INSERT INTO events (aggregate_type, aggregate_id, sequence, \
+         event_type, event_version, payload, metadata) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, '{}')",
+    )
+    .bind(Entity::AGGREGATE_TYPE)
+    .bind(aggregate_id)
+    .bind(sequence)
+    .bind(event.event_type())
+    .bind(event.event_version())
+    .bind(serde_json::to_string(event).unwrap())
+    .execute(pool)
+    .await
+    .unwrap();
 }
 
 /// File-backed variant of [`setup_test_db`] with production-shaped pool


### PR DESCRIPTION
## What

Closes RAI-1506 (PR 3/3 of the ADR 0018 stack: schema -> ingester/reactor -> read-path cutover).

Cuts `/pnl`'s read path over to the `pnl_*` ledger tables and deletes the raw-SQL/JSON payload parsing layer.

## Why

With the ledger ingesting all four source aggregates (previous PRs), the report no longer needs to parse event payloads per request. Reading typed rows keeps the request path narrow and decouples the report from raw event shapes.

## How

- Loaders in `source.rs` read the four position row kinds, cost entries, and bot gas costs from the ledger, watermarked by `event_rowid <= asOfRowid`; `validate_pnl_snapshot_rowid` became a sync check against the head returned by `catch_up()`.
- The `/pnl` handler runs `catch_up()` first (async I/O, outside the replay admission permit), validates `asOfRowid` against the returned head, then acquires the permit and builds the report.
- Replay, cost classification, samples, and builder all consume typed rows (`PositionLedgerRow`, `CostLedgerRow`); a NULL tokenization-fee amount is a missing cost observation deduped per mint, a NULL CCTP amount is a corrupt-row error (schema CHECK forbids it).
- One shared `Arc<PnlLedger>` is constructed before `AppState` and handed to both the API handler and the conductor's boot catch-up, so all ingestion serializes on one instance.
- `PnlError` drops the payload-parsing variants (`InvalidPayload`, `InvalidBotGasReceiptCost`) and gains `Ledger` + `InvalidLedgerRow`.

## Testing

The full `/pnl` suite was adapted without losing coverage: row-level tests construct typed ledger rows; pool-level tests seed real typed events into a fully migrated database and exercise actual ledger ingestion; malformed/incomplete payload tests moved to the layer where those failures now occur (ingestion) and assert `PnlError::Ledger`. The legacy fixture test pins stable report fields across the cutover, and responses stay byte-identical.

## Screenshots

N/A -- response shape is unchanged.

## Anything else

Whole-result-per-watermark memoization of the replay is noted as future work in the ADR; FIFO replay stays at query time because execution-timestamp order diverges from commit order.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788635327&installation_model_id=19370&pr_number=1136&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1136&signature=d3d1f63e63e1494ad393fe2bbdae62b90ab52edb9673617571e22d7b9ec45113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * P&L reports now use an up-to-date ledger before validating snapshots, improving report accuracy.
  * Added stronger validation for position, cost, fee, and transaction data.
* **Bug Fixes**
  * Ledger ingestion failures now return clear server errors instead of being silently ignored.
  * Duplicate records remain safely handled while other data errors are surfaced.
  * Invalid timestamps, amounts, symbols, fees, and ledger entries now produce actionable validation errors.
* **Tests**
  * Expanded coverage for ledger ingestion, P&L calculations, filtering, fees, and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->