### PR TITLE
[RAI-1760] Add HyperEVM to the tokenization CLI network flag

### DIFF
--- a/config/s01-issuer.toml
+++ b/config/s01-issuer.toml
@@ -10,7 +10,7 @@
 #
 # The encrypted secret (secret/s01-issuer.toml.age) must carry the FULL secret
 # surface the shared validate-config gate checks, or the deploy fails closed:
-#   [evm]       rpc_url, base_rpc_url, ethereum_rpc_url
+#   [evm]       rpc_url, base_rpc_url, ethereum_rpc_url, hyperevm_rpc_url
 #   [broker]    type = "alpaca-broker-api" + api_key/api_secret/account_id
 #   [wallet]    api_private_key (turnkey)
 #   [issuance]  base_url + api_key (required unconditionally by the validator)

--- a/crates/config/src/evm.rs
+++ b/crates/config/src/evm.rs
@@ -249,6 +249,10 @@ pub struct EvmSecrets {
     /// `[wallet]` is configured.
     #[serde(rename = "ethereum_rpc_url")]
     pub ethereum: Option<Url>,
+    /// HyperEVM mainnet RPC URL for wallet operations. Required when
+    /// `[wallet]` is configured.
+    #[serde(rename = "hyperevm_rpc_url")]
+    pub hyperevm: Option<Url>,
 }
 
 #[derive(Clone)]
@@ -318,6 +322,7 @@ mod tests {
             rpc: Url::parse("http://localhost:8545").unwrap(),
             base: None,
             ethereum: None,
+            hyperevm: None,
         }
     }
 

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -875,6 +875,7 @@ struct WalletInputs {
     secrets: toml::Value,
     base_rpc_url: Url,
     ethereum_rpc_url: Url,
+    hyperevm_rpc_url: Url,
 }
 
 /// Non-secret wallet metadata extracted from the config TOML during
