### PR TITLE
fix: size Alpaca->Base USDC capacity to fund its own conversion collar

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2760,6 +2760,13 @@ enum BridgeStage { Burn, Attestation, Mint }
   - BaseToAlpaca requires USDC-to-USD conversion AFTER deposit (USDC arrives in
     crypto wallet, must convert to USD buying power for trading)
   - Conversion uses USDC/USD crypto trading pair on Alpaca (market orders)
+  - Collar reservation: Alpaca prices a market buy for a _quantity_ of USDC with
+    a collar, holding ~102% of the requested amount in USD until the order
+    fills. Alpaca-to-Base transfer capacity is therefore sized as
+    `(withdrawable cash - reserve) / collar multiplier` so a transfer at the cap
+    can always fund its own conversion. The multiplier carries a small margin
+    over the documented collar because the hold tracks the ask rather than par,
+    and crypto buys draw on settled cash only
   - Crypto trading is available 24/7 on Alpaca (no market hours restrictions)
   - Market orders are near-instant but NOT guaranteed to fill immediately
   - Slippage: ~17bps observed in live tests (reduces effective USD received)

--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -143,12 +143,6 @@ vault_id = "0xfab"
 rebalancing = "enabled"
 # Maximum USDC moved per rebalance operation.
 operational_limit = 10000
-# Cash held back at the broker. This is a stopgap, not an operational floor. A
-# transfer sized at the full withdrawable balance cannot fund the ~2% collar that
-# the USDCUSD market buy reserves, so the conversion returns 403 and the circuit
-# opens. Keep this above 2% of operational_limit. RAI-1522 sizes capacity from the
-# collar instead, after which this goes back to 0 (omitted).
-reserved = 250
 
 # Per-equity asset configuration.
 # - trading: whether the bot hedges fills for this asset.

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -64,7 +64,7 @@ pub use executor::AlpacaBrokerApi;
 pub use journal::{JournalResponse, JournalStatus};
 pub use order::{
     AlpacaLimitOrder, AlpacaLimitPrice, ConversionDirection, CryptoOrderOutcome,
-    CryptoOrderResponse, ParseAlpacaLimitPriceError,
+    CryptoOrderResponse, ParseAlpacaLimitPriceError, USDC_CONVERSION_COLLAR_MULTIPLIER,
 };
 
 impl fmt::Display for CryptoOrderFailureReason {

--- a/crates/execution/src/alpaca_broker_api/order.rs
+++ b/crates/execution/src/alpaca_broker_api/order.rs
@@ -793,6 +793,16 @@ fn validate_usdc_amount_for_alpaca_precision(amount: Float) -> Result<Float, Alp
     Ok(amount)
 }
 
+/// Multiplier for the USD that Alpaca reserves against a `USDCUSD` market buy.
+///
+/// Alpaca's documented 2% collar holds `quantity x price x 1.02` until fill,
+/// so callers sizing a buy from available cash must divide by this multiplier
+/// or the order is rejected with `403 40310000: insufficient balance`.
+///
+/// The extra 0.1% is a prod-observed margin: the hold tracks the ask, not par,
+/// and settled cash is all a crypto buy can draw on.
+pub const USDC_CONVERSION_COLLAR_MULTIPLIER: Float = float!(1.021);
+
 /// Convert USDC to/from USD on Alpaca.
 ///
 /// This uses the USDC/USD trading pair:

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -28,7 +28,7 @@ mod rate_limit;
 pub use alpaca_broker_api::{
     AlpacaAccountId, AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiError,
     AlpacaBrokerApiMode, ConversionDirection, CryptoOrderOutcome, JournalResponse, JournalStatus,
-    TimeInForce,
+    TimeInForce, USDC_CONVERSION_COLLAR_MULTIPLIER,
 };
 // `AlpacaMarketDataError` is wrapped by `AlpacaBrokerApiError::LatestTrade`,
 // which delegates its own `backpressure()` classification straight to the

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -12,7 +12,9 @@ use tracing::{debug, error, warn};
 
 use st0x_config::ImbalanceThreshold;
 use st0x_dto::{InFlightCash, InFlightEquity, SymbolInventory, UsdcInventory};
