### PR TITLE
fix: release the broker-idempotency anchor when the order is terminal

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -491,7 +491,17 @@ resume hedging — once the cancellation confirms.
 
 - Orders carry a broker-side `client_order_id` idempotency key so a retry after
   a lost placement response is deduped by the broker rather than
-  double-submitted.
+  double-submitted. The key anchors retries only while the broker order under it
+  can still become the placement's outcome: a broker-documented terminal failure
+  (expired, rejected, or done-for-day -- terminal only because every order this
+  bot places is Day time-in-force and so cannot resume in a later session)
+  releases the anchor so the next hedge derives a fresh key. A broker status
+  that can still resume or continue (suspended, replaced, calculated) does NOT
+  release the anchor -- doing so would let a fresh retry double-hedge alongside
+  an order that can still fill. A placement failure with unknown broker state
+  also keeps the anchor, since that is the window a lost response can still
+  land. Intentional cancellation and manual adjustment already release the
+  anchor.
 - Broker `PartiallyFilled` status is preserved through the executor boundary
   (cumulative fills are not collapsed into `Submitted`), and broker-confirmed
   `Cancelled` is represented distinctly from `Failed`.

--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -201,12 +201,33 @@ impl Executor for AlpacaBrokerApi {
             // filled_qty, which the retained-fill path records; an absent
             // field remains unknown downstream rather than being treated as
             // proof of a zero fill.
-            OrderStatus::Failed => Ok(OrderState::Failed {
-                failed_at: order_update.updated_at,
-                error_reason: None,
-                shares_filled: order_update.shares_filled,
-                avg_price: order_update.price.map(Usd::new),
-            }),
+            OrderStatus::Failed => {
+                // `classify_broker_status` is a single exhaustive match that
+                // sets `status` and `failure_terminality` together, so a
+                // `Failed` status can no longer be classified without also
+                // supplying terminality -- unlike the two-independent-matches
+                // shape this replaced, where a status added to one match's
+                // arm list without the other could silently leave this
+                // `None`. `OrderUpdate` still types the field as `Option`
+                // (it's meaningful only for this one status), so the pairing
+                // isn't provable by the compiler at this call site; fail fast
+                // rather than silently defaulting a caller's idempotency
+                // decision if it were ever violated.
+                let terminality = order_update.failure_terminality.ok_or_else(|| {
+                    AlpacaBrokerApiError::IncompleteOrder {
+                        order_id: ExecutorOrderId::new(order_id),
+                        field: MissingOrderField::FailureTerminality,
+                    }
+                })?;
+
+                Ok(OrderState::Failed {
+                    failed_at: order_update.updated_at,
+                    error_reason: None,
+                    shares_filled: order_update.shares_filled,
+                    avg_price: order_update.price.map(Usd::new),
+                    terminality,
+                })
+            }
         }
     }
 
@@ -523,7 +544,7 @@ mod tests {
     use crate::alpaca_broker_api::order::AlpacaLimitPrice;
     use crate::{
         ClientOrderId, CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason,
-        Direction, FractionalShares, LimitOrder, Positive, Usd,
+        Direction, FractionalShares, LimitOrder, OrderFailureTerminality, Positive, Usd,
     };
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
@@ -1747,6 +1768,88 @@ mod tests {
         };
         assert_eq!(shares_filled, None);
         assert_eq!(avg_price, None);
+    }
+
+    #[tokio::test]
+    async fn get_order_status_expired_order_is_terminal() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let account_mock = create_account_mock(&server);
+        let order_id = "61e7b016-9c91-4a97-b912-615c9d365c9d".to_string();
+
+        let status_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "client_order_id": "33333333-3333-4333-8333-333333333333",
+                    "symbol": "AAPL",
+                    "asset_class": "us_equity",
+                    "qty": "100",
+                    "filled_qty": "0",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "status": "expired",
+                    "submitted_at": "2025-01-06T14:30:00.000000Z",
+                    "updated_at": "2025-01-06T21:00:00.000000Z"
+                }));
+        });
+
+        let executor = AlpacaBrokerApi::try_from_ctx(ctx).await.unwrap();
+        account_mock.assert();
+
+        let state = executor.get_order_status(&order_id).await.unwrap();
+
+        status_mock.assert();
+        let OrderState::Failed { terminality, .. } = state else {
+            panic!("expected OrderState::Failed, got {state:?}");
+        };
+        assert_eq!(terminality, OrderFailureTerminality::Terminal);
+    }
+
+    #[tokio::test]
+    async fn get_order_status_suspended_order_is_not_terminal() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let account_mock = create_account_mock(&server);
+        let order_id = "61e7b016-9c91-4a97-b912-615c9d365c9d".to_string();
+
+        let status_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "client_order_id": "44444444-4444-4444-8444-444444444444",
+                    "symbol": "AAPL",
+                    "asset_class": "us_equity",
+                    "qty": "100",
+                    "filled_qty": "0",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "status": "suspended",
+                    "submitted_at": "2025-01-06T14:30:00.000000Z",
+                    "updated_at": "2025-01-06T14:30:05.000000Z"
+                }));
+        });
+
+        let executor = AlpacaBrokerApi::try_from_ctx(ctx).await.unwrap();
+        account_mock.assert();
+
+        let state = executor.get_order_status(&order_id).await.unwrap();
+
+        status_mock.assert();
+        let OrderState::Failed { terminality, .. } = state else {
+            panic!("expected OrderState::Failed, got {state:?}");
+        };
+        assert_eq!(terminality, OrderFailureTerminality::NotTerminal);
     }
 
     #[tokio::test]

--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -1093,10 +1093,7 @@ fn register_order_placement_endpoint(server: &MockServer, state: &Arc<Mutex<Mock
                     .any(|order| order.client_order_id.as_deref() == Some(client_id));
                 if already_recorded {
                     drop(state);
-                    return json_response(
-                        422,
-                        &json!({"message": "client_order_id must be unique"}),
-                    );
+                    return json_response(422, &super::duplicate_client_order_id_body());
                 }
             }
 

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -147,6 +147,22 @@ pub enum MissingOrderField {
     Price,
     FilledAt,
     CanceledAt,
+    FailureTerminality,
+}
+
+/// The real Alpaca 422 body for a re-used `client_order_id`: a numeric
+/// `code` alongside the message. Shared by `order.rs`'s unit tests and the
+/// `mock_api` E2E mock so both speak this exact shape instead of two
+/// fixtures drifting apart (a code-less mock would let an `alpaca_code`
+/// parsing regression pass unnoticed). `#[cfg(any(test, feature = "mock"))]`
+/// covers both consumers: `order.rs`'s tests compile under plain `cfg(test)`,
+/// `mock_api` only under the `mock` feature.
+#[cfg(any(test, feature = "mock"))]
+pub(crate) fn duplicate_client_order_id_body() -> serde_json::Value {
+    serde_json::json!({
+        "code": 40_010_001,
+        "message": "client_order_id must be unique",
+    })
 }
 
 #[derive(Debug, Error)]

--- a/crates/execution/src/alpaca_broker_api/order.rs
+++ b/crates/execution/src/alpaca_broker_api/order.rs
@@ -9,9 +9,10 @@ use uuid::Uuid;
 use super::client::AlpacaBrokerApiClient;
 use super::{AlpacaBrokerApiError, CryptoOrderFailureReason, MissingOrderField, TimeInForce};
 use crate::{
-    ClientOrderId, Direction, ExecutorOrderId, FractionalShares, MarketOrder, OrderPlacement,
-    OrderStatus, OrderUpdate, Positive, Symbol, Usd, deserialize_float_from_number_or_string,
-    deserialize_option_float_from_number_or_string, serialize_float_as_string,
+    ClientOrderId, Direction, ExecutorOrderId, FractionalShares, MarketOrder,
+    OrderFailureTerminality, OrderPlacement, OrderStatus, OrderUpdate, Positive, Symbol, Usd,
+    deserialize_float_from_number_or_string, deserialize_option_float_from_number_or_string,
+    serialize_float_as_string,
 };
 
 const ALPACA_CRYPTO_MAX_DECIMAL_PLACES: u8 = 6;
@@ -297,7 +298,7 @@ impl CryptoOrderResponse {
     }
 
     /// Classifies the order's current status into a fill/pending/failed outcome,
-    /// consistent with the terminal mapping in `map_broker_status_to_order_status`.
+    /// consistent with the terminal mapping in `classify_broker_status`.
     ///
     /// The match is exhaustive (no wildcard) so a newly added Alpaca status forces
     /// a compile error here rather than silently mapping to `Pending` and retrying
