### PR TITLE
Orchestrator-mode EIP-712 mint recipient authorization signing and delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ markets by providing continuous two-sided liquidity.
   directional exposure from onchain fills
 - **Operator Vault Controls**: CLI supports generic ERC20 deposits to and
   withdrawals from Raindex vaults, with a USDC-specific withdrawal shortcut
+- **Orchestrator-Mode Mint Authorization**: For assets issuance serves through
+  an `ST0xOrchestrator` vault, signs an EIP-712 MintAuthV1 recipient
+  authorization (nonce persisted before delivery, byte-identical retries) and
+  delivers it to issuance before the mint can complete; vault-direct assets are
+  untouched (see SPEC.md "Mint Recipient Authorization")
 
 ## Getting Started
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -168,6 +168,51 @@ Removing or repricing the standing Raindex orders to avoid stale-NAV arbitrage
 during the freeze window is order-management work external to this bot, and out
 of scope here.
 
+#### Mint Recipient Authorization (Orchestrator Mode)
+
+Issuance is migrating vaults behind an `ST0xOrchestrator` contract. For an
+orchestrator-mode asset, issuance will not mint until the **recipient** has
+authorized the exact mint with an EIP-712
+`MintAuth(token, recipient, amount, nonce)` signature. `MintAuth` names the
+EIP-712 struct; **MintAuthV1** — the term issuance's wire DTOs and this repo's
+module docs use — labels version 1 of the `{nonce, signature}` authorization
+payload delivered to issuance. The recipient of rebalancing mints is this bot,
+so it must sign and deliver that authorization. The point is a two-key security
+property: the mint-signing key (issuance, Turnkey `S01Minter`) and the
+recipient-authorization key (this bot's wallet, a different Turnkey wallet) are
+distinct — neither key alone can both mint and authorize.
+
+- **Mode discovery**: per-asset `vault_mode` (`"vault_direct"` |
+  `"orchestrator"`) comes from issuance's status endpoint — the same
+  InternalAuth endpoint the freeze gate polls. Issuance's config is the single
+  source of truth; this bot keeps no asset-mode list. The mode read is part of
+  every server-side mint initiation and fails closed — an indeterminate mode is
+  never treated as vault-direct. For vault-direct assets the post-discovery
+  execution path is unchanged: no signing, no delivery.
+- **Signing**: the bot reads the digest from the configured orchestrator's
+  `mintAuthDigest(token, recipient, amount, nonce)` view and signs that — never
+  constructing EIP-712 locally, so typehash/domain drift is impossible. `amount`
+  is the mint quantity scaled losslessly to 18-decimal share-wei. The wallet
+  seam is `Wallet::sign_digest`: private-key backend for dev/test, Turnkey
+  `ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2` (no-op hashing, hex payload) in
+  production.
+- **Nonce discipline**: a random `bytes32` generated once per mint, persisted
+  (`MintAuthorizationSigned`) before any delivery attempt, and redelivered
+  byte-identically on every retry. A fresh nonce only ever belongs to a
+  replacement mint (a new aggregate); signing is a no-op when a signed
+  authorization already exists.
+- **Delivery**: a durable job posts `{nonce, signature}` to issuance keyed by
+  `tokenization_request_id`. Outcomes: `200` recorded (idempotent on
+  byte-identical redelivery); `404` (issuance has no mint yet — the initiation
+  race) and transport/`502` failures get bounded delayed redrives; `409`/`422`
+  park the delivery with an operator alert (a conflicting or rejected
+  authorization is never retried automatically — the mint then stalls at polling
+  until an operator resolves it).
+- **Configuration**: `[orchestrator] address = "0x…"` in the plaintext config,
+  optional as a whole — while every asset is vault-direct the bot deploys
+  without the section. An orchestrator-mode mint reaching the signing step
+  without it fails loudly rather than guessing an address.
+
 ## Bot Implementation Specification
 
 The arbitrage bot will be built in Rust to leverage its performance, safety, and
@@ -2119,8 +2164,12 @@ vault for liquidity provision.
 
 **Services**:
 `EquityTransferServices { raindex: Arc<dyn Raindex>, tokenizer:
-Arc<dyn Tokenizer>, wrapper: Arc<dyn Wrapper> }`
--- shared with `EquityRedemption`.
+Arc<dyn Tokenizer>, wrapper: Arc<dyn Wrapper>, mint_authorizer:
+ConfiguredMintAuthorizer, .. }`
+-- shared with `EquityRedemption`. `mint_authorizer` signs MintAuthV1 recipient
+authorizations for orchestrator-mode mints; `Disabled` without an
+`[orchestrator]` config section, so `SignMintAuthorization` fails loudly rather
+than guessing an orchestrator address.
 
 ##### State Flow
 
@@ -2155,13 +2204,22 @@ Terminal states store audit-critical fields not available from earlier events:
 ```rust
 enum TokenizedEquityMint {
     MintRequested { symbol, quantity, wallet, requested_at },
-    MintAccepted { /* + issuer_request_id, tokenization_request_id */ },
+    MintAccepted { /* + issuer_request_id, tokenization_request_id,
+        authorization: MintAuthorizationProgress */ },
     TokensReceived { /* + token_tx_hash, receipt_id, shares_minted */ },
     TokensWrapped { /* + wrap_tx_hash, wrapped_shares */ },
     DepositedIntoRaindex { symbol, quantity, issuer_request_id,
         tokenization_request_id, token_tx_hash, wrap_tx_hash,
         vault_deposit_tx_hash, deposited_at },
     Failed { symbol, quantity, reason, requested_at, failed_at },
+}
+
+/// Orchestrator-mode recipient-authorization progress, tracked on
+/// `MintAccepted`; stays `NotSigned` for vault-direct mints.
+enum MintAuthorizationProgress {
+    NotSigned,
+    Signed { nonce, signature },
+    Delivered { nonce, signature },
 }
 ```
 
@@ -2172,6 +2230,16 @@ enum TokenizedEquityMintCommand {
     /// Initialize: calls tokenizer.request_mint(), emits
     /// MintRequested + MintAccepted (or MintRejected on rejection).
     RequestMint { issuer_request_id, symbol, quantity, wallet },
+    /// Orchestrator mode only: reads the orchestrator digest, signs it,
+    /// emits MintAuthorizationSigned. No-op when already signed -- the
+    /// persisted nonce is the mint's idempotency key and is never
+    /// regenerated for the same mint.
+    SignMintAuthorization { token },
+    /// Records issuance's 200 acknowledgement of the delivered
+    /// authorization; dispatched by the delivery job. Emits
+    /// MintAuthorizationDelivered (also when the mint has already
+    /// advanced past MintAccepted -- see business rules).
+    RecordMintAuthorizationDelivered,
     /// Transition: calls tokenizer.poll_mint_until_complete(),
     /// emits TokensReceived (or MintAcceptanceFailed).
     Poll,
@@ -2190,6 +2258,9 @@ enum TokenizedEquityMintEvent {
 
     MintAccepted { issuer_request_id, tokenization_request_id, accepted_at },
     MintAcceptanceFailed { reason, failed_at },
+
+    MintAuthorizationSigned { nonce, signature, signed_at },
+    MintAuthorizationDelivered { delivered_at },
 
     TokensReceived { tx_hash, receipt_id, shares_minted, received_at },
 
@@ -2213,6 +2284,28 @@ enum TokenizedEquityMintEvent {
   ERC-4626 shares
 - `DepositToVault` only from TokensWrapped state
 - DepositedIntoRaindex and Failed are terminal states
+- `SignMintAuthorization` only in MintAccepted (the saga dispatches it between
+  acceptance and `Poll` for orchestrator-mode assets); a no-op when already
+  signed, so at-least-once saga re-drives reuse the persisted nonce
+  byte-identically. A late signing attempt after tokens arrive is a benign no-op
+  (issuance already consumed the authorization or never needed one); only
+  pre-acceptance and terminal states hard-error
+- `RecordMintAuthorizationDelivered`: in MintAccepted it requires a signed
+  authorization (acknowledging an unsigned mint is a caller bug). It normally
+  executes AFTER the mint advanced past MintAccepted: `Poll` holds the
+  per-aggregate lock for the whole Alpaca wait, and issuance completes the mint
+  only once the authorization arrived, so the acknowledgement queues behind
+  `Poll` and lands on `TokensReceived` or later — recorded there as an audit
+  fact with no state change. Advanced states carry no authorization progress, so
+  the signed-authorization requirement is a delivery-job invariant there, not
+  aggregate validation: the job only fires after `MintAuthorizationSigned`
+  persisted (still durable in the event stream), and the advanced state itself
+  proves issuance accepted the mint. No-op on already-delivered and on terminal
+  states.
+- A mint interrupted between `MintAuthorizationSigned` and
+  `MintAuthorizationDelivered` is resumed by startup recovery, which re-enqueues
+  delivery of the persisted authorization (issuance's `200` is idempotent on
+  byte-identical redelivery)
 
 #### EquityRedemption Aggregate
 

--- a/docs/cqrs.md
+++ b/docs/cqrs.md
@@ -135,6 +135,35 @@ store.send(&symbol, PositionCommand::AcknowledgeFill { /* ... */ }).await?;
 - Live -> `Entity::transition`
 - Failed -> returns the stored error
 
+### Per-Aggregate Command Serialization
+
+`Store::send()` serializes per aggregate ID, and the lock is held for the ENTIRE
+command execution -- including every `await` inside the handler. A
+same-aggregate `send()` issued from within a command's own await-chain fails
+fast with `LifecycleError::ReentrantCommand`.
+
+Consequences that have bitten us:
+
+- A long-running handler blocks every other `send()` to that aggregate until it
+  returns. `TokenizedEquityMint::Poll` awaits `poll_mint_until_complete()` for
+  the whole Alpaca wait (up to the 30-minute poll timeout), so a command
+  dispatched mid-mint (e.g. `RecordMintAuthorizationDelivered` from the delivery
+  job) queues behind it and executes against the POST-transition state, not the
+  state at dispatch time. Handlers for such commands must accept the states the
+  aggregate can have advanced to meanwhile -- and `evolve` must apply the
+  resulting event in those states too, because `Ok(None)` from `evolve` is
+  `LifecycleError::UnexpectedEvent` and poisons every future replay of that
+  aggregate.
+- A worker whose job dispatches a command to a busy aggregate holds its
+  (single-concurrency) worker slot until the lock frees. Acceptable when the
+  wait is bounded and nothing else queues behind it; otherwise decouple.
+
+`Store::load()` does NOT take the lock -- it replays persisted events -- so
+reads never block behind an in-flight command. While the handler is still
+executing (events not yet persisted), a `load()` sees the pre-transition state;
+once the command's events persist -- momentarily before `send()` returns and
+releases the lock -- a concurrent `load()` already observes them.
+
 ## Reading State via Projections
 
 Production code reads entity state through `Projection`, never by loading

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -207,3 +207,18 @@ equities:
 
 Both operations provide an immutable audit trail, tracked as CQRS event-sourced
 aggregates (`TokenizedEquityMint`, `EquityRedemption`).
+
+### Mint Recipient Authorization
+
+For assets issuance serves through an `ST0xOrchestrator` vault
+(`vault_mode: "orchestrator"` on issuance's status endpoint), issuance will not
+mint until the recipient signs an EIP-712
+`MintAuth(token, recipient, amount, nonce)` authorization over the digest read
+from the orchestrator contract. `MintAuth` names the EIP-712 struct;
+`MintAuthV1` labels version 1 of the `{nonce, signature}` payload built from it
+and delivered to issuance. This bot is the recipient of rebalancing mints, so it
+signs (`MintAuthorizationService`, wallet seam `Wallet::sign_digest`) and
+delivers the authorization to issuance (`DeliverMintAuthorization` job). The
+nonce is generated once per mint, persisted before delivery, and reused
+byte-identically on retries. See SPEC.md "Mint Recipient Authorization
+(Orchestrator Mode)".


### PR DESCRIPTION
## What

Adds orchestrator-mode mint recipient authorization support, where assets served through an `ST0xOrchestrator` vault require the mint recipient (this bot) to sign and deliver an EIP-712 `MintAuth(token, recipient, amount, nonce)` authorization before issuance will complete the mint.

## Why

Issuance is migrating vaults behind an `ST0xOrchestrator` contract that enforces a two-key security property: the mint-signing key (issuance's Turnkey `S01Minter`) and the recipient-authorization key (this bot's wallet) are distinct, so neither key alone can both mint and authorize a recipient.

## How

**Mode discovery**: The bot reads `vault_mode` (`"vault_direct"` | `"orchestrator"`) from issuance's existing status endpoint. Vault-direct assets take the pre-existing path completely unchanged.

**Signing**: Rather than constructing EIP-712 locally, the bot reads the digest directly from the orchestrator contract's `mintAuthDigest(token, recipient, amount, nonce)` view and signs it via `Wallet::sign_digest`, eliminating any risk of typehash or domain drift. The `amount` is scaled losslessly to 18-decimal share-wei.

**Nonce discipline**: A random `bytes32` nonce is generated once per mint, persisted as `MintAuthorizationSigned` before any delivery attempt, and reused byte-identically on every retry. A fresh nonce only belongs to a replacement mint.

**Delivery**: A durable job posts `{nonce, signature}` to issuance keyed by `tokenization_request_id`. `200` responses are recorded as idempotent; `404` and transport failures get bounded delayed redrives; `409`/`422` park delivery with an operator alert and never retry automatically.

**State tracking**: `MintAccepted` now carries a `MintAuthorizationProgress` field (`NotSigned` | `Signed` | `Delivered`). Two new commands (`SignMintAuthorization`, `RecordMintAuthorizationDelivered`) and two new events (`MintAuthorizationSigned`, `MintAuthorizationDelivered`) are added to the `TokenizedEquityMint` aggregate. Because `Poll` holds the per-aggregate lock for the entire Alpaca wait, `RecordMintAuthorizationDelivered` will typically execute against a post-`Poll` state and is handled as an audit-only no-op in those cases.

**Configuration**: An optional `[orchestrator] address = "0x…"` section is added to the plaintext config. Without it the authorizer is `Disabled`; an orchestrator-mode mint reaching the signing step without a configured address fails loudly. An indeterminate vault-mode read always fails closed and is never treated as vault-direct.

CQRS documentation is updated to explicitly call out per-aggregate command serialization consequences, particularly around long-running handlers blocking same-aggregate commands and the resulting state the late command must handle.

## Testing

## Screenshots

## Anything else

Startup recovery re-enqueues delivery of any persisted-but-undelivered authorization, relying on issuance's idempotent `200` response for byte-identical redelivery.



Closes [RAI-1685](https://linear.app/makeitrain/issue/RAI-1686/docs-update)

Closes [RAI-1243](https://linear.app/makeitrain/issue/RAI-1243/liquidity-bot-sign-and-deliver-mintauthv1-for-orchestrator-mode-mints)

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Orchestrator-mode asset issuance now supports recipient authorization using EIP-712 MintAuthV1 signatures.
  * Authorization progress is tracked through signing and delivery, with persisted nonces and idempotent retries.
  * Interrupted authorization delivery can recover after service restart.
  * Vault-direct asset issuance remains unchanged.

* **Documentation**
  * Added guidance for mint authorization, command processing, and aggregate command serialization.
  * Documented recipient authorization concepts, signing requirements, delivery handling, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->