### PR TITLE
fix: give partial-fill conversions a legal terminal transition

### DIFF
--- a/crates/execution/src/alpaca_broker_api/order.rs
+++ b/crates/execution/src/alpaca_broker_api/order.rs
@@ -352,6 +352,17 @@ enum TerminalCryptoOutcome {
 }
 
 impl CryptoOrderOutcome {
+    /// Whether this classification is an answer, or the order can still
+    /// change state.
+    ///
+    /// Exposed so callers outside this crate decide "keep waiting?" from the
+    /// same rule the polls use, rather than re-deriving it from the variant.
+    /// Matching on [`Self::Pending`] alone is not equivalent: a `Failed`
+    /// status the broker may still resume from is also not an answer.
+    pub fn is_terminal(self) -> bool {
+        self.terminal().is_some()
+    }
+
     /// The terminal outcome this classification represents, or `None` while
     /// the order can still change state.
     ///

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -776,6 +776,27 @@ impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
                     warn!(target: "rebalance", ?error, "Failed to deliver USDC hedging inconclusive-burn alert");
                 }
             }
+            // The post-deposit conversion's fate is unknown and the order may
+            // still fill, so retrying would race a live order and recording a
+            // failure would terminalize the rebalance against one. Latched for
+            // the operator, matching the Alpaca->Base leg.
+            Err(UsdcTransferError::ConversionOutcomeUnresolved { id, source }) => {
+                error!(
+                    target: "rebalance",
+                    %id, %source,
+                    "Base->Alpaca USDC transfer: conversion outcome unresolved; the broker \
+                     order may still be live. Latched for operator reconciliation \
+                     (no auto-retry, no failure recorded)"
+                );
+                let message = format!(
+                    "USDC transfer {id}: post-deposit conversion outcome unresolved ({source}). \
+                     The broker order may still be live and may still fill; verify at Alpaca \
+                     before forcing this rebalance either way."
+                );
+                if let Err(error) = ctx.notifier.notify(&message).await {
+                    warn!(target: "rebalance", ?error, "Failed to deliver USDC hedging unresolved-conversion alert");
+                }
+            }
             // Deterministic vault-liquidity revert: the withdraw is atomic
             // (nothing left the vault) and re-issuing it just reverts again
             // until the vault is refunded, burning gas per attempt. Returning
@@ -1436,6 +1457,17 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
                     warn!(target: "rebalance", ?error, "Failed to deliver USDC market-making inconclusive-burn alert");
                 }
             }
+            // Both outcomes are deterministic across retries and neither has a
+            // safe automatic next step, so they latch for an operator instead
+            // of burning the retry budget on an identical failure. Returning
+            // `Ok` is what stops apalis re-entering the resume, which for an
+            // unresolved conversion would reach the `Converting` arm and emit
+            // `FailConversion` -- releasing the in-flight guard while the
+            // broker order may still be live and still fill.
+            Err(
+                error @ (UsdcTransferError::ConversionBelowWithdrawalMinimum { .. }
+                | UsdcTransferError::ConversionOutcomeUnresolved { .. }),
+            ) => self.latch_conversion_for_reconciliation(ctx, &error).await,
             Err(error) => return self.handle_terminal_or_backpressure_error(ctx, error).await,
         }
 
