### PR TITLE
docs: explain close-flatten operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,33 @@ reprice cadence; `broker.close_flatten_reprice_timeout_secs`, the faster cadence
 inside close-flatten; `broker.extended_hours_close_flatten_window_secs`, the
 length of the final window before weekends, exchange holidays, or an unknown
 next session; and `broker.close_flatten_cross_max_bps`, the maximum cross at the
-session close. All five are required and have no implicit defaults. Ordinary
-extended-hours orders retain their 300-second timeout, while close-flatten
-orders use the dedicated 60-second timeout and cross progressively wider until
-the session closes.
+session close. The maximum cross must be at least `counter_trade_slippage_bps`,
+since the ramp starts there, and no more than `9,999` bps, the global
+counter-trade slippage ceiling. All five are required and have no implicit
+defaults. Ordinary extended-hours orders retain their 300-second timeout, while
+close-flatten orders use the dedicated 60-second timeout and cross progressively
+wider until the session closes.
+
+Extended-hours limit orders use an ordered reference chain: an optional current
+bid/ask quote source, the broker's **position mark**, then an emergency
+`delayed_sip` quote. The current deployment has no primary quote provider, so
+its effective behaviour remains mark first, delayed SIP second. The executor
+capability is already present for a future source such as Alpaca SIP, and the
+mark remains the fallback if that source is missing or fails. No market-data
+feed config is exposed until a real provider is selected. See
+[ADR 0019](adrs/0019-mark-priced-close-flatten-with-widening-cross.md).
+
+Inside the close-flatten window the cross ramps linearly from
+`counter_trade_slippage_bps` at the window's start to
+`close_flatten_cross_max_bps` at the close, so each reprice crosses further than
+the last and the bot converges on a fill before the gap. Outside it,
+extended-hours orders keep the flat `counter_trade_slippage_bps` band. Only once
+every reference source has failed does the attempt dead-letter (counted by
+`hedge_dead_lettered_total{symbol,reason}`). Transient failures in queued
+`PlaceHedge` attempts, such as timeouts and 5xx, receive three durable redrives
+after 1s, 2s, and 4s; exhausting that budget increments the same dead-letter
+metric. Scan-time transient and rate-limited preflight failures instead wait for
+`CheckPositions` to re-enqueue the hedge on its next scan.
 
 ## Deployment
 

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -838,26 +838,123 @@ the order cannot strand the position with a pending ID no retry can claim.
 
 During an Extended market session, only symbols with
 `extended_hours_counter_trading = enabled` place limit orders; disabled symbols
-skip. Extended-hours pricing tries the optional primary quote first, then the
-broker position mark, then Alpaca's hardcoded delayed-SIP quote feed. Buys use
-the ask and sells use the bid before applying the configured cross.
+skip. Ordinary extended-hours orders use the shared reference-price resolver
+plus the configured `counter_trade_slippage_bps` buffer. With no primary
+provider wired today, the broker position mark is the first available production
+source.
 
 The executor's `MarketSessionStatus` also classifies the gap after the current
 session as `OrdinaryOvernight`, `MultiDayClosure`, or `Unknown`. Both
 `CheckPositions` and `PlaceHedge` use the same `CloseFlattenPolicy`: during the
 configured final window before a multi-day or unknown gap, the scanner cancels
