### PR TITLE
fix: three cutover defects in the OCI images

### DIFF
--- a/.github/workflows/build-oci.yml
+++ b/.github/workflows/build-oci.yml
@@ -53,6 +53,9 @@ jobs:
           - package: dashboard-oci
             local_name: t0-liquidity-dashboard
             image: t0-liquidity-dashboard
+          - package: datasette-oci
+            local_name: t0-liquidity-datasette
+            image: t0-liquidity-datasette
     steps:
       - uses: actions/checkout@v4
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -385,6 +385,7 @@
                 })
                 bot-oci
                 dashboard-oci
+                datasette-oci
                 ;
 
               ci = pkgs.writeShellApplication {

--- a/nix/oci-images.nix
+++ b/nix/oci-images.nix
@@ -8,11 +8,15 @@
 # Image contract (consumed by the stack's docker-compose in t0.devops —
 # keep the two in sync):
 #   bot:       Entrypoint = the `server` binary; env configs baked at
-#              /app/config/{staging,prod}/st0x-hedge.toml; the compose
+#              /app/config/{staging,staging-gcp,prod}/st0x-hedge.toml; the compose
 #              command appends --config <baked path> --secrets <mounted
 #              Secret Manager file>. database_url in the configs stays
 #              sqlite:///mnt/data/st0x-hedge.db (the VM mounts its data
 #              disk there — byte-identical to the droplet).
+#   datasette: the nixpkgs datasette (same package the droplet runs), NOT
+#              the upstream Docker image -- that one's bundled SQLite is too
+#              old to parse the schema's STRICT table (dashboard_trade_delivery)
+#              and dies with "malformed database schema".
 #   dashboard: nginx serving the SvelteKit build, proxying the API paths to
 #              the compose service name `bot` on :8001 (same location list
 #              the droplet's os.nix nginx serves, minus TLS — the VM has no
@@ -25,8 +29,13 @@
 
 let
   bakedConfigs = pkgs.runCommand "st0x-hedge-configs" { } ''
-    mkdir -p $out/app/config/staging $out/app/config/prod
+    mkdir -p $out/app/config/staging $out/app/config/staging-gcp $out/app/config/prod
     cp ${../config/staging/st0x-hedge.toml} $out/app/config/staging/st0x-hedge.toml
+    # The GCP VM runs this variant: kms_api_key (keyless Turnkey auth, so
+    # the secrets file has no [wallet]) and no [telemetry]. #1182 added the
+    # file but not this line, so the image shipped without the directory
+    # and the bot crash-looped on "failed to read config file" at cutover.
+    cp ${../config/staging-gcp/st0x-hedge.toml} $out/app/config/staging-gcp/st0x-hedge.toml
     cp ${../config/prod/st0x-hedge.toml} $out/app/config/prod/st0x-hedge.toml
   '';
 
@@ -57,16 +66,24 @@ let
       uwsgi_temp_path /tmp/uwsgi;
       scgi_temp_path /tmp/scgi;
 
+      # Docker's embedded DNS. Without an explicit resolver + variable
+      # upstream, nginx resolves `bot` at CONFIG LOAD and exits
+      # "host not found in upstream" whenever the bot container is not
+      # already up -- which is every restart where the bot is slower, and
+      # every moment the workload is gated off.
+      resolver 127.0.0.11 valid=10s ipv6=off;
+
       server {
         listen 80;
         root /usr/share/t0-liquidity-dashboard;
+        set $bot_upstream "bot:8001";
 
         location / {
           try_files $uri $uri/ /index.html;
         }
 
         location /api/ws {
-          proxy_pass http://bot:8001/api/ws;
+          proxy_pass http://$bot_upstream/api/ws;
           proxy_http_version 1.1;
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection "upgrade";
@@ -75,13 +92,13 @@ let
           proxy_read_timeout 86400;
         }
 
-        location /health      { proxy_pass http://bot:8001/health; }
-        location /logs        { proxy_pass http://bot:8001/logs; }
-        location /orders/     { proxy_pass http://bot:8001/orders/; }
-        location /pnl         { proxy_pass http://bot:8001/pnl; }
-        location /trades      { proxy_pass http://bot:8001/trades; }
-        location /transfers   { proxy_pass http://bot:8001/transfers; }
-        location /performance { proxy_pass http://bot:8001/performance; }
+        location /health      { proxy_pass http://$bot_upstream/health; }
+        location /logs        { proxy_pass http://$bot_upstream/logs; }
+        location /orders/     { proxy_pass http://$bot_upstream/orders/; }
+        location /pnl         { proxy_pass http://$bot_upstream/pnl; }
+        location /trades      { proxy_pass http://$bot_upstream/trades; }
+        location /transfers   { proxy_pass http://$bot_upstream/transfers; }
+        location /performance { proxy_pass http://$bot_upstream/performance; }
       }
     }
   '';
@@ -105,6 +122,31 @@ in
         "8001/tcp" = { };
         "8002/tcp" = { };
       };
+    };
+  };
+
+  # Waits for the database before exec'ing: it only appears at cutover (copied
+  # from the droplet), and datasette exits immediately on a missing file.
+  datasette-oci = pkgs.dockerTools.streamLayeredImage {
+    name = "t0-liquidity-datasette";
+    tag = "latest";
+    created = "1970-01-01T00:00:01Z";
+    contents = [
+      pkgs.datasette
+      pkgs.busybox
+      pkgs.cacert
+    ];
+    config = {
+      Entrypoint = [ "/bin/sh" "-c" ];
+      Cmd = [
+        (
+          "until [ -f /mnt/data/st0x-hedge.db ]; do "
+          + "echo 'waiting for /mnt/data/st0x-hedge.db'; sleep 10; done; "
+          + "exec ${pkgs.datasette}/bin/datasette serve /mnt/data/st0x-hedge.db "
+          + "--host 0.0.0.0 --port 8081 --setting sql_time_limit_ms 5000"
+        )
+      ];
+      ExposedPorts."8081/tcp" = { };
     };
   };
 

--- a/nix/oci-images.nix
+++ b/nix/oci-images.nix
@@ -137,7 +137,10 @@ in
       pkgs.cacert
     ];
     config = {
-      Entrypoint = [ "/bin/sh" "-c" ];
+      Entrypoint = [
+        "/bin/sh"
+        "-c"
+      ];
       Cmd = [
         (
           "until [ -f /mnt/data/st0x-hedge.db ]; do "


### PR DESCRIPTION
The GCP staging cutover started the workload and all three containers failed. Every cause is visible in the logs and fixed here.

| Container | Failure | Cause | Fix |
|---|---|---|---|
| bot | `failed to read config file /app/config/staging-gcp/st0x-hedge.toml` | #1182 added the config file but **not** the line baking it into the image — my edit was swallowed by a shell parse error and I committed without re-reading | bake `config/staging-gcp` alongside staging/prod |
| dashboard | `nginx: [emerg] host not found in upstream "bot"` | `proxy_pass http://bot:8001` resolves at **config load**, so nginx refuses to start whenever the bot isn't already up — every restart where the bot is slower, and the entire gated-off window | explicit `resolver 127.0.0.11` + variable upstream, so resolution happens per request |
| datasette | `malformed database schema (dashboard_trade_delivery) - near "STRICT"` | the schema has a `STRICT` table; the upstream image's bundled SQLite is too old to parse it. The droplet never hit this — it runs `pkgs.datasette` | build `datasette-oci` from nixpkgs (same package as the droplet), plus a wait-for-database guard since the file only appears at cutover |

Consequence worth noting: **all three images are now first-party and attested**, so the VM's roll-time provenance check covers the whole stack instead of two thirds of it. The t0.devops follow-up repoints `datasette_image` at `t0-liquidity-datasette` in the AR repo.

Droplet path untouched: `config/staging` unchanged, `deploy-staging.yaml`/`deploy-prod.yaml` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789213679&installation_model_id=19370&pr_number=1190&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1190&signature=abfe63ac2c1a602dae79bb9d7a0af5f462b8db514b32564221d34853ef90bbd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deployable Datasette image for serving the application database on port 8081.
  * Added the Datasette image to available package outputs and automated image publishing.
  * Included GCP staging configuration in the baked deployment image.

* **Bug Fixes**
  * Improved service connectivity so the application can start reliably even when dependent services are temporarily unavailable.
  * Added database readiness handling before Datasette begins serving requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->