### PR TITLE
ci: skip BinAuthz signing when the attestation already exists

### DIFF
--- a/.github/workflows/build-oci.yml
+++ b/.github/workflows/build-oci.yml
@@ -135,9 +135,21 @@ jobs:
           subject-name: ${{ env.AR_REPO }}/${{ matrix.image }}
           subject-digest: ${{ steps.push.outputs.sha256 }}
 
+      # Nix image builds are reproducible, so a push that does not change an
+      # image reproduces its digest, and sign-and-create 409s on the occurrence
+      # that already exists for (attestor, digest). Skipping is sound: the
+      # attestation the VM's roll timer verifies is exactly the one found.
       - name: Sign Binary Authorization attestation
         run: |
           set -euo pipefail
+          if gcloud beta container binauthz attestations list \
+              --project="t0-artifacts" \
+              --attestor="${ATTESTOR}" \
+              --artifact-url="${{ steps.push.outputs.digest }}" \
+              --format='value(name)' | grep -q .; then
+            echo "Attestation already exists for ${{ steps.push.outputs.digest }}; skipping"
+            exit 0
+          fi
           gcloud beta container binauthz attestations sign-and-create \
             --project="t0-artifacts" \
             --artifact-url="${{ steps.push.outputs.digest }}" \


### PR DESCRIPTION
# What

Makes the BinAuthz signing step in `build-oci.yml` idempotent: if an attestation already exists for the pushed digest, skip signing instead of failing.

# Why

Nix image builds are reproducible, so a master push that does not change an image reproduces its digest, and `sign-and-create` 409s on the occurrence that already exists for (attestor, digest). The datasette image does not depend on the application source, so it collides on nearly every push — [a02024c9](https://github.com/ST0x-Technology/st0x.liquidity/actions/runs/31709123546) and [8f2ab850](https://github.com/ST0x-Technology/st0x.liquidity/actions/runs/31722957080) both failed on the same digest that [a7e80ffc](https://github.com/ST0x-Technology/st0x.liquidity/actions/runs/31705778657) had already attested.

# How

`gcloud beta container binauthz attestations list --artifact-url` before `sign-and-create`; a non-empty result skips the signing. Safe for the VM's roll-timer verification: the attestation it verifies is exactly the one found.

# Anything else

st0x.bebop's `deploy-cloudrun.yml`, which this workflow mirrors, likely carries the same latent bug.