-any order resting since before the window and placement switches to
-quote-crossing limits. Buys use ask plus the configured buffer; sells use bid
-minus it. The final quote fallback explicitly selects Alpaca's delayed-SIP feed
-so the result is independent of a subscription-dependent default. The hedge is
-abandoned only after every configured source fails.
+any order resting since before the window and placement switches to aggressive
+limits. This close-flatten cancellation is independent of
+`extended_hours_reprice_timeout_secs`: it targets live extended-hours orders
+placed before `CloseFlattenWindow.started_at`, even when they are younger than
+the timeout. That timeout gates only the separate reprice-timeout cancellation
+sweep. The shared resolver first asks an optional current bid/ask quote source,
+then falls back to the broker's position `current_price`, then to the emergency
+delayed quote. No primary provider is wired today, so effective production
+behaviour remains mark first. Buys add the cross and sells subtract it. The
+cross ramps linearly with elapsed time inside the window, from
+`counter_trade_slippage_bps` at the window's start to
+`close_flatten_cross_max_bps` at the close. `CloseFlattenCrossRamp` anchors it
+to the window rather than to a per-order attempt count, so it is a pure function
+of the window and the current time: restart-safe, identical across apalis
+retries, and independent of how many reprice cycles land. A hedge that first
+becomes ready mid-window opens partway up the ramp. See
+[ADR 0019](../adrs/0019-mark-priced-close-flatten-with-widening-cross.md) for
+the source-order and fallback decision.
+
+If the optional primary provider is absent or fails, and the symbol has no
+broker position or its mark lookup also fails, placement falls back to a quote
+on the `delayed_sip` feed. That emergency feed is hardcoded rather than
+configured: `sip` draws an entitlement 403, `iex` publishes single-venue stub
+quotes once it stops trading around 16:00 ET, and `delayed_sip` is the only
+value currently available that returns a real consolidated book. Its quote is a
+genuine NBBO fifteen minutes stale. After validating the book, the order price
+crosses its ask for a buy or its bid for a sell, regardless of spread width,
+since refusing that reference would leave the position unflattened.
+
+Only after the resolver has exhausted the optional primary quote, broker mark,
+and delayed SIP fallback does the selected missing, non-positive, bid-above-ask,
+or failed quote outcome classify as `ErrorScope::SymbolScoped` in
+`TradeAccountingError::scope()`. That says only that the failure was raised
+before this attempt ran `PositionCommand::PlaceOffChainOrder`.
+`handle_place_hedge_error` needs a second answer before it abandons the job,
+because the same variant boxes an opaque source: `find_permanence` walks the
+error chain for a broker `AlpacaBrokerApiError::permanence()` classification. A
+non-429 4xx (the entitlement 403 a `sip` quote draws on a Basic plan) and a
+syntactically malformed response are permanent. A valid but incomplete,
+non-positive, bid-above-ask, or wrong-symbol quote is a dynamic snapshot that
+may clear on the next request; those outcomes, 5xx, timeouts, and transport
+errors are transient.
+
+A permanent cause dead-letters at once, since re-asking cannot change the
+answer. A transient one is re-driven on the job's own durable budget first:
+`redrive_transient_failure` pushes a successor carrying an incremented
+`TransientFailureStreak` after 1s, 2s, then 4s, mirroring the supervised
+worker's `RetryPolicy::retries(3)` and its backoff, so the retry cadence is
+unchanged and only the terminal action differs. The streak is a `#[serde]`
+payload field, so it survives a restart rather than resetting the budget. Once
+`TRANSIENT_RESCHEDULE_LIMIT` re-drives are spent the symbol dead-letters like a
+permanent cause, because propagating instead would exhaust the shared retry
+budget and stop hedging for every other symbol -- the outage this isolation
+exists to prevent (RAI-1690).
+
+On a terminal symbol-scoped path the dead-letter is the same: the job increments
+`hedge_dead_lettered_total{symbol,reason}`, logs the cause, pages the operator
+through the shared `Notifier` (once per `(symbol, reason)`, so the ~60s
+`CheckPositions` re-enqueue cannot spam the channel), and returns `Ok(())`
+rather than consuming the shared retry budget or propagating an error that
+affects other symbols. A process-scoped recovery failure instead propagates
+through `dead_letter_or_propagate` so apalis can retry it. Notification delivery
+is bounded so an unreachable alert channel cannot serialize the single hedge
+worker; a failed or timed-out delivery releases the dedup reservation for the
+next scan. `CheckPositions` re-enqueues the hedge on its next scan. The dedup
+set is not a process-lifetime latch: `route_placement_outcome` drops every entry
+for a symbol as soon as one of its hedges reaches the broker, so a regression
+that recurs the following session pages again instead of silently accumulating a
+delta.
+
+`CheckPositions` can also drop an extended-hours buy before a `PlaceHedge` job
+exists, when the scan-time preflight cannot resolve a reference price or cannot
+cross it. Nothing downstream can report that, so the scan counts it on
+`hedge_scan_skipped_total{symbol,reason}` with the leg that failed. A permanent
+or unclassified failed reference-price lookup pages through the same
+`alert_dead_letter` and shared `(symbol, reason)` set as the hedge job. A
+transient or rate-limited failure remains counted but waits for the next scan
+instead of creating a dead-letter page on its first observation. Any page is
+released by the same successful placement.
+
+Dead-lettering does not assume the position is unclaimed. apalis re-runs
+`perform_body` from the top, so a retry can fail this pre-claim lookup after an
+earlier attempt already claimed the position and left a broker order behind;
+`handle_place_hedge_error` therefore resolves the claim through
+`recover_pending_poll_status` -- a no-op when nothing is claimed, a re-drive or
+re-arm of polling when something is -- _before_ it records the abandonment, and
+propagates a failed process-scoped recovery so apalis retries instead of
+counting a hedge that is still in flight as given up on. The one place pricing
+runs with a claim outstanding -- `recover_pending_poll_status`'s `Pending`
+re-drive -- wraps the failure as `ClaimedHedgeOrderKind`. Its symbol-scoped
+source uses the same bounded backpressure/transient budgets as the pre-claim
+path, then dead-letters while deliberately leaving the claim for the periodic
+recovery sweep; a genuinely process-scoped source still propagates. Placement
+dead-letters only once the optional primary quote, the mark, and the hardcoded
+`delayed_sip` quote feed have all failed: flattening before a multi-day gap is
+mandatory, so a worse fill price always beats no fill.
 
 Ordinary extended-hours orders retain the explicit 300-second
 `extended_hours_reprice_timeout_secs` cadence. Orders placed by close-flatten
