### PR TITLE
chore: remove Alex access keys

### DIFF
--- a/keys.nix
+++ b/keys.nix
@@ -12,7 +12,6 @@ rec {
     # purpose: op sec auditing and manual cli while fixing gaps in automation
     alastair = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJArH3PA+bFIon0JkCVQGs9aWr45lnVjiiTLLO9BPItn";
     jakub = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM8D2RLBbEfB0GZKhT7tlT43pkKbrMnOR7cZfXoG9NbH";
-    alex = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA9MytndYpB/zpdh4kCXE0KF+NoLrpe+ij+zctM3xUCf";
 
     # purpose: deployments from github actions
     ci = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIARWUchVuQvkFm2tzspdC79hhRyYbWzRjs5iimhxewUy";
@@ -42,7 +41,6 @@ rec {
         juan
         alastair
         jakub
-        alex
         st0x-op
         ci
       ];
@@ -51,7 +49,6 @@ rec {
         juan
         alastair
         jakub
-        alex
         host-prod
       ];
     };
@@ -61,7 +58,6 @@ rec {
         juan
         alastair
         jakub
-        alex
         st0x-op
         ci
       ];
@@ -70,7 +66,6 @@ rec {
         juan
         alastair
         jakub
-        alex
         host-staging
       ];
     };


### PR DESCRIPTION
## What

- Drop Alex's SSH public key from `keys.nix`.
- Remove him from the prod and staging `ssh` and `service` roles.

## Why

- Alex should no longer have operator access to the liquidity hosts or their encrypted service config.

## How

- Delete the `alex` key entry.
- Drop `alex` from `prod.ssh`, `prod.service`, `staging.ssh`, and `staging.service`.
- Jakub stays.

## Testing

- Evaluated `keys.nix` with `nix eval`. Confirmed `alex` is gone from `keys`.
- Ran `nix fmt -- --check keys.nix`.

## Screenshots

N/A

## Anything else

- Existing `.age` files still encrypt to Alex's key until we rekey. SSH access goes away on next deploy. Decrypt access stays until we rekey.
