### PR TITLE
fix: hold back prod cash reserve to fund the USDC conversion collar

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -145,8 +145,12 @@ vault_id = "0xfab2"
 rebalancing = "enabled"
 # Maximum USDC moved per rebalance operation.
 operational_limit = 10000
-# No cash reserve: all offchain USDC is available for rebalancing.
-# (Omitted because `reserved` is typed Positive<Usd> and rejects 0.)
+# Cash held back at the broker. This is a stopgap, not an operational floor. A
+# transfer sized at the full withdrawable balance cannot fund the ~2% collar that
+# the USDCUSD market buy reserves, so the conversion returns 403 and the circuit
+# opens. Keep this above 2% of operational_limit. RAI-1522 sizes capacity from the
+# collar instead, after which this goes back to 0 (omitted).
+reserved = 250
 
 # Per-equity asset configuration.
 # - trading: whether the bot hedges fills for this asset.


### PR DESCRIPTION
## What

- Sets `reserved = 250` under `[assets.cash]` in `config/prod/st0x-hedge.toml`.
- Replaces the comment that said the prod cash reserve is 0.
- Closes [RAI-1698](https://linear.app/makeitrain/issue/RAI-1698/persist-the-prod-cash-reserve-so-a-deploy-does-not-re-break-usdc). Stopgap for [RAI-1522](https://linear.app/makeitrain/issue/RAI-1522/size-alpacatobase-usdc-capacity-so-the-transfer-can-fund-its-own-usd).

## Why

- The Alpaca to Base rebalance sizes the transfer at the full withdrawable cash. The `USDCUSD` market buy that funds it needs about 2% more. So the conversion returns 403 and the circuit opens.
- The reserve is the only thing that covers that 2% today. At 0 it fails every time and no USDC moves.
- [RAI-902](https://linear.app/makeitrain/issue/RAI-902/set-prod-cash-reserve-to-0-in-checked-in-config) removed the reserve from this file. A deploy therefore reverts any live fix, which is how prod broke again on 2026-08-10.

## How

- 250 is above 2% of `operational_limit` (10000). That covers the largest transfer the bot will size.
- `reserved` is typed `Option<Positive<Usd>>`. The loader rejects 0, so a positive amount is the only way to express this.
- The value is already live on prod. I set it in `/run/st0x/st0x-hedge.config` and restarted the bot. This PR stops the next deploy from reverting it.

## Testing

- `cargo nextest run -p st0x-config server_config_toml_is_valid` passes. That test parses this exact file.
- No new tests. This is a config value change.
- I checked prod after the restart. The rebalance now skips cleanly instead of failing, and there are no terminal failures since.

## Anything else

- The comment in the file says this is a stopgap and points at RAI-1522. Delete the value when that lands. Do not inherit it.
- Keep in mind that raising `operational_limit` breaks this again. It breaks silently, cause the 2% scales with the transfer size and a fixed reserve does not.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788960741&installation_model_id=19370&pr_number=1154&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1154&signature=56d0c712f08d19d8d18d1bad5e31c574306a7126f1fde26d815824b924458b8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated cash management settings to reserve 250 USDC for broker-held cash.
  * Prevents reserved off-chain funds from being used for rebalancing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->