### PR TITLE
OCI images + AR push/attest workflow for the GCP staging VM

### DIFF
--- a/.github/workflows/build-oci.yml
+++ b/.github/workflows/build-oci.yml
@@ -1,0 +1,127 @@
+name: build-oci
+
+# Liquidity bot + dashboard OCI images → t0-artifacts Artifact Registry
+# (t0-liquidity repo), mirroring st0x.bebop's deploy-cloudrun.yml: nix build
+# the flake's dockerTools images → push digests → sign (GitHub/Sigstore +
+# the t0-artifacts liquidity-image KMS attestor). NO deploy job: the staging
+# GCE VM rolls by pulling t0.devops terraform/staging-liquidity/images.yaml
+# state and verifying the attestation itself — promoting a digest is a PR
+# there, not a push here.
+#
+# Auth: GitHub OIDC → the t0-artifacts WIF provider, bound to
+# liquidity-deployer (master only — the WIF binding lives in t0.devops
+# terraform/production-artifacts/liquidity.tf). PRs get nothing.
+#
+# Coexists with deploy-staging.yaml / deploy-prod.yaml (the DO droplet
+# deploy-rs path) until the staging cutover retires the staging half.
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch: {}
+
+concurrency:
+  group: build-oci
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+  # GitHub/Sigstore provenance attestation on every pushed digest.
+  attestations: write
+
+env:
+  REGION: europe-west3
+  AR_REPO: europe-west3-docker.pkg.dev/t0-artifacts/t0-liquidity
+  # t0-artifacts hub WIF provider (same as oracle/pricing/bebop;
+  # st0x.liquidity is admitted via extra_repos, bound to liquidity-deployer).
+  WIF_PROVIDER: projects/684788085322/locations/global/workloadIdentityPools/github-actions/providers/github-oidc
+  DEPLOYER_SA: liquidity-deployer@t0-artifacts.iam.gserviceaccount.com
+  ATTESTOR: projects/t0-artifacts/attestors/liquidity-image
+  ATTESTOR_KEY: projects/t0-artifacts/locations/europe-west3/keyRings/attestors/cryptoKeys/liquidity-image-attestor/cryptoKeyVersions/1
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - package: bot-oci
+            local_name: t0-liquidity
+            image: t0-liquidity
+          - package: dashboard-oci
+            local_name: t0-liquidity-dashboard
+            image: t0-liquidity-dashboard
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-oci-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock', 'Cargo.lock') }}
+          restore-prefixes-first-match: nix-oci-${{ runner.os }}-
+          gc-max-store-size-linux: 10G
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.DEPLOYER_SA }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+        with:
+          # `container binauthz` lives in the beta component.
+          install_components: beta
+
+      - name: Configure docker for Artifact Registry
+        run: gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+      - name: Build OCI image from the flake
+        run: |
+          set -euo pipefail
+          nix build .#${{ matrix.package }}
+          # streamLayeredImage output is a script that streams the tar.
+          ./result | docker load
+          docker tag "${{ matrix.local_name }}:latest" "${AR_REPO}/${{ matrix.image }}:${GITHUB_SHA}"
+
+      - name: Push image and resolve digest
+        id: push
+        run: |
+          set -euo pipefail
+          docker push "${AR_REPO}/${{ matrix.image }}:${GITHUB_SHA}"
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${AR_REPO}/${{ matrix.image }}:${GITHUB_SHA}")
+          echo "Pushed: ${DIGEST}"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "sha256=${DIGEST##*@}" >> "$GITHUB_OUTPUT"
+
+      # Two independent provenance proofs (bebop/oracle rationale): the
+      # GitHub/Sigstore attestation is non-blocking (needs a paid plan on
+      # private repos); the KMS/BinAuthz attestation below is the one the
+      # VM's roll timer actually verifies and MUST succeed.
+      - name: Attest build provenance (GitHub / Sigstore)
+        continue-on-error: true
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.AR_REPO }}/${{ matrix.image }}
+          subject-digest: ${{ steps.push.outputs.sha256 }}
+
+      - name: Sign Binary Authorization attestation
+        run: |
+          set -euo pipefail
+          gcloud beta container binauthz attestations sign-and-create \
+            --project="t0-artifacts" \
+            --artifact-url="${{ steps.push.outputs.digest }}" \
+            --attestor="${ATTESTOR}" \
+            --keyversion="${ATTESTOR_KEY}"

--- a/flake.nix
+++ b/flake.nix
@@ -360,7 +360,7 @@
                 '';
               };
 