@@ -401,7 +402,8 @@ pub(super) async fn place_market_order(
     let (order_id, shares, extended_hours, limit_price) = match client.place_order(&request).await {
         Ok(response) => (response.id, placed_shares, false, None),
         Err(error) if is_duplicate_client_order_id(&error) => {
-            debug!(
+            warn!(
+                %error,
                 client_order_id = %market_order.client_order_id,
                 "Broker rejected duplicate client_order_id; reconciling the order it already accepted"
             );
@@ -541,7 +543,8 @@ pub(super) async fn place_limit_order(
             Some(*limit_order.limit_price.as_price()),
         ),
         Err(error) if is_duplicate_client_order_id(&error) => {
-            debug!(
+            warn!(
+                %error,
                 client_order_id = %limit_order.client_order_id,
                 "Broker rejected duplicate client_order_id; reconciling the order it already accepted"
             );
@@ -597,7 +600,7 @@ pub(super) async fn get_order_status(
         OrderSide::Sell => Direction::Sell,
     };
 
-    let status = map_broker_status_to_order_status(response.status);
+    let (status, failure_terminality) = classify_broker_status(response.status);
     let price = response.filled_average_price;
     let shares_filled = response.filled_quantity.map(FractionalShares::new);
 
@@ -654,6 +657,7 @@ pub(super) async fn get_order_status(
         updated_at,
         price,
         shares_filled,
+        failure_terminality,
     })
 }
 
@@ -699,34 +703,48 @@ fn broker_time_or_observation(broker_time: Option<DateTime<Utc>>, order_id: &str
     })
 }
 
-fn map_broker_status_to_order_status(status: BrokerOrderStatus) -> OrderStatus {
+/// Classifies a broker status into the `OrderStatus` it maps to, and --
+/// whenever that status is `OrderStatus::Failed` -- the failure's
+/// terminality per Alpaca's order lifecycle
+/// (https://docs.alpaca.markets/docs/orders-at-alpaca). `DoneForDay` is
+/// terminal only because every order this bot places is Day time-in-force,
+/// so it cannot resume in a later session.
+///
+/// A single exhaustive match producing both classifications together, rather
+/// than two independent matches over `BrokerOrderStatus`: the previous shape
+/// let a status be added to one match's `Failed`/terminal arm without the
+/// other match being updated to agree, which only surfaced as a runtime
+/// `MissingOrderField::FailureTerminality` error. Here, a newly added status
+/// must be classified for both dimensions in the same arm or the match is
+/// non-exhaustive and the crate fails to compile.
+fn classify_broker_status(
+    status: BrokerOrderStatus,
+) -> (OrderStatus, Option<OrderFailureTerminality>) {
+    use BrokerOrderStatus::*;
+    use OrderFailureTerminality::{NotTerminal, Terminal};
+
     match status {
-        // Submitted to broker and in progress
-        BrokerOrderStatus::New
-        | BrokerOrderStatus::Accepted
-        | BrokerOrderStatus::PendingNew
-        | BrokerOrderStatus::AcceptedForBidding
-        | BrokerOrderStatus::PendingCancel
-        | BrokerOrderStatus::PendingReplace
-        | BrokerOrderStatus::Stopped => OrderStatus::Submitted,
+        // Submitted to broker and in progress.
+        New | Accepted | PendingNew | AcceptedForBidding | PendingCancel | PendingReplace
+        | Stopped => (OrderStatus::Submitted, None),
 
         // Partially filled -- distinct from Submitted so the poll loop can
         // drive `UpdatePartialFill` on the aggregate before any cancel.
-        BrokerOrderStatus::PartiallyFilled => OrderStatus::PartiallyFilled,
+        PartiallyFilled => (OrderStatus::PartiallyFilled, None),
 
-        // Successfully filled
-        BrokerOrderStatus::Filled => OrderStatus::Filled,
+        // Successfully filled.
+        Filled => (OrderStatus::Filled, None),
 
         // Cancelled by the broker after a cancel request was accepted.
-        BrokerOrderStatus::Canceled => OrderStatus::Cancelled,
+        Canceled => (OrderStatus::Cancelled, None),
 
-        // Failed/terminal statuses
-        BrokerOrderStatus::Expired
-        | BrokerOrderStatus::DoneForDay
-        | BrokerOrderStatus::Rejected
-        | BrokerOrderStatus::Replaced
-        | BrokerOrderStatus::Suspended
-        | BrokerOrderStatus::Calculated => OrderStatus::Failed,
+        // Failed/terminal statuses: the order will never resume or fill
+        // further, so a caller may release its idempotency key.
+        Expired | Rejected | DoneForDay => (OrderStatus::Failed, Some(Terminal)),
+
+        // Failed statuses the order may still resume or fill from: a caller
+        // must NOT release its idempotency key on these.
+        Replaced | Suspended | Calculated => (OrderStatus::Failed, Some(NotTerminal)),
     }
 }
 
@@ -860,6 +878,7 @@ mod tests {
     use crate::alpaca_broker_api::auth::{
         AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode,
     };
+    use crate::alpaca_broker_api::duplicate_client_order_id_body;
     use st0x_float_macro::float;
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
@@ -1053,7 +1072,7 @@ mod tests {
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
             then.status(422)
                 .header("content-type", "application/json")
-                .json_body(json!({"message": "client_order_id must be unique"}));
+                .json_body(duplicate_client_order_id_body());
         });
 
         // We reconcile by adopting the order the broker actually accepted.
@@ -1102,6 +1121,52 @@ mod tests {
         assert_eq!(placement.limit_price, None);
     }
 
+    /// The duplicate-422 warn log includes the Alpaca-reported numeric code
+    /// alongside the message. `place_market_order`'s reconciliation swallows
+    /// the intermediate `ApiError` on success, so this drives `place_order`
+    /// directly against a realistic duplicate-client_order_id body to prove
+    /// `code` is actually parsed into `alpaca_code`, not just `message`.
+    #[tokio::test]
+    async fn place_order_parses_alpaca_code_from_duplicate_client_order_id_body() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(422)
+                .header("content-type", "application/json")
+                .json_body(duplicate_client_order_id_body());
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let request = OrderRequest {
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            side: OrderSide::Buy,
+            order_type: "market",
+            time_in_force: TimeInForce::Day.as_api_str(),
+            extended_hours: false,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "77777777-7777-4777-8777-777777777777"
+            )),
+        };
+
+        let error = client.place_order(&request).await.unwrap_err();
+
+        mock.assert();
+        let AlpacaBrokerApiError::ApiError {
+            alpaca_code,
+            message,
+            ..
+        } = error
+        else {
+            panic!("expected ApiError, got {error:?}");
+        };
+        assert_eq!(alpaca_code, Some(40_010_001));
+        assert_eq!(message, "client_order_id must be unique");
+    }
+
     #[tokio::test]
     async fn place_market_order_adoption_reports_adopted_extended_hours_terms() {
         // Lost-response scenario the convergence sweep depends on: an
@@ -1122,7 +1187,7 @@ mod tests {
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
             then.status(422)
                 .header("content-type", "application/json")
-                .json_body(json!({"message": "client_order_id must be unique"}));
+                .json_body(duplicate_client_order_id_body());
         });
 
         let lookup_mock = server.mock(|when, then| {
@@ -1184,7 +1249,7 @@ mod tests {
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
             then.status(422)
                 .header("content-type", "application/json")
-                .json_body(json!({"message": "client_order_id must be unique"}));
+                .json_body(duplicate_client_order_id_body());
         });
 
         let lookup_mock = server.mock(|when, then| {
@@ -1244,7 +1309,7 @@ mod tests {
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
             then.status(422)
                 .header("content-type", "application/json")
-                .json_body(json!({"message": "client_order_id must be unique"}));
+                .json_body(duplicate_client_order_id_body());
         });
 
         let lookup_mock = server.mock(|when, then| {
@@ -1314,7 +1379,7 @@ mod tests {
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
             then.status(422)
                 .header("content-type", "application/json")
-                .json_body(json!({"message": "client_order_id must be unique"}));
+                .json_body(duplicate_client_order_id_body());
         });
 
         let lookup_mock = server.mock(|when, then| {
@@ -1416,7 +1481,7 @@ mod tests {
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
             then.status(422)
                 .header("content-type", "application/json")
-                .json_body(json!({"message": "client_order_id must be unique"}));
+                .json_body(duplicate_client_order_id_body());
         });
 
         // The broker reported a duplicate but the lookup finds nothing -- an
@@ -2274,43 +2339,129 @@ mod tests {
     }
 
     #[test]
-    fn test_map_broker_status_new() {
+    fn classify_broker_status_new_is_submitted_with_no_terminality() {
         assert_eq!(
-            map_broker_status_to_order_status(BrokerOrderStatus::New),
-            OrderStatus::Submitted
+            classify_broker_status(BrokerOrderStatus::New),
+            (OrderStatus::Submitted, None)
         );
     }
 
     #[test]
-    fn test_map_broker_status_filled() {
+    fn classify_broker_status_filled_has_no_terminality() {
         assert_eq!(
-            map_broker_status_to_order_status(BrokerOrderStatus::Filled),
-            OrderStatus::Filled
+            classify_broker_status(BrokerOrderStatus::Filled),
+            (OrderStatus::Filled, None)
         );
     }
 
     #[test]
-    fn test_map_broker_status_rejected() {
+    fn classify_broker_status_partially_filled_has_no_terminality() {
         assert_eq!(
-            map_broker_status_to_order_status(BrokerOrderStatus::Rejected),
-            OrderStatus::Failed
+            classify_broker_status(BrokerOrderStatus::PartiallyFilled),
+            (OrderStatus::PartiallyFilled, None)
         );
     }
 
     #[test]
-    fn test_map_broker_status_partially_filled() {
+    fn classify_broker_status_cancelled_has_no_terminality() {
         assert_eq!(
-            map_broker_status_to_order_status(BrokerOrderStatus::PartiallyFilled),
-            OrderStatus::PartiallyFilled
+            classify_broker_status(BrokerOrderStatus::Canceled),
+            (OrderStatus::Cancelled, None)
         );
     }
 
     #[test]
-    fn test_map_broker_status_cancelled() {
+    fn classify_broker_status_rejected_is_failed_and_terminal() {
         assert_eq!(
-            map_broker_status_to_order_status(BrokerOrderStatus::Canceled),
-            OrderStatus::Cancelled
+            classify_broker_status(BrokerOrderStatus::Rejected),
+            (OrderStatus::Failed, Some(OrderFailureTerminality::Terminal))
         );
+    }
+
+    #[test]
+    fn classify_broker_status_expired_is_failed_and_terminal() {
+        assert_eq!(
+            classify_broker_status(BrokerOrderStatus::Expired),
+            (OrderStatus::Failed, Some(OrderFailureTerminality::Terminal))
+        );
+    }
+
+    #[test]
+    fn classify_broker_status_done_for_day_is_failed_and_terminal() {
+        assert_eq!(
+            classify_broker_status(BrokerOrderStatus::DoneForDay),
+            (OrderStatus::Failed, Some(OrderFailureTerminality::Terminal))
+        );
+    }
+
+    #[test]
+    fn classify_broker_status_suspended_is_failed_and_not_terminal() {
+        assert_eq!(
+            classify_broker_status(BrokerOrderStatus::Suspended),
+            (
+                OrderStatus::Failed,
+                Some(OrderFailureTerminality::NotTerminal)
+            )
+        );
+    }
+
+    #[test]
+    fn classify_broker_status_replaced_is_failed_and_not_terminal() {
+        assert_eq!(
+            classify_broker_status(BrokerOrderStatus::Replaced),
+            (
+                OrderStatus::Failed,
+                Some(OrderFailureTerminality::NotTerminal)
+            )
+        );
+    }
+
+    #[test]
+    fn classify_broker_status_calculated_is_failed_and_not_terminal() {
+        assert_eq!(
+            classify_broker_status(BrokerOrderStatus::Calculated),
+            (
+                OrderStatus::Failed,
+                Some(OrderFailureTerminality::NotTerminal)
+            )
+        );
+    }
+
+    /// Pins the whole mapping, one row per `BrokerOrderStatus`. Asserting the
+    /// exact pair rather than only the Failed-implies-terminality invariant
+    /// also catches a status routed to the wrong non-failure `OrderStatus`,
+    /// which carries `None` either way.
+    #[test]
+    fn classify_broker_status_maps_every_status_to_its_expected_pair() {
+        use BrokerOrderStatus::*;
+        use OrderFailureTerminality::{NotTerminal, Terminal};
+
+        let expected = [
+            (New, OrderStatus::Submitted, None),
+            (PendingNew, OrderStatus::Submitted, None),
+            (Accepted, OrderStatus::Submitted, None),
+            (AcceptedForBidding, OrderStatus::Submitted, None),
+            (PendingCancel, OrderStatus::Submitted, None),
+            (PendingReplace, OrderStatus::Submitted, None),
+            (Stopped, OrderStatus::Submitted, None),
+            (PartiallyFilled, OrderStatus::PartiallyFilled, None),
+            (Filled, OrderStatus::Filled, None),
+            (Canceled, OrderStatus::Cancelled, None),
+            (Expired, OrderStatus::Failed, Some(Terminal)),
+            (Rejected, OrderStatus::Failed, Some(Terminal)),
+            (DoneForDay, OrderStatus::Failed, Some(Terminal)),
+            (Replaced, OrderStatus::Failed, Some(NotTerminal)),
+            (Suspended, OrderStatus::Failed, Some(NotTerminal)),
+            (Calculated, OrderStatus::Failed, Some(NotTerminal)),
+        ];
+
+        for (status, expected_status, expected_terminality) in expected {
+            assert_eq!(
+                classify_broker_status(status),
+                (expected_status, expected_terminality),
+                "unexpected classification for {status:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -42,7 +42,7 @@ pub use error::PersistenceError;
 pub use mock::{MockExecutor, MockExecutorCtx};
 pub use order::{
     CancellationOutcome, ClientOrderId, ClientOrderIdError, LimitOrder, MarketOrder,
-    OrderPlacement, OrderState, OrderStatus, OrderUpdate,
+    OrderFailureTerminality, OrderPlacement, OrderState, OrderStatus, OrderUpdate,
 };
 pub use rate_limit::retry_after_from_response_headers;
 

--- a/crates/execution/src/order/mod.rs
+++ b/crates/execution/src/order/mod.rs
@@ -13,7 +13,7 @@ use crate::{Direction, FractionalShares, Positive, Symbol, Usd};
 pub mod state;
 pub mod status;
 
-pub use state::OrderState;
+pub use state::{OrderFailureTerminality, OrderState};
 pub use status::OrderStatus;
 
 /// Caller-supplied idempotency key forwarded to the broker so retries of
@@ -124,6 +124,12 @@ pub struct OrderUpdate<OrderId> {
     /// `OrderStatus::PartiallyFilled` so the caller can reconcile the local
     /// aggregate via `UpdatePartialFill`.
     pub shares_filled: Option<FractionalShares>,
+    /// Broker-terminality classification of the failure, populated only when
+    /// `status` is `OrderStatus::Failed`. Carries the evidence executor
+    /// implementations need to build `OrderState::Failed`'s `terminality`
+    /// field without leaking their broker-specific status enum across the
+    /// `Executor` boundary.
+    pub failure_terminality: Option<OrderFailureTerminality>,
 }
 
 impl<OrderId: Debug> Debug for OrderUpdate<OrderId> {
@@ -137,6 +143,7 @@ impl<OrderId: Debug> Debug for OrderUpdate<OrderId> {
             .field("updated_at", &self.updated_at)
             .field("price", &DebugOptionFloat(&self.price))
             .field("shares_filled", &self.shares_filled)
+            .field("failure_terminality", &self.failure_terminality)
             .finish()
     }
 }

--- a/crates/execution/src/order/state.rs
+++ b/crates/execution/src/order/state.rs
@@ -1,8 +1,23 @@
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 use crate::{ExecutorOrderId, FractionalShares, Usd};
 
 use super::OrderStatus;
+
+/// Whether a broker-reported order failure is documented as final, or whether the
+/// order may still resume or fill after this status.
+///
+/// Treating a non-final failure as final releases a broker-idempotency key while
+/// the original order can still fill, which lets a retry hedge the same position
+/// twice.
+///
+/// See Alpaca's order lifecycle (https://docs.alpaca.markets/docs/orders-at-alpaca).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OrderFailureTerminality {
+    Terminal,
+    NotTerminal,
+}
 
 /// Runtime representation of an offchain order's lifecycle state.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -37,6 +52,7 @@ pub enum OrderState {
         error_reason: Option<String>,
         shares_filled: Option<FractionalShares>,
         avg_price: Option<Usd>,
+        terminality: OrderFailureTerminality,
     },
 }
 
@@ -113,6 +129,7 @@ mod tests {
                 error_reason: None,
                 shares_filled: None,
                 avg_price: None,
+                terminality: OrderFailureTerminality::Terminal,
             }
             .status(),
             OrderStatus::Failed

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -24,7 +24,7 @@ use crate::offchain::order::{
 use crate::portfolio_snapshot::{
     PortfolioSnapshot, PortfolioSnapshotCommand, PortfolioSnapshotId, PortfolioSnapshotProjection,
 };
-use crate::position::{Position, PositionCommand};
+use crate::position::{AnchorDisposition, Position, PositionCommand};
 
 pub(super) async fn set_portfolio_snapshot_mark_command<W: Write>(
     stdout: &mut W,
@@ -247,6 +247,11 @@ pub(super) async fn fail_pending_offchain_order_command<W: Write>(
             PositionCommand::FailOffChainOrder {
                 offchain_order_id,
                 error: reason.clone(),
+                // The repaired order is typically still live at the broker
+                // (this command force-fails stuck Pending/Submitted orders,
+                // not confirmed broker-terminal ones); releasing here would
+                // re-arm the double-hedge the anchor exists to prevent.
+                anchor: AnchorDisposition::Preserve,
             },
         )
         .await
@@ -863,6 +868,42 @@ mod tests {
         );
     }
 
+    /// `seed_offchain_order` seeds a broker `executor_order_id`, which is not
+    /// terminality evidence and must not flip the disposition to `Release`.
+    /// Guards against a refactor that derives the disposition from it instead
+    /// of the hardcoded `Preserve`.
+    #[tokio::test]
+    async fn fail_pending_preserves_anchor_despite_executor_order_id_evidence() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("MSTR").unwrap();
+        let order_id = OffchainOrderId::new();
+        seed_pending_position(&pool, &symbol, order_id).await;
+        seed_offchain_order(&pool, order_id, &symbol).await;
+
+        fail_pending_offchain_order_command(
+            &mut Vec::new(),
+            &pool,
+            &symbol,
+            order_id,
+            "operator repair".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let view = projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            view.last_failed_offchain_order_id,
+            Some(order_id),
+            "repair must preserve the anchor: a force-failed order is typically \
+             still live at the broker, and an executor_order_id proves nothing \
+             about terminality"
+        );
+    }
+
     /// A Filled order with the pointer still set means the fill was never
     /// accounted: the repair must refuse and leave the pointer for the fill
     /// reconciliation path.
@@ -1142,6 +1183,7 @@ mod tests {
                 PositionCommand::FailOffChainOrder {
                     offchain_order_id: order_id,
                     error: "partial prior run".to_string(),
+                    anchor: AnchorDisposition::Preserve,
                 },
             )
             .await
@@ -1314,6 +1356,7 @@ mod tests {
                 PositionCommand::FailOffChainOrder {
                     offchain_order_id: order_id,
                     error: "partial prior run".to_string(),
+                    anchor: AnchorDisposition::Preserve,
                 },
             )
             .await
@@ -1392,6 +1435,7 @@ mod tests {
                 PositionCommand::FailOffChainOrder {
                     offchain_order_id: pointed,
                     error: "clears the pointer".to_string(),
+                    anchor: AnchorDisposition::Preserve,
                 },
             )
             .await
@@ -1509,6 +1553,7 @@ mod tests {
                 PositionCommand::FailOffChainOrder {
                     offchain_order_id: order_id,
                     error: "clears the pointer".to_string(),
+                    anchor: AnchorDisposition::Preserve,
                 },
             )
             .await

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -15,8 +15,8 @@ use st0x_evm::ReadOnlyEvm;
 use st0x_execution::alpaca_broker_api::{AlpacaLimitOrder, AlpacaLimitPrice};
 use st0x_execution::{
     ClientOrderId, Direction, Executor, ExecutorOrderId, FractionalShares, MarketOrder,
-    MockExecutor, MockExecutorCtx, OrderPlacement, OrderState, Positive, Symbol, TimeInForce,
-    TryIntoExecutor,
+    MockExecutor, MockExecutorCtx, OrderFailureTerminality, OrderPlacement, OrderState, Positive,
+    Symbol, TimeInForce, TryIntoExecutor,
 };
 use st0x_float_serde::format_float_with_fallback;
 
@@ -35,7 +35,7 @@ use crate::onchain::pyth::PythFeedIds;
 use crate::onchain::trade::{BotOperator, RecoveryActors};
 use crate::onchain::{OnChainError, OnchainTrade, TradeValidationError};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeId};
-use crate::position::{Position, PositionCommand};
+use crate::position::{AnchorDisposition, Position, PositionCommand};
 use st0x_registry::SymbolCache;
 
 /// OrderPlacer for the CLI that delegates to the broker-specific executor
@@ -233,6 +233,7 @@ fn write_order_status<W: Write>(stdout: &mut W, state: OrderState) -> anyhow::Re
             error_reason,
             shares_filled,
             avg_price,
+            terminality,
         } => {
             writeln!(stdout, "❌ Order Status: FAILED")?;
             writeln!(stdout, "   Failed At: {failed_at}")?;
@@ -244,6 +245,18 @@ fn write_order_status<W: Write>(stdout: &mut W, state: OrderState) -> anyhow::Re
             }
             if let Some(avg_price) = avg_price {
                 writeln!(stdout, "   Avg Fill Price: ${avg_price}")?;
+            }
+            match terminality {
+                OrderFailureTerminality::Terminal => writeln!(
+                    stdout,
+                    "   Terminality: TERMINAL -- the broker order cannot resume; \
+                     a fresh order is needed"
+                )?,
+                OrderFailureTerminality::NotTerminal => writeln!(
+                    stdout,
+                    "   Terminality: NOT TERMINAL -- the broker order may still \
+                     resume or fill"
+                )?,
             }
         }
     }
@@ -951,12 +964,15 @@ async fn reconcile_loaded_post_place_state<W: Write>(
         Some(OffchainOrder::Failed { error, .. }) => {
             // Broker placement failed: clear pending_offchain_order_id so the
             // position is not permanently stuck and the normal pipeline can retry.
+            // No broker terminality classification available here; fail-safe
+            // preserves.
             position_store
                 .send(
                     symbol,
                     PositionCommand::FailOffChainOrder {
                         offchain_order_id,
                         error,
+                        anchor: AnchorDisposition::Preserve,
                     },
                 )
                 .await?;
@@ -984,6 +1000,7 @@ async fn reconcile_loaded_post_place_state<W: Write>(
                     PositionCommand::FailOffChainOrder {
                         offchain_order_id,
                         error: "Offchain order missing after Place".to_owned(),
+                        anchor: AnchorDisposition::Preserve,
                     },
                 )
                 .await?;
@@ -1901,6 +1918,7 @@ mod tests {
             error_reason: Some("rejected".to_string()),
             shares_filled: None,
             avg_price: None,
+            terminality: st0x_execution::OrderFailureTerminality::Terminal,
         });
         let order = MarketOrder {
             symbol: Symbol::new("AAPL").unwrap(),
@@ -2726,6 +2744,96 @@ mod tests {
             !output.contains("normal pipeline"),
             "existing pending cleanup should not imply re-hedging waits for the normal pipeline, \
              got: {output}"
+        );
+
+        let position = position_store
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(offchain_order_id),
+            "a fresh placement failure with no broker order id must preserve \
+             the anchor"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_loaded_post_place_state_failed_with_executor_id_preserves_the_anchor() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let block_timestamp = Utc::now();
+
+        let (position_store, _) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let onchain_trade = OnchainTradeBuilder::default()
+            .with_block_number(42)
+            .with_block_timestamp(Some(block_timestamp))
+            .build();
+
+        execute_acknowledge_fill(
+            &position_store,
+            &onchain_trade,
+            ExecutionThreshold::whole_share(),
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+
+        position_store
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares: positive_shares("1"),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let failed_order = OffchainOrder::Failed {
+            symbol: symbol.clone(),
+            shares: positive_shares("1"),
+            requested_shares: None,
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            retained_fill: None,
+            filled_shares: None,
+            executor_order_id: Some(ExecutorOrderId::new("already-poll-failed")),
+            error: "previous placement failed".to_string(),
+            placed_at: block_timestamp,
+            failed_at: block_timestamp,
+        };
+
+        let mut stdout = Vec::new();
+        reconcile_loaded_post_place_state(
+            Some(failed_order),
+            &position_store,
+            &symbol,
+            offchain_order_id,
+            CliPendingClearNextStep::ContinueThisRun,
+            &mut stdout,
+        )
+        .await
+        .unwrap();
+
+        let position = position_store
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(offchain_order_id),
+            "this path has no broker-terminality classification to derive \
+             from, so a broker order id alone must not release the anchor"
         );
     }
 
@@ -3659,6 +3767,65 @@ mod tests {
         assert!(
             output.contains("some-broker-order-id"),
             "status output must include the broker order id, got: {output}"
+        );
+    }
+
+    #[test]
+    fn write_order_status_displays_terminal_failure() {
+        let mut stdout = Vec::new();
+
+        write_order_status(
+            &mut stdout,
+            OrderState::Failed {
+                failed_at: Utc::now(),
+                error_reason: Some("order expired".to_string()),
+                shares_filled: None,
+                avg_price: None,
+                terminality: OrderFailureTerminality::Terminal,
+            },
+        )
+        .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("TERMINAL"),
+            "a Terminal failure must be labeled TERMINAL, got: {output}"
+        );
+        assert!(
+            !output.contains("NOT TERMINAL"),
+            "a Terminal failure must not also read NOT TERMINAL, got: {output}"
+        );
+        assert!(
+            output.contains("fresh order is needed"),
+            "a Terminal failure must tell the operator to place a fresh order, got: {output}"
+        );
+    }
+
+    #[test]
+    fn write_order_status_displays_not_terminal_failure() {
+        let mut stdout = Vec::new();
+
+        write_order_status(
+            &mut stdout,
+            OrderState::Failed {
+                failed_at: Utc::now(),
+                error_reason: Some("order suspended".to_string()),
+                shares_filled: None,
+                avg_price: None,
+                terminality: OrderFailureTerminality::NotTerminal,
+            },
+        )
+        .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("NOT TERMINAL"),
+            "a NotTerminal failure must be labeled NOT TERMINAL, got: {output}"
+        );
+        assert!(
+            output.contains("may still resume or fill"),
+            "a NotTerminal failure must tell the operator the order may still \
+             resolve, got: {output}"
         );
     }
 }

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -93,7 +93,9 @@ use crate::performance::equity_timing::EquityTimingProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
 use crate::performance::reliability::LifecycleFailureProjection;
 use crate::portfolio_snapshot::{PortfolioSnapshot, PortfolioSnapshotProjection};
-use crate::position::{Position, PositionCommand, PositionError, PositionEvent, TradeId};
+use crate::position::{
+    AnchorDisposition, Position, PositionCommand, PositionError, PositionEvent, TradeId,
+};
 use crate::rebalancing::equity::{
     CrossVenueEquityTransfer, EquityTransferServices, ResumeTokenizationAggregate,
     ResumeTokenizationCtx, ResumeTokenizationJobQueue, ResumeTokenizationTarget,
@@ -2650,6 +2652,9 @@ async fn recover_single_orphaned_order(
                         PositionCommand::FailOffChainOrder {
                             offchain_order_id: order_id,
                             error,
+                            // No broker terminality classification available
+                            // here; fail-safe preserves.
+                            anchor: AnchorDisposition::Preserve,
                         },
                     )
                     .await?;
@@ -2696,6 +2701,7 @@ async fn resolve_terminal_claimed_order(
                 PositionCommand::FailOffChainOrder {
                     offchain_order_id: order_id,
                     error: "pending offchain order has no offchain order aggregate".to_string(),
+                    anchor: AnchorDisposition::Preserve,
                 },
             )
             .await?;
@@ -3832,6 +3838,9 @@ async fn dispatch_post_place_state(
                     PositionCommand::FailOffChainOrder {
                         offchain_order_id,
                         error,
+                        // No broker terminality classification available
+                        // here; fail-safe preserves.
+                        anchor: AnchorDisposition::Preserve,
                     },
                 )
                 .await?;
@@ -3869,6 +3878,7 @@ async fn dispatch_post_place_state(
                     PositionCommand::FailOffChainOrder {
                         offchain_order_id,
                         error: "Offchain order missing after Place".to_string(),
+                        anchor: AnchorDisposition::Preserve,
                     },
                 )
                 .await?;
@@ -4150,6 +4160,9 @@ where
                         PositionCommand::FailOffChainOrder {
                             offchain_order_id,
                             error: error.clone(),
+                            // No broker terminality classification available
+                            // here; fail-safe preserves.
+                            anchor: AnchorDisposition::Preserve,
                         },
                     )
                     .await?;
@@ -4188,7 +4201,7 @@ mod tests {
     use sqlx::{ConnectOptions, SqlitePool};
     use std::future::pending;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, RwLock};
+    use std::sync::{Arc, Mutex as StdMutex, RwLock};
     use task_supervisor::SupervisorBuilder;
     use tokio::sync::broadcast;
     use url::Url;
@@ -9727,24 +9740,28 @@ mod tests {
 
     #[tokio::test]
     async fn broker_rejection_does_not_leave_position_stuck() {
-        fn failing_order_placer() -> Arc<dyn OrderPlacer> {
-            struct RejectingOrderPlacer;
+        fn failing_order_placer() -> (Arc<dyn OrderPlacer>, Arc<StdMutex<Option<ClientOrderId>>>) {
+            struct RejectingOrderPlacer {
+                captured_client_order_id: Arc<StdMutex<Option<ClientOrderId>>>,
+            }
 
             #[async_trait::async_trait]
             impl OrderPlacer for RejectingOrderPlacer {
                 async fn place_market_order(
                     &self,
-                    _order: MarketOrder,
+                    order: MarketOrder,
                 ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
                 {
+                    *self.captured_client_order_id.lock().unwrap() = Some(order.client_order_id);
                     Err("API error (403 Forbidden): trade denied due to pattern day trading protection".into())
                 }
 
                 async fn place_limit_order(
                     &self,
-                    _order: st0x_execution::LimitOrder,
+                    order: st0x_execution::LimitOrder,
                 ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
                 {
+                    *self.captured_client_order_id.lock().unwrap() = Some(order.client_order_id);
                     Err("API error (403 Forbidden): trade denied due to pattern day trading protection".into())
                 }
 
@@ -9759,7 +9776,13 @@ mod tests {
                 }
             }
 
-            Arc::new(RejectingOrderPlacer)
+            let captured_client_order_id = Arc::new(StdMutex::new(None));
+            (
+                Arc::new(RejectingOrderPlacer {
+                    captured_client_order_id: captured_client_order_id.clone(),
+                }),
+                captured_client_order_id,
+            )
         }
 
         let (pool, apalis_pool) = setup_test_pools().await;
@@ -9770,7 +9793,8 @@ mod tests {
             ExecutionThreshold::whole_share(),
             &apalis_pool,
         );
-        cqrs.order_placer = failing_order_placer();
+        let (order_placer, captured_client_order_id) = failing_order_placer();
+        cqrs.order_placer = order_placer;
 
         let trade_event = make_trade_event(70);
         let trade = test_trade_with_amount(float!(1.5), 70);
@@ -9793,6 +9817,18 @@ mod tests {
             "Position should not have a pending order after broker rejection, \
              but got {:?}. This leaves the position permanently stuck.",
             position.pending_offchain_order_id
+        );
+
+        let ClientOrderId::Automated(rejected_uuid) =
+            captured_client_order_id.lock().unwrap().clone().unwrap()
+        else {
+            panic!("expected an automated client_order_id");
+        };
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(OffchainOrderId::from_uuid(rejected_uuid)),
+            "a fresh placement failure with no broker order id must preserve \
+             the anchor"
         );
 
         // After clearing the stuck state, the periodic position checker should
@@ -9835,6 +9871,120 @@ mod tests {
         assert!(
             position.pending_offchain_order_id.is_some(),
             "Periodic checker should retry execution after broker rejection is cleared"
+        );
+    }
+
+    /// Recovers the target order id from the placement's own `client_order_id`,
+    /// matching how both placement paths derive it.
+    fn already_poll_failed_order_placer(
+        offchain_order: Arc<Store<OffchainOrder>>,
+    ) -> Arc<dyn OrderPlacer> {
+        struct AlreadyPollFailedPlacer {
+            offchain_order: Arc<Store<OffchainOrder>>,
+        }
+
+        #[async_trait::async_trait]
+        impl OrderPlacer for AlreadyPollFailedPlacer {
+            async fn place_market_order(
+                &self,
+                order: MarketOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                let ClientOrderId::Automated(uuid) = order.client_order_id else {
+                    panic!("expected an automated client_order_id");
+                };
+                let offchain_order_id = OffchainOrderId::from_uuid(uuid);
+
+                self.offchain_order
+                    .send(
+                        &offchain_order_id,
+                        OffchainOrderCommand::MarkAccepted {
+                            executor_order_id: ExecutorOrderId::new("already-poll-failed"),
+                            placed_shares: order.shares,
+                            submitted_at: Utc::now(),
+                            market_session: MarketSession::Regular,
+                            limit_price: None,
+                        },
+                    )
+                    .await
+                    .unwrap();
+                self.offchain_order
+                    .send(
+                        &offchain_order_id,
+                        OffchainOrderCommand::MarkFailed {
+                            error: "broker observed terminal failure".to_string(),
+                            filled_shares: None,
+                            failed_at: Utc::now(),
+                        },
+                    )
+                    .await
+                    .unwrap();
+
+                Err("this attempt's own broker outcome is moot: the order is already Failed".into())
+            }
+
+            async fn place_limit_order(
+                &self,
+                _order: st0x_execution::LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err("test must not place a limit order".into())
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &st0x_execution::ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
+            }
+        }
+
+        Arc::new(AlreadyPollFailedPlacer { offchain_order })
+    }
+
+    #[tokio::test]
+    async fn execute_create_offchain_order_failed_with_executor_id_preserves_the_anchor() {
+        // A concurrent poll closes this order out between this attempt's
+        // `Pending` load and its broker call landing, so `MarkPlacementFailed`
+        // no-ops. `dispatch_post_place_state` has no broker-terminality
+        // classification for this path, so it must preserve regardless of the
+        // broker order id the concurrent poll recorded.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
+        let mut cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+        cqrs.order_placer = already_poll_failed_order_placer(cqrs.offchain_order.clone());
+
+        let trade_event = make_trade_event(70);
+        let trade = test_trade_with_amount(float!(1.5), 70);
+
+        let offchain_order_id =
+            process_queued_trade(&MockExecutor::new(), &trade_event, trade, &cqrs, true)
+                .await
+                .unwrap()
+                .expect("a failed placement still reports the order id");
+
+        let position = cqrs
+            .position_projection
+            .load(&Symbol::new("AAPL").unwrap())
+            .await
+            .unwrap()
+            .expect("position should exist");
+
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "the position must not be left stuck behind the already-failed order"
+        );
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(offchain_order_id),
+            "dispatch_post_place_state has no broker-terminality classification \
+             to derive from, so a broker order id alone must not release the anchor"
         );
     }
 
@@ -10642,6 +10792,116 @@ mod tests {
         assert_eq!(
             pos.pending_offchain_order_id, None,
             "a rejected re-drive must clear the position claim so hedging can retry"
+        );
+        assert_eq!(
+            pos.last_failed_offchain_order_id,
+            Some(offchain_order_id),
+            "a fresh re-drive failure with no broker order id must preserve \
+             the anchor"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_orphaned_pending_redrives_and_preserves_the_anchor_on_already_poll_failed_order()
+     {
+        // Same broker-terminal race, replayed through the orphan-recovery
+        // sweep's re-drive rather than the original placement attempt. This
+        // path has no broker-terminality classification to derive from, so
+        // it must preserve regardless of the broker order id the concurrent
+        // poll recorded.
+        let pool = setup_test_db().await;
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (offchain_order, _offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(noop_order_placer())
+                .await
+                .unwrap();
+
+        let symbol = Symbol::new("SGOV").unwrap();
+        let threshold = ExecutionThreshold::whole_share();
+        let offchain_order_id = OffchainOrderId::new();
+        let shares = Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap();
+        let order_placer = already_poll_failed_order_placer(offchain_order.clone());
+
+        position
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: TradeId {
+                        tx_hash: fixed_bytes!(
+                            "0000000000000000000000000000000000000000000000000000000000000005"
+                        ),
+                        log_index: 0,
+                    },
+                    amount: st0x_execution::FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(100),
+                    block_timestamp: Utc::now(),
+                    block_number: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    threshold,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Leave the order in Pending: a crash during placement persists `Placed`
+        // (Pending) but never records the broker outcome.
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(
+                        offchain_order_id.as_uuid(),
+                    ),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+
+        recover_orphaned_pending_offchain_orders(
+            &position,
+            &position_projection,
+            &offchain_order,
+            order_placer.as_ref(),
+        )
+        .await
+        .unwrap();
+
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            pos.pending_offchain_order_id, None,
+            "the sweep must clear the position claim behind the already-failed order"
+        );
+        assert_eq!(
+            pos.last_failed_offchain_order_id,
+            Some(offchain_order_id),
+            "this path has no broker-terminality classification to derive \
+             from, so a broker order id alone must not release the anchor"
         );
     }
 
@@ -11931,6 +12191,59 @@ mod tests {
         assert_eq!(
             position.pending_offchain_order_id, None,
             "Failed state must clear the position's pending offchain order id"
+        );
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(offchain_order_id),
+            "a fresh placement failure with no broker order id must preserve \
+             the anchor"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_post_place_state_failed_with_executor_id_preserves_the_anchor() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _projection) = create_cqrs_frameworks(&pool).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let offchain_order_id = drive_position_to_pending(&frameworks, &symbol, shares).await;
+
+        let failed_state = OffchainOrder::Failed {
+            symbol: symbol.clone(),
+            shares,
+            requested_shares: None,
+            direction: Direction::Sell,
+            executor: st0x_execution::SupportedExecutor::DryRun,
+            retained_fill: None,
+            filled_shares: None,
+            executor_order_id: Some(ExecutorOrderId::new("already-poll-failed")),
+            error: "broker rejected".to_string(),
+            placed_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        dispatch_post_place_state(Some(failed_state), &symbol, &cqrs, offchain_order_id)
+            .await
+            .unwrap();
+
+        let position = frameworks
+            .position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(offchain_order_id),
+            "this path has no broker-terminality classification to derive \
+             from, so a broker order id alone must not release the anchor"
         );
     }
 

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -27,7 +27,8 @@ use st0x_config::{
 use st0x_event_sorcery::{Projection, Store, StoreBuilder, test_store};
 use st0x_evm::{ReadOnlyEvm, USDC_BASE};
 use st0x_execution::{
-    Direction, ExecutorOrderId, FractionalShares, MockExecutor, OrderState, Positive, Symbol,
+    Direction, ExecutorOrderId, FractionalShares, MockExecutor, OrderFailureTerminality,
+    OrderState, Positive, Symbol,
 };
 use st0x_float_macro::float;
 use st0x_float_serde::format_float_with_fallback;
@@ -38,17 +39,21 @@ use crate::bindings::IRaindexV6::{self, TakeOrderV3};
 use crate::bindings::{
     DeployableERC20, Deployer, Interpreter, Parser, RaindexV6, Store as RainStore,
 };
+use crate::conductor::job::{BackpressureStreak, Job};
 use crate::conductor::{
     AccumulatedPositionExecutionCtx, TradeProcessingCqrs, VaultDiscoveryCtx,
     check_and_execute_accumulated_positions, discover_vaults_for_trade, process_queued_trade,
 };
+use crate::offchain::order::handle_rejection::HandleOrderRejectionCtx;
+use crate::offchain::order::poll_status::PollOrderStatusCtx;
 use crate::offchain::order::{
-    ExecutorOrderPlacer, OffchainOrder, OffchainOrderCommand, OffchainOrderId,
+    ExecutorOrderPlacer, HandleOrderRejection, HandleOrderRejectionJobQueue, OffchainOrder,
+    OffchainOrderCommand, OffchainOrderId, PollOrderStatus, ReconcileOrderFillJobQueue,
 };
 use crate::onchain::OnchainTrade;
 use crate::onchain::pyth::PythFeedIds;
 use crate::onchain::trade::RaindexTradeEvent;
-use crate::position::{Position, PositionCommand};
+use crate::position::{AnchorDisposition, Position, PositionCommand};
 use crate::test_utils::{
     TEST_POLL_INTERVAL, TestAnvilInstance, deploy_tofu_singleton, setup_test_pools, spawn_anvil,
 };
@@ -237,6 +242,7 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
                 shares_filled,
                 avg_price,
                 failed_at,
+                ..
             } => {
                 let error =
                     error_reason.unwrap_or_else(|| "Order failed with no error reason".to_string());
@@ -290,6 +296,7 @@ async fn poll_submitted_orders<E: st0x_execution::Executor + Clone>(
                             PositionCommand::FailOffChainOrder {
                                 offchain_order_id: order_id,
                                 error,
+                                anchor: AnchorDisposition::Preserve,
                             },
                         )
                         .await?;
@@ -381,6 +388,88 @@ async fn record_poll_partial_fill(
         price: avg_price,
         broker_timestamp,
     }))
+}
+
+/// Drives a simulated broker terminal failure through the real
+/// `PollOrderStatus` -> `HandleOrderRejection` job chain (unlike
+/// `poll_submitted_orders`, which hand-replays the CQRS commands and
+/// hardcodes `AnchorDisposition::Preserve`, bypassing the anchor-release
+/// decision entirely). Runs each job's real `perform` directly against a
+/// freshly-built ctx rather than through an apalis worker loop, mirroring
+/// `drain_one_poll_job_for_order` (`src/position_check.rs`).
+async fn poll_and_reject_via_real_jobs<E>(
+    executor: &E,
+    apalis_pool: &apalis_sqlite::SqlitePool,
+    offchain_order_projection: &Arc<Projection<OffchainOrder>>,
+    offchain_order: &Arc<Store<OffchainOrder>>,
+    position: &Arc<Store<Position>>,
+    poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue,
+    offchain_order_id: OffchainOrderId,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    E: st0x_execution::Executor + Clone + Send + Sync + 'static,
+    crate::offchain::order::JobError: From<E::Error>,
+{
+    let poll_ctx = PollOrderStatusCtx {
+        executor: executor.clone(),
+        offchain_order_projection: offchain_order_projection.clone(),
+        offchain_order_store: offchain_order.clone(),
+        position_store: position.clone(),
+        poll_status_queue,
+        reconcile_queue: ReconcileOrderFillJobQueue::new(apalis_pool),
+        rejection_queue: HandleOrderRejectionJobQueue::new(apalis_pool),
+        poll_interval: TEST_POLL_INTERVAL,
+    };
+
+    PollOrderStatus {
+        offchain_order_id,
+        backpressure_streak: BackpressureStreak::default(),
+    }
+    .perform(&poll_ctx)
+    .await?;
+
+    let rejection_row: Option<(String, Vec<u8>)> = sqlx_apalis::query_as(
+        "SELECT id, job FROM Jobs \
+         WHERE job_type = ? \
+           AND status IN ('Pending', 'Queued', 'Running') \
+         ORDER BY run_at ASC LIMIT 1",
+    )
+    .bind(std::any::type_name::<HandleOrderRejection>())
+    .fetch_optional(apalis_pool)
+    .await?;
+
+    let Some((job_id, payload)) = rejection_row else {
+        return Err(format!(
+            "expected PollOrderStatus to enqueue a HandleOrderRejection job for \
+             order {offchain_order_id}, found none"
+        )
+        .into());
+    };
+
+    let rejection_job: HandleOrderRejection = serde_json::from_slice(&payload)
+        .map_err(|error| format!("deserialize HandleOrderRejection payload: {error}"))?;
+
+    if rejection_job.offchain_order_id != offchain_order_id {
+        return Err(format!(
+            "expected the dequeued HandleOrderRejection job to be for order \
+             {offchain_order_id}, but found job {job_id} for order {}",
+            rejection_job.offchain_order_id
+        )
+        .into());
+    }
+
+    let rejection_ctx = HandleOrderRejectionCtx {
+        offchain_order: offchain_order.clone(),
+        position: position.clone(),
+    };
+    rejection_job.perform(&rejection_ctx).await?;
+
+    sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+        .bind(&job_id)
+        .execute(apalis_pool)
+        .await?;
+
+    Ok(())
 }
 
 /// Holds a deployed Rain OrderBook on a local Anvil node, ready to create real take-order events.
@@ -1099,12 +1188,21 @@ async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std:
         error_reason: Some("Broker rejected order".to_string()),
         shares_filled: None,
         avg_price: None,
+        terminality: OrderFailureTerminality::Terminal,
     });
-    poll_submitted_orders(
+    // Drives the real PollOrderStatus -> HandleOrderRejection job chain
+    // (rather than `poll_submitted_orders`'s hand-replay, which hardcodes
+    // AnchorDisposition::Preserve and so cannot catch an anchor-release
+    // regression) so the terminal broker failure's release decision is
+    // exercised end to end.
+    poll_and_reject_via_real_jobs(
         &failed_executor,
-        offchain_order_projection.as_ref(),
+        &apalis_pool,
+        &offchain_order_projection,
         &offchain_order,
         &position,
+        cqrs.poll_status_queue.clone(),
+        order_id,
     )
     .await?;
 
@@ -1119,6 +1217,16 @@ async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std:
         .last_price_usdc(float!(&AAPL_PRICE.to_string()))
         .call()
         .await;
+
+    let position_after_terminal_failure = position_query
+        .load(&symbol)
+        .await?
+        .expect("position should exist");
+    assert_eq!(
+        position_after_terminal_failure.last_failed_offchain_order_id, None,
+        "a broker-documented terminal failure must release the idempotency \
+         anchor so the retry below derives a fresh key"
+    );
 
     let mut expected = vec![
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
@@ -1273,6 +1381,7 @@ async fn retains_failed_terminal_partial_fill() -> Result<(), Box<dyn std::error
         error_reason: Some("broker rejected after partial fill".to_string()),
         shares_filled: Some(FractionalShares::new(float!(0.4))),
         avg_price: Some(st0x_finance::Usd::new(float!(100.25))),
+        terminality: OrderFailureTerminality::Terminal,
     });
     poll_submitted_orders(
         &failed_executor,
@@ -2863,6 +2972,7 @@ async fn operational_limits_shares_cap_constrains_counter_trades_with_failure_an
         error_reason: Some("Broker rejected".to_string()),
         shares_filled: None,
         avg_price: None,
+        terminality: OrderFailureTerminality::Terminal,
     });
     poll_submitted_orders(
         &failed_executor,

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -46,14 +46,14 @@ use st0x_event_sorcery::{DomainEvent, EventSourced, SendError, Store, Table};
 use st0x_execution::{
     AlpacaBrokerApiError, CancellationOutcome, ClientOrderId, CounterTradePreflight,
     ExecutionError, Executor, ExecutorOrderId, FractionalShares, LatestQuote, LimitOrder,
-    MarketOrder, MarketSession, MarketSessionStatus, OrderState, PersistenceError, Positive,
-    SupportedExecutor, Symbol,
+    MarketOrder, MarketSession, MarketSessionStatus, OrderFailureTerminality, OrderState,
+    PersistenceError, Positive, SupportedExecutor, Symbol,
 };
 use st0x_finance::{NonNegative, NotNonNegative, Usd};
 
 use crate::conductor::job::{QueuePushError, find_backpressure};
 use crate::onchain::OnChainError;
-use crate::position::{Position, PositionCommand};
+use crate::position::{AnchorDisposition, Position, PositionCommand};
 
 /// Errors surfaced by the per-order job pipeline.
 ///
@@ -1957,9 +1957,11 @@ pub(crate) enum NoFillOutcome {
         reason: CancellationReason,
         cancelled_at: DateTime<Utc>,
     },
-    /// Broker rejection/failure: issue `PositionCommand::FailOffChainOrder`,
-    /// which sets the failure anchor for the next attempt's idempotency key.
-    Failed { error: String },
+    /// Broker rejection/failure: issue `PositionCommand::FailOffChainOrder`.
+    Failed {
+        error: String,
+        anchor: AnchorDisposition,
+    },
 }
 
 /// Maps a [`TerminalPositionFinalization`] onto the [`PositionCommand`] that
@@ -1993,10 +1995,11 @@ pub(crate) fn position_command_for_finalization(
             reason,
             cancelled_at,
         }),
-        TerminalPositionFinalization::NoFill(NoFillOutcome::Failed { error }) => {
+        TerminalPositionFinalization::NoFill(NoFillOutcome::Failed { error, anchor }) => {
             Some(PositionCommand::FailOffChainOrder {
                 offchain_order_id,
                 error,
+                anchor,
             })
         }
         TerminalPositionFinalization::UnpricedFill { .. } => None,
@@ -2077,8 +2080,12 @@ pub(crate) fn terminal_position_finalization(
             *retained_fill,
             *direction,
             executor_order_id.clone(),
+            // The aggregate does not persist broker terminality here, so
+            // there is no positive evidence to release on; fail-safe
+            // preserves.
             NoFillOutcome::Failed {
                 error: error.clone(),
+                anchor: AnchorDisposition::Preserve,
             },
         )),
 
@@ -2086,6 +2093,7 @@ pub(crate) fn terminal_position_finalization(
         OffchainOrder::Failed { error, .. } => Some(TerminalPositionFinalization::NoFill(
             NoFillOutcome::Failed {
                 error: error.clone(),
+                anchor: AnchorDisposition::Preserve,
             },
         )),
 
@@ -2204,58 +2212,13 @@ async fn reconcile_pre_cancel(
             avg_price,
             partially_filled_at,
             ..
-        } => {
-            if Positive::new(broker_filled).is_err() {
-                if broker_filled == FractionalShares::ZERO {
-                    return Ok(Vec::new());
-                }
-
-                return Err(OffchainOrderError::InvalidTerminalFillQuantity {
-                    executor_order_id: executor_order_id.clone(),
-                    shares_filled: broker_filled,
-                });
-            }
-
-            // Only emit when the broker reports STRICTLY MORE fills than
-            // the local aggregate already records. Equal => no-op (the
-            // local state is already up to date). LESS => stale broker
-            // read (the poll loop recorded fresher data); never regress
-            // the recorded cumulative quantity. A comparison failure
-            // propagates (fail closed, like the status-fetch failure above)
-            // so the cancel retries instead of proceeding blind and
-            // dropping the broker-reported fill.
-            if let Some(local) = local_filled
-                && !broker_fill_exceeds_local(broker_filled, local)?
-            {
-                tracing::debug!(
-                    %executor_order_id,
-                    "Broker partial-fill <= local; skipping pre-cancel reconcile"
-                );
-                return Ok(Vec::new());
-            }
-
-            // We need an avg_price for the event. If the broker did not
-            // return one, drop the reconciliation -- without a price we
-            // can't record the fill correctly. The position would be left
-            // unhedged for the partial quantity, but that's safer than
-            // recording a zero-price fill.
-            let Some(price) = avg_price else {
-                tracing::warn!(
-                    %executor_order_id,
-                    "Broker reports PartiallyFilled but no avg_price; will retry without cancelling"
-                );
-                return Err(OffchainOrderError::PreCancelPartialFillMissingAvgPrice {
-                    executor_order_id: executor_order_id.clone(),
-                    shares_filled: broker_filled,
-                });
-            };
-
-            Ok(vec![OffchainOrderEvent::PartiallyFilled {
-                shares_filled: broker_filled,
-                avg_price: price,
-                partially_filled_at,
-            }])
-        }
+        } => reconcile_partial_fill_event(
+            executor_order_id,
+            local_filled,
+            broker_filled,
+            avg_price,
+            partially_filled_at,
+        ),
 
         OrderState::Filled {
             price, executed_at, ..
@@ -2279,6 +2242,7 @@ async fn reconcile_pre_cancel(
             failed_at,
             shares_filled,
             avg_price,
+            terminality: OrderFailureTerminality::Terminal,
         } => {
             // Order terminally failed at the broker between our last poll
             // and the cancel attempt. Emit Failed (which short-circuits
@@ -2303,6 +2267,35 @@ async fn reconcile_pre_cancel(
                     filled_shares: shares_filled,
                     failed_at,
                 },
+            )
+        }
+
+        // A NotTerminal broker failure (suspended/replaced/calculated) means
+        // the order may still resume or fill at the broker -- it must NOT
+        // short-circuit the DELETE with a terminal Failed event, or a live
+        // order gets orphaned from polling while the broker can still fill
+        // it. Reconcile any newer fill the broker already reported, then let
+        // the cancel proceed as normal (mirrors the Pending/Submitted arm).
+        OrderState::Failed {
+            error_reason,
+            failed_at,
+            shares_filled,
+            avg_price,
+            terminality: OrderFailureTerminality::NotTerminal,
+        } => {
+            tracing::info!(
+                %executor_order_id,
+                ?error_reason,
+                "Broker reports order Failed-but-NotTerminal at cancel time; \
+                 proceeding with the cancel instead of terminalizing locally"
+            );
+
+            reconcile_partial_fill_event(
+                executor_order_id,
+                local_filled,
+                shares_filled.unwrap_or(FractionalShares::ZERO),
+                avg_price,
+                failed_at,
             )
         }
 
@@ -2333,6 +2326,72 @@ async fn reconcile_pre_cancel(
 
         OrderState::Pending | OrderState::Submitted { .. } => Ok(Vec::new()),
     }
+}
+
+/// Reconciles a possibly-newer broker-reported fill into a `PartiallyFilled`
+/// event ahead of a pending cancel attempt, without any terminal event --
+/// the caller proceeds with the real cancel DELETE afterward regardless of
+/// what this returns. Shared by [`reconcile_pre_cancel`]'s `PartiallyFilled`
+/// arm and its `Failed`-but-`NotTerminal` arm, which both need "record any
+/// newer fill, then let the cancel proceed" and must not drift apart.
+///
+/// Returns an empty vec when there is nothing new to record: no fill, or a
+/// stale/equal broker read the local aggregate already covers.
+fn reconcile_partial_fill_event(
+    executor_order_id: &ExecutorOrderId,
+    local_filled: Option<FractionalShares>,
+    broker_filled: FractionalShares,
+    avg_price: Option<Usd>,
+    partially_filled_at: DateTime<Utc>,
+) -> Result<Vec<OffchainOrderEvent>, OffchainOrderError> {
+    if Positive::new(broker_filled).is_err() {
+        if broker_filled == FractionalShares::ZERO {
+            return Ok(Vec::new());
+        }
+
+        return Err(OffchainOrderError::InvalidTerminalFillQuantity {
+            executor_order_id: executor_order_id.clone(),
+            shares_filled: broker_filled,
+        });
+    }
+
+    // Only emit when the broker reports STRICTLY MORE fills than the local
+    // aggregate already records. Equal => no-op (the local state is already
+    // up to date). LESS => stale broker read (the poll loop recorded fresher
+    // data); never regress the recorded cumulative quantity. A comparison
+    // failure propagates (fail closed, like the status-fetch failure above)
+    // so the cancel retries instead of proceeding blind and dropping the
+    // broker-reported fill.
+    if let Some(local) = local_filled
+        && !broker_fill_exceeds_local(broker_filled, local)?
+    {
+        tracing::debug!(
+            %executor_order_id,
+            "Broker fill <= local; skipping pre-cancel reconcile"
+        );
+        return Ok(Vec::new());
+    }
+
+    // We need an avg_price for the event. If the broker did not return one,
+    // drop the reconciliation -- without a price we can't record the fill
+    // correctly. The position would be left unhedged for the partial
+    // quantity, but that's safer than recording a zero-price fill.
+    let Some(price) = avg_price else {
+        tracing::warn!(
+            %executor_order_id,
+            "Broker reports filled shares but no avg_price; will retry without cancelling"
+        );
+        return Err(OffchainOrderError::PreCancelPartialFillMissingAvgPrice {
+            executor_order_id: executor_order_id.clone(),
+            shares_filled: broker_filled,
+        });
+    };
+
+    Ok(vec![OffchainOrderEvent::PartiallyFilled {
+        shares_filled: broker_filled,
+        avg_price: price,
+        partially_filled_at,
+    }])
 }
 
 /// Shared tail of the `Failed`/`Cancelled` arms of [`reconcile_pre_cancel`]:
