### PR TITLE
Wire orchestrator-mode mint authorization signing and delivery

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1136,7 +1136,9 @@ fn stuck_mint_info(rows: &[(String, String, i64)]) -> Option<StuckTransferInfo> 
             | TokensReceived { .. }
             | WrapSubmitted { .. }
             | TokensWrapped { .. }
-            | VaultDepositSubmitted { .. } => {}
+            | VaultDepositSubmitted { .. }
+            | MintAuthorizationSigned { .. }
+            | MintAuthorizationDelivered { .. } => {}
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1978,6 +1978,7 @@ mod tests {
     use st0x_wrapper::MockWrapper;
 
     use super::*;
+    use crate::mint_authorization::ConfiguredMintAuthorizer;
     use crate::offchain::order::OffchainOrderEvent;
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::EquityTransferServices;
@@ -2841,6 +2842,7 @@ mod tests {
                 tokenizer: Arc::new(MockTokenizer::new()),
                 wrapper: Arc::new(MockWrapper::new()),
                 bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+                mint_authorizer: ConfiguredMintAuthorizer::Disabled,
             })
             .await
             .unwrap();

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -22,6 +22,8 @@ use st0x_execution::{
     FractionalShares, Network, Symbol, TimeInForce,
 };
 use st0x_finance::Usdc;
+use st0x_issuance_client::IssuanceClient;
+use st0x_issuance_dto::VaultModeTag;
 use st0x_raindex::{RaindexService, RaindexVaultId};
 use st0x_tokenization::{
     AlpacaTokenizationService, IssuerRequestId, TokenizationRequest, TokenizationRequestStatus,
@@ -36,6 +38,7 @@ use crate::bot_gas::BotGasReceiptCostEnqueuer;
 use crate::equity_redemption::{
     DetectionFailure, EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId,
 };
+use crate::mint_authorization::{ConfiguredMintAuthorizer, VaultModeReader};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
 use crate::rebalancing::to_wrapped_equities;
 use crate::rebalancing::usdc::{CrossVenueCashTransfer, UsdcSettlementParams, UsdcTransferError};
@@ -136,6 +139,14 @@ async fn build_equity_transfer_services(
         tokenizer: tokenization_service.clone(),
         wrapper: wrapper.clone(),
         bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+        // The CLI transfer path never signs mint authorizations:
+        // `transfer_equity_command` rejects orchestrator-mode mints up
+        // front (`ensure_vault_direct_mint`), so only vault-direct assets
+        // reach this saga, which also skips `with_mint_authorization` and
+        // therefore never consults this value. Orchestrator-mode mints run
+        // through the server, where the authorizer and vault-mode wiring
+        // come from `[orchestrator]` config.
+        mint_authorizer: ConfiguredMintAuthorizer::Disabled,
     };
 
     let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
@@ -157,6 +168,32 @@ async fn build_equity_transfer_services(
     );
 
     Ok(EquityTransferCliServices { transfer, wallet })
+}
+
+/// Refuses an orchestrator-mode CLI mint before any aggregate is created.
+///
+/// The CLI wires no vault-mode reader, mint authorizer, or delivery
+/// worker: an orchestrator-mode mint initiated here would sit unauthorized
+/// (stalled at polling) until a server restart resumed it. Fails closed --
+/// an indeterminate mode is never treated as vault-direct, mirroring the
+/// server saga's own rule.
+async fn ensure_vault_direct_mint(
+    vault_mode_reader: &dyn VaultModeReader,
+    symbol: &Symbol,
+) -> anyhow::Result<()> {
+    let mode = vault_mode_reader
+        .vault_mode(symbol)
+        .await
+        .context("could not determine the asset's vault mode; refusing to mint blind")?;
+
+    match mode {
+        VaultModeTag::VaultDirect => Ok(()),
+        VaultModeTag::Orchestrator => anyhow::bail!(
+            "{symbol} is orchestrator-mode: its mint needs a signed recipient \
+             authorization, which only the server wires (vault-mode reads, \
+             signing, delivery). Run this transfer through the server instead."
+        ),
+    }
 }
 
 pub(super) async fn transfer_equity_command<Writer: Write>(
@@ -183,6 +220,13 @@ pub(super) async fn transfer_equity_command<Writer: Write>(
 
     match direction {
         TransferDirection::ToRaindex => {
+            let issuance = IssuanceClient::new(
+                ctx.issuance.base_url.clone(),
+                ctx.issuance.api_key.header_value(),
+            )
+            .context("failed to build the issuance client for the vault-mode check")?;
+            ensure_vault_direct_mint(&issuance, symbol).await?;
+
             writeln!(stdout, "   Creating mint request...")?;
             writeln!(stdout, "   Receiving Wallet: {}", cli_services.wallet)?;
 
@@ -1784,6 +1828,7 @@ mod tests {
     use super::*;
     use crate::equity_redemption::{EquityRedemptionError, redemption_aggregate_id};
     use crate::inventory::ImbalanceThreshold;
+    use crate::mint_authorization::StubVaultModeReader;
     use crate::onchain::mock::MockRaindex;
     use crate::test_utils::setup_test_db;
     use crate::usdc_rebalance::{ReconcileReason, TransferRef, UsdcRebalanceCommand};
@@ -4068,6 +4113,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         }
     }
 
@@ -4811,5 +4857,32 @@ mod tests {
             err_msg.contains("already failed"),
             "failing an already-failed redemption must refuse; got: {err_msg}"
         );
+    }
+
+    /// The CLI wires no authorization infrastructure, so an
+    /// orchestrator-mode mint must be refused before any aggregate exists
+    /// -- accepting it would strand the mint unauthorized until a server
+    /// restart resumed it.
+    #[tokio::test]
+    async fn cli_mint_refuses_orchestrator_mode_asset() {
+        let reader = StubVaultModeReader(VaultModeTag::Orchestrator);
+
+        let error = ensure_vault_direct_mint(&reader, &Symbol::new("RKLB").unwrap())
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("orchestrator-mode"),
+            "the refusal must say why and point at the server: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cli_mint_allows_vault_direct_asset() {
+        let reader = StubVaultModeReader(VaultModeTag::VaultDirect);
+
+        ensure_vault_direct_mint(&reader, &Symbol::new("RKLB").unwrap())
+            .await
+            .unwrap();
     }
 }

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -69,6 +69,7 @@ use crate::equity_redemption::{
 use crate::inventory::{
     BroadcastingInventory, Inventory, InventoryProjection, InventorySnapshot, Venue,
 };
+use crate::mint_authorization::{ConfiguredMintAuthorizer, MintAuthorizationService};
 use crate::offchain::order::{
     ExecutorOrderPlacer, OffchainOrder, OffchainOrderId, OffchainOrderPlacement, OrderPlacer,
     PollOrderStatus, PollOrderStatusJobQueue, TerminalPositionFinalization,
@@ -99,7 +100,8 @@ use crate::position::{
 };
 use crate::position_check::{HedgeScanSkipReason, record_scan_skip};
 use crate::rebalancing::equity::{
-    CrossVenueEquityTransfer, EquityTransferServices, ResumeTokenizationAggregate,
+    CrossVenueEquityTransfer, DeliverMintAuthorizationCtx, DeliverMintAuthorizationJobQueue,
+    EquityTransferServices, MintAuthorizationWiring, ResumeTokenizationAggregate,
     ResumeTokenizationCtx, ResumeTokenizationJobQueue, ResumeTokenizationTarget,
     TransferEquityToHedging, TransferEquityToHedgingCtx, TransferEquityToMarketMaking,
     TransferEquityToMarketMakingCtx,
@@ -832,22 +834,7 @@ impl Conductor {
             seed_vault_registry_ctx,
         ) = setup_vault_registry(&pool, &apalis_pool, &ctx).await?;
 
-        // Grant one-time idempotent MAX approvals to the trusted spenders (our
-        // ERC-4626 wrapper vaults and the Raindex orderbook) before any worker
-        // or rebalancer runs, so wrap/deposit never reverts with
-        // ERC20InsufficientAllowance. Fails fast -- the bot must not come up
-        // healthy with these missing. Only runs when a wallet is configured;
-        // without one the bot cannot submit on-chain transactions at all.
-        grant_startup_token_approvals(&ctx).await?;
-
-        // Catch the lifecycle-failure read model up to the event log before
-        // its OffchainOrder reactor (registered below) goes live, in both
-        // modes. Must run BEFORE `PositionAndRebalancing::setup`: setup spawns
-        // resume workers that write the event store concurrently, and this
-        // catch-up's deferred read-then-write transaction surfaces
-        // SQLITE_BUSY_SNAPSHOT immediately (busy_timeout does not apply to
-        // deferred-upgrade conflicts), failing the whole boot.
-        catch_up_lifecycle_failures(&pool).await?;
+        run_startup_maintenance(&ctx, &pool).await?;
 
         let rebalancing = optional_rebalancing_ctx(&ctx)?;
         let notifier = build_alert_notifier(ctx.alerts.as_ref(), "Operational alerting")?;
@@ -871,6 +858,8 @@ impl Conductor {
             transfer_equity_to_market_making_ctx,
             transfer_equity_to_hedging_ctx,
             resume_tokenization_queue,
+            deliver_mint_authorization_queue,
+            deliver_mint_authorization_ctx,
         } = PositionAndRebalancing::setup(
             rebalancing,
             RebalancingDeps {
@@ -1024,6 +1013,8 @@ impl Conductor {
             .seed_vault_registry_ctx(seed_vault_registry_ctx)
             .resume_tokenization_queue(resume_tokenization_queue)
             .maybe_resume_tokenization_ctx(resume_tokenization_ctx)
+            .deliver_mint_authorization_queue(deliver_mint_authorization_queue)
+            .maybe_deliver_mint_authorization_ctx(deliver_mint_authorization_ctx)
             .record_bot_gas_receipt_cost_queue(record_bot_gas_receipt_cost_queue)
             .maybe_record_bot_gas_receipt_cost_ctx(record_bot_gas_receipt_cost_ctx)
             .job_cleanup(job_cleanup)
@@ -1626,6 +1617,8 @@ struct RebalancingInfrastructure {
     transfer_equity_to_market_making_ctx: Arc<TransferEquityToMarketMakingCtx>,
     transfer_equity_to_hedging_ctx: Arc<TransferEquityToHedgingCtx>,
     resume_tokenization_queue: ResumeTokenizationJobQueue,
+    deliver_mint_authorization_queue: DeliverMintAuthorizationJobQueue,
+    deliver_mint_authorization_ctx: Arc<DeliverMintAuthorizationCtx>,
 }
 
 /// Shared infrastructure dependencies needed to spawn rebalancing.
@@ -1674,6 +1667,10 @@ struct PositionAndRebalancing {
     transfer_equity_to_market_making_ctx: Option<Arc<TransferEquityToMarketMakingCtx>>,
     transfer_equity_to_hedging_ctx: Option<Arc<TransferEquityToHedgingCtx>>,
     resume_tokenization_queue: Option<ResumeTokenizationJobQueue>,
+    /// Always present (unlike the ctx): the builder needs a queue handle
+    /// either way, and workers skip registration via the absent ctx.
+    deliver_mint_authorization_queue: DeliverMintAuthorizationJobQueue,
+    deliver_mint_authorization_ctx: Option<Arc<DeliverMintAuthorizationCtx>>,
 }
 
 /// Builds the wrapper service from the single wallet/config source shared by
@@ -1757,10 +1754,13 @@ impl PositionAndRebalancing {
                 ),
                 transfer_equity_to_hedging_ctx: Some(infra.transfer_equity_to_hedging_ctx),
                 resume_tokenization_queue: Some(infra.resume_tokenization_queue),
+                deliver_mint_authorization_queue: infra.deliver_mint_authorization_queue,
+                deliver_mint_authorization_ctx: Some(infra.deliver_mint_authorization_ctx),
             })
         } else {
             let RebalancingDeps {
                 pool,
+                apalis_pool,
                 ctx,
                 inventory,
                 broadcaster,
@@ -1809,6 +1809,10 @@ impl PositionAndRebalancing {
                 transfer_equity_to_market_making_ctx: None,
                 transfer_equity_to_hedging_ctx: None,
                 resume_tokenization_queue: None,
+                deliver_mint_authorization_queue: DeliverMintAuthorizationJobQueue::new(
+                    &apalis_pool,
+                ),
+                deliver_mint_authorization_ctx: None,
             })
         }
     }
@@ -1839,6 +1843,116 @@ fn build_alert_notifier(
         TelegramNotifier::new(&alerts.bot_token, alerts.chat_id, alerts.message_thread_id)?;
     info!("{channel}: Telegram notifier configured");
     Ok(Arc::new(notifier))
+}
+
+/// One-time startup maintenance that must precede
+/// `PositionAndRebalancing::setup`.
+///
+/// Grants the one-time idempotent MAX approvals to the trusted spenders
+/// (our ERC-4626 wrapper vaults and the Raindex orderbook) before any
+/// worker or rebalancer runs, so wrap/deposit never reverts with
+/// ERC20InsufficientAllowance. Fails fast -- the bot must not come up
+/// healthy with these missing; only runs when a wallet is configured.
+///
+/// Then catches the lifecycle-failure read model up to the event log before
+/// its OffchainOrder reactor goes live, in both modes. Must run BEFORE
+/// `PositionAndRebalancing::setup`: setup spawns resume workers that write
+/// the event store concurrently, and this catch-up's deferred
+/// read-then-write transaction surfaces SQLITE_BUSY_SNAPSHOT immediately
+/// (busy_timeout does not apply to deferred-upgrade conflicts), failing the
+/// whole boot.
+async fn run_startup_maintenance(ctx: &Ctx, pool: &SqlitePool) -> anyhow::Result<()> {
+    grant_startup_token_approvals(ctx).await?;
+    catch_up_lifecycle_failures(pool).await?;
+    Ok(())
+}
+
+/// Mint-authorization infrastructure for orchestrator-mode mints
+/// (RAI-1243), built once per conductor start.
+struct MintAuthorizationInfra {
+    /// Signs `MintAuthV1` inside the mint aggregate's command handler.
+    /// `Disabled` without an `[orchestrator]` config section.
+    authorizer: ConfiguredMintAuthorizer,
+    /// Delivery job queue, shared by the saga's enqueue and the worker.
+    queue: DeliverMintAuthorizationJobQueue,
+    /// The saga-side bundle: vault-mode reads, token map, delivery enqueue.
+    wiring: MintAuthorizationWiring,
+    /// One issuance client serves both mint-authorization consumers (the
+    /// saga's vault-mode read and the delivery job), built from the same
+    /// `[issuance]` credentials as the freeze guard's own client instance.
+    issuance_client: Arc<IssuanceClient>,
+}
+
+/// Builds [`MintAuthorizationInfra`]. The authorizer is `Enabled` only when
+/// `[orchestrator]` is configured: while every asset is vault-direct the bot
+/// deploys dark without the section, and an orchestrator-mode mint reaching
+/// the signing step then fails loudly rather than guessing an address.
+///
+/// Also runs the queue's orphan sweep for delivery rows a crash caught
+/// mid-run; pending rows stay queued (still-valid work for the persisted
+/// authorization, unlike resume jobs, which startup re-derives). A failed
+/// sweep fails startup -- an unrepaired orphan would read as a live
+/// delivery and suppress resume.
+async fn build_mint_authorization_infra<Chain>(
+    ctx: &Ctx,
+    apalis_pool: &apalis_sqlite::SqlitePool,
+    base_wallet: &Chain,
+) -> anyhow::Result<MintAuthorizationInfra>
+where
+    Chain: Wallet + Clone + Send + Sync + 'static,
+{
+    let issuance_client = Arc::new(IssuanceClient::new(
+        ctx.issuance.base_url.clone(),
+        ctx.issuance.api_key.header_value(),
+    )?);
+
+    let queue = DeliverMintAuthorizationJobQueue::new(apalis_pool);
+
+    // Fails startup on sweep failure rather than continuing: an unrepaired
+    // `Running` orphan counts as live in `has_live_delivery_job`, which
+    // would suppress the resume path's re-enqueue and stall the mint until
+    // a later restart's sweep succeeded.
+    let orphaned = queue
+        .requeue_orphaned()
+        .await
+        .context("failed to re-queue orphaned mint-authorization delivery jobs at startup")?;
+    if orphaned > 0 {
+        info!(
+            target: "tokenization",
+            count = orphaned,
+            "Re-queued orphaned mint-authorization delivery job(s) for \
+             crash-safe resume"
+        );
+    }
+
+    let token_addresses = ctx
+        .assets
+        .equities
+        .symbols
+        .iter()
+        .map(|(symbol, equity)| (symbol.clone(), equity.tokenized_equity))
+        .collect();
+
+    let authorizer = ctx.orchestrator.as_ref().map_or_else(
+        || ConfiguredMintAuthorizer::Disabled,
+        |orchestrator| {
+            ConfiguredMintAuthorizer::Enabled(Arc::new(MintAuthorizationService::new(
+                base_wallet.clone(),
+                orchestrator.address,
+            )))
+        },
+    );
+
+    Ok(MintAuthorizationInfra {
+        authorizer,
+        wiring: MintAuthorizationWiring {
+            vault_mode_reader: issuance_client.clone(),
+            token_addresses,
+            delivery_queue: queue.clone(),
+        },
+        queue,
+        issuance_client,
+    })
 }
 
 /// Wires the dividend freeze guard onto the rebalancing service when enabled.
@@ -2131,12 +2245,16 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
 
         let wrapper = build_wrapper(base_wallet.clone(), &deps.ctx);
 
+        let mint_authorization =
+            build_mint_authorization_infra(&deps.ctx, &deps.apalis_pool, &base_wallet).await?;
+
         let equity_transfer_services = EquityTransferServices {
             raindex: raindex_service.clone(),
             vault_lookup: vault_lookup.clone(),
             tokenizer: tokenizer.clone(),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: bot_gas_enqueuer.clone(),
+            mint_authorizer: mint_authorization.authorizer,
         };
 
         let transfer_usdc_to_hedging_queue = deps.schedulers.transfer_usdc_to_hedging.clone();
@@ -2197,7 +2315,8 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
                 built.mint.clone(),
                 built.redemption.clone(),
             )
-            .with_bot_gas_enqueuer(bot_gas_enqueuer.clone()),
+            .with_bot_gas_enqueuer(bot_gas_enqueuer.clone())
+            .with_mint_authorization(mint_authorization.wiring),
         );
 
         // Built outside `QueryManifest`: services depend on mint/redemption stores
@@ -2256,6 +2375,13 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             bot_gas_enqueuer.clone(),
         );
 
