### PR TITLE
[RAI-1626] Log WARN for a live USDC transfer only after its timeout elapses

### DIFF
--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1018,7 +1018,7 @@ impl RebalancingService {
         // - Pre-burn entries (not yet post-burn) are only selected after the
         //   timeout elapses, as before: they cannot have an in-flight on-chain
         //   burn so abandonment is safe to defer until then.
-        let candidate_ids = {
+        let candidates = {
             let tracking = self.usdc_tracking.read().await;
             tracking
                 .iter()
@@ -1027,7 +1027,7 @@ impl RebalancingService {
                         Self::elapsed_since_timeout_start(tracking.last_progress_at, now)?;
 
                     if tracking.is_post_burn() || elapsed >= self.config.transfer_timeout {
-                        Some(id.clone())
+                        Some((id.clone(), elapsed))
                     } else {
                         None
                     }
@@ -1035,7 +1035,7 @@ impl RebalancingService {
                 .collect::<Vec<_>>()
         };
 
-        for id in candidate_ids {
+        for (id, elapsed) in candidates {
             // A timed-out transfer whose apalis row is still live is NOT
             // abandoned: the job will resume and may have an irreversible on-chain
             // withdraw/burn already submitted. "Live" includes retryable Failed
@@ -1044,14 +1044,28 @@ impl RebalancingService {
             // in-progress guard / inventory inflight nor mark it timed-out (which
             // would make the reactor ignore its eventual terminal event and latch
             // the guard forever). Let apalis drive it to terminal.
+            // A candidate past the burn can land here before its timeout;
+            // that is the healthy in flight state and is logged at debug.
             match self.transfer_live_job_for_id(&id).await {
                 Ok(true) => {
-                    warn!(
-                        target: "rebalance",
-                        aggregate_id = %id,
-                        "USDC transfer exceeded its timeout but its apalis row is still live; \
-                         deferring cleanup to the job rather than clearing the guard"
-                    );
+                    if elapsed >= self.config.transfer_timeout {
+                        warn!(
+                            target: "rebalance",
+                            aggregate_id = %id,
+                            ?elapsed,
+                            "USDC transfer exceeded its timeout but its apalis row is still live; \
+                             deferring cleanup to the job rather than clearing the guard"
+                        );
+                    } else {
+                        debug!(
+                            target: "rebalance",
+                            aggregate_id = %id,
+                            ?elapsed,
+                            "USDC transfer job is live and within its timeout; the sweep \
+                             selected it only because it is past the burn, where durable \
+                             Reconciled state is checked on every tick"
+                        );
+                    }
                     continue;
                 }
                 Ok(false) => {}

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -13526,6 +13526,114 @@ mod tests {
         );
     }
 
+    /// Entries past the CCTP burn are selected on every sweep tick
+    /// regardless of age so a durable Reconciled state is applied promptly.
+    /// An entry whose job row is live and whose elapsed time is below
+    /// transfer_timeout is running normally: the sweep logs the visit at
+    /// debug and leaves the guard and tracking intact.
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn healthy_post_burn_transfer_with_live_job_does_not_warn() {
+        let trigger = make_trigger_with_inventory_config(
+            InventoryView::default(),
+            test_config_with_timeout(Duration::from_secs(1800)),
+        )
+        .await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        let mut queue = trigger.transfer_usdc_to_hedging_queue.clone();
+        queue
+            .push(TransferUsdcToHedging {
+                id: id.clone(),
+                amount: usdc(400),
+                revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
+            })
+            .await
+            .unwrap();
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::BaseToAlpaca,
+                initiated_amount: usdc(400),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::BridgingInitiated,
+                last_progress_at: Utc::now() - ChronoDuration::seconds(20),
+            },
+        );
+
+        trigger
+            .expire_stuck_usdc_rebalances(Utc::now())
+            .await
+            .unwrap();
+
+        assert!(
+            !logs_contain("exceeded its timeout"),
+            "WARN requires elapsed >= transfer_timeout",
+        );
+        assert!(
+            logs_contain("live and within its timeout"),
+            "a live transfer below its timeout logs the sweep visit at debug",
+        );
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "the sweep visit must not clear the guard while the job row is live",
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "the sweep visit must not drop tracking while the job row is live",
+        );
+    }
+
+    /// WARN fires when elapsed reaches transfer_timeout and the job row is
+    /// live, including for entries past the burn, whose selection ignores
+    /// elapsed time.
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn timed_out_post_burn_transfer_with_live_job_still_warns() {
+        let trigger = make_trigger_with_inventory_config(
+            InventoryView::default(),
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        let mut queue = trigger.transfer_usdc_to_hedging_queue.clone();
+        queue
+            .push(TransferUsdcToHedging {
+                id: id.clone(),
+                amount: usdc(400),
+                revert_redrive_attempts: 0,
+                backpressure_streak: BackpressureStreak::default(),
+            })
+            .await
+            .unwrap();
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::BaseToAlpaca,
+                initiated_amount: usdc(400),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::BridgingInitiated,
+                last_progress_at: Utc::now() - ChronoDuration::minutes(31),
+            },
+        );
+
+        trigger
+            .expire_stuck_usdc_rebalances(Utc::now())
+            .await
+            .unwrap();
+
+        assert!(
+            logs_contain("exceeded its timeout"),
+            "a transfer past its timeout with a live job row must keep the WARN",
+        );
+    }
+
     #[tokio::test]
     async fn in_flight_hedging_transfer_blocks_market_making_enqueue() {
         let service = make_trigger_with_inventory(InventoryView::default()).await;


### PR DESCRIPTION
## What

Fixes RAI-1626
The stuck transfer spam logged the timeout WARN for every healthy post burn USDC transfer on every tick. WARN will now fire only when elapsed time has reached `transfer_timeout` and the job row is live.

## Why

Healthy transfers flooded the logs (1094 WARNs in 3h on prod).

## How

`expire_stuck_usdc_rebalances` already computes each candidate's elapsed time during selection; it now carries that value into the sweep loop.
When the sweep finds that a candidate's job is still running, it checks the elapsed time:
- if the transfer has been running longer than `transfer_timeout`, it logs the WARN (as before)
- if it has not, it logs a debug line saying the job is alive

## Testing

- `healthy_post_burn_transfer_with_live_job_does_not_warn`: no WARN, debug line present, guard and tracking untouched
- `timed_out_post_burn_transfer_with_live_job_still_warns` - WARN kept

## Screenshots

n/a

## Anything else

The genuine WARN path still logs on every tick for a truly stuck transfer; dedup is out of scope here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788978134&installation_model_id=19370&pr_number=1161&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1161&signature=686c8219ad1ab4b3f4eea7042ef3a11e8ac59afd78b9f8767080b45b495c3949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stuck USDC transfer handling during sweep checks.
  * Post-burn transfers are now evaluated on every sweep cycle.
  * Transfers with active jobs retain tracking until completion or timeout.
  * Added clearer diagnostics for healthy and timed-out transfer states.
  * Expanded test coverage for post-burn transfers with active jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->