@@ -3283,6 +3342,64 @@ mod tests {
         assert_eq!(
             broker_timestamp, fill_time,
             "finalization must stamp the broker fill time, not the failure time"
+        );
+    }
+
+    #[test]
+    fn zero_fill_failed_with_executor_order_id_preserves_the_anchor() {
+        // executor_order_id presence alone is not broker-terminality evidence;
+        // this aggregate does not persist terminality, so it always preserves.
+        let failure_time = "2026-01-06T14:32:01Z".parse::<DateTime<Utc>>().unwrap();
+        let order = OffchainOrder::Failed {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            requested_shares: Some(Positive::new(FractionalShares::new(float!(1))).unwrap()),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            retained_fill: None,
+            filled_shares: Some(FractionalShares::ZERO),
+            executor_order_id: Some(ExecutorOrderId::new("expired-order")),
+            error: "expired".to_string(),
+            placed_at: failure_time,
+            failed_at: failure_time,
+        };
+
+        let finalization =
+            terminal_position_finalization(&order).expect("terminal Failed order must classify");
+        assert_eq!(
+            finalization,
+            TerminalPositionFinalization::NoFill(NoFillOutcome::Failed {
+                error: "expired".to_string(),
+                anchor: AnchorDisposition::Preserve,
+            })
+        );
+    }
+
+    #[test]
+    fn zero_fill_failed_without_executor_order_id_preserves_the_anchor() {
+        let failure_time = "2026-01-06T14:32:01Z".parse::<DateTime<Utc>>().unwrap();
+        let order = OffchainOrder::Failed {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            requested_shares: Some(Positive::new(FractionalShares::new(float!(1))).unwrap()),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            retained_fill: None,
+            filled_shares: None,
+            executor_order_id: None,
+            error: "broker unreachable".to_string(),
+            placed_at: failure_time,
+            failed_at: failure_time,
+        };
+
+        let finalization =
+            terminal_position_finalization(&order).expect("terminal Failed order must classify");
+        assert_eq!(
+            finalization,
+            TerminalPositionFinalization::NoFill(NoFillOutcome::Failed {
+                error: "broker unreachable".to_string(),
+                anchor: AnchorDisposition::Preserve,
+            })
         );
     }
 