+        let deliver_mint_authorization_ctx = Arc::new(DeliverMintAuthorizationCtx {
+            deliverer: mint_authorization.issuance_client,
+            mint_store: built.mint.clone(),
+            notifier: notifier.clone(),
+            job_queue: mint_authorization.queue.clone(),
+        });
+
         let transfer_usdc_to_market_making_ctx = Arc::new(TransferUsdcToMarketMakingCtx {
             transfer: usdc_handles.resume_alpaca_to_base,
             job_queue: transfer_usdc_to_market_making_queue,
@@ -2301,6 +2427,8 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             transfer_equity_to_market_making_ctx,
             transfer_equity_to_hedging_ctx,
             resume_tokenization_queue,
+            deliver_mint_authorization_queue: mint_authorization.queue,
+            deliver_mint_authorization_ctx,
         })
     })
 }
@@ -5178,6 +5306,7 @@ mod tests {
             tokenizer: tokenizer.clone(),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(
@@ -5720,6 +5849,7 @@ mod tests {
             tokenizer: tokenizer.clone(),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let seeding_mint_store = Arc::new(test_store::<TokenizedEquityMint>(
@@ -5817,6 +5947,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let seeding_mint_store2 = Arc::new(test_store::<TokenizedEquityMint>(

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -65,6 +65,7 @@ use crate::portfolio_snapshot::{
 use crate::position::Position;
 use crate::position_check::{CheckPositions, CheckPositionsCtx, CheckPositionsJobQueue};
 use crate::rebalancing::equity::{
+    DeliverMintAuthorization, DeliverMintAuthorizationCtx, DeliverMintAuthorizationJobQueue,
     ResumeTokenizationAggregate, ResumeTokenizationCtx, ResumeTokenizationJobQueue,
     TransferEquityToHedging, TransferEquityToHedgingCtx, TransferEquityToHedgingJobQueue,
     TransferEquityToMarketMaking, TransferEquityToMarketMakingCtx,
@@ -220,6 +221,8 @@ pub(crate) fn spawn<Prov, Exec>(
     seed_vault_registry_ctx: Arc<SeedVaultRegistryCtx>,
     resume_tokenization_queue: ResumeTokenizationJobQueue,
     resume_tokenization_ctx: Option<Arc<ResumeTokenizationCtx>>,
+    deliver_mint_authorization_queue: DeliverMintAuthorizationJobQueue,
+    deliver_mint_authorization_ctx: Option<Arc<DeliverMintAuthorizationCtx>>,
     record_bot_gas_receipt_cost_queue: RecordBotGasReceiptCostJobQueue,
     record_bot_gas_receipt_cost_ctx: Option<Arc<RecordBotGasReceiptCostCtx>>,
     job_cleanup: JoinHandle<()>,
@@ -528,6 +531,8 @@ where
         transfer_equity_to_hedging_ctx,
         resume_tokenization_queue,
         resume_tokenization_ctx,
+        deliver_mint_authorization_queue,
+        deliver_mint_authorization_ctx,
         record_bot_gas_receipt_cost_queue,
         record_bot_gas_receipt_cost_ctx,
         apalis_shutdown_token,
@@ -594,6 +599,8 @@ where
     transfer_equity_to_hedging_ctx: Option<Arc<TransferEquityToHedgingCtx>>,
     resume_tokenization_queue: ResumeTokenizationJobQueue,
     resume_tokenization_ctx: Option<Arc<ResumeTokenizationCtx>>,
+    deliver_mint_authorization_queue: DeliverMintAuthorizationJobQueue,
+    deliver_mint_authorization_ctx: Option<Arc<DeliverMintAuthorizationCtx>>,
     record_bot_gas_receipt_cost_queue: RecordBotGasReceiptCostJobQueue,
     record_bot_gas_receipt_cost_ctx: Option<Arc<RecordBotGasReceiptCostCtx>>,
     apalis_shutdown_token: CancellationToken,
@@ -647,6 +654,8 @@ where
             transfer_equity_to_hedging_ctx,
             resume_tokenization_queue,
             resume_tokenization_ctx,
+            deliver_mint_authorization_queue,
+            deliver_mint_authorization_ctx,
             record_bot_gas_receipt_cost_queue,
             record_bot_gas_receipt_cost_ctx,
             apalis_shutdown_token,
@@ -691,6 +700,8 @@ where
         let failure_injector_for_transfer_equity_to_hedging = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_resume_tokenization = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_deliver_mint_authorization = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_record_bot_gas_receipt_cost = failure_injector.clone();
         let failure_notify = Arc::new(TerminalFailureSignal::default());
@@ -920,6 +931,14 @@ where
                 resume_tokenization_queue,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_resume_tokenization,
+            );
+
+            let apalis_monitor = register_deliver_mint_authorization_worker(
+                apalis_monitor,
+                deliver_mint_authorization_ctx,
+                deliver_mint_authorization_queue,
+                #[cfg(any(test, feature = "test-support"))]
+                failure_injector_for_deliver_mint_authorization,
             );
 
             let apalis_monitor = register_record_bot_gas_receipt_cost_worker(
@@ -1221,6 +1240,37 @@ fn register_resume_tokenization_worker(
     })
 }
 
+/// Conditionally registers the `DeliverMintAuthorization` worker. The ctx
+/// is `None` when rebalancing is disabled: no mints happen, so no
+/// authorization ever needs delivering. Best-effort -- a stuck
+/// authorization must never halt hedging or fill detection.
+fn register_deliver_mint_authorization_worker(
+    monitor: Monitor,
+    delivery_ctx: Option<Arc<DeliverMintAuthorizationCtx>>,
+    delivery_queue: DeliverMintAuthorizationJobQueue,
+    #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
+) -> Monitor {
+    let Some(delivery_ctx) = delivery_ctx else {
+        debug!(
+            "DeliverMintAuthorization worker not registered: rebalancing disabled \
+             (no delivery ctx). Orchestrator-mode mint authorizations will not be \
+             delivered."
+        );
+        return monitor;
+    };
+
+    monitor.register(move |index| {
+        build_best_effort_worker!(
+            ::<DeliverMintAuthorizationCtx, DeliverMintAuthorization>,
+            index,
+            delivery_queue.clone(),
+            delivery_ctx.clone(),
+            #[cfg(any(test, feature = "test-support"))]
+            failure_injector.clone(),
+        )
+    })
+}
+
 /// Conditionally registers the `RecordBotGasReceiptCost` worker. The ctx is
 /// `None` when `[bot_gas_valuation]` is not configured, or when it is
 /// configured but no `[wallet]` is (see `build_record_bot_gas_receipt_cost_ctx`);
@@ -1275,6 +1325,7 @@ mod tests {
     use super::*;
     use crate::conductor::job::BackpressureStreak;
     use crate::equity_redemption::RedemptionAggregateId;
+    use crate::mint_authorization::ConfiguredMintAuthorizer;
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::{
         EquityTransferServices, MintError, MintTransferError, RedemptionError,
@@ -1367,6 +1418,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper,
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         Arc::new(TransferEquityToMarketMakingCtx {

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -739,6 +739,7 @@ pub enum JobKind {
     DashboardTradeDelivery,
     PortfolioSnapshot,
     RecordBotGasReceiptCost,
+    DeliverMintAuthorization,
 }
 
 /// Job execution error. Wraps the concrete `Job::Error` type at
@@ -783,6 +784,7 @@ pub struct FailureInjector {
     dashboard_trade_delivery: Arc<Mutex<InjectionState>>,
     portfolio_snapshot: Arc<Mutex<InjectionState>>,
     record_bot_gas_receipt_cost: Arc<Mutex<InjectionState>>,
+    deliver_mint_authorization: Arc<Mutex<InjectionState>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -825,6 +827,7 @@ impl FailureInjector {
             dashboard_trade_delivery: Arc::new(Mutex::new(InjectionState::Idle)),
             portfolio_snapshot: Arc::new(Mutex::new(InjectionState::Idle)),
             record_bot_gas_receipt_cost: Arc::new(Mutex::new(InjectionState::Idle)),
+            deliver_mint_authorization: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
@@ -879,6 +882,7 @@ impl FailureInjector {
             JobKind::DashboardTradeDelivery => &self.dashboard_trade_delivery,
             JobKind::PortfolioSnapshot => &self.portfolio_snapshot,
             JobKind::RecordBotGasReceiptCost => &self.record_bot_gas_receipt_cost,
+            JobKind::DeliverMintAuthorization => &self.deliver_mint_authorization,
         };
 
         match mutex.lock() {

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -186,6 +186,7 @@ mod tests {
     use crate::inventory::{
         BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, Operator, Venue,
     };
+    use crate::mint_authorization::ConfiguredMintAuthorizer;
     use crate::onchain::mock::MockRaindex;
     use crate::position::{PositionCommand, TradeId};
     use crate::rebalancing::equity::TransferEquityToMarketMaking;
@@ -265,6 +266,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let frameworks = manifest.build(pool, services).await.unwrap();
@@ -332,6 +334,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let built = manifest.build(pool, services).await.unwrap();
 
@@ -462,6 +465,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let built = manifest.build(pool.clone(), services).await.unwrap();
 

--- a/src/dashboard/pnl/ledger.rs
+++ b/src/dashboard/pnl/ledger.rs
@@ -490,6 +490,8 @@ async fn ingest_mint(
         TokenizedEquityMintEvent::MintRejected { .. }
         | TokenizedEquityMintEvent::MintAccepted { .. }
         | TokenizedEquityMintEvent::MintAcceptanceFailed { .. }
+        | TokenizedEquityMintEvent::MintAuthorizationSigned { .. }
+        | TokenizedEquityMintEvent::MintAuthorizationDelivered { .. }
         | TokenizedEquityMintEvent::WrapSubmitted { .. }
         | TokenizedEquityMintEvent::TokensWrapped { .. }
         | TokenizedEquityMintEvent::WrappingFailed { .. }

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -2884,6 +2884,7 @@ mod tests {
     use st0x_wrapper::MockWrapper;
 
     use super::*;
+    use crate::mint_authorization::ConfiguredMintAuthorizer;
     use crate::onchain::mock::{ConfirmTxBehavior, MockRaindex};
     use crate::vault_lookup::MockVaultLookup;
 
@@ -2898,6 +2899,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         }
     }
 
@@ -3449,6 +3451,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new().with_tokenized_shares(underlying_token)),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let store = TestStore::<EquityRedemption>::new(services);
@@ -3532,6 +3535,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Enabled(queue),
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let underlying_token = Address::random();
@@ -3577,6 +3581,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let store = TestStore::<EquityRedemption>::new(services);
         let id = redemption_aggregate_id("partial-withdraw");
@@ -3626,6 +3631,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let store = TestStore::<EquityRedemption>::new(services);
         let id = redemption_aggregate_id("unwrap-partial-withdraw");
@@ -3686,6 +3692,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let store = TestStore::<EquityRedemption>::new(services);
         let id = redemption_aggregate_id("missing-withdraw-transfer");
@@ -3742,6 +3749,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let store = TestStore::<EquityRedemption>::new(services);
         let id = redemption_aggregate_id("no-block-number");
@@ -4215,6 +4223,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new().with_send_failure()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let store = TestStore::<EquityRedemption>::new(services);
@@ -4283,6 +4292,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new().with_no_redemption_wallet()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let store = TestStore::<EquityRedemption>::new(services);
@@ -4351,6 +4361,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::failing_unwrap()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         // UnwrapTokens is now pure (emits UnwrapPending).
@@ -4378,6 +4389,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::failing_lookup()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         // UnwrapTokens now emits UnwrapSubmitted (no lookup yet).
@@ -5441,6 +5453,7 @@ mod tests {
             tokenizer: mock_tokenizer.clone(),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let events = TestHarness::<EquityRedemption>::with(services)
@@ -5495,6 +5508,7 @@ mod tests {
             tokenizer: mock_tokenizer.clone(),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let events = TestHarness::<EquityRedemption>::with(services)
@@ -5546,6 +5560,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new().failing_wait_for_block()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let error = TestHarness::<EquityRedemption>::with(services)
@@ -5591,6 +5606,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: mock_wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let token = Address::ZERO;
@@ -5641,6 +5657,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: mock_wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let token = Address::ZERO;
@@ -5695,6 +5712,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::failing_wait_for_block()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let error = TestHarness::<EquityRedemption>::with(services)

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -54,6 +54,7 @@ use crate::inventory::view::InFlightEquityLocation;
 use crate::inventory::{
     BroadcastingInventory, ImbalanceThreshold, InventoryView, PollFreshness, Venue,
 };
+use crate::mint_authorization::ConfiguredMintAuthorizer;
 use crate::offchain::order::OffchainOrderId;
 use crate::onchain::mock::MockRaindex;
 use crate::position::{Position, PositionCommand, TradeId};
@@ -471,6 +472,7 @@ fn build_equity_transfer_with_wrapper(
         tokenizer: Arc::clone(&tokenizer),
         wrapper: Arc::clone(&wrapper),
         bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+        mint_authorizer: ConfiguredMintAuthorizer::Disabled,
     };
     let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
         pool.clone(),
@@ -512,6 +514,7 @@ async fn build_equity_transfer_with_service(
         tokenizer: Arc::clone(&tokenizer),
         wrapper: Arc::clone(&wrapper),
         bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+        mint_authorizer: ConfiguredMintAuthorizer::Disabled,
     };
 
     let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
@@ -688,6 +691,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         },
     ));
     let ctx = TransferEquityToMarketMakingCtx {
@@ -1658,6 +1662,7 @@ async fn mint_api_failure_produces_rejected_event() {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         },
     ));
     let ctx = TransferEquityToMarketMakingCtx {
@@ -2243,6 +2248,7 @@ async fn mint_accepted_sets_offchain_inflight() {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         },
     ));
     let transfer_handle = tokio::spawn({
@@ -2461,6 +2467,7 @@ async fn completed_mint_clears_inflight_and_updates_inventory() {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         },
     ));
     let ctx = TransferEquityToMarketMakingCtx {
@@ -2538,6 +2545,7 @@ async fn transfer_failed_cancels_redemption_inflight() {
         tokenizer,
         wrapper: Arc::new(MockWrapper::new()),
         bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+        mint_authorizer: ConfiguredMintAuthorizer::Disabled,
     };
 
     let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
@@ -2663,6 +2671,7 @@ async fn wrapped_recovery_reschedules_when_held_for_recovery_but_no_balance() {
         tokenizer: Arc::clone(&tokenizer),
         wrapper: Arc::clone(&wrapper),
         bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+        mint_authorizer: ConfiguredMintAuthorizer::Disabled,
     };
     let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
         pool.clone(),
@@ -2784,6 +2793,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_landed_wrapped_equity_recovery()
         tokenizer: Arc::clone(&tokenizer),
         wrapper: Arc::clone(&wrapper),
         bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+        mint_authorizer: ConfiguredMintAuthorizer::Disabled,
     };
     let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
         pool.clone(),
@@ -2924,6 +2934,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_unwrapped_equity_recovery
         tokenizer: Arc::clone(&tokenizer),
         wrapper: Arc::clone(&wrapper),
         bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+        mint_authorizer: ConfiguredMintAuthorizer::Disabled,
     };
     let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
         pool.clone(),
@@ -3056,6 +3067,7 @@ async fn recovery_job_breaks_deadlock_when_wrap_failed_dispatches_active_mint() 
         tokenizer: Arc::clone(&tokenizer),
         wrapper: Arc::clone(&wrapper),
         bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+        mint_authorizer: ConfiguredMintAuthorizer::Disabled,
     };
     let mint_store = Arc::new(test_store::<TokenizedEquityMint>(
         pool.clone(),

--- a/src/mint_authorization.rs
+++ b/src/mint_authorization.rs
@@ -15,6 +15,8 @@
 use alloy::primitives::{Address, B256, Bytes, U256};
 use async_trait::async_trait;
 use rain_math_float::Float;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use st0x_evm::{EvmError, NoOpErrorRegistry, Wallet};
 use st0x_execution::Symbol;
@@ -34,11 +36,49 @@ pub use crate::tokenized_equity_mint::QuantityScalingError;
 ///
 /// `signature` is the raw 65-byte ECDSA signature over the orchestrator's
 /// `mintAuthDigest`; issuance forwards both values verbatim to
-/// `orchestrator.mint`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// `orchestrator.mint`. Serde (hex strings for both fields) because the
+/// mint aggregate embeds this in its snapshot-persisted state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SignedMintAuthorization {
     pub nonce: B256,
     pub signature: Bytes,
+}
+
+/// Mint-authorizer handle for the mint aggregate's services.
+///
+/// `Disabled` when the config has no `[orchestrator]` section -- the bot
+/// runs dark while every asset is vault-direct, and an orchestrator-mode
+/// mint reaching the signing step then fails loudly rather than guessing
+/// an address. Mirrors `BotGasReceiptCostEnqueuer`'s explicit-absence
+/// shape.
+#[derive(Clone)]
+pub enum ConfiguredMintAuthorizer {
+    Enabled(Arc<dyn MintAuthorizer>),
+    Disabled,
+}
+
+impl ConfiguredMintAuthorizer {
+    /// Delegates to the configured authorizer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MintAuthorizationError::NotConfigured`] when disabled, or
+    /// the authorizer's own failure.
+    pub async fn sign(
+        &self,
+        token: Address,
+        quantity: Float,
+        nonce: B256,
+    ) -> Result<SignedMintAuthorization, MintAuthorizationError> {
+        match self {
+            Self::Enabled(authorizer) => {
+                authorizer
+                    .sign_mint_authorization(token, quantity, nonce)
+                    .await
+            }
+            Self::Disabled => Err(MintAuthorizationError::NotConfigured),
+        }
+    }
 }
 
 /// Produces a [`SignedMintAuthorization`] for one orchestrator-mode mint.
@@ -82,6 +122,14 @@ pub enum MintAuthorizationError {
     QuantityScaling(#[from] QuantityScalingError),
     #[error(transparent)]
     Evm(#[from] EvmError),
+    /// An orchestrator-mode mint reached the signing step but the config
+    /// has no `[orchestrator]` section. Fails loudly instead of guessing an
+    /// address; the mint stays `MintAccepted` and resumes once configured.
+    #[error(
+        "orchestrator-mode mint requires an [orchestrator] config section; \
+         the mint authorizer is disabled"
+    )]
+    NotConfigured,
 }
 
 /// [`MintAuthorizer`] backed by the configured orchestrator contract and
@@ -274,6 +322,60 @@ impl VaultModeReader for IssuanceClient {
                 symbol: symbol.clone(),
             }),
         }
+    }
+}
+
+/// Test authorizer that echoes the caller's nonce with a fixed 65-byte
+/// signature, so aggregate tests can assert nonce ownership and event
+/// shapes without chain access.
+#[cfg(any(test, feature = "test-support"))]
+pub struct MockMintAuthorizer;
+
+#[cfg(any(test, feature = "test-support"))]
+#[async_trait]
+impl MintAuthorizer for MockMintAuthorizer {
+    async fn sign_mint_authorization(
+        &self,
+        _token: Address,
+        _quantity: Float,
+        nonce: B256,
+    ) -> Result<SignedMintAuthorization, MintAuthorizationError> {
+        Ok(SignedMintAuthorization {
+            nonce,
+            signature: Bytes::from(vec![0x42; 65]),
+        })
+    }
+}
+
+/// Test vault-mode reader with a fixed outcome, so saga tests can exercise
+/// both minting paths without a live issuance service.
+#[cfg(any(test, feature = "test-support"))]
+pub struct StubVaultModeReader(pub VaultModeTag);
+
+#[cfg(any(test, feature = "test-support"))]
+#[async_trait]
+impl VaultModeReader for StubVaultModeReader {
+    async fn vault_mode(&self, _symbol: &Symbol) -> Result<VaultModeTag, VaultModeCheckError> {
+        let Self(mode) = self;
+        Ok(*mode)
+    }
+}
+
+/// Test deliverer with a fixed scripted outcome, so job tests can exercise
+/// each delivery classification without a live issuance service.
+#[cfg(any(test, feature = "test-support"))]
+pub struct StubMintAuthorizationDeliverer(pub MintAuthorizationDelivery);
+
+#[cfg(any(test, feature = "test-support"))]
+#[async_trait]
+impl MintAuthorizationDeliverer for StubMintAuthorizationDeliverer {
+    async fn deliver(
+        &self,
+        _tokenization_request_id: &TokenizationRequestId,
+        _authorization: &SignedMintAuthorization,
+    ) -> MintAuthorizationDelivery {
+        let Self(outcome) = self;
+        outcome.clone()
     }
 }
 

--- a/src/performance/equity_timing/mint.rs
+++ b/src/performance/equity_timing/mint.rs
@@ -138,8 +138,14 @@ impl StoredOperation {
                 );
                 self.open_once(MintWrap, *received_at);
             }
-            // Pure markers within their already-open stage.
-            WrapSubmitted { .. } | VaultDepositSubmitted { .. } => {}
+            // Pure markers within their already-open stage. Authorization
+            // signing/delivery happen inside the open `MintReceipt` run (the
+            // wait between acceptance and tokens arriving) and are not
+            // tracked as their own timing stage.
+            WrapSubmitted { .. }
+            | VaultDepositSubmitted { .. }
+            | MintAuthorizationSigned { .. }
+            | MintAuthorizationDelivered { .. } => {}
             // Mid-stream-first case as above: no open `MintWrap` run when
             // `TokensReceived` was never seen.
             TokensWrapped { wrapped_at, .. } => {
@@ -259,6 +265,8 @@ pub(super) fn mint_observed_at(event: &TokenizedEquityMintEvent) -> DateTime<Utc
         | MintAccepted {
             accepted_at: at, ..
         }
+        | MintAuthorizationSigned { signed_at: at, .. }
+        | MintAuthorizationDelivered { delivered_at: at }
         | MintAcceptanceFailed { failed_at: at, .. }
         | TokensReceived {
             received_at: at, ..

--- a/src/performance/reliability.rs
+++ b/src/performance/reliability.rs
@@ -531,6 +531,8 @@ fn tokenized_equity_mint_failure(
         }
         TokenizedEquityMintEvent::MintRequested { .. }
         | TokenizedEquityMintEvent::MintAccepted { .. }
+        | TokenizedEquityMintEvent::MintAuthorizationSigned { .. }
+        | TokenizedEquityMintEvent::MintAuthorizationDelivered { .. }
         | TokenizedEquityMintEvent::TokensReceived { .. }
         | TokenizedEquityMintEvent::WrapSubmitted { .. }
         | TokenizedEquityMintEvent::TokensWrapped { .. }

--- a/src/performance/simulated_transfers.rs
+++ b/src/performance/simulated_transfers.rs
@@ -46,6 +46,7 @@ use st0x_wrapper::{
 
 use crate::bot_gas::BotGasReceiptCostEnqueuer;
 use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
+use crate::mint_authorization::ConfiguredMintAuthorizer;
 use crate::performance::equity_timing::EquityTimingProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
 use crate::rebalancing::equity::EquityTransferServices;
@@ -1050,6 +1051,7 @@ pub async fn seed_simulated_equity_redemption_history(
                 day,
             )),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let redemption = StoreBuilder::<EquityRedemption>::new(pool.clone())

--- a/src/rebalancing/equity/authorization_job.rs
+++ b/src/rebalancing/equity/authorization_job.rs
@@ -1,0 +1,731 @@
+//! Apalis job that delivers a signed MintAuthV1 recipient authorization to
+//! the issuance bot for an orchestrator-mode mint (RAI-1243).
+//!
+//! Enqueued (idempotently, keyed on the issuer request id) right after
+//! `MintAuthorizationSigned` persists. The payload carries only the
+//! aggregate identity: the tokenization request id and the signed
+//! `{nonce, signature}` are loaded from the aggregate at `perform` time, so
+//! every attempt redelivers the PERSISTED authorization byte-identically --
+//! issuance treats an identical redelivery as an idempotent `200`, and the
+//! nonce is the mint's on-chain idempotency key, so this job never signs.
+//!
+//! Outcome handling: `Recorded` dispatches
+//! `RecordMintAuthorizationDelivered`; the retryable classifications
+//! (issuance has no mint yet -- the initiation race -- or a transport
+//! failure) re-enqueue a delayed successor instead of consuming the
+//! three-attempt apalis retry budget -- a bounded fast cadence, then one
+//! operator alert and a slow cadence that keeps the chain alive until
+//! issuance accepts; the non-retryable rejections (`409`/`422`, unexpected
+//! `4xx`) park the mint with a single operator alert.
+//! Runs on a best-effort worker: a stuck authorization must never halt
+//! hedging or fill detection.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tracing::{error, info, warn};
+
+use st0x_event_sorcery::{SendError, Store};
+use st0x_tokenization::{IssuerRequestId, TokenizationRequestId};
+
+use crate::alerts::Notifier;
+use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
+use crate::mint_authorization::{
+    MintAuthorizationDeliverer, MintAuthorizationDelivery, SignedMintAuthorization,
+};
+use crate::tokenized_equity_mint::{
+    MintAuthorizationProgress, TokenizedEquityMint, TokenizedEquityMintCommand,
+};
+
+/// Apalis queue type for [`DeliverMintAuthorization`].
+pub(crate) type DeliverMintAuthorizationJobQueue = JobQueue<DeliverMintAuthorization>;
+
+/// Delay before re-enqueueing after a retryable delivery outcome. Long
+/// enough to ride out the Alpaca->issuance initiation race (the usual cause
+/// of `MintNotFoundYet`) and transient issuance unavailability.
+const DELIVERY_REDRIVE_DELAY: Duration = Duration::from_secs(30);
+
+/// Bounded fast-redrive budget (~10 minutes at the delay above). At the
+/// limit the job alerts once and degrades to
+/// [`DELIVERY_SLOW_REDRIVE_DELAY`]: an issuance service unreachable for
+/// that long needs a human anyway, but the chain must stay alive -- the
+/// initial enqueue's idempotency key survives in the finished row and
+/// blocks a replacement chain until cleanup prunes it, so dead-lettering
+/// here would strand the mint instead of letting it complete on its own
+/// once issuance recovers.
+const MAX_DELIVERY_REDRIVES: u32 = 20;
+
+/// Cadence past the fast budget: slow enough to be negligible load on a
+/// struggling issuance service, frequent enough that delivery completes
+/// within minutes of it recovering, with no restart required.
+const DELIVERY_SLOW_REDRIVE_DELAY: Duration = Duration::from_secs(600);
+
+/// Apalis job payload. Carries only the aggregate identity; the
+/// authorization itself is loaded from the aggregate at `perform` time.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct DeliverMintAuthorization {
+    pub(crate) issuer_request_id: IssuerRequestId,
+    /// Count of consecutive delayed redrives leading up to this attempt.
+    /// `#[serde(default)]` so a row enqueued under an older payload shape
+    /// still deserializes.
+    #[serde(default)]
+    pub(crate) redrive_attempts: u32,
+}
+
+/// Dependencies the job needs.
+pub(crate) struct DeliverMintAuthorizationCtx {
+    pub(crate) deliverer: Arc<dyn MintAuthorizationDeliverer>,
+    pub(crate) mint_store: Arc<Store<TokenizedEquityMint>>,
+    /// Operator alerting for the park outcomes (`NoopNotifier` when
+    /// `[alerts]` is unconfigured -- absence is explicit, never a skip).
+    pub(crate) notifier: Arc<dyn Notifier>,
+    /// For delayed self-redrives on retryable outcomes.
+    pub(crate) job_queue: DeliverMintAuthorizationJobQueue,
+}
+
+/// Errors emitted by [`DeliverMintAuthorization::perform`].
+#[derive(Debug, Error)]
+pub(crate) enum DeliverMintAuthorizationError {
+    #[error(transparent)]
+    Mint(#[from] Box<SendError<TokenizedEquityMint>>),
+    #[error(transparent)]
+    QueuePush(#[from] QueuePushError),
+    /// The delivery job fired for an aggregate that does not exist -- the
+    /// job is only ever enqueued after the aggregate persisted its signed
+    /// authorization, so this is a caller bug, not a race.
+    #[error("no mint aggregate found for {issuer_request_id}")]
+    MintNotFound { issuer_request_id: IssuerRequestId },
+}
+
+impl From<SendError<TokenizedEquityMint>> for DeliverMintAuthorizationError {
+    fn from(error: SendError<TokenizedEquityMint>) -> Self {
+        Self::Mint(Box::new(error))
+    }
+}
+
+impl Job<DeliverMintAuthorizationCtx> for DeliverMintAuthorization {
+    type Output = ();
+    type Error = DeliverMintAuthorizationError;
+
+    const WORKER_NAME: &'static str = "deliver-mint-authorization-worker";
+    const TERMINAL_FAILURE_MSG: &'static str = "Mint authorization delivery failed all retries; the orchestrator-mode \
+         mint cannot proceed until the authorization reaches issuance. \
+         Operator action required.";
+
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::DeliverMintAuthorization;
+
+    fn label(&self) -> Label {
+        Label::new(format!(
+            "DeliverMintAuthorization:{}",
+            self.issuer_request_id
+        ))
+    }
+
+    async fn perform(&self, ctx: &DeliverMintAuthorizationCtx) -> Result<(), Self::Error> {
+        let Some(mint) = ctx.mint_store.load(&self.issuer_request_id).await? else {
+            return Err(DeliverMintAuthorizationError::MintNotFound {
+                issuer_request_id: self.issuer_request_id.clone(),
+            });
+        };
+
+        let Some((tokenization_request_id, authorization)) = awaiting_delivery(&mint) else {
+            info!(
+                target: "tokenization",
+                issuer_request_id = %self.issuer_request_id,
+                "Mint no longer awaiting authorization delivery; nothing to do"
+            );
+            return Ok(());
+        };
+
+        match ctx
+            .deliverer
+            .deliver(&tokenization_request_id, &authorization)
+            .await
+        {
+            MintAuthorizationDelivery::Recorded => {
+                ctx.mint_store
+                    .send(
+                        &self.issuer_request_id,
+                        TokenizedEquityMintCommand::RecordMintAuthorizationDelivered,
+                    )
+                    .await
+                    .map_err(Box::new)?;
+                Ok(())
+            }
+            MintAuthorizationDelivery::MintNotFoundYet => {
+                self.redrive(ctx, "issuance has no mint for the tokenization request yet")
+                    .await
+            }
+            MintAuthorizationDelivery::RetryableFailure(failure) => {
+                self.redrive(ctx, &format!("issuance request failed: {failure}"))
+                    .await
+            }
+            MintAuthorizationDelivery::Conflict => {
+                self.park_with_alert(
+                    ctx,
+                    "issuance reports a conflicting authorization (409): either a \
+                     different authorization is already recorded for this mint, or \
+                     its transaction already binds a nonce",
+                )
+                .await
+            }
+            MintAuthorizationDelivery::Rejected => {
+                self.park_with_alert(
+                    ctx,
+                    "issuance rejected the authorization (422): vault-direct mint, \
+                     signer mismatch, or the nonce is already consumed on-chain",
+                )
+                .await
+            }
+            MintAuthorizationDelivery::PermanentFailure(status) => {
+                self.park_with_alert(
+                    ctx,
+                    &format!(
+                        "issuance returned a permanent client failure ({status}): \
+                         redelivering the identical request cannot succeed \
+                         (defective request or credentials)"
+                    ),
+                )
+                .await
+            }
+        }
+    }
+}
+
+impl DeliverMintAuthorization {
+    /// Re-enqueues a delayed successor: [`DELIVERY_REDRIVE_DELAY`] within
+    /// the fast budget, then one operator alert and
+    /// [`DELIVERY_SLOW_REDRIVE_DELAY`] from there on. The chain never
+    /// dead-letters: its live row is what the one-live-chain guard keys on,
+    /// and the initial enqueue's idempotency key blocks a replacement
+    /// chain, so killing the chain would strand the mint until manual
+    /// action. Uses delayed redrives rather than `Err` so a slow issuance
+    /// start-up cannot burn the three-attempt apalis budget in seconds (or
+    /// repeat the boundary alert on every apalis retry).
+    async fn redrive(
+        &self,
+        ctx: &DeliverMintAuthorizationCtx,
+        reason: &str,
+    ) -> Result<(), DeliverMintAuthorizationError> {
+        let attempts = self.redrive_attempts + 1;
+
+        if attempts == MAX_DELIVERY_REDRIVES + 1 {
+            error!(
+                target: "tokenization",
+                issuer_request_id = %self.issuer_request_id,
+                attempts,
+                reason,
+                "Mint authorization delivery exhausted its fast-redrive \
+                 budget; degrading to slow redrives"
+            );
+            notify_swallowing_failure(
+                ctx,
+                &format!(
+                    "Mint authorization delivery for {} failed {} consecutive \
+                     retries ({reason}). It keeps redelivering every {} minutes \
+                     and completes automatically once issuance accepts; \
+                     operator attention needed if this persists.",
+                    self.issuer_request_id,
+                    MAX_DELIVERY_REDRIVES,
+                    DELIVERY_SLOW_REDRIVE_DELAY.as_secs() / 60
+                ),
+            )
+            .await;
+        }
+
+        let delay = if attempts > MAX_DELIVERY_REDRIVES {
+            DELIVERY_SLOW_REDRIVE_DELAY
+        } else {
+            DELIVERY_REDRIVE_DELAY
+        };
+
+        warn!(
+            target: "tokenization",
+            issuer_request_id = %self.issuer_request_id,
+            attempt = attempts,
+            reason,
+            "Re-enqueueing mint authorization delivery"
+        );
+
+        let mut queue = ctx.job_queue.clone();
+        queue
+            .push_with_delay(
+                Self {
+                    issuer_request_id: self.issuer_request_id.clone(),
+                    redrive_attempts: attempts,
+                },
+                delay,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    /// Parks a non-retryable rejection: one loud error, one operator alert,
+    /// then `Ok` so the best-effort worker keeps running. The mint stays in
+    /// `MintAccepted` with its authorization `Signed`; resolution is manual
+    /// (issuance's admin surface owns the conflicting state).
+    async fn park_with_alert(
+        &self,
+        ctx: &DeliverMintAuthorizationCtx,
+        outcome: &str,
+    ) -> Result<(), DeliverMintAuthorizationError> {
+        error!(
+            target: "tokenization",
+            issuer_request_id = %self.issuer_request_id,
+            outcome,
+            "Mint authorization delivery parked; operator action required"
+        );
+        notify_swallowing_failure(
+            ctx,
+            &format!(
+                "Mint authorization delivery for {} parked: {outcome}. The mint \
+                 stays in MintAccepted until resolved on the issuance side.",
+                self.issuer_request_id
+            ),
+        )
+        .await;
+
+        Ok(())
+    }
+}
+
+/// Whether a live delivery row already exists for `issuer_request_id`. The
+/// saga consults this before enqueueing: redrive successors are pushed via
+/// `push_with_delay` and carry no idempotency key, so `push_idempotent`
+/// alone cannot see them -- without this bound, a restart during a
+/// delayed-redrive window would start a second delivery chain. Chains
+/// deliver byte-identically (issuance-idempotent), so a duplicate is
+/// benign rather than dangerous; this mirrors the one-poll-job-per-order
+/// bound on `PollOrderStatus`. "Live" matches `requeue_orphaned`'s
+/// in-flight definition: `Pending`, `Queued` (claimed, not yet running),
+/// or `Running`.
+pub(crate) async fn has_live_delivery_job(
+    queue: &DeliverMintAuthorizationJobQueue,
+    issuer_request_id: &IssuerRequestId,
+) -> Result<bool, sqlx_apalis::Error> {
+    let live_rows: i64 = sqlx_apalis::query_scalar(
+        "SELECT COUNT(*) FROM Jobs \
+         WHERE job_type = ? \
+           AND json_valid(CAST(job AS TEXT)) \
+           AND json_extract(CAST(job AS TEXT), '$.issuer_request_id') = ? \
+           AND status IN ('Pending', 'Queued', 'Running')",
+    )
+    .bind(std::any::type_name::<DeliverMintAuthorization>())
+    .bind(issuer_request_id.to_string())
+    .fetch_one(queue.pool())
+    .await?;
+
+    Ok(live_rows > 0)
+}
+
+/// The delivery-relevant projection of the aggregate: `Some` only when a
+/// signed authorization is waiting for issuance's acknowledgement.
+fn awaiting_delivery(
+    mint: &TokenizedEquityMint,
+) -> Option<(TokenizationRequestId, SignedMintAuthorization)> {
+    match mint {
+        TokenizedEquityMint::MintAccepted {
+            authorization: MintAuthorizationProgress::Signed(signed),
+            tokenization_request_id,
+            ..
+        } => Some((tokenization_request_id.clone(), signed.clone())),
+        // Delivered/NotSigned, and every state past or outside acceptance:
+        // nothing awaits delivery. Terminal races (mint advanced or failed
+        // while this job was queued) land here and no-op.
+        TokenizedEquityMint::MintAccepted { .. }
+        | TokenizedEquityMint::MintRequested { .. }
+        | TokenizedEquityMint::TokensReceived { .. }
+        | TokenizedEquityMint::WrapSubmitted { .. }
+        | TokenizedEquityMint::TokensWrapped { .. }
+        | TokenizedEquityMint::VaultDepositSubmitted { .. }
+        | TokenizedEquityMint::DepositedIntoRaindex { .. }
+        | TokenizedEquityMint::Failed { .. }
+        | TokenizedEquityMint::Reconciled { .. } => None,
+    }
+}
+
+/// Alert delivery failures are logged, never allowed to mask the job
+/// outcome (mirrors the USDC transfer jobs' alert handling).
+async fn notify_swallowing_failure(ctx: &DeliverMintAuthorizationCtx, message: &str) {
+    if let Err(alert_error) = ctx.notifier.notify(message).await {
+        warn!(
+            target: "tokenization",
+            ?alert_error,
+            "Failed to deliver mint-authorization operator alert"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::Address;
+    use httpmock::MockServer;
+    use st0x_event_sorcery::test_store;
+    use st0x_execution::Symbol;
+    use st0x_float_macro::float;
+    use st0x_raindex::Raindex;
+    use st0x_tokenization::issuer_request_id;
+    use st0x_tokenization::mock::MockTokenizer;
+    use st0x_wrapper::{MockWrapper, Wrapper};
+
+    use super::*;
+    use crate::alerts::CapturingNotifier;
+    use crate::bot_gas::BotGasReceiptCostEnqueuer;
+    use crate::conductor::job::Job;
+    use crate::mint_authorization::{
+        ConfiguredMintAuthorizer, MockMintAuthorizer, StubMintAuthorizationDeliverer,
+    };
+    use crate::onchain::mock::MockRaindex;
+    use crate::rebalancing::equity::EquityTransferServices;
+    use crate::vault_lookup::MockVaultLookup;
+
+    async fn build_ctx_with_deliverer(
+        deliverer: Arc<dyn MintAuthorizationDeliverer>,
+    ) -> (
+        DeliverMintAuthorizationCtx,
+        Arc<Store<TokenizedEquityMint>>,
+        Arc<CapturingNotifier>,
+    ) {
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
+        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+        let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
+
+        let services = EquityTransferServices {
+            raindex,
+            vault_lookup: Arc::new(MockVaultLookup::new()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper,
+            bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Enabled(Arc::new(MockMintAuthorizer)),
+        };
+        let mint_store = Arc::new(test_store(pool, services));
+        let notifier = Arc::new(CapturingNotifier::default());
+
+        let ctx = DeliverMintAuthorizationCtx {
+            deliverer,
+            mint_store: mint_store.clone(),
+            notifier: notifier.clone(),
+            job_queue: DeliverMintAuthorizationJobQueue::new(&apalis_pool),
+        };
+        (ctx, mint_store, notifier)
+    }
+
+    async fn build_ctx(
+        outcome: MintAuthorizationDelivery,
+    ) -> (
+        DeliverMintAuthorizationCtx,
+        Arc<Store<TokenizedEquityMint>>,
+        Arc<CapturingNotifier>,
+    ) {
+        build_ctx_with_deliverer(Arc::new(StubMintAuthorizationDeliverer(outcome))).await
+    }
+
+    /// Drives a mint to `MintAccepted` with a `Signed` authorization -- the
+    /// state the delivery job is enqueued from.
+    async fn seed_signed_mint(store: &Store<TokenizedEquityMint>) -> IssuerRequestId {
+        let id = issuer_request_id("ISS-DELIVERY");
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("RKLB").unwrap(),
+                    quantity: float!(10),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::SignMintAuthorization {
+                    token: Address::repeat_byte(0x11),
+                },
+            )
+            .await
+            .unwrap();
+        id
+    }
+
+    fn delivery_job(id: &IssuerRequestId) -> DeliverMintAuthorization {
+        DeliverMintAuthorization {
+            issuer_request_id: id.clone(),
+            redrive_attempts: 0,
+        }
+    }
+
+    async fn pending_delivery_rows(ctx: &DeliverMintAuthorizationCtx) -> i64 {
+        sqlx_apalis::query_scalar::<_, i64>("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<DeliverMintAuthorization>())
+            .fetch_one(ctx.job_queue.pool())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn recorded_outcome_marks_the_aggregate_delivered() {
+        let (ctx, mint_store, notifier) = build_ctx(MintAuthorizationDelivery::Recorded).await;
+        let id = seed_signed_mint(&mint_store).await;
+
+        delivery_job(&id).perform(&ctx).await.unwrap();
+
+        let entity = mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                entity,
+                TokenizedEquityMint::MintAccepted {
+                    authorization: MintAuthorizationProgress::Delivered(_),
+                    ..
+                }
+            ),
+            "expected Delivered after a 200, got: {entity:?}"
+        );
+        assert_eq!(notifier.messages().len(), 0);
+    }
+
+    /// 409/422 park the mint: one operator alert, `Ok` so the best-effort
+    /// worker keeps running, aggregate untouched (still `Signed`).
+    #[tokio::test]
+    async fn rejected_outcome_parks_with_a_single_operator_alert() {
+        let (ctx, mint_store, notifier) = build_ctx(MintAuthorizationDelivery::Rejected).await;
+        let id = seed_signed_mint(&mint_store).await;
+
+        delivery_job(&id).perform(&ctx).await.unwrap();
+
+        let messages = notifier.messages();
+        assert_eq!(messages.len(), 1, "exactly one alert: {messages:?}");
+        assert!(
+            messages[0].contains("parked"),
+            "alert must say the delivery parked: {}",
+            messages[0]
+        );
+        let entity = mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                entity,
+                TokenizedEquityMint::MintAccepted {
+                    authorization: MintAuthorizationProgress::Signed(_),
+                    ..
+                }
+            ),
+            "a parked delivery must leave the authorization Signed, got: {entity:?}"
+        );
+    }
+
+    /// An out-of-contract 4xx (defective request or credentials) parks
+    /// like 409/422: redelivering identical bytes cannot succeed.
+    #[tokio::test]
+    async fn permanent_client_failure_parks_with_alert() {
+        let (ctx, mint_store, notifier) =
+            build_ctx(MintAuthorizationDelivery::PermanentFailure(401)).await;
+        let id = seed_signed_mint(&mint_store).await;
+
+        delivery_job(&id).perform(&ctx).await.unwrap();
+
+        let messages = notifier.messages();
+        assert_eq!(messages.len(), 1, "exactly one alert: {messages:?}");
+        assert!(
+            messages[0].contains("401"),
+            "the alert must carry the offending status: {}",
+            messages[0]
+        );
+        assert_eq!(
+            pending_delivery_rows(&ctx).await,
+            0,
+            "no successor may follow a permanent failure"
+        );
+    }
+
+    /// The initiation race (404) re-enqueues a delayed successor rather
+    /// than erroring into the 3-attempt apalis budget.
+    #[tokio::test]
+    async fn mint_not_found_yet_schedules_a_delayed_redrive() {
+        let (ctx, mint_store, notifier) =
+            build_ctx(MintAuthorizationDelivery::MintNotFoundYet).await;
+        let id = seed_signed_mint(&mint_store).await;
+
+        delivery_job(&id).perform(&ctx).await.unwrap();
+
+        assert_eq!(
+            pending_delivery_rows(&ctx).await,
+            1,
+            "a delayed successor must be enqueued"
+        );
+        assert_eq!(notifier.messages().len(), 0);
+    }
+
+    /// Past the fast budget the chain alerts once and degrades to the slow
+    /// cadence instead of dead-lettering: the initial enqueue's idempotency
+    /// key survives in the finished row and blocks a replacement chain, so
+    /// a dead chain would strand the mint. The slow successor keeps the
+    /// chain alive to complete once issuance recovers, and later slow
+    /// redrives must not repeat the alert.
+    #[tokio::test]
+    async fn exhausted_fast_budget_alerts_once_and_degrades_to_slow_redrives() {
+        let (ctx, mint_store, notifier) =
+            build_ctx(MintAuthorizationDelivery::MintNotFoundYet).await;
+        let id = seed_signed_mint(&mint_store).await;
+
+        DeliverMintAuthorization {
+            issuer_request_id: id.clone(),
+            redrive_attempts: MAX_DELIVERY_REDRIVES,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let messages = notifier.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "exactly one boundary alert: {messages:?}"
+        );
+        assert!(
+            messages[0].contains("keeps redelivering"),
+            "the alert must say the chain stays alive: {}",
+            messages[0]
+        );
+        let slow_successor_run_at: i64 = sqlx_apalis::query_scalar(
+            "SELECT run_at - strftime('%s', 'now') FROM Jobs WHERE job_type = ?",
+        )
+        .bind(std::any::type_name::<DeliverMintAuthorization>())
+        .fetch_one(ctx.job_queue.pool())
+        .await
+        .unwrap();
+        let slow_delay_seconds: i64 = DELIVERY_SLOW_REDRIVE_DELAY.as_secs().try_into().unwrap();
+        assert!(
+            slow_successor_run_at > slow_delay_seconds - 60,
+            "the successor must be scheduled at the slow cadence, \
+             got {slow_successor_run_at}s out"
+        );
+
+        DeliverMintAuthorization {
+            issuer_request_id: id,
+            redrive_attempts: MAX_DELIVERY_REDRIVES + 5,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            notifier.messages().len(),
+            1,
+            "slow redrives past the boundary must not re-alert"
+        );
+        assert_eq!(
+            pending_delivery_rows(&ctx).await,
+            2,
+            "every slow redrive must keep the chain alive"
+        );
+    }
+
+    /// The wire-level half of nonce fixity, over the real HTTP client: the
+    /// initiation race (404, issuance has no mint yet) followed by a retry
+    /// must put the SAME persisted nonce and signature on the wire, byte
+    /// for byte -- issuance treats an identical redelivery as an idempotent
+    /// `200`, while a differing one is a `409` conflict. Exact-JSON-body
+    /// matchers on both mocks prove each attempt carried exactly the
+    /// persisted authorization.
+    #[tokio::test]
+    async fn redelivery_after_initiation_race_is_byte_identical_on_the_wire() {
+        use httpmock::Method::POST;
+
+        let server = MockServer::start_async().await;
+        let client = st0x_issuance_client::IssuanceClient::new(
+            url::Url::parse(&server.base_url()).expect("valid mock URL"),
+            "test-key",
+        )
+        .expect("client builds");
+        let (ctx, mint_store, notifier) = build_ctx_with_deliverer(Arc::new(client)).await;
+        let id = seed_signed_mint(&mint_store).await;
+
+        let TokenizedEquityMint::MintAccepted {
+            authorization: MintAuthorizationProgress::Signed(signed),
+            tokenization_request_id,
+            ..
+        } = mint_store.load(&id).await.unwrap().unwrap()
+        else {
+            panic!("expected a Signed MintAccepted mint after seeding");
+        };
+        let path = format!(
+            "/internal/mints/{}/authorization",
+            tokenization_request_id.as_ref()
+        );
+        let expected_body = serde_json::json!({
+            "nonce": signed.nonce.to_string(),
+            "signature": signed.signature.to_string(),
+        });
+
+        let not_found_yet = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(&path)
+                    .json_body(expected_body.clone());
+                then.status(404);
+            })
+            .await;
+        delivery_job(&id).perform(&ctx).await.unwrap();
+        not_found_yet.assert_async().await;
+        not_found_yet.delete_async().await;
+
+        let recorded = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(&path)
+                    .json_body(expected_body.clone());
+                then.status(200).json_body(serde_json::json!({
+                    "issuer_request_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "status": "authorized",
+                }));
+            })
+            .await;
+        DeliverMintAuthorization {
+            issuer_request_id: id.clone(),
+            redrive_attempts: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+        recorded.assert_async().await;
+
+        let entity = mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                entity,
+                TokenizedEquityMint::MintAccepted {
+                    authorization: MintAuthorizationProgress::Delivered(_),
+                    ..
+                }
+            ),
+            "the 200 retry must record the delivery, got: {entity:?}"
+        );
+        assert_eq!(notifier.messages().len(), 0);
+    }
+
+    /// A mint that already recorded its delivery (or advanced past
+    /// acceptance) makes the job a no-op -- no delivery attempt, no alert.
+    #[tokio::test]
+    async fn already_delivered_mint_is_a_noop() {
+        // A Conflict outcome would park+alert IF the deliverer were called;
+        // an empty notifier therefore proves the early return.
+        let (ctx, mint_store, notifier) = build_ctx(MintAuthorizationDelivery::Conflict).await;
+        let id = seed_signed_mint(&mint_store).await;
+        mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordMintAuthorizationDelivered,
+            )
+            .await
+            .unwrap();
+
+        delivery_job(&id).perform(&ctx).await.unwrap();
+
+        assert_eq!(notifier.messages().len(), 0);
+    }
+}

--- a/src/rebalancing/equity/job.rs
+++ b/src/rebalancing/equity/job.rs
@@ -561,6 +561,7 @@ mod tests {
 
     use super::*;
     use crate::equity_redemption::{EquityRedemptionError, redemption_aggregate_id};
+    use crate::mint_authorization::ConfiguredMintAuthorizer;
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::{EquityTransferServices, MintError};
     use crate::tokenized_equity_mint::TokenizedEquityMintCommand;
@@ -587,6 +588,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let mint_store = Arc::new(test_store(pool, transfer_services));
 

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -9,9 +9,13 @@
 //! - **Market-Making -> Hedging** (redemption): withdraws tokenized equity
 //!   from a Raindex vault and sends it to Alpaca for redemption.
 
+mod authorization_job;
 mod job;
 mod resume_job;
 
+pub(crate) use authorization_job::{
+    DeliverMintAuthorization, DeliverMintAuthorizationCtx, DeliverMintAuthorizationJobQueue,
+};
 #[cfg(test)]
 pub(crate) use job::{
     ResumeEquityToHedging, ResumeEquityToMarketMaking, TransferEquityToMarketMakingJobError,
@@ -31,6 +35,7 @@ use alloy::primitives::{Address, TxHash, U256};
 use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;
 use sqlx::SqlitePool;
+use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::{debug, error, info, instrument, warn};
@@ -38,6 +43,7 @@ use tracing::{debug, error, info, instrument, warn};
 use st0x_event_sorcery::{AggregateError, LifecycleError, SendError, Store};
 use st0x_evm::EvmError;
 use st0x_execution::{FractionalShares, SharesConversionError, Symbol};
+use st0x_issuance_dto::VaultModeTag;
 use st0x_raindex::{Raindex, RaindexError, RaindexVaultId};
 use st0x_tokenization::{
     AlpacaTokenizationError, IssuerRequestId, MintVerificationError, TokenizationRequest,
@@ -55,10 +61,12 @@ use crate::bot_gas::{
     BotGasEnqueueFailure, BotGasOperationCategory, BotGasReceiptCostEnqueuer,
     RecordBotGasReceiptCost,
 };
+use crate::conductor::job::QueuePushError;
 use crate::equity_redemption::{
     DetectionFailure, EquityRedemption, EquityRedemptionCommand, EquityRedemptionError,
     RedemptionAggregateId,
 };
+use crate::mint_authorization::{ConfiguredMintAuthorizer, VaultModeCheckError, VaultModeReader};
 use crate::tokenized_equity_mint::{
     TOKENIZED_EQUITY_DECIMALS, TokenizedEquityMint, TokenizedEquityMintCommand,
 };
@@ -207,6 +215,11 @@ pub(crate) struct EquityTransferServices {
     /// `TokenizedEquityMint`'s confirmations go through
     /// `CrossVenueEquityTransfer`'s own field instead (see that struct).
     pub(crate) bot_gas_enqueuer: BotGasReceiptCostEnqueuer,
+    /// Signs MintAuthV1 recipient authorizations for orchestrator-mode
+    /// mints (RAI-1243). `Disabled` while the config has no
+    /// `[orchestrator]` section; `SignMintAuthorization` then fails
+    /// loudly instead of guessing an orchestrator address.
+    pub(crate) mint_authorizer: ConfiguredMintAuthorizer,
 }
 
 impl EquityTransferServices {
@@ -224,6 +237,7 @@ impl EquityTransferServices {
             tokenizer: Arc::new(PanickingTokenizer),
             wrapper: Arc::new(PanickingWrapper),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         }
     }
 }
@@ -469,6 +483,22 @@ pub(crate) enum MintError {
     /// needs to re-surface it -- see [`crate::bot_gas::redrive`].
     #[error("Failed to enqueue bot-gas receipt cost recording: {0}")]
     BotGasEnqueue(BotGasEnqueueFailure),
+    /// The asset's `vault_mode` could not be determined from issuance. The
+    /// saga must not guess: assuming vault-direct would skip a required
+    /// authorization and stall the mint at issuance's on-chain step. The
+    /// mint stays `MintAccepted`; the resume path retries the check.
+    #[error("Vault-mode check failed: {0}")]
+    VaultModeCheck(#[from] VaultModeCheckError),
+    /// `vault_mode` reads orchestrator but the symbol has no
+    /// `[assets.equities.<symbol>] tokenized_equity` config entry to bind
+    /// the authorization to.
+    #[error("No tokenized-equity address configured for {symbol}")]
+    UnknownTokenizedEquity { symbol: Symbol },
+    /// Enqueueing the authorization delivery job failed -- a local SQLite
+    /// write. The signed authorization is already persisted on the
+    /// aggregate, so the resume path re-enqueues without re-signing.
+    #[error("Failed to enqueue mint-authorization delivery: {0}")]
+    AuthorizationEnqueue(#[from] QueuePushError),
 }
 
 /// Selector for `ERC20InsufficientBalance(address,uint256,uint256)`.
@@ -517,7 +547,10 @@ impl BotGasFailureClassifier for MintError {
             | Self::VaultLookup(_)
             | Self::Verification(_)
             | Self::EntityNotFound { .. }
-            | Self::UnexpectedState { .. } => false,
+            | Self::UnexpectedState { .. }
+            | Self::VaultModeCheck(_)
+            | Self::UnknownTokenizedEquity { .. }
+            | Self::AuthorizationEnqueue(_) => false,
         }
     }
 }
@@ -649,6 +682,44 @@ pub(crate) struct CrossVenueEquityTransfer {
     /// confirmations succeed (ADR 0017). Defaults to `Disabled`;
     /// production wiring opts in via [`Self::with_bot_gas_enqueuer`].
     bot_gas_enqueuer: BotGasReceiptCostEnqueuer,
+    /// Mint-authorization capability for orchestrator-mode assets
+    /// (RAI-1243). Defaults to [`ConfiguredMintAuthorization::VaultDirectOnly`]
+    /// (an explicit assertion, mirroring `BotGasReceiptCostEnqueuer`'s
+    /// explicit-absence shape); production opts into
+    /// [`ConfiguredMintAuthorization::Wired`] via
+    /// [`Self::with_mint_authorization`].
+    mint_authorization: ConfiguredMintAuthorization,
+}
+
+/// Whether this transfer can produce and deliver MintAuthV1 recipient
+/// authorizations. Absence is a stated capability, not an inferred one: a
+/// construction site choosing `VaultDirectOnly` asserts that every asset it
+/// mints is vault-direct, rather than silently defaulting there.
+pub(crate) enum ConfiguredMintAuthorization {
+    /// Full orchestrator-mode wiring -- the server path, which always has
+    /// the issuance client and job queue to build it.
+    Wired(Box<MintAuthorizationWiring>),
+    /// No wiring: the caller (CLI transfer subcommands, recovery jobs,
+    /// tests) asserts the assets it mints are vault-direct. Without the
+    /// wiring `vault_mode` cannot be read at all, so an orchestrator-mode
+    /// mint through such a path proceeds unauthorized and stalls at
+    /// polling -- surfaced by a warning per mint.
+    VaultDirectOnly,
+}
+
+/// Everything the mint saga needs to produce and deliver a MintAuthV1
+/// recipient authorization for orchestrator-mode assets (RAI-1243).
+pub(crate) struct MintAuthorizationWiring {
+    /// Reads each asset's `vault_mode` from issuance -- the single source
+    /// of truth for which assets need an authorization; the bot keeps no
+    /// asset-mode list of its own.
+    pub(crate) vault_mode_reader: Arc<dyn VaultModeReader>,
+    /// Tokenized-equity ERC-20 per symbol, from
+    /// `[assets.equities.<SYM>] tokenized_equity` config -- the `token`
+    /// the EIP-712 MintAuth binds.
+    pub(crate) token_addresses: HashMap<Symbol, Address>,
+    /// Delivery job queue; enqueued idempotently per issuer request id.
+    pub(crate) delivery_queue: DeliverMintAuthorizationJobQueue,
 }
 
 impl CrossVenueEquityTransfer {
@@ -670,6 +741,7 @@ impl CrossVenueEquityTransfer {
             mint_store,
             redemption_store,
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorization: ConfiguredMintAuthorization::VaultDirectOnly,
         }
     }
 
@@ -679,6 +751,117 @@ impl CrossVenueEquityTransfer {
     pub(crate) fn with_bot_gas_enqueuer(mut self, enqueuer: BotGasReceiptCostEnqueuer) -> Self {
         self.bot_gas_enqueuer = enqueuer;
         self
+    }
+
+    /// Opts this transfer into orchestrator-mode mint authorization.
+    /// Called at the production wiring site only.
+    pub(crate) fn with_mint_authorization(mut self, wiring: MintAuthorizationWiring) -> Self {
+        self.mint_authorization = ConfiguredMintAuthorization::Wired(Box::new(wiring));
+        self
+    }
+
+    /// Ensures an orchestrator-mode mint has its recipient authorization
+    /// signed and its delivery enqueued before polling begins; a no-op for
+    /// vault-direct assets. Idempotent end to end: signing no-ops once an
+    /// authorization exists (the nonce is the mint's on-chain idempotency
+    /// key and must never be re-minted), and the delivery enqueue is keyed
+    /// on the issuer request id.
+    async fn ensure_mint_authorization(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+        symbol: &Symbol,
+    ) -> Result<(), MintError> {
+        let wiring = match &self.mint_authorization {
+            ConfiguredMintAuthorization::Wired(wiring) => wiring,
+            // The construction site asserted vault-direct-only; without the
+            // wiring `vault_mode` cannot be read, so the assertion cannot
+            // be verified -- surface it per mint.
+            ConfiguredMintAuthorization::VaultDirectOnly => {
+                warn!(
+                    target: "rebalance",
+                    %issuer_request_id,
+                    %symbol,
+                    "Transfer constructed VaultDirectOnly; minting without a \
+                     vault-mode check (an orchestrator-mode asset would \
+                     stall at polling -- such mints must run through the \
+                     server, which always wires authorization)"
+                );
+                return Ok(());
+            }
+        };
+
+        // Fails closed: an indeterminate mode must not be guessed as
+        // vault-direct, or a required authorization would be skipped and
+        // the mint would stall at issuance's on-chain step.
+        match wiring.vault_mode_reader.vault_mode(symbol).await? {
+            VaultModeTag::VaultDirect => Ok(()),
+            VaultModeTag::Orchestrator => {
+                let token = wiring.token_addresses.get(symbol).copied().ok_or_else(|| {
+                    MintError::UnknownTokenizedEquity {
+                        symbol: symbol.clone(),
+                    }
+                })?;
+
+                self.mint_store
+                    .send(
+                        issuer_request_id,
+                        TokenizedEquityMintCommand::SignMintAuthorization { token },
+                    )
+                    .await?;
+
+                // Bounds delivery to ONE live chain per mint: redrive
+                // successors carry no idempotency key, so without this
+                // check a resume during a delayed-redrive window would
+                // start a second chain. Fails open on a guard read error
+                // (warn + push): a duplicate chain delivers byte-identical
+                // payloads and is benign, while a skipped push would stall
+                // the delivery.
+                let delivery_live = authorization_job::has_live_delivery_job(
+                    &wiring.delivery_queue,
+                    issuer_request_id,
+                )
+                .await
+                .unwrap_or_else(|error| {
+                    warn!(
+                        target: "rebalance",
+                        %issuer_request_id,
+                        ?error,
+                        "Live-delivery guard read failed; enqueueing anyway \
+                         (duplicate chains are benign)"
+                    );
+                    false
+                });
+                if delivery_live {
+                    info!(
+                        target: "rebalance",
+                        %issuer_request_id,
+                        %symbol,
+                        "Mint authorization delivery already live; not \
+                         enqueueing another"
+                    );
+                    return Ok(());
+                }
+
+                let mut delivery_queue = wiring.delivery_queue.clone();
+                delivery_queue
+                    .push_idempotent(
+                        &issuer_request_id.to_string(),
+                        DeliverMintAuthorization {
+                            issuer_request_id: issuer_request_id.clone(),
+                            redrive_attempts: 0,
+                        },
+                    )
+                    .await?;
+
+                info!(
+                    target: "rebalance",
+                    %issuer_request_id,
+                    %symbol,
+                    "Mint authorization signed and delivery enqueued"
+                );
+                Ok(())
+            }
+        }
     }
 
     /// Enqueues bot-gas cost recording for a confirmed mint-side tx (vault
@@ -985,8 +1168,15 @@ impl CrossVenueEquityTransfer {
     ) -> Result<(), MintError> {
         loop {
             match self.load_mint_entity(issuer_request_id).await? {
-                TokenizedEquityMint::MintAccepted { .. } => {
+                TokenizedEquityMint::MintAccepted { symbol, .. } => {
                     info!(%issuer_request_id, "Resuming accepted mint");
+                    // Idempotent: signing no-ops once an authorization
+                    // exists and the delivery enqueue is keyed on the
+                    // issuer request id, so a resumed orchestrator-mode
+                    // mint re-delivers its PERSISTED authorization rather
+                    // than minting a fresh nonce.
+                    self.ensure_mint_authorization(issuer_request_id, &symbol)
+                        .await?;
                     self.mint_store
                         .send(issuer_request_id, TokenizedEquityMintCommand::Poll)
                         .await?;
@@ -1762,6 +1952,14 @@ impl CrossVenueEquityTransfer {
             .await
             .map_err(|error| MintTransferError::PreReceipt(error.into()))?;
 
+        // Orchestrator-mode assets need the recipient authorization signed
+        // and on its way to issuance BEFORE polling: issuance will not mint
+        // (and the poll cannot complete) until the authorization arrives.
+        // Still pre-receipt -- a failure here leaves the mint resumable.
+        self.ensure_mint_authorization(issuer_request_id, symbol)
+            .await
+            .map_err(MintTransferError::PreReceipt)?;
+
         info!(target: "rebalance", "Mint request accepted, polling for completion");
 
         self.mint_store
@@ -1863,6 +2061,7 @@ mod tests {
     use crate::inventory::{
         BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, Venue,
     };
+    use crate::mint_authorization::{MockMintAuthorizer, StubVaultModeReader};
     use crate::onchain::mock::{DepositBehavior, MockRaindex};
     use crate::rebalancing::{RebalancingSchedulers, RebalancingServiceConfig};
     use crate::tokenized_equity_mint::TokenizedEquityMintEvent;
@@ -1884,6 +2083,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         }
     }
 
@@ -2831,6 +3031,297 @@ mod tests {
         );
     }
 
+    /// Builds a transfer with full mint-authorization wiring: a stubbed
+    /// vault-mode reader, a token map for AAPL, an Enabled mock authorizer
+    /// in the aggregate services, and a real (in-memory) delivery queue.
+    /// Returns the event pool and the apalis pool for assertions.
+    async fn create_authorization_wired_transfer(
+        mode: VaultModeTag,
+    ) -> (
+        CrossVenueEquityTransfer,
+        SqlitePool,
+        apalis_sqlite::SqlitePool,
+    ) {
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
+        let services = EquityTransferServices {
+            mint_authorizer: ConfiguredMintAuthorizer::Enabled(Arc::new(MockMintAuthorizer)),
+            ..mock_services()
+        };
+
+        let mint_store = Arc::new(test_store(pool.clone(), services.clone()));
+        let redemption_store = Arc::new(test_store(pool.clone(), services));
+
+        let mut token_addresses = HashMap::new();
+        token_addresses.insert(Symbol::new("AAPL").unwrap(), Address::repeat_byte(0x11));
+
+        let transfer = CrossVenueEquityTransfer::new(
+            Arc::new(MockRaindex::new()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockWrapper::new()),
+            Address::random(),
+            mint_store,
+            redemption_store,
+        )
+        .with_mint_authorization(MintAuthorizationWiring {
+            vault_mode_reader: Arc::new(StubVaultModeReader(mode)),
+            token_addresses,
+            delivery_queue: DeliverMintAuthorizationJobQueue::new(&apalis_pool),
+        });
+
+        (transfer, pool, apalis_pool)
+    }
+
+    async fn count_events(pool: &SqlitePool, event_type: &str) -> i64 {
+        sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE event_type = ?")
+            .bind(event_type)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    async fn count_delivery_jobs(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {
+        sqlx_apalis::query_scalar::<_, i64>("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<DeliverMintAuthorization>())
+            .fetch_one(apalis_pool)
+            .await
+            .unwrap()
+    }
+
+    /// An orchestrator-mode mint resumed from `MintAccepted` signs its
+    /// authorization, enqueues exactly one delivery, and still completes
+    /// the workflow -- and a SECOND resume never signs a fresh nonce or
+    /// duplicates the delivery job (the resume idempotency invariant).
+    #[tokio::test]
+    async fn resume_of_orchestrator_mint_signs_once_and_enqueues_delivery() {
+        let (transfer, pool, apalis_pool) =
+            create_authorization_wired_transfer(VaultModeTag::Orchestrator).await;
+
+        let id = issuer_request_id("ISS-ORCH-RESUME");
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+
+        transfer.resume_mint(&id).await.unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::DepositedIntoRaindex { .. }),
+            "Expected deposited mint after resume, got: {entity:?}"
+        );
+        assert_eq!(
+            count_events(&pool, "TokenizedEquityMintEvent::MintAuthorizationSigned").await,
+            1
+        );
+        assert_eq!(count_delivery_jobs(&apalis_pool).await, 1);
+
+        // Second resume: the mint is DepositedIntoRaindex, so resume_mint
+        // short-circuits on the terminal state before ever reaching
+        // authorization -- the unchanged counts pin that short-circuit.
+        // (Signing idempotency itself is pinned by
+        // `re_signing_keeps_the_original_nonce` in tokenized_equity_mint.)
+        transfer.resume_mint(&id).await.unwrap();
+        assert_eq!(
+            count_events(&pool, "TokenizedEquityMintEvent::MintAuthorizationSigned").await,
+            1
+        );
+        assert_eq!(count_delivery_jobs(&apalis_pool).await, 1);
+    }
+
+    /// A restart during a delayed-redrive window leaves an UNKEYED pending
+    /// successor row (`push_with_delay` records no idempotency key), which
+    /// `push_idempotent` alone cannot see. The live-delivery guard must
+    /// bound the mint to one chain: re-ensuring the authorization enqueues
+    /// nothing while that successor is live.
+    #[tokio::test]
+    async fn ensure_does_not_start_a_second_delivery_chain_over_a_redrive_successor() {
+        let (transfer, _pool, apalis_pool) =
+            create_authorization_wired_transfer(VaultModeTag::Orchestrator).await;
+
+        let id = issuer_request_id("ISS-ORCH-REDRIVE");
+        let symbol = Symbol::new("AAPL").unwrap();
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::SignMintAuthorization {
+                    token: Address::repeat_byte(0x11),
+                },
+            )
+            .await
+            .unwrap();
+
+        // The state a crash mid-redrive leaves behind: one delayed,
+        // UNKEYED successor row.
+        let mut queue = DeliverMintAuthorizationJobQueue::new(&apalis_pool);
+        queue
+            .push_with_delay(
+                DeliverMintAuthorization {
+                    issuer_request_id: id.clone(),
+                    redrive_attempts: 3,
+                },
+                std::time::Duration::from_secs(30),
+            )
+            .await
+            .unwrap();
+        assert_eq!(count_delivery_jobs(&apalis_pool).await, 1);
+
+        transfer
+            .ensure_mint_authorization(&id, &symbol)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            count_delivery_jobs(&apalis_pool).await,
+            1,
+            "the live-delivery guard must not start a second chain over a \
+             pending redrive successor"
+        );
+    }
+
+    /// A vault-direct asset takes the pre-authorization path untouched: no
+    /// signing event, no delivery job.
+    #[tokio::test]
+    async fn resume_of_vault_direct_mint_signs_nothing() {
+        let (transfer, pool, apalis_pool) =
+            create_authorization_wired_transfer(VaultModeTag::VaultDirect).await;
+
+        let id = issuer_request_id("ISS-DIRECT-RESUME");
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+
+        transfer.resume_mint(&id).await.unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::DepositedIntoRaindex { .. }),
+            "Expected deposited mint after resume, got: {entity:?}"
+        );
+        assert_eq!(
+            count_events(&pool, "TokenizedEquityMintEvent::MintAuthorizationSigned").await,
+            0
+        );
+        assert_eq!(count_delivery_jobs(&apalis_pool).await, 0);
+    }
+
+    /// An orchestrator-mode asset with no `[assets.equities.<SYM>]`
+    /// tokenized-equity entry cannot bind the EIP-712 MintAuth to a token:
+    /// the mint must fail with the exact variant, never proceed
+    /// unauthorized.
+    #[tokio::test]
+    async fn orchestrator_asset_without_token_address_fails_before_signing() {
+        let (transfer, pool, apalis_pool) =
+            create_authorization_wired_transfer(VaultModeTag::Orchestrator).await;
+
+        // TSLA is absent from the helper's AAPL-only token map.
+        let tsla = Symbol::new("TSLA").unwrap();
+        let error = transfer
+            .ensure_mint_authorization(&issuer_request_id("ISS-NO-TOKEN"), &tsla)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                MintError::UnknownTokenizedEquity { symbol } if symbol == tsla
+            ),
+            "expected UnknownTokenizedEquity for the unmapped symbol"
+        );
+        assert_eq!(
+            count_events(&pool, "TokenizedEquityMintEvent::MintAuthorizationSigned").await,
+            0,
+            "the failed lookup must precede any signing"
+        );
+        assert_eq!(count_delivery_jobs(&apalis_pool).await, 0);
+    }
+
+    /// A transfer built without `with_mint_authorization` carries the
+    /// explicit `VaultDirectOnly` assertion: `ensure_mint_authorization`
+    /// cannot read `vault_mode` at all, so it must sign nothing and
+    /// enqueue nothing -- pinned so the assertion stays a stated
+    /// capability rather than drifting into silent behavior.
+    #[tokio::test]
+    async fn vault_direct_only_transfer_signs_nothing_and_enqueues_nothing() {
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
+        let services = EquityTransferServices {
+            mint_authorizer: ConfiguredMintAuthorizer::Enabled(Arc::new(MockMintAuthorizer)),
+            ..mock_services()
+        };
+        let mint_store = Arc::new(test_store(pool.clone(), services.clone()));
+        let redemption_store = Arc::new(test_store(pool.clone(), services));
+        let transfer = CrossVenueEquityTransfer::new(
+            Arc::new(MockRaindex::new()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockWrapper::new()),
+            Address::random(),
+            mint_store,
+            redemption_store,
+        );
+
+        let id = issuer_request_id("ISS-VAULT-DIRECT-ONLY");
+        let symbol = Symbol::new("AAPL").unwrap();
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+
+        transfer
+            .ensure_mint_authorization(&id, &symbol)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            count_events(&pool, "TokenizedEquityMintEvent::MintAuthorizationSigned").await,
+            0,
+            "a VaultDirectOnly transfer must never sign an authorization"
+        );
+        assert_eq!(count_delivery_jobs(&apalis_pool).await, 0);
+    }
+
     /// Re-running the job entry point with an id whose aggregate already
     /// exists must resume from the persisted state (the crash-recovery path)
     /// rather than re-requesting the mint from Alpaca.
@@ -3006,6 +3497,7 @@ mod tests {
             tokenizer: tokenizer.clone(),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Enabled(queue),
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let mint_store = Arc::new(test_store(pool.clone(), services.clone()));
         let redemption_store = Arc::new(test_store(pool, services));
@@ -3066,6 +3558,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Enabled(queue),
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let redemption_store = Arc::new(test_store::<EquityRedemption>(pool, services));
 

--- a/src/rebalancing/equity/resume_job.rs
+++ b/src/rebalancing/equity/resume_job.rs
@@ -161,6 +161,7 @@ mod tests {
     use crate::equity_redemption::{
         EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,
     };
+    use crate::mint_authorization::ConfiguredMintAuthorizer;
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintCommand};
@@ -200,6 +201,7 @@ mod tests {
             tokenizer: tokenizer.clone(),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
 
         let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
@@ -513,6 +515,7 @@ mod tests {
             tokenizer: tokenizer.clone(),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Enabled(bot_gas_queue.clone()),
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
         let redemption_store = Arc::new(test_store(pool, transfer_services));

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -258,6 +258,16 @@ impl MintTracking {
                 self.stage = MintTrackingStage::VaultDepositSubmitted;
                 self.last_progress_at = *submitted_at;
             }
+            // Authorization signing/delivery are genuine forward progress
+            // for an orchestrator-mode mint waiting in `Accepted` (issuance
+            // will not mint until the authorization arrives), so they
+            // refresh the stall clock without advancing the stage.
+            TokenizedEquityMintEvent::MintAuthorizationSigned { signed_at, .. } => {
+                self.last_progress_at = *signed_at;
+            }
+            TokenizedEquityMintEvent::MintAuthorizationDelivered { delivered_at } => {
+                self.last_progress_at = *delivered_at;
+            }
             TokenizedEquityMintEvent::MintRequested { .. }
             | TokenizedEquityMintEvent::MintRejected { .. }
             | TokenizedEquityMintEvent::MintAcceptanceFailed { .. }
@@ -444,6 +454,8 @@ fn mint_event_tokenization_request_id(
         | TokenizedEquityMintEvent::VaultDepositSubmitted { .. }
         | TokenizedEquityMintEvent::DepositedIntoRaindex { .. }
         | TokenizedEquityMintEvent::RaindexDepositFailed { .. }
+        | TokenizedEquityMintEvent::MintAuthorizationSigned { .. }
+        | TokenizedEquityMintEvent::MintAuthorizationDelivered { .. }
         | TokenizedEquityMintEvent::OperatorReconciled { .. } => None,
     }
 }
@@ -2627,6 +2639,11 @@ impl RebalancingService {
             | VaultDepositSubmitted { .. }
             | WrappingFailed { .. }
             | RaindexDepositFailed { .. }
+            // Authorization signing/delivery move no shares: the Hedging
+            // inflight `MintAccepted` started is untouched until tokens
+            // arrive.
+            | MintAuthorizationSigned { .. }
+            | MintAuthorizationDelivered { .. }
             // Reconciliation is a pure bookkeeping terminal transition from
             // `Failed`: the failure already settled inventory, so nothing to do.
             | OperatorReconciled { .. } => None,
@@ -5323,6 +5340,8 @@ impl RebalancingService {
 
             MintRequested { .. }
             | MintAccepted { .. }
+            | MintAuthorizationSigned { .. }
+            | MintAuthorizationDelivered { .. }
             | TokensReceived { .. }
             | ProviderCompletionRecovered { .. }
             | WrapSubmitted { .. }
@@ -5445,6 +5464,7 @@ mod tests {
     };
     use crate::inventory::view::{EquityReconcileBusy, InFlightEquityLocation, Operator};
     use crate::inventory::{InventoryError, InventoryView, TransferOp, Venue};
+    use crate::mint_authorization::ConfiguredMintAuthorizer;
     use crate::offchain::order::OffchainOrderId;
     use crate::onchain::mock::MockRaindex;
     use crate::position::{
@@ -5756,6 +5776,8 @@ mod tests {
                     tokenization_request_id: tokenization_request_id("TOK-1"),
                     requested_at: Utc::now(),
                     accepted_at,
+                    authorization: crate::tokenized_equity_mint::MintAuthorizationProgress::default(
+                    ),
                 },
             )
             .await
@@ -14320,6 +14342,7 @@ mod tests {
                 tokenizer: Arc::new(MockTokenizer::new()),
                 wrapper: Arc::new(MockWrapper::new()),
                 bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+                mint_authorizer: ConfiguredMintAuthorizer::Disabled,
             },
         );
         store
@@ -14358,6 +14381,7 @@ mod tests {
                 tokenizer: Arc::new(MockTokenizer::new()),
                 wrapper: Arc::new(MockWrapper::new()),
                 bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+                mint_authorizer: ConfiguredMintAuthorizer::Disabled,
             },
         );
         store

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -38,7 +38,7 @@
 //! - Terminal states (DepositedIntoRaindex, Failed) reject all state-changing commands
 //! - All state transitions are captured as events for complete audit trail
 
-use alloy::primitives::{Address, TxHash, U256};
+use alloy::primitives::{Address, B256, Bytes, TxHash, U256};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rain_math_float::{Float, FloatError};
@@ -54,6 +54,7 @@ use st0x_tokenization::{IssuerRequestId, TokenizationRequestId, TokenizationRequ
 
 #[cfg(test)]
 use crate::bot_gas::BotGasReceiptCostEnqueuer;
+use crate::mint_authorization::SignedMintAuthorization;
 use crate::rebalancing::equity::EquityTransferServices;
 
 /// Errors that can occur during tokenized equity mint operations.
@@ -134,6 +135,17 @@ pub(crate) enum TokenizedEquityMintError {
     /// Vault deposit transaction failed
     #[error("Vault deposit failed")]
     VaultDepositFailed,
+    /// Mint-authorization signing failed. Like `RequestFailed`, the source
+    /// (`MintAuthorizationError`) wraps non-serde types (EVM transport),
+    /// which the DomainError serde bound forbids embedding, so only the
+    /// rendered message is carried.
+    #[error("Mint authorization signing failed: {error_message}")]
+    AuthorizationSigningFailed { error_message: String },
+    /// Attempted to record an authorization delivery before any
+    /// authorization was signed -- the delivery job only fires after
+    /// `MintAuthorizationSigned` is persisted, so this is a caller bug.
+    #[error("Cannot record authorization delivery: no authorization signed")]
+    AuthorizationNotSigned,
 }
 
 impl PartialEq for TokenizedEquityMintError {
@@ -150,10 +162,15 @@ impl PartialEq for TokenizedEquityMintError {
             | (Self::AlreadyReconciled, Self::AlreadyReconciled)
             | (Self::ReconcileReasonRequired, Self::ReconcileReasonRequired)
             | (Self::MissingTxHash, Self::MissingTxHash)
-            | (Self::VaultDepositFailed, Self::VaultDepositFailed) => true,
+            | (Self::VaultDepositFailed, Self::VaultDepositFailed)
+            | (Self::AuthorizationNotSigned, Self::AuthorizationNotSigned) => true,
             (
                 Self::RequestFailed { error_message: a },
                 Self::RequestFailed { error_message: b },
+            )
+            | (
+                Self::AuthorizationSigningFailed { error_message: a },
+                Self::AuthorizationSigningFailed { error_message: b },
             )
             | (Self::Float(a), Self::Float(b)) => a == b,
             (Self::VaultLookupFailed(a), Self::VaultLookupFailed(b))
@@ -229,6 +246,34 @@ pub(crate) enum TokenizedEquityMintCommand {
     PollAt {
         received_at: DateTime<Utc>,
     },
+    /// Signs and persists the recipient authorization for an
+    /// orchestrator-mode mint (the asset's `vault_mode` on issuance's
+    /// status endpoint reads `"orchestrator"`). Generates the mint's nonce,
+    /// signs via the mint-authorizer service, and emits
+    /// `MintAuthorizationSigned` -- persisted BEFORE any delivery attempt.
+    /// No-op when an authorization is already signed or delivered: the
+    /// nonce is this mint's on-chain idempotency key, so at-least-once saga
+    /// re-drives must reuse the persisted one, never mint a fresh one.
+    ///
+    /// Emits MintAuthorizationSigned (or nothing when already signed).
+    SignMintAuthorization {
+        /// The asset's tokenized-equity ERC-20 address -- the `token` the
+        /// EIP-712 MintAuth binds; issuance mints exactly this token.
+        token: Address,
+    },
+    /// Records issuance's acknowledgement (`200`) that the delivered
+    /// authorization was validated and recorded. Dispatched by the durable
+    /// delivery job. Usually lands AFTER the mint advanced past
+    /// `MintAccepted` (the in-flight `Poll` holds the aggregate until
+    /// Alpaca completes, which requires the delivery) -- still recorded
+    /// there as an audit fact. No-op when already delivered or terminal.
+    /// Post-advance the aggregate keeps no delivered marker (the progress
+    /// is dropped with the authorization's purpose), so a re-driven
+    /// acknowledgement there may record more than once; each is an
+    /// independent audit fact, deliberately not deduplicated.
+    ///
+    /// Emits MintAuthorizationDelivered (or nothing).
+    RecordMintAuthorizationDelivered,
     /// Record that a wrap transaction has been submitted (before confirmation).
     SubmitWrap {
         wrap_tx_hash: TxHash,
@@ -328,6 +373,19 @@ pub(crate) enum TokenizedEquityMintEvent {
         tokenization_request_id: TokenizationRequestId,
         accepted_at: DateTime<Utc>,
     },
+    /// Recipient authorization signed for an orchestrator-mode mint,
+    /// persisted before the first delivery attempt so a crash cannot lose
+    /// the nonce: the nonce is this mint's on-chain idempotency key, and
+    /// every delivery retry must reuse it (and the signature)
+    /// byte-identically.
+    MintAuthorizationSigned {
+        nonce: B256,
+        signature: Bytes,
+        signed_at: DateTime<Utc>,
+    },
+    /// Issuance validated and recorded the delivered authorization
+    /// (idempotent `200` on the internal mint-authorization call).
+    MintAuthorizationDelivered { delivered_at: DateTime<Utc> },
     /// Mint failed before tokens were received. Two cases:
     /// - failed after `MintAccepted`: shares were moved to inflight (Hedging),
     ///   so the inventory reactor restores them to offchain available (Cancel).
@@ -426,6 +484,7 @@ pub(crate) enum TokenizedEquityMintEvent {
 }
 
 impl PartialEq for TokenizedEquityMintEvent {
+    #[allow(clippy::too_many_lines)]
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (
@@ -499,6 +558,26 @@ impl PartialEq for TokenizedEquityMintEvent {
                     accepted_at: acc_b,
                 },
             ) => iss_a == iss_b && tok_a == tok_b && acc_a == acc_b,
+            (
+                Self::MintAuthorizationSigned {
+                    nonce,
+                    signature,
+                    signed_at,
+                },
+                Self::MintAuthorizationSigned {
+                    nonce: nonce_b,
+                    signature: sig_b,
+                    signed_at: time_b,
+                },
+            ) => (nonce, signature, signed_at) == (nonce_b, sig_b, time_b),
+            (
+                Self::MintAuthorizationDelivered {
+                    delivered_at: time_a,
+                },
+                Self::MintAuthorizationDelivered {
+                    delivered_at: time_b,
+                },
+            ) => time_a == time_b,
             (
                 Self::TokensReceived {
                     tx_hash: hash_a,
@@ -630,6 +709,12 @@ impl DomainEvent for TokenizedEquityMintEvent {
             Self::MintRequested { .. } => "TokenizedEquityMintEvent::MintRequested".to_string(),
             Self::MintRejected { .. } => "TokenizedEquityMintEvent::MintRejected".to_string(),
             Self::MintAccepted { .. } => "TokenizedEquityMintEvent::MintAccepted".to_string(),
+            Self::MintAuthorizationSigned { .. } => {
+                "TokenizedEquityMintEvent::MintAuthorizationSigned".to_string()
+            }
+            Self::MintAuthorizationDelivered { .. } => {
+                "TokenizedEquityMintEvent::MintAuthorizationDelivered".to_string()
+            }
             Self::MintAcceptanceFailed { .. } => {
                 "TokenizedEquityMintEvent::MintAcceptanceFailed".to_string()
             }
@@ -658,6 +743,26 @@ impl DomainEvent for TokenizedEquityMintEvent {
     fn event_version(&self) -> String {
         "1.0".to_string()
     }
+}
+
+/// Recipient-authorization progress for an orchestrator-mode mint sitting
+/// in `MintAccepted`.
+///
+/// Defaults to `NotSigned` so event streams and snapshots from before this
+/// field existed replay unchanged -- and a vault-direct mint's progress
+/// simply never leaves `NotSigned`. The progress is dropped once tokens
+/// arrive: from `TokensReceived` on, the authorization has served its
+/// purpose (issuance minted with it) and is no longer actionable.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum MintAuthorizationProgress {
+    /// No authorization signed -- vault-direct mint, or signing has not
+    /// happened yet.
+    #[default]
+    NotSigned,
+    /// Signed and persisted; issuance has not yet acknowledged receipt.
+    Signed(SignedMintAuthorization),
+    /// Issuance acknowledged recording the authorization.
+    Delivered(SignedMintAuthorization),
 }
 
 /// Tokenized equity mint aggregate state machine.
@@ -692,6 +797,10 @@ pub(crate) enum TokenizedEquityMint {
         tokenization_request_id: TokenizationRequestId,
         requested_at: DateTime<Utc>,
         accepted_at: DateTime<Utc>,
+        /// Orchestrator-mode recipient-authorization progress; stays
+        /// `NotSigned` for vault-direct mints.
+        #[serde(default)]
+        authorization: MintAuthorizationProgress,
     },
 
     /// Onchain token transfer detected with transaction details
@@ -876,6 +985,7 @@ impl PartialEq for TokenizedEquityMint {
                     tokenization_request_id: tok_a,
                     requested_at: req_a,
                     accepted_at: acc_a,
+                    authorization: auth_a,
                 },
                 Self::MintAccepted {
                     symbol: sym_b,
@@ -885,6 +995,7 @@ impl PartialEq for TokenizedEquityMint {
                     tokenization_request_id: tok_b,
                     requested_at: req_b,
                     accepted_at: acc_b,
+                    authorization: auth_b,
                 },
             ) => {
                 sym_a == sym_b
@@ -894,6 +1005,7 @@ impl PartialEq for TokenizedEquityMint {
                     && tok_a == tok_b
                     && req_a == req_b
                     && acc_a == acc_b
+                    && auth_a == auth_b
             }
             (
                 Self::TokensReceived {
@@ -1348,6 +1460,16 @@ impl TokenizedEquityMint {
 
 /// Returns mint aggregate IDs whose latest event is non-terminal and should be
 /// resumed after restart.
+///
+/// The delivery acknowledgement normally trails the whole mint (the ack is
+/// recorded as an audit fact after `DepositedIntoRaindex`), so a completed
+/// mint's LATEST event is `MintAuthorizationDelivered` -- latest-event
+/// membership alone would resume every completed orchestrator-mode mint on
+/// every boot, forever. The `NOT EXISTS` clause excludes any aggregate that
+/// deposited: a deposit anywhere in the stream means the mint is complete
+/// regardless of trailing acknowledgements, while a `Delivered` latest
+/// WITHOUT a deposit (the ack landed while still `MintAccepted`) is a
+/// genuine interruption and stays included.
 pub(crate) async fn interrupted_mint_ids(
     pool: &SqlitePool,
 ) -> Result<Vec<IssuerRequestId>, sqlx::Error> {
@@ -1366,11 +1488,20 @@ pub(crate) async fn interrupted_mint_ids(
          WHERE last_ev.aggregate_type = 'TokenizedEquityMint' \
            AND last_ev.event_type IN ( \
                'TokenizedEquityMintEvent::MintAccepted', \
+               'TokenizedEquityMintEvent::MintAuthorizationSigned', \
+               'TokenizedEquityMintEvent::MintAuthorizationDelivered', \
                'TokenizedEquityMintEvent::ProviderCompletionRecovered', \
                'TokenizedEquityMintEvent::TokensReceived', \
                'TokenizedEquityMintEvent::WrapSubmitted', \
                'TokenizedEquityMintEvent::TokensWrapped', \
                'TokenizedEquityMintEvent::VaultDepositSubmitted' \
+           ) \
+           AND NOT EXISTS ( \
+               SELECT 1 FROM events deposited \
+               WHERE deposited.aggregate_type = 'TokenizedEquityMint' \
+                 AND deposited.aggregate_id = last_ev.aggregate_id \
+                 AND deposited.event_type = \
+                     'TokenizedEquityMintEvent::DepositedIntoRaindex' \
            ) \
          ORDER BY latest.aggregate_id",
     )
@@ -1443,7 +1574,12 @@ impl EventSourced for TokenizedEquityMint {
     // event for operator reconciliation of stuck `Failed` mints. Additive only;
     // bumped to clear stale snapshots so they rebuild from events under the new
     // schema (existing events replay unchanged).
-    const SCHEMA_VERSION: u64 = 4;
+    // v5: added the `authorization` field on `MintAccepted` plus the
+    // `MintAuthorizationSigned`/`MintAuthorizationDelivered` events for
+    // orchestrator-mode recipient authorizations (RAI-1243). Additive only;
+    // bumped to clear stale snapshots (existing events replay unchanged --
+    // the field is `#[serde(default)]`).
+    const SCHEMA_VERSION: u64 = 5;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use TokenizedEquityMintEvent::*;
@@ -1531,8 +1667,75 @@ impl EventSourced for TokenizedEquityMint {
                     tokenization_request_id: tokenization_request_id.clone(),
                     requested_at: *requested_at,
                     accepted_at: *accepted_at,
+                    authorization: MintAuthorizationProgress::default(),
                 })
             }
+
+            MintAuthorizationSigned {
+                nonce, signature, ..
+            } => {
+                let Self::MintAccepted {
+                    symbol,
+                    quantity,
+                    wallet,
+                    issuer_request_id,
+                    tokenization_request_id,
+                    requested_at,
+                    accepted_at,
+                    ..
+                } = entity
+                else {
+                    return Ok(None);
+                };
+
+                Some(Self::MintAccepted {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    wallet: *wallet,
+                    issuer_request_id: issuer_request_id.clone(),
+                    tokenization_request_id: tokenization_request_id.clone(),
+                    requested_at: *requested_at,
+                    accepted_at: *accepted_at,
+                    authorization: MintAuthorizationProgress::Signed(SignedMintAuthorization {
+                        nonce: *nonce,
+                        signature: signature.clone(),
+                    }),
+                })
+            }
+
+            MintAuthorizationDelivered { .. } => match entity {
+                Self::MintAccepted {
+                    symbol,
+                    quantity,
+                    wallet,
+                    issuer_request_id,
+                    tokenization_request_id,
+                    requested_at,
+                    accepted_at,
+                    authorization: MintAuthorizationProgress::Signed(signed),
+                } => Some(Self::MintAccepted {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    wallet: *wallet,
+                    issuer_request_id: issuer_request_id.clone(),
+                    tokenization_request_id: tokenization_request_id.clone(),
+                    requested_at: *requested_at,
+                    accepted_at: *accepted_at,
+                    authorization: MintAuthorizationProgress::Delivered(signed.clone()),
+                }),
+                // The acknowledgement was recorded after the mint advanced
+                // (the usual ordering -- `Poll` holds the aggregate for the
+                // whole Alpaca wait): an audit marker only, no state change.
+                Self::TokensReceived { .. }
+                | Self::WrapSubmitted { .. }
+                | Self::TokensWrapped { .. }
+                | Self::VaultDepositSubmitted { .. }
+                | Self::DepositedIntoRaindex { .. } => Some(entity.clone()),
+                Self::MintRequested { .. }
+                | Self::MintAccepted { .. }
+                | Self::Failed { .. }
+                | Self::Reconciled { .. } => return Ok(None),
+            },
 
             MintAcceptanceFailed { reason, failed_at } => {
                 // Emitted from `MintAccepted` (post-acceptance failure) or
@@ -1577,6 +1780,9 @@ impl EventSourced for TokenizedEquityMint {
                     tokenization_request_id,
                     requested_at,
                     accepted_at,
+                    // The authorization served its purpose once tokens
+                    // arrive; later states deliberately do not carry it.
+                    authorization: _,
                 } = entity
                 else {
                     return Ok(None);
@@ -1962,6 +2168,14 @@ impl EventSourced for TokenizedEquityMint {
                 self.transition_poll(services, Some(received_at)).await
             }
 
+            TokenizedEquityMintCommand::SignMintAuthorization { token } => {
+                self.transition_sign_authorization(services, token).await
+            }
+
+            TokenizedEquityMintCommand::RecordMintAuthorizationDelivered => {
+                self.transition_record_authorization_delivered()
+            }
+
             TokenizedEquityMintCommand::SubmitWrap { wrap_tx_hash } => match self {
                 Self::TokensReceived { .. } => Ok(vec![WrapSubmitted {
                     wrap_tx_hash,
@@ -2137,6 +2351,175 @@ impl EventSourced for TokenizedEquityMint {
 }
 
 impl TokenizedEquityMint {
+    /// Human-readable state label for logs: `Debug` on the aggregate dumps
+    /// every field, and `std::mem::discriminant` prints an opaque token
+    /// that does not identify the state.
+    const fn state_name(&self) -> &'static str {
+        match self {
+            Self::MintRequested { .. } => "MintRequested",
+            Self::MintAccepted { .. } => "MintAccepted",
+            Self::TokensReceived { .. } => "TokensReceived",
+            Self::WrapSubmitted { .. } => "WrapSubmitted",
+            Self::TokensWrapped { .. } => "TokensWrapped",
+            Self::VaultDepositSubmitted { .. } => "VaultDepositSubmitted",
+            Self::DepositedIntoRaindex { .. } => "DepositedIntoRaindex",
+            Self::Failed { .. } => "Failed",
+            Self::Reconciled { .. } => "Reconciled",
+        }
+    }
+
+    /// Signs the recipient authorization exactly once per mint: the nonce
+    /// minted here is the mint's on-chain idempotency key, so a re-drive
+    /// finding one already signed emits nothing rather than re-signing.
+    async fn transition_sign_authorization(
+        &self,
+        services: &EquityTransferServices,
+        token: Address,
+    ) -> Result<Vec<TokenizedEquityMintEvent>, TokenizedEquityMintError> {
+        use TokenizedEquityMintEvent::*;
+        match self {
+            Self::MintAccepted {
+                authorization: MintAuthorizationProgress::NotSigned,
+                symbol,
+                quantity,
+                issuer_request_id,
+                ..
+            } => {
+                let nonce = B256::random();
+                let signed = services
+                    .mint_authorizer
+                    .sign(token, *quantity, nonce)
+                    .await
+                    .map_err(
+                        |error| TokenizedEquityMintError::AuthorizationSigningFailed {
+                            error_message: error.to_string(),
+                        },
+                    )?;
+
+                info!(
+                    target: "tokenization",
+                    %issuer_request_id,
+                    %symbol,
+                    %token,
+                    nonce = %signed.nonce,
+                    "Signed mint recipient authorization"
+                );
+
+                Ok(vec![MintAuthorizationSigned {
+                    nonce: signed.nonce,
+                    signature: signed.signature,
+                    signed_at: Utc::now(),
+                }])
+            }
+            Self::MintAccepted {
+                authorization:
+                    MintAuthorizationProgress::Signed(_) | MintAuthorizationProgress::Delivered(_),
+                issuer_request_id,
+                ..
+            } => {
+                info!(
+                    target: "tokenization",
+                    %issuer_request_id,
+                    "Mint authorization already signed; re-drive is a no-op"
+                );
+                Ok(vec![])
+            }
+            Self::MintRequested { .. } => Err(TokenizedEquityMintError::NotAccepted),
+            // Tokens already arrived: issuance has consumed the
+            // authorization (or never needed one), so a late signing
+            // attempt is a benign race, not an error the saga must handle.
+            Self::TokensReceived { .. }
+            | Self::WrapSubmitted { .. }
+            | Self::TokensWrapped { .. }
+            | Self::VaultDepositSubmitted { .. }
+            | Self::DepositedIntoRaindex { .. } => {
+                warn!(
+                    target: "tokenization",
+                    state = self.state_name(),
+                    "Ignoring authorization signing for a mint past acceptance"
+                );
+                Ok(vec![])
+            }
+            Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+            Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
+        }
+    }
+
+    /// Records issuance's delivery acknowledgement. The acknowledgement
+    /// normally lands AFTER the mint has advanced past `MintAccepted`:
+    /// `Poll` holds the per-aggregate lock for the whole Alpaca wait, and
+    /// issuance only completes the mint once the authorization arrived, so
+    /// this command queues behind `Poll` and runs against `TokensReceived`
+    /// or later. The event is still recorded there -- the acknowledgement
+    /// is a fact regardless of mint progress. Terminal states are no-ops;
+    /// only delivery before signing is a hard error (the job loads the
+    /// signed authorization from this aggregate, so its absence is a
+    /// caller bug).
+    fn transition_record_authorization_delivered(
+        &self,
+    ) -> Result<Vec<TokenizedEquityMintEvent>, TokenizedEquityMintError> {
+        use TokenizedEquityMintEvent::*;
+        match self {
+            Self::MintAccepted {
+                authorization: MintAuthorizationProgress::Signed(_),
+                issuer_request_id,
+                ..
+            } => {
+                info!(
+                    target: "tokenization",
+                    %issuer_request_id,
+                    "Mint authorization delivery acknowledged by issuance"
+                );
+                Ok(vec![MintAuthorizationDelivered {
+                    delivered_at: Utc::now(),
+                }])
+            }
+            Self::MintAccepted {
+                authorization: MintAuthorizationProgress::Delivered(_),
+                ..
+            } => Ok(vec![]),
+            Self::MintAccepted {
+                authorization: MintAuthorizationProgress::NotSigned,
+                ..
+            } => Err(TokenizedEquityMintError::AuthorizationNotSigned),
+            Self::MintRequested { .. } => Err(TokenizedEquityMintError::NotAccepted),
+            Self::TokensReceived {
+                issuer_request_id, ..
+            }
+            | Self::WrapSubmitted {
+                issuer_request_id, ..
+            }
+            | Self::TokensWrapped {
+                issuer_request_id, ..
+            }
+            | Self::VaultDepositSubmitted {
+                issuer_request_id, ..
+            }
+            | Self::DepositedIntoRaindex {
+                issuer_request_id, ..
+            } => {
+                info!(
+                    target: "tokenization",
+                    %issuer_request_id,
+                    "Mint authorization delivery acknowledged by issuance \
+                     after the mint advanced"
+                );
+                Ok(vec![MintAuthorizationDelivered {
+                    delivered_at: Utc::now(),
+                }])
+            }
+            Self::Failed { .. } | Self::Reconciled { .. } => {
+                warn!(
+                    target: "tokenization",
+                    state = self.state_name(),
+                    "Ignoring authorization-delivery acknowledgement for a \
+                     terminal mint"
+                );
+                Ok(vec![])
+            }
+        }
+    }
+
     /// Shared body for `WrapTokens`/`WrapTokensAt`.
     fn transition_wrap_tokens(
         &self,
@@ -2312,6 +2695,7 @@ mod tests {
     use st0x_wrapper::MockWrapper;
 
     use super::*;
+    use crate::mint_authorization::{ConfiguredMintAuthorizer, MockMintAuthorizer};
     use crate::onchain::mock::MockRaindex;
     use crate::vault_lookup::MockVaultLookup;
 
@@ -2326,6 +2710,16 @@ mod tests {
             vault_lookup: Arc::new(mock_vault_lookup()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
+        }
+    }
+
+    /// Like [`mint_services`] but with a working (mock) mint authorizer, for
+    /// tests exercising the orchestrator-mode signing path.
+    fn mint_services_with_authorizer(tokenizer: MockTokenizer) -> EquityTransferServices {
+        EquityTransferServices {
+            mint_authorizer: ConfiguredMintAuthorizer::Enabled(Arc::new(MockMintAuthorizer)),
+            ..mint_services(tokenizer)
         }
     }
 
@@ -2621,6 +3015,7 @@ mod tests {
             tokenization_request_id: tokenization_request_id("TOK456"),
             requested_at: Utc::now(),
             accepted_at: Utc::now(),
+            authorization: crate::tokenized_equity_mint::MintAuthorizationProgress::default(),
         };
 
         let event = TokenizedEquityMintEvent::MintRejected {
@@ -2702,6 +3097,7 @@ mod tests {
             tokenization_request_id: tokenization_request_id("TOK456"),
             requested_at: Utc::now(),
             accepted_at: Utc::now(),
+            authorization: crate::tokenized_equity_mint::MintAuthorizationProgress::default(),
         };
 
         let event = TokenizedEquityMintEvent::DepositedIntoRaindex {
@@ -2751,6 +3147,7 @@ mod tests {
             tokenization_request_id: tokenization_request_id("TOK456"),
             requested_at: Utc::now(),
             accepted_at: Utc::now(),
+            authorization: crate::tokenized_equity_mint::MintAuthorizationProgress::default(),
         };
 
         let event = TokenizedEquityMintEvent::TokensWrapped {
@@ -2846,6 +3243,7 @@ mod tests {
             vault_lookup: Arc::new(mock_vault_lookup()),
             wrapper: Arc::new(MockWrapper::new()),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         });
         let id = issuer_request_id("ISS001");
 
@@ -3138,6 +3536,610 @@ mod tests {
         assert_eq!(result, vec![mint_accepted_id]);
     }
 
+    /// Raw persisted payload for `MintAuthorizationSigned`, pinning the hex
+    /// wire format events must keep forever (65-byte `0x42` signature).
+    fn mint_authorization_signed_payload() -> String {
+        format!(
+            r#"{{"MintAuthorizationSigned":{{"nonce":"0x{}","signature":"0x{}","signed_at":"2026-01-01T00:00:00Z"}}}}"#,
+            "07".repeat(32),
+            "42".repeat(65),
+        )
+    }
+
+    /// The acknowledgement normally trails the whole mint, so a completed
+    /// stream ends `DepositedIntoRaindex` -> `MintAuthorizationDelivered`.
+    /// Latest-event membership alone would resume that mint on every boot
+    /// forever; the deposit anywhere in the stream must exclude it. The
+    /// inverse case -- `Delivered` latest with NO deposit (the ack landed
+    /// while still `MintAccepted`) -- is a genuine interruption and must
+    /// stay included.
+    #[tokio::test]
+    async fn interrupted_mint_ids_excludes_completed_mint_with_trailing_ack() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        let completed_id = issuer_request_id("mint-completed-trailing-ack");
+        for (sequence, event_type, payload) in [
+            (
+                0,
+                "TokenizedEquityMintEvent::MintRequested",
+                mint_requested_payload("RKLB"),
+            ),
+            (
+                1,
+                "TokenizedEquityMintEvent::MintAccepted",
+                mint_accepted_payload(&completed_id),
+            ),
+            (
+                2,
+                "TokenizedEquityMintEvent::MintAuthorizationSigned",
+                mint_authorization_signed_payload(),
+            ),
+            (
+                3,
+                "TokenizedEquityMintEvent::DepositedIntoRaindex",
+                r#"{"DepositedIntoRaindex":{"vault_deposit_tx_hash":"0x0000000000000000000000000000000000000000000000000000000000000002","deposited_at":"2026-01-01T00:00:00Z"}}"#.to_string(),
+            ),
+            (
+                4,
+                "TokenizedEquityMintEvent::MintAuthorizationDelivered",
+                r#"{"MintAuthorizationDelivered":{"delivered_at":"2026-01-01T00:00:01Z"}}"#
+                    .to_string(),
+            ),
+        ] {
+            insert_event(
+                &pool,
+                &completed_id.to_string(),
+                sequence,
+                event_type,
+                &payload,
+            )
+            .await;
+        }
+
+        let interrupted_id = issuer_request_id("mint-acked-while-accepted");
+        for (sequence, event_type, payload) in [
+            (
+                0,
+                "TokenizedEquityMintEvent::MintRequested",
+                mint_requested_payload("RKLB"),
+            ),
+            (
+                1,
+                "TokenizedEquityMintEvent::MintAccepted",
+                mint_accepted_payload(&interrupted_id),
+            ),
+            (
+                2,
+                "TokenizedEquityMintEvent::MintAuthorizationSigned",
+                mint_authorization_signed_payload(),
+            ),
+            (
+                3,
+                "TokenizedEquityMintEvent::MintAuthorizationDelivered",
+                r#"{"MintAuthorizationDelivered":{"delivered_at":"2026-01-01T00:00:01Z"}}"#
+                    .to_string(),
+            ),
+        ] {
+            insert_event(
+                &pool,
+                &interrupted_id.to_string(),
+                sequence,
+                event_type,
+                &payload,
+            )
+            .await;
+        }
+
+        let result = interrupted_mint_ids(&pool).await.unwrap();
+        assert_eq!(
+            result,
+            vec![interrupted_id],
+            "the completed mint's trailing ack must not make it interrupted, \
+             while the still-accepted acked mint must stay resumable"
+        );
+    }
+
+    /// A mint whose LATEST event is `MintAuthorizationSigned` is still
+    /// mid-flight (state `MintAccepted`): startup recovery must resume it,
+    /// or an orchestrator-mode mint interrupted between signing and
+    /// delivery would strand until manual intervention.
+    #[tokio::test]
+    async fn interrupted_mint_ids_includes_mint_awaiting_authorization_delivery() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        let signed_id = issuer_request_id("mint-auth-signed");
+        insert_event(
+            &pool,
+            &signed_id.to_string(),
+            0,
+            "TokenizedEquityMintEvent::MintRequested",
+            &mint_requested_payload("RKLB"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            &signed_id.to_string(),
+            1,
+            "TokenizedEquityMintEvent::MintAccepted",
+            &mint_accepted_payload(&signed_id),
+        )
+        .await;
+        insert_event(
+            &pool,
+            &signed_id.to_string(),
+            2,
+            "TokenizedEquityMintEvent::MintAuthorizationSigned",
+            &mint_authorization_signed_payload(),
+        )
+        .await;
+
+        let result = interrupted_mint_ids(&pool).await.unwrap();
+        assert_eq!(result, vec![signed_id]);
+    }
+
+    /// Replays a raw persisted stream through the store: the pinned hex
+    /// payload must materialize as `Signed` progress carrying the exact
+    /// nonce and signature bytes -- this is the read-side half of the
+    /// permanent wire-format contract.
+    #[tokio::test]
+    async fn persisted_authorization_stream_replays_to_signed_progress() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let id = issuer_request_id("mint-auth-replay");
+
+        insert_event(
+            &pool,
+            &id.to_string(),
+            1,
+            "TokenizedEquityMintEvent::MintRequested",
+            &mint_requested_payload("RKLB"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            &id.to_string(),
+            2,
+            "TokenizedEquityMintEvent::MintAccepted",
+            &mint_accepted_payload(&id),
+        )
+        .await;
+        insert_event(
+            &pool,
+            &id.to_string(),
+            3,
+            "TokenizedEquityMintEvent::MintAuthorizationSigned",
+            &mint_authorization_signed_payload(),
+        )
+        .await;
+
+        let store = st0x_event_sorcery::test_store(
+            pool,
+            mint_services_with_authorizer(MockTokenizer::new()),
+        );
+        let entity = store.load(&id).await.unwrap().unwrap();
+
+        let TokenizedEquityMint::MintAccepted {
+            authorization: MintAuthorizationProgress::Signed(signed),
+            ..
+        } = entity
+        else {
+            panic!("expected Signed authorization after replay, got: {entity:?}");
+        };
+        assert_eq!(signed.nonce, B256::repeat_byte(0x07));
+        assert_eq!(
+            signed.signature,
+            alloy::primitives::Bytes::from(vec![0x42; 65])
+        );
+    }
+
+    /// A pre-authorization event stream (no authorization events, as every
+    /// stream persisted before this feature) must still replay -- landing on
+    /// `NotSigned`, the truthful default for a vault-direct mint.
+    #[tokio::test]
+    async fn pre_authorization_stream_replays_with_not_signed_default() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let id = issuer_request_id("mint-pre-auth");
+
+        insert_event(
+            &pool,
+            &id.to_string(),
+            1,
+            "TokenizedEquityMintEvent::MintRequested",
+            &mint_requested_payload("AAPL"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            &id.to_string(),
+            2,
+            "TokenizedEquityMintEvent::MintAccepted",
+            &mint_accepted_payload(&id),
+        )
+        .await;
+
+        let store = st0x_event_sorcery::test_store(pool, mint_services(MockTokenizer::new()));
+        let entity = store.load(&id).await.unwrap().unwrap();
+
+        assert!(
+            matches!(
+                entity,
+                TokenizedEquityMint::MintAccepted {
+                    authorization: MintAuthorizationProgress::NotSigned,
+                    ..
+                }
+            ),
+            "expected NotSigned default after legacy replay, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sign_authorization_persists_signed_progress() {
+        let store = TestStore::<TokenizedEquityMint>::new(mint_services_with_authorizer(
+            MockTokenizer::new(),
+        ));
+        let id = issuer_request_id("ISS001");
+        store.send(&id, mint_command()).await.unwrap();
+
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::SignMintAuthorization {
+                    token: Address::repeat_byte(0x11),
+                },
+            )
+            .await
+            .unwrap();
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        let TokenizedEquityMint::MintAccepted {
+            authorization: MintAuthorizationProgress::Signed(signed),
+            ..
+        } = entity
+        else {
+            panic!("expected Signed authorization, got: {entity:?}");
+        };
+        assert_eq!(
+            signed.signature,
+            alloy::primitives::Bytes::from(vec![0x42; 65])
+        );
+        assert_ne!(signed.nonce, B256::ZERO);
+    }
+
+    /// THE nonce-fixity guarantee: a re-driven signing command must emit
+    /// nothing and keep the original nonce -- the nonce is the mint's
+    /// on-chain idempotency key, and a fresh one on retry could double-mint.
+    #[tokio::test]
+    async fn re_signing_keeps_the_original_nonce() {
+        let store = TestStore::<TokenizedEquityMint>::new(mint_services_with_authorizer(
+            MockTokenizer::new(),
+        ));
+        let id = issuer_request_id("ISS001");
+        store.send(&id, mint_command()).await.unwrap();
+
+        let sign_command = TokenizedEquityMintCommand::SignMintAuthorization {
+            token: Address::repeat_byte(0x11),
+        };
+        store.send(&id, sign_command.clone()).await.unwrap();
+        let first = store.load(&id).await.unwrap().unwrap();
+
+        store.send(&id, sign_command).await.unwrap();
+        let second = store.load(&id).await.unwrap().unwrap();
+
+        let (
+            TokenizedEquityMint::MintAccepted {
+                authorization: MintAuthorizationProgress::Signed(first_signed),
+                ..
+            },
+            TokenizedEquityMint::MintAccepted {
+                authorization: MintAuthorizationProgress::Signed(second_signed),
+                ..
+            },
+        ) = (first, second)
+        else {
+            panic!("expected both loads to be Signed");
+        };
+        assert_eq!(first_signed.nonce, second_signed.nonce);
+        assert_eq!(first_signed.signature, second_signed.signature);
+    }
+
+    /// Each mint owns its own random nonce: two aggregates must never share
+    /// one (a replacement mint gets a fresh nonce by construction).
+    #[tokio::test]
+    async fn distinct_mints_generate_independent_nonces() {
+        let store = TestStore::<TokenizedEquityMint>::new(mint_services_with_authorizer(
+            MockTokenizer::new(),
+        ));
+        let sign_command = TokenizedEquityMintCommand::SignMintAuthorization {
+            token: Address::repeat_byte(0x11),
+        };
+
+        let mut nonces = Vec::new();
+        for id_str in ["ISS-NONCE-A", "ISS-NONCE-B"] {
+            let id = issuer_request_id(id_str);
+            store
+                .send(
+                    &id,
+                    TokenizedEquityMintCommand::RequestMint {
+                        issuer_request_id: id.clone(),
+                        symbol: Symbol::new("AAPL").unwrap(),
+                        quantity: float!(10),
+                        wallet: Address::ZERO,
+                    },
+                )
+                .await
+                .unwrap();
+            store.send(&id, sign_command.clone()).await.unwrap();
+
+            let entity = store.load(&id).await.unwrap().unwrap();
+            let TokenizedEquityMint::MintAccepted {
+                authorization: MintAuthorizationProgress::Signed(signed),
+                ..
+            } = entity
+            else {
+                panic!("expected Signed authorization, got: {entity:?}");
+            };
+            nonces.push(signed.nonce);
+        }
+
+        assert_ne!(nonces[0], nonces[1]);
+    }
+
+    /// An orchestrator-mode mint reaching signing with no `[orchestrator]`
+    /// config must fail loudly, never guess an address or sign nothing.
+    #[tokio::test]
+    async fn signing_with_disabled_authorizer_fails_loudly() {
+        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let id = issuer_request_id("ISS001");
+        store.send(&id, mint_command()).await.unwrap();
+
+        let error = store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::SignMintAuthorization {
+                    token: Address::repeat_byte(0x11),
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AggregateError::UserError(LifecycleError::Apply(
+                    TokenizedEquityMintError::AuthorizationSigningFailed { .. }
+                ))
+            ),
+            "expected AuthorizationSigningFailed, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn recording_delivery_transitions_to_delivered_and_is_idempotent() {
+        let store = TestStore::<TokenizedEquityMint>::new(mint_services_with_authorizer(
+            MockTokenizer::new(),
+        ));
+        let id = issuer_request_id("ISS001");
+        store.send(&id, mint_command()).await.unwrap();
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::SignMintAuthorization {
+                    token: Address::repeat_byte(0x11),
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordMintAuthorizationDelivered,
+            )
+            .await
+            .unwrap();
+        // Idempotent: the at-least-once delivery job may acknowledge twice.
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordMintAuthorizationDelivered,
+            )
+            .await
+            .unwrap();
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                entity,
+                TokenizedEquityMint::MintAccepted {
+                    authorization: MintAuthorizationProgress::Delivered(_),
+                    ..
+                }
+            ),
+            "expected Delivered authorization, got: {entity:?}"
+        );
+    }
+
+    /// The usual production ordering: `Poll` holds the aggregate for the
+    /// whole Alpaca wait and issuance completes the mint only after the
+    /// authorization arrived, so the acknowledgement lands after the mint
+    /// advanced past `MintAccepted`. It must still be recorded, and the
+    /// aggregate must replay through the trailing event.
+    #[tokio::test]
+    async fn recording_delivery_after_mint_advanced_still_records() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = st0x_event_sorcery::test_store(
+            pool.clone(),
+            mint_services_with_authorizer(MockTokenizer::new()),
+        );
+        let id = issuer_request_id("ISS001");
+        store.send(&id, mint_command()).await.unwrap();
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::SignMintAuthorization {
+                    token: Address::repeat_byte(0x11),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(&id, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordMintAuthorizationDelivered,
+            )
+            .await
+            .unwrap();
+
+        // The audit fact must actually persist: an advanced-state
+        // acknowledgement that quietly emitted no event would leave the
+        // state assertion below passing while recording nothing.
+        let delivered_events: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("TokenizedEquityMintEvent::MintAuthorizationDelivered")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            delivered_events, 1,
+            "the trailing acknowledgement must persist its audit event"
+        );
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::TokensReceived { .. }),
+            "state must stay TokensReceived after the trailing \
+             acknowledgement, got: {entity:?}"
+        );
+    }
+
+    /// Replays a raw persisted stream where the acknowledgement landed
+    /// after `TokensReceived` (the usual production ordering): the trailing
+    /// `MintAuthorizationDelivered` must apply as a no-op, not fail the
+    /// lifecycle as an unexpected event.
+    #[tokio::test]
+    async fn persisted_stream_with_delivery_after_tokens_received_replays() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let id = issuer_request_id("mint-auth-late-ack");
+
+        insert_event(
+            &pool,
+            &id.to_string(),
+            1,
+            "TokenizedEquityMintEvent::MintRequested",
+            &mint_requested_payload("RKLB"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            &id.to_string(),
+            2,
+            "TokenizedEquityMintEvent::MintAccepted",
+            &mint_accepted_payload(&id),
+        )
+        .await;
+        insert_event(
+            &pool,
+            &id.to_string(),
+            3,
+            "TokenizedEquityMintEvent::MintAuthorizationSigned",
+            &mint_authorization_signed_payload(),
+        )
+        .await;
+        insert_event(
+            &pool,
+            &id.to_string(),
+            4,
+            "TokenizedEquityMintEvent::TokensReceived",
+            r#"{"TokensReceived":{"tx_hash":"0x0000000000000000000000000000000000000000000000000000000000000001","shares_minted":"0xde0b6b3a7640000","fees":null,"received_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+        insert_event(
+            &pool,
+            &id.to_string(),
+            5,
+            "TokenizedEquityMintEvent::MintAuthorizationDelivered",
+            r#"{"MintAuthorizationDelivered":{"delivered_at":"2026-01-01T00:00:01Z"}}"#,
+        )
+        .await;
+
+        let store = st0x_event_sorcery::test_store(
+            pool,
+            mint_services_with_authorizer(MockTokenizer::new()),
+        );
+        let entity = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::TokensReceived { .. }),
+            "expected TokensReceived after replay with a trailing \
+             acknowledgement, got: {entity:?}"
+        );
+    }
+
+    /// The delivery job only fires after `MintAuthorizationSigned` persists,
+    /// so an acknowledgement with nothing signed is a caller bug.
+    #[tokio::test]
+    async fn recording_delivery_without_signed_authorization_errors() {
+        let store = TestStore::<TokenizedEquityMint>::new(mint_services_with_authorizer(
+            MockTokenizer::new(),
+        ));
+        let id = issuer_request_id("ISS001");
+        store.send(&id, mint_command()).await.unwrap();
+
+        let error = store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RecordMintAuthorizationDelivered,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AggregateError::UserError(LifecycleError::Apply(
+                    TokenizedEquityMintError::AuthorizationNotSigned
+                ))
+            ),
+            "expected AuthorizationNotSigned, got: {error:?}"
+        );
+    }
+
+    /// The on-disk shape of the new events is permanent -- pin it against
+    /// literal JSON (hex-encoded nonce/signature), not just a round-trip.
+    #[test]
+    fn authorization_events_pin_hex_wire_format() {
+        let signed = TokenizedEquityMintEvent::MintAuthorizationSigned {
+            nonce: B256::repeat_byte(0x07),
+            signature: alloy::primitives::Bytes::from(vec![0xab, 0xcd]),
+            signed_at: "2026-01-02T03:04:05Z".parse().unwrap(),
+        };
+        assert_eq!(
+            serde_json::to_value(&signed).unwrap(),
+            serde_json::json!({
+                "MintAuthorizationSigned": {
+                    "nonce": "0x0707070707070707070707070707070707070707070707070707070707070707",
+                    "signature": "0xabcd",
+                    "signed_at": "2026-01-02T03:04:05Z"
+                }
+            })
+        );
+
+        let delivered = TokenizedEquityMintEvent::MintAuthorizationDelivered {
+            delivered_at: "2026-01-02T03:04:05Z".parse().unwrap(),
+        };
+        assert_eq!(
+            serde_json::to_value(&delivered).unwrap(),
+            serde_json::json!({
+                "MintAuthorizationDelivered": {
+                    "delivered_at": "2026-01-02T03:04:05Z"
+                }
+            })
+        );
+    }
+
     #[test]
     fn evolve_full_happy_path_with_event_helpers() {
         let mut state: Option<TokenizedEquityMint> = None;
@@ -3202,6 +4204,7 @@ mod tests {
             tokenization_request_id: tokenization_request_id("TOK001"),
             requested_at: now,
             accepted_at: later,
+            authorization: crate::tokenized_equity_mint::MintAuthorizationProgress::default(),
         };
         let TransferOperation::EquityMint(op) = accepted.to_dto(&id) else {
             panic!("Expected EquityMint");
@@ -3907,6 +4910,7 @@ mod tests {
                 tokenization_request_id: tok.clone(),
                 requested_at: now,
                 accepted_at: now,
+                authorization: crate::tokenized_equity_mint::MintAuthorizationProgress::default(),
             }
             .is_terminal(),
         );

--- a/src/unwrapped_equity_recovery/aggregate.rs
+++ b/src/unwrapped_equity_recovery/aggregate.rs
@@ -907,6 +907,7 @@ mod tests {
 
     use crate::bot_gas::{BotGasChain, RecordBotGasReceiptCostJobQueue, pending_bot_gas_jobs};
     use crate::equity_redemption::redemption_aggregate_id;
+    use crate::mint_authorization::ConfiguredMintAuthorizer;
     use crate::onchain::mock::{ConfirmTxBehavior, DepositBehavior, DepositCall, MockRaindex};
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::vault_lookup::{MockVaultLookup, VaultLookup};
@@ -984,6 +985,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let mint_store = Arc::new(st0x_event_sorcery::test_store(
             pool.clone(),

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -764,6 +764,7 @@ mod tests {
     use crate::equity_redemption::{
         EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,
     };
+    use crate::mint_authorization::ConfiguredMintAuthorizer;
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
     use crate::rebalancing::trigger::InProgressGuard;
@@ -817,6 +818,7 @@ mod tests {
             tokenizer: tokenizer.clone(),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
         let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
@@ -892,6 +894,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
         let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
@@ -976,6 +979,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
         let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
@@ -2090,6 +2094,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
         let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -634,6 +634,7 @@ mod tests {
 
     use crate::bot_gas::{BotGasChain, pending_bot_gas_jobs};
     use crate::equity_redemption::redemption_aggregate_id;
+    use crate::mint_authorization::ConfiguredMintAuthorizer;
     use crate::onchain::mock::{DepositBehavior, MockRaindex};
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::vault_lookup::MockVaultLookup;
@@ -677,6 +678,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let mint_store = Arc::new(st0x_event_sorcery::test_store(
             pool.clone(),
@@ -943,6 +945,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let mint_store = Arc::new(st0x_event_sorcery::test_store(
             pool.clone(),

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -592,6 +592,7 @@ mod tests {
     use super::*;
     use crate::inventory::BroadcastingInventory;
     use crate::inventory::view::InventoryView;
+    use crate::mint_authorization::ConfiguredMintAuthorizer;
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
     use crate::vault_lookup::{MockVaultLookup, VaultLookup};
@@ -626,6 +627,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
         let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
@@ -757,6 +759,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: wrapper.clone(),
             bot_gas_enqueuer: BotGasReceiptCostEnqueuer::Disabled,
+            mint_authorizer: ConfiguredMintAuthorizer::Disabled,
         };
         let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
         let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));


### PR DESCRIPTION
## What

Implements orchestrator-mode mint authorization (RAI-1243). When an asset's `vault_mode` on the issuance service reads `"orchestrator"`, the mint saga now signs a `MintAuthV1` recipient authorization and delivers it to issuance before polling for completion. Vault-direct assets are unaffected.

## Why

Issuance will not execute an orchestrator-mode mint until it receives a valid recipient authorization signed by the configured orchestrator wallet. Without this, orchestrator-mode mints would be accepted by the bot but stall indefinitely at the issuance polling step.

## How

**Aggregate changes (`tokenized_equity_mint.rs`):**

- Added `MintAuthorizationProgress` enum (`NotSigned`, `Signed`, `Delivered`) embedded in the `MintAccepted` state with `#[serde(default)]` so existing event streams replay unchanged.
- Added `MintAuthorizationSigned` and `MintAuthorizationDelivered` events, persisted to the event log with hex-encoded nonce and signature.
- Added `SignMintAuthorization` and `RecordMintAuthorizationDelivered` commands. Signing is idempotent: a re-drive finding an existing authorization emits nothing rather than minting a fresh nonce (the nonce is the mint's on-chain idempotency key).
- Bumped `SCHEMA_VERSION` to 5 to clear stale snapshots.
- Extended `interrupted_mint_ids` to include mints whose latest event is `MintAuthorizationSigned` or `MintAuthorizationDelivered`, so a crash between signing and delivery is recovered on restart.

**`ConfiguredMintAuthorizer`:**

- New `Enabled`/`Disabled` enum added to `mint_authorization.rs`, mirroring `BotGasReceiptCostEnqueuer`. `Disabled` fails loudly if signing is ever reached without an `[orchestrator]` config section. Added to `EquityTransferServices`.

**Saga wiring (`rebalancing/equity/mod.rs`):**

- `CrossVenueEquityTransfer` gains an optional `MintAuthorizationWiring` (vault-mode reader, token address map, delivery queue), opted in via `with_mint_authorization`.
- `ensure_mint_authorization` is called both on the initial mint acceptance path and on every resume from `MintAccepted`. It reads `vault_mode` from issuance, signs if orchestrator-mode, and enqueues the delivery job. A live-delivery guard prevents a second delivery chain from starting during a delayed-redrive window.

**Delivery job (`rebalancing/equity/authorization_job.rs`):**

- New `DeliverMintAuthorization` apalis job. Loads the persisted authorization from the aggregate and delivers it to issuance. Uses bounded delayed redrives (30 s delay, 20-attempt budget, ~10 minutes total) for retryable outcomes (`MintNotFoundYet`, transport failures) rather than consuming the three-attempt apalis budget. Non-retryable rejections (409/422) park the mint with an operator alert and return `Ok` so the best-effort worker keeps running.
- Registered on a best-effort worker so a stuck authorization never halts hedging or fill detection.

**Conductor wiring:**

- `build_mint_authorization_infra` constructs the `ConfiguredMintAuthorizer` (enabled only when `[orchestrator]` is configured), the delivery queue, the `MintAuthorizationWiring`, and a shared `IssuanceClient`. Orphaned delivery rows from a prior crash are requeued at startup.
- `DeliverMintAuthorizationJobQueue` and `DeliverMintAuthorizationCtx` are threaded through `PositionAndRebalancing`, `RebalancingInfrastructure`, and the conductor builder.
- CLI and non-rebalancing paths set `mint_authorizer: ConfiguredMintAuthorizer::Disabled`; the comment explains why orchestrator-mode mints must run through the server.

**Stall clock and performance tracking:**

- `MintAuthorizationSigned` and `MintAuthorizationDelivered` refresh the stall clock in `MintTracking` without advancing the stage (genuine forward progress for a mint waiting in `Accepted`).
- Both events are treated as no-ops in inventory, reliability, and timing projections where they carry no share movement.

## Testing

- Unit tests on the aggregate cover: signing persists `Signed` progress; re-signing keeps the original nonce; distinct mints generate independent nonces; signing with `Disabled` authorizer fails loudly; delivery transitions to `Delivered` and is idempotent; delivery without a signed authorization errors.
- Wire-format pin tests assert the exact hex JSON shape of `MintAuthorizationSigned` and `MintAuthorizationDelivered` events.
- Replay tests confirm pre-authorization streams default to `NotSigned` and that a pinned hex payload materializes with the correct nonce and signature bytes.
- `interrupted_mint_ids` test confirms mints awaiting delivery are included in startup recovery.
- Delivery job tests cover: `Recorded` marks the aggregate delivered; `Rejected`/`Conflict` parks with one operator alert; `MintNotFoundYet` schedules a delayed redrive; budget exhaustion dead-letters with an alert; an already-delivered mint is a no-op.
- Integration tests on `CrossVenueEquityTransfer` cover: orchestrator-mode resume signs once and enqueues exactly one delivery job; a second resume is idempotent; the live-delivery guard prevents a second chain over a pending redrive successor; vault-direct resume signs nothing and enqueues nothing.

## Anything else

The `[orchestrator]` config section remains optional. While every asset is vault-direct the bot deploys without it, and an orchestrator-mode mint reaching the signing step fails loudly rather than guessing an address. The mint stays in `MintAccepted` with its authorization persisted and is resumable once the section is added.



Closes [RAI-1677](https://linear.app/makeitrain/issue/RAI-1677/mint-authorization-signing-delivery-and-mode-discovery)  
Part of [RAI-1243](https://linear.app/makeitrain/issue/RAI-1243/liquidity-bot-sign-and-deliver-mintauthv1-for-orchestrator-mode-mints)

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added orchestrator-mode mint authorization with signing, persistence, and delivery acknowledgements.
  * Added stable per-mint nonces, signature reuse, idempotent delivery, and duplicate protection.
  * Added automatic retries for temporary delivery failures and operator alerts for unresolved authorizations.
  * Vault-direct mints continue without authorization delivery.
* **Bug Fixes**
  * Authorization events now update mint progress and timing without advancing lifecycle stages or reporting failures.
  * Improved recovery handling for interrupted authorization deliveries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->