### PR TITLE
fix: decouple Tailscale renewal from deployments

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1121,9 +1121,10 @@ _System configuration_ (deploy-rs `activate.nixos`):
 - ragenix integration for secret decryption
 - Nix configuration (flakes, garbage collection)
 
-The dashboard's Tailscale-issued TLS certificate renews on a persistent daily
-systemd timer. The renewal oneshot returns to inactive after each run so the
-timer can start it again without a deployment or operator action. A successful
+The dashboard's Tailscale-issued TLS certificate uses separate provisioning and
+renewal services. The provisioning oneshot remains active after first boot so a
+NixOS switch does not call the certificate API. A persistent daily timer starts
+the bounded renewal oneshot independently of nginx activation. A successful
 renewal reloads nginx so it serves the new certificate.
 
 _Per-service profiles_ (deploy-rs `activate.custom`, deployed independently):

--- a/nix/tailscale.nix
+++ b/nix/tailscale.nix
@@ -4,12 +4,12 @@
 # and provisions a Tailscale-issued HTTPS certificate that nginx
 # serves the dashboard from.
 #
-# The `tailscale-cert` oneshot waits for tailscaled to be Running,
-# then writes the cert/key into `/var/lib/tailscale-cert` and reloads
-# nginx so it picks up the new files. A daily timer re-runs the same
-# oneshot to renew before expiry. `tailscaled.ExecStartPre` deletes
-# the stale `tailscale0` TUN device so the unit doesn't crash-loop
-# when a previous tailscaled hasn't released it yet.
+# The `tailscale-cert` oneshot provisions the initial certificate and
+# remains active so later NixOS switches do not call the certificate API.
+# A separate daily `tailscale-cert-renew` oneshot renews the certificate
+# and reloads nginx. `tailscaled.ExecStartPre` deletes the stale
+# `tailscale0` TUN device so the unit doesn't crash-loop when a previous
+# tailscaled hasn't released it yet.
 {
   pkgs,
   environment,
@@ -19,6 +19,24 @@
 
 let
   certDir = "/var/lib/tailscale-cert";
+  certPath = "${certDir}/${tailscaleMagicDnsName}.crt";
+  keyPath = "${certDir}/${tailscaleMagicDnsName}.key";
+  certificateScript = ''
+    set -euo pipefail
+    retries=0
+    until [ "$(tailscale status --json 2>/dev/null | jq -r '.BackendState' 2>/dev/null)" = "Running" ]; do
+      retries=$((retries + 1))
+      if [ "$retries" -ge 30 ]; then
+        echo "Tailscale BackendState != Running after 60s" >&2
+        exit 1
+      fi
+      sleep 2
+    done
+    tailscale cert \
+      --cert-file ${certPath} \
+      --key-file ${keyPath} \
+      ${tailscaleMagicDnsName}
+  '';
 in
 {
   # Per-environment reusable, tagged auth key. Used only on first
@@ -69,37 +87,43 @@ in
         ];
         serviceConfig = {
           Type = "oneshot";
-          # The daily timer can only restart a oneshot that returns to inactive.
-          RemainAfterExit = false;
+          RemainAfterExit = true;
+          TimeoutStartSec = "5min";
           User = "nginx";
           Group = "nginx";
-          # Reload nginx after timer-triggered renewals. An inactive nginx is
-          # expected on first boot; an attempted reload failure is not.
+          # An inactive nginx is expected while the first certificate is
+          # provisioned, so there is nothing to reload on first boot.
           ExecStartPost = "+${pkgs.bash}/bin/bash -c 'if systemctl is-active --quiet nginx.service; then systemctl reload nginx.service; fi'";
         };
-        script = ''
-          set -euo pipefail
-          retries=0
-          until [ "$(tailscale status --json 2>/dev/null | jq -r '.BackendState' 2>/dev/null)" = "Running" ]; do
-            retries=$((retries + 1))
-            if [ "$retries" -ge 30 ]; then
-              echo "Tailscale BackendState != Running after 60s" >&2
-              exit 1
-            fi
-            sleep 2
-          done
-          tailscale cert \
-            --cert-file ${certDir}/${tailscaleMagicDnsName}.crt \
-            --key-file ${certDir}/${tailscaleMagicDnsName}.key \
-            ${tailscaleMagicDnsName}
-        '';
+        script = certificateScript;
+      };
+
+      # Renew independently of nginx and NixOS activation. A slow certificate
+      # API can fail this timer run without blocking or rolling back a deploy.
+      tailscale-cert-renew = {
+        description = "Renew Tailscale HTTPS certificate for ${tailscaleMagicDnsName}";
+        after = [ "tailscale-cert.service" ];
+        wants = [ "tailscale-cert.service" ];
+        path = [
+          pkgs.tailscale
+          pkgs.jq
+        ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = false;
+          TimeoutStartSec = "5min";
+          User = "nginx";
+          Group = "nginx";
+          ExecStartPost = "+${pkgs.bash}/bin/bash -c 'if systemctl is-active --quiet nginx.service; then systemctl reload nginx.service; fi'";
+        };
+        script = certificateScript;
       };
 
       nginx.after = [ "tailscale-cert.service" ];