@@ -5941,6 +6058,177 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancel_order_with_not_terminal_broker_failure_proceeds_with_cancel() {
+        // A NotTerminal Failed state (suspended/replaced/calculated) means
+        // the broker order may still resume. CancelOrder must NOT emit a
+        // bare Failed event here -- that would terminalize an order the
+        // broker itself has not given up on. It must proceed with the real
+        // cancel DELETE instead.
+        fn not_terminal_failure_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-OK"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(CancellationOutcome::Requested)
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(st0x_execution::OrderState::Failed {
+                        failed_at: Utc::now(),
+                        error_reason: Some("order suspended".to_string()),
+                        shares_filled: None,
+                        avg_price: None,
+                        terminality: OrderFailureTerminality::NotTerminal,
+                    })
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(not_terminal_failure_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(inner, OffchainOrder::Cancelling { .. }),
+            "Expected the cancel to proceed to Cancelling rather than \
+             terminalizing on a NotTerminal broker failure, got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_order_with_not_terminal_broker_failure_reconciles_newer_partial_fill() {
+        // Same NotTerminal case as above, but the broker also reports a
+        // newer fill than the local aggregate knows about. That fill must
+        // still be reconciled (mirrors the plain PartiallyFilled arm) even
+        // though the state carries a Failed status wrapper.
+        fn not_terminal_failure_with_fill_placer() -> Arc<dyn OrderPlacer> {
+            struct Placer;
+
+            #[async_trait]
+            impl OrderPlacer for Placer {
+                async fn place_market_order(
+                    &self,
+                    order: MarketOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(OrderPlacementResult {
+                        executor_order_id: ExecutorOrderId::new("ORD-OK"),
+                        placed_shares: noop_placed_shares(order.shares),
+                        is_extended_hours: false,
+                        limit_price: None,
+                    })
+                }
+
+                async fn place_limit_order(
+                    &self,
+                    _order: LimitOrder,
+                ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    unimplemented!()
+                }
+
+                async fn cancel_order(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(CancellationOutcome::Requested)
+                }
+
+                async fn get_order_status(
+                    &self,
+                    _executor_order_id: &ExecutorOrderId,
+                ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    Ok(st0x_execution::OrderState::Failed {
+                        failed_at: Utc::now(),
+                        error_reason: Some("order suspended".to_string()),
+                        shares_filled: Some(FractionalShares::new(float!(50))),
+                        avg_price: Some(Usd::new(float!(150.0))),
+                        terminality: OrderFailureTerminality::NotTerminal,
+                    })
+                }
+            }
+
+            Arc::new(Placer)
+        }
+
+        let store = TestStore::<OffchainOrder>::new(not_terminal_failure_with_fill_placer());
+        let id = OffchainOrderId::new();
+        place_and_submit(&store, &id).await;
+
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inner = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                inner,
+                OffchainOrder::Cancelling {
+                    retained_fill:
+                        Some(RetainedFill::Priced {
+                            shares_filled,
+                            ..
+                        }),
+                    ..
+                } if shares_filled == FractionalShares::new(float!(50))
+            ),
+            "Expected Cancelling with the NotTerminal-reported fill reconciled, \
+             got: {inner:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn cancel_order_blocks_when_broker_failed_with_unpriced_fill() {
         // If the broker reports the order Failed with filled shares but no
         // avg_price at cancel time, CancelOrder must NOT emit a bare Failed
@@ -5995,6 +6283,7 @@ mod tests {
                         error_reason: Some("broker failed".to_string()),
                         shares_filled: Some(FractionalShares::new(float!(50))),
                         avg_price: None,
+                        terminality: st0x_execution::OrderFailureTerminality::Terminal,
                     })
                 }
             }

