### PR TITLE
Add `sign_digest` to `Wallet` trait with local and Turnkey backends

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1212,6 +1212,27 @@ The main crate forwards these as `wallet-turnkey` and `wallet-private-key`
 features. Domain logic is decoupled from the signing backend. See
 [crates/evm/](crates/evm/) for implementation details.
 
+#### Detached Digest Signing
+
+Beyond transaction submission, the `Wallet` trait exposes `sign_digest`: it
+signs a caller-supplied, precomputed 32-byte digest (e.g. an EIP-712 signing
+hash) exactly as given -- no EIP-191 message prefix and no further hashing --
+and returns the detached secp256k1 signature. Nothing is broadcast and no
+transaction nonce is consumed. The caller is responsible for supplying the exact
+digest the verifier expects, typically by reading it from the verifying contract
+itself rather than reconstructing it locally.
+
+Backend expectations:
+
+- **Turnkey**: signs via the raw-payload activity
+  (`ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2`) with hexadecimal payload encoding and
+  the no-op hash function, so the enclave signs the digest bytes as-is. The
+  returned `r`/`s`/`v` components are strictly parsed (exact 32-byte scalars;
+  only the `00`/`01`/`1b`/`1c` recovery-id encodings are accepted), and the
+  assembled signature must recover to the wallet address over the requested
+  digest -- any mismatch fails closed.
+- **Raw private key**: signs the prehash directly with the local key.
+
 ## Crate Architecture
 
 The codebase is organized into multiple Rust crates to achieve:

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -1747,6 +1747,13 @@ mod tests {
             self.inner.address()
         }
 
