### PR TITLE
Add optional `[orchestrator]` config section for ST0xOrchestrator address

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -9,6 +9,7 @@ mod bot_gas_valuation;
 mod evm;
 mod imbalance_threshold;
 mod loader;
+mod orchestrator;
 mod order_poller;
 mod rebalancing;
 mod telemetry;
@@ -23,6 +24,7 @@ pub use evm::{
 };
 pub use imbalance_threshold::{ImbalanceThreshold, InvalidImbalanceThreshold};
 pub use loader::*;
+pub use orchestrator::{OrchestratorConfig, OrchestratorError};
 pub use order_poller::OrderPollerCtx;
 pub use rebalancing::{
     ALPACA_MINIMUM_WITHDRAWAL, RebalancingConfig, RebalancingCtx, RebalancingCtxError,

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -25,8 +25,8 @@ use url::Url;
 
 use crate::{
     AlertsConfig, AlertsCtx, AlertsSecrets, BotGasValuationConfig, EvmConfig, EvmCtx, EvmSecrets,
-    ExecutionThreshold, InvalidThresholdError, InventoryAdapters, RebalancingConfig,
-    RebalancingCtx, RebalancingCtxError, TelemetryConfig, TelemetryCtx,
+    ExecutionThreshold, InvalidThresholdError, InventoryAdapters, OrchestratorConfig,
+    RebalancingConfig, RebalancingCtx, RebalancingCtxError, TelemetryConfig, TelemetryCtx,
 };
 use st0x_float_macro::float;
 
@@ -244,6 +244,8 @@ struct Config {
     /// ETH/USD valuation source for bot-gas cost recording. See
     /// [`Ctx::bot_gas_valuation`] for when this is required.
     bot_gas_valuation: Option<BotGasValuationConfig>,
+    /// ST0xOrchestrator contract address. See [`Ctx::orchestrator`].
+    orchestrator: Option<OrchestratorConfig>,
 }
 
 /// Plaintext REST API settings (URL only). Credentials live in secrets.
@@ -657,6 +659,13 @@ pub struct Ctx {
     /// including in Standalone mode, where an operator may still configure it
     /// even though no rebalancing path will ever enqueue to it.
     pub bot_gas_valuation: Option<BotGasValuationConfig>,
+    /// ST0xOrchestrator contract address from `[orchestrator]`, needed to
+    /// sign `MintAuthV1` recipient authorizations for orchestrator-mode
+    /// mints. `Some` when the config includes an `[orchestrator]` section.
+    /// Optional so the bot runs unchanged while every asset is
+    /// vault-direct; a mint that discovers an orchestrator-mode asset with
+    /// this absent must fail loudly, never guess an address.
+    pub orchestrator: Option<OrchestratorConfig>,
 }
 
 /// Runtime broker configuration assembled from `BrokerSecrets`.
@@ -789,7 +798,8 @@ impl std::fmt::Debug for Ctx {
             .field("redemption_wallet", &self.redemption_wallet)
             .field("rest_api", &self.rest_api)
             .field("issuance", &self.issuance)
-            .field("bot_gas_valuation", &self.bot_gas_valuation);
+            .field("bot_gas_valuation", &self.bot_gas_valuation)
+            .field("orchestrator", &self.orchestrator);
 
         debug_struct.finish()
     }
@@ -861,6 +871,7 @@ struct ValidatedParts {
     issuance: IssuanceStatusCtx,
     redemption_wallet: Option<Address>,
     bot_gas_valuation: Option<BotGasValuationConfig>,
+    orchestrator: Option<OrchestratorConfig>,
     /// Wallet construction inputs. Always present — `parse_and_validate`
     /// returns `WalletNotConfigured` when both config and secrets lack
     /// a `[wallet]` section. Actual async wallet construction is deferred
@@ -961,6 +972,46 @@ fn validate_extended_hours_counter_trading(assets: &AssetsConfig) -> Result<(), 
     Ok(())
 }
 
+/// The poll cadences with defaults applied, each rejected at zero -- a zero
+/// interval would spin the corresponding poller in a hot loop.
+struct PollingIntervals {
+    order_polling_interval: u64,
+    position_check_interval: u64,
+    inventory_poll_interval: u64,
+    order_fill_poll_interval: u64,
+    apalis_finished_job_cleanup_interval_secs: u64,
+}
+
+fn validated_polling_intervals(config: &Config) -> Result<PollingIntervals, CtxError> {
+    let intervals = PollingIntervals {
+        order_polling_interval: config.order_polling_interval.unwrap_or(15),
+        position_check_interval: config.position_check_interval.unwrap_or(60),
+        inventory_poll_interval: config.inventory_poll_interval.unwrap_or(60),
+        order_fill_poll_interval: config.order_fill_poll_interval.unwrap_or(5),
+        apalis_finished_job_cleanup_interval_secs: config.apalis_finished_job_cleanup_interval_secs,
+    };
+
+    for (value, field) in [
+        (intervals.order_polling_interval, "order_polling_interval"),
+        (intervals.position_check_interval, "position_check_interval"),
+        (intervals.inventory_poll_interval, "inventory_poll_interval"),
+        (
+            intervals.order_fill_poll_interval,
+            "order_fill_poll_interval",
+        ),
+        (
+            intervals.apalis_finished_job_cleanup_interval_secs,
+            "apalis_finished_job_cleanup_interval_secs",
+        ),
+    ] {
+        if value == 0 {
+            return Err(CtxError::ZeroPollingInterval { field });
+        }
+    }
+
+    Ok(intervals)
+}
+
 /// Single validation path shared by [`Ctx::load_files`] and
 /// [`Ctx::validate_files`]. All config/secrets business-rule checks live
 /// here — neither caller duplicates validation logic.
@@ -987,6 +1038,7 @@ fn parse_and_validate(
     }
 
     validate_extended_hours_counter_trading(&config.assets)?;
+    let polling_intervals = validated_polling_intervals(&config)?;
 
     let broker = BrokerCtx::from_parts(secrets.broker, config.broker.as_ref())?;
     let telemetry = config.telemetry.map(TelemetryCtx::from);
@@ -1051,48 +1103,12 @@ fn parse_and_validate(
 
     let log_level = config.log_level.unwrap_or(LogLevel::Debug);
 
-    let order_polling_interval = config.order_polling_interval.unwrap_or(15);
-    if order_polling_interval == 0 {
-        return Err(CtxError::ZeroPollingInterval {
-            field: "order_polling_interval",
-        });
-    }
-
-    let position_check_interval = config.position_check_interval.unwrap_or(60);
-    if position_check_interval == 0 {
-        return Err(CtxError::ZeroPollingInterval {
-            field: "position_check_interval",
-        });
-    }
-
-    let inventory_poll_interval = config.inventory_poll_interval.unwrap_or(60);
-    if inventory_poll_interval == 0 {
-        return Err(CtxError::ZeroPollingInterval {
-            field: "inventory_poll_interval",
-        });
-    }
-
-    let order_fill_poll_interval = config.order_fill_poll_interval.unwrap_or(5);
-    if order_fill_poll_interval == 0 {
-        return Err(CtxError::ZeroPollingInterval {
-            field: "order_fill_poll_interval",
-        });
-    }
-
     let ExtendedHoursBrokerWindows {
         reprice_timeout_secs: extended_hours_reprice_timeout_secs,
         close_flatten_reprice_timeout_secs,
         close_flatten_window_secs: extended_hours_close_flatten_window_secs,
         close_flatten_cross_max_bps,
     } = extended_hours_broker_windows(&broker, config.broker.as_ref(), &config.assets)?;
-
-    let apalis_finished_job_cleanup_interval_secs =
-        config.apalis_finished_job_cleanup_interval_secs;
-    if apalis_finished_job_cleanup_interval_secs == 0 {
-        return Err(CtxError::ZeroPollingInterval {
-            field: "apalis_finished_job_cleanup_interval_secs",
-        });
-    }
 
     let travel_rule = config
         .broker
@@ -1122,17 +1138,18 @@ fn parse_and_validate(
         board_port: config.board_port,
         evm,
         inventory_adapters: config.raindex.inventory_adapters,
-        order_polling_interval,
+        order_polling_interval: polling_intervals.order_polling_interval,
         order_polling_max_jitter: config.order_polling_max_jitter.unwrap_or(5),
-        position_check_interval,
-        inventory_poll_interval,
+        position_check_interval: polling_intervals.position_check_interval,
+        inventory_poll_interval: polling_intervals.inventory_poll_interval,
         inventory_divergence_threshold: config.inventory_divergence_threshold,
-        order_fill_poll_interval,
+        order_fill_poll_interval: polling_intervals.order_fill_poll_interval,
         extended_hours_reprice_timeout_secs,
         close_flatten_reprice_timeout_secs,
         extended_hours_close_flatten_window_secs,
         close_flatten_cross_max_bps,
-        apalis_finished_job_cleanup_interval_secs,
+        apalis_finished_job_cleanup_interval_secs: polling_intervals
+            .apalis_finished_job_cleanup_interval_secs,
         broker,
         telemetry,
         alerts,
@@ -1165,6 +1182,7 @@ fn parse_and_validate(
         )?,
         redemption_wallet,
         bot_gas_valuation: config.bot_gas_valuation,
+        orchestrator: config.orchestrator,
         wallet_inputs,
         wallet_meta,
     })
@@ -1298,6 +1316,7 @@ impl Ctx {
             issuance: parts.issuance,
             redemption_wallet: parts.redemption_wallet,
             bot_gas_valuation: parts.bot_gas_valuation,
+            orchestrator: parts.orchestrator,
         })
     }
 