-use st0x_execution::{Direction, FractionalShares, HasZero, Symbol};
+use st0x_execution::{
+    Direction, FractionalShares, HasZero, Symbol, USDC_CONVERSION_COLLAR_MULTIPLIER,
+};
 use st0x_finance::{Usd, Usdc};
 use st0x_tokenization::IssuerRequestId;
 use st0x_wrapper::{RatioError, UnderlyingPerWrapped};
@@ -915,6 +917,12 @@ impl InventoryView {
     /// below the reserve — the caller is expected to surface this as a
     /// distinct skip reason rather than treating it as "below minimum
     /// withdrawal."
+    ///
+    /// The result is sized so the USD->USDC market buy that funds the
+    /// transfer can cover its own collared hold: Alpaca reserves
+    /// [`USDC_CONVERSION_COLLAR_MULTIPLIER`] times the requested quantity
+    /// until the buy fills, so capacity is the cash after the reserve
+    /// *divided by* that multiplier, not the full remainder.
     pub(crate) fn alpaca_to_base_usdc_capacity(
         &self,
         reserved: Option<Usd>,
@@ -930,7 +938,10 @@ impl InventoryView {
             return Ok(Some(Usdc::ZERO));
         }
 
-        Ok(Some((withdrawable - reserved)?))
+        let after_reserve = (withdrawable - reserved)?;
+        let capacity = (after_reserve.inner() / USDC_CONVERSION_COLLAR_MULTIPLIER)?;
+
+        Ok(Some(Usdc::new(capacity)))
     }
 
     /// Converts the in-memory inventory view to a DTO for dashboard serialization.
@@ -6622,5 +6633,52 @@ mod tests {
             reset.is_restart_cash_tainted(),
             "the recovery reset must preserve the cash restart taint"
         );
+    }
+
+    #[test]
+    fn alpaca_to_base_capacity_divides_withdrawable_by_collar() {
+        // $102.10 withdrawable, no reserve: the USDCUSD market buy reserves
+        // the collar multiple of the requested quantity, so at most $100 of
+        // USDC can be bought.
+        let view = InventoryView::default().with_withdrawable_cash_cents(10_210);
+
+        let capacity = view.alpaca_to_base_usdc_capacity(None).unwrap().unwrap();
+
+        assert_eq!(capacity, Usdc::new(float!(100)));
+    }
+
+    #[test]
+    fn alpaca_to_base_capacity_divides_reserve_adjusted_cash_by_collar() {
+        // $352.10 withdrawable - $250 reserve = $102.10; divided by the
+        // collar multiplier leaves exactly $100 of purchasable USDC.
+        let view = InventoryView::default().with_withdrawable_cash_cents(35_210);
+
+        let capacity = view
+            .alpaca_to_base_usdc_capacity(Some(Usd::new(float!(250))))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(capacity, Usdc::new(float!(100)));
+    }
+
+    #[test]
+    fn alpaca_to_base_capacity_zero_when_reserve_exceeds_withdrawable() {
+        let view = InventoryView::default().with_withdrawable_cash_cents(10_000);
+
+        let capacity = view
+            .alpaca_to_base_usdc_capacity(Some(Usd::new(float!(250))))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(capacity, Usdc::ZERO);
+    }
+
+    #[test]
+    fn alpaca_to_base_capacity_none_when_withdrawable_missing() {
+        let view = InventoryView::default();
+
+        let capacity = view.alpaca_to_base_usdc_capacity(None).unwrap();
+
+        assert_eq!(capacity, None);
     }
 }

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -1356,11 +1356,12 @@ pub(crate) async fn drain_pending_usdc_jobs(service: &Arc<RebalancingService>) -
 mod tests {
     use alloy::primitives::{B256, TxHash};
     use chrono::TimeZone;
+    use proptest::prelude::*;
     use tokio::sync::broadcast;
     use uuid::Uuid;
 
     use st0x_dto::Statement;
-    use st0x_execution::ClientOrderId;
+    use st0x_execution::{ClientOrderId, HasZero};
     use st0x_float_macro::float;
 
     use super::*;
@@ -1713,12 +1714,14 @@ mod tests {
 
     #[tokio::test]
     async fn alpaca_to_base_is_capped_by_withdrawable_cash_after_reserve() {
+        // $352.10 withdrawable - $250 reserve = $102.10; divided by the
+        // conversion collar multiplier -> capacity = $100.
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
             InventoryView::default()
                 .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
                 .with_offchain_gross_usd_cents(50_000)
-                .with_withdrawable_cash_cents(35_000),
+                .with_withdrawable_cash_cents(35_210),
             event_sender,
         ));
         let threshold = ImbalanceThreshold {
@@ -1836,14 +1839,15 @@ mod tests {
         );
 
         // Polling-side recovery: withdrawable cash arrives with enough
-        // headroom over the reserve to fund the transfer.
+        // headroom over the reserve (and the conversion collar) to fund the
+        // transfer: (352.10 - 250) / collar = capacity of exactly $100.
         {
             let mut guard = inventory.write().await;
             let taken = std::mem::take(&mut *guard);
             *guard = taken
                 .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
                 .with_offchain_gross_usd_cents(50_000)
-                .with_withdrawable_cash_cents(35_000);
+                .with_withdrawable_cash_cents(35_210);
         }
 
         let after =
@@ -1921,14 +1925,15 @@ mod tests {
 
     #[tokio::test]
     async fn alpaca_to_base_is_capped_by_withdrawable_cash_with_no_reserve() {
-        // 100 onchain / 500 offchain -> excess = 200; withdrawable = $150 (below excess).
-        // With no reserve, the withdrawable cap must still apply -> transfer capped at 150.
+        // 100 onchain / 500 offchain -> excess = 200; withdrawable = $153.15
+        // (below excess). With no reserve, the withdrawable cap must still
+        // apply, collar-adjusted -> transfer capped at 150.
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
             InventoryView::default()
                 .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
                 .with_offchain_gross_usd_cents(50_000)
-                .with_withdrawable_cash_cents(15_000),
+                .with_withdrawable_cash_cents(15_315),
             event_sender,
         ));
         let threshold = ImbalanceThreshold {
@@ -1948,16 +1953,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn alpaca_to_base_proceeds_when_withdrawable_exactly_at_minimum_no_reserve() {
-        // 100 onchain / 500 offchain -> excess = 200; withdrawable = $51 (exactly the minimum).
-        // The capacity check uses strict `lt` (not `le`), so withdrawable exactly at the minimum
-        // must NOT skip; it must produce a transfer capped at $51 (the binding capacity).
+    async fn alpaca_to_base_proceeds_when_capacity_just_clears_minimum_no_reserve() {
+        // 100 onchain / 500 offchain -> excess = 200. $52.08 withdrawable is
+        // the smallest whole-cent balance whose collar-adjusted capacity
+        // clears the $51 minimum, so this pins the proceed side of the
+        // boundary to within one cent of input. (Capacity landing exactly on
+        // $51 is unreachable: no whole-cent balance divides by the collar
+        // multiplier to $51, so `lt` versus `le` is no longer separable from
+        // this entry point.)
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
             InventoryView::default()
                 .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
                 .with_offchain_gross_usd_cents(50_000)
-                .with_withdrawable_cash_cents(5_100),
+                .with_withdrawable_cash_cents(5_208),
             event_sender,
         ));
         let threshold = ImbalanceThreshold {
@@ -1970,23 +1979,51 @@ mod tests {
         assert_eq!(
             result,
             Ok(UsdcRebalanceOperation::AlpacaToBase {
-                amount: Usdc::new(float!(51))
+                amount: Usdc::new(float!(51.008814))
             }),
-            "Withdrawable exactly at $51 minimum must not skip; expected AlpacaToBase {{ amount: 51 }}, got {result:?}"
+            "Capacity just above the $51 minimum must not skip, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_skips_one_cent_below_the_capacity_minimum() {
+        // The skip side of the same boundary: $52.07 withdrawable is one cent
+        // less than the test above, leaving capacity a whisker under $51.
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_offchain_gross_usd_cents(50_000)
+                .with_withdrawable_cash_cents(5_207),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
+
+        assert_eq!(
+            result,
+            Err(UsdcTriggerSkip::WithdrawableBelowMinimum),
+            "Capacity just below the $51 minimum must skip, got {result:?}"
         );
     }
 
     #[tokio::test]
     async fn alpaca_to_base_withdrawable_binds_below_operational_limit_with_no_reserve() {
-        // 100 onchain / 900 offchain -> excess = 400; usdc_limit = $200; withdrawable = $150.
-        // Both the $200 operational limit and $150 withdrawable are below the $400 excess.
-        // Withdrawable ($150) is the tighter bound and must be the final transfer amount.
+        // 100 onchain / 900 offchain -> excess = 400; usdc_limit = $200;
+        // withdrawable = $153.15 -> collar-adjusted capacity = $150. Both the
+        // $200 operational limit and the $150 capacity are below the $400
+        // excess. Capacity ($150) is the tighter bound and must be the final
+        // transfer amount.
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
             InventoryView::default()
                 .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(900)))
                 .with_offchain_gross_usd_cents(90_000)
-                .with_withdrawable_cash_cents(15_000),
+                .with_withdrawable_cash_cents(15_315),
             event_sender,
         ));
         let threshold = ImbalanceThreshold {
@@ -2003,7 +2040,7 @@ mod tests {
             Ok(UsdcRebalanceOperation::AlpacaToBase {
                 amount: Usdc::new(float!(150))
             }),
-            "Withdrawable ($150) must bind below the operational limit ($200); expected 150, got {result:?}"
+            "Capacity ($150) must bind below the operational limit ($200); expected 150, got {result:?}"
         );
     }
 
@@ -2056,6 +2093,91 @@ mod tests {
             Err(UsdcTriggerSkip::WithdrawableBelowMinimum),
             "Withdrawable below $51 minimum with no reserve must return WithdrawableBelowMinimum, got {result:?}"
         );
+    }
+
+    /// The worst hold ratio seen in production, used to check sizing against
+    /// observed broker behaviour rather than against the multiplier the code
+    /// itself divides by. Alpaca's hold tracks the ask, not par, so the
+    /// effective ratio runs fractionally above the documented 2% collar; a
+    /// sizing rule that only satisfies the nominal collar is not safe.
+    const OBSERVED_WORST_HOLD_RATIO: Float = float!(1.0201);
+
+    #[tokio::test]
+    async fn alpaca_to_base_transfer_at_the_cap_funds_its_own_conversion_collar() {
+        // Regression for the prod failure behind this sizing rule: a
+        // withdrawable balance well below the target transfer, no reserve.
+        // The old sizing requested the full withdrawable balance and the
+        // USDCUSD market buy reserved the collar multiple of it, returning
+        // 403 40310000 (insufficient balance) every time. The transfer must
+        // instead be sized so its collared hold fits inside withdrawable cash.
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(20000)))
+                .with_offchain_gross_usd_cents(2_000_000)
+                .with_withdrawable_cash_cents(584_705),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
+
+        assert_eq!(
+            result,
+            Ok(UsdcRebalanceOperation::AlpacaToBase {
+                amount: Usdc::new(float!(5726.787463))
+            }),
+            "Transfer at the cap must leave room for the conversion collar, got {result:?}"
+        );
+
+        let Ok(UsdcRebalanceOperation::AlpacaToBase { amount }) = result else {
+            unreachable!("asserted above");
+        };
+        let hold = (amount.inner() * OBSERVED_WORST_HOLD_RATIO).unwrap();
+        assert!(
+            !hold.gt(float!(5847.05)).unwrap(),
+            "Hold {hold:?} at the observed worst ratio must not exceed withdrawable cash 5847.05"
+        );
+    }
+
+    proptest! {
+        /// Sizing must survive the hold ratio actually seen at the broker, not
+        /// merely the multiplier the capacity calculation divides by —
+        /// asserting the latter would only restate the implementation. The
+        /// reserve is an operational cash floor, so it must still be there
+        /// once the broker's hold is taken out.
+        #[test]
+        fn hold_at_observed_ratio_leaves_the_reserve_intact(
+            withdrawable_cents in 0i64..=100_000_000_000,
+            reserved_cents in proptest::option::of(0i64..=1_000_000_000),
+        ) {
+            let view = InventoryView::default().with_withdrawable_cash_cents(withdrawable_cents);
+            let reserved = reserved_cents.map(|cents| Usd::from_cents(cents).unwrap());
+
+            let capacity = view
+                .alpaca_to_base_usdc_capacity(reserved)
+                .unwrap()
+                .unwrap();
+            let amount = truncate_for_transfer(capacity).unwrap();
+
+            let hold = Usdc::new((amount.inner() * OBSERVED_WORST_HOLD_RATIO).unwrap());
+            let withdrawable = Usdc::from_cents(withdrawable_cents).unwrap();
+            let reserved_usdc = reserved.map_or(Usdc::ZERO, |value| Usdc::new(value.inner()));
+
+            if reserved_usdc.gt(&withdrawable).unwrap() {
+                prop_assert_eq!(capacity, Usdc::ZERO);
+            } else {
+                let committed = (hold + reserved_usdc).unwrap();
+                prop_assert!(
+                    !committed.gt(&withdrawable).unwrap(),
+                    "hold plus reserve {committed:?} exceeds withdrawable {withdrawable:?} \
+                     (capacity {capacity:?}, reserved {reserved:?})"
+                );
+            }
+        }
     }
 
     fn ts(seconds: i64) -> DateTime<Utc> {


### PR DESCRIPTION
# What

Sizes Alpaca->Base USDC transfer capacity as `(withdrawable - reserved) / 1.021` so a transfer at the cap can always fund its own USD->USDC conversion, and removes the `reserved = 250` stopgap from the prod config.

# Why

Alpaca prices a `USDCUSD` market buy with a collar and holds ~102% of the requested quantity until fill. Capacity was sized at 100% of withdrawable cash, so any transfer landing on the cap 403'd (`requested: 5964.05, available: 5847.05`), failed terminally and opened the circuit. Hit prod on 2026-07-24 and again on 2026-08-10 (RAI-1522).

# How

- `USDC_CONVERSION_COLLAR_MULTIPLIER` (1.021) declared beside `convert_usdc_usd`, the code whose order triggers the hold
- `alpaca_to_base_usdc_capacity` divides reserve-adjusted withdrawable cash by it; the existing 6-decimal transfer truncation floors the result, so the collared hold never exceeds withdrawable cash
- The multiplier carries 0.1% over the documented 2% collar. The hold is `quantity x price x collar`, so it tracks the ask rather than par — holds observed in production have run fractionally above `quantity x 1.02`, and sizing at the nominal collar leaves nothing for an ask above $1.00. Crypto buys draw on settled cash only, so no unsettled balance can absorb an overshoot. The margin costs ~0.1% of per-transfer capacity.
- Prod config: `reserved = 250` removed, as its own comment instructs once RAI-1522 lands

# Testing

- Regression test sized from the prod incident's withdrawable balance
- Proptest invariant: for any withdrawable/reserve combination, the hold at the **worst ratio observed at the broker** never exceeds withdrawable cash. Asserting against the multiplier the code divides by would only restate the implementation, so both the proptest and the regression test check against the observed ratio instead
- Capacity unit tests on `alpaca_to_base_usdc_capacity`; existing trigger tests adapted to collar-aware fixtures; the minimum-withdrawal boundary is now pinned from both sides (one cent below skips, one cent above proceeds), since no whole-cent balance divides by the multiplier to exactly $51

# Anything else

This compensates for the collar rather than avoiding it, so it hardcodes a broker constant we don't control and leaves ~2.1% of withdrawable cash unmoved per transfer. The alternative the issue mentions — placing the conversion as a `notional` order, which sidesteps the collar entirely — is tracked as follow-up RAI-1709, blocked by RAI-1710 (paper-account confirmation that the buying-power hold on a notional buy equals the notional). Adopting it means deleting this divisor, not layering on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USDC conversion capacity calculations to account for Alpaca’s approximately 102% market-buy reserve.
  * Prevented transfers from exceeding withdrawable cash after required reserves and pricing adjustments.
  * Correctly handles insufficient, missing, and excessive reserve balances.

* **Tests**
  * Added coverage for reserve-adjusted capacity, minimum withdrawal boundaries, operational limits, and broker hold ratios.
  * Verified transfers remain within available cash across no-reserve and reserved-balance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->