### PR TITLE
docs: make rust docs compile

### DIFF
--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -311,7 +311,8 @@ fn parse_received_message(message: &[u8]) -> Result<CctpReceivedMessage<'_>, Cct
 /// Provides the minimal set of values needed to construct the bridge.
 /// CCTP contract addresses default to production addresses but can be
 /// overridden for testing with locally deployed contracts.
-/// Providers are obtained from the wallets via [`Wallet::provider()`].
+/// Providers are obtained from the wallets via `Wallet`'s inherited
+/// [`Evm::provider()`](st0x_evm::Evm::provider).
 pub struct CctpCtx<EthWallet, BaseWallet> {
     /// USDC token address on Ethereum
     pub usdc_ethereum: Address,

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1198,11 +1198,12 @@ impl Ctx {
 
     /// Validates config and secrets files without constructing runtime objects.
     ///
-    /// Calls the same [`parse_and_validate`] function as [`load_files`](Self::load_files),
-    /// ensuring identical validation. The only difference is that `load_files`
-    /// additionally performs async wallet construction (which connects to RPC
-    /// endpoints). Suitable for pre-deploy validation where we want to catch
-    /// config errors before restarting the service.
+    /// Calls the same `parse_and_validate` function (private to this module) as
+    /// [`load_files`](Self::load_files), ensuring identical validation. The only
+    /// difference is that `load_files` additionally performs async wallet
+    /// construction (which connects to RPC endpoints). Suitable for pre-deploy
+    /// validation where we want to catch config errors before restarting the
+    /// service.
     pub fn validate_files(config_path: &Path, secrets_path: &Path) -> Result<(), CtxError> {
         let config_str =
             std::fs::read_to_string(config_path).map_err(|source| CtxError::ConfigIo {

--- a/crates/dto/src/statement.rs
+++ b/crates/dto/src/statement.rs
@@ -21,8 +21,8 @@ use crate::{CurrentState, LegacyTrade, Position, Trade};
 /// [`VariantNames`] derives `Statement::VARIANTS` — a compile-time
 /// slice of all variant names in snake_case. Adding a variant
 /// automatically updates the list; no manual bookkeeping needed.
-/// The dashboard uses [`guard_ts`] output to validate incoming
-/// WebSocket messages at runtime before dispatching.
+/// The dashboard uses [`guard_ts`](Statement::guard_ts) output to
+/// validate incoming WebSocket messages at runtime before dispatching.
 #[derive(Debug, Clone, Serialize, VariantNames, TS)]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -43,7 +43,7 @@ impl Statement {
     /// `Statement` so the subsequent `matcher` call is type-safe —
     /// without it the dashboard would need an unsafe cast.
     ///
-    /// Tags come from [`VARIANTS`] (derived by strum from this enum).
+    /// Tags come from `VARIANTS` (derived by strum from this enum).
     /// The `satisfies StatementType[]` clause in the output gives a
     /// TypeScript-side compile error if the tags ever drift from the
     /// generated `Statement` type definition.

--- a/crates/evm/src/nonce.rs
+++ b/crates/evm/src/nonce.rs
@@ -20,16 +20,15 @@
 //!   `submit::TxSubmitter::pending_nonce`'s doc comment), so the send
 //!   would be accepted and merely queue behind it, and the replacement
 //!   would never happen.
-//! - [`set_next_nonce()`] seeds the cache with a known-good nonce,
-//!   skipping the re-fetch entirely. Nonce-too-low recovery in
-//!   `submit::retry_after_nonce_too_low` uses this to seed a
+//! - `set_next_nonce()` (crate-internal) seeds the cache with a
+//!   known-good nonce, skipping the re-fetch entirely. Nonce-too-low
+//!   recovery in `submit::retry_after_nonce_too_low` uses this to seed a
 //!   pending-aware target nonce it computes itself (the higher of the
 //!   node's reported next nonce and its own `pending` read), since the
 //!   cold-cache re-fetch above intentionally stays on `latest`.
 //!
 //! [`CachedNonceManager`]: alloy::providers::fillers::CachedNonceManager
 //! [`invalidate()`]: ResettableNonceManager::invalidate
-//! [`set_next_nonce()`]: ResettableNonceManager::set_next_nonce
 
 use alloy::network::Network;
 use alloy::primitives::Address;

--- a/crates/execution/src/order/state.rs
+++ b/crates/execution/src/order/state.rs
@@ -12,7 +12,7 @@ use super::OrderStatus;
 /// the original order can still fill, which lets a retry hedge the same position
 /// twice.
 ///
-/// See Alpaca's order lifecycle (https://docs.alpaca.markets/docs/orders-at-alpaca).
+/// See Alpaca's order lifecycle (<https://docs.alpaca.markets/docs/orders-at-alpaca>).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OrderFailureTerminality {
     Terminal,

--- a/crates/execution/src/rate_limit.rs
+++ b/crates/execution/src/rate_limit.rs
@@ -70,7 +70,7 @@ pub fn parse_retry_after(header_value: &str, now: SystemTime) -> Option<Duration
 }
 
 /// Reads and parses the `Retry-After` header from a response's headers, if
-/// present, using [`parse_retry_after`].
+/// present, using `parse_retry_after` (private to this module).
 ///
 /// Returns `None` for a missing header, a header value that is not valid
 /// ASCII/visible-text, or a value the parser cannot interpret.

--- a/crates/wrapper/src/lib.rs
+++ b/crates/wrapper/src/lib.rs
@@ -266,9 +266,9 @@ pub trait Wrapper: Send + Sync {
     ///
     /// Load-balanced RPCs may route the next request to a backend that has
     /// not yet indexed the block produced by a just-confirmed transaction.
-    /// Call this with the block number returned by [`confirm_unwrap`] before
-    /// submitting any dependent on-chain write that reads the unwrapped
-    /// token balance.
+    /// Call this with the block number returned by
+    /// [`confirm_unwrap`](Wrapper::confirm_unwrap) before submitting any
+    /// dependent on-chain write that reads the unwrapped token balance.
     ///
     /// # Errors
     ///

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -68,8 +68,9 @@ pub enum TransferType {
 
 /// Why an operator is reconciling a stuck post-burn USDC transfer.
 ///
-/// CLI-facing mirror of [`crate::usdc_rebalance::ReconcileReason`]; mapped to
-/// the domain enum in the command handler so clap stays out of the aggregate.
+/// CLI-facing mirror of the crate-internal `usdc_rebalance::ReconcileReason`;
+/// mapped to the domain enum in the command handler so clap stays out of the
+/// aggregate.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum ReconcileReasonArg {
     /// The minted USDC was moved to its destination manually.
@@ -358,7 +359,7 @@ pub enum Commands {
         /// Issuer request id for mint resume (printed by a fresh to-raindex run)
         #[arg(long = "issuer-request-id")]
         issuer_request_id: Option<Uuid>,
-        /// Alpaca redemption wallet (overrides [tokenization] config)
+        /// Alpaca redemption wallet (overrides the tokenization config section)
         #[arg(long = "redemption-wallet")]
         redemption_wallet: Option<Address>,
     },
@@ -668,7 +669,7 @@ pub enum Commands {
         /// Number of shares to redeem (supports fractional shares)
         #[arg(short = 'q', long = "quantity")]
         quantity: FractionalShares,
-        /// Alpaca redemption wallet (overrides [tokenization] config)
+        /// Alpaca redemption wallet (overrides the tokenization config section)
         #[arg(long = "redemption-wallet")]
         redemption_wallet: Option<Address>,
         /// Target network for the redemption (selects the wallet that sends

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -453,9 +453,9 @@ pub enum OffchainOrder {
         market_session: MarketSession,
     },
     /// `shares` carries the broker-accepted quantity for orders placed after the
-    /// durable-job extraction (built from [`OffchainOrderEvent::Accepted`]'s
+    /// durable-job extraction (built from `OffchainOrderEvent::Accepted`'s
     /// `placed_shares`), but the originally-requested quantity for pre-extraction
-    /// orders that replay the legacy [`OffchainOrderEvent::Submitted`] event. The
+    /// orders that replay the legacy `OffchainOrderEvent::Submitted` event. The
     /// two can differ when the broker truncated to its precision; consumers that
     /// compare fills against `shares` should treat the legacy value as the
     /// request, not a guaranteed broker-accepted amount.

--- a/src/performance/simulated_transfers.rs
+++ b/src/performance/simulated_transfers.rs
@@ -1011,7 +1011,7 @@ impl Wrapper for FixtureWrapper {
 /// `ConfirmUnwrap`/`SendTokens`) drive the side effect FROM WITHIN
 /// `transition()` itself (mint's analogous commands take the service
 /// result as command input instead), so a fresh, single-cycle-scoped
-/// [`FixtureRaindex`]/[`FixtureVaultLookup`]/[`FixtureWrapper`] triple is
+/// `FixtureRaindex`/`FixtureVaultLookup`/`FixtureWrapper` triple is
 /// built for every redemption.
 pub async fn seed_simulated_equity_redemption_history(
     pool: &SqlitePool,


### PR DESCRIPTION
## What

Fixes 12 broken intra-doc links so `cargo doc` builds the workspace again.

## Why

Rustdoc runs with `-D warnings`, so every broken link is a hard error and no crate produces docs.

## How

- Links to items that aren't publicly reachable (`set_next_nonce`, `parse_retry_after`, `parse_and_validate`, `ReconcileReason`, two `OffchainOrderEvent` variants, the `Fixture*` triple) de-linked to inline code.
- Links that were just written wrong turned into real ones: `guard_ts`, `confirm_unwrap` (bare method names don't resolve from a trait's own doc), and `Wallet::provider()` — which never existed, since `provider()` comes from the `Evm` supertrait.
- Markdown accidents: bare Alpaca URL wrapped in `<>`, strum-derived `VARIANTS` de-linked, and two clap help strings reading `overrides [tokenization] config` reworded rather than backslash-escaped, since those doc comments are also `--help` output.

## Testing

`cargo doc --workspace --no-deps` and `--all-features` both error-free; `cargo fmt --check` passes. Comments only, no behaviour change.

## Anything else

Three errors surface only under `--all-features`. Seven warnings remain from `rain-math-float`, which nix materializes read-only under `.tmp/` from upstream — not ours to edit; `--exclude rain-math-float` silences them.
