### PR TITLE
chore: remove QSEP from production config

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -230,15 +230,6 @@ vault_id = "0xfab"
 tokenized_equity = "0x013b782f402d61aa1004cca95b9f5bb402c9d5fe"
 tokenized_equity_derivative = "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2"
 
-[assets.equities.QSEP]
-trading = "disabled"
-rebalancing = "disabled"
-wrapped_equity_recovery = "disabled"
-extended_hours_counter_trading = "disabled"
-vault_id = "0xfab"
-tokenized_equity = "0x4a9a9fc94a507559481270d0bff3315ab92fcefa"
-tokenized_equity_derivative = "0x849e389982209f901b7b9ffca57ae4c9eeb11c0d"
-
 [assets.equities.IAU]
 trading = "enabled"
 rebalancing = "enabled"

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -26,7 +26,6 @@ cross-checking. Current addresses:
 | AMZN   | `0x466cb2e46fa1afc0ab5e22274b34d0391db18efd` |
 | NVDA   | `0x7271a3c91bb6070ed09333b84a815949d4f16d14` |
 | MSTR   | `0x013b782f402d61aa1004cca95b9f5bb402c9d5fe` |
-| QSEP   | `0x4a9a9fc94a507559481270d0bff3315ab92fcefa` |
 | IAU    | `0x9a507314ea2a6c5686c0d07bfecb764dcf324dff` |
 | COIN   | `0x626757e6f50675d17fcad312e82f989ae7a23d38` |
 | SIVR   | `0x58ce5024b89b4f73c27814c0f0abbea331c99be8` |


### PR DESCRIPTION
## What

- [RAI-1704](https://linear.app/makeitrain/issue/RAI-1704/remove-wtqsep-from-the-prod-liquidity-bot-config)
- Remove QSEP from the production liquidity bot config.
- Remove QSEP from the deployed CLI token-address reference.

## Why

- QSEP has no st0x.pricing feed, Raindex order, or Bebop maker config.
- Production snapshots show zero available and zero inflight QSEP inventory through August 15.

## How

- Delete the complete `[assets.equities.QSEP]` block from `config/prod/st0x-hedge.toml`.
- Leave staging configuration unchanged.

## Testing

- `server_config_toml_is_valid`
- `all_repo_config_tomls_are_valid`
- Pre-commit hooks

## Screenshots

Not applicable.

## Anything else

Nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Removed the disabled QSEP asset configuration from production settings.
* **Documentation**
  * Removed the QSEP token address from the CLI operations reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->