@@ -1444,6 +1476,49 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
 }
 
 impl TransferUsdcToMarketMaking {
+    /// Ends the attempt without a retry for the two conversion outcomes that
+    /// are deterministic across retries and have no safe automatic next step,
+    /// alerting the operator instead.
+    ///
+    /// The caller returns `Ok` after this, which is the whole mechanism: an
+    /// unresolved conversion re-entered by apalis would reach the `Converting`
+    /// resume arm and emit `FailConversion`, releasing the in-flight guard
+    /// while the broker order may still be live and still fill. A sub-minimum
+    /// conversion would simply fail identically every attempt.
+    async fn latch_conversion_for_reconciliation(
+        &self,
+        ctx: &TransferUsdcToMarketMakingCtx,
+        error: &UsdcTransferError,
+    ) {
+        let (context, detail) = match error {
+            UsdcTransferError::ConversionBelowWithdrawalMinimum {
+                converted, minimum, ..
+            } => (
+                "conversion settled below the broker's withdrawal minimum; the converted \
+                 USDC is in the Alpaca crypto wallet and needs reconciliation",
+                format!(
+                    "settled at {converted}, below Alpaca's {minimum} withdrawal minimum. \
+                     No withdrawal was attempted."
+                ),
+            ),
+            _ => (
+                "conversion outcome unresolved; the broker order may still be live. Latched \
+                 with no failure recorded",
+                format!(
+                    "outcome unresolved ({error}). The order may still fill; verify at \
+                     Alpaca before forcing this rebalance either way."
+                ),
+            ),
+        };
+
+        error!(target: "rebalance", id = %self.id, %error, "Alpaca->Base USDC transfer: {context}");
+
+        let message = format!("USDC transfer {}: {detail}", self.id);
+        if let Err(notify_error) = ctx.notifier.notify(&message).await {
+            warn!(target: "rebalance", ?notify_error, "Failed to deliver USDC market-making conversion-latch alert");
+        }
+    }
+
     /// `reason` is supplied by the caller, where the concrete settlement
     /// variant is already known statically. Re-deriving it here from the
     /// widened `&UsdcTransferError` would need an `unreachable!` fallback that
@@ -1799,10 +1874,12 @@ mod tests {
     use alloy::primitives::{Address, TxHash, U256};
     use chrono::{DateTime, Utc};
     use reqwest::StatusCode;
-    use uuid::Uuid;
+    use uuid::{Uuid, uuid};
 
     use st0x_evm::EvmError;
-    use st0x_execution::{AlpacaTransferId, AlpacaWalletError};
+    use st0x_execution::{
+        AlpacaBrokerApiError, AlpacaTransferId, AlpacaWalletError, DeadlineCancel,
+    };
     use st0x_float_macro::float;
 
     use super::*;
@@ -2061,6 +2138,13 @@ mod tests {
         /// Deterministic vault-liquidity revert: re-issuing the withdraw just
         /// reverts again until the vault is refunded, so the job must latch.
         InsufficientVaultLiquidity,
+        /// The conversion order may still be live: a redrive would race it and
+        /// could reach the resume's failure transition, releasing the in-flight
+        /// guard while real money can still move.
+        ConversionOutcomeUnresolved,
+        /// Deterministic across retries -- the converted amount cannot grow --
+        /// and the withdrawal it blocks needs an operator, not a retry.
+        ConversionBelowWithdrawalMinimum,
     }
 
     impl TerminalOutcome {
@@ -2096,6 +2180,23 @@ mod tests {
                     requested: U256::from(100),
                     received: U256::from(40),
                 },
+                Self::ConversionOutcomeUnresolved => {
+                    UsdcTransferError::ConversionOutcomeUnresolved {
+                        id: id.clone(),
+                        source: Box::new(AlpacaBrokerApiError::ConversionCancelNotSettled {
+                            order_id: uuid!("61e7b016-9c91-4a97-b912-615c9d365c9d"),
+                            cancel: DeadlineCancel::Accepted,
+                            filled_quantity: None,
+                        }),
+                    }
+                }
+                Self::ConversionBelowWithdrawalMinimum => {
+                    UsdcTransferError::ConversionBelowWithdrawalMinimum {
+                        id: id.clone(),
+                        converted: Usdc::new(float!(20)),
+                        minimum: *st0x_config::ALPACA_MINIMUM_WITHDRAWAL,
+                    }
+                }
             }
         }
     }
