### PR TITLE
feat: config/prod-gcp variant for the GCP production VM

### DIFF
--- a/config/prod-gcp/st0x-hedge.toml
+++ b/config/prod-gcp/st0x-hedge.toml
@@ -1,0 +1,522 @@
+# HTTP API port for the dashboard and health checks.
+server_port = 8001
+# HTTP port for the apalis-board job queue UI.
+board_port = 8002
+# Minimum log level: trace, debug, info, warn, error.
+log_level = "trace"
+# Directory for rotated log files (stdout if omitted).
+log_dir = "/mnt/data/logs"
+# SQLite database path for event store, projections, and job queue.
+database_url = "sqlite:///mnt/data/st0x-hedge.db"
+# How often (seconds) Apalis purges finished background jobs.
+apalis_finished_job_cleanup_interval_secs = 3600
+# Consecutive offchain polls that must diverge from the inventory view's
+# Hedging balance for a symbol before the poller escalates a forced snapshot
+# reconciliation.
+inventory_divergence_threshold = 10
+[broker]
+counter_trade_slippage_bps = 100
+extended_hours_reprice_timeout_secs = 300
+close_flatten_reprice_timeout_secs = 60
+extended_hours_close_flatten_window_secs = 900
+close_flatten_cross_max_bps = 400
+
+# Travel Rule beneficiary identity for Alpaca whitelist creation.
+[broker.travel_rule]
+beneficiary_entity_name = "T0 TRADE (BVI) LTD"
+
+# On-chain orderbook settings.
+[raindex]
+# Rain Orderbook contract on Base.
+orderbook = "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D"
+# Rebalancing settlement mode: "legacy" (settle directly against the orderbook
+# with bot-EOA-owned vaults) or "managed" (settle through the shared
+# RaindexInventory below, which the bot must operate via OPERATOR_ROLE).
+#
+# Dedicated production inventory. The wallet must hold OPERATOR_ROLE because
+# startup verifies that role explicitly, even when the wallet is also admin.
+inventory_mode = "managed"
+# Operator addresses that attribute inventory settlements to venues.
+inventory_adapters = [
+  { venue = "bebop", operator = "0x3EE87Dcabfb324B2231044928080Dd4E6AC19baE" },
+]
+inventory = "0x10e4db39275C3b128C01bA1194D45D19aE1520d9"
+# REQUIRED. Owner used for vault balances, registry entries, and order-fill
+# matching. Managed mode requires this to equal `inventory`.
+vault_owner = "0x10e4db39275C3b128C01bA1194D45D19aE1520d9"
+# Backfill floor. No inventory-owned event can predate its deployment block; an
+# existing later checkpoint still resumes at checkpoint + 1.
+deployment_block = 49746968
+# Block confirmations required before a submitted transaction is treated as
+# settled. Does not govern fill ingestion (controlled by ingestion_cutoff).
+required_confirmations = 3
+# Use the OP-Stack safe block as the fill-ingestion cutoff. This cuts hedging
+# lag from ~20 min (finalized) to ~seconds. See example.config.toml for tradeoffs.
+ingestion_cutoff = "safe"
+
+# Wallet configuration (Turnkey secure enclave signing).
+[wallet]
+# Keyless Turnkey auth: the API key lives in Cloud KMS; the secrets file
+# carries no api_private_key. Key minted by t0.devops #270 (2026-08-14).
+kms_api_key = "projects/t0-liquidity/locations/europe-west3/keyRings/t0-liquidity/cryptoKeys/turnkey-api-key/cryptoKeyVersions/1"
+kind = "turnkey"
+# On-chain address controlled by the Turnkey key.
+address = "0xA9C16673F65AE808688cB18952AFE3d9658C808f"
+# Turnkey organization that owns the signing key.
+organization_id = "b100145e-7894-4c17-b3e7-160435f84803"
+
+# Alpaca tokenization settings.
+# Required when [rebalancing] is configured (used for equity redemptions).
+# Also needed for CLI commands: alpaca-redeem and transfer-equity.
+# Not needed for alpaca-tokenize or alpaca-tokenization-requests.
+[tokenization]
+redemption_wallet = "0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE"
+
+# ETH/USD valuation source for bot-gas cost recording (ADR 0017). Required
+# because [rebalancing] is configured below. Both values are public (not
+# secrets): the Pyth oracle contract on Base, and its ETH/USD price feed id.
+# pyth_contract is Pyth's EVM deployment on Base mainnet, per the
+# contract-address registry at
+# https://docs.pyth.network/price-feeds/contract-addresses/evm. Pinned by
+# crates/config's repo_config_bot_gas_valuation_pyth_contract_matches_base_deployment
+# test against BASE_PYTH_CONTRACT_ADDRESS (src/onchain/pyth/mod.rs) -- update
+# both if this deployment address ever changes.
+# eth_usd_feed_id is Pyth's Crypto.ETH/USD feed id, per the registry at
+# https://www.pyth.network/developers/price-feed-ids#pyth-evm-stable (also
+# resolvable via https://pyth.network/price-feeds/crypto-eth-usd).
+[bot_gas_valuation]
+pyth_contract = "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a"
+eth_usd_feed_id = "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
+
+[rebalancing]
+transfer_timeout_secs = 1800
+transfer_attempt_timeout_secs = 3600
+attestation_retry_deadline_secs = 86400
+max_burn_revert_redrives = 5
+# Dividend freeze guard: query issuance each equity cycle and fail closed when
+# the status cannot be confirmed. Set to "disabled" to fail open during an
+# issuance outage (issuance secrets stay required, so re-enabling is config-only).
+freeze_check = "enabled"
+
+[rebalancing.usdc]
+mode = "enabled"
+target = 0.6
+deviation = 0.05
+
+[rebalancing.equity]
+target = 0.5
+deviation = 0.05
+
+[rest_api]
+url = "https://api.st0x.io"
+
+# Low-gas balance alerting for the bot wallet. Telegram bot_token lives in the
+# encrypted secrets file under [alerts]. Every field is required (no defaults).
+[alerts]
+# Telegram chat alerts are delivered to (St0x Product Operations supergroup).
+chat_id = -1003850406522
+# Forum topic alerts post into (the "DEX Liquidity" topic).
+message_thread_id = 50
+# Native-ETH balance below which a low-gas alert fires (decimal ETH).
+low_balance_threshold = "0.05"
+# Seconds between native-balance polls.
+poll_interval = 300
+# Minimum seconds between repeated alerts while the balance stays below threshold.
+# 43200 = 12 hours.
+realert_interval = 43200
+
+# USDC vault and rebalancing settings.
+[assets.cash]
+# USDC vault used by Bebop and cash rebalancing. The inventory keys vaults by
+# (token, vaultId), so both paths must use the same vault.
+vault_id = "0xfab"
+# Whether automatic USDC rebalancing between venues is active.
+rebalancing = "enabled"
+# Maximum USDC moved per rebalance operation.
+operational_limit = 10000
+
+# Per-equity asset configuration.
+# - trading: whether the bot hedges fills for this asset.
+# - rebalancing: whether automatic equity rebalancing is active.
+# - wrapped_equity_recovery: whether wrapped equity tokens detected in bot
+#   wallets are auto-recovered (resume stalled transfer or deposit orphans).
+# - extended_hours_counter_trading: whether counter-trades for this asset may
+#   be placed during extended (pre-/after-market) sessions as limit orders.
+# - tokenized_equity: unwrapped tTOKEN contract address on Base.
+# - tokenized_equity_derivative: wrapped wtTOKEN contract address on Base.
+# - vault_ids: Raindex vault ID(s) — single string or array of strings.
+#   (alias: vault_id for backward compat. Required when rebalancing is enabled.)
+# - pyth_feed_id: Optional Pyth feed ID for trade-enrichment reference prices.
+#   Only the symbols below carry one — they are the feeds confirmed from prod
+#   on-chain reads (COIN, CRCL, MSTR, QQQM, SGOV, TSLA). The remaining symbols
+#   are intentionally left unset until their current feed is confirmed on-chain;
+#   Pyth has multiple feeds per ticker and the feeds migrate, so values are not
+#   taken from the public registry unconfirmed. A missing feed only skips
+#   enrichment (analytics) for that symbol — hedging is unaffected.
+
+[assets.equities.RKLB]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+# operational_limit = 1
+vault_id = "0xfab"
+tokenized_equity = "0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b"
+tokenized_equity_derivative = "0xf4f8c66085910d583c01f3b4e44bf731d4e2c565"
+
+[assets.equities.SGOV]
+pyth_feed_id = "0x8d6a29bb5ed522931d711bb12c4bbf92af986936e52af582032913b5ffcbf4d5"
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612"
+tokenized_equity_derivative = "0x78c31580c97101694c70022c83d570150c11e935"
+
+[assets.equities.SPYM]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x8fdf41116f755771bfe0747d5f8c3711d5debfbb"
+tokenized_equity_derivative = "0x31c2c14134e6e3b7ef9478297f199331133fc2d8"
+
+[assets.equities.TSLA]
+pyth_feed_id = "0x2a797e196973b72447e0ab8e841d9f5706c37dc581fe66a0bd21bcd256cdb9b9"
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x4e169cd2ab4f82640a8c65c68fed55863866fdb0"
+tokenized_equity_derivative = "0x219a8d384a10bf19b9f24cb5cc53f79dd0e5a03d"
+
+[assets.equities.AMZN]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x466cb2e46fa1afc0ab5e22274b34d0391db18efd"
+tokenized_equity_derivative = "0x997bae3ec193a249596d3708c3fab7c501bb8a53"
+
+[assets.equities.NVDA]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x7271a3c91bb6070ed09333b84a815949d4f16d14"
+tokenized_equity_derivative = "0xfb5b41acdba20a3230f84be995173cfb98b8d6e7"
+
+[assets.equities.MSTR]
+pyth_feed_id = "0xe1e80251e5f5184f2195008382538e847fafc36f751896889dd3d1b1f6111f09"
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x013b782f402d61aa1004cca95b9f5bb402c9d5fe"
+tokenized_equity_derivative = "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2"
+
+[assets.equities.QSEP]
+trading = "disabled"
+rebalancing = "disabled"
+wrapped_equity_recovery = "disabled"
+extended_hours_counter_trading = "disabled"
+vault_id = "0xfab"
+tokenized_equity = "0x4a9a9fc94a507559481270d0bff3315ab92fcefa"
+tokenized_equity_derivative = "0x849e389982209f901b7b9ffca57ae4c9eeb11c0d"
+
+[assets.equities.IAU]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x9a507314ea2a6c5686c0d07bfecb764dcf324dff"
+tokenized_equity_derivative = "0x1e46d7efef64a833afb1cd49299a7ad5b439f4d8"
+
+[assets.equities.COIN]
+pyth_feed_id = "0xfee33f2a978bf32dd6b662b65ba8083c6773b494f8401194ec1870c640860245"
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x626757e6f50675d17fcad312e82f989ae7a23d38"
+tokenized_equity_derivative = "0x5cda0e1ca4ce2af96315f7f8963c85399c172204"
+
+[assets.equities.SIVR]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x58ce5024b89b4f73c27814c0f0abbea331c99be8"
+tokenized_equity_derivative = "0xeb7f3e4093c9d68253b6104fbbff561f3ec0442f"
+
+[assets.equities.CRCL]
+pyth_feed_id = "0x92b8527aabe59ea2b12230f7b532769b133ffb118dfbd48ff676f14b273f1365"
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x38eb797892ed71da69bdc27a456a7c83ff813b52"
+tokenized_equity_derivative = "0x8afba81dec38de0a18e2df5e1967a7493651eebf"
+
+[assets.equities.PPLT]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x1f17523b147ccc2a2328c0f014f6d49c479ea063"
+tokenized_equity_derivative = "0x82f5baee1076334357a34a19e04f7c282d51ce47"
+
+[assets.equities.BMNR]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xfbde45df60249203b12148452fc77c3b5f811eb2"
+tokenized_equity_derivative = "0x2512EC661f0bA089c275EA105E31bAD6FcFcf319"
+
+[assets.equities.QQQM]
+pyth_feed_id = "0x433b196b3b026f46f76b5e901c84c575a7280dcba0f4272edefe0529b599ad64"
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x09ee803ba675052e10a54bfc8e18c0f67793056b"
+tokenized_equity_derivative = "0x823FF7Bbde2869aAe73A6CD53e7f614442836757"
+
+[assets.equities.VWO]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x0acfea6833c4a3f41bf2fbd736aa9eea547d90ee"
+tokenized_equity_derivative = "0x23ec6886b49D7ab123E9ee8e474D2fa7AB6Cbc2d"
+
+[assets.equities.ARKK]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x323804af6f3bb463d688b854667c6870a0fc06ad"
+tokenized_equity_derivative = "0x9FfF48B4535AF3765Ac9E1b164720EDc01DF8EE7"
+
+[assets.equities.SPCX]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xc585AeB8B76c5F5e4215470A7625258e86ED7746"
+tokenized_equity_derivative = "0x19F89aaEf8a93f38A974beca9776f09aB844887F"
+
+[assets.equities.CEG]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x9a5D3cAeC90b0332b18C0B93fEF42F3F8C918289"
+tokenized_equity_derivative = "0x3aF952888Cd89DAD3e8AF67cf4b7E740B36829C3"
+
+[assets.equities.DRAM]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x96DE077262609298CD891E4Ab21bd34837dE33aB"
+tokenized_equity_derivative = "0x1A91Df4a970EBaB1bB4AF32Eb6d10509028eE4b8"
+
+[assets.equities.TSM]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x7001e2974F775f0Fd73a3D2e5914e591f3EC3fBB"
+tokenized_equity_derivative = "0x71C66449d2528E23514A9c197BFD55Ae9DB3B714"
+
+[assets.equities.ASML]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x722Cb373f1871A176fb5DC3953046f2EAE22F619"
+tokenized_equity_derivative = "0x8200c6d9AB9E02A25D7F2099244C476d99a085ef"
+
+[assets.equities.SKHY]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x4DBA41f0feb390F208a85e96168fF5d8aC2b6F5c"
+tokenized_equity_derivative = "0xFcD17aC4c4BF6a72c93018096F3fC09e66573Ff9"
+
+[assets.equities.MU]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x7d89a2DFfDaF9f48A64337C725D925381b431aE2"
+tokenized_equity_derivative = "0x89EcfE9E0728D6b3c5eb0EE7236f8C6F806C7B56"
+
+[assets.equities.AMD]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x50b5225409A55B873fD6C2Fd5880AF5a11acE9b1"
+tokenized_equity_derivative = "0x648042Acd8638E12fEfd51C2b25A9f993f21a612"
+
+[assets.equities.AVGO]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x6088F8ef741AE1f5A61882866f130631b41617E2"
+tokenized_equity_derivative = "0x70A182f481AEF05836666B6CfDbe84dCBCE8AC19"
+
+[assets.equities.AMAT]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x98C02B58b7E65EF5a4262d9536162949e3B2E141"
+tokenized_equity_derivative = "0x522DC65c89C9Af4f410BAe01bbf53aF75854a9f9"
+
+[assets.equities.LRCX]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xDdE9346107609A05439A0B59Ab6eD4f7F81a1FBF"
+tokenized_equity_derivative = "0x328B9aFFa511fE26673edBb4fEa37eDaF908A3bc"
+
+[assets.equities.TTWO]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x1a29eD11DF8295D5F3B5F59849FD94caD615E024"
+tokenized_equity_derivative = "0x045Fb493D970f94a54FeaF931033622fC82192e6"
+
+[assets.equities.GOOGL]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x15De944Cd020A18C8E5626fB0F81b36e73956199"
+tokenized_equity_derivative = "0x6a2357Df4975C667B171bE53dA6FFe6deBf7030c"
+
+[assets.equities.INTC]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xBDC237Aa3B67cC3088adAf117913F30Bf08157a3"
+tokenized_equity_derivative = "0xf567652fC2d7Db8D5469fD06AEbe8C9c4372d722"
+
+[assets.equities.AAPL]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xD36056a4a03707D3743fCE4e9C08852820ADcfdC"
+tokenized_equity_derivative = "0x1020EC8Aa3f709a1f3D8705cdBa89b950451bd88"
+
+[assets.equities.MSFT]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x6a071E25fa25653cF15d1ee320eA3df771926Aa0"
+tokenized_equity_derivative = "0x515A3Ac2a6aB590bDFa970caFFFd7fAdC680886E"
+
+[assets.equities.LLY]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xA41Ce7B8255A01062ED1AF23ea5E8137B9300554"
+tokenized_equity_derivative = "0x892CcF5E75f4a7Ee6402971a1587F65BEE4d52bd"
+
+[assets.equities.PTY]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xb6021810971714cD48572af527307Acc324ecF61"
+tokenized_equity_derivative = "0xb6D779A79E7493ed821a65D52bA419F0F6D5dD0a"
+
+[assets.equities.HOOD]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x5cEfd886dD05001c2Fc32c313E05360D07f37d8f"
+tokenized_equity_derivative = "0xd50f561322fe3235DBc9Ec8b3aB7693383d8A425"
+
+[assets.equities.ORCL]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x57573351f3fdD20a57dEE4a7f836de1cE9900d4B"
+tokenized_equity_derivative = "0xCB9571aB96aA47374eF30D8E9ACCC1cD51064726"
+
+[assets.equities.SMCI]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x8518931497d2A8f07Bc607D1D3295b398D065A65"
+tokenized_equity_derivative = "0xA759FAbbD866e6DB8bF76613C35825dC2e380bf0"
+
+[assets.equities.BABA]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0x6B8fa7288dBEc7C1c62BfE59Cbd7Bec7EBF846C5"
+tokenized_equity_derivative = "0x7e5cc7eAe0455A07Ab4abf354E0f5657BA2888BD"
+
+[assets.equities.TQQQ]
+trading = "enabled"
+rebalancing = "enabled"
+wrapped_equity_recovery = "enabled"
+extended_hours_counter_trading = "enabled"
+vault_id = "0xfab"
+tokenized_equity = "0xcA1A378F9a250131A2fE51c10f120FeF7EDCa56E"
+tokenized_equity_derivative = "0x295e9eCAb319006900a53b3f8D6Fcb0C131F4ada"

