### PR TITLE
test: await bot shutdown before restart

### DIFF
--- a/tests/e2e/rebalancing.rs
+++ b/tests/e2e/rebalancing.rs
@@ -2361,6 +2361,11 @@ async fn inflight_state_survives_restart() -> anyhow::Result<()> {
 
     // Stop the first bot.
     bot1.abort();
+    let join_error = bot1.await.unwrap_err();
+    assert!(
+        join_error.is_cancelled(),
+        "First bot should be cancelled, got: {join_error}"
+    );
     // Allow the abort to propagate and release the database.
     tokio::time::sleep(Duration::from_secs(1)).await;
 


### PR DESCRIPTION
## What

- Wait for `bot1` to finish aborting in `inflight_state_survives_restart`.

## Why

- The merge queue exposed a race during the restart test.
- The second bot could start while the first bot still held the SQLite database.
- The overlap caused the equity stage-timing read model to fail during startup.

## How

- Await the aborted task before the existing one-second database release delay.

## Testing

- Ran `inflight_state_survives_restart` four consecutive times. All four runs passed.
- Ran `cargo nextest run --workspace --all-features`. All 4,359 tests passed, with 6 skipped.

## Screenshots

N/A

## Anything else

- This only changes test shutdown synchronization. It does not change production code.
- The failure occurred in [merge-queue run 31428669855](https://github.com/ST0x-Technology/st0x.liquidity/actions/runs/31428669855/job/93588799422).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved restart test reliability by confirming the first task was cancelled before starting the next one.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->