@@ -3824,6 +3925,43 @@ mod tests {
             TerminalOutcome::BurnTxDropped,
             "BurnTxDropped (market-making)",
             Some(TxHash::from([0xAB; 32])),
+        )
+        .await;
+    }
+
+    /// An unresolved conversion outcome must latch on both legs. A redrive
+    /// would re-enter the resume while the broker order may still be live,
+    /// and on the Alpaca->Base leg that reaches the `Converting` arm and
+    /// emits `FailConversion`, releasing the in-flight guard.
+    #[tokio::test]
+    async fn hedging_job_latches_on_unresolved_conversion_outcome() {
+        assert_hedging_fail_closed(
+            TerminalOutcome::ConversionOutcomeUnresolved,
+            "ConversionOutcomeUnresolved (hedging)",
+            None,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn market_making_job_latches_on_unresolved_conversion_outcome() {
+        assert_market_making_fail_closed(
+            TerminalOutcome::ConversionOutcomeUnresolved,
+            "ConversionOutcomeUnresolved (market-making)",
+            None,
+        )
+        .await;
+    }
+
+    /// Every retry converts the same sub-minimum amount and is refused
+    /// identically, so retrying only burns the budget an operator alert is
+    /// worth more than.
+    #[tokio::test]
+    async fn market_making_job_latches_on_conversion_below_withdrawal_minimum() {
+        assert_market_making_fail_closed(
+            TerminalOutcome::ConversionBelowWithdrawalMinimum,
+            "ConversionBelowWithdrawalMinimum (market-making)",
+            None,
         )
         .await;
     }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -14,12 +14,14 @@ use uuid::Uuid;
 
 use st0x_bridge::cctp::{AttestationResponse, CctpBridge, CctpError};
 use st0x_bridge::{Attestation, Bridge, BridgeDirection, BurnReceipt, BurnTxStatus, MintReceipt};
+use st0x_config::ALPACA_MINIMUM_WITHDRAWAL;
 use st0x_event_sorcery::Store;
 use st0x_evm::{USDC_BASE, Wallet};
 use st0x_execution::alpaca_broker_api::CryptoOrderResponse;
 use st0x_execution::{
-    AlpacaTransferId, AlpacaWalletError, AlpacaWalletService, ClientOrderId, ConversionDirection,
-    CryptoOrderOutcome, Network, Positive, TokenSymbol, Transfer, TransferStatus,
+    AlpacaBrokerApiError, AlpacaTransferId, AlpacaWalletError, AlpacaWalletService, ClientOrderId,
+    ConversionDirection, CryptoOrderOutcome, Network, Positive, TokenSymbol, Transfer,
+    TransferStatus,
 };
 use st0x_finance::Usdc;
 use st0x_raindex::{Raindex, RaindexError, RaindexService, RaindexVaultId};
@@ -640,6 +642,21 @@ impl<
             .await
         {
             Ok(order) => order,
+            // The order's fate is unknown: it may still be live at the broker
+            // and still fill. Recording a failure would release the in-flight
+            // guard and let the trigger arm a second conversion for the same
+            // imbalance while real money can still move, so the aggregate is
+            // left at `Converting` for operator reconciliation instead.
+            Err(
+                error @ (AlpacaBrokerApiError::ConversionCancelNotSettled { .. }
+                | AlpacaBrokerApiError::ConversionOrderNotFound { .. }),
+            ) => {
+                error!(target: "rebalance", %error, "USD to USDC conversion outcome unresolved");
+                return Err(UsdcTransferError::ConversionOutcomeUnresolved {
+                    id: id.clone(),
+                    source: Box::new(error),
+                });
+            }
             Err(error) => {
                 // Conversion placement fails fast on ANY error (RAI-1494:
                 // deliberately NOT rescheduled, unlike the deposit/withdrawal
@@ -675,6 +692,42 @@ impl<
             .record_conversion_or_fail(id, &correlation_id, &order, ConversionDirection::UsdToUsdc)
             .await?;
         let received_amount = conversion.received_amount;
+
+        // The trigger's floor only covers the amount it *requests*; a stalled
+        // conversion whose remainder was cancelled delivers whatever filled,
+        // and Alpaca rejects a withdrawal below its minimum outright. Failing
+        // here rather than at the withdrawal is what keeps the rebalance
+        // terminalizable: `FailConversion` is only legal while the aggregate
+        // is still `Converting`, so confirming first would leave it holding
+        // the in-flight guard with no terminal transition left.
+        if received_amount.lt(&ALPACA_MINIMUM_WITHDRAWAL)? {
+            error!(target: "rebalance",
+                order_id = %order.id,
+                requested = %amount,
+                converted = %received_amount,
+                minimum = %*ALPACA_MINIMUM_WITHDRAWAL,
+                "USD to USDC conversion settled below Alpaca's withdrawal minimum; \
+                 no withdrawal will be attempted"
+            );
+            self.cqrs
+                .send(
+                    id,
+                    UsdcRebalanceCommand::FailConversion {
+                        reason: format!(
+                            "conversion settled at {received_amount}, below Alpaca's {} \
+                             withdrawal minimum; the converted USDC needs reconciliation \
+                             in the Alpaca crypto wallet",
+                            *ALPACA_MINIMUM_WITHDRAWAL
+                        ),
+                    },
+                )
+                .await?;
+            return Err(UsdcTransferError::ConversionBelowWithdrawalMinimum {
+                id: id.clone(),
+                converted: received_amount,
+                minimum: *ALPACA_MINIMUM_WITHDRAWAL,
+            });
+        }
 
         self.cqrs
             .send(id, UsdcRebalanceCommand::ConfirmConversion { conversion })
@@ -742,6 +795,21 @@ impl<
             .await
         {
             Ok(order) => order,
+            // Identical broker state decides identically on both legs: the
+            // order's fate is unknown and it may still fill, so recording a
+            // durable failure against it is wrong here for the same reason it
+            // is wrong on the USD->USDC leg. Left unterminalized for operator
+            // reconciliation.
+            Err(
+                error @ (AlpacaBrokerApiError::ConversionCancelNotSettled { .. }
+                | AlpacaBrokerApiError::ConversionOrderNotFound { .. }),
+            ) => {
+                error!(target: "rebalance", %error, "USDC to USD conversion outcome unresolved");
+                return Err(UsdcTransferError::ConversionOutcomeUnresolved {
+                    id: id.clone(),
+                    source: Box::new(error),
+                });
+            }
             Err(error) => {
                 // Conversion placement fails fast on ANY error (RAI-1494):
                 // same rationale as `execute_usd_to_usdc_conversion` above --
@@ -768,6 +836,47 @@ impl<
             .record_conversion_or_fail(id, &correlation_id, &order, ConversionDirection::UsdcToUsd)
             .await?;
         let proceeds = conversion.received_amount;
+
+        // `source_amount` is the USDC actually sold. A stalled order whose
+        // remainder was cancelled sells less than was deposited, and the rest
+        // stays as USDC in the Alpaca crypto wallet -- a denomination the
+        // offchain cash inventory does not read, so the imbalance calculation
+        // cannot see it and no later rebalance sweeps it. Confirming here
+        // would report a rebalance that moved part of the cash as a complete
+        // success. Fail instead, naming the unconverted amount: the same
+        // treatment `resume_converting` already gives an identical broker
+        // outcome. This asymmetry with the USD->USDC leg is deliberate --
+        // there the unfilled remainder stays as USD buying power, which the
+        // inventory does see.
+        if conversion.source_amount.lt(&amount)? {
+            let unconverted = (amount - conversion.source_amount)?;
+
+            error!(target: "rebalance",
+                order_id = %order.id,
+                requested = %amount,
+                converted = %conversion.source_amount,
+                %unconverted,
+                "USDC to USD conversion filled short; unconverted USDC is stranded in the \
+                 Alpaca crypto wallet"
+            );
+            self.cqrs
+                .send(
+                    id,
+                    UsdcRebalanceCommand::FailConversion {
+                        reason: format!(
+                            "post-deposit conversion filled only {} of {}; {unconverted} \
+                             USDC needs reconciliation in the Alpaca crypto wallet",
+                            conversion.source_amount, amount
+                        ),
+                    },
+                )
+                .await?;
+            return Err(UsdcTransferError::PostDepositConversionShortFill {
+                id: id.clone(),
+                converted: conversion.source_amount,
+                unconverted,
+            });
+        }
 
         self.cqrs
             .send(id, UsdcRebalanceCommand::ConfirmConversion { conversion })
@@ -1649,6 +1758,30 @@ impl<
         id: &UsdcRebalanceId,
         amount: Usdc,
     ) -> Result<Transfer, UsdcTransferError> {
+        // Defence in depth for the resume path. `execute_usd_to_usdc_conversion`
+        // refuses a sub-minimum fill while the aggregate is still `Converting`
+        // and `FailConversion` is legal, so a freshly converted rebalance never
+        // arrives here short. An aggregate that persisted `ConversionComplete`
+        // before that guard existed still can, and from there no failure
+        // transition remains -- so this refuses the call Alpaca would reject
+        // and leaves the aggregate for reconciliation rather than recording a
+        // terminal state it has no transition for. The job latches on this
+        // error instead of retrying, since every retry fails identically.
+        if amount.lt(&ALPACA_MINIMUM_WITHDRAWAL)? {
+            error!(target: "rebalance",
+                %id,
+                converted = %amount,
+                minimum = %*ALPACA_MINIMUM_WITHDRAWAL,
+                "Refusing an Alpaca withdrawal below the broker minimum; the converted \
+                 USDC needs reconciliation in the Alpaca crypto wallet"
+            );
+            return Err(UsdcTransferError::ConversionBelowWithdrawalMinimum {
+                id: id.clone(),
+                converted: amount,
+                minimum: *ALPACA_MINIMUM_WITHDRAWAL,
+            });
+        }
+
         let usdc = TokenSymbol::new("USDC");
         let positive_amount = Positive::new(amount)?;
 
@@ -2616,14 +2749,33 @@ impl<
         // per-attempt window -- and let the timeout sweep clear the in-progress
         // guard while the conversion is still healthy, the partial-completion clobber
         // this resume path exists to prevent.
-        let order = match order.classify() {
-            CryptoOrderOutcome::Pending => {
-                warn!(target: "rebalance", order_id = %order.id, "Resumed conversion still settling; awaiting terminal state");
-                self.alpaca_broker
-                    .poll_conversion_to_terminal(order.id)
-                    .await?
-            }
-            _ => order,
+        // Gate on terminality rather than on `Pending` alone: a `suspended`,
+        // `replaced` or `calculated` order is reported as `Failed` but the
+        // broker may still resume and fill it, so failing on sight here would
+        // record a failed rebalance against live money -- the same drift the
+        // shared terminality rule exists to prevent.
+        let order = if order.classify().is_terminal() {
+            order
+        } else {
+            warn!(target: "rebalance", order_id = %order.id, "Resumed conversion not yet terminal; awaiting a terminal state");
+            self.alpaca_broker
+                .poll_conversion_to_terminal(order.id)
+                .await
+                .map_err(|error| match error {
+                    // The order's fate is unknown: it may still be live and
+                    // still fill. Mapping here is what routes the job to its
+                    // latch arm instead of the generic retry path, so resume
+                    // decides the same way as both direct conversion legs.
+                    error @ (AlpacaBrokerApiError::ConversionCancelNotSettled { .. }
+                    | AlpacaBrokerApiError::ConversionOrderNotFound { .. }) => {
+                        error!(target: "rebalance", %error, "Resumed conversion outcome unresolved");
+                        UsdcTransferError::ConversionOutcomeUnresolved {
+                            id: id.clone(),
+                            source: Box::new(error),
+                        }
+                    }
+                    other => other.into(),
+                })?
         };
 
         match order.classify() {
@@ -8015,6 +8167,440 @@ mod tests {
         );
     }
 
+    /// A conversion whose stalled remainder was cancelled can settle below
+    /// Alpaca's withdrawal minimum, which the trigger only enforces on the
+    /// requested amount. The withdrawal must be refused before it is sent,
+    /// naming the converted amount, instead of being attempted and rejected
+    /// by Alpaca as an opaque wallet error. Driven through the resume path
+    /// because that is the one an apalis retry re-enters.
+    #[tokio::test]
+    async fn conversion_settling_below_the_alpaca_minimum_refuses_the_withdrawal() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("500");
+        let converted = usdc("20");
+
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                conversion: ConversionAmounts::new(usdc("20.002"), converted),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Any wallet call is a failure of the guard, so the whitelist lookup
+        // the withdrawal starts from is mocked only to count its calls.
+        let whitelist = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/whitelists");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([]));
+        });
+
+        let error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            whitelist.calls(),
+            0,
+            "a sub-minimum withdrawal must not reach Alpaca"
+        );
+        match error {
+            UsdcTransferError::ConversionBelowWithdrawalMinimum {
+                converted: reported,
+                minimum,
+                ..
+            } => {
+                assert_eq!(reported, converted);
+                assert_eq!(minimum, *st0x_config::ALPACA_MINIMUM_WITHDRAWAL);
+            }
+            other => panic!("expected ConversionBelowWithdrawalMinimum, got {other:?}"),
+        }
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::ConversionComplete { .. }),
+            "the resume path has no legal failure transition from ConversionComplete, so it \
+             must leave the aggregate there for reconciliation, got: {state:?}"
+        );
+    }
+
+    /// The fresh conversion path must refuse a sub-minimum fill before it
+    /// confirms, because `FailConversion` is only legal while the aggregate is
+    /// still `Converting`. Confirming first would leave the rebalance holding
+    /// the in-flight guard with no terminal transition left.
+    #[tokio::test]
+    async fn fresh_conversion_settling_below_the_alpaca_minimum_fails_the_rebalance() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("500");
+
+        // 500 requested, 20 settled: what a stalled order whose remainder was
+        // cancelled delivers, well under Alpaca's withdrawal minimum.
+        let _order_mock = create_conversion_order_pending_mock(&server, "500");
+        let _get_mock = create_get_order_mock_with_fill(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "500",
+            "20",
+            "1.0001",
+        );
+
+        // Any wallet call is a failure of the guard, so the whitelist lookup
+        // the withdrawal starts from is mocked only to count its calls.
+        let whitelist = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/whitelists");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([]));
+        });
+
+        let error = manager
+            .execute_usd_to_usdc_conversion(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            whitelist.calls(),
+            0,
+            "a sub-minimum conversion must not reach the withdrawal"
+        );
+        match error {
+            UsdcTransferError::ConversionBelowWithdrawalMinimum {
+                converted, minimum, ..
+            } => {
+                assert_eq!(converted, usdc("20"));
+                assert_eq!(minimum, *st0x_config::ALPACA_MINIMUM_WITHDRAWAL);
+            }
+            other => panic!("expected ConversionBelowWithdrawalMinimum, got {other:?}"),
+        }
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::ConversionFailed { .. }),
+            "refusing before ConfirmConversion is what keeps the rebalance terminalizable, \
+             got: {state:?}"
+        );
+    }
+
+    /// The floor is exclusive: a conversion settling at exactly the Alpaca
+    /// minimum is withdrawable and must confirm, not fail. Pins the `.lt()`
+    /// boundary on the fresh path -- a `<=` regression would terminalize a
+    /// perfectly viable rebalance.
+    #[tokio::test]
+    async fn fresh_conversion_settling_exactly_at_the_alpaca_minimum_confirms() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("500");
+
+        // 500 requested, 51 settled: the smallest fill Alpaca will still
+        // accept a withdrawal for.
+        let _order_mock = create_conversion_order_pending_mock(&server, "500");
+        let _get_mock = create_get_order_mock_with_fill(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "500",
+            "51",
+            "1.0001",
+        );
+
+        let received = manager
+            .execute_usd_to_usdc_conversion(&id, amount)
+            .await
+            .expect("an exact-minimum conversion must not be refused");
+
+        assert_eq!(received, usdc("51"));
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::ConversionComplete { .. }),
+            "an exact-minimum conversion must confirm, got: {state:?}"
+        );
+    }
+
+    /// The same exclusive boundary on the resume path's defensive re-check:
+    /// an aggregate resuming from `ConversionComplete` with exactly the
+    /// minimum converted must attempt the withdrawal, not refuse it.
+    #[tokio::test]
+    async fn resumed_conversion_settled_exactly_at_the_alpaca_minimum_attempts_the_withdrawal() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("500");
+        let converted = usdc("51");
+
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                conversion: ConversionAmounts::new(usdc("51.0051"), converted),
+            },
+        )
+        .await
+        .unwrap();
+
+        let whitelist = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/whitelists");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([]));
+        });
+
+        // Unmocked past the whitelist lookup; the assertion is that the
+        // re-check let the boundary amount through to the withdrawal.
+        let error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert!(
+            !matches!(
+                error,
+                UsdcTransferError::ConversionBelowWithdrawalMinimum { .. }
+            ),
+            "an exact-minimum withdrawal must not be refused, got: {error:?}"
+        );
+        assert_eq!(
+            whitelist.calls(),
+            1,
+            "an exact-minimum withdrawal must be attempted"
+        );
+    }
+
+    /// Mocks a conversion order that never leaves `new`, answers the deadline
+    /// cancel, and keeps reading back non-terminal afterwards, so the cancel
+    /// never settles and the order's fill state stays unknowable. Returns the
+    /// cancel mock for hit assertions.
+    fn mock_conversion_whose_cancel_never_settles<'a>(
+        server: &'a MockServer,
+        amount: &str,
+    ) -> httpmock::Mock<'a> {
+        let _get_mock = create_get_order_mock(
+            server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "new",
+            amount,
+        );
+
+        server.mock(|when, then| {
+            when.method(DELETE).path(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/61e7b016-9c91-4a97-b912-615c9d365c9d",
+            );
+            then.status(204);
+        })
+    }
+
+    /// One burst of virtual time, sized below the broker client's HTTP request
+    /// timeout so a request that happens to be in flight cannot have its own
+    /// deadline jumped by a single step.
+    const CONVERSION_DEADLINE_STEP: Duration = Duration::from_secs(25);
+
+    /// Skips the conversion poll's compiled-in deadlines (five minutes of order
+    /// wait plus half a minute of cancel settling) instead of waiting them out.
+    ///
+    /// The clock is frozen only across an `advance`, during which this task
+    /// stays runnable, so the runtime never parks under a frozen clock and
+    /// tokio's auto-advance -- which would otherwise fire the broker client's
+    /// own request timeouts -- never engages. The real sleep between bursts
+    /// leaves the poll far more time than a mock round trip needs, so bursts
+    /// land while it is parked between reads.
+    async fn skip_conversion_poll_deadlines() {
+        loop {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            tokio::time::pause();
+            tokio::time::advance(CONVERSION_DEADLINE_STEP).await;
+            tokio::time::resume();
+        }
+    }
+
+    /// A cancel that never settles leaves the order possibly live and still
+    /// able to fill. Recording a failure would release the in-flight guard and
+    /// let the trigger arm a second conversion for the same imbalance while
+    /// real money can still move, so the aggregate must stay `Converting`.
+    #[tokio::test]
+    async fn unresolved_conversion_outcome_leaves_the_aggregate_converting() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("500");
+
+        let _order_mock = create_conversion_order_pending_mock(&server, "500");
+        let cancel = mock_conversion_whose_cancel_never_settles(&server, "500");
+
+        let clock = tokio::spawn(skip_conversion_poll_deadlines());
+        let error = manager
+            .execute_usd_to_usdc_conversion(&id, amount)
+            .await
+            .unwrap_err();
+        clock.abort();
+
+        assert_eq!(
+            cancel.calls(),
+            1,
+            "the stalled order's remainder must be cancelled at the deadline"
+        );
+        match error {
+            UsdcTransferError::ConversionOutcomeUnresolved { source, .. }
+                if matches!(
+                    *source,
+                    AlpacaBrokerApiError::ConversionCancelNotSettled { .. }
+                ) => {}
+            other => panic!("expected ConversionOutcomeUnresolved, got {other:?}"),
+        }
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::Converting { .. }),
+            "an unresolved outcome must not terminalize the rebalance, got: {state:?}"
+        );
+    }
+
+    /// The same unknowable broker state must decide the same way on the
+    /// post-deposit leg. The remainder may still sell, so this leg must not
+    /// record the failure it records for a conversion whose short fill is
+    /// known.
+    #[tokio::test]
+    async fn unresolved_post_deposit_conversion_outcome_leaves_the_aggregate_converting() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("100");
+        advance_to_bridged_base_to_alpaca(&cqrs, &id, amount, amount_received).await;
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateDeposit {
+                deposit: TransferRef::OnchainTx(fixed_bytes!(
+                    "0xbbbb111111111111111111111111111111111111111111111111111111111111"
+                )),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::ConfirmDeposit)
+            .await
+            .unwrap();
+
+        let _order_mock = create_conversion_order_pending_mock(&server, "100");
+        let cancel = mock_conversion_whose_cancel_never_settles(&server, "100");
+
+        let clock = tokio::spawn(skip_conversion_poll_deadlines());
+        let error = manager
+            .execute_usdc_to_usd_conversion(&id, amount_received)
+            .await
+            .unwrap_err();
+        clock.abort();
+
+        assert_eq!(
+            cancel.calls(),
+            1,
+            "the stalled order's remainder must be cancelled at the deadline"
+        );
+        match error {
+            UsdcTransferError::ConversionOutcomeUnresolved { source, .. }
+                if matches!(
+                    *source,
+                    AlpacaBrokerApiError::ConversionCancelNotSettled { .. }
+                ) => {}
+            other => panic!("expected ConversionOutcomeUnresolved, got {other:?}"),
+        }
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::Converting { .. }),
+            "an unresolved outcome must not terminalize the rebalance, got: {state:?}"
+        );
+    }
+
+    /// A post-deposit conversion that sells less USDC than was deposited
+    /// leaves the remainder in the Alpaca crypto wallet, where the offchain
+    /// cash inventory cannot see it. That must fail the rebalance for
+    /// reconciliation, not confirm it as a completed one.
+    #[tokio::test]
+    async fn post_deposit_conversion_short_fill_fails_instead_of_confirming() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("100");
+        advance_to_bridged_base_to_alpaca(&cqrs, &id, amount, amount_received).await;
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateDeposit {
+                deposit: TransferRef::OnchainTx(fixed_bytes!(
+                    "0xbbbb111111111111111111111111111111111111111111111111111111111111"
+                )),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::ConfirmDeposit)
+            .await
+            .unwrap();
+
+        let _conversion_mock = create_conversion_order_mock(&server, "100");
+        let _get_order_mock = create_get_order_mock_with_fill(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "100",
+            "30",
+            "0.9999",
+        );
+
+        let error = manager
+            .execute_usdc_to_usd_conversion(&id, amount_received)
+            .await
+            .unwrap_err();
+
+        match error {
+            UsdcTransferError::PostDepositConversionShortFill {
+                converted,
+                unconverted,
+                ..
+            } => {
+                assert_eq!(converted, usdc("30"));
+                assert_eq!(unconverted, usdc("70"));
+            }
+            other => panic!("expected PostDepositConversionShortFill, got {other:?}"),
+        }
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::ConversionFailed { .. }),
+            "short fill must terminalize the rebalance, got: {state:?}"
+        );
+    }
+
     #[tokio::test]
     async fn resume_base_to_alpaca_from_conversion_complete_is_noop() {
         let server = MockServer::start();
@@ -8216,6 +8802,103 @@ mod tests {
         assert!(
             matches!(state, Some(UsdcRebalance::ConversionFailed { .. })),
             "aggregate must be ConversionFailed after the awaited order terminates failed, got {state:?}"
+        );
+    }
+
+    /// A cancel that never settles on the RESUME path must latch exactly as
+    /// it does on both direct legs: surfaced as `ConversionOutcomeUnresolved`
+    /// so the job latches for reconciliation, not as a generic broker error
+    /// the worker would retry -- re-entering this resume and, from
+    /// `Converting`, emitting the `FailConversion` that releases the guard
+    /// against a possibly-live order.
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_latches_when_the_cancel_never_settles() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let correlation_id =
+            ClientOrderId::from_uuid(uuid!("44444444-4444-4444-8444-444444444444"));
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, &correlation_id)
+            .await;
+
+        // Still settling at lookup; the poll then never observes a terminal
+        // state, and the deadline cancel never settles either -- the order
+        // reads back `new` even after the DELETE is accepted.
+        let lookup_mock = mock_conversion_lookup(&server, &correlation_id, "new", "0");
+        let _poll_mock = mock_get_crypto_order(&server, "new", "0");
+        let cancel = server.mock(|when, then| {
+            when.method(DELETE).path(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/904837e3-3b76-47ec-b432-046db621571b",
+            );
+            then.status(204);
+        });
+
+        let clock = tokio::spawn(skip_conversion_poll_deadlines());
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+        clock.abort();
+
+        lookup_mock.assert();
+        assert_eq!(
+            cancel.calls(),
+            1,
+            "the stalled order's remainder must be cancelled at the deadline"
+        );
+        match error {
+            UsdcTransferError::ConversionOutcomeUnresolved { source, .. }
+                if matches!(
+                    *source,
+                    AlpacaBrokerApiError::ConversionCancelNotSettled { .. }
+                ) => {}
+            other => panic!("expected ConversionOutcomeUnresolved, got {other:?}"),
+        }
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::Converting { .. }),
+            "an unresolved outcome on resume must not terminalize the rebalance, got: {state:?}"
+        );
+    }
+
+    /// `suspended` reads as a failure but is one the broker can resume from,
+    /// so the order may still fill. Resume must wait it out to a terminal
+    /// state; failing on sight would record a failed rebalance against money
+    /// that can still move.
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_awaits_a_suspended_order() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let correlation_id =
+            ClientOrderId::from_uuid(uuid!("66666666-6666-4666-8666-666666666666"));
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, &correlation_id)
+            .await;
+
+        let lookup_mock = mock_conversion_lookup(&server, &correlation_id, "suspended", "0");
+        let poll_mock = mock_get_crypto_order(&server, "filled", "99.99");
+
+        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+
+        lookup_mock.assert();
+        poll_mock.assert();
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                &state,
+                UsdcRebalance::ConversionComplete { conversion, .. }
+                    if conversion.received_amount == usdc("99.99")
+            ),
+            "a suspended order must be polled to its terminal state, not failed on sight, \
+             got: {state:?}"
         );
     }
 

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -222,6 +222,59 @@ pub(crate) enum UsdcTransferError {
         withdrawn: alloy::primitives::U256,
         requested: alloy::primitives::U256,
     },