--- a/nix/oci-images.nix
+++ b/nix/oci-images.nix
@@ -8,7 +8,7 @@
 # Image contract (consumed by the stack's docker-compose in t0.devops —
 # keep the two in sync):
 #   bot:       Entrypoint = the `server` binary; env configs baked at
-#              /app/config/{staging,staging-gcp,prod}/st0x-hedge.toml; the compose
+#              /app/config/{staging,staging-gcp,prod,prod-gcp}/st0x-hedge.toml; the compose
 #              command appends --config <baked path> --secrets <mounted
 #              Secret Manager file>. database_url in the configs stays
 #              sqlite:///mnt/data/st0x-hedge.db (the VM mounts its data
@@ -29,7 +29,7 @@
 
 let
   bakedConfigs = pkgs.runCommand "st0x-hedge-configs" { } ''
-    mkdir -p $out/app/config/staging $out/app/config/staging-gcp $out/app/config/prod
+    mkdir -p $out/app/config/staging $out/app/config/staging-gcp $out/app/config/prod $out/app/config/prod-gcp
     cp ${../config/staging/st0x-hedge.toml} $out/app/config/staging/st0x-hedge.toml
     # The GCP VM runs this variant: kms_api_key (keyless Turnkey auth, so
     # the secrets file has no [wallet]) and no [telemetry]. #1182 added the
