### PR TITLE
ci: add `cargo doc` check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,14 +129,19 @@ jobs:
           save-if: ${{ env.UNTRUSTED_PR != 'true' }}
 
       # Build the test binaries once into a nextest archive shared by all four
-      # partitions, and run clippy here since this is the single full compile.
-      - name: Build nextest archive and run clippy
+      # partitions, and run clippy and rustdoc here since this is the single
+      # full compile.
+      - name: Build nextest archive, run clippy and docs
         run: |
           nix develop .#ci-backend -c bash -c "
             set -euxo pipefail
             cargo nextest archive --workspace --all-features --profile ci \
               --archive-file \"\$RUNNER_TEMP/nextest-archive.tar.zst\"
             cargo clippy --workspace --all-targets --all-features
+            # rain-math-float is upstream source nix materializes under .tmp/,
+            # so it is a workspace member we do not own; exclude it rather than
+            # gate CI on its rustdoc warnings.
+            cargo doc --workspace --no-deps --all-features --exclude rain-math-float
             # compile_fail_tests (trybuild) shells out to cargo at run time, so
             # run it here where the workspace build cache is warm. The archive
             # partitions only carry prebuilt binaries and would compile it cold.


### PR DESCRIPTION
## What

Adds a `cargo doc` check to the backend CI job.

## Why

Nothing in CI ever ran rustdoc, so 12 broken intra-doc links accumulated unnoticed until #1156 fixed them. This stops the next batch from landing.

## How

One line inside `backend-build`'s existing `nix develop .#ci-backend` block, next to clippy. That step is the single full compile, so the check reuses the warm cache instead of paying for a separate job.

`--exclude rain-math-float` keeps upstream source — which nix materializes read-only under `.tmp/`, making it a workspace member we do not own — from gating our CI on its seven rustdoc warnings.

## Testing

Ran the exact CI command locally: zero warnings, exit 0.

## Anything else

Stacked on #1156. No `-D warnings` plumbing needed: the workspace sets `warnings = "deny"` with per-crate `[lints] workspace = true`, which is what makes broken links hard errors — the same mechanism clippy relies on.