-      nginx.wants = [ "tailscale-cert.service" ];
+      nginx.requires = [ "tailscale-cert.service" ];
     };
 
-    timers.tailscale-cert = {
+    timers.tailscale-cert-renew = {
       description = "Renew Tailscale HTTPS certificate daily";
       wantedBy = [ "timers.target" ];
       timerConfig = {

--- a/scripts/validate-tailscale-cert-renewal.nu
+++ b/scripts/validate-tailscale-cert-renewal.nu
@@ -6,12 +6,22 @@ const CONFIGURATIONS = [
 ]
 
 const SELECT_RENEWAL_CONFIG = '{ systemd, ... }: {
-  type = systemd.services.tailscale-cert.serviceConfig.Type;
-  remainAfterExit = systemd.services.tailscale-cert.serviceConfig.RemainAfterExit;
-  onCalendar = systemd.timers.tailscale-cert.timerConfig.OnCalendar;
-  persistent = systemd.timers.tailscale-cert.timerConfig.Persistent;
-  wantedBy = systemd.timers.tailscale-cert.wantedBy;
-  execStartPost = systemd.services.tailscale-cert.serviceConfig.ExecStartPost;
+  provisionType = systemd.services.tailscale-cert.serviceConfig.Type;
+  provisionRemainAfterExit = systemd.services.tailscale-cert.serviceConfig.RemainAfterExit;
+  provisionTimeout = systemd.services.tailscale-cert.serviceConfig.TimeoutStartSec;
+  provisionWantedBy = systemd.services.tailscale-cert.wantedBy;
+  provisionExecStartPost = systemd.services.tailscale-cert.serviceConfig.ExecStartPost;
+  renewalType = systemd.services.tailscale-cert-renew.serviceConfig.Type;
+  renewalRemainAfterExit = systemd.services.tailscale-cert-renew.serviceConfig.RemainAfterExit;
+  renewalTimeout = systemd.services.tailscale-cert-renew.serviceConfig.TimeoutStartSec;
+  renewalWantedBy = systemd.services.tailscale-cert-renew.wantedBy;
+  renewalAfter = systemd.services.tailscale-cert-renew.after;
+  renewalWants = systemd.services.tailscale-cert-renew.wants;
+  onCalendar = systemd.timers.tailscale-cert-renew.timerConfig.OnCalendar;
+  persistent = systemd.timers.tailscale-cert-renew.timerConfig.Persistent;
+  timerWantedBy = systemd.timers.tailscale-cert-renew.wantedBy;
+  renewalExecStartPost = systemd.services.tailscale-cert-renew.serviceConfig.ExecStartPost;
+  nginxAfter = systemd.services.nginx.after;
   nginxWants = systemd.services.nginx.wants;
   nginxRequires = systemd.services.nginx.requires;
 }'
@@ -53,16 +63,30 @@ def assert-nginx-reload [configuration: string, exec_start_post: any] {
   }
 }
 
-def assert-nginx-dependency [configuration: string, wants: list<string>, requires: list<string>] {
-  if "tailscale-cert.service" not-in $wants {
+def assert-nginx-dependency [configuration: string, after: list<string>, wants: list<string>, requires: list<string>] {
+  if "tailscale-cert.service" not-in $after {
     error make {
-      msg: $"($configuration) nginx does not want tailscale-cert.service"
+      msg: $"($configuration) nginx can start before certificate provisioning"
     }
   }
 
-  if "tailscale-cert.service" in $requires {
+  if "tailscale-cert.service" not-in $requires {
     error make {
-      msg: $"($configuration) nginx hard-requires tailscale-cert.service"
+      msg: $"($configuration) nginx does not require certificate provisioning"
+    }
+  }
+
+  if "tailscale-cert-renew.service" in ($wants | append $requires) {
+    error make {
+      msg: $"($configuration) nginx activation starts certificate renewal"
+    }
+  }
+}
+
+def assert-renewal-dependency [configuration: string, after: list<string>, wants: list<string>] {
+  if "tailscale-cert.service" not-in $after or "tailscale-cert.service" not-in $wants {
+    error make {
+      msg: $"($configuration) renewal can race initial certificate provisioning"
     }
   }
 }
@@ -71,12 +95,20 @@ def main [] {
   for configuration in $CONFIGURATIONS {
     let config = (evaluate-config $configuration)
 
-    assert-config $configuration "type" $config.type "oneshot"
-    assert-config $configuration "remainAfterExit" $config.remainAfterExit false
+    assert-config $configuration "provisionType" $config.provisionType "oneshot"
+    assert-config $configuration "provisionRemainAfterExit" $config.provisionRemainAfterExit true
+    assert-config $configuration "provisionTimeout" $config.provisionTimeout "5min"
+    assert-config $configuration "provisionWantedBy" $config.provisionWantedBy ["multi-user.target"]
+    assert-config $configuration "renewalType" $config.renewalType "oneshot"
+    assert-config $configuration "renewalRemainAfterExit" $config.renewalRemainAfterExit false
+    assert-config $configuration "renewalTimeout" $config.renewalTimeout "5min"
+    assert-config $configuration "renewalWantedBy" $config.renewalWantedBy []
     assert-config $configuration "onCalendar" $config.onCalendar "daily"
     assert-config $configuration "persistent" $config.persistent true
-    assert-config $configuration "wantedBy" $config.wantedBy ["timers.target"]
-    assert-nginx-reload $configuration $config.execStartPost
-    assert-nginx-dependency $configuration $config.nginxWants $config.nginxRequires
+    assert-config $configuration "timerWantedBy" $config.timerWantedBy ["timers.target"]
+    assert-nginx-reload $configuration $config.provisionExecStartPost
+    assert-nginx-reload $configuration $config.renewalExecStartPost
+    assert-renewal-dependency $configuration $config.renewalAfter $config.renewalWants
+    assert-nginx-dependency $configuration $config.nginxAfter $config.nginxWants $config.nginxRequires
   }
 }


### PR DESCRIPTION
## What

- Split Tailscale certificate provisioning from recurring renewal.
- Add deployment invariants for both production and staging.
- Update the certificate lifecycle contract in `SPEC.md`.

## Why

- [Production deployment 31650088038](https://github.com/ST0x-Technology/st0x.liquidity/actions/runs/31650088038) blocked while `tailscale-cert.service` called the certificate API.
- deploy-rs timed out waiting for NixOS activation and rolled back before it activated any application profile.

## How

- Keep `tailscale-cert` active after initial provisioning, so routine NixOS switches do not rerun it.
- Run `tailscale-cert-renew` from an independent persistent daily timer.
- Bound renewal to five minutes, and reload nginx only after a successful renewal.
- Keep nginx dependent on initial provisioning, but remove every nginx and target path to the renewal service.

## Testing

- `nix develop .#ci-hooks -c nu scripts/validate-tailscale-cert-renewal.nu`
- `nix develop .#ci-hooks -c pre-commit run --files SPEC.md nix/tailscale.nix scripts/validate-tailscale-cert-renewal.nu`
- `nix run .#ci`

## Screenshots

N/A

## Anything else

The next deployment still needs live verification. The production SSH safety probe did not return `ok`, so I did not retry it or inspect the server journal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * TLS certificate provisioning and renewal are now handled independently for more reliable lifecycle management.
  * Certificates are renewed automatically once per day with a five-minute execution limit.
  * Nginx reloads automatically after a successful renewal.
  * Initial certificate setup no longer fails when Nginx is not yet active during first boot.
  * Nginx now waits for initial certificate provisioning before starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->