@@ -893,6 +894,7 @@ fn validate_wallet_inputs(
     wallet_secrets: Option<toml::Value>,
     base_rpc_url: Option<Url>,
     ethereum_rpc_url: Option<Url>,
+    hyperevm_rpc_url: Option<Url>,
     config_path: &Path,
 ) -> Result<(WalletInputs, WalletMeta), CtxError> {
     match (wallet_config, wallet_secrets) {
@@ -914,6 +916,9 @@ fn validate_wallet_inputs(
             let ethereum_rpc_url = ethereum_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
                 field: "ethereum_rpc_url",
             })?;
+            let hyperevm_rpc_url = hyperevm_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
+                field: "hyperevm_rpc_url",
+            })?;
             let wallet_meta = WalletMeta::deserialize(wallet_config.clone()).map_err(|source| {
                 CtxError::ConfigToml {
                     path: config_path.to_path_buf(),
@@ -927,6 +932,7 @@ fn validate_wallet_inputs(
                     secrets: wallet_secrets,
                     base_rpc_url,
                     ethereum_rpc_url,
+                    hyperevm_rpc_url,
                 },
                 wallet_meta,
             ))
@@ -1001,12 +1007,14 @@ fn parse_and_validate(
     // Extract RPC URLs before EvmCtx consumes secrets.evm.
     let base_rpc_url = secrets.evm.base.take();
     let ethereum_rpc_url = secrets.evm.ethereum.take();
+    let hyperevm_rpc_url = secrets.evm.hyperevm.take();
     let evm = EvmCtx::new(&config.raindex, secrets.evm)?;
     let (wallet_inputs, wallet_meta) = validate_wallet_inputs(
         config.wallet,
         secrets.wallet,
         base_rpc_url,
         ethereum_rpc_url,
+        hyperevm_rpc_url,
         config_path,
     )?;
 
@@ -1258,6 +1266,7 @@ impl Ctx {
             parts.wallet_inputs.secrets,
             parts.wallet_inputs.base_rpc_url,
             parts.wallet_inputs.ethereum_rpc_url,
+            parts.wallet_inputs.hyperevm_rpc_url,
         )
         .await?;
 
@@ -1698,7 +1707,8 @@ pub enum CtxError {
     MissingBotGasValuation,
     #[error(
         "operation requires a configured [wallet] section \
-         (base_rpc_url and ethereum_rpc_url in [evm] secrets)"
+         (base_rpc_url, ethereum_rpc_url, and hyperevm_rpc_url in [evm] \
+         secrets)"
     )]
     WalletNotConfigured,
     #[error(transparent)]
@@ -2120,6 +2130,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "alpaca-broker-api"
@@ -2181,6 +2192,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "dry-run"
@@ -2513,6 +2525,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "dry-run"
@@ -2597,6 +2610,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "dry-run"
@@ -3038,6 +3052,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "alpaca-broker-api"
@@ -3174,6 +3189,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "schwab"
@@ -3549,6 +3565,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.example.com"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "alpaca-broker-api"
@@ -3639,6 +3656,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.example.com"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "alpaca-broker-api"
@@ -3737,6 +3755,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.example.com"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "dry-run"
@@ -3876,6 +3895,7 @@ mod tests {
             rpc_url = "http://localhost:1"
             base_rpc_url = "http://localhost:1"
             ethereum_rpc_url = "http://localhost:1"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "alpaca-broker-api"
@@ -4048,6 +4068,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.example.com"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "alpaca-broker-api"
@@ -4242,6 +4263,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.example.com"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "alpaca-broker-api"
@@ -4302,6 +4324,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.example.com"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "alpaca-broker-api"
@@ -4490,6 +4513,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "alpaca-broker-api"
@@ -4595,6 +4619,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "dry-run"
@@ -4622,6 +4647,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "dry-run"
@@ -4652,6 +4678,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "dry-run"
@@ -4683,6 +4710,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "dry-run"
@@ -4717,6 +4745,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "dry-run"
@@ -4819,6 +4848,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "alpaca-broker-api"
@@ -4861,6 +4891,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "schwab"
@@ -7134,6 +7165,7 @@ mod tests {
             rpc_url = "http://localhost:8545"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
+            hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
             [broker]
             type = "alpaca-broker-api"

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -3982,6 +3982,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn wallet_without_hyperevm_rpc_url_fails() {
+        let config = toml_file(
+            r#"
+            database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
+            apalis_finished_job_cleanup_interval_secs = 3600
+            inventory_divergence_threshold = 10
+
+            [assets.equities]
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+            inventory_mode = "managed"
+            inventory_adapters = []
+            inventory = "0x2222222222222222222222222222222222222222"
+            vault_owner = "0x3333333333333333333333333333333333333333"
+            deployment_block = 1
+            required_confirmations = 3
+            ingestion_cutoff = "safe"
+
+            [broker]
+            counter_trade_slippage_bps = 100
+            close_flatten_cross_max_bps = 400
+            extended_hours_reprice_timeout_secs = 300
+            close_flatten_reprice_timeout_secs = 60
+            extended_hours_close_flatten_window_secs = 900
+
+            [broker.travel_rule]
+            beneficiary_entity_name = "Test Corp"
+
+            [wallet]
+            kind = "private-key"
+            address = "0x0000000000000000000000000000000000000001"
+        "#,
+        );
+
+        let secrets = toml_file(
+            r#"
+            [evm]
+            rpc_url = "http://localhost:8545"
+            base_rpc_url = "https://base.example.com"
+            ethereum_rpc_url = "https://mainnet.example.com"
+
+            [broker]
+            type = "alpaca-broker-api"
+            api_key = "test-key"
+            api_secret = "test-secret"
+            account_id = "dddddddd-eeee-aaaa-dddd-beeeeeeeeeef"
+            mode = "sandbox"
+
+            [wallet]
+            private_key = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        "#,
+        );
+
+        let result = Ctx::load_files(config.path(), secrets.path()).await;
+        assert!(
+            matches!(
+                result,
+                Err(CtxError::WalletMissingRpcUrl {
+                    field: "hyperevm_rpc_url"
+                })
+            ),
+            "Expected WalletMissingRpcUrl for hyperevm_rpc_url, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn default_execution_threshold_is_one_share_for_dry_run() {
         let config = minimal_config_toml();
         let secrets = dry_run_secrets_toml();

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -887,28 +887,6 @@ pub struct WalletMeta {
     pub organization_id: Option<String>,
 }
 
-/// Rejects wallet RPC URLs that would carry signing traffic over cleartext
-/// HTTP. HTTP is allowed only for loopback hosts, so local test nodes
-/// (Anvil) keep working while any routable endpoint must be HTTPS.
-fn require_secure_wallet_rpc_url(url: Url, field: &'static str) -> Result<Url, CtxError> {
-    if url.scheme() == "https" {
-        return Ok(url);
-    }
-
-    let is_loopback = match url.host() {
-        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
-        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
-        Some(url::Host::Domain(host)) => host == "localhost",
-        None => false,
-    };
-
-    if is_loopback {
-        Ok(url)
-    } else {
-        Err(CtxError::WalletInsecureRpcUrl { field })
-    }
-}
-
 /// Validates the config/secrets pairing and RPC prerequisites for wallet
 /// construction without connecting to either chain.
 fn validate_wallet_inputs(
@@ -932,24 +910,18 @@ fn validate_wallet_inputs(
                 None => return Err(CtxError::WalletSecretsMissing),
             };
 
-            let base_rpc_url = require_secure_wallet_rpc_url(
-                base_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
-                    field: "base_rpc_url",
-                })?,
-                "base_rpc_url",
-            )?;
-            let ethereum_rpc_url = require_secure_wallet_rpc_url(
-                ethereum_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
-                    field: "ethereum_rpc_url",
-                })?,
-                "ethereum_rpc_url",
-            )?;
-            let hyperevm_rpc_url = require_secure_wallet_rpc_url(
-                hyperevm_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
-                    field: "hyperevm_rpc_url",
-                })?,
-                "hyperevm_rpc_url",
-            )?;
+            let base_rpc_url = base_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
+                field: "base_rpc_url",
+            })?;
+            let ethereum_rpc_url = ethereum_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
+                field: "ethereum_rpc_url",
+            })?;
+            let hyperevm_rpc_url = hyperevm_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
+                field: "hyperevm_rpc_url",
+            })?;
+            crate::wallet::require_secure_wallet_rpc_url(&base_rpc_url, "base_rpc_url")?;
+            crate::wallet::require_secure_wallet_rpc_url(&ethereum_rpc_url, "ethereum_rpc_url")?;
+            crate::wallet::require_secure_wallet_rpc_url(&hyperevm_rpc_url, "hyperevm_rpc_url")?;
             let wallet_meta = WalletMeta::deserialize(wallet_config.clone()).map_err(|source| {
                 CtxError::ConfigToml {
                     path: config_path.to_path_buf(),
@@ -1746,11 +1718,6 @@ pub enum CtxError {
     Wallet(#[from] crate::wallet::WalletCtxError),
     #[error("[evm] {field} is required when [wallet] is configured")]
     WalletMissingRpcUrl { field: &'static str },
-    #[error(
-        "[evm] {field} must use https; http is allowed only for loopback \
-         hosts (local test nodes)"
-    )]
-    WalletInsecureRpcUrl { field: &'static str },
     #[error("[wallet] config present but [wallet] secrets missing")]
     WalletSecretsMissing,
     #[error(
@@ -1847,7 +1814,6 @@ impl CtxError {
             Self::WalletNotConfigured => "wallet not configured",
             Self::Wallet(_) => "wallet construction error",
             Self::WalletMissingRpcUrl { .. } => "wallet missing RPC URL",
-            Self::WalletInsecureRpcUrl { .. } => "wallet RPC URL not https",
             Self::WalletSecretsMissing => "wallet secrets missing",
             Self::RestApiClient(_) => "failed to build REST API HTTP client",
             Self::MissingIssuanceConfig => "missing issuance config",
@@ -4091,12 +4057,12 @@ mod tests {
     fn wallet_rpc_url_rejects_routable_http() {
         let url = Url::parse("http://mainnet.example.com").unwrap();
 
-        let result = require_secure_wallet_rpc_url(url, "hyperevm_rpc_url");
+        let result = crate::wallet::require_secure_wallet_rpc_url(&url, "hyperevm_rpc_url");
 
         assert!(
             matches!(
                 result,
-                Err(CtxError::WalletInsecureRpcUrl {
+                Err(crate::wallet::WalletCtxError::InsecureRpcUrl {
                     field: "hyperevm_rpc_url"
                 })
             ),
@@ -4113,8 +4079,7 @@ mod tests {
             "http://[::1]:8545",
         ] {
             let parsed = Url::parse(url).unwrap();
-            let accepted = require_secure_wallet_rpc_url(parsed.clone(), "base_rpc_url").unwrap();
-            assert_eq!(accepted, parsed, "{url} must be accepted unchanged");
+            crate::wallet::require_secure_wallet_rpc_url(&parsed, "base_rpc_url").unwrap();
         }
     }
 

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -887,6 +887,28 @@ pub struct WalletMeta {
     pub organization_id: Option<String>,
 }
 
+/// Rejects wallet RPC URLs that would carry signing traffic over cleartext
+/// HTTP. HTTP is allowed only for loopback hosts, so local test nodes
+/// (Anvil) keep working while any routable endpoint must be HTTPS.
+fn require_secure_wallet_rpc_url(url: Url, field: &'static str) -> Result<Url, CtxError> {
+    if url.scheme() == "https" {
+        return Ok(url);
+    }
+
+    let is_loopback = match url.host() {
+        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+        Some(url::Host::Domain(host)) => host == "localhost",
+        None => false,
+    };
+
+    if is_loopback {
+        Ok(url)
+    } else {
+        Err(CtxError::WalletInsecureRpcUrl { field })
+    }
+}
+
 /// Validates the config/secrets pairing and RPC prerequisites for wallet
 /// construction without connecting to either chain.
 fn validate_wallet_inputs(
@@ -910,15 +932,24 @@ fn validate_wallet_inputs(
                 None => return Err(CtxError::WalletSecretsMissing),
             };
 
-            let base_rpc_url = base_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
-                field: "base_rpc_url",
-            })?;
-            let ethereum_rpc_url = ethereum_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
-                field: "ethereum_rpc_url",
-            })?;
-            let hyperevm_rpc_url = hyperevm_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
-                field: "hyperevm_rpc_url",
-            })?;
+            let base_rpc_url = require_secure_wallet_rpc_url(
+                base_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
+                    field: "base_rpc_url",
+                })?,
+                "base_rpc_url",
+            )?;
+            let ethereum_rpc_url = require_secure_wallet_rpc_url(
+                ethereum_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
+                    field: "ethereum_rpc_url",
+                })?,
+                "ethereum_rpc_url",
+            )?;
+            let hyperevm_rpc_url = require_secure_wallet_rpc_url(
+                hyperevm_rpc_url.ok_or(CtxError::WalletMissingRpcUrl {
+                    field: "hyperevm_rpc_url",
+                })?,
+                "hyperevm_rpc_url",
+            )?;
             let wallet_meta = WalletMeta::deserialize(wallet_config.clone()).map_err(|source| {
                 CtxError::ConfigToml {
                     path: config_path.to_path_buf(),
@@ -1715,6 +1746,11 @@ pub enum CtxError {
     Wallet(#[from] crate::wallet::WalletCtxError),
     #[error("[evm] {field} is required when [wallet] is configured")]
     WalletMissingRpcUrl { field: &'static str },
+    #[error(
+        "[evm] {field} must use https; http is allowed only for loopback \
+         hosts (local test nodes)"
+    )]
+    WalletInsecureRpcUrl { field: &'static str },
     #[error("[wallet] config present but [wallet] secrets missing")]
     WalletSecretsMissing,
     #[error(
@@ -1811,6 +1847,7 @@ impl CtxError {
             Self::WalletNotConfigured => "wallet not configured",
             Self::Wallet(_) => "wallet construction error",
             Self::WalletMissingRpcUrl { .. } => "wallet missing RPC URL",
+            Self::WalletInsecureRpcUrl { .. } => "wallet RPC URL not https",
             Self::WalletSecretsMissing => "wallet secrets missing",
             Self::RestApiClient(_) => "failed to build REST API HTTP client",
             Self::MissingIssuanceConfig => "missing issuance config",
@@ -4048,6 +4085,39 @@ mod tests {
             ),
             "Expected WalletMissingRpcUrl for hyperevm_rpc_url, got {result:?}"
         );
+    }
+
+    #[test]
+    fn wallet_rpc_url_rejects_routable_http() {
+        let url = Url::parse("http://mainnet.example.com").unwrap();
+
+        let result = require_secure_wallet_rpc_url(url, "hyperevm_rpc_url");
+
+        assert!(
+            matches!(
+                result,
+                Err(CtxError::WalletInsecureRpcUrl {
+                    field: "hyperevm_rpc_url"
+                })
+            ),
+            "routable http must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn wallet_rpc_url_allows_https_and_loopback_http() {
+        for url in [
+            "https://rpc.hyperliquid.xyz/evm",
+            "http://localhost:8545",
+            "http://127.0.0.1:8545",
+            "http://[::1]:8545",
+        ] {
+            let parsed = Url::parse(url).unwrap();
+            assert!(
+                require_secure_wallet_rpc_url(parsed, "base_rpc_url").is_ok(),
+                "{url} must be accepted"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -4113,10 +4113,8 @@ mod tests {
             "http://[::1]:8545",
         ] {
             let parsed = Url::parse(url).unwrap();
-            assert!(
-                require_secure_wallet_rpc_url(parsed, "base_rpc_url").is_ok(),
-                "{url} must be accepted"
-            );
+            let accepted = require_secure_wallet_rpc_url(parsed.clone(), "base_rpc_url").unwrap();
+            assert_eq!(accepted, parsed, "{url} must be accepted unchanged");
         }
     }
 

--- a/crates/config/src/wallet.rs
+++ b/crates/config/src/wallet.rs
@@ -19,6 +19,7 @@ const REQUIRED_CONFIRMATIONS: u64 = 3;
 const RPC_MAX_RETRIES: u32 = 10;
 const RPC_INITIAL_BACKOFF_MS: u64 = 1000;
 const RPC_COMPUTE_UNITS_PER_SECOND: u64 = 100;
+const RPC_REQUEST_TIMEOUT_SECS: u64 = 20;
 
 /// Extracts just the `kind` discriminant from the wallet TOML table,
 /// ignoring backend-specific fields that vary by wallet type.
@@ -133,7 +134,9 @@ impl OnchainWalletCtx {
 ///
 /// Redirects are disabled: the RPC URL is validated at config load (https or
 /// loopback), and following a redirect would let the server route signing
-/// traffic to a destination that never passed that validation.
+/// traffic to a destination that never passed that validation. The request
+/// timeout bounds a hung endpoint; the retry layer above it handles the
+/// resulting failures.
 fn http_client_with_retry(url: Url) -> Result<RpcClient, reqwest::Error> {
     let retry_layer = RetryBackoffLayer::new(
         RPC_MAX_RETRIES,
@@ -142,6 +145,7 @@ fn http_client_with_retry(url: Url) -> Result<RpcClient, reqwest::Error> {
     );
     let http_client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
+        .timeout(std::time::Duration::from_secs(RPC_REQUEST_TIMEOUT_SECS))
         .build()?;
     let transport = alloy::transports::http::Http::with_client(http_client, url);
     Ok(RpcClient::builder()
@@ -170,15 +174,23 @@ pub async fn build_wallet(
 #[cfg(any(test, feature = "test-support"))]
 impl OnchainWalletCtx {
     /// Create a stub wallet context for tests.
+    ///
+    /// Each chain gets a distinct marker address so a test that routes
+    /// through the wrong chain's wallet observes the wrong address instead
+    /// of passing by coincidence.
     pub fn stub() -> Self {
-        use alloy::primitives::Address;
-
-        let stub_wallet = st0x_evm::StubWallet::stub(Address::ZERO);
+        use alloy::primitives::address;
 
         Self {
-            base: stub_wallet.clone(),
-            ethereum: stub_wallet.clone(),
-            hyperevm: stub_wallet,
+            base: st0x_evm::StubWallet::stub(address!(
+                "0x0000000000000000000000000000000000000ba5"
+            )),
+            ethereum: st0x_evm::StubWallet::stub(address!(
+                "0x0000000000000000000000000000000000000e78"
+            )),
+            hyperevm: st0x_evm::StubWallet::stub(address!(
+                "0x0000000000000000000000000000000000000999"
+            )),
         }
     }
 }

--- a/crates/config/src/wallet.rs
+++ b/crates/config/src/wallet.rs
@@ -46,6 +46,8 @@ impl st0x_evm::Parser for TomlValue {
 pub enum WalletCtxError {
     #[error("invalid wallet config: {0}")]
     WalletConfig(#[from] toml::de::Error),
+    #[error("failed to build the wallet RPC HTTP client: {0}")]
+    HttpClient(#[from] reqwest::Error),
     #[error(transparent)]
     Evm(#[from] st0x_evm::EvmError),
 }
@@ -127,14 +129,24 @@ impl OnchainWalletCtx {
     }
 }
 
-/// Creates an HTTP RPC client with retry layer for transient errors.
-fn http_client_with_retry(url: Url) -> RpcClient {
+/// Creates an HTTP RPC client with a retry layer for transient errors.
+///
+/// Redirects are disabled: the RPC URL is validated at config load (https or
+/// loopback), and following a redirect would let the server route signing
+/// traffic to a destination that never passed that validation.
+fn http_client_with_retry(url: Url) -> Result<RpcClient, reqwest::Error> {
     let retry_layer = RetryBackoffLayer::new(
         RPC_MAX_RETRIES,
         RPC_INITIAL_BACKOFF_MS,
         RPC_COMPUTE_UNITS_PER_SECOND,
     );
-    RpcClient::builder().layer(retry_layer).http(url)
+    let http_client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
+    let transport = alloy::transports::http::Http::with_client(http_client, url);
+    Ok(RpcClient::builder()
+        .layer(retry_layer)
+        .transport(transport, false))
 }
 
 pub async fn build_wallet(
@@ -143,7 +155,7 @@ pub async fn build_wallet(
     wallet_secrets: toml::Value,
     rpc_url: Url,
 ) -> Result<Arc<dyn Wallet<Provider = RootProvider>>, WalletCtxError> {
-    let provider = RootProvider::new(http_client_with_retry(rpc_url));
+    let provider = RootProvider::new(http_client_with_retry(rpc_url)?);
 
     Ok(kind
         .try_into_wallet(EvmWalletCtx {

--- a/crates/config/src/wallet.rs
+++ b/crates/config/src/wallet.rs
@@ -109,6 +109,11 @@ impl OnchainWalletCtx {
         })
     }
 
+    // The accessors below are deliberately trivial getters: the fields are
+    // private across the crate boundary, and wallet selection logic stays
+    // out of this crate on purpose. The consumer pairs a wallet with its
+    // Alpaca wire value in a single match (see the CLI's
+    // tokenization_network_context) so the two cannot diverge.
     pub fn base_wallet(&self) -> &Arc<dyn Wallet<Provider = RootProvider>> {
         &self.base
     }

--- a/crates/config/src/wallet.rs
+++ b/crates/config/src/wallet.rs
@@ -58,10 +58,11 @@ pub enum WalletCtxError {
 pub struct OnchainWalletCtx {
     base_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
     ethereum_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
+    hyperevm_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
 }
 
 impl OnchainWalletCtx {
-    /// Build wallets for both chains from raw TOML config/secrets and RPC URLs.
+    /// Build wallets for all chains from raw TOML config/secrets and RPC URLs.
     ///
     /// Without wallet features, `WalletKind` is uninhabited so
     /// deserialization always fails at the `?` — making later clones
@@ -75,28 +76,36 @@ impl OnchainWalletCtx {
         wallet_secrets: toml::Value,
         base_rpc_url: Url,
         ethereum_rpc_url: Url,
+        hyperevm_rpc_url: Url,
     ) -> Result<Self, WalletCtxError> {
         let WalletKindTag { kind } = WalletKindTag::deserialize(wallet_config.clone())?;
 
-        let (base_wallet, ethereum_wallet) = tokio::try_join!(
+        let (base_wallet, ethereum_wallet, hyperevm_wallet) = tokio::try_join!(
             build_wallet(
                 &kind,
                 wallet_config.clone(),
                 wallet_secrets.clone(),
                 base_rpc_url,
             ),
-            build_wallet(&kind, wallet_config, wallet_secrets, ethereum_rpc_url,),
+            build_wallet(
+                &kind,
+                wallet_config.clone(),
+                wallet_secrets.clone(),
+                ethereum_rpc_url,
+            ),
+            build_wallet(&kind, wallet_config, wallet_secrets, hyperevm_rpc_url,),
         )?;
 
         info!(
             target: "wallet",
             wallet = %base_wallet.address(),
-            "Initialized onchain wallet (Base + Ethereum)"
+            "Initialized onchain wallet (Base + Ethereum + HyperEVM)"
         );
 
         Ok(Self {
             base_wallet,
             ethereum_wallet,
+            hyperevm_wallet,
         })
     }
 
@@ -106,6 +115,10 @@ impl OnchainWalletCtx {
 
     pub fn ethereum_wallet(&self) -> &Arc<dyn Wallet<Provider = RootProvider>> {
         &self.ethereum_wallet
+    }
+
+    pub fn hyperevm_wallet(&self) -> &Arc<dyn Wallet<Provider = RootProvider>> {
+        &self.hyperevm_wallet
     }
 }
 
@@ -147,7 +160,8 @@ impl OnchainWalletCtx {
 
         Self {
             base_wallet: stub_wallet.clone(),
-            ethereum_wallet: stub_wallet,
+            ethereum_wallet: stub_wallet.clone(),
+            hyperevm_wallet: stub_wallet,
         }
     }
 }
@@ -158,10 +172,12 @@ impl OnchainWalletCtx {
     pub fn from_wallets(
         base_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
         ethereum_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
+        hyperevm_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
     ) -> Self {
         Self {
             base_wallet,
             ethereum_wallet,
+            hyperevm_wallet,
         }
     }
 }

--- a/crates/config/src/wallet.rs
+++ b/crates/config/src/wallet.rs
@@ -56,9 +56,9 @@ pub enum WalletCtxError {
 /// configure a wallet for manual CLI operations.
 #[derive(Clone)]
 pub struct OnchainWalletCtx {
-    base_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
-    ethereum_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
-    hyperevm_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
+    base: Arc<dyn Wallet<Provider = RootProvider>>,
+    ethereum: Arc<dyn Wallet<Provider = RootProvider>>,
+    hyperevm: Arc<dyn Wallet<Provider = RootProvider>>,
 }
 
 impl OnchainWalletCtx {
@@ -103,22 +103,22 @@ impl OnchainWalletCtx {
         );
 
         Ok(Self {
-            base_wallet,
-            ethereum_wallet,
-            hyperevm_wallet,
+            base: base_wallet,
+            ethereum: ethereum_wallet,
+            hyperevm: hyperevm_wallet,
         })
     }
 
     pub fn base_wallet(&self) -> &Arc<dyn Wallet<Provider = RootProvider>> {
-        &self.base_wallet
+        &self.base
     }
 
     pub fn ethereum_wallet(&self) -> &Arc<dyn Wallet<Provider = RootProvider>> {
-        &self.ethereum_wallet
+        &self.ethereum
     }
 
     pub fn hyperevm_wallet(&self) -> &Arc<dyn Wallet<Provider = RootProvider>> {
-        &self.hyperevm_wallet
+        &self.hyperevm
     }
 }
 
@@ -159,9 +159,9 @@ impl OnchainWalletCtx {
         let stub_wallet = st0x_evm::StubWallet::stub(Address::ZERO);
 
         Self {
-            base_wallet: stub_wallet.clone(),
-            ethereum_wallet: stub_wallet.clone(),
-            hyperevm_wallet: stub_wallet,
+            base: stub_wallet.clone(),
+            ethereum: stub_wallet.clone(),
+            hyperevm: stub_wallet,
         }
     }
 }
@@ -175,9 +175,9 @@ impl OnchainWalletCtx {
         hyperevm_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
     ) -> Self {
         Self {
-            base_wallet,
-            ethereum_wallet,
-            hyperevm_wallet,
+            base: base_wallet,
+            ethereum: ethereum_wallet,
+            hyperevm: hyperevm_wallet,
         }
     }
 }

--- a/crates/config/src/wallet.rs
+++ b/crates/config/src/wallet.rs
@@ -49,8 +49,37 @@ pub enum WalletCtxError {
     WalletConfig(#[from] toml::de::Error),
     #[error("failed to build the wallet RPC HTTP client: {0}")]
     HttpClient(#[from] reqwest::Error),
+    #[error(
+        "{field} must use https; http is allowed only for loopback hosts \
+         (local test nodes)"
+    )]
+    InsecureRpcUrl { field: &'static str },
     #[error(transparent)]
     Evm(#[from] st0x_evm::EvmError),
+}
+
+/// Rejects wallet RPC URLs that would carry signing traffic over cleartext
+/// HTTP. HTTP is allowed only for loopback hosts, so local test nodes
+/// (Anvil) keep working while any routable endpoint must be HTTPS. Enforced
+/// both at config load and in [`OnchainWalletCtx::new`], so no caller of the
+/// public constructor can bypass it.
+pub fn require_secure_wallet_rpc_url(url: &Url, field: &'static str) -> Result<(), WalletCtxError> {
+    if url.scheme() == "https" {
+        return Ok(());
+    }
+
+    let is_loopback = match url.host() {
+        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+        Some(url::Host::Domain(host)) => host == "localhost",
+        None => false,
+    };
+
+    if is_loopback {
+        Ok(())
+    } else {
+        Err(WalletCtxError::InsecureRpcUrl { field })
+    }
 }
 
 /// Pre-built signing wallets for Base and Ethereum chains.
@@ -81,6 +110,10 @@ impl OnchainWalletCtx {
         ethereum_rpc_url: Url,
         hyperevm_rpc_url: Url,
     ) -> Result<Self, WalletCtxError> {
+        require_secure_wallet_rpc_url(&base_rpc_url, "base_rpc_url")?;
+        require_secure_wallet_rpc_url(&ethereum_rpc_url, "ethereum_rpc_url")?;
+        require_secure_wallet_rpc_url(&hyperevm_rpc_url, "hyperevm_rpc_url")?;
+
         let WalletKindTag { kind } = WalletKindTag::deserialize(wallet_config.clone())?;
 
         let (base_wallet, ethereum_wallet, hyperevm_wallet) = tokio::try_join!(

--- a/example.secrets.toml
+++ b/example.secrets.toml
@@ -5,6 +5,7 @@ rpc_url = "https://mainnet.base.org"
 # Required when [wallet] is configured:
 base_rpc_url = "https://mainnet.base.org"
 ethereum_rpc_url = "https://mainnet.infura.io"
+hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
 [broker]
 mode = "sandbox"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2075,6 +2075,28 @@ mod tests {
     }
 
     #[test]
+    fn alpaca_tokenize_parses_hyperevm_network() {
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "alpaca-tokenize",
+            "-s",
+            "RKLB",
+            "-q",
+            "1",
+            "--network",
+            "hyperevm",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::AlpacaTokenize { network, .. } => {
+                assert_eq!(network, TokenizationNetwork::HyperEvm);
+            }
+            other => panic!("expected alpaca-tokenize command, got: {other:?}"),
+        }
+    }
+
+    #[test]
     fn dividend_bump_command_parses_symbol_and_quantity() {
         let cli =
             Cli::try_parse_from(["st0x-cli", "dividend-bump", "-s", "COIN", "-q", "10.5"]).unwrap();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -157,6 +157,9 @@ pub enum TokenizationNetwork {
     Base,
     /// Ethereum mainnet
     Ethereum,
+    /// HyperEVM mainnet
+    #[value(name = "hyperevm")]
+    HyperEvm,
 }
 
 /// Manual position-recovery operations for stuck local CQRS state.
@@ -3689,6 +3692,7 @@ mod tests {
                 rpc_url = "http://localhost:8545"
                 base_rpc_url = "https://base.example.com"
                 ethereum_rpc_url = "https://mainnet.infura.io"
+                hyperevm_rpc_url = "https://rpc.hyperliquid.xyz/evm"
 
                 [broker]
                 type = "dry-run"

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -79,6 +79,10 @@ fn tokenization_network_context(
             wallet_ctx.ethereum_wallet().clone(),
             Network::new("ethereum"),
         ),
+        TokenizationNetwork::HyperEvm => (
+            wallet_ctx.hyperevm_wallet().clone(),
+            Network::new("hyperevm"),
+        ),
     }
 }
 
@@ -1072,6 +1076,10 @@ fn resolve_tokenization_token(
         }),
         TokenizationNetwork::Ethereum => Err(anyhow::anyhow!(
             "pass --token with the Ethereum tStock address for {symbol}: \
+             [assets.equities] holds Base addresses only"
+        )),
+        TokenizationNetwork::HyperEvm => Err(anyhow::anyhow!(
+            "pass --token with the HyperEVM tStock address for {symbol}: \
              [assets.equities] holds Base addresses only"
         )),
     }
@@ -2803,16 +2811,19 @@ mod tests {
     }
 
     /// One match yields both the wallet and the wire value, so the pairing is
-    /// pinned here for both networks: ethereum selects the ethereum wallet and
-    /// the "ethereum" wire value, base the base pair.
+    /// pinned here for every network: ethereum selects the ethereum wallet and
+    /// the "ethereum" wire value, base the base pair, hyperevm the hyperevm
+    /// pair.
     #[cfg(feature = "test-support")]
     #[test]
     fn tokenization_network_context_pairs_wallet_and_wire() {
         let base_address = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let ethereum_address = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let hyperevm_address = address!("0xcccccccccccccccccccccccccccccccccccccccc");
         let wallet_ctx = OnchainWalletCtx::from_wallets(
             StubWallet::stub(base_address),
             StubWallet::stub(ethereum_address),
+            StubWallet::stub(hyperevm_address),
         );
 
         let (base_wallet, base_wire) =
@@ -2824,6 +2835,11 @@ mod tests {
             tokenization_network_context(&wallet_ctx, TokenizationNetwork::Ethereum);
         assert_eq!(ethereum_wallet.address(), ethereum_address);
         assert_eq!(ethereum_wire, Network::new("ethereum"));
+
+        let (hyperevm_wallet, hyperevm_wire) =
+            tokenization_network_context(&wallet_ctx, TokenizationNetwork::HyperEvm);
+        assert_eq!(hyperevm_wallet.address(), hyperevm_address);
+        assert_eq!(hyperevm_wire, Network::new("hyperevm"));
     }
 
     async fn seed_to_withdrawal_complete(

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -4057,6 +4057,29 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn hyperevm_network_requires_explicit_token_address() {
+        let ctx = create_alpaca_ctx_without_rebalancing();
+        let mut stdout = Vec::new();
+
+        let error = alpaca_redeem_command(
+            &mut stdout,
+            Symbol::new("RKLB").unwrap(),
+            FractionalShares::new(float!(1)),
+            None,
+            TokenizationNetwork::HyperEvm,
+            None,
+            &ctx,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("pass --token"),
+            "hyperevm without --token must fail closed, got: {error}"
+        );
+    }
+
     #[test]
     fn token_override_bypasses_assets_config() {
         let ctx = create_alpaca_ctx_without_rebalancing();

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -141,7 +141,11 @@ pub(crate) fn build_full_system_ctx<P: Provider + Clone>(
         .with_circle_api_base(cctp.attestation_base_url)
         .with_cctp_addresses(cctp.token_messenger, cctp.message_transmitter);
 
-    let wallet_ctx = st0x_config::OnchainWalletCtx::from_wallets(base_wallet, ethereum_wallet);
+    let wallet_ctx = st0x_config::OnchainWalletCtx::from_wallets(
+        base_wallet,
+        ethereum_wallet.clone(),
+        ethereum_wallet,
+    );
 
     Ctx::for_test()
         .database_url(db_path.display().to_string())
@@ -589,6 +593,7 @@ rebalancing = "enabled"
 rpc_url = "{rpc_url}"
 base_rpc_url = "{base_rpc_url}"
 ethereum_rpc_url = "{ethereum_rpc_url}"
+hyperevm_rpc_url = "{ethereum_rpc_url}"
 
 [broker]
 type = "alpaca-broker-api"

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -264,7 +264,11 @@ pub(crate) fn build_rebalancing_ctx<P: Provider + Clone>(
         .usdc(usdc_rebalancing)
         .call();
 
-    let wallet_ctx = st0x_config::OnchainWalletCtx::from_wallets(base_wallet.clone(), base_wallet);
+    let wallet_ctx = st0x_config::OnchainWalletCtx::from_wallets(
+        base_wallet.clone(),
+        base_wallet.clone(),
+        base_wallet,
+    );
 
     let assets = AssetsConfig {
         equities: EquitiesConfig {
@@ -372,7 +376,11 @@ where
         .with_circle_api_base(cctp.attestation_base_url)
         .with_cctp_addresses(cctp.token_messenger, cctp.message_transmitter);
 
-    let wallet_ctx = st0x_config::OnchainWalletCtx::from_wallets(base_wallet, ethereum_wallet);
+    let wallet_ctx = st0x_config::OnchainWalletCtx::from_wallets(
+        base_wallet,
+        ethereum_wallet.clone(),
+        ethereum_wallet,
+    );
 
     Ctx::for_test()
         .database_url(db_path.display().to_string())


### PR DESCRIPTION
## What

Closes RAI-1760. Adds HyperEVM to the tokenization CLI: alpaca-tokenize / alpaca-redeem now accept --network hyperevm.

## Why

RAI-1743 needs one bounded HyperEVM mint and redeem, and the CLI could not target the chain: TokenizationNetwork only had Base and Ethereum. Alpaca already publishes hyperevm in the TokenizationNetwork OpenAPI enum (verified 2026-08-14).

## How

Mirrors the Ethereum addition from PR #1110:

- TokenizationNetwork::HyperEvm, pinned to the exact wire value with value(name = "hyperevm") since clap's kebab case default would produce hyper-evm
- tokenization_network_context arm pairing the hyperevm wallet with the "hyperevm" wire value; resolve_tokenization_token arm requiring --token like Ethereum
- OnchainWalletCtx carries a third wallet; hyperevm_rpc_url joins [evm] secrets and is required when [wallet] is configured, threaded through validate_wallet_inputs into wallet construction

## Testing

- tokenization_network_context pairing test extended to the hyperevm wallet/wire pair
- loader fixtures, CLI config test, and e2e secrets template updated with hyperevm_rpc_url
- cargo check --workspace --tests clean

## Screenshots

n/a

## Anything else

Deploy note: staging/prod [evm] secrets need a hyperevm_rpc_url line before this rolls out; wallet construction now requires all three RPC URLs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789307183&installation_model_id=19370&pr_number=1208&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1208&signature=53fad90bb1cc7d3a62e062f44c6c8fa7a5f9c71d38b582f03043880c37f83848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added HyperEVM as a supported tokenization network through the `hyperevm` CLI option.
  - Added HyperEVM RPC configuration and wallet support.
  - Enabled rebalancing operations on HyperEVM.
  - Added HyperEVM-specific token address handling, including `--token` guidance when required.

- **Bug Fixes**
  - Rejected insecure RPC URLs except for loopback hosts.
  - Improved RPC reliability with request timeouts and redirect protection.

- **Documentation**
  - Updated configuration examples with the HyperEVM RPC URL setting.

- **Tests**
  - Expanded coverage for HyperEVM wallet setup and rebalancing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->