### PR TITLE
fix(dashboard): stop dropping the path in the proxy, and keep the socket on-origin

### DIFF
--- a/dashboard/src/lib/env.test.ts
+++ b/dashboard/src/lib/env.test.ts
@@ -2,8 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getWebSocketUrl, getExplorerTxUrl } from './env'
 
 const mockEnv = { current: {} as Record<string, string | undefined> }
+const mockDev = { current: true }
 
-vi.mock('$app/environment', () => ({ browser: true, dev: true }))
+vi.mock('$app/environment', () => ({
+  browser: true,
+  get dev() {
+    return mockDev.current
+  }
+}))
 vi.mock('$env/dynamic/public', () => ({
   get env() {
     return mockEnv.current
@@ -13,6 +19,7 @@ vi.mock('$env/dynamic/public', () => ({
 describe('getWebSocketUrl', () => {
   beforeEach(() => {
     mockEnv.current = {}
+    mockDev.current = true
     Object.defineProperty(globalThis, 'window', {
       value: {
         location: {
@@ -106,6 +113,47 @@ describe('getWebSocketUrl', () => {
     })
 
     expect(getWebSocketUrl()).toBe('ws://localhost:5173/api/ws')
+  })
+
+  // The built bundle behind an IAP tunnel: served by nginx at
+  // http://localhost:8080 alongside the bot, so the socket must stay on the
+  // page's own origin. Keying off the hostname sent it to :8001 instead --
+  // a port nobody forwards -- and the dashboard sat "Disconnected".
+  it('uses the page origin for a built bundle served over a localhost tunnel', () => {
+    mockDev.current = false
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        location: {
+          hostname: 'localhost',
+          port: '8080',
+          host: 'localhost:8080',
+          protocol: 'http:'
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+
+    expect(getWebSocketUrl()).toBe('ws://localhost:8080/api/ws')
+  })
+
+  it('still honors an explicit PUBLIC_ALPACA_WS_URL over a localhost tunnel', () => {
+    mockDev.current = false
+    mockEnv.current = { PUBLIC_ALPACA_WS_URL: 'ws://localhost:9999/api/ws' }
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        location: {
+          hostname: 'localhost',
+          port: '8080',
+          host: 'localhost:8080',
+          protocol: 'http:'
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+
+    expect(getWebSocketUrl()).toBe('ws://localhost:9999/api/ws')
   })
 })
 

--- a/dashboard/src/lib/env.ts
+++ b/dashboard/src/lib/env.ts
@@ -1,4 +1,4 @@
-import { browser } from '$app/environment'
+import { browser, dev } from '$app/environment'
 import { env } from '$env/dynamic/public'
 
 const DEFAULT_LOCAL_DEV_PORT = '8001'
@@ -9,8 +9,19 @@ const localDevPort = (): string => {
   return configured !== undefined && configured !== '' ? configured : DEFAULT_LOCAL_DEV_PORT
 }
 
+// `dev` is the discriminator, not the hostname. A built bundle is served by
+// nginx next to the bot, so REST and the socket share an origin -- but it is
+// now routinely reached at http://localhost:8080 through a `gcloud compute
+// start-iap-tunnel` (the GCP VM has no public IP and no tailnet, so that
+// tunnel is the ONLY way in). On hostname alone that looked like `vite dev`,
+// and the socket was sent to ws://localhost:8001 -- a port nobody has
+// forwarded -- while every REST call, which uses window.location.origin,
+// worked. Result: a permanently "Disconnected" dashboard whose tables render.
+// `dev` is true only under the Vite dev server, which is exactly the case
+// that needs a different port.
 const isLocalDev = (): boolean => {
   if (!browser) return true
+  if (!dev) return false
   const { hostname, port } = window.location
   return ['localhost', '127.0.0.1', '::1'].includes(hostname) && port !== '80' && port !== ''
 }

--- a/nix/oci-images.nix
+++ b/nix/oci-images.nix
@@ -82,8 +82,19 @@ let
           try_files $uri $uri/ /index.html;
         }
 
+        # NO URI after $bot_upstream, in any of these. nginx normally
+        # replaces the matched location prefix with the proxy_pass URI, but
+        # when proxy_pass contains a VARIABLE that rewriting is skipped and
+        # the literal URI is sent instead of the request path. So
+        # `proxy_pass http://$bot_upstream/orders/` sent every /orders/*
+        # request to the bot as plain `/orders/` -- 404 for /orders/pending
+        # and /orders/raindex (the whole Orders tab), and 404 for all four
+        # /performance/* endpoints. Worse than the 404s: /transfers/interrupted
+        # and /trades/{venue}/{id}/events silently returned the plain
+        # /transfers and /trades lists, a wrong answer with a 200.
+        # With no URI part, nginx forwards the original request URI unchanged.
         location /api/ws {
-          proxy_pass http://$bot_upstream/api/ws;
+          proxy_pass http://$bot_upstream;
           proxy_http_version 1.1;
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection "upgrade";
@@ -92,13 +103,13 @@ let
           proxy_read_timeout 86400;
         }
 
-        location /health      { proxy_pass http://$bot_upstream/health; }
-        location /logs        { proxy_pass http://$bot_upstream/logs; }
-        location /orders/     { proxy_pass http://$bot_upstream/orders/; }
-        location /pnl         { proxy_pass http://$bot_upstream/pnl; }
-        location /trades      { proxy_pass http://$bot_upstream/trades; }
-        location /transfers   { proxy_pass http://$bot_upstream/transfers; }
-        location /performance { proxy_pass http://$bot_upstream/performance; }
+        location /health      { proxy_pass http://$bot_upstream; }
+        location /logs        { proxy_pass http://$bot_upstream; }
+        location /orders/     { proxy_pass http://$bot_upstream; }
+        location /pnl         { proxy_pass http://$bot_upstream; }
+        location /trades      { proxy_pass http://$bot_upstream; }
+        location /transfers   { proxy_pass http://$bot_upstream; }
+        location /performance { proxy_pass http://$bot_upstream; }
       }
     }
   '';

--- a/nix/oci-images.nix
+++ b/nix/oci-images.nix
@@ -93,7 +93,16 @@ let
         # and /trades/{venue}/{id}/events silently returned the plain
         # /transfers and /trades lists, a wrong answer with a 200.
         # With no URI part, nginx forwards the original request URI unchanged.
+        # Every location is GET-only (limit_except GET also admits HEAD).
+        # The dashboard is a read surface; the bot's /transfers/resume and
+        # /transfers/recheck/{kind}/{id} are POST mutation endpoints that
+        # src/api.rs marks TODO(auth) -- unauthenticated by design until the
+        # role-gated API work, so they must stay unreachable through any
+        # exposed surface. Forwarding paths correctly (the fix above) would
+        # otherwise have exposed them here. Operators invoke them via an IAP
+        # tunnel to the bot port directly; this proxy refuses the method.
         location /api/ws {
+          limit_except GET { deny all; }
           proxy_pass http://$bot_upstream;
           proxy_http_version 1.1;
           proxy_set_header Upgrade $http_upgrade;
@@ -103,13 +112,13 @@ let
           proxy_read_timeout 86400;
         }
 
-        location /health      { proxy_pass http://$bot_upstream; }
-        location /logs        { proxy_pass http://$bot_upstream; }
-        location /orders/     { proxy_pass http://$bot_upstream; }
-        location /pnl         { proxy_pass http://$bot_upstream; }
-        location /trades      { proxy_pass http://$bot_upstream; }
-        location /transfers   { proxy_pass http://$bot_upstream; }
-        location /performance { proxy_pass http://$bot_upstream; }
+        location /health      { limit_except GET { deny all; } proxy_pass http://$bot_upstream; }
+        location /logs        { limit_except GET { deny all; } proxy_pass http://$bot_upstream; }
+        location /orders/     { limit_except GET { deny all; } proxy_pass http://$bot_upstream; }
+        location /pnl         { limit_except GET { deny all; } proxy_pass http://$bot_upstream; }
+        location /trades      { limit_except GET { deny all; } proxy_pass http://$bot_upstream; }
+        location /transfers   { limit_except GET { deny all; } proxy_pass http://$bot_upstream; }
+        location /performance { limit_except GET { deny all; } proxy_pass http://$bot_upstream; }
       }
     }
   '';


### PR DESCRIPTION
Both defects only show up on the GCP VM, where the dashboard is reached through an IAP tunnel rather than a `.ts.net` hostname. Found while verifying the staging cutover.

## 1. nginx was throwing away the path

When `proxy_pass` contains a variable, nginx does **not** replace the matched location prefix with the directive's URI — it sends that URI literally. The variable upstream is required here (the `bot` container may not be up at config-load time), so every URI suffix was silently discarded.

Verified against a real nginx on a compose-like network, same config shape:

```
/orders/pending        -> backend received: /orders/
/orders/raindex        -> backend received: /orders/
/performance/infra     -> backend received: /performance
/transfers/interrupted -> backend received: /transfers
(no-URI form)          -> backend received: /fixed/deep/path?limit=1
```

Live confirmation on the staging VM — same path, through the proxy vs straight to the bot:

| path | via nginx | direct to bot |
|---|---|---|
| `/orders/pending` | 404 | 200 |
| `/orders/raindex` | 404 | 200 |
| `/performance/{infra,latencies,rebalances,reliability}` | 404 | 200 |

That is the entire Orders tab and every Performance endpoint. The quieter half is the worse one: `/transfers/interrupted` and `/trades/{venue}/{id}/events` returned the plain `/transfers` and `/trades` lists **with a 200** — a wrong answer instead of an error.

Removing the URI part makes nginx forward the request URI unchanged, query string included.

## 2. The WebSocket left the page's origin

`isLocalDev()` keyed off the hostname, so a built bundle served by nginx at `http://localhost:8080` through `gcloud compute start-iap-tunnel` looked like `vite dev` and dialed `ws://localhost:8001` — a port nobody forwards. REST calls use `window.location.origin` and worked fine, so the dashboard rendered its tables while sitting permanently **Disconnected** with "Waiting for inventory data…".

`dev` from `$app/environment` is the actual discriminator: true only under the Vite dev server, which is the one case that needs a different port. Dev behaviour is unchanged (Vite already proxies `/api/ws`), an explicit `PUBLIC_ALPACA_WS_URL` still wins, and two regression tests cover the tunnel case.

## Verification

Confirmed on the live staging VM: opening a second tunnel on 8001 flipped the header to **Connected** and the inventory table, cash row and per-asset rows all populated — which is what isolated defect 2 from defect 1. After this lands, one tunnel on 8080 is enough.

I could not run the dashboard unit tests locally (neither `nix` nor `bun` is installed on this machine), so CI is the check on those.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789240610&installation_model_id=19370&pr_number=1200&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1200&signature=36577ab63022d10a5b9bd6b6f36c7b98917ebeb15d52828d608f7ac28135c68a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebSocket connection handling for production builds accessed through localhost tunnels.
  - Ensured explicitly configured WebSocket URLs continue to take precedence.
  - Fixed proxy routing so WebSocket, health, trading, and performance requests preserve their original paths.
  - Improved reliability for health checks, logs, orders, P&L, trades, transfers, and performance data requests.
  - Restricted proxied WebSocket and API access to safe read-oriented request methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->