### PR TITLE
fix: renew Tailscale certificates automatically

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -389,6 +389,9 @@ jobs:
       - name: deploy migration invariants
         run: ./scripts/validate-deploy-migration.sh
 
+      - name: tailscale certificate renewal invariants
+        run: nix develop .#ci-hooks -c nu scripts/validate-tailscale-cert-renewal.nu
+
       - name: pre-commit hooks
         run: nix develop .#ci-hooks -c pre-commit run --all-files
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1000,6 +1000,11 @@ _System configuration_ (deploy-rs `activate.nixos`):
 - ragenix integration for secret decryption
 - Nix configuration (flakes, garbage collection)
 
+The dashboard's Tailscale-issued TLS certificate renews on a persistent daily
+systemd timer. The renewal oneshot returns to inactive after each run so the
+timer can start it again without a deployment or operator action. A successful
+renewal reloads nginx so it serves the new certificate.
+
 _Per-service profiles_ (deploy-rs `activate.custom`, deployed independently):
 
 The set of deployed profiles is declared as a registry in `services.nix`. Each

--- a/flake.nix
+++ b/flake.nix
@@ -652,7 +652,7 @@
                 ${rustShell.shellHook}
                 ${rainMathFloatLink}
               '';
-              inherit (rustShell) buildInputs;
+              buildInputs = rustShell.buildInputs ++ [ pkgs.nushell ];
             };
           };
       }

--- a/nix/tailscale.nix
+++ b/nix/tailscale.nix
@@ -69,13 +69,13 @@ in
         ];
         serviceConfig = {
           Type = "oneshot";
-          RemainAfterExit = true;
+          # The daily timer can only restart a oneshot that returns to inactive.
+          RemainAfterExit = false;
           User = "nginx";
           Group = "nginx";
-          # Reload nginx so it picks up renewed certs on subsequent runs
-          # triggered by the timer. || true keeps the unit green on first
-          # boot when nginx hasn't started yet.
-          ExecStartPost = "+${pkgs.bash}/bin/bash -c 'systemctl is-active --quiet nginx.service && systemctl reload nginx.service || true'";
+          # Reload nginx after timer-triggered renewals. An inactive nginx is
+          # expected on first boot; an attempted reload failure is not.
+          ExecStartPost = "+${pkgs.bash}/bin/bash -c 'if systemctl is-active --quiet nginx.service; then systemctl reload nginx.service; fi'";
         };
         script = ''
           set -euo pipefail
@@ -96,7 +96,7 @@ in
       };
 
       nginx.after = [ "tailscale-cert.service" ];
-      nginx.requires = [ "tailscale-cert.service" ];
+      nginx.wants = [ "tailscale-cert.service" ];
     };
 
     timers.tailscale-cert = {

--- a/scripts/validate-tailscale-cert-renewal.nu
+++ b/scripts/validate-tailscale-cert-renewal.nu
@@ -1,0 +1,82 @@
+#!/usr/bin/env nu
+
+const CONFIGURATIONS = [
+  "st0x-liquidity"
+  "st0x-liquidity-staging"
+]
+
+const SELECT_RENEWAL_CONFIG = '{ systemd, ... }: {
+  type = systemd.services.tailscale-cert.serviceConfig.Type;
+  remainAfterExit = systemd.services.tailscale-cert.serviceConfig.RemainAfterExit;
+  onCalendar = systemd.timers.tailscale-cert.timerConfig.OnCalendar;
+  persistent = systemd.timers.tailscale-cert.timerConfig.Persistent;
+  wantedBy = systemd.timers.tailscale-cert.wantedBy;
+  execStartPost = systemd.services.tailscale-cert.serviceConfig.ExecStartPost;
+  nginxWants = systemd.services.nginx.wants;
+  nginxRequires = systemd.services.nginx.requires;
+}'
+
+def evaluate-config [configuration: string]: nothing -> record {
+  let attribute = $".#nixosConfigurations.($configuration).config"
+  let result = (^nix eval --json --apply $SELECT_RENEWAL_CONFIG $attribute | complete)
+
+  if $result.exit_code != 0 {
+    error make {
+      msg: $"failed to evaluate ($attribute): ($result.stderr | str trim)"
+    }
+  }
+
+  $result.stdout | from json
+}
+
+def assert-config [configuration: string, option: string, actual: any, expected: any] {
+  if $actual != $expected {
+    error make {
+      msg: $"($configuration) expected ($option)=($expected | to nuon), got ($actual | to nuon)"
+    }
+  }
+}
+
+def assert-nginx-reload [configuration: string, exec_start_post: any] {
+  let command_text = ($exec_start_post | to text)
+
+  if not ($command_text | str contains "systemctl reload nginx.service") {
+    error make {
+      msg: $"($configuration) certificate renewal does not reload nginx"
+    }
+  }
+
+  if ($command_text | str contains "|| true") {
+    error make {
+      msg: $"($configuration) certificate renewal swallows nginx reload failures"
+    }
+  }
+}
+
+def assert-nginx-dependency [configuration: string, wants: list<string>, requires: list<string>] {
+  if "tailscale-cert.service" not-in $wants {
+    error make {
+      msg: $"($configuration) nginx does not want tailscale-cert.service"
+    }
+  }
+
+  if "tailscale-cert.service" in $requires {
+    error make {
+      msg: $"($configuration) nginx hard-requires tailscale-cert.service"
+    }
+  }
+}
+
+def main [] {
+  for configuration in $CONFIGURATIONS {
+    let config = (evaluate-config $configuration)
+
+    assert-config $configuration "type" $config.type "oneshot"
+    assert-config $configuration "remainAfterExit" $config.remainAfterExit false
+    assert-config $configuration "onCalendar" $config.onCalendar "daily"
+    assert-config $configuration "persistent" $config.persistent true
+    assert-config $configuration "wantedBy" $config.wantedBy ["timers.target"]
+    assert-nginx-reload $configuration $config.execStartPost
+    assert-nginx-dependency $configuration $config.nginxWants $config.nginxRequires
+  }
+}


### PR DESCRIPTION
## What

- Fix [RAI-1708](https://linear.app/makeitrain/issue/RAI-1708/make-tailscale-tls-certificates-renew-automatically).
- Let the persistent daily timer start `tailscale-cert` more than once.
- Reload nginx after each successful renewal so it serves the new certificate.

## Why

- `RemainAfterExit = true` left the oneshot service active after it finished.
- Later timer starts did nothing, so certificate renewal required a deployment or manual restart.

## How

- Set `RemainAfterExit = false` in the shared Tailscale module for prod and staging.
- Add `validate-tailscale-cert-renewal.sh` to check the service lifecycle, timer schedule, timer activation, persistence, and nginx reload.
- Run the new check in CI and document the renewal contract in `SPEC.md`.

## Testing

- `./scripts/validate-tailscale-cert-renewal.sh`
- `nix develop .#ci-hooks -c pre-commit run --files .github/workflows/ci.yaml SPEC.md nix/tailscale.nix scripts/validate-tailscale-cert-renewal.sh`
- `nix develop .#ci-backend -c cargo check --workspace --all-features`
- `nix develop .#ci-backend -c cargo clippy --workspace --all-targets --all-features`
- `nix develop .#ci-backend -c cargo fmt -- --check`
- GitHub CI passed, including all four backend test shards.

## Screenshots

N/A

## Anything else

One deployment is required to install the corrected systemd unit. After that, renewals need no deployment or manual restart.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789052282&installation_model_id=19370&pr_number=1169&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1169&signature=02d9305c5125802b736ca30aecc5a2212bb1661e6b7177b2077efc26d6c5cf43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
