### PR TITLE
[RAI-1010] Add cli cancel subcommand for open alpaca orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,14 @@ cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.to
 ```
 
 Manual cancellation of an open Alpaca order by the order id printed at
-placement. A cancel for an id the broker does not recognise (already filled,
-cancelled, or never placed) reports not found instead of erroring:
+placement:
 
 ```bash
 cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml cancel 61e7b016-9c91-4a97-b912-615c9d365c9d
 ```
+
+A cancel for an id the broker does not recognise (already filled, cancelled, or
+never placed) reports not found instead of erroring.
 
 Manual repair of local position tracking after an operator trade or rebalance:
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ configured Base liquidity wallet):
 cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml unwrap-equity --symbol AAPL --quantity 10.5
 ```
 
-Manual cancellation of an open Alpaca order by the order id printed at
-placement:
+Manual cancellation of an open Alpaca order by the id printed at placement:
 
 ```bash
 cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml cancel 61e7b016-9c91-4a97-b912-615c9d365c9d

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ configured Base liquidity wallet):
 cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml unwrap-equity --symbol AAPL --quantity 10.5
 ```
 
+Manual cancellation of an open Alpaca order by the order id printed at
+placement. A cancel for an id the broker does not recognise (already filled,
+cancelled, or never placed) reports not found instead of erroring:
+
+```bash
+cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml cancel 61e7b016-9c91-4a97-b912-615c9d365c9d
+```
+
 Manual repair of local position tracking after an operator trade or rebalance:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ Manual cancellation of an open Alpaca order by the id printed at placement:
 cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml cancel 61e7b016-9c91-4a97-b912-615c9d365c9d
 ```
 
-A cancel for an id the broker does not recognise (already filled, cancelled, or
-never placed) reports not found instead of erroring.
+A cancel for an id the broker does not know reports it as unknown, and a cancel
+for an order that already filled or was cancelled reports it as no longer
+cancelable — neither is an error.
 
 Manual repair of local position tracking after an operator trade or rebalance:
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -328,6 +328,15 @@ pub enum Commands {
         #[arg(long = "extended-hours", requires = "limit_price")]
         extended_hours: bool,
     },
+    /// Cancel an open Alpaca order by its broker order id
+    ///
+    /// Reports the outcome: cancellation requested, or order not found when
+    /// the broker does not recognise the id (already filled, cancelled, or
+    /// never placed).
+    Cancel {
+        /// Broker order id (UUID) printed at placement
+        order_id: Uuid,
+    },
     /// Account a missed onchain fill by its transaction hash, then place the
     /// opposite-side hedge.
     ///
@@ -962,6 +971,9 @@ enum SimpleCommand {
         limit_price: Option<AlpacaLimitPrice>,
         extended_hours: bool,
     },
+    Cancel {
+        order_id: Uuid,
+    },
     TransferEquity {
         direction: TransferDirection,
         symbol: Symbol,
@@ -1316,6 +1328,7 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
             limit_price,
             extended_hours,
         }),
+        Commands::Cancel { order_id } => Ok(SimpleCommand::Cancel { order_id }),
         Commands::TransferEquity {
             direction,
             symbol,
@@ -1542,6 +1555,9 @@ async fn run_simple_command<W: Write>(
                 error
             })?;
             execute_order(request, ctx, pool, stdout).await
+        }
+        SimpleCommand::Cancel { order_id } => {
+            trading::cancel_broker_order(ctx, &order_id.to_string(), stdout).await
         }
         SimpleCommand::TransferEquity {
             direction,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -330,9 +330,8 @@ pub enum Commands {
     },
     /// Cancel an open Alpaca order by its broker order id
     ///
-    /// Reports the outcome: cancellation requested, or order not found when
-    /// the broker does not recognise the id (already filled, cancelled, or
-    /// never placed).
+    /// Reports the outcome: cancellation requested, order id unknown to the
+    /// broker, or order no longer cancelable (already filled or cancelled).
     Cancel {
         /// Broker order id (UUID) printed at placement
         order_id: Uuid,
@@ -1557,7 +1556,7 @@ async fn run_simple_command<W: Write>(
             execute_order(request, ctx, pool, stdout).await
         }
         SimpleCommand::Cancel { order_id } => {
-            trading::cancel_broker_order(ctx, &order_id.to_string(), stdout).await
+            trading::cancel_broker_order(ctx, order_id, stdout).await
         }
         SimpleCommand::TransferEquity {
             direction,

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -1782,6 +1782,56 @@ mod tests {
         );
     }
 
+    /// A sustained 429 on the cancel DELETE must be retried in place with the
+    /// bounded CLI budget and then propagate as an error: exactly
+    /// `BACKPRESSURE_RETRY_MAX_ATTEMPTS` DELETEs, no more. This pins the
+    /// cancel path's wiring through the real client (`Retry-After` capture,
+    /// `find_backpressure` classification); the retry-then-succeed half is
+    /// pinned generically in `backpressure_retry`'s unit tests, since
+    /// `httpmock` cannot sequence a 429 followed by a 204.
+    #[tokio::test]
+    async fn cancel_broker_order_retries_429_up_to_budget_then_errors() {
+        let server = MockServer::start();
+        let ctx = create_alpaca_broker_api_test_ctx(&server);
+        let account_mock = mock_active_account(&server);
+
+        let order_id = uuid!("61e7b016-9c91-4a97-b912-615c9d365c9d");
+        let delete_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::DELETE).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("Retry-After", "0")
+                .json_body(json!({ "message": "rate limited" }));
+        });
+
+        let mut stdout = Vec::new();
+        let error = cancel_broker_order(&ctx, order_id, &mut stdout)
+            .await
+            .unwrap_err();
+
+        account_mock.assert();
+        assert_eq!(
+            delete_mock.calls(),
+            BACKPRESSURE_RETRY_MAX_ATTEMPTS as usize,
+            "must stop after exactly the bounded CLI retry budget"
+        );
+        assert!(
+            matches!(
+                error.downcast_ref::<AlpacaBrokerApiError>(),
+                Some(AlpacaBrokerApiError::ApiError { status, .. })
+                    if *status == StatusCode::TOO_MANY_REQUESTS
+            ),
+            "expected the 429 ApiError to propagate unchanged, got {error:?}"
+        );
+        assert_eq!(
+            String::from_utf8(stdout).unwrap(),
+            "",
+            "no outcome line may be printed when the cancel ultimately fails"
+        );
+    }
+
     #[tokio::test]
     async fn cancel_broker_order_dry_run_reports_requested() {
         let mut ctx = create_base_test_ctx();

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -14,9 +14,9 @@ use st0x_event_sorcery::{Store, StoreBuilder};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::alpaca_broker_api::{AlpacaLimitOrder, AlpacaLimitPrice};
 use st0x_execution::{
-    ClientOrderId, Direction, Executor, ExecutorOrderId, FractionalShares, MarketOrder,
-    MockExecutor, MockExecutorCtx, OrderFailureTerminality, OrderPlacement, OrderState, Positive,
-    Symbol, TimeInForce, TryIntoExecutor,
+    CancellationOutcome, ClientOrderId, Direction, Executor, ExecutorOrderId, FractionalShares,
+    MarketOrder, MockExecutor, MockExecutorCtx, OrderFailureTerminality, OrderPlacement,
+    OrderState, Positive, Symbol, TimeInForce, TryIntoExecutor,
 };
 use st0x_float_serde::format_float_with_fallback;
 
@@ -71,7 +71,7 @@ impl OrderPlacer for CliOrderPlacer {
     async fn cancel_order(
         &self,
         _executor_order_id: &ExecutorOrderId,
-    ) -> Result<st0x_execution::CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<CancellationOutcome, Box<dyn std::error::Error + Send + Sync>> {
         Err("CLI does not support order cancellation".into())
     }
 
@@ -285,6 +285,46 @@ async fn get_broker_order_status<W: Write>(
             Ok(broker.get_order_status(&order_id.to_string()).await?)
         }
     }
+}
+
+/// Cancels an open broker order by the id the broker assigned at placement
+/// and reports the outcome. `OrderNotFound` is a result, not an error: the
+/// broker does not know the id, so no live order exists under it and a retry
+/// of the cancel can never succeed.
+pub(super) async fn cancel_broker_order<W: Write>(
+    ctx: &Ctx,
+    order_id: &str,
+    stdout: &mut W,
+) -> anyhow::Result<()> {
+    let outcome = match &ctx.broker {
+        BrokerCtx::AlpacaBrokerApi(alpaca_auth) => {
+            let broker = alpaca_auth.clone().try_into_executor().await?;
+            let order_id = order_id.to_string();
+            retry_on_backpressure(
+                || broker.cancel_order(&order_id),
+                BACKPRESSURE_RETRY_MAX_ATTEMPTS,
+            )
+            .await?
+        }
+        BrokerCtx::DryRun => {
+            let broker = MockExecutorCtx.try_into_executor().await?;
+            broker.cancel_order(&order_id.to_string()).await?
+        }
+    };
+
+    match outcome {
+        CancellationOutcome::Requested => {
+            writeln!(stdout, "Cancellation requested for order {order_id}")?;
+        }
+        CancellationOutcome::OrderNotFound => {
+            writeln!(
+                stdout,
+                "Order {order_id} not found at the broker (already filled, cancelled, or unknown)"
+            )?;
+        }
+    }
+
+    Ok(())
 }
 
 pub(super) async fn execute_order_with_writers<W: Write>(

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -3,6 +3,7 @@
 use alloy::primitives::TxHash;
 use alloy::providers::Provider;
 use async_trait::async_trait;
+use reqwest::StatusCode;
 use sqlx::SqlitePool;
 use std::io::Write;
 use std::sync::Arc;
@@ -14,9 +15,9 @@ use st0x_event_sorcery::{Store, StoreBuilder};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::alpaca_broker_api::{AlpacaLimitOrder, AlpacaLimitPrice};
 use st0x_execution::{
-    CancellationOutcome, ClientOrderId, Direction, Executor, ExecutorOrderId, FractionalShares,
-    MarketOrder, MockExecutor, MockExecutorCtx, OrderFailureTerminality, OrderPlacement,
-    OrderState, Positive, Symbol, TimeInForce, TryIntoExecutor,
+    AlpacaBrokerApiError, CancellationOutcome, ClientOrderId, Direction, Executor, ExecutorOrderId,
+    FractionalShares, MarketOrder, MockExecutor, MockExecutorCtx, OrderFailureTerminality,
+    OrderPlacement, OrderState, Positive, Symbol, TimeInForce, TryIntoExecutor,
 };
 use st0x_float_serde::format_float_with_fallback;
 
@@ -288,23 +289,38 @@ async fn get_broker_order_status<W: Write>(
 }
 
 /// Cancels an open broker order by the id the broker assigned at placement
-/// and reports the outcome. `OrderNotFound` is a result, not an error: the
-/// broker does not know the id, so no live order exists under it and a retry
-/// of the cancel can never succeed.
+/// and reports the outcome. Two broker responses are results, not errors,
+/// because retrying the cancel can never succeed: a 404 means the broker does
+/// not know the id at all, and a 422 means the order is known but no longer
+/// cancelable (already filled or cancelled).
 pub(super) async fn cancel_broker_order<W: Write>(
     ctx: &Ctx,
-    order_id: &str,
+    order_id: Uuid,
     stdout: &mut W,
 ) -> anyhow::Result<()> {
     let outcome = match &ctx.broker {
         BrokerCtx::AlpacaBrokerApi(alpaca_auth) => {
             let broker = alpaca_auth.clone().try_into_executor().await?;
-            let order_id = order_id.to_string();
-            retry_on_backpressure(
-                || broker.cancel_order(&order_id),
+            let broker_order_id = order_id.to_string();
+            let cancellation = retry_on_backpressure(
+                || broker.cancel_order(&broker_order_id),
                 BACKPRESSURE_RETRY_MAX_ATTEMPTS,
             )
-            .await?
+            .await;
+
+            match cancellation {
+                Ok(outcome) => outcome,
+                Err(AlpacaBrokerApiError::ApiError { status, .. })
+                    if status == StatusCode::UNPROCESSABLE_ENTITY =>
+                {
+                    writeln!(
+                        stdout,
+                        "Order {order_id} is no longer cancelable (already filled or cancelled)"
+                    )?;
+                    return Ok(());
+                }
+                Err(error) => return Err(error.into()),
+            }
         }
         BrokerCtx::DryRun => {
             let broker = MockExecutorCtx.try_into_executor().await?;
@@ -317,10 +333,7 @@ pub(super) async fn cancel_broker_order<W: Write>(
             writeln!(stdout, "Cancellation requested for order {order_id}")?;
         }
         CancellationOutcome::OrderNotFound => {
-            writeln!(
-                stdout,
-                "Order {order_id} not found at the broker (already filled, cancelled, or unknown)"
-            )?;
+            writeln!(stdout, "Order {order_id} unknown to the broker")?;
         }
     }
 
@@ -1487,13 +1500,8 @@ mod tests {
         };
     }
 
-    fn setup_alpaca_broker_market_order_mocks<'a>(
-        server: &'a MockServer,
-        symbol: &'a str,
-        quantity: &'a str,
-        side: &'a str,
-    ) -> (httpmock::Mock<'a>, httpmock::Mock<'a>, httpmock::Mock<'a>) {
-        let account_mock = server.mock(|when, then| {
+    fn mock_active_account(server: &MockServer) -> httpmock::Mock<'_> {
+        server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
             then.status(200)
@@ -1502,7 +1510,16 @@ mod tests {
                     "id": "904837e3-3b76-47ec-b432-046db621571b",
                     "status": "ACTIVE"
                 }));
-        });
+        })
+    }
+
+    fn setup_alpaca_broker_market_order_mocks<'a>(
+        server: &'a MockServer,
+        symbol: &'a str,
+        quantity: &'a str,
+        side: &'a str,
+    ) -> (httpmock::Mock<'a>, httpmock::Mock<'a>, httpmock::Mock<'a>) {
+        let account_mock = mock_active_account(server);
 
         let asset_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
@@ -1562,16 +1579,7 @@ mod tests {
     fn setup_alpaca_broker_limit_order_mocks(
         server: &MockServer,
     ) -> (httpmock::Mock<'_>, httpmock::Mock<'_>, httpmock::Mock<'_>) {
-        let account_mock = server.mock(|when, then| {
-            when.method(httpmock::Method::GET)
-                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!({
-                    "id": "904837e3-3b76-47ec-b432-046db621571b",
-                    "status": "ACTIVE"
-                }));
-        });
+        let account_mock = mock_active_account(server);
 
         let asset_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/v1/assets/AAPL");
@@ -1684,26 +1692,13 @@ mod tests {
         order_mock.assert();
     }
 
-    fn mock_active_account(server: &MockServer) -> httpmock::Mock<'_> {
-        server.mock(|when, then| {
-            when.method(httpmock::Method::GET)
-                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!({
-                    "id": "904837e3-3b76-47ec-b432-046db621571b",
-                    "status": "ACTIVE"
-                }));
-        })
-    }
-
     #[tokio::test]
     async fn cancel_broker_order_reports_requested_on_success() {
         let server = MockServer::start();
         let ctx = create_alpaca_broker_api_test_ctx(&server);
         let account_mock = mock_active_account(&server);
 
-        let order_id = "61e7b016-9c91-4a97-b912-615c9d365c9d";
+        let order_id = uuid!("61e7b016-9c91-4a97-b912-615c9d365c9d");
         let delete_mock = server.mock(|when, then| {
             when.method(httpmock::Method::DELETE).path(format!(
                 "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
@@ -1730,7 +1725,7 @@ mod tests {
         let ctx = create_alpaca_broker_api_test_ctx(&server);
         let account_mock = mock_active_account(&server);
 
-        let order_id = "61e7b016-9c91-4a97-b912-615c9d365c9d";
+        let order_id = uuid!("61e7b016-9c91-4a97-b912-615c9d365c9d");
         let delete_mock = server.mock(|when, then| {
             when.method(httpmock::Method::DELETE).path(format!(
                 "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
@@ -1749,9 +1744,41 @@ mod tests {
         delete_mock.assert();
         assert_eq!(
             String::from_utf8(stdout).unwrap(),
-            format!(
-                "Order {order_id} not found at the broker (already filled, cancelled, or unknown)\n"
-            )
+            format!("Order {order_id} unknown to the broker\n")
+        );
+    }
+
+    /// An order that just filled or was already cancelled is KNOWN to the
+    /// broker, so the DELETE answers 422 ("order is not cancelable"), not
+    /// 404. The CLI must report that as an outcome and exit 0 -- the most
+    /// likely operator scenario is the limit order filling before the cancel
+    /// lands, which is not an error.
+    #[tokio::test]
+    async fn cancel_broker_order_reports_no_longer_cancelable_on_422() {
+        let server = MockServer::start();
+        let ctx = create_alpaca_broker_api_test_ctx(&server);
+        let account_mock = mock_active_account(&server);
+
+        let order_id = uuid!("61e7b016-9c91-4a97-b912-615c9d365c9d");
+        let delete_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::DELETE).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(422)
+                .header("content-type", "application/json")
+                .json_body(json!({ "message": "order is not cancelable" }));
+        });
+
+        let mut stdout = Vec::new();
+        cancel_broker_order(&ctx, order_id, &mut stdout)
+            .await
+            .unwrap();
+
+        account_mock.assert();
+        delete_mock.assert();
+        assert_eq!(
+            String::from_utf8(stdout).unwrap(),
+            format!("Order {order_id} is no longer cancelable (already filled or cancelled)\n")
         );
     }
 
@@ -1760,14 +1787,15 @@ mod tests {
         let mut ctx = create_base_test_ctx();
         ctx.broker = BrokerCtx::DryRun;
 
+        let order_id = uuid!("61e7b016-9c91-4a97-b912-615c9d365c9d");
         let mut stdout = Vec::new();
-        cancel_broker_order(&ctx, "test-order-id", &mut stdout)
+        cancel_broker_order(&ctx, order_id, &mut stdout)
             .await
             .unwrap();
 
         assert_eq!(
             String::from_utf8(stdout).unwrap(),
-            "Cancellation requested for order test-order-id\n"
+            format!("Cancellation requested for order {order_id}\n")
         );
     }
 
@@ -1777,16 +1805,7 @@ mod tests {
         let ctx = create_alpaca_broker_api_test_ctx(&server);
         let pool = setup_test_db().await;
 
-        server.mock(|when, then| {
-            when.method(httpmock::Method::GET)
-                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!({
-                    "id": "904837e3-3b76-47ec-b432-046db621571b",
-                    "status": "ACTIVE"
-                }));
-        });
+        mock_active_account(&server);
 
         server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/v1/assets/AAPL");

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -1684,6 +1684,93 @@ mod tests {
         order_mock.assert();
     }
 
+    fn mock_active_account(server: &MockServer) -> httpmock::Mock<'_> {
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": "904837e3-3b76-47ec-b432-046db621571b",
+                    "status": "ACTIVE"
+                }));
+        })
+    }
+
+    #[tokio::test]
+    async fn cancel_broker_order_reports_requested_on_success() {
+        let server = MockServer::start();
+        let ctx = create_alpaca_broker_api_test_ctx(&server);
+        let account_mock = mock_active_account(&server);
+
+        let order_id = "61e7b016-9c91-4a97-b912-615c9d365c9d";
+        let delete_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::DELETE).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(204);
+        });
+
+        let mut stdout = Vec::new();
+        cancel_broker_order(&ctx, order_id, &mut stdout)
+            .await
+            .unwrap();
+
+        account_mock.assert();
+        delete_mock.assert();
+        assert_eq!(
+            String::from_utf8(stdout).unwrap(),
+            format!("Cancellation requested for order {order_id}\n")
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_broker_order_reports_not_found_on_404() {
+        let server = MockServer::start();
+        let ctx = create_alpaca_broker_api_test_ctx(&server);
+        let account_mock = mock_active_account(&server);
+
+        let order_id = "61e7b016-9c91-4a97-b912-615c9d365c9d";
+        let delete_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::DELETE).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(404)
+                .header("content-type", "application/json")
+                .json_body(json!({ "message": "Resource does not exist" }));
+        });
+
+        let mut stdout = Vec::new();
+        cancel_broker_order(&ctx, order_id, &mut stdout)
+            .await
+            .unwrap();
+
+        account_mock.assert();
+        delete_mock.assert();
+        assert_eq!(
+            String::from_utf8(stdout).unwrap(),
+            format!(
+                "Order {order_id} not found at the broker (already filled, cancelled, or unknown)\n"
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_broker_order_dry_run_reports_requested() {
+        let mut ctx = create_base_test_ctx();
+        ctx.broker = BrokerCtx::DryRun;
+
+        let mut stdout = Vec::new();
+        cancel_broker_order(&ctx, "test-order-id", &mut stdout)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            String::from_utf8(stdout).unwrap(),
+            "Cancellation requested for order test-order-id\n"
+        );
+    }
+
     #[tokio::test]
     async fn test_execute_order_failure_stdout_contains_error() {
         let server = MockServer::start();


### PR DESCRIPTION
## What

Adds a cancel CLI subcommand that cancels an open Alpaca order by its broker order id and reports the outcome.

## Why

The CLI can place Alpaca limit orders (`--limit-price`) but had no way to cancel them. An unfilled limit order could only be cancelled through Alpaca's dashboard, outside the bot.

## How

Thin wiring over the existing cancellation plumbing that landed with the extended hours counter trading work.
- `cancel_broker_order` handler in `src/cli/trading.rs`, modeled on `get_broker_order_status`: constructs the broker executor from config, calls `cancel_order` with backpressure retry, prints the outcome. `OrderNotFound` is a reported result, not an error: the broker does not know the id, so a retry can never succeed
- `Commands::Cancel { order_id: Uuid }` to `SimpleCommand::Cancel` to the handler in `src/cli/mod.rs`. The id is typed as Uuid, so a malformed id fails at argument parsing before any network call

## Testing

Unit tests using httpmock against the Alpaca DELETE endpoint:
- 204 prints `Cancellation requested for order <id>`
- 404 prints `Order <id> not found at the broker (already filled, cancelled, or unknown)` and exits 0
- dry run broker goes through the mock executor path and prints the requested outcome

End to end against the real binary (built with the mock feature, secrets `mode = { type = "mock", base_url = ... }` pointing at a local fake Alpaca):
- open order: cancellation requested, DELETE observed by the fake
- unknown order: not found line, exit 0
- `cancel not-a-uuid`: clap error invalid value 'not-a-uuid' for '<ORDER_ID>', no network call

## Screenshots

<!-- If applicable, add screenshots or recordings. -->

## Anything else

`CliOrderPlacer::cancel_order` keeps its "not supported" stub. The subcommand calls the executor directly and does not route through `OrderPlacer`.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789235447&installation_model_id=19370&pr_number=1195&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1195&signature=6688c7da3b8b9235ddbbd069bdd8d11fa84d5a85ac56f868ca376c3454a508e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to cancel broker orders by UUID.
  * Supports order cancellation for Alpaca and dry-run brokers.
  * Reports successful cancellations and handles unknown or already completed orders without errors.

* **Documentation**
  * Added README instructions for manually cancelling orders, including command usage and expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->