-            others = {
+            others = rec {
               inherit (rust)
                 st0x-dto
                 st0x-liquidity
@@ -373,6 +373,19 @@
                 inherit bun2nix;
                 inherit (rust) st0x-dto;
               };
+
+              # OCI images for the GCP staging VM (pushed + attested to
+              # t0-artifacts by build-oci.yml; consumed by t0.devops
+              # terraform/staging-liquidity). See nix/oci-images.nix for the
+              # image contract.
+              inherit
+                (import ./nix/oci-images.nix {
+                  inherit pkgs st0x-dashboard;
+                  inherit (rust) st0x-liquidity;
+                })
+                bot-oci
+                dashboard-oci
+                ;
 
               ci = pkgs.writeShellApplication {
                 name = "ci";

--- a/nix/oci-images.nix
+++ b/nix/oci-images.nix
@@ -1,0 +1,134 @@
+# OCI images for the GCP staging VM (t0.devops terraform/staging-liquidity).
+# Built by the flake (dockerTools, no Dockerfile, no base image); `created` is
+# pinned so the same commit rebuilds to the same digest — the convention
+# st0x.bebop established for its Cloud Run image. Pushed + attested to the
+# t0-liquidity Artifact Registry repo in t0-artifacts by
+# .github/workflows/build-oci.yml (master only).
+#
+# Image contract (consumed by the stack's docker-compose in t0.devops —
+# keep the two in sync):
+#   bot:       Entrypoint = the `server` binary; env configs baked at
+#              /app/config/{staging,prod}/st0x-hedge.toml; the compose
+#              command appends --config <baked path> --secrets <mounted
+#              Secret Manager file>. database_url in the configs stays
+#              sqlite:///mnt/data/st0x-hedge.db (the VM mounts its data
+#              disk there — byte-identical to the droplet).
+#   dashboard: nginx serving the SvelteKit build, proxying the API paths to
+#              the compose service name `bot` on :8001 (same location list
+#              the droplet's os.nix nginx serves, minus TLS — the VM has no
+#              tailnet; humans reach it over an IAP tunnel).
+{
+  pkgs,
+  st0x-liquidity,
+  st0x-dashboard,
+}:
+
+let
+  bakedConfigs = pkgs.runCommand "st0x-hedge-configs" { } ''
+    mkdir -p $out/app/config/staging $out/app/config/prod
+    cp ${../config/staging/st0x-hedge.toml} $out/app/config/staging/st0x-hedge.toml
+    cp ${../config/prod/st0x-hedge.toml} $out/app/config/prod/st0x-hedge.toml
+  '';
+
+  dashboardRoot = pkgs.runCommand "st0x-dashboard-root" { } ''
+    mkdir -p $out/usr/share
+    cp -r ${st0x-dashboard} $out/usr/share/st0x-dashboard
+  '';
+
+  # Same proxy surface as os.nix's virtualHost locations, addressed to the
+  # compose service `bot` instead of 127.0.0.1 (the two containers share the
+  # compose default network). Logs to stdout/stderr for the gcplogs driver.
+  nginxConf = pkgs.writeText "nginx.conf" ''
+    user nobody;
+    worker_processes 1;
+    error_log /dev/stderr warn;
+    pid /tmp/nginx.pid;
+
+    events { worker_connections 1024; }
+
+    http {
+      include ${pkgs.nginx}/conf/mime.types;
+      default_type application/octet-stream;
+      access_log /dev/stdout;
+
+      client_body_temp_path /tmp/client_body;
+      proxy_temp_path /tmp/proxy;
+      fastcgi_temp_path /tmp/fastcgi;
+      uwsgi_temp_path /tmp/uwsgi;
+      scgi_temp_path /tmp/scgi;
+
+      server {
+        listen 80;
+        root /usr/share/st0x-dashboard;
+
+        location / {
+          try_files $uri $uri/ /index.html;
+        }
+
+        location /api/ws {
+          proxy_pass http://bot:8001/api/ws;
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+          proxy_connect_timeout 60;
+          proxy_send_timeout 60;
+          proxy_read_timeout 86400;
+        }
+
+        location /health      { proxy_pass http://bot:8001/health; }
+        location /logs        { proxy_pass http://bot:8001/logs; }
+        location /orders/     { proxy_pass http://bot:8001/orders/; }
+        location /pnl         { proxy_pass http://bot:8001/pnl; }
+        location /trades      { proxy_pass http://bot:8001/trades; }
+        location /transfers   { proxy_pass http://bot:8001/transfers; }
+        location /performance { proxy_pass http://bot:8001/performance; }
+      }
+    }
+  '';
+in
+{
+  bot-oci = pkgs.dockerTools.streamLayeredImage {
+    name = "t0-liquidity";
+    tag = "latest";
+    created = "1970-01-01T00:00:01Z";
+    contents = [
+      st0x-liquidity
+      pkgs.cacert
+      bakedConfigs
+    ];
+    config = {
+      Entrypoint = [ "${st0x-liquidity}/bin/server" ];
+      Env = [
+        "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+      ];
+      ExposedPorts = {
+        "8001/tcp" = { };
+        "8002/tcp" = { };
+      };
+    };
+  };
+
+  dashboard-oci = pkgs.dockerTools.streamLayeredImage {
+    name = "t0-liquidity-dashboard";
+    tag = "latest";
+    created = "1970-01-01T00:00:01Z";
+    contents = [
+      pkgs.nginx
+      pkgs.dockerTools.fakeNss
+      dashboardRoot
+    ];
+    extraCommands = ''
+      mkdir -p tmp var/log/nginx var/cache/nginx
+    '';
+    config = {
+      Cmd = [
+        "${pkgs.nginx}/bin/nginx"
+        "-c"
+        "${nginxConf}"
+        "-g"
+        "daemon off;"
+      ];
+      ExposedPorts."80/tcp" = { };
+    };
+  };
+}

--- a/nix/oci-images.nix
+++ b/nix/oci-images.nix
@@ -32,7 +32,7 @@ let
 
   dashboardRoot = pkgs.runCommand "st0x-dashboard-root" { } ''
     mkdir -p $out/usr/share
-    cp -r ${st0x-dashboard} $out/usr/share/st0x-dashboard
+    cp -r ${st0x-dashboard} $out/usr/share/t0-liquidity-dashboard
   '';
 
   # Same proxy surface as os.nix's virtualHost locations, addressed to the
@@ -59,7 +59,7 @@ let
 
       server {
         listen 80;
-        root /usr/share/st0x-dashboard;
+        root /usr/share/t0-liquidity-dashboard;
 
         location / {
           try_files $uri $uri/ /index.html;


### PR DESCRIPTION
App-repo half of the liquidity staging GCP migration (t0.devops: decision T0Trade/t0.devops#265, artifacts hub T0Trade/t0.devops#266, stack T0Trade/t0.devops#269).

## What

- **`nix/oci-images.nix`** — two `dockerTools.streamLayeredImage` flake outputs, st0x.bebop conventions (pinned `created`, no Dockerfile/base image):
  - `bot-oci` (`t0-liquidity`): entrypoint = the `server` binary; staging/prod TOMLs baked at `/app/config/<env>/st0x-hedge.toml`; the VM's compose appends `--config <baked> --secrets <Secret Manager file>`. `database_url` stays `sqlite:///mnt/data/st0x-hedge.db` — byte-identical to the droplet, the VM mounts its data disk at /mnt/data.
  - `dashboard-oci` (`t0-liquidity-dashboard`): nginx + the SvelteKit build, serving the same location list as os.nix's vhost (incl. `/pnl`, WS on `/api/ws`), proxying to the compose service `bot:8001`.
- **`.github/workflows/build-oci.yml`** (master only, mirrors st0x.bebop's deploy-cloudrun.yml): nix build → push both images to the `t0-liquidity` AR repo in `t0-artifacts` (WIF → `liquidity-deployer`, no stored keys) → GitHub/Sigstore attestation (non-blocking, private-repo plan limitation) → **Binary Authorization attestation with the `liquidity-image` KMS attestor** (the one the VM's roll timer verifies before any roll).

## What it deliberately does NOT do

- No deploy job — promoting a digest is an `images.yaml` PR in t0.devops, pulled and attestation-verified by the VM.
- No droplet-path changes: `deploy-staging.yaml`/`deploy-prod.yaml` untouched, configs baked as-is (the staging `[telemetry]` OTLP endpoints keep pointing at the st0x-tailnet obs VM — unreachable from the GCP VM, where the exporters drop best-effort; the section is removed in the cutover PR so the droplet keeps its telemetry until then).

## Sequencing

Merging is safe now, but the workflow will fail until T0Trade/t0.devops#266 is applied (WIF binding + AR repo + attestor don't exist yet). Nix evaluation is exercised by this repo's CI — no local nix on the authoring machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789056019&installation_model_id=19370&pr_number=1173&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1173&signature=1fd8f4b161153e37ededc17df5fe4efe2039b9539bce97883273a92ebdce055d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reproducible container images for the liquidity bot and dashboard.
  - Dashboard images serve the web interface and route API and WebSocket traffic to the bot.
  - Automated builds publish commit-tagged images to the container registry after master updates or manual runs.
  - Added security attestations and provenance records to support verified image deployment.
  - Bot images include staging and production configurations and expose the required service ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->