### PR TITLE
chore: add Jakub and Alex access keys

### DIFF
--- a/keys.nix
+++ b/keys.nix
@@ -11,6 +11,8 @@ rec {
     juan = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHHNeV3nfiJS0QE2JoW3d0dRw1j6OVKl7rXor24XHvsd";
     # purpose: op sec auditing and manual cli while fixing gaps in automation
     alastair = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJArH3PA+bFIon0JkCVQGs9aWr45lnVjiiTLLO9BPItn";
+    jakub = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM8D2RLBbEfB0GZKhT7tlT43pkKbrMnOR7cZfXoG9NbH";
+    alex = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA9MytndYpB/zpdh4kCXE0KF+NoLrpe+ij+zctM3xUCf";
 
     # purpose: deployments from github actions
     ci = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIARWUchVuQvkFm2tzspdC79hhRyYbWzRjs5iimhxewUy";
@@ -39,6 +41,8 @@ rec {
       ssh = [
         juan
         alastair
+        jakub
+        alex
         st0x-op
         ci
       ];
@@ -46,6 +50,8 @@ rec {
         st0x-op
         juan
         alastair
+        jakub
+        alex
         host-prod
       ];
     };
@@ -54,6 +60,8 @@ rec {
       ssh = [
         juan
         alastair
+        jakub
+        alex
         st0x-op
         ci
       ];
@@ -61,6 +69,8 @@ rec {
         st0x-op
         juan
         alastair
+        jakub
+        alex
         host-staging
       ];
     };


### PR DESCRIPTION
## What

- Add Jakub and Alex SSH public keys to `keys.nix`.
- Grant both users SSH and service-secret access in production and staging.

## Why

- Jakub and Alex need operator access to both deployments and their encrypted service config.

## How

- Register each ED25519 key once in `keys`.
- Add both keys to the `ssh` and `service` roles for each environment.

## Testing

- Ran `nix fmt -- --check keys.nix`.
- Evaluated all four role lists with `nix eval`.
- Validated both keys with `ssh-keygen`.

## Screenshots

N/A

## Anything else

- Existing `.age` files still need rekeying before the new service keys can decrypt them.
