### PR TITLE
fix: build-oci needs Nix >= 2.30 for rainix's foundry input

### DIFF
--- a/.github/workflows/build-oci.yml
+++ b/.github/workflows/build-oci.yml
@@ -61,14 +61,29 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@v1.3.1
 
-      - uses: nixbuild/nix-quick-install-action@v30
+      # Same nix setup as ci.yaml, for the same reason its comment records:
+      # Nix 2.24-2.28 fail to resolve rainix's overridden `foundry` input
+      # (`cannot find flake 'flake:foundry'`); fixed in 2.30. v30 of this
+      # action only shipped up to 2.26 — pin a working release.
+      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
         with:
+          nix_version: "2.31.2"
           nix_conf: |
+            accept-flake-config = true
+            fallback = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             keep-env-derivations = true
             keep-outputs = true
 
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          useDaemon: false
+
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
         with:
           primary-key: nix-oci-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock', 'Cargo.lock') }}
           restore-prefixes-first-match: nix-oci-${{ runner.os }}-

--- a/.github/workflows/build-oci.yml
+++ b/.github/workflows/build-oci.yml
@@ -65,7 +65,7 @@ jobs:
       # Nix 2.24-2.28 fail to resolve rainix's overridden `foundry` input
       # (`cannot find flake 'flake:foundry'`); fixed in 2.30. v30 of this
       # action only shipped up to 2.26 — pin a working release.
-      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035  # v34
         with:
           nix_version: "2.31.2"
           nix_conf: |
@@ -75,7 +75,7 @@ jobs:
             keep-env-derivations = true
             keep-outputs = true
 
-      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
         continue-on-error: true
         with:
           name: rainlanguage
@@ -83,7 +83,7 @@ jobs:
           useDaemon: false
 
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569  # v7
         with:
           primary-key: nix-oci-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock', 'Cargo.lock') }}
           restore-prefixes-first-match: nix-oci-${{ runner.os }}-


### PR DESCRIPTION
The first master run of build-oci ([31526592321](https://github.com/ST0x-Technology/st0x.liquidity/actions/runs/31526592321)) died in flake evaluation with `cannot find flake 'flake:foundry'` — the exact bug ci.yaml's nix-setup comment documents: Nix 2.24–2.28 can't resolve rainix's overridden `foundry` input; fixed in Nix 2.30. I had copied st0x.bebop's `nix-quick-install-action@v30` (ships ≤2.26).

Fix: mirror ci.yaml's pinned setup — `nix-quick-install-action` v34 with `nix_version: 2.31.2` and the same nix_conf, plus the cachix (rainlanguage) + `cache-nix-action` v7 caching so the cold Rust build doesn't take the scenic route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789067731&installation_model_id=19370&pr_number=1176&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1176&signature=f1488ac86dd812515383e2e17bd89ba60b3efbd430da7b1c26829f47bf1ad2f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->