+        async fn sign_digest(
+            &self,
+            digest: alloy::primitives::B256,
+        ) -> Result<alloy::primitives::Signature, EvmError> {
+            self.inner.sign_digest(digest).await
+        }
+
         async fn send_pending(
             &self,
             contract: Address,

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -18,7 +18,7 @@
 
 use alloy::consensus::Transaction;
 use alloy::eips::BlockId;
-use alloy::primitives::{Address, Bytes, TxHash};
+use alloy::primitives::{Address, B256, Bytes, Signature, TxHash};
 use alloy::providers::Provider;
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use alloy::sol_types::SolCall;
@@ -225,6 +225,8 @@ pub enum EvmError {
     #[cfg(feature = "local-signer")]
     #[error("invalid private key: {0}")]
     InvalidPrivateKey(#[from] alloy::signers::k256::ecdsa::Error),
+    #[error("signer error: {0}")]
+    Signer(#[from] alloy::signers::Error),
     #[cfg(feature = "turnkey")]
     #[error("Turnkey error: {0}")]
     Turnkey(#[from] turnkey::TurnkeyError),
@@ -270,7 +272,10 @@ impl EvmError {
             Self::Transport(rpc_error) => rpc_error.as_error_resp().is_some_and(|payload| {
                 payload.code == 3 || payload.message.contains("execution reverted")
             }),
-            Self::Transaction(_) | Self::AbiDecode(_) | Self::WalletConfigParse(_) => false,
+            Self::Transaction(_)
+            | Self::AbiDecode(_)
+            | Self::WalletConfigParse(_)
+            | Self::Signer(_) => false,
             #[cfg(any(feature = "turnkey", feature = "local-signer"))]
             Self::ReceiptTimeout { .. } => false,
             #[cfg(any(feature = "turnkey", feature = "local-signer"))]
@@ -301,7 +306,8 @@ impl EvmError {
             | Self::AbiDecode(_)
             | Self::DecodedRevert(_)
             | Self::Reverted { .. }
-            | Self::WalletConfigParse(_) => false,
+            | Self::WalletConfigParse(_)
+            | Self::Signer(_) => false,
             #[cfg(any(feature = "turnkey", feature = "local-signer"))]
             Self::ReceiptTimeout { .. } => false,
             #[cfg(any(feature = "turnkey", feature = "local-signer"))]
@@ -342,6 +348,7 @@ impl EvmError {
             | Self::Transaction(_)
             | Self::AbiDecode(_)
             | Self::WalletConfigParse(_)
+            | Self::Signer(_)
             | Self::NodeBehindRequiredBlock { .. } => None,
             #[cfg(any(feature = "turnkey", feature = "local-signer"))]
             Self::ReceiptTimeout { .. } => None,
@@ -552,6 +559,16 @@ pub trait Wallet: Evm {
     /// Returns the address this wallet signs transactions from.
     fn address(&self) -> Address;
 
+    /// Signs a precomputed 32-byte digest (e.g. an EIP-712 signing hash)
+    /// with this wallet's key, returning the raw signature.
+    ///
+    /// The digest is signed as-is -- no message prefix and no further
+    /// hashing -- so the caller is responsible for supplying the exact
+    /// digest the verifier expects (typically read from the verifying
+    /// contract itself). Detached-signature counterpart to transaction
+    /// signing: nothing is broadcast and no nonce is consumed.
+    async fn sign_digest(&self, digest: B256) -> Result<Signature, EvmError>;
+
     /// Submit a signed transaction and return the tx hash immediately,
     /// without waiting for confirmation.
     ///
@@ -753,6 +770,10 @@ impl<Inner: Evm + ?Sized> Evm for Arc<Inner> {
 impl<Inner: Wallet + ?Sized> Wallet for Arc<Inner> {
     fn address(&self) -> Address {
         (**self).address()
+    }
+
+    async fn sign_digest(&self, digest: B256) -> Result<Signature, EvmError> {
+        (**self).sign_digest(digest).await
     }
 
     async fn send_pending(

--- a/crates/evm/src/local.rs
+++ b/crates/evm/src/local.rs
@@ -5,12 +5,13 @@
 //! directly.
 
 use alloy::network::{Ethereum, EthereumWallet};
-use alloy::primitives::{Address, B256, Bytes, TxHash};
+use alloy::primitives::{Address, B256, Bytes, Signature, TxHash};
 use alloy::providers::fillers::{
     BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, WalletFiller,
 };
 use alloy::providers::{Identity, Provider, ProviderBuilder, WalletProvider};
 use alloy::rpc::types::TransactionReceipt;
+use alloy::signers::Signer;
 use alloy::signers::local::PrivateKeySigner;
 use async_trait::async_trait;
 use futures::lock::Mutex;
@@ -64,6 +65,10 @@ pub type SignerProvider<P> = FillProvider<
 pub struct RawPrivateKeyWallet<P: Provider> {
     /// Base provider for read-only chain access.
     provider: P,
+    /// The signing key, kept for detached-digest signing
+    /// ([`Wallet::sign_digest`]); transaction signing goes through the
+    /// `WalletFiller` inside `signing_provider` instead.
+    signer: PrivateKeySigner,
     /// Provider wrapped with gas/nonce/chain-id/wallet fillers for
     /// transaction signing and submission.
     signing_provider: SignerProvider<P>,
@@ -95,7 +100,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> RawPrivateKeyWallet<P> {
         required_confirmations: u64,
     ) -> Result<Self, EvmError> {
         let signer = PrivateKeySigner::from_bytes(private_key)?;
-        let eth_wallet = EthereumWallet::from(signer);
+        let eth_wallet = EthereumWallet::from(signer.clone());
 
         let base_provider = provider.clone();
         let nonce_manager = ResettableNonceManager::default();
@@ -115,6 +120,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> RawPrivateKeyWallet<P> {
 
         Ok(Self {
             provider: base_provider,
+            signer,
             signing_provider,
             nonce_manager,
             in_flight: InFlightNonces::default(),
@@ -149,6 +155,10 @@ where
 {
     fn address(&self) -> Address {
         self.signing_provider.default_signer_address()
+    }
+
+    async fn sign_digest(&self, digest: B256) -> Result<Signature, EvmError> {
+        Ok(self.signer.sign_hash(&digest).await?)
     }
 
     async fn send_pending(
@@ -285,6 +295,24 @@ mod tests {
         let wallet = RawPrivateKeyWallet::try_from_ctx(ctx).await.unwrap();
 
         assert_eq!(wallet.address(), expected_address);
+    }
+
+    /// Recovery-based rather than vector-based: whatever bytes
+    /// `sign_digest` produces must recover to this wallet's address over
+    /// the exact digest signed, which is precisely the check the
+    /// orchestrator's MintAuthV1 verification performs on-chain.
+    #[tokio::test]
+    async fn sign_digest_recovers_to_wallet_address() {
+        let (_anvil, wallet, _token_address, signer_address) = setup_anvil_with_token().await;
+
+        let digest = alloy::primitives::keccak256(b"detached digest");
+
+        let signature = wallet.sign_digest(digest).await.unwrap();
+
+        assert_eq!(
+            signature.recover_address_from_prehash(&digest).unwrap(),
+            signer_address
+        );
     }
 
     #[tokio::test]

--- a/crates/evm/src/stub.rs
+++ b/crates/evm/src/stub.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use alloy::primitives::{Address, Bytes, TxHash};
+use alloy::primitives::{Address, B256, Bytes, Signature, TxHash};
 use alloy::providers::RootProvider;
 use alloy::rpc::client::RpcClient;
 use alloy::rpc::types::TransactionReceipt;
@@ -46,6 +46,10 @@ impl Evm for StubWallet {
 impl Wallet for StubWallet {
     fn address(&self) -> Address {
         self.address
+    }
+
+    async fn sign_digest(&self, _digest: B256) -> Result<Signature, EvmError> {
+        panic!("StubWallet::sign_digest called - use a real wallet in tests that need signing")
     }
 
     async fn send_pending(

--- a/crates/evm/src/turnkey.rs
+++ b/crates/evm/src/turnkey.rs
@@ -11,7 +11,7 @@ use alloy::consensus::{SignableTransaction, TxEnvelope};
 use alloy::eips::eip2718::{Decodable2718, Eip2718Error};
 use alloy::network::{Ethereum, EthereumWallet, TxSigner};
 use alloy::primitives::{
-    Address, B256, Bytes, ChainId, Signature, SignatureError, TxHash, hex, keccak256,
+    Address, B256, Bytes, ChainId, Signature, SignatureError, TxHash, U256, hex, keccak256,
 };
 use alloy::providers::fillers::{
     BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, WalletFiller,
@@ -29,9 +29,10 @@ use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
 use tracing::{info, trace};
 use turnkey_api_key_stamper::{Stamp, StampHeader, TurnkeyP256ApiKey};
 use turnkey_client::generated::{
-    Activity, ActivityResponse, ActivityStatus, SignTransactionIntentV2, SignTransactionRequest,
-    immutable::activity::v1::{SignTransactionResult, result},
-    immutable::common::v1::TransactionType,
+    Activity, ActivityResponse, ActivityStatus, SignRawPayloadIntentV2, SignRawPayloadRequest,
+    SignTransactionIntentV2, SignTransactionRequest,
+    immutable::activity::v1::{SignRawPayloadResult, SignTransactionResult, result},
+    immutable::common::v1::{HashFunction, PayloadEncoding, TransactionType},
 };
 use turnkey_client::{RetryConfig, TurnkeyClientError};
 
@@ -121,6 +122,16 @@ pub enum TracingTurnkeySignerError {
     MissingTxChainId,
     #[error("system time is before UNIX epoch: {source}")]
     SystemTime { source: SystemTimeError },
+    #[error(
+        "Turnkey raw-payload signature component `{component}` is not a valid \
+         32-byte scalar"
+    )]
+    InvalidRawSignatureScalar { component: &'static str },
+    #[error(
+        "Turnkey raw-payload recovery id `{value}` is not a recognized parity \
+         (expected 00/01 or 1b/1c)"
+    )]
+    InvalidRecoveryId { value: String },
 }
 
 /// Full resource name of a GCP KMS `EC_SIGN_P256_SHA256` key version.
@@ -218,6 +229,11 @@ pub struct TurnkeyWallet<P: Provider> {
     /// build two transactions at the same nonce. Shared across clones so
     /// every handle to the same address contends on one lock.
     send_lock: Arc<Mutex<()>>,
+    /// Second handle to the signer (sharing the transaction signer's HTTP
+    /// client via `Arc`) for detached-digest signing
+    /// ([`Wallet::sign_digest`]) -- the transaction copy is consumed by
+    /// the `EthereumWallet` inside `signing_provider`.
+    digest_signer: TracingTurnkeySigner,
     address: Address,
     required_confirmations: u64,
 }
@@ -279,6 +295,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> TurnkeyWallet<P> {
             .map_err(|error| TurnkeyError::Signer(error.into()))?;
         let signer = TracingTurnkeySigner::new(client, organization_id, address, Some(chain_id));
 
+        let digest_signer = signer.clone();
         let eth_wallet = EthereumWallet::from(signer);
 
         let base_provider = ctx.provider.clone();
@@ -303,6 +320,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> TurnkeyWallet<P> {
             nonce_manager,
             in_flight: InFlightNonces::default(),
             send_lock: Arc::new(Mutex::new(())),
+            digest_signer,
             address,
             required_confirmations,
         })
@@ -324,6 +342,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> TurnkeyWallet<P> {
 
         let signer = TracingTurnkeySigner::new(client, organization_id, address, Some(chain_id));
 
+        let digest_signer = signer.clone();
         let eth_wallet = EthereumWallet::from(signer);
 
         let base_provider = provider.clone();
@@ -344,6 +363,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> TurnkeyWallet<P> {
             nonce_manager,
             in_flight: InFlightNonces::default(),
             send_lock: Arc::new(Mutex::new(())),
+            digest_signer,
             address,
             required_confirmations,
         })
@@ -501,6 +521,37 @@ impl TracingTurnkeyClient {
         }
     }
 
+    async fn sign_raw_payload(
+        &self,
+        organization_id: TurnkeyOrganizationId,
+        timestamp_ms: u128,
+        params: SignRawPayloadIntentV2,
+    ) -> Result<SignRawPayloadResult, TurnkeyRequestError> {
+        let TurnkeyOrganizationId(organization_id) = organization_id;
+        let request = SignRawPayloadRequest {
+            r#type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2".to_string(),
+            timestamp_ms: timestamp_ms.to_string(),
+            parameters: Some(params),
+            organization_id,
+        };
+        let activity = self
+            .process_activity(&request, "/public/v1/submit/sign_raw_payload")
+            .await?;
+        let inner = activity
+            .result
+            .ok_or(TurnkeyClientError::MissingResult)?
+            .inner
+            .ok_or(TurnkeyClientError::MissingInnerResult)?;
+
+        match inner {
+            result::Inner::SignRawPayloadResult(result) => Ok(result),
+            other => Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+                serde_json::to_string(&other).map_err(TurnkeyClientError::from)?,
+            )
+            .into()),
+        }
+    }
+
     async fn process_activity<Request: Serialize + Sync>(
         &self,
         request: &Request,
@@ -643,8 +694,13 @@ impl TracingTurnkeyClient {
     }
 }
 
+/// `Clone` (via the `Arc`'d client) so [`TurnkeyWallet`] can keep one copy
+/// for detached-digest signing while a second lives inside the
+/// `EthereumWallet` for transaction signing -- both share the same HTTP
+/// client and credentials.
+#[derive(Clone)]
 struct TracingTurnkeySigner {
-    client: TracingTurnkeyClient,
+    client: Arc<TracingTurnkeyClient>,
     organization_id: TurnkeyOrganizationId,
     address: Address,
     chain_id: Option<ChainId>,
@@ -669,7 +725,7 @@ impl TracingTurnkeySigner {
         chain_id: Option<ChainId>,
     ) -> Self {
         Self {
-            client,
+            client: Arc::new(client),
             organization_id,
             address,
             chain_id,
@@ -706,6 +762,94 @@ impl TracingTurnkeySigner {
         }
 
         Ok(signature)
+    }
+
+    /// Signs a precomputed 32-byte digest via Turnkey's raw-payload
+    /// activity. The payload is transmitted as the bare digest hex with
+    /// `HASH_FUNCTION_NO_OP`: the digest already IS the final hash (e.g.
+    /// an EIP-712 signing hash), so Turnkey must sign it as-is rather
+    /// than hashing again.
+    async fn sign_digest(&self, digest: B256) -> Result<Signature, TracingTurnkeySignerError> {
+        let response = self
+            .client
+            .sign_raw_payload(
+                self.organization_id.clone(),
+                TracingTurnkeyClient::current_timestamp()?,
+                SignRawPayloadIntentV2 {
+                    sign_with: self.address.to_string(),
+                    payload: hex::encode(digest),
+                    encoding: PayloadEncoding::Hexadecimal,
+                    hash_function: HashFunction::NoOp,
+                },
+            )
+            .await?;
+
+        Self::parse_raw_signature(&response, digest, self.address)
+    }
+
+    /// Assembles Turnkey's raw-payload `r`/`s`/`v` components into a
+    /// [`Signature`], verifying it actually recovers to `expected_signer`
+    /// over `digest` -- the same defensive check
+    /// [`parse_signature`](Self::parse_signature) performs for
+    /// transactions, turning "trust Turnkey's components" into
+    /// "cryptographically verify they sign what we asked, by us". The
+    /// check also fails closed on any mis-parse of the components
+    /// themselves.
+    fn parse_raw_signature(
+        response: &SignRawPayloadResult,
+        digest: B256,
+        expected_signer: Address,
+    ) -> Result<Signature, TracingTurnkeySignerError> {
+        let r = Self::parse_signature_scalar(&response.r, "r")?;
+        let s = Self::parse_signature_scalar(&response.s, "s")?;
+        let parity = Self::parse_recovery_parity(&response.v)?;
+
+        let signature = Signature::new(r, s, parity);
+        let recovered = signature.recover_address_from_prehash(&digest)?;
+
+        if recovered != expected_signer {
+            return Err(TracingTurnkeySignerError::SignerAddressMismatch {
+                expected: expected_signer,
+                recovered,
+            });
+        }
+
+        Ok(signature)
+    }
+
+    /// Turnkey returns `r`/`s` as full 32-byte big-endian hex; anything
+    /// shorter or longer is malformed and rejected here with a precise
+    /// error rather than being zero-extended into a signature that only
+    /// fails later at the recovered-address check.
+    fn parse_signature_scalar(
+        hex_scalar: &str,
+        component: &'static str,
+    ) -> Result<U256, TracingTurnkeySignerError> {
+        let bytes = hex::decode(hex_scalar)?;
+        let scalar: [u8; 32] = bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| TracingTurnkeySignerError::InvalidRawSignatureScalar { component })?;
+
+        Ok(U256::from_be_bytes(scalar))
+    }
+
+    /// Turnkey documents `v` as the recovery id (`00`/`01`); the
+    /// Ethereum-style `1b`/`1c` (27/28) spelling is accepted too so a
+    /// provider-side representation change cannot silently flip parity.
+    /// Only these four one-byte encodings are accepted: anything else --
+    /// including an empty value, which `hex::decode` happily produces from
+    /// an empty or missing field -- fails loudly rather than guessing.
+    fn parse_recovery_parity(hex_value: &str) -> Result<bool, TracingTurnkeySignerError> {
+        let bytes = hex::decode(hex_value)?;
+
+        match bytes.as_slice() {
+            [0x00 | 0x1b] => Ok(false),
+            [0x01 | 0x1c] => Ok(true),
+            _ => Err(TracingTurnkeySignerError::InvalidRecoveryId {
+                value: hex_value.to_string(),
+            }),
+        }
     }
 }
 
@@ -788,6 +932,14 @@ where
         self.address
     }
 
+    async fn sign_digest(&self, digest: B256) -> Result<Signature, EvmError> {
+        Ok(self
+            .digest_signer
+            .sign_digest(digest)
+            .await
+            .map_err(TurnkeyError::from)?)
+    }
+
     async fn send_pending(
         &self,
         contract: Address,
@@ -856,6 +1008,7 @@ mod tests {
     use alloy::node_bindings::{Anvil, AnvilInstance};
     use alloy::primitives::{TxKind, U256};
     use alloy::providers::ext::AnvilApi;
+    use alloy::signers::Signer;
     use alloy::signers::local::PrivateKeySigner;
     use httpmock::MockServer;
 
@@ -944,6 +1097,28 @@ mod tests {
                 "fingerprint": "fingerprint",
                 "result": {
                     "signTransactionResult": { "signedTransaction": signed_transaction_hex }
+                }
+            }
+        })
+    }
+
+    /// JSON body for a COMPLETED `sign_raw_payload` activity carrying the
+    /// given signature's r/s/v components, shaped like a real Turnkey
+    /// response (`v` is the recovery id, `00`/`01`).
+    fn completed_sign_raw_payload_body(signature: &Signature) -> serde_json::Value {
+        serde_json::json!({
+            "activity": {
+                "id": "activity-id",
+                "organizationId": "org-test",
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
+                "fingerprint": "fingerprint",
+                "result": {
+                    "signRawPayloadResult": {
+                        "r": hex::encode(signature.r().to_be_bytes::<32>()),
+                        "s": hex::encode(signature.s().to_be_bytes::<32>()),
+                        "v": if signature.v() { "01" } else { "00" },
+                    }
                 }
             }
         })
@@ -1123,6 +1298,264 @@ mod tests {
             TracingTurnkeySignerError::SignerAddressMismatch { expected, recovered }
                 if expected == key_signer.address() && recovered != key_signer.address()
         ));
+    }
+
+    /// The full raw-payload round trip: the request must carry the bare
+    /// digest hex with `HASH_FUNCTION_NO_OP` (the digest is already the
+    /// final hash -- re-hashing would sign the wrong message), and the
+    /// r/s/v response must assemble into exactly the signature the
+    /// "enclave" key produced.
+    #[tokio::test]
+    async fn sign_digest_returns_signature_from_completed_activity() {
+        let key_signer = PrivateKeySigner::random();
+        let address = key_signer.address();
+        let digest = keccak256(b"detached digest");
+        let expected_signature = key_signer.sign_hash(&digest).await.unwrap();
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method("POST")
+                .path("/public/v1/submit/sign_raw_payload")
+                .json_body_includes(
+                    serde_json::json!({
+                        "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
+                        "parameters": {
+                            "signWith": address.to_string(),
+                            "payload": hex::encode(digest),
+                            "encoding": "PAYLOAD_ENCODING_HEXADECIMAL",
+                            "hashFunction": "HASH_FUNCTION_NO_OP",
+                        }
+                    })
+                    .to_string(),
+                );
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(completed_sign_raw_payload_body(&expected_signature));
+        });
+
+        let signer = TracingTurnkeySigner::new(
+            mock_client(&server),
+            TurnkeyOrganizationId::new("org-test".to_string()),
+            address,
+            Some(8453),
+        );
+
+        let signature = signer.sign_digest(digest).await.unwrap();
+
+        mock.assert();
+        assert_eq!(signature, expected_signature);
+        assert_eq!(
+            signature.recover_address_from_prehash(&digest).unwrap(),
+            address
+        );
+    }
+
+    /// The same trust boundary as transaction signing: components that
+    /// recover to someone else's key -- however well-formed -- must be
+    /// rejected, never returned.
+    #[tokio::test]
+    async fn sign_digest_rejects_signature_from_wrong_signer() {
+        let configured_signer = PrivateKeySigner::random();
+        let different_signer = PrivateKeySigner::random();
+        let digest = keccak256(b"detached digest");
+        let foreign_signature = different_signer.sign_hash(&digest).await.unwrap();
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method("POST")
+                .path("/public/v1/submit/sign_raw_payload");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(completed_sign_raw_payload_body(&foreign_signature));
+        });
+
+        let signer = TracingTurnkeySigner::new(
+            mock_client(&server),
+            TurnkeyOrganizationId::new("org-test".to_string()),
+            configured_signer.address(),
+            Some(8453),
+        );
+
+        let error = signer.sign_digest(digest).await.unwrap_err();
+
+        mock.assert();
+        assert!(matches!(
+            error,
+            TracingTurnkeySignerError::SignerAddressMismatch { expected, recovered }
+                if expected == configured_signer.address()
+                    && recovered == different_signer.address()
+        ));
+    }
+
+    /// Turnkey documents `v` as the recovery id (`00`/`01`), but the
+    /// Ethereum-style 27/28 spelling must assemble to the same parity --
+    /// a provider-side representation change must not flip signatures.
+    #[tokio::test]
+    async fn parse_raw_signature_accepts_ethereum_style_recovery_id() {
+        let key_signer = PrivateKeySigner::random();
+        let digest = keccak256(b"detached digest");
+        let signature = key_signer.sign_hash(&digest).await.unwrap();
+
+        let response = SignRawPayloadResult {
+            r: hex::encode(signature.r().to_be_bytes::<32>()),
+            s: hex::encode(signature.s().to_be_bytes::<32>()),
+            v: if signature.v() { "1c" } else { "1b" }.to_string(),
+        };
+
+        let parsed =
+            TracingTurnkeySigner::parse_raw_signature(&response, digest, key_signer.address())
+                .unwrap();
+
+        assert_eq!(parsed, signature);
+    }
+
+    #[tokio::test]
+    async fn parse_raw_signature_rejects_unknown_recovery_id() {
+        let key_signer = PrivateKeySigner::random();
+        let digest = keccak256(b"detached digest");
+        let signature = key_signer.sign_hash(&digest).await.unwrap();
+
+        let response = SignRawPayloadResult {
+            r: hex::encode(signature.r().to_be_bytes::<32>()),
+            s: hex::encode(signature.s().to_be_bytes::<32>()),
+            v: "05".to_string(),
+        };
+
+        let error =
+            TracingTurnkeySigner::parse_raw_signature(&response, digest, key_signer.address())
+                .unwrap_err();
+
+        assert!(matches!(
+            error,
+            TracingTurnkeySignerError::InvalidRecoveryId { value } if value == "05"
+        ));
+    }
+
+    /// `hex::decode("")` succeeds with an empty vector, so a response with
+    /// a missing or empty `v` field must be rejected explicitly -- not
+    /// silently parsed as parity 0.
+    #[tokio::test]
+    async fn parse_raw_signature_rejects_empty_recovery_id() {
+        let key_signer = PrivateKeySigner::random();
+        let digest = keccak256(b"detached digest");
+        let signature = key_signer.sign_hash(&digest).await.unwrap();
+
+        let response = SignRawPayloadResult {
+            r: hex::encode(signature.r().to_be_bytes::<32>()),
+            s: hex::encode(signature.s().to_be_bytes::<32>()),
+            v: String::new(),
+        };
+
+        let error =
+            TracingTurnkeySigner::parse_raw_signature(&response, digest, key_signer.address())
+                .unwrap_err();
+
+        assert!(matches!(
+            error,
+            TracingTurnkeySignerError::InvalidRecoveryId { value } if value.is_empty()
+        ));
+    }
+
+    #[tokio::test]
+    async fn parse_raw_signature_rejects_oversized_scalar() {
+        let key_signer = PrivateKeySigner::random();
+        let digest = keccak256(b"detached digest");
+        let signature = key_signer.sign_hash(&digest).await.unwrap();
+
+        // 33 bytes: one more than a 32-byte scalar can hold.
+        let response = SignRawPayloadResult {
+            r: hex::encode([0x11u8; 33]),
+            s: hex::encode(signature.s().to_be_bytes::<32>()),
+            v: "00".to_string(),
+        };
+
+        let error =
+            TracingTurnkeySigner::parse_raw_signature(&response, digest, key_signer.address())
+                .unwrap_err();
+
+        assert!(matches!(
+            error,
+            TracingTurnkeySignerError::InvalidRawSignatureScalar { component: "r" }
+        ));
+    }
+
+    /// Turnkey pads scalars to 32 bytes; a short component must be
+    /// rejected with a precise error, not zero-extended into a signature
+    /// that only fails later at the recovered-address check.
+    #[tokio::test]
+    async fn parse_raw_signature_rejects_short_scalar() {
+        let key_signer = PrivateKeySigner::random();
+        let digest = keccak256(b"detached digest");
+        let signature = key_signer.sign_hash(&digest).await.unwrap();
+
+        // 31 bytes: one short of a full scalar.
+        let response = SignRawPayloadResult {
+            r: hex::encode(signature.r().to_be_bytes::<32>()),
+            s: hex::encode([0x22u8; 31]),
+            v: "00".to_string(),
+        };
+
+        let error =
+            TracingTurnkeySigner::parse_raw_signature(&response, digest, key_signer.address())
+                .unwrap_err();
+
+        assert!(matches!(
+            error,
+            TracingTurnkeySignerError::InvalidRawSignatureScalar { component: "s" }
+        ));
+    }
+
+    #[test]
+    fn parse_raw_signature_rejects_invalid_hex_component() {
+        let response = SignRawPayloadResult {
+            r: "not-hex".to_string(),
+            s: hex::encode([0x22u8; 32]),
+            v: "00".to_string(),
+        };
+
+        let error =
+            TracingTurnkeySigner::parse_raw_signature(&response, B256::ZERO, Address::random())
+                .unwrap_err();
+
+        assert!(matches!(error, TracingTurnkeySignerError::Hex(_)));
+    }
+
+    /// Wallet-level wiring: `TurnkeyWallet::sign_digest` must route through
+    /// the stored `digest_signer` (the clone sharing the transaction
+    /// signer's client), not panic or hit the transaction path.
+    #[tokio::test]
+    async fn turnkey_wallet_signs_digest_via_raw_payload_activity() {
+        let key_signer = PrivateKeySigner::random();
+        let address = key_signer.address();
+        let digest = keccak256(b"wallet-level digest");
+        let expected_signature = key_signer.sign_hash(&digest).await.unwrap();
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method("POST")
+                .path("/public/v1/submit/sign_raw_payload");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(completed_sign_raw_payload_body(&expected_signature));
+        });
+
+        let anvil = Anvil::new().spawn();
+        let provider = ProviderBuilder::new().connect_http(anvil.endpoint_url());
+
+        let wallet = TurnkeyWallet::from_client(
+            mock_client(&server),
+            TurnkeyOrganizationId::new("org-test".to_string()),
+            address,
+            provider,
+            1,
+        )
+        .await
+        .unwrap();
+
+        let signature = wallet.sign_digest(digest).await.unwrap();
+
+        mock.assert();
+        assert_eq!(signature, expected_signature);
     }
 
     #[tokio::test]
@@ -1650,6 +2083,38 @@ mod tests {
         .expect("failed to construct TurnkeyWallet from env vars");
 
         (wallet, anvil)
+    }
+
+    /// Proves the raw-payload activity against the REAL Turnkey API: the
+    /// request shape, the org's policy allowance for `SIGN_RAW_PAYLOAD`
+    /// (a separate policy surface from transaction signing), and the
+    /// payload encoding -- the digest is sent as unprefixed lowercase hex
+    /// (matching the prod-proven transaction path), and only the real
+    /// endpoint can prove `PAYLOAD_ENCODING_HEXADECIMAL` accepts it, since
+    /// the mocked tests pin whatever we send. Run this before any
+    /// production cutover that depends on digest signing -- it is the
+    /// preflight for a path whose routine tests all use the private-key
+    /// backend.
+    #[ignore = "requires TURNKEY_* env vars -- run with `cargo test -- --ignored`"]
+    #[tokio::test]
+    async fn turnkey_digest_signing_integration() {
+        let (api_key, org_id, address) = turnkey_env()
+            .expect("TURNKEY_API_PRIVATE_KEY, TURNKEY_ORG_ID, and TURNKEY_ADDRESS must be set");
+
+        let (wallet, _anvil) = integration_wallet(api_key, org_id, address).await;
+
+        let digest = keccak256(b"st0x digest-signing integration test");
+
+        let signature = wallet
+            .sign_digest(digest)
+            .await
+            .expect("Turnkey raw-payload signing should succeed (policy must allow it)");
+
+        assert_eq!(
+            signature.recover_address_from_prehash(&digest).unwrap(),
+            address,
+            "signature must recover to the Turnkey-managed address"
+        );
     }
 
     #[ignore = "requires TURNKEY_* env vars -- run with `cargo test -- --ignored`"]

--- a/crates/wrapper/src/service.rs
+++ b/crates/wrapper/src/service.rs
@@ -462,6 +462,13 @@ mod tests {
             self.address
         }
 
+        async fn sign_digest(
+            &self,
+            _digest: alloy::primitives::B256,
+        ) -> Result<alloy::primitives::Signature, EvmError> {
+            panic!("StubWallet::sign_digest called - use a real wallet in tests that need signing")
+        }
+
         async fn send_pending(
             &self,
             _contract: Address,
@@ -692,6 +699,13 @@ mod tests {
     impl<P: Provider + Clone + Send + Sync + 'static> Wallet for MockedWallet<P> {
         fn address(&self) -> Address {
             self.address
+        }
+
+        async fn sign_digest(
+            &self,
+            _digest: alloy::primitives::B256,
+        ) -> Result<alloy::primitives::Signature, EvmError> {
+            panic!("MockedWallet::sign_digest should not be called in wrapper tests")
         }
 
         async fn send_pending(

--- a/src/bot_gas/job.rs
+++ b/src/bot_gas/job.rs
@@ -585,6 +585,13 @@ mod tests {
             self.address
         }
 
+        async fn sign_digest(
+            &self,
+            _digest: alloy::primitives::B256,
+        ) -> Result<alloy::primitives::Signature, EvmError> {
+            panic!("MockWallet::sign_digest should not be called in job tests")
+        }
+
         async fn send_pending(
             &self,
             _contract: Address,

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -1783,6 +1783,13 @@ mod tests {
             self.address
         }
 
+        async fn sign_digest(
+            &self,
+            _digest: alloy::primitives::B256,
+        ) -> Result<alloy::primitives::Signature, EvmError> {
+            panic!("MockEthereumWallet::sign_digest should not be called in polling tests")
+        }
+
         async fn send_pending(
             &self,
             _contract: Address,
@@ -1819,6 +1826,13 @@ mod tests {
     impl Wallet for MockBaseWallet {
         fn address(&self) -> Address {
             self.address
+        }
+
+        async fn sign_digest(
+            &self,
+            _digest: alloy::primitives::B256,
+        ) -> Result<alloy::primitives::Signature, EvmError> {
+            panic!("MockBaseWallet::sign_digest should not be called in polling tests")
         }
 
         async fn send_pending(

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -18,6 +18,7 @@ use alloy::providers::fillers::{
 use alloy::providers::{Identity, ProviderBuilder, RootProvider};
 use alloy::rpc::client::RpcClient;
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
+use alloy::signers::Signer;
 use alloy::signers::local::PrivateKeySigner;
 use async_trait::async_trait;
 use rain_math_float::Float;
@@ -75,6 +76,7 @@ pub(crate) struct TestWallet {
     address: Address,
     read_provider: RootProvider,
     signing_provider: SigningProvider,
+    signer: PrivateKeySigner,
     required_confirmations: u64,
 }
 
@@ -86,7 +88,7 @@ impl TestWallet {
     ) -> anyhow::Result<Self> {
         let signer = PrivateKeySigner::from_bytes(private_key)?;
         let address = signer.address();
-        let eth_wallet = EthereumWallet::from(signer);
+        let eth_wallet = EthereumWallet::from(signer.clone());
 
         let read_provider = RootProvider::new(RpcClient::builder().http(rpc_url.clone()));
         let signing_provider = ProviderBuilder::new()
@@ -97,6 +99,7 @@ impl TestWallet {
             address,
             read_provider,
             signing_provider,
+            signer,
             required_confirmations,
         })
     }
@@ -115,6 +118,10 @@ impl Evm for TestWallet {
 impl Wallet for TestWallet {
     fn address(&self) -> Address {
         self.address
+    }
+
+    async fn sign_digest(&self, digest: B256) -> Result<alloy::primitives::Signature, EvmError> {
+        Ok(self.signer.sign_hash(&digest).await?)
     }
 
     async fn send_pending(


### PR DESCRIPTION
## What

Adds a `sign_digest` method to the `Wallet` trait that signs a precomputed 32-byte digest (e.g. an EIP-712 signing hash) without broadcasting a transaction or consuming a nonce.

## Why

Certain on-chain verification flows (e.g. MintAuthV1) require a detached signature over a precomputed hash rather than a signed transaction. Neither the local nor Turnkey wallet backends previously exposed this capability through the `Wallet` trait.

## How

A new `sign_digest(digest: B256) -> Result<Signature, EvmError>` method is added to the `Wallet` trait and implemented across all backends:

- **Local signer**: delegates directly to `PrivateKeySigner::sign_hash`. The signer is now stored alongside the `signing_provider` so it is available for detached signing without going through the transaction pipeline.
- **Turnkey**: uses the `ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2` activity with `HASH_FUNCTION_NO_OP`, transmitting the digest as bare lowercase hex so Turnkey signs it as-is rather than hashing again. `TracingTurnkeySigner` is made `Clone` and `Arc`\-wrapped so `TurnkeyWallet` can hold a dedicated `digest_signer` handle while the original lives inside the `EthereumWallet` for transaction signing — both share the same HTTP client. The assembled `r`/`s`/`v` components are validated by recovering the signer address from the digest, applying the same defensive trust boundary used for transaction signatures.
- **Stub/mock wallets**: panic with a descriptive message, making accidental calls in unrelated tests immediately visible.

Recovery id parsing accepts both the canonical `00`/`01` encoding Turnkey documents and the Ethereum-style `1b`/`1c` (27/28) encoding, so a provider-side representation change cannot silently flip signature parity. Short, oversized, or non-hex scalar components are rejected with precise errors rather than being silently zero-extended.

## Testing

- **`sign_digest_recovers_to_wallet_address`** (local): signs a digest with the local wallet and verifies the signature recovers to the wallet's address.
- **`sign_digest_returns_signature_from_completed_activity`** (Turnkey): mocks the `/sign_raw_payload` endpoint, asserts the request carries the correct `HASH_FUNCTION_NO_OP` and hex-encoded digest, and verifies the assembled signature matches and recovers correctly.
- **`sign_digest_rejects_signature_from_wrong_signer`**: confirms components recovering to a different address are rejected.
- **`parse_raw_signature_accepts_ethereum_style_recovery_id`**: verifies `1b`/`1c` parity values are accepted.
- **`parse_raw_signature_rejects_unknown_recovery_id`**, **`rejects_empty_recovery_id`**: confirm out-of-range and empty `v` values fail loudly.
- **`parse_raw_signature_rejects_oversized_scalar`**, **`rejects_short_scalar`**, **`rejects_invalid_hex_component`**: confirm malformed `r`/`s` components are caught before reaching the recovery check.
- **`turnkey_wallet_signs_digest_via_raw_payload_activity`**: wallet-level wiring test confirming `TurnkeyWallet::sign_digest` routes through `digest_signer`.
- **`turnkey_digest_signing_integration`** (ignored): end-to-end test against the real Turnkey API, intended as a preflight before any production cutover that depends on digest signing.

## Anything else

The integration test (`turnkey_digest_signing_integration`) requires `TURNKEY_API_PRIVATE_KEY`, `TURNKEY_ORG_ID`, and `TURNKEY_ADDRESS` environment variables and must be run explicitly with `cargo test -- --ignored`. It validates that the org's Turnkey policy permits `SIGN_RAW_PAYLOAD` activities, which is a separate policy surface from transaction signing and cannot be verified by the mocked unit tests alone.

Closes [RAI-1675](https://linear.app/makeitrain/issue/RAI-1675/digest-signing)

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Wallets can now sign detached 32-byte digests and return standard signatures.
  - Local and Turnkey wallets support digest signing, including signature validation and signer-address verification.
  - Wallet wrappers and delegated wallet types forward digest-signing requests consistently.

- **Bug Fixes**
  - Signer failures are now reported separately from transaction revert errors, without incorrectly exposing revert data.
  - Invalid signing responses are rejected with clearer validation errors, while sensitive response contents remain protected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->