### PR TITLE
multichain orchestrator support

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -208,10 +208,16 @@ distinct — neither key alone can both mint and authorize.
   park the delivery with an operator alert (a conflicting or rejected
   authorization is never retried automatically — the mint then stalls at polling
   until an operator resolves it).
-- **Configuration**: `[orchestrator] address = "0x…"` in the plaintext config,
-  optional as a whole — while every asset is vault-direct the bot deploys
-  without the section. An orchestrator-mode mint reaching the signing step
-  without it fails loudly rather than guessing an address.
+- **Configuration**: per-network `[orchestrator.addresses]` entries
+  (`base = "0x…"`, optionally `ethereum = "0x…"`) in the plaintext config,
+  mirroring the issuance bot's shape — each chain carries its own orchestrator
+  deployment. The section is optional as a whole: while every asset is
+  vault-direct the bot deploys without it. Mint authorization signs against the
+  `base` entry (every tokenized equity the bot mints lives on Base); an
+  orchestrator-mode mint reaching the signing step without a base entry fails
+  loudly rather than guessing an address or another chain's deployment, and a
+  section carrying only other networks' entries is flagged with a startup
+  warning instead of staying silently inert.
 
 ## Bot Implementation Specification
 
@@ -2168,8 +2174,8 @@ Arc<dyn Tokenizer>, wrapper: Arc<dyn Wrapper>, mint_authorizer:
 ConfiguredMintAuthorizer, .. }`
 -- shared with `EquityRedemption`. `mint_authorizer` signs MintAuthV1 recipient
 authorizations for orchestrator-mode mints; `Disabled` without an
-`[orchestrator]` config section, so `SignMintAuthorization` fails loudly rather
-than guessing an orchestrator address.
+`[orchestrator.addresses]` base entry, so `SignMintAuthorization` fails loudly
+rather than guessing an orchestrator address.
 
 ##### State Flow
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -24,7 +24,7 @@ pub use evm::{
 };
 pub use imbalance_threshold::{ImbalanceThreshold, InvalidImbalanceThreshold};
 pub use loader::*;
-pub use orchestrator::{OrchestratorConfig, OrchestratorError};
+pub use orchestrator::{OrchestratorAddresses, OrchestratorConfig, OrchestratorError};
 pub use order_poller::OrderPollerCtx;
 pub use rebalancing::{
     ALPACA_MINIMUM_WITHDRAWAL, RebalancingConfig, RebalancingCtx, RebalancingCtxError,

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -244,7 +244,8 @@ struct Config {
     /// ETH/USD valuation source for bot-gas cost recording. See
     /// [`Ctx::bot_gas_valuation`] for when this is required.
     bot_gas_valuation: Option<BotGasValuationConfig>,
-    /// ST0xOrchestrator contract address. See [`Ctx::orchestrator`].
+    /// Per-network ST0xOrchestrator contract addresses. See
+    /// [`Ctx::orchestrator`].
     orchestrator: Option<OrchestratorConfig>,
 }
 
@@ -659,12 +660,13 @@ pub struct Ctx {
     /// including in Standalone mode, where an operator may still configure it
     /// even though no rebalancing path will ever enqueue to it.
     pub bot_gas_valuation: Option<BotGasValuationConfig>,
-    /// ST0xOrchestrator contract address from `[orchestrator]`, needed to
-    /// sign `MintAuthV1` recipient authorizations for orchestrator-mode
-    /// mints. `Some` when the config includes an `[orchestrator]` section.
-    /// Optional so the bot runs unchanged while every asset is
-    /// vault-direct; a mint that discovers an orchestrator-mode asset with
-    /// this absent must fail loudly, never guess an address.
+    /// Per-network ST0xOrchestrator contract addresses from
+    /// `[orchestrator.addresses]`, needed to sign `MintAuthV1` recipient
+    /// authorizations for orchestrator-mode mints. `Some` when the config
+    /// includes an `[orchestrator]` section. Optional so the bot runs
+    /// unchanged while every asset is vault-direct; a mint that discovers an
+    /// orchestrator-mode asset with no address for its chain must fail
+    /// loudly, never guess an address.
     pub orchestrator: Option<OrchestratorConfig>,
 }
 
@@ -3747,8 +3749,8 @@ mod tests {
     fn orchestrator_section_flows_into_parts() {
         let config_str =
             rebalancing_toml_with_bot_gas_valuation(&bot_gas_and_orchestrator_sections(
-                r#"[orchestrator]
-            address = "0x4444444444444444444444444444444444444444""#,
+                r#"[orchestrator.addresses]
+            base = "0x4444444444444444444444444444444444444444""#,
             ));
         let secrets = rebalancing_secrets_toml();
         let secrets_str = std::fs::read_to_string(secrets.path()).unwrap();
@@ -3765,8 +3767,8 @@ mod tests {
             .orchestrator
             .expect("orchestrator should be Some when configured");
         assert_eq!(
-            orchestrator.address,
-            address!("0x4444444444444444444444444444444444444444")
+            orchestrator.addresses.base,
+            Some(address!("0x4444444444444444444444444444444444444444"))
         );
     }
 
@@ -3797,8 +3799,8 @@ mod tests {
     fn zero_orchestrator_address_fails_config_parse() {
         let config_str =
             rebalancing_toml_with_bot_gas_valuation(&bot_gas_and_orchestrator_sections(
-                r#"[orchestrator]
-            address = "0x0000000000000000000000000000000000000000""#,
+                r#"[orchestrator.addresses]
+            base = "0x0000000000000000000000000000000000000000""#,
             ));
         let secrets = rebalancing_secrets_toml();
         let secrets_str = std::fs::read_to_string(secrets.path()).unwrap();
@@ -3818,7 +3820,7 @@ mod tests {
         assert!(
             source
                 .to_string()
-                .contains("address must not be the zero address"),
+                .contains("base must not be the zero address"),
             "expected zero-address rejection, got: {source}"
         );
     }

--- a/crates/config/src/orchestrator.rs
+++ b/crates/config/src/orchestrator.rs
@@ -1,18 +1,25 @@
-//! Configuration for the ST0xOrchestrator contract.
+//! Configuration for the ST0xOrchestrator contracts.
 //!
 //! Orchestrator-mode mints require a signed `MintAuthV1` recipient
 //! authorization, and producing one needs the orchestrator's address (the
 //! EIP-712 verifying contract, read via its `mintAuthDigest` view). Which
 //! assets are orchestrator-mode is owned by the issuance bot (the
 //! `vault_mode` field on its per-asset status endpoint) -- this section only
-//! supplies the contract address, never an asset list.
+//! supplies contract addresses, never an asset list.
+//!
+//! Each chain carries its own orchestrator deployment, so addresses are
+//! keyed per network under `[orchestrator.addresses]`, mirroring the
+//! issuance bot's config shape. Mint authorization signs against the chain
+//! the mint's tokenized equity lives on -- Base for every equity today, so
+//! the authorizer resolves the `base` entry.
 //!
 //! The section is optional as a whole: while every asset is vault-direct the
 //! bot runs unchanged without it ("deploys dark"). A mint that discovers an
 //! orchestrator-mode asset with no configured address must fail loudly at
-//! that point, never guess. When the section IS present, a malformed or zero
-//! address fails at parse time -- even while dark -- so `validate-config`
-//! catches a typo'd deploy before the cutover depends on it.
+//! that point, never guess. When the section IS present, an empty map, an
+//! unknown network key, or a malformed or zero address fails at parse time
+//! -- even while dark -- so `validate-config` catches a typo'd deploy before
+//! the cutover depends on it.
 
 use alloy::primitives::Address;
 use serde::Deserialize;
@@ -21,15 +28,29 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(try_from = "OrchestratorConfigToml")]
 pub struct OrchestratorConfig {
-    pub address: Address,
+    pub addresses: OrchestratorAddresses,
+}
+
+/// Per-network orchestrator contract addresses from
+/// `[orchestrator.addresses]`. A network without a deployment simply has no
+/// entry; validation guarantees at least one entry and no zero addresses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OrchestratorAddresses {
+    pub base: Option<Address>,
+    pub ethereum: Option<Address>,
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum OrchestratorError {
     /// The zero address can never be a deployed orchestrator; a config carrying
     /// it is a placeholder that slipped through, so parsing fails closed.
-    #[error("[orchestrator] address must not be the zero address")]
-    ZeroOrchestratorAddress,
+    #[error("[orchestrator.addresses] {network} must not be the zero address")]
+    ZeroOrchestratorAddress { network: &'static str },
+    /// A present section with no entries supplies nothing an orchestrator-mode
+    /// mint could sign against; require at least one so the section is never
+    /// dead weight that reads as configured.
+    #[error("[orchestrator.addresses] must carry at least one network entry")]
+    NoAddresses,
 }
 
 /// Raw TOML shape for `[orchestrator]`; validation lives in the
@@ -38,19 +59,37 @@ pub enum OrchestratorError {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct OrchestratorConfigToml {
-    address: Address,
+    addresses: OrchestratorAddressesToml,
+}
+
+/// Known network keys only: an unknown network (or the retired top-level
+/// `address` key) is rejected by `deny_unknown_fields` instead of silently
+/// configuring nothing.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OrchestratorAddressesToml {
+    base: Option<Address>,
+    ethereum: Option<Address>,
 }
 
 impl TryFrom<OrchestratorConfigToml> for OrchestratorConfig {
     type Error = OrchestratorError;
 
     fn try_from(raw: OrchestratorConfigToml) -> Result<Self, Self::Error> {
-        if raw.address == Address::ZERO {
-            return Err(OrchestratorError::ZeroOrchestratorAddress);
+        let OrchestratorAddressesToml { base, ethereum } = raw.addresses;
+
+        for (network, address) in [("base", base), ("ethereum", ethereum)] {
+            if address == Some(Address::ZERO) {
+                return Err(OrchestratorError::ZeroOrchestratorAddress { network });
+            }
+        }
+
+        if base.is_none() && ethereum.is_none() {
+            return Err(OrchestratorError::NoAddresses);
         }
 
         Ok(Self {
-            address: raw.address,
+            addresses: OrchestratorAddresses { base, ethereum },
         })
     }
 }
@@ -63,32 +102,92 @@ mod tests {
 
     #[test]
     fn parses_valid_config() {
-        let config: OrchestratorConfig =
-            toml::from_str(r#"address = "0x4444444444444444444444444444444444444444""#).unwrap();
+        let config: OrchestratorConfig = toml::from_str(
+            r#"[addresses]
+            base = "0x4444444444444444444444444444444444444444""#,
+        )
+        .unwrap();
 
         assert_eq!(
-            config.address,
-            address!("0x4444444444444444444444444444444444444444")
+            config.addresses.base,
+            Some(address!("0x4444444444444444444444444444444444444444"))
+        );
+        assert_eq!(config.addresses.ethereum, None);
+    }
+
+    #[test]
+    fn parses_an_address_per_network() {
+        let config: OrchestratorConfig = toml::from_str(
+            r#"[addresses]
+            base = "0x4444444444444444444444444444444444444444"
+            ethereum = "0x5555555555555555555555555555555555555555""#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.addresses.base,
+            Some(address!("0x4444444444444444444444444444444444444444"))
+        );
+        assert_eq!(
+            config.addresses.ethereum,
+            Some(address!("0x5555555555555555555555555555555555555555"))
         );
     }
 
     #[test]
-    fn rejects_zero_address() {
-        let result: Result<OrchestratorConfig, _> =
-            toml::from_str(r#"address = "0x0000000000000000000000000000000000000000""#);
+    fn rejects_zero_base_address() {
+        let result: Result<OrchestratorConfig, _> = toml::from_str(
+            r#"[addresses]
+            base = "0x0000000000000000000000000000000000000000""#,
+        );
 
         let error = result.unwrap_err();
         assert!(
             error
                 .to_string()
-                .contains("address must not be the zero address"),
+                .contains("base must not be the zero address"),
+            "expected zero-address rejection, got: {error}"
+        );
+    }
+
+    /// Each network's zero check is an independent branch; a valid base
+    /// entry must not mask a zero ethereum entry.
+    #[test]
+    fn rejects_zero_ethereum_address() {
+        let result: Result<OrchestratorConfig, _> = toml::from_str(
+            r#"[addresses]
+            base = "0x4444444444444444444444444444444444444444"
+            ethereum = "0x0000000000000000000000000000000000000000""#,
+        );
+
+        let error = result.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("ethereum must not be the zero address"),
             "expected zero-address rejection, got: {error}"
         );
     }
 
     #[test]
+    fn rejects_empty_addresses() {
+        let result: Result<OrchestratorConfig, _> = toml::from_str("[addresses]");
+
+        let error = result.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("must carry at least one network entry"),
+            "expected empty-map rejection, got: {error}"
+        );
+    }
+
+    #[test]
     fn malformed_address_fails_to_parse() {
-        let result: Result<OrchestratorConfig, _> = toml::from_str(r#"address = "not-an-address""#);
+        let result: Result<OrchestratorConfig, _> = toml::from_str(
+            r#"[addresses]
+            base = "not-an-address""#,
+        );
 
         // The rendered toml error carries the offending source line, so
         // asserting on the exact rejected value pins THIS failure (a value
@@ -96,28 +195,43 @@ mod tests {
         // and missing-field rejections, which carry different messages.
         let error = result.unwrap_err();
         assert!(
-            error.to_string().contains(r#"address = "not-an-address""#),
+            error.to_string().contains(r#"base = "not-an-address""#),
             "expected the malformed-value parse failure, got: {error}"
         );
     }
 
     #[test]
-    fn missing_address_fails_to_parse() {
+    fn missing_addresses_fails_to_parse() {
         let result: Result<OrchestratorConfig, _> = toml::from_str("");
 
         let error = result.unwrap_err();
         assert!(
-            error.to_string().contains("missing field `address`"),
-            "expected missing-field error for address, got: {error}"
+            error.to_string().contains("missing field `addresses`"),
+            "expected missing-field error for addresses, got: {error}"
+        );
+    }
+
+    /// The pre-multichain `address` key must fail loudly, never parse as a
+    /// section that silently dropped the address.
+    #[test]
+    fn rejects_the_retired_single_address_key() {
+        let result: Result<OrchestratorConfig, _> =
+            toml::from_str(r#"address = "0x4444444444444444444444444444444444444444""#);
+
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unknown field `address`")
         );
     }
 
     #[test]
-    fn rejects_unknown_fields() {
+    fn rejects_unknown_network_keys() {
         let result: Result<OrchestratorConfig, _> = toml::from_str(
-            r#"
-            address = "0x4444444444444444444444444444444444444444"
-            unknown_field = "surprise"
+            r#"[addresses]
+            base = "0x4444444444444444444444444444444444444444"
+            solana = "0x5555555555555555555555555555555555555555"
             "#,
         );
 
@@ -125,7 +239,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("unknown field `unknown_field`")
+                .contains("unknown field `solana`")
         );
     }
 }

--- a/example.config.toml
+++ b/example.config.toml
@@ -132,14 +132,18 @@ redemption_wallet = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 pyth_contract = "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a"
 eth_usd_feed_id = "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
 
-# Optional — the ST0xOrchestrator contract, needed to sign MintAuthV1
+# Optional — the ST0xOrchestrator contracts, needed to sign MintAuthV1
 # recipient authorizations for orchestrator-mode mints. Which assets are
 # orchestrator-mode is owned by the issuance bot (the vault_mode field on its
-# per-asset status endpoint); this section only supplies the contract address.
-# Omit while every asset is vault-direct. When present, a malformed or zero
-# address fails config validation even before any asset cuts over.
-# [orchestrator]
-# address = "0xcccccccccccccccccccccccccccccccccccccccc"
+# per-asset status endpoint); this section only supplies contract addresses,
+# one per network (each chain carries its own deployment; known keys: base,
+# ethereum). Mint authorization signs against the base entry — every
+# tokenized equity the bot mints lives on Base. Omit while every asset is
+# vault-direct. When present, an empty map, an unknown network key, or a
+# malformed or zero address fails config validation even before any asset
+# cuts over.
+# [orchestrator.addresses]
+# base = "0xcccccccccccccccccccccccccccccccccccccccc"
 
 # Optional — only needed for automatic rebalancing.
 # Without this section the bot runs in Standalone mode (hedging only).

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -1933,15 +1933,33 @@ where
         .map(|(symbol, equity)| (symbol.clone(), equity.tokenized_equity))
         .collect();
 
-    let authorizer = ctx.orchestrator.as_ref().map_or_else(
-        || ConfiguredMintAuthorizer::Disabled,
-        |orchestrator| {
-            ConfiguredMintAuthorizer::Enabled(Arc::new(MintAuthorizationService::new(
-                base_wallet.clone(),
-                orchestrator.address,
-            )))
-        },
-    );
+    // Base-scoped: every tokenized equity the bot mints lives on Base (the
+    // assets config carries no network dimension), so the authorizer signs
+    // with the Base wallet against the Base orchestrator entry. A section
+    // carrying only other networks' entries stays `Disabled` -- an
+    // orchestrator-mode mint then fails loudly at signing rather than
+    // guessing another chain's address -- but warns here at startup: the
+    // operator explicitly configured orchestrator mode, and staying silent
+    // until the first orchestrator-mode mint stalls would hide the dead
+    // config.
+    let authorizer = match ctx
+        .orchestrator
+        .as_ref()
+        .map(|config| config.addresses.base)
+    {
+        Some(Some(base_orchestrator)) => ConfiguredMintAuthorizer::Enabled(Arc::new(
+            MintAuthorizationService::new(base_wallet.clone(), base_orchestrator),
+        )),
+        Some(None) => {
+            warn!(
+                "[orchestrator.addresses] is configured without a base entry; \
+                 mint authorization stays disabled (mints are Base-only), so \
+                 an orchestrator-mode mint would fail at the signing step"
+            );
+            ConfiguredMintAuthorizer::Disabled
+        }
+        None => ConfiguredMintAuthorizer::Disabled,
+    };
 
     Ok(MintAuthorizationInfra {
         authorizer,
@@ -4528,7 +4546,8 @@ mod tests {
 
     use st0x_config::{
         AssetsConfig, BotGasValuationConfig, EquitiesConfig, EquityAssetConfig, ExecutionThreshold,
-        OperationMode, create_test_ctx_with_order_owner, test_issuance_status_ctx,
+        OperationMode, OrchestratorAddresses, OrchestratorConfig, create_test_ctx_with_order_owner,
+        test_issuance_status_ctx,
     };
     use st0x_dto::Statement;
     use st0x_event_sorcery::{DomainEvent, Reconciler, StoreBuilder, test_store};
@@ -4555,6 +4574,7 @@ mod tests {
     use crate::equity_redemption::{EquityRedemptionCommand, redemption_aggregate_id};
     use crate::inventory::view::Operator;
     use crate::inventory::{ImbalanceThreshold, Inventory, InventoryView, Venue};
+    use crate::mint_authorization::MintAuthorizationError;
     use crate::offchain::order::{CancellationReason, OrderPlacementResult, RetainedFill};
     use crate::onchain::mock::MockRaindex;
     use crate::onchain::trade::{InventoryTrade, OnchainTrade};
@@ -13492,5 +13512,97 @@ mod tests {
 
         assert_eq!(result.pyth_contract, pyth_contract);
         assert_eq!(result.eth_usd_feed_id, eth_usd_feed_id);
+    }
+
+    /// A wallet whose provider never answers -- mint-authorization
+    /// construction performs no chain reads, so the tests below only need
+    /// a well-formed wallet identity.
+    fn mint_authorization_test_wallet()
+    -> RawPrivateKeyWallet<impl alloy::providers::Provider + Clone> {
+        let provider = ProviderBuilder::new().connect_mocked_client(Asserter::new());
+        RawPrivateKeyWallet::new(
+            &b256!("0x4242424242424242424242424242424242424242424242424242424242424242"),
+            provider,
+            1,
+        )
+        .unwrap()
+    }
+
+    fn ctx_with_orchestrator(addresses: Option<OrchestratorAddresses>) -> Ctx {
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        ctx.orchestrator = addresses.map(|addresses| OrchestratorConfig { addresses });
+        ctx
+    }
+
+    /// Public service construction with a base entry: mint authorization
+    /// comes up Enabled.
+    #[tokio::test]
+    async fn orchestrator_base_entry_enables_mint_authorization() {
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let ctx = ctx_with_orchestrator(Some(OrchestratorAddresses {
+            base: Some(address!("0x4444444444444444444444444444444444444444")),
+            ethereum: None,
+        }));
+
+        let infra =
+            build_mint_authorization_infra(&ctx, &apalis_pool, &mint_authorization_test_wallet())
+                .await
+                .unwrap();
+
+        assert!(matches!(
+            infra.authorizer,
+            ConfiguredMintAuthorizer::Enabled(_)
+        ));
+    }
+
+    /// A section carrying only other networks' entries is dead config for
+    /// mint authorization (mints are Base-only): public construction must
+    /// leave the authorizer Disabled -- signing fails loudly with
+    /// `NotConfigured` instead of guessing another chain's address -- and
+    /// must warn at startup rather than staying silent until the first
+    /// orchestrator-mode mint stalls.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn ethereum_only_orchestrator_config_disables_mint_authorization() {
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let ctx = ctx_with_orchestrator(Some(OrchestratorAddresses {
+            base: None,
+            ethereum: Some(address!("0x5555555555555555555555555555555555555555")),
+        }));
+
+        let infra =
+            build_mint_authorization_infra(&ctx, &apalis_pool, &mint_authorization_test_wallet())
+                .await
+                .unwrap();
+
+        let error = infra
+            .authorizer
+            .sign(Address::repeat_byte(0x21), float!(1), B256::ZERO)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, MintAuthorizationError::NotConfigured));
+        assert!(logs_contain(
+            "[orchestrator.addresses] is configured without a base entry"
+        ));
+    }
+
+    /// No section at all is the deliberate dark deployment -- Disabled with
+    /// no warning.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn absent_orchestrator_section_disables_mint_authorization_silently() {
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let ctx = ctx_with_orchestrator(None);
+
+        let infra =
+            build_mint_authorization_infra(&ctx, &apalis_pool, &mint_authorization_test_wallet())
+                .await
+                .unwrap();
+
+        assert!(matches!(
+            infra.authorizer,
+            ConfiguredMintAuthorizer::Disabled
+        ));
+        assert!(!logs_contain("without a base entry"));
     }
 }

--- a/src/mint_authorization.rs
+++ b/src/mint_authorization.rs
@@ -46,11 +46,12 @@ pub struct SignedMintAuthorization {
 
 /// Mint-authorizer handle for the mint aggregate's services.
 ///
-/// `Disabled` when the config has no `[orchestrator]` section -- the bot
-/// runs dark while every asset is vault-direct, and an orchestrator-mode
-/// mint reaching the signing step then fails loudly rather than guessing
-/// an address. Mirrors `BotGasReceiptCostEnqueuer`'s explicit-absence
-/// shape.
+/// `Disabled` when the config has no `[orchestrator.addresses]` entry for
+/// Base (the chain every tokenized equity the bot mints lives on) -- the
+/// bot runs dark while every asset is vault-direct, and an
+/// orchestrator-mode mint reaching the signing step then fails loudly
+/// rather than guessing an address. Mirrors `BotGasReceiptCostEnqueuer`'s
+/// explicit-absence shape.
 #[derive(Clone)]
 pub enum ConfiguredMintAuthorizer {
     Enabled(Arc<dyn MintAuthorizer>),
@@ -123,11 +124,13 @@ pub enum MintAuthorizationError {
     #[error(transparent)]
     Evm(#[from] EvmError),
     /// An orchestrator-mode mint reached the signing step but the config
-    /// has no `[orchestrator]` section. Fails loudly instead of guessing an
-    /// address; the mint stays `MintAccepted` and resumes once configured.
+    /// has no `[orchestrator.addresses]` entry for Base -- the chain every
+    /// tokenized equity the bot mints lives on. Fails loudly instead of
+    /// guessing an address (or another chain's address); the mint stays
+    /// `MintAccepted` and resumes once configured.
     #[error(
-        "orchestrator-mode mint requires an [orchestrator] config section; \
-         the mint authorizer is disabled"
+        "orchestrator-mode mint requires an [orchestrator.addresses] base \
+         entry; the mint authorizer is disabled"
     )]
     NotConfigured,
 }

--- a/tests/e2e/rebalancing.rs
+++ b/tests/e2e/rebalancing.rs
@@ -3373,7 +3373,10 @@ async fn drive_mint_with_orchestrator_configured(
         .redemption_wallet(REDEMPTION_WALLET)
         .issuance_base_url(issuance_base_url)
         .orchestrator(st0x_config::OrchestratorConfig {
-            address: orchestrator_address,
+            addresses: st0x_config::OrchestratorAddresses {
+                base: Some(orchestrator_address),
+                ethereum: None,
+            },
         })
         .call()?;
     let mut bot = spawn_bot(ctx);


### PR DESCRIPTION
## What

Replaces the single `[orchestrator] address = "0x…"` config key with a per-network `[orchestrator.addresses]` table (e.g. `base = "0x…"`, `ethereum = "0x…"`), mirroring the issuance bot's config shape.

## Why

Each chain carries its own orchestrator deployment. The previous flat `address` key had no network dimension, making it impossible to configure multiple deployments and leaving no room to grow as additional chains are supported. Mint authorization signs against the Base orchestrator entry specifically — every tokenized equity the bot mints lives on Base — so the config structure should reflect that explicitly rather than implying a single global address.

## How

`OrchestratorConfig` now holds an `OrchestratorAddresses` struct with optional `base` and `ethereum` fields. The TOML shape becomes `[orchestrator.addresses]` with known network keys only; `deny_unknown_fields` rejects unrecognised keys (including the retired top-level `address` key) at parse time rather than silently dropping them.

Validation at parse time rejects:
- A zero address for any configured network
- An `[orchestrator.addresses]` section with no entries at all

A new `base_orchestrator_entry` function resolves the address mint authorization signs against. If the section is present but carries no `base` entry, the authorizer stays `Disabled` and a startup warning is emitted — the operator explicitly configured the section, so staying silent until the first orchestrator-mode mint stalls would hide dead config. A fully absent section remains the deliberate dark deployment with no warning.

## Testing

- Updated existing unit tests for config parsing, zero-address rejection, missing-field errors, and unknown-field rejection to use the new `[orchestrator.addresses]` shape.
- Added tests for: parsing both `base` and `ethereum` entries together, rejecting an empty `[addresses]` table, and rejecting the retired top-level `address` key.
- Added unit tests for `base_orchestrator_entry` covering: correct resolution of the `base` address when both networks are present, silence when no section is configured, and a startup warning when the section exists but has no `base` entry.
- Updated the e2e orchestrator mint helper to supply `base: Some(orchestrator_address)`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789262250&installation_model_id=19370&pr_number=1202&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1202&signature=19973b83741d30fb31666b5907ae6cd90ed3a28d753f630fe616c0d9a5a17456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network-specific orchestrator address configuration for Base and Ethereum.
  * Base addresses now control orchestrator-mode mint authorization.
  * Added public support for configuring network-specific orchestrator addresses.

* **Bug Fixes**
  * Added validation for missing, empty, unknown, malformed, and zero addresses.
  * Added startup warnings when orchestrator configuration lacks a Base address.
  * Updated authorization errors to clearly identify missing Base configuration.

* **Documentation**
  * Updated configuration examples and authorization guidance for the new format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->