@@ -37,6 +37,11 @@ let
     # and the bot crash-looped on "failed to read config file" at cutover.
     cp ${../config/staging-gcp/st0x-hedge.toml} $out/app/config/staging-gcp/st0x-hedge.toml
     cp ${../config/prod/st0x-hedge.toml} $out/app/config/prod/st0x-hedge.toml
+    # The GCP production VM's variant, same shape as staging-gcp: kms_api_key
+    # (keyless Turnkey, no [wallet] secret) and no [telemetry]. The plain
+    # prod config remains the droplet's. Baked HERE, not just committed --
+    # the staging cutover crash-looped on exactly that omission (#1182/#1190).
+    cp ${../config/prod-gcp/st0x-hedge.toml} $out/app/config/prod-gcp/st0x-hedge.toml
   '';
 
   dashboardRoot = pkgs.runCommand "st0x-dashboard-root" { } ''


### PR DESCRIPTION
The production twin of #1182's staging-gcp variant, for the GCP VM (t0.devops terraform/production-liquidity): config/prod minus [telemetry], plus kms_api_key = the production KMS-held Turnkey API key (t0.devops#270, minted 2026-08-14). Secrets for this variant carry no [wallet]. Separate file because the droplet still deploys config/prod (kms_api_key there would trip the both-credentials refusal). Baked into bakedConfigs in the same PR — the staging cutover crash-looped on a committed-but-not-baked config (#1190). Inert until the production stack's --config points at it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/1215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789395398&installation_model_id=19370&pr_number=1215&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F1215&signature=349974ef6810d4e9621893ad42dc6192be55d83df17164777a46c4d184a21a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production GCP configuration for the st0x hedge bot, including trading, rebalancing, recovery, vaults, tokenized assets, alerts, and REST API settings.
  * Added support for building OCI images with the production GCP configuration included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->