+    /// The USD->USDC conversion settled below Alpaca's withdrawal minimum,
+    /// which the trigger can only enforce on the amount it *requests*: a
+    /// stalled conversion whose remainder was cancelled delivers whatever
+    /// filled, and any non-zero fill under the floor produces a withdrawal
+    /// Alpaca rejects. Named here rather than left to that rejection so the
+    /// recorded cause is the short conversion, and so the amount now sitting
+    /// in the Alpaca crypto wallet is in the failure itself.
+    #[error(
+        "USDC rebalance {id} converted only {converted}, below Alpaca's {minimum} \
+         withdrawal minimum; no withdrawal was attempted and the converted USDC is \
+         held in the Alpaca crypto wallet pending operator reconciliation"
+    )]
+    ConversionBelowWithdrawalMinimum {
+        id: UsdcRebalanceId,
+        converted: Usdc,
+        minimum: Usdc,
+    },
+    /// The conversion order's outcome could not be established: the deadline
+    /// cancel was never confirmed settled, or the broker stopped recognising
+    /// the order. The order may still be live and still fill, so the
+    /// rebalance is deliberately NOT terminalized -- it stays latched at
+    /// `Converting` with the in-flight guard held, the same fail-closed
+    /// treatment an inconclusive burn submission gets. Terminalizing instead
+    /// would release the guard and re-arm a second conversion for the same
+    /// imbalance while real money can still move.
+    #[error(
+        "USDC rebalance {id} conversion outcome could not be established, so the \
+         rebalance is latched for operator reconciliation: {source}"
+    )]
+    ConversionOutcomeUnresolved {
+        id: UsdcRebalanceId,
+        /// Boxed to keep it off every `Result<_, UsdcTransferError>` in this
+        /// module: the broker error is by far the largest variant payload, and
+        /// inlining it widens the error type for callers that can never return
+        /// this variant.
+        #[source]
+        source: Box<AlpacaBrokerApiError>,
+    },
+    /// The post-deposit USDC->USD conversion sold less USDC than was
+    /// deposited, because a stalled order's remainder was cancelled. The
+    /// unconverted USDC stays in the Alpaca crypto wallet, which the offchain
+    /// cash inventory does not read, so the rebalance is failed for
+    /// reconciliation rather than confirmed as a success that moved only part
+    /// of the cash.
+    #[error(
+        "USDC rebalance {id} post-deposit conversion sold only {converted}; {unconverted} \
+         is stranded as USDC in the Alpaca crypto wallet and needs operator reconciliation"
+    )]
+    PostDepositConversionShortFill {
+        id: UsdcRebalanceId,
+        converted: Usdc,
+        unconverted: Usdc,
+    },
     #[error(
         "USDC rebalance {id} Withdrawing has non-Alpaca withdrawal ref; \
          AlpacaToBase always records the Alpaca transfer ID"