@@ -1510,6 +1529,7 @@ impl Ctx {
         #[builder(default = create_test_issuance_ctx())] issuance: IssuanceStatusCtx,
         redemption_wallet: Option<Address>,
         bot_gas_valuation: Option<BotGasValuationConfig>,
+        orchestrator: Option<OrchestratorConfig>,
     ) -> Result<Self, CtxError> {
         let execution_threshold = match execution_threshold_override {
             Some(threshold) => threshold,
@@ -1581,6 +1601,7 @@ impl Ctx {
             issuance,
             redemption_wallet,
             bot_gas_valuation,
+            orchestrator,
         })
     }
 }
@@ -1934,6 +1955,7 @@ pub fn create_test_ctx_with_order_owner(order_owner: Address) -> Ctx {
         issuance: create_test_issuance_ctx(),
         redemption_wallet: None,
         bot_gas_valuation: None,
+        orchestrator: None,
     }
 }
 
@@ -3704,6 +3726,100 @@ mod tests {
         assert_eq!(
             bot_gas_valuation.eth_usd_feed_id,
             b256!("0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace")
+        );
+    }
+
+    /// The full bot-gas section plus the section under test -- the splice
+    /// hole in [`rebalancing_toml_with_bot_gas_valuation`] is plain TOML
+    /// text, and section order is insignificant, so appending
+    /// `[orchestrator]` there exercises the complete real config shape.
+    fn bot_gas_and_orchestrator_sections(orchestrator_section: &str) -> String {
+        format!(
+            r#"[bot_gas_valuation]
+            pyth_contract = "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a"
+            eth_usd_feed_id = "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
+
+            {orchestrator_section}"#
+        )
+    }
+
+    #[test]
+    fn orchestrator_section_flows_into_parts() {
+        let config_str =
+            rebalancing_toml_with_bot_gas_valuation(&bot_gas_and_orchestrator_sections(
+                r#"[orchestrator]
+            address = "0x4444444444444444444444444444444444444444""#,
+            ));
+        let secrets = rebalancing_secrets_toml();
+        let secrets_str = std::fs::read_to_string(secrets.path()).unwrap();
+
+        let parts = parse_and_validate(
+            &config_str,
+            Path::new("config.toml"),
+            &secrets_str,
+            Path::new("secrets.toml"),
+        )
+        .unwrap();
+
+        let orchestrator = parts
+            .orchestrator
+            .expect("orchestrator should be Some when configured");
+        assert_eq!(
+            orchestrator.address,
+            address!("0x4444444444444444444444444444444444444444")
+        );
+    }
+
+    /// Absence of `[orchestrator]` is the dark default: every asset is
+    /// vault-direct and the bot must run unchanged without the section.
+    #[test]
+    fn missing_orchestrator_section_parses_as_none() {
+        let config_str =
+            rebalancing_toml_with_bot_gas_valuation(&bot_gas_and_orchestrator_sections(""));
+        let secrets = rebalancing_secrets_toml();
+        let secrets_str = std::fs::read_to_string(secrets.path()).unwrap();
+
+        let parts = parse_and_validate(
+            &config_str,
+            Path::new("config.toml"),
+            &secrets_str,
+            Path::new("secrets.toml"),
+        )
+        .unwrap();
+
+        assert_eq!(parts.orchestrator, None);
+    }
+
+    /// A zero orchestrator address is a placeholder that slipped through;
+    /// it must fail the whole config parse (and thus `validate-config`)
+    /// even while no asset is orchestrator-mode.
+    #[test]
+    fn zero_orchestrator_address_fails_config_parse() {
+        let config_str =
+            rebalancing_toml_with_bot_gas_valuation(&bot_gas_and_orchestrator_sections(
+                r#"[orchestrator]
+            address = "0x0000000000000000000000000000000000000000""#,
+            ));
+        let secrets = rebalancing_secrets_toml();
+        let secrets_str = std::fs::read_to_string(secrets.path()).unwrap();
+
+        let result = parse_and_validate(
+            &config_str,
+            Path::new("config.toml"),
+            &secrets_str,
+            Path::new("secrets.toml"),
+        );
+
+        let source = match result {
+            Err(CtxError::ConfigToml { source, .. }) => source,
+            Err(other) => panic!("expected ConfigToml error, got {other:?}"),
+            Ok(_) => panic!("zero orchestrator address must fail config parse"),
+        };
+        assert!(
+            source
+                .to_string()
+                .contains("address must not be the zero address"),
+            "expected zero-address rejection, got: {source}"
         );
     }
 