-use the separate 60-second `close_flatten_reprice_timeout_secs` cadence. Each
-confirmed cancellation releases the position after applying any partial fill, so
-the next scan retries the broker-executable residual using a fresh reference and
-a later point on the cross ramp. This produces repeated bounded-loss attempts
+use the separate 60-second `close_flatten_reprice_timeout_secs` cadence. The
+initial close-flatten cancellation remains independent of both timeouts: it
+targets any live extended-hours order placed before the window. Each confirmed
+cancellation releases the position after applying any partial fill, so a later
+scan retries the broker-executable residual using a fresh reference and a later
+point on the cross ramp. That retry also waits for `position_check_interval`.
+The shipped deployments use 60 seconds, but cancellation confirmation and job
+execution add variable delay, so neither that interval nor the reprice timeout
+defines a fixed attempt count. This produces repeated bounded-loss attempts
 until the session closes, while the existing buying-power, equity-inventory,
 operational-limit, and broker-minimum checks continue to block invalid or
 leveraged orders.


### PR DESCRIPTION
## What

- Track [RAI-1690](https://linear.app/makeitrain/issue/RAI-1690).
- Document the required close-flatten config and ordered price source chain.
- Document cross widening, failure classification, dead letters, alerts, claim recovery, and outcome metrics.

## Why

- Operators need the runtime behavior and failure signals in one place.
- The old docs still described the unentitled SIP path and 300-second repricing.

## How

- Update `README.md` with config and price source behavior.
- Update `docs/conductor.md` with the retry, dead-letter, recovery, and alert flow.
- Document the 60-second reprice cycle and its interaction with the position scan.

## Testing

No new tests. This PR only changes `README.md` and `docs/conductor.md`.

## Screenshots

N/A

## Anything else

- This is the final PR in the stack.
- Runtime changes are in [#1180](https://app.graphite.com/github/pr/ST0x-Technology/st0x.liquidity/1180).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extended-hours hedge pricing with validated quotes, broker marks, and delayed market-data fallback.
  * Added progressive cross-limit widening as the close window approaches.
  * Added automatic repricing every 60 seconds using fresh pricing references.

* **Reliability**
  * Added bounded retries, dead-letter handling, claim recovery, and deduplicated notifications for failed hedge attempts.
  * Added safe handling for unavailable symbols and permanent versus temporary quote failures.

* **Documentation**
  * Documented close-flatten settings, pricing fallbacks, retry behavior, and cross-limit requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->