--- a/src/offchain/order/handle_rejection.rs
+++ b/src/offchain/order/handle_rejection.rs
@@ -14,14 +14,16 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 use st0x_event_sorcery::Store;
-use st0x_execution::{Direction, ExecutorOrderId, FractionalShares, Positive};
+use st0x_execution::{
+    Direction, ExecutorOrderId, FractionalShares, OrderFailureTerminality, Positive,
+};
 
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::offchain::order::{
     JobError, NoFillOutcome, OffchainOrder, OffchainOrderCommand, OffchainOrderId, RetainedFill,
     TerminalPositionFinalization, terminal_position_finalization,
 };
-use crate::position::{Position, PositionCommand};
+use crate::position::{AnchorDisposition, Position, PositionCommand};
 
 pub(crate) type HandleOrderRejectionJobQueue = JobQueue<HandleOrderRejection>;
 
@@ -43,10 +45,17 @@ pub(crate) struct HandleOrderRejection {
     /// Broker-reported failure time, when the enqueuing poll observed a
     /// broker `Failed` state. `None` when the rejection has no broker
     /// timestamp (the job then stamps its own observation time).
+    /// `#[serde(default)]` so payloads already in the queue without it still deserialize.
+    #[serde(default)]
+    pub(crate) broker_failed_at: Option<DateTime<Utc>>,
+    /// Broker-terminality classification, when the enqueuing poll observed a
+    /// broker `Failed` state carrying one. `None` when this rejection has no
+    /// broker-terminality evidence (e.g. cleanup paths) -- `AnchorDisposition`
+    /// must never release the idempotency anchor on `None`.
     /// `#[serde(default)]` so jobs queued before this field existed still
     /// deserialize.
     #[serde(default)]
-    pub(crate) broker_failed_at: Option<DateTime<Utc>>,
+    pub(crate) broker_terminality: Option<OrderFailureTerminality>,
 }
 
 impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
@@ -182,6 +191,7 @@ impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
                 *avg_price,
                 *partially_filled_at,
                 self.error.clone(),
+                self.broker_terminality,
             ),
 
             // A locally-`Cancelled` order is already terminal and must NOT be
@@ -227,21 +237,19 @@ impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
                     | None => PositionCommand::FailOffChainOrder {
                         offchain_order_id: self.offchain_order_id,
                         error: self.error.clone(),
+                        anchor: AnchorDisposition::Preserve,
                     },
                 }
             }
 
-            Pending { .. }
-            | Submitted { .. }
-            | Cancelling { .. }
-            | Failed {
-                executor_order_id: None,
-                ..
+            Pending { .. } | Submitted { .. } | Cancelling { .. } | Failed { .. } => {
+                PositionCommand::FailOffChainOrder {
+                    offchain_order_id: self.offchain_order_id,
+                    error: self.error.clone(),
+                    anchor: AnchorDisposition::from_broker_terminality(self.broker_terminality),
+                }
             }
-            | Failed { .. } => PositionCommand::FailOffChainOrder {
-                offchain_order_id: self.offchain_order_id,
-                error: self.error.clone(),
-            },
+
             Filled { .. } => unreachable!("filled orders return before position update"),
         };
 