--- a/crates/config/src/orchestrator.rs
+++ b/crates/config/src/orchestrator.rs
@@ -1,0 +1,131 @@
+//! Configuration for the ST0xOrchestrator contract.
+//!
+//! Orchestrator-mode mints require a signed `MintAuthV1` recipient
+//! authorization, and producing one needs the orchestrator's address (the
+//! EIP-712 verifying contract, read via its `mintAuthDigest` view). Which
+//! assets are orchestrator-mode is owned by the issuance bot (the
+//! `vault_mode` field on its per-asset status endpoint) -- this section only
+//! supplies the contract address, never an asset list.
+//!
+//! The section is optional as a whole: while every asset is vault-direct the
+//! bot runs unchanged without it ("deploys dark"). A mint that discovers an
+//! orchestrator-mode asset with no configured address must fail loudly at
+//! that point, never guess. When the section IS present, a malformed or zero
+//! address fails at parse time -- even while dark -- so `validate-config`
+//! catches a typo'd deploy before the cutover depends on it.
+
+use alloy::primitives::Address;
+use serde::Deserialize;
+
+/// `[orchestrator]` section of the plaintext config TOML.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(try_from = "OrchestratorConfigToml")]
+pub struct OrchestratorConfig {
+    pub address: Address,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum OrchestratorError {
+    /// The zero address can never be a deployed orchestrator; a config carrying
+    /// it is a placeholder that slipped through, so parsing fails closed.
+    #[error("[orchestrator] address must not be the zero address")]
+    ZeroOrchestratorAddress,
+}
+
+/// Raw TOML shape for `[orchestrator]`; validation lives in the
+/// `TryFrom<OrchestratorConfigToml>` conversion so an invalid value can
+/// never become an [`OrchestratorConfig`] through parsing.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OrchestratorConfigToml {
+    address: Address,
+}
+
+impl TryFrom<OrchestratorConfigToml> for OrchestratorConfig {
+    type Error = OrchestratorError;
+
+    fn try_from(raw: OrchestratorConfigToml) -> Result<Self, Self::Error> {
+        if raw.address == Address::ZERO {
+            return Err(OrchestratorError::ZeroOrchestratorAddress);
+        }
+
+        Ok(Self {
+            address: raw.address,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::address;
+
+    use super::*;
+
+    #[test]
+    fn parses_valid_config() {
+        let config: OrchestratorConfig =
+            toml::from_str(r#"address = "0x4444444444444444444444444444444444444444""#).unwrap();
+
+        assert_eq!(
+            config.address,
+            address!("0x4444444444444444444444444444444444444444")
+        );
+    }
+
+    #[test]
+    fn rejects_zero_address() {
+        let result: Result<OrchestratorConfig, _> =
+            toml::from_str(r#"address = "0x0000000000000000000000000000000000000000""#);
+
+        let error = result.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("address must not be the zero address"),
+            "expected zero-address rejection, got: {error}"
+        );
+    }
+
+    #[test]
+    fn malformed_address_fails_to_parse() {
+        let result: Result<OrchestratorConfig, _> = toml::from_str(r#"address = "not-an-address""#);
+
+        // The rendered toml error carries the offending source line, so
+        // asserting on the exact rejected value pins THIS failure (a value
+        // that does not parse as an address) apart from the zero-address
+        // and missing-field rejections, which carry different messages.
+        let error = result.unwrap_err();
+        assert!(
+            error.to_string().contains(r#"address = "not-an-address""#),
+            "expected the malformed-value parse failure, got: {error}"
+        );
+    }
+
+    #[test]
+    fn missing_address_fails_to_parse() {
+        let result: Result<OrchestratorConfig, _> = toml::from_str("");
+
+        let error = result.unwrap_err();
+        assert!(
+            error.to_string().contains("missing field `address`"),
+            "expected missing-field error for address, got: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let result: Result<OrchestratorConfig, _> = toml::from_str(
+            r#"
+            address = "0x4444444444444444444444444444444444444444"
+            unknown_field = "surprise"
+            "#,
+        );
+
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unknown field `unknown_field`")
+        );
+    }
+}

--- a/example.config.toml
+++ b/example.config.toml
@@ -132,6 +132,15 @@ redemption_wallet = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 pyth_contract = "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a"
 eth_usd_feed_id = "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
 
+# Optional — the ST0xOrchestrator contract, needed to sign MintAuthV1
+# recipient authorizations for orchestrator-mode mints. Which assets are
+# orchestrator-mode is owned by the issuance bot (the vault_mode field on its
+# per-asset status endpoint); this section only supplies the contract address.
+# Omit while every asset is vault-direct. When present, a malformed or zero
+# address fails config validation even before any asset cuts over.
+# [orchestrator]
+# address = "0xcccccccccccccccccccccccccccccccccccccccc"
+
 # Optional — only needed for automatic rebalancing.
 # Without this section the bot runs in Standalone mode (hedging only).
 [rebalancing]

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -777,6 +777,7 @@ mod tests {
             issuance: create_test_issuance_ctx(),
             redemption_wallet: None,
             bot_gas_valuation: None,
+            orchestrator: None,
         }
     }
 
@@ -882,6 +883,7 @@ mod tests {
             issuance: create_test_issuance_ctx(),
             redemption_wallet: Some(Address::ZERO),
             bot_gas_valuation: None,
+            orchestrator: None,
         }
     }
 

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -300,6 +300,7 @@ mod tests {
             issuance: create_test_issuance_ctx(),
             redemption_wallet: None,
             bot_gas_valuation: None,
+            orchestrator: None,
         }
     }
 

--- a/src/cli/dividend.rs
+++ b/src/cli/dividend.rs
@@ -112,6 +112,7 @@ mod tests {
             issuance: create_test_issuance_ctx(),
             redemption_wallet: None,
             bot_gas_valuation: None,
+            orchestrator: None,
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2032,6 +2032,7 @@ mod tests {
             issuance: create_test_issuance_ctx(),
             redemption_wallet: None,
             bot_gas_valuation: None,
+            orchestrator: None,
         }
     }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -2214,6 +2214,7 @@ mod tests {
             issuance: create_test_issuance_ctx(),
             redemption_wallet: None,
             bot_gas_valuation: None,
+            orchestrator: None,
         }
     }
 
@@ -2299,6 +2300,7 @@ mod tests {
             issuance: create_test_issuance_ctx(),
             redemption_wallet: Some(Address::ZERO),
             bot_gas_valuation: None,
+            orchestrator: None,
         }
     }
 

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -1376,6 +1376,7 @@ mod tests {
             issuance: create_test_issuance_ctx(),
             redemption_wallet: None,
             bot_gas_valuation: None,
+            orchestrator: None,
         }
     }
 

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -256,6 +256,7 @@ mod tests {
             issuance: create_test_issuance_ctx(),
             redemption_wallet: None,
             bot_gas_valuation: None,
+            orchestrator: None,
         }
     }
 