@@ -378,6 +431,9 @@ impl BotGasFailureClassifier for UsdcTransferError {
             | Self::MissingFilledQuantity { .. }
             | Self::MissingFilledAveragePrice { .. }
             | Self::ResumeIndeterminateConversion { .. }
+            | Self::ConversionBelowWithdrawalMinimum { .. }
+            | Self::ConversionOutcomeUnresolved { .. }
+            | Self::PostDepositConversionShortFill { .. }
             | Self::ResumeWithoutMintScanBound { .. }
             | Self::AttestationTimedOut { .. }
             | Self::AttestationRetryDeadlineElapsed { .. }


### PR DESCRIPTION
# What

Gives every conversion outcome the bounded poll can produce a defined, legal transition in the rebalancing aggregate, so none of them strands funds, leaks the in-flight guard, or terminalizes a rebalance against an order that may still fill.

Closes RAI-1718. Stacked on #1174, which is what makes these outcomes reachable.

# Why

Bounding the conversion poll (#1174) is correct at the execution layer, but accepting a partial fill lets two states reach the aggregate that it had no legal transition for:

A conversion settling **below Alpaca's $51 withdrawal minimum**. The floor is enforced trigger-side on the *requested* amount, so a partial fill under it produced a withdrawal Alpaca rejects — terminalizing the transfer on a withdrawal error and misattributing the cause.

A conversion whose **cancel never settles** (`ConversionCancelNotSettled` / `ConversionOrderNotFound`). The order may still be live and still fill, so recording a failure releases the in-flight guard while real money can move, and lets the trigger arm a second conversion for the same imbalance.

# How

**The sub-minimum case is refused at two points, because only one of them can record a failure.** `execute_usd_to_usdc_conversion` checks before sending `ConfirmConversion` — the only moment `FailConversion` is legal, since `transition_fail_conversion` rejects it from `ConversionComplete` with `ConversionAlreadyCompleted`. `initiate_alpaca_withdrawal` checks again as defence for the resume path, where an aggregate persisted before this change can still arrive short and no failure transition remains; there it refuses the call without emitting a command and leaves the aggregate for reconciliation.

**Unresolved outcomes latch instead of retrying.** Both legs map the two broker errors to `ConversionOutcomeUnresolved` without emitting `FailConversion`, and both apalis jobs handle it by logging, notifying, and returning `Ok(())` — modelled on the existing `BurnSubmitInconclusive` arm. The `Ok` is the mechanism: it stops apalis re-entering the resume, which would otherwise reach the `Converting` arm and emit `FailConversion`, releasing the guard against a live order.

**Both legs now decide identically for identical broker state.** The post-deposit leg previously sent `FailConversion` for every error including a possibly-live order.

**`resume_converting` derives terminality from the same source as the polls.** It gated on `CryptoOrderOutcome::Pending` alone, so a `suspended` / `replaced` / `calculated` order seen on the first read was failed on sight — contradicting the single-source terminality rule #1174 introduced. `CryptoOrderOutcome::is_terminal()` is added so callers outside the execution crate ask the same question the polls do rather than re-deriving it from the variant.

**Sub-minimum USDC is accounted for, not silently stranded.** Both paths alert with the converted amount named, since the USDC sits in the Alpaca crypto wallet in a denomination the offchain cash inventory does not read.

# Testing

- The sub-minimum resume test now asserts the **aggregate state**, not merely that no HTTP call happened — the weaker assertion passed under both the correct and the broken design, which is what let the original defect through.
- Fresh-path sub-minimum terminalizes to `ConversionFailed` with no withdrawal attempted.
- Unresolved outcomes leave the aggregate at `Converting` on both legs, specifically not `ConversionFailed`.
- `resume_converting` waits out a `suspended` order rather than failing on sight.
- Three job-level tests cover both jobs latching on both new variants.

# Anything else

One judgement call worth review: on the fresh path a sub-minimum conversion emits `FailConversion`, which releases the guard, and the operator is alerted. The alternative — latching at `Converting` and holding the guard — would block all USDC rebalancing until someone intervenes. For under $51 stranded, alerting was judged better than wedging; the opposite trade is defensible.

None of this is reachable on master today. It becomes reachable only once partial fills are accepted, which is what the parent PR does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USDC conversion handling for below-minimum amounts, unresolved broker statuses, suspended orders, and partial fills.
  * Prevented unsafe retries when conversion outcomes cannot be confirmed.
  * Added clearer reconciliation failures and operator alerts for unresolved conversions.
  * Improved recovery behavior when resuming conversions, including withdrawal-minimum validation and terminal order-state checks.
  * Preserved conversions in progress when cancellation does not settle, enabling accurate reconciliation rather than premature completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->