@@ -259,11 +267,29 @@ fn position_command_for_retained_fill(
     avg_price: st0x_finance::Usd,
     broker_timestamp: chrono::DateTime<chrono::Utc>,
     fallback_error: String,
+    broker_terminality: Option<OrderFailureTerminality>,
 ) -> PositionCommand {
+    let anchor = AnchorDisposition::from_broker_terminality(broker_terminality);
+
+    // Only a confirmed-Terminal broker failure may finalize the position off a
+    // retained partial fill. `NotTerminal` and `None` (no evidence, e.g. a
+    // legacy job payload from before this field existed) both mean the broker
+    // order may still resume and fill the remainder -- completing the
+    // position here would lock in the partial quantity as final and lose any
+    // later fill once this order is retried under a fresh id.
+    if broker_terminality != Some(OrderFailureTerminality::Terminal) {
+        return PositionCommand::FailOffChainOrder {
+            offchain_order_id,
+            error: fallback_error,
+            anchor,
+        };
+    }
+
     Positive::new(shares_filled).map_or_else(
         |_| PositionCommand::FailOffChainOrder {
             offchain_order_id,
             error: fallback_error,
+            anchor,
         },
         |positive_filled| PositionCommand::CompleteOffChainOrder {
             offchain_order_id,
@@ -444,6 +470,7 @@ mod tests {
             error: error_message.clone(),
             broker_filled_shares: Some(FractionalShares::ZERO),
             broker_failed_at: None,
+            broker_terminality: None,
         }
         .perform(&infra.ctx)
         .await
@@ -480,15 +507,29 @@ mod tests {
         );
     }
 
+    /// Without terminal broker evidence, a partial fill's rejection must NOT
+    /// finalize the position at the partial quantity: the broker order may
+    /// still be suspended/live rather than genuinely done, and completing
+    /// here would lock in the partial as final and lose any later fill. Only
+    /// `Some(OrderFailureTerminality::Terminal)` may complete off a retained
+    /// partial (see `rejection_with_terminal_broker_terminality_releases_the_anchor`
+    /// for that path).
     #[tokio::test]
-    async fn partial_fill_rejection_retains_executed_quantity_on_position() {
+    async fn partial_fill_rejection_without_terminal_evidence_does_not_complete_the_position() {
         let infra = build_test_infra().await;
         let symbol = Symbol::new("TSLA").unwrap();
         let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
         let order_id =
             submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
-        let broker_timestamp = Utc::now();
         mark_order_accepted(&infra, order_id, shares).await;
+
+        let position_before = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
 
         infra
             .ctx
@@ -498,7 +539,7 @@ mod tests {
                 OffchainOrderCommand::UpdatePartialFill {
                     shares_filled: FractionalShares::new(float!(0.75)),
                     avg_price: Usd::new(float!(150.25)),
-                    partially_filled_at: broker_timestamp,
+                    partially_filled_at: Utc::now(),
                 },
             )
             .await
@@ -509,6 +550,7 @@ mod tests {
             error: "broker cancelled after partial fill".to_string(),
             broker_filled_shares: None,
             broker_failed_at: None,
+            broker_terminality: None,
         }
         .perform(&infra.ctx)
         .await
@@ -523,7 +565,7 @@ mod tests {
             .expect("offchain order should exist");
         assert!(
             matches!(offchain, OffchainOrder::Failed { .. }),
-            "terminal partial rejection must still mark the offchain order failed"
+            "the rejection must still mark the offchain order failed locally"
         );
 
         let position = infra
@@ -534,23 +576,90 @@ mod tests {
             .unwrap()
             .expect("position should exist");
         assert_eq!(
-            position.net,
-            FractionalShares::new(float!(1.25)),
-            "position must retain the partially executed sell quantity"
+            position.net, position_before.net,
+            "without terminal broker evidence, the retained partial fill must \
+             NOT be applied to net -- the broker order may still resume and \
+             fill the remainder under a fresh retry"
         );
         assert_eq!(
             position.pending_offchain_order_id, None,
-            "partial fill completion must clear pending state"
+            "the rejection must still clear the pending slot"
         );
         assert_eq!(
-            position.last_failed_offchain_order_id, None,
-            "retained partial fills are completed, not marked as no-fill failures"
+            position.last_failed_offchain_order_id,
+            Some(order_id),
+            "with no terminal evidence, the anchor must be preserved rather \
+             than released"
         );
-        assert!(
-            position
-                .last_updated
-                .is_some_and(|updated| updated >= broker_timestamp),
-            "position timestamp should reflect the retained broker fill"
+    }
+
+    /// An order partially fills, then the broker suspends it (`NotTerminal`).
+    /// The suspended order may still resume and fill the remainder, so this
+    /// rejection must NOT complete the position off the partial quantity,
+    /// and must preserve the anchor.
+    #[tokio::test]
+    async fn suspended_partial_fill_rejection_does_not_complete_the_position() {
+        let infra = build_test_infra().await;
+        let symbol = Symbol::new("TSLA").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+        mark_order_accepted(&infra, order_id, shares).await;
+
+        let position_before = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+
+        infra
+            .ctx
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::new(float!(0.75)),
+                    avg_price: Usd::new(float!(150.25)),
+                    partially_filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        HandleOrderRejection {
+            offchain_order_id: order_id,
+            error: "broker suspended the order".to_string(),
+            broker_filled_shares: Some(FractionalShares::new(float!(0.75))),
+            broker_failed_at: Some(Utc::now()),
+            broker_terminality: Some(OrderFailureTerminality::NotTerminal),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let position = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.net, position_before.net,
+            "a NotTerminal broker failure must NOT complete the position off \
+             the partial fill -- the broker order may still resume and fill \
+             the remainder"
+        );
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "the rejection must still clear the pending slot"
+        );
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(order_id),
+            "a NotTerminal classification must preserve the anchor"
         );
     }
 
@@ -603,6 +712,7 @@ mod tests {
             error: original_error,
             broker_filled_shares: None,
             broker_failed_at: None,
+            broker_terminality: None,
         }
         .perform(&infra.ctx)
         .await
@@ -619,16 +729,112 @@ mod tests {
             position_after.pending_offchain_order_id, None,
             "Retry must clear the position's pending state by running step 2"
         );
+        assert_eq!(
+            position_after.last_failed_offchain_order_id,
+            Some(order_id),
+            "the order's own executor_order_id (recorded by the earlier \
+             attempt's step 1) is not broker-terminality evidence, so with \
+             no broker_terminality classification the anchor must preserve"
+        );
     }
 
+    /// A retry that lands after step 1 already committed (order `Failed`,
+    /// `executor_order_id` recorded) but whose `broker_terminality` is
+    /// `Some(NotTerminal)` -- the enqueuing poll observed the broker order
+    /// as suspended/replaced, i.e. still able to resume or fill. The
+    /// explicit `NotTerminal` classification must win over the
+    /// `executor_order_id` presence and preserve the anchor; releasing it
+    /// would let a fresh retry double-hedge alongside an order the broker
+    /// says can still fill.
     #[tokio::test]
-    async fn retry_after_failed_partial_fill_completes_position_fill() {
+    async fn retry_of_suspended_order_rejection_preserves_the_anchor() {
+        let infra = build_test_infra().await;
+        let symbol = Symbol::new("TSLA").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+
+        let original_error = "broker suspended the order".to_string();
+        infra
+            .ctx
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::MarkFailed {
+                    error: original_error.clone(),
+                    filled_shares: None,
+                    failed_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let position_before = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position_before.pending_offchain_order_id,
+            Some(order_id),
+            "test setup: position must still be expecting this order"
+        );
+
+        HandleOrderRejection {
+            offchain_order_id: order_id,
+            error: original_error,
+            broker_filled_shares: None,
+            broker_failed_at: None,
+            broker_terminality: Some(OrderFailureTerminality::NotTerminal),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let position_after = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position_after.pending_offchain_order_id, None,
+            "Retry must clear the position's pending state by running step 2"
+        );
+        assert_eq!(
+            position_after.last_failed_offchain_order_id,
+            Some(order_id),
+            "an explicit NotTerminal classification must be authoritative and \
+             preserve the anchor even though the order carries an \
+             executor_order_id from the earlier attempt's step 1"
+        );
+    }
+
+    /// Simulates a retry landing after step 1 (`MarkFailed`) already
+    /// committed a retained partial fill, but with no broker-terminality
+    /// evidence carried on the job (`None`, e.g. a legacy payload or a
+    /// cleanup path). Release now depends only on `broker_terminality`, so
+    /// this must preserve the anchor and NOT complete the position off the
+    /// retained partial -- the broker order may still resume.
+    #[tokio::test]
+    async fn retry_of_failed_partial_fill_without_terminal_evidence_preserves_the_anchor() {
         let infra = build_test_infra().await;
         let symbol = Symbol::new("TSLA").unwrap();
         let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
         let order_id =
             submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
         mark_order_accepted(&infra, order_id, shares).await;
+
+        let position_before = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
 
         infra
             .ctx
@@ -662,6 +868,7 @@ mod tests {
             error: "broker failed after partial fill".to_string(),
             broker_filled_shares: None,
             broker_failed_at: None,
+            broker_terminality: None,
         }
         .perform(&infra.ctx)
         .await
@@ -676,7 +883,17 @@ mod tests {
             .expect("position should exist");
         assert_eq!(
             position_after.pending_offchain_order_id, None,
-            "Retry must clear pending by completing the retained partial fill"
+            "Retry must clear pending state regardless of anchor disposition"
+        );
+        assert_eq!(
+            position_after.net, position_before.net,
+            "without terminal evidence, the retained partial fill must NOT be \
+             applied to net"
+        );
+        assert_eq!(
+            position_after.last_failed_offchain_order_id,
+            Some(order_id),
+            "with no broker-terminality evidence, the anchor must be preserved"
         );
     }
 
@@ -699,6 +916,7 @@ mod tests {
             error: error_message.clone(),
             broker_filled_shares: None,
             broker_failed_at: None,
+            broker_terminality: None,
         }
         .perform(&infra.ctx)
         .await
@@ -710,6 +928,7 @@ mod tests {
             error: error_message,
             broker_filled_shares: None,
             broker_failed_at: None,
+            broker_terminality: None,
         }
         .perform(&infra.ctx)
         .await
@@ -746,6 +965,7 @@ mod tests {
             error: "broker rejected".to_string(),
             broker_filled_shares: None,
             broker_failed_at: Some(broker_failed_at),
+            broker_terminality: Some(OrderFailureTerminality::Terminal),
         }
         .perform(&infra.ctx)
         .await
@@ -767,10 +987,298 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn rejection_with_terminal_broker_terminality_releases_the_anchor() {
+        let infra = build_test_infra().await;
+        let symbol = Symbol::new("TSLA").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+
+        let first_order_id =
+            submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+        infra
+            .ctx
+            .position
+            .send(
+                &symbol,
+                PositionCommand::FailOffChainOrder {
+                    offchain_order_id: first_order_id,
+                    error: "first attempt lost in flight".to_string(),
+                    anchor: AnchorDisposition::Preserve,
+                },
+            )
+            .await
+            .unwrap();
+
+        // A second order under the same net position (already at threshold
+        // from the first fill) rather than a second onchain fill, since
+        // `submit_offchain_order`'s fixed trade id would collide on reuse.
+        let second_order_id = OffchainOrderId::new();
+        infra
+            .ctx
+            .position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id: second_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+        infra
+            .ctx
+            .offchain_order
+            .send(
+                &second_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    client_order_id: ClientOrderId::from_uuid(second_order_id.as_uuid()),
+                    kind: crate::offchain::order::CounterTradeOrderKind::Market,
+                },
+            )
+            .await
+            .unwrap();
+        mark_order_accepted(&infra, second_order_id, shares).await;
+
+        HandleOrderRejection {
+            offchain_order_id: second_order_id,
+            error: "order expired".to_string(),
+            broker_filled_shares: None,
+            broker_failed_at: Some(Utc::now()),
+            broker_terminality: Some(OrderFailureTerminality::Terminal),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let position = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "rejection must clear the pending slot"
+        );
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "a broker-observed terminal failure must release the anchor, \
+             even one stashed by an earlier attempt"
+        );
+    }
+
+    /// An `executor_order_id` proves nothing about broker terminality by
+    /// itself; only direct `broker_terminality` evidence from the enqueuing
+    /// poll may release the anchor here.
+    #[tokio::test]
+    async fn rejection_of_submitted_order_without_broker_terminality_preserves_the_anchor() {
+        let infra = build_test_infra().await;
+        let symbol = Symbol::new("TSLA").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+
+        let offchain = infra
+            .ctx
+            .offchain_order
+            .load(&order_id)
+            .await
+            .unwrap()
+            .expect("offchain order should exist");
+        let OffchainOrder::Submitted { .. } = offchain else {
+            panic!(
+                "expected OffchainOrder::Submitted carrying an executor_order_id, \
+                 got {offchain:?}"
+            );
+        };
+
+        HandleOrderRejection {
+            offchain_order_id: order_id,
+            error: "broker rejected: insufficient buying power".to_string(),
+            broker_filled_shares: None,
+            broker_failed_at: None,
+            broker_terminality: None,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let position = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(order_id),
+            "with no broker-terminality evidence, the Submitted order's own \
+             executor_order_id must NOT release the anchor -- the broker order \
+             may still be live"
+        );
+    }
+
+    /// A `Submitted` order's rejection with an explicit `NotTerminal`
+    /// classification must preserve the anchor.
+    #[tokio::test]
+    async fn rejection_of_submitted_order_with_not_terminal_evidence_preserves_the_anchor() {
+        let infra = build_test_infra().await;
+        let symbol = Symbol::new("TSLA").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+
+        HandleOrderRejection {
+            offchain_order_id: order_id,
+            error: "broker suspended the order".to_string(),
+            broker_filled_shares: None,
+            broker_failed_at: None,
+            broker_terminality: Some(OrderFailureTerminality::NotTerminal),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let position = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(order_id),
+            "a NotTerminal classification must preserve the anchor -- the \
+             broker order may still resume or fill"
+        );
+    }
+
+    /// A `Cancelling` order with no retained fill must route through the
+    /// same `Submitted | Cancelling` arm as a plain `Submitted` rejection
+    /// (not the retained-fill arm), so the anchor disposition depends only
+    /// on broker-terminality evidence.
+    #[tokio::test]
+    async fn cancelling_without_retained_fill_preserves_the_anchor() {
+        let infra = build_test_infra().await;
+        let symbol = Symbol::new("TSLA").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+
+        infra
+            .ctx
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::CancelOrder {
+                    reason: crate::offchain::order::CancellationReason::MarketOpenReplacement,
+                },
+            )
+            .await
+            .unwrap();
+
+        let offchain = infra
+            .ctx
+            .offchain_order
+            .load(&order_id)
+            .await
+            .unwrap()
+            .expect("offchain order should exist");
+        let OffchainOrder::Cancelling { retained_fill, .. } = offchain else {
+            panic!("expected OffchainOrder::Cancelling, got {offchain:?}");
+        };
+        assert_eq!(
+            retained_fill, None,
+            "test setup: this order must carry no retained fill so the \
+             rejection routes through the Submitted | Cancelling arm"
+        );
+
+        HandleOrderRejection {
+            offchain_order_id: order_id,
+            error: "broker rejected during cancellation".to_string(),
+            broker_filled_shares: None,
+            broker_failed_at: None,
+            broker_terminality: None,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let position = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "rejection must still clear the pending slot"
+        );
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(order_id),
+            "with no retained fill and no broker-terminality evidence, the \
+             anchor must be preserved rather than released"
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_order_rejection_releases_anchor_and_pending() {
+        let infra = build_test_infra().await;
+        let symbol = Symbol::new("TSLA").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+
+        HandleOrderRejection {
+            offchain_order_id: order_id,
+            error: "expired".to_string(),
+            broker_filled_shares: Some(FractionalShares::ZERO),
+            broker_failed_at: Some(Utc::now()),
+            broker_terminality: Some(OrderFailureTerminality::Terminal),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let position = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "an expired order's rejection must clear the pending slot"
+        );
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "an expired order's rejection must release the idempotency \
+             anchor so the next hedge derives a fresh key"
+        );
+    }
+
     /// A rejection that lands while the order is `Cancelling` with a retained
-    /// fill must finalize the position with the fill's broker timestamp (the
+    /// fill, carrying `Some(Terminal)` broker-terminality evidence, must
+    /// finalize the position with the fill's broker timestamp (the
     /// `partially_filled_at` carried onto the Cancelling state), not the
-    /// local cancel-request wall clock.
+    /// local cancel-request wall clock. Terminal evidence is required here:
+    /// completing the position off a retained partial is only correct once
+    /// the broker order is confirmed done (see
+    /// `partial_fill_rejection_without_terminal_evidence_does_not_complete_the_position`
+    /// for the non-terminal/no-evidence case).
     #[tokio::test]
     async fn cancelling_rejection_finalizes_position_with_fill_broker_time() {
         let infra = build_test_infra().await;
@@ -811,6 +1319,7 @@ mod tests {
             error: "broker rejected during cancellation".to_string(),
             broker_filled_shares: None,
             broker_failed_at: None,
+            broker_terminality: Some(OrderFailureTerminality::Terminal),
         }
         .perform(&infra.ctx)
         .await
@@ -832,6 +1341,55 @@ mod tests {
             Some(broker_fill_time),
             "Position must be stamped with the fill's broker time, not the \
              cancel-request wall clock"
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_partial_fill_rejection_without_broker_terminality_preserves_the_anchor() {
+        let infra = build_test_infra().await;
+        let symbol = Symbol::new("TSLA").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(1))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtTSLA", shares, Direction::Sell).await;
+
+        infra
+            .ctx
+            .offchain_order
+            .send(
+                &order_id,
+                OffchainOrderCommand::UpdatePartialFill {
+                    shares_filled: FractionalShares::ZERO,
+                    avg_price: Usd::new(float!(150)),
+                    partially_filled_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        HandleOrderRejection {
+            offchain_order_id: order_id,
+            error: "broker rejected".to_string(),
+            broker_filled_shares: None,
+            broker_failed_at: None,
+            broker_terminality: None,
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        let position = infra
+            .ctx
+            .position
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(order_id),
+            "the order's own executor_order_id is not broker-terminality \
+             evidence, so with no broker_terminality classification the \
+             anchor must preserve"
         );
     }
 }

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -16,7 +16,8 @@ use tracing::{debug, error, info, warn};
 
 use st0x_event_sorcery::{Projection, Store};
 use st0x_execution::{
-    Executor, ExecutorOrderId, FractionalShares, OrderState, Positive, SupportedExecutor, Symbol,
+    Executor, ExecutorOrderId, FractionalShares, OrderFailureTerminality, OrderState, Positive,
+    SupportedExecutor, Symbol,
 };
 use st0x_finance::{NonNegative, Usd};
 
@@ -282,6 +283,7 @@ impl PollOrderStatus {
                 shares_filled: Some(shares_filled),
                 avg_price: Some(avg_price),
                 failed_at,
+                terminality,
             } => {
                 self.record_partial_fill(ctx, symbol, shares_filled, Some(avg_price), failed_at)
                     .await?;
@@ -291,6 +293,7 @@ impl PollOrderStatus {
                     error_reason,
                     Some(shares_filled),
                     Some(failed_at),
+                    Some(terminality),
                 )
                 .await
             }
@@ -308,6 +311,7 @@ impl PollOrderStatus {
                 shares_filled: Some(shares_filled),
                 avg_price: None,
                 failed_at,
+                ..
             } if Positive::new(shares_filled).is_ok() => {
                 error!(
                     target: "broker",
@@ -325,10 +329,18 @@ impl PollOrderStatus {
                 error_reason,
                 shares_filled,
                 failed_at,
+                terminality,
                 ..
             } => {
-                self.enqueue_rejection(ctx, symbol, error_reason, shares_filled, Some(failed_at))
-                    .await
+                self.enqueue_rejection(
+                    ctx,
+                    symbol,
+                    error_reason,
+                    shares_filled,
+                    Some(failed_at),
+                    Some(terminality),
+                )
+                .await
             }
 
             Cancelled {
@@ -560,6 +572,11 @@ impl PollOrderStatus {
     /// rejection stems from a broker `Failed` state; `None` when no broker
     /// timestamp exists for the rejection (the job then stamps its own
     /// observation time).
+    ///
+    /// `broker_terminality` is the broker-terminality classification
+    /// carried by that same `Failed` state; `None` when this rejection has
+    /// no broker-terminality evidence at all (e.g. cleanup paths), which
+    /// must never release the idempotency anchor.
     async fn enqueue_rejection<E>(
         &self,
         ctx: &PollOrderStatusCtx<E>,
@@ -567,6 +584,7 @@ impl PollOrderStatus {
         error_reason: Option<String>,
         broker_filled_shares: Option<FractionalShares>,
         broker_failed_at: Option<DateTime<Utc>>,
+        broker_terminality: Option<OrderFailureTerminality>,
     ) -> Result<(), JobError>
     where
         E: Executor + Clone + Send + Sync + 'static,
@@ -588,6 +606,7 @@ impl PollOrderStatus {
                 error: error_message,
                 broker_filled_shares,
                 broker_failed_at,
+                broker_terminality,
             })
             .await?;
 
@@ -670,6 +689,7 @@ impl PollOrderStatus {
                     ctx,
                     symbol,
                     Some("Broker reported Cancelled before local cancellation request".to_string()),
+                    None,
                     None,
                     None,
                 )
@@ -2387,6 +2407,7 @@ mod tests {
             error_reason: Some("broker rejected".to_string()),
             shares_filled: None,
             avg_price: None,
+            terminality: OrderFailureTerminality::Terminal,
         });
         let infra = build_test_infra(executor).await;
         let symbol = Symbol::new("AAPL").unwrap();
@@ -2420,6 +2441,118 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn poll_with_expired_broker_order_enqueues_rejection_with_broker_time() {
+        let failed_at = Utc::now();
+        let executor = MockExecutor::new().with_order_status(OrderState::Failed {
+            failed_at,
+            error_reason: Some("expired".to_string()),
+            shares_filled: Some(FractionalShares::ZERO),
+            avg_price: None,
+            terminality: OrderFailureTerminality::Terminal,
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
+            1,
+            "an expired broker order must enqueue exactly one HandleOrderRejection"
+        );
+
+        let extracted: String = sqlx_apalis::query_scalar(
+            "SELECT json_extract(CAST(job AS TEXT), '$.broker_failed_at') FROM Jobs \
+             WHERE job_type = ?",
+        )
+        .bind(handle_order_rejection_job_type())
+        .fetch_one(&infra.apalis_pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            extracted,
+            serde_json::to_value(failed_at)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string(),
+            "the enqueued rejection must carry the broker's own failure \
+             time, not a None/observation-time fallback"
+        );
+
+        let extracted_terminality: String = sqlx_apalis::query_scalar(
+            "SELECT json_extract(CAST(job AS TEXT), '$.broker_terminality') FROM Jobs \
+             WHERE job_type = ?",
+        )
+        .bind(handle_order_rejection_job_type())
+        .fetch_one(&infra.apalis_pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            extracted_terminality, "Terminal",
+            "the enqueued rejection must carry the broker's terminality \
+             classification, not drop it"
+        );
+    }
+
+    /// The classification must survive into the enqueued job, not be silently dropped.
+    #[tokio::test]
+    async fn poll_with_suspended_broker_order_enqueues_rejection_as_not_terminal() {
+        let executor = MockExecutor::new().with_order_status(OrderState::Failed {
+            failed_at: Utc::now(),
+            error_reason: Some("suspended".to_string()),
+            shares_filled: Some(FractionalShares::ZERO),
+            avg_price: None,
+            terminality: OrderFailureTerminality::NotTerminal,
+        });
+        let infra = build_test_infra(executor).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
+        let order_id =
+            submit_offchain_order(&infra, &symbol, "wtAAPL", shares, Direction::Sell).await;
+
+        PollOrderStatus {
+            offchain_order_id: order_id,
+            backpressure_streak: BackpressureStreak::default(),
+        }
+        .perform(&infra.ctx)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
+            1,
+            "a suspended broker order must still enqueue exactly one HandleOrderRejection"
+        );
+
+        let extracted_terminality: String = sqlx_apalis::query_scalar(
+            "SELECT json_extract(CAST(job AS TEXT), '$.broker_terminality') FROM Jobs \
+             WHERE job_type = ?",
+        )
+        .bind(handle_order_rejection_job_type())
+        .fetch_one(&infra.apalis_pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            extracted_terminality, "NotTerminal",
+            "a suspended broker order must be enqueued as NotTerminal so the \
+             anchor is preserved rather than released"
+        );
+    }
+
+    #[tokio::test]
     async fn poll_with_failed_partial_fill_records_fill_before_rejection() {
         let shares_filled = FractionalShares::new(float!(1));
         let avg_price = Usd::new(float!(150.0));
@@ -2428,6 +2561,7 @@ mod tests {
             error_reason: Some("broker rejected after partial fill".to_string()),
             shares_filled: Some(shares_filled),
             avg_price: Some(avg_price),
+            terminality: OrderFailureTerminality::Terminal,
         });
         let infra = build_test_infra(executor).await;
         let symbol = Symbol::new("AAPL").unwrap();
@@ -2815,6 +2949,7 @@ mod tests {
             error_reason: Some("broker rejected after partial fill".to_string()),
             shares_filled: Some(FractionalShares::new(float!(50))),
             avg_price: None,
+            terminality: OrderFailureTerminality::Terminal,
         });
         let infra = build_test_infra(executor).await;
         let symbol = Symbol::new("AAPL").unwrap();
@@ -2867,6 +3002,7 @@ mod tests {
             error_reason: Some("broker rejected remainder".to_string()),
             shares_filled: Some(FractionalShares::new(float!(50))),
             avg_price: None,
+            terminality: OrderFailureTerminality::Terminal,
         });
         let infra = build_test_infra(executor).await;
         let symbol = Symbol::new("AAPL").unwrap();
@@ -2917,6 +3053,7 @@ mod tests {
             error_reason: Some("broker rejected remainder".to_string()),
             shares_filled: Some(FractionalShares::new(float!(50))),
             avg_price: None,
+            terminality: OrderFailureTerminality::Terminal,
         });
         let infra = build_test_infra(executor).await;
         let symbol = Symbol::new("AAPL").unwrap();

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -515,7 +515,7 @@ pub(super) mod test_helpers {
     use st0x_execution::{Direction, FractionalShares, Positive, SupportedExecutor, Symbol};
     use st0x_float_macro::float;
 
-    use crate::position::{Position, PositionEvent, TradeId, TriggerReason};
+    use crate::position::{AnchorDisposition, Position, PositionEvent, TradeId, TriggerReason};
     use crate::test_utils::setup_test_db;
 
     use super::projection::HedgeLatencyProjection;
@@ -567,6 +567,7 @@ pub(super) mod test_helpers {
             offchain_order_id: order_id,
             error: "broker rejected".to_string(),
             failed_at: timestamp(failed_offset),
+            anchor: AnchorDisposition::Preserve,
         }
     }
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -18,7 +18,8 @@ use tracing::{debug, info, warn};
 use st0x_config::ExecutionThreshold;
 use st0x_event_sorcery::{DomainEvent, EventSourced, Projection, ProjectionError, Table};
 use st0x_execution::{
-    Direction, ExecutorOrderId, FractionalShares, HasZero, Positive, SupportedExecutor, Symbol,
+    Direction, ExecutorOrderId, FractionalShares, HasZero, OrderFailureTerminality, Positive,
+    SupportedExecutor, Symbol,
 };
 use st0x_finance::{Usd, Usdc};
 use st0x_float_macro::float;
@@ -43,6 +44,33 @@ impl std::fmt::Debug for PriceObservation {
             .field("price", &DebugFloat(&self.price))
             .field("observed_at", &self.observed_at)
             .finish()
+    }
+}
+
+/// Whether an offchain order failure releases the position's
+/// broker-idempotency anchor (`last_failed_offchain_order_id`) or preserves
+/// it. `Release` requires `Some(OrderFailureTerminality::Terminal)`: positive,
+/// broker-documented evidence that the order under the failed placement's
+/// `client_order_id` reached a state the broker will never advance further,
+/// so the key is spent and no retry can usefully dedupe against it.
+/// `Preserve` is the fail-safe default for everything else, including
+/// `None` -- unknown terminality must never release, and the presence of an
+/// `executor_order_id` is not evidence of terminality on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum AnchorDisposition {
+    #[default]
+    Preserve,
+    Release,
+}
+
+impl AnchorDisposition {
+    /// Only a direct `Terminal` classification releases. `NotTerminal` and
+    /// `None` both preserve.
+    pub fn from_broker_terminality(broker_terminality: Option<OrderFailureTerminality>) -> Self {
+        match broker_terminality {
+            Some(OrderFailureTerminality::Terminal) => Self::Release,
+            Some(OrderFailureTerminality::NotTerminal) | None => Self::Preserve,
+        }
     }
 }
 
@@ -173,7 +201,7 @@ impl EventSourced for Position {
 
     const AGGREGATE_TYPE: &'static str = "Position";
     const PROJECTION: Table = Table("position_view");
-    const SCHEMA_VERSION: u64 = 6;
+    const SCHEMA_VERSION: u64 = 7;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use PositionEvent::*;
@@ -340,25 +368,33 @@ impl EventSourced for Position {
             OffChainOrderFailed {
                 offchain_order_id,
                 failed_at,
+                anchor,
                 ..
-            } => Ok(Some(Self {
-                pending_offchain_order_id: None,
-                // Stash the failed OID so the next placement attempt can
-                // reuse it as `client_order_id` and let the broker dedupe.
-                //
-                // Preserve the *first* failed anchor across a chain of
-                // failures: the broker recorded the original attempt under
-                // that key, so a later attempt whose own response was also
-                // lost must keep deduping against the original key. Overwriting
-                // with each new OID would point the next retry at a key the
-                // broker never saw, double-submitting the order. Cleared only
-                // by a successful fill.
-                last_failed_offchain_order_id: entity
-                    .last_failed_offchain_order_id
-                    .or(Some(*offchain_order_id)),
-                last_updated: Some(*failed_at),
-                ..entity.clone()
-            })),
+            } => {
+                let last_failed_offchain_order_id = match anchor {
+                    // Stash the failed OID so the next placement attempt can
+                    // reuse it as `client_order_id` and let the broker
+                    // dedupe.
+                    //
+                    // Preserve the *first* failed anchor across a chain of
+                    // failures: the broker recorded the original attempt
+                    // under that key, so a later attempt whose own response
+                    // was also lost must keep deduping against the original
+                    // key. Overwriting with each new OID would point the
+                    // next retry at a key the broker never saw,
+                    // double-submitting the order.
+                    AnchorDisposition::Preserve => entity
+                        .last_failed_offchain_order_id
+                        .or(Some(*offchain_order_id)),
+                    AnchorDisposition::Release => None,
+                };
+                Ok(Some(Self {
+                    pending_offchain_order_id: None,
+                    last_failed_offchain_order_id,
+                    last_updated: Some(*failed_at),
+                    ..entity.clone()
+                }))
+            }
 
             OffChainOrderCancelled {
                 offchain_order_id, ..
@@ -636,12 +672,13 @@ impl EventSourced for Position {
             FailOffChainOrder {
                 offchain_order_id,
                 error,
+                anchor,
             } => {
                 self.validate_pending_execution(offchain_order_id)?;
 
                 warn!(
                     target: "hedge",
-                    %offchain_order_id, symbol = %self.symbol, %error,
+                    %offchain_order_id, symbol = %self.symbol, %error, ?anchor,
                     "Offchain venue rejected"
                 );
 
@@ -649,6 +686,7 @@ impl EventSourced for Position {
                     offchain_order_id,
                     error,
                     failed_at: Utc::now(),
+                    anchor,
                 }])
             }
 
@@ -1166,6 +1204,12 @@ pub enum PositionCommand {
     FailOffChainOrder {
         offchain_order_id: OffchainOrderId,
         error: String,
+        /// Whether this failure releases or preserves the position's
+        /// broker-idempotency anchor (`last_failed_offchain_order_id`).
+        /// Callers derive this from evidence that the broker order under
+        /// the failed placement's key reached a terminal state; see
+        /// `AnchorDisposition`.
+        anchor: AnchorDisposition,
     },
     /// Clear a pending offchain order that was intentionally cancelled (e.g.
     /// the extended-hours -> regular cancel-and-replace), distinct from a broker
@@ -1257,6 +1301,8 @@ pub enum PositionEvent {
         offchain_order_id: OffchainOrderId,
         error: String,
         failed_at: DateTime<Utc>,
+        #[serde(default)]
+        anchor: AnchorDisposition,
     },
     /// A pending offchain order was intentionally cancelled (not a failure), so
     /// failure-rate analytics can tell the two apart. Clears the pending
@@ -1449,13 +1495,15 @@ impl PartialEq for PositionEvent {
                     offchain_order_id: o1,
                     error: e1,
                     failed_at: f1,
+                    anchor: a1,
                 },
                 Self::OffChainOrderFailed {
                     offchain_order_id: o2,
                     error: e2,
                     failed_at: f2,
+                    anchor: a2,
                 },
-            ) => o1 == o2 && e1 == e2 && f1 == f2,
+            ) => o1 == o2 && e1 == e2 && f1 == f2 && a1 == a2,
             (
                 Self::OffChainOrderCancelled {
                     offchain_order_id: o1,
@@ -1693,10 +1741,12 @@ impl std::fmt::Debug for PositionCommand {
             Self::FailOffChainOrder {
                 offchain_order_id,
                 error,
+                anchor,
             } => f
                 .debug_struct("FailOffChainOrder")
                 .field("offchain_order_id", offchain_order_id)
                 .field("error", error)
+                .field("anchor", anchor)
                 .finish(),
             Self::CancelOffChainOrder {
                 offchain_order_id,
@@ -1817,11 +1867,13 @@ impl std::fmt::Debug for PositionEvent {
                 offchain_order_id,
                 error,
                 failed_at,
+                anchor,
             } => f
                 .debug_struct("OffChainOrderFailed")
                 .field("offchain_order_id", offchain_order_id)
                 .field("error", error)
                 .field("failed_at", failed_at)
+                .field("anchor", anchor)
                 .finish(),
             Self::OffChainOrderCancelled {
                 offchain_order_id,
@@ -1892,6 +1944,7 @@ impl std::fmt::Debug for TriggerReason {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
     use st0x_execution::Positive;
 
     use st0x_event_sorcery::{LifecycleError, StoreBuilder, TestHarness, replay};
@@ -1903,6 +1956,37 @@ mod tests {
 
     fn one_share_threshold() -> ExecutionThreshold {
         ExecutionThreshold::shares(Positive::new(FractionalShares::new(float!(1))).unwrap())
+    }
+
+    #[test]
+    fn broker_evidence_terminal_releases_the_anchor() {
+        assert_eq!(
+            AnchorDisposition::from_broker_terminality(Some(OrderFailureTerminality::Terminal)),
+            AnchorDisposition::Release
+        );
+    }
+
+    #[test]
+    fn broker_evidence_not_terminal_preserves_the_anchor() {
+        // A suspended/replaced/calculated broker status is NOT positive
+        // evidence: the broker order can still resume or continue, so
+        // releasing here would let a fresh retry double-hedge alongside it.
+        assert_eq!(
+            AnchorDisposition::from_broker_terminality(Some(OrderFailureTerminality::NotTerminal)),
+            AnchorDisposition::Preserve
+        );
+    }
+
+    #[test]
+    fn broker_evidence_none_preserves_even_with_executor_order_id_present() {
+        // An executor_order_id existing on the position is irrelevant: the
+        // constructor takes terminality alone, so unknown terminality always
+        // preserves regardless of what else is known about the order.
+        let _executor_order_id = ExecutorOrderId::new("test-order-id");
+        assert_eq!(
+            AnchorDisposition::from_broker_terminality(None),
+            AnchorDisposition::Preserve
+        );
     }
 
     #[tokio::test]
@@ -2619,6 +2703,7 @@ mod tests {
             .when(PositionCommand::FailOffChainOrder {
                 offchain_order_id,
                 error: "Broker API timeout".to_string(),
+                anchor: AnchorDisposition::Preserve,
             })
             .await
             .events();
@@ -2736,6 +2821,7 @@ mod tests {
                 offchain_order_id: failed_order_id,
                 error: "broker rejected".to_string(),
                 failed_at: Utc::now(),
+                anchor: AnchorDisposition::Preserve,
             },
             placed(cancelled_order_id),
             PositionEvent::OffChainOrderCancelled {
@@ -3422,6 +3508,7 @@ mod tests {
                 offchain_order_id,
                 error: "Market closed".to_string(),
                 failed_at: Utc::now(),
+                anchor: AnchorDisposition::Preserve,
             },
         ])
         .unwrap()
@@ -3481,6 +3568,7 @@ mod tests {
                 offchain_order_id: first_order_id,
                 error: "Market closed".to_string(),
                 failed_at: Utc::now(),
+                anchor: AnchorDisposition::Preserve,
             },
             OffChainOrderPlaced {
                 offchain_order_id: second_order_id,
@@ -3497,6 +3585,7 @@ mod tests {
                 offchain_order_id: second_order_id,
                 error: "Market closed".to_string(),
                 failed_at: Utc::now(),
+                anchor: AnchorDisposition::Preserve,
             },
         ])
         .unwrap()
@@ -3510,6 +3599,154 @@ mod tests {
              must keep deduping against it rather than a key the broker \
              never saw"
         );
+    }
+
+    #[test]
+    fn off_chain_order_failed_with_release_clears_the_anchor() {
+        use PositionEvent::*;
+
+        let first_order_id = OffchainOrderId::new();
+        let second_order_id = OffchainOrderId::new();
+
+        let position = replay::<Position>(vec![
+            Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: Utc::now(),
+            },
+            OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(1.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: Utc::now(),
+                block_number: None,
+                seen_at: Utc::now(),
+            },
+            OffChainOrderPlaced {
+                offchain_order_id: first_order_id,
+                shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor: SupportedExecutor::DryRun,
+                trigger_reason: TriggerReason::SharesThreshold {
+                    net_position_shares: float!(1.5),
+                    threshold_shares: float!(1),
+                },
+                placed_at: Utc::now(),
+            },
+            OffChainOrderFailed {
+                offchain_order_id: first_order_id,
+                error: "Market closed".to_string(),
+                failed_at: Utc::now(),
+                anchor: AnchorDisposition::Preserve,
+            },
+            OffChainOrderPlaced {
+                offchain_order_id: second_order_id,
+                shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor: SupportedExecutor::DryRun,
+                trigger_reason: TriggerReason::SharesThreshold {
+                    net_position_shares: float!(1.5),
+                    threshold_shares: float!(1),
+                },
+                placed_at: Utc::now(),
+            },
+            OffChainOrderFailed {
+                offchain_order_id: second_order_id,
+                error: "expired".to_string(),
+                failed_at: Utc::now(),
+                anchor: AnchorDisposition::Release,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "a Release failure must clear a pre-existing Preserve-stashed \
+             anchor: the broker order under that key reached a terminal \
+             state, so the key is spent and no retry can dedupe against it"
+        );
+    }
+
+    #[test]
+    fn off_chain_order_failed_with_release_does_not_stash_its_own_id() {
+        use PositionEvent::*;
+
+        let offchain_order_id = OffchainOrderId::new();
+
+        let position = replay::<Position>(vec![
+            Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: Utc::now(),
+            },
+            OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(1.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: Utc::now(),
+                block_number: None,
+                seen_at: Utc::now(),
+            },
+            OffChainOrderPlaced {
+                offchain_order_id,
+                shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor: SupportedExecutor::DryRun,
+                trigger_reason: TriggerReason::SharesThreshold {
+                    net_position_shares: float!(1.5),
+                    threshold_shares: float!(1),
+                },
+                placed_at: Utc::now(),
+            },
+            OffChainOrderFailed {
+                offchain_order_id,
+                error: "expired".to_string(),
+                failed_at: Utc::now(),
+                anchor: AnchorDisposition::Release,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "with no pre-existing anchor, a Release failure must not stash \
+             its own order id either"
+        );
+    }
+
+    /// Replay-parity contract (verify-migrations): a `PositionEvent::OffChainOrderFailed`
+    /// payload persisted before `anchor` existed has no `anchor` key at all. It must still
+    /// deserialize, defaulting to `Preserve` so replaying prod history reproduces the
+    /// pre-change anchor behavior exactly.
+    #[test]
+    fn legacy_off_chain_order_failed_event_defaults_to_preserve() {
+        // A literal, not re-serialized from the current type: a change to the wire
+        // format must break this test rather than move both sides together.
+        let payload = json!({
+            "OffChainOrderFailed": {
+                "offchain_order_id": "946fba4e-28d6-4454-b311-02e3f42340b7",
+                "error": "Order failed with no error reason",
+                "failed_at": "2026-08-05T14:15:25.926147Z"
+            }
+        });
+
+        let legacy: PositionEvent = serde_json::from_value(payload)
+            .expect("a pre-anchor event (missing the new field) must still deserialize");
+
+        let PositionEvent::OffChainOrderFailed { anchor, .. } = legacy else {
+            panic!("expected OffChainOrderFailed, got: {legacy:?}");
+        };
+        assert_eq!(anchor, AnchorDisposition::Preserve);
     }
 
     #[test]
@@ -3552,6 +3789,7 @@ mod tests {
                 offchain_order_id: failed_order_id,
                 error: "Market closed".to_string(),
                 failed_at: Utc::now(),
+                anchor: AnchorDisposition::Preserve,
             },
             OffChainOrderPlaced {
                 offchain_order_id: retry_order_id,
@@ -3624,6 +3862,7 @@ mod tests {
                 offchain_order_id,
                 error: "Market closed".to_string(),
                 failed_at: Utc::now(),
+                anchor: AnchorDisposition::Preserve,
             },
             PositionEvent::ManualPositionAdjusted {
                 previous_net: FractionalShares::new(float!(1.5)),
@@ -4100,6 +4339,7 @@ mod tests {
             offchain_order_id: OffchainOrderId::new(),
             error: "Market closed".to_string(),
             failed_at: timestamp,
+            anchor: AnchorDisposition::Preserve,
         };
 
         assert_eq!(event.timestamp(), timestamp);

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -5447,7 +5447,9 @@ mod tests {
     use crate::inventory::{InventoryError, InventoryView, TransferOp, Venue};
     use crate::offchain::order::OffchainOrderId;
     use crate::onchain::mock::MockRaindex;
-    use crate::position::{Position, PositionCommand, PositionEvent, TradeId, TriggerReason};
+    use crate::position::{
+        AnchorDisposition, Position, PositionCommand, PositionEvent, TradeId, TriggerReason,
+    };
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::test_utils::rebalancing_enabled_equities;
     use crate::tokenized_equity_mint::TokenizedEquityMintCommand;
@@ -7852,6 +7854,7 @@ mod tests {
             offchain_order_id,
             error: "test failure".to_string(),
             failed_at: Utc::now(),
+            anchor: AnchorDisposition::Preserve,
         }
     }
 

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -34,7 +34,7 @@ use crate::offchain::order::{
     finalize_cancelled_position_or_log_unpriced, place_offchain_order_at_broker,
     push_poll_job_if_absent,
 };
-use crate::position::{Position, PositionCommand, PositionError};
+use crate::position::{AnchorDisposition, Position, PositionCommand, PositionError};
 use crate::trading::offchain::close_flatten::{CloseFlattenPolicy, preflight_skip_reason_label};
 use crate::trading::onchain::trade_accountant::TradeAccountingError;
 
@@ -546,6 +546,9 @@ async fn route_placement_outcome(
                     PositionCommand::FailOffChainOrder {
                         offchain_order_id,
                         error,
+                        // No broker terminality classification available
+                        // here; fail-safe preserves.
+                        anchor: AnchorDisposition::Preserve,
                     },
                 )
                 .await?;
@@ -570,6 +573,7 @@ async fn route_placement_outcome(
                     PositionCommand::FailOffChainOrder {
                         offchain_order_id,
                         error: "Offchain order missing after Place".to_string(),
+                        anchor: AnchorDisposition::Preserve,
                     },
                 )
                 .await?;
@@ -862,7 +866,7 @@ mod tests {
     use crate::offchain::order::{
         OffchainOrder, OffchainOrderCommand, OrderPlacementResult, OrderPlacer,
     };
-    use crate::position::{Position, PositionCommand, TradeId};
+    use crate::position::{AnchorDisposition, Position, PositionCommand, TradeId};
     use crate::test_utils::TEST_POLL_INTERVAL;
 
     /// Builds an [`AssetsConfig`] with a single equity whose extended-hours
@@ -939,6 +943,59 @@ mod tests {
         }
 
         Arc::new(SucceedingPlacer)
+    }
+
+    /// Succeeds like [`succeeding_order_placer`], but records every
+    /// `client_order_id` submitted with `place_market_order`, letting a test
+    /// assert on the key the real placement path actually derived.
+    fn capturing_order_placer() -> (Arc<dyn OrderPlacer>, Arc<StdMutex<Vec<ClientOrderId>>>) {
+        struct CapturingPlacer {
+            captured_client_order_ids: Arc<StdMutex<Vec<ClientOrderId>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl OrderPlacer for CapturingPlacer {
+            async fn place_market_order(
+                &self,
+                order: st0x_execution::MarketOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                self.captured_client_order_ids
+                    .lock()
+                    .unwrap()
+                    .push(order.client_order_id);
+                Ok(OrderPlacementResult {
+                    executor_order_id: ExecutorOrderId::new("test-order-123"),
+                    placed_shares: order.shares,
+                    is_extended_hours: false,
+                    limit_price: None,
+                })
+            }
+
+            async fn place_limit_order(
+                &self,
+                _order: st0x_execution::LimitOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err("regular-session test must not place a limit order".into())
+            }
+
+            async fn cancel_order(
+                &self,
+                _executor_order_id: &st0x_execution::ExecutorOrderId,
+            ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(st0x_execution::CancellationOutcome::Requested)
+            }
+        }
+
+        let captured_client_order_ids = Arc::new(StdMutex::new(Vec::new()));
+        (
+            Arc::new(CapturingPlacer {
+                captured_client_order_ids: captured_client_order_ids.clone(),
+            }),
+            captured_client_order_ids,
+        )
     }
 
     fn rejecting_order_placer() -> Arc<dyn OrderPlacer> {
@@ -1702,6 +1759,162 @@ mod tests {
         assert_eq!(
             position.pending_offchain_order_id, None,
             "a missing order after Place must clear the position claim"
+        );
+    }
+
+    #[tokio::test]
+    async fn placement_failure_without_executor_id_preserves_the_anchor() {
+        let TestInfra {
+            ctx,
+            position_projection,
+            ..
+        } = create_hedge_ctx(succeeding_order_placer()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2.0))).unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let offchain_order_id = OffchainOrderId::new();
+        ctx.position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let failed = OffchainOrder::Failed {
+            symbol: symbol.clone(),
+            shares,
+            requested_shares: Some(shares),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            retained_fill: None,
+            filled_shares: None,
+            executor_order_id: None,
+            error: "broker unreachable".to_string(),
+            placed_at: chrono::Utc::now(),
+            failed_at: chrono::Utc::now(),
+        };
+
+        route_placement_outcome(&ctx, &symbol, offchain_order_id, Some(failed))
+            .await
+            .unwrap();
+
+        let position = position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(offchain_order_id),
+            "no broker order id is the lost-2xx window the anchor exists \
+             for; the failed order's own id must be stashed"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_failed_retry_with_executor_id_preserves_the_anchor() {
+        let TestInfra {
+            ctx,
+            position_projection,
+            ..
+        } = create_hedge_ctx(succeeding_order_placer()).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2.0))).unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let first_order_id = OffchainOrderId::new();
+        ctx.position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id: first_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+        ctx.position
+            .send(
+                &symbol,
+                PositionCommand::FailOffChainOrder {
+                    offchain_order_id: first_order_id,
+                    error: "first attempt lost in flight".to_string(),
+                    anchor: AnchorDisposition::Preserve,
+                },
+            )
+            .await
+            .unwrap();
+
+        let second_order_id = OffchainOrderId::new();
+        ctx.position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id: second_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let failed = OffchainOrder::Failed {
+            symbol: symbol.clone(),
+            shares,
+            requested_shares: Some(shares),
+            direction: Direction::Sell,
+            executor: SupportedExecutor::DryRun,
+            retained_fill: None,
+            filled_shares: Some(FractionalShares::ZERO),
+            executor_order_id: Some(ExecutorOrderId::new("expired-order")),
+            error: "expired".to_string(),
+            placed_at: chrono::Utc::now(),
+            failed_at: chrono::Utc::now(),
+        };
+
+        route_placement_outcome(&ctx, &symbol, second_order_id, Some(failed))
+            .await
+            .unwrap();
+
+        let position = position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(first_order_id),
+            "route_placement_outcome has no broker-terminality classification \
+             to derive from, so it always preserves; a broker order id alone \
+             is not evidence of terminality, and Preserve keeps the original \
+             anchor across the retry chain"
         );
     }
 
@@ -3442,6 +3655,76 @@ mod tests {
             position.pending_offchain_order_id,
             Some(job.offchain_order_id),
             "placement proceeds once the lock is released"
+        );
+    }
+
+    #[tokio::test]
+    async fn client_order_id_for_placement_derives_fresh_key_after_release() {
+        let (placer, captured_client_order_ids) = capturing_order_placer();
+        let TestInfra {
+            ctx,
+            position_projection,
+            ..
+        } = create_hedge_ctx(placer).await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let shares = Positive::new(FractionalShares::new(float!(2.0))).unwrap();
+
+        fill_position(
+            &ctx.position,
+            &symbol,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let expired_order_id = OffchainOrderId::new();
+        ctx.position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id: expired_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+        ctx.position
+            .send(
+                &symbol,
+                PositionCommand::FailOffChainOrder {
+                    offchain_order_id: expired_order_id,
+                    error: "expired".to_string(),
+                    anchor: AnchorDisposition::Release,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Drive `PlaceHedge::perform_body`, not a hand re-derivation: this proves
+        // the live wiring reads the cleared anchor.
+        let job = hedge_job(&symbol, 2.0, Direction::Sell);
+        job.perform(&ctx).await.unwrap();
+
+        let position = position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "a successful placement must not leave a stale anchor behind"
+        );
+
+        let captured = captured_client_order_ids.lock().unwrap().clone();
+        assert_eq!(
+            captured,
+            [ClientOrderId::from_uuid(job.offchain_order_id.as_uuid())],
+            "after a Release failure clears the anchor, the real placement \
+             path must derive a fresh client_order_id from its own id, not \
+             the dead expired order's key"
         );
     }
 


### PR DESCRIPTION
## What

- Releases the broker-idempotency anchor (`Position.last_failed_offchain_order_id`) when the Alpaca order under it is finished, so a symbol whose order expired can hedge again with no operator action. Closes [RAI-1559](https://linear.app/makeitrain/issue/RAI-1559/release-the-broker-idempotency-anchor-when-the-referenced-order-is).
- Adds `AnchorDisposition { Preserve, Release }` on the `Position` aggregate, threaded through `PositionCommand::FailOffChainOrder` and `PositionEvent::OffChainOrderFailed`.
- Adds `OrderFailureTerminality { Terminal, NotTerminal }` in `st0x-execution`, so the bot can tell an Alpaca status that is final from one that can still resume.
- Logs the real Alpaca reply when a placement is rejected for a duplicate `client_order_id`.

## Why

The anchor is never released when the Alpaca order it points at is already terminal. Every later placement for that symbol reuses the dead order's `client_order_id`, Alpaca answers `422 client_order_id must be unique`, the duplicate-recovery path adopts the stale terminal order as the result, and the hedge never reaches the market. Only a fill clears the anchor, and a fill cannot happen while the anchor holds, so the loop feeds itself and needs an operator to break it.

Production hit this more than once. DRAM on 2026-07-28 produced 402 failed orders and left about USD 830 short unhedged. DRAM and NVDA on 2026-08-04 and 2026-08-05 produced 843 failed placements over about 16 hours. Each one ended only when an operator ran a manual position adjustment.

## How

- **Release rule.** `OffChainOrderFailed` carries an `anchor` field. `Release` clears the anchor, `Preserve` keeps the first failed order id as before. The event field is `#[serde(default)]`, so events written before this change replay exactly as they did.
- **Evidence, not guesswork.** `Release` needs positive evidence that the broker order under the key is finished. A direct broker classification always wins. When there is no classification, the presence of an `executor_order_id` is the fallback. Every other site keeps `Preserve`, which is the fail-safe.
- **Terminality classification.** `map_broker_status_to_order_status` folds six Alpaca statuses into `OrderStatus::Failed`. `broker_failure_terminality` now splits them. `expired` and `rejected` are final. `done_for_day` is final only because every order this bot places is Day time-in-force, so it cannot resume in a later session. `replaced`, `suspended`, and `calculated` are not final, because those orders can still fill. The match is exhaustive, so a new Alpaca status cannot default into "final".
- **CLI repair keeps `Preserve`.** That path force-fails an order that is usually still live at the broker. A release there would re-arm the double hedge the anchor prevents.
- **Duplicate 422.** Both duplicate-recovery branches in `alpaca_broker_api/order.rs` log at `warn!` with the Alpaca code and message, instead of hiding them in a `debug!`.

## Testing

- `legacy_off_chain_order_failed_event_defaults_to_preserve` deserializes a hand-written JSON literal in the shape of a real production event, so a change to the wire format breaks the test instead of moving both sides together.
- `poll_with_expired_broker_order_enqueues_rejection_with_broker_time` and `expired_order_rejection_releases_anchor_and_pending` mirror the existing cancellation test across the poll job and the rejection job.
- `poll_with_suspended_broker_order_enqueues_rejection_as_not_terminal` plus an httpmock fixture with a real Alpaca `"status": "suspended"` body pin the classification at the executor boundary.
- `retry_of_suspended_order_rejection_preserves_the_anchor` covers the at-least-once retry window. It failed against the code before the fix, and passes after.
- `fail_pending_preserves_anchor_despite_executor_order_id_evidence` guards the deliberate CLI repair override, so a later refactor cannot turn it into a release without a red test.
- Preserve and Release pairs cover `dispatch_post_place_state`, `route_placement_outcome`, orphan recovery, the trade retry loop, and the CLI reconcile path.
- `cargo nextest run` passes 3021 tests in `st0x-hedge` and 350 in `st0x-execution`. `cargo clippy --workspace --all-targets --all-features` and `cargo fmt` are clean.

## Anything else

`Position::SCHEMA_VERSION` goes from 6 to 7, so snapshots rebuild on boot and every persisted aggregate replays under the new code. Run `nix run .#prodVerifyMigrations` before deploy. The unit test above covers the legacy event shape, but only a replay against real production data proves it.

Two follow-ups are filed under [RAI-1678](https://linear.app/makeitrain/issue/RAI-1678/address-follow-ups-from-review-of-rai-1559-broker-idempotency-anchor):

- [RAI-1679](https://linear.app/makeitrain/issue/RAI-1679/carry-broker-terminality-on-the-offchainorder-aggregate-so-every): five release sites still infer terminality from the presence of an `executor_order_id`, because the `OffchainOrder` aggregate drops the classification when it records `Failed`. The path that observes a suspended order is correct and tested here. These sites are the narrower retry window, and the fix needs a second event-schema change.
- [RAI-1680](https://linear.app/makeitrain/issue/RAI-1680/release-the-anchor-in-the-cli-force-fail-repair-path-when-the-order-is): the CLI repair path preserves the anchor even when the order is already known finished. It depends on RAI-1679.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of failed broker orders by distinguishing terminal outcomes from retryable failures.
  - Prevented duplicate hedges by preserving client-order safeguards when execution cannot be confirmed.
  - Released safeguards after confirmed terminal outcomes, intentional cancellation, expiry, rejection, or completion.
  - Improved recovery and reconciliation for missing, suspended, and failed orders.
  - Added compatibility handling for previously stored order and position data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->