@@ -317,6 +318,7 @@ mod tests {
             issuance: create_test_issuance_ctx(),
             redemption_wallet: Some(Address::ZERO),
             bot_gas_valuation: None,
+            orchestrator: None,
         }
     }
 

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -252,6 +252,7 @@ mod tests {
             issuance: create_test_issuance_ctx(),
             redemption_wallet: None,
             bot_gas_valuation: None,
+            orchestrator: None,
         }
     }
 


### PR DESCRIPTION
## What

Adds an optional `[orchestrator]` config section that carries the `ST0xOrchestrator` contract address, exposing it as `OrchestratorConfig` through `Ctx`.

## Why

Orchestrator-mode mints require a signed `MintAuthV1` recipient authorization, which needs the orchestrator's contract address as the EIP-712 verifying contract. Without a place to configure this address, the bot cannot support orchestrator-mode assets. The section is optional so the bot continues to run unchanged while all assets remain vault-direct ("deploys dark"), but a mint that encounters an orchestrator-mode asset with no configured address must fail loudly rather than guess.

## How

A new `orchestrator` module defines `OrchestratorConfig`, which wraps a single `Address` field. Deserialization goes through an intermediate `OrchestratorConfigToml` type whose `TryFrom` conversion rejects the zero address at parse time — meaning a misconfigured or placeholder address fails `validate-config` before any asset ever cuts over to orchestrator mode. The `[orchestrator]` section is absent from the config by default (`None`), preserving existing vault-direct behavior with no required migration.

`OrchestratorConfig` is threaded through `Config`, `ValidatedParts`, and `Ctx`, including the builder used in tests.

## Testing

Unit tests in `orchestrator.rs` cover valid address parsing, zero-address rejection, malformed addresses, missing `address` field, and unknown fields.

Integration-level tests in `loader.rs` verify that a well-formed `[orchestrator]` section flows through `parse_and_validate` into `ValidatedParts`, that omitting the section produces `None`, and that a zero address causes a `ConfigToml` error with the expected message.

## Anything else

Which assets are orchestrator-mode is determined by the issuance bot's per-asset `vault_mode` status field — this config section only supplies the contract address and never an asset list. The `example.config.toml` entry for `[orchestrator]` is commented out to reflect that it is optional.  
  
Closes [RAI-1674](https://linear.app/makeitrain/issue/RAI-1674/orchestrator-config)

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional orchestrator configuration with a validated contract address.
  * Added an example configuration section for setting the orchestrator address.
  * Configured orchestrator settings are now available throughout runtime contexts.

* **Bug Fixes**
  * Invalid, malformed, unknown, zero-valued, or incomplete orchestrator addresses are rejected during configuration parsing.

* **Tests**
  * Added coverage for configured, omitted, and